### PR TITLE
removed default scope showing up on scope selection popup in API Store.

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list-element/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list-element/template.jag
@@ -462,7 +462,6 @@
                     </div>
                     <div class="modal-body">
                         <ul>
-                        <li><input type="checkbox" name="Default Scope" value="default" id="default" class="Checkbox"> Default Scope : default</li>
 
                                 <% for (var i = 0; i < lenS; i++) {
 


### PR DESCRIPTION
Merge remote-tracking branch 'remotes/wso2/release-1.9.0' into release-1.9.0.