### PR TITLE
removed the possibility of passing an empty set of identifiers to getScopesBySubscibedAPIs()

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
@@ -2603,7 +2603,9 @@ public class APIStoreHostObject extends ScriptableObject {
 
 		                }
 		                //get scopes for subscribed apis
-		                scopeSet = apiConsumer.getScopesBySubscribedAPIs(identifiers);
+		                if(!identifiers.isEmpty()){
+			                scopeSet = apiConsumer.getScopesBySubscribedAPIs(identifiers);
+		                }
 
 		                for (Scope scope : scopeSet) {
 			                NativeObject scopeObj = new NativeObject();
@@ -3627,6 +3629,7 @@ public class APIStoreHostObject extends ScriptableObject {
                     }
 
 	                tokenScope = apiConsumer.getScopesByToken(accessToken);
+	                Set<Scope> scopeSet = new LinkedHashSet<Scope>();
 	                Subscriber subscriber = new Subscriber(userId);
 	                //get subscribed APIs set for application
 	                Set<SubscribedAPI> subscribedAPIs =
@@ -3638,7 +3641,9 @@ public class APIStoreHostObject extends ScriptableObject {
 	                }
 
 	                //get scopes for subscribed apis
-	                Set<Scope> scopeSet = apiConsumer.getScopesBySubscribedAPIs(identifiers);
+	                if(!identifiers.isEmpty()){
+		                scopeSet = apiConsumer.getScopesBySubscribedAPIs(identifiers);
+	                }
 	                //convert scope keys to names
 	                String tokenScopeNames = getScopeNamesbyKey(tokenScope, scopeSet);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
@@ -2605,8 +2605,8 @@ public class APIStoreHostObject extends ScriptableObject {
 
 		                }
 
-		                //get scopes for subscribed apis
 		                if (!identifiers.isEmpty()) {
+			                //get scopes for subscribed apis
 			                scopeSet = apiConsumer.getScopesBySubscribedAPIs(identifiers);
 			                for (Scope scope : scopeSet) {
 				                NativeObject scopeObj = new NativeObject();
@@ -3643,8 +3643,8 @@ public class APIStoreHostObject extends ScriptableObject {
 		                identifiers.add(subscribedAPI.getApiId());
 	                }
 
-	                //get scopes for subscribed apis
 	                if(!identifiers.isEmpty()){
+		                //get scopes for subscribed apis
 		                scopeSet = apiConsumer.getScopesBySubscribedAPIs(identifiers);
 		                //convert scope keys to names
 		                tokenScopeNames = getScopeNamesbyKey(tokenScope, scopeSet);

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
@@ -2604,16 +2604,16 @@ public class APIStoreHostObject extends ScriptableObject {
 			                identifiers.add(subscribedAPI.getApiId());
 
 		                }
-		                //get scopes for subscribed apis
-		                if(!identifiers.isEmpty()){
-			                scopeSet = apiConsumer.getScopesBySubscribedAPIs(identifiers);
-		                }
 
-		                for (Scope scope : scopeSet) {
-			                NativeObject scopeObj = new NativeObject();
-			                scopeObj.put("scopeKey", scopeObj, scope.getKey());
-			                scopeObj.put("scopeName", scopeObj, scope.getName());
-			                scopesArray.put(scopesArray.getIds().length, scopesArray, scopeObj);
+		                //get scopes for subscribed apis
+		                if (!identifiers.isEmpty()) {
+			                scopeSet = apiConsumer.getScopesBySubscribedAPIs(identifiers);
+			                for (Scope scope : scopeSet) {
+				                NativeObject scopeObj = new NativeObject();
+				                scopeObj.put("scopeKey", scopeObj, scope.getKey());
+				                scopeObj.put("scopeName", scopeObj, scope.getName());
+				                scopesArray.put(scopesArray.getIds().length, scopesArray, scopeObj);
+			                }
 		                }
 
 		                if (log.isDebugEnabled()) {
@@ -3632,6 +3632,7 @@ public class APIStoreHostObject extends ScriptableObject {
 
 	                tokenScope = apiConsumer.getScopesByToken(accessToken);
 	                Set<Scope> scopeSet = new LinkedHashSet<Scope>();
+	                String tokenScopeNames = "";
 	                Subscriber subscriber = new Subscriber(userId);
 	                //get subscribed APIs set for application
 	                Set<SubscribedAPI> subscribedAPIs =
@@ -3645,9 +3646,9 @@ public class APIStoreHostObject extends ScriptableObject {
 	                //get scopes for subscribed apis
 	                if(!identifiers.isEmpty()){
 		                scopeSet = apiConsumer.getScopesBySubscribedAPIs(identifiers);
+		                //convert scope keys to names
+		                tokenScopeNames = getScopeNamesbyKey(tokenScope, scopeSet);
 	                }
-	                //convert scope keys to names
-	                String tokenScopeNames = getScopeNamesbyKey(tokenScope, scopeSet);
 
                     row.put("accessToken", row, dto.getApplicationAccessToken());
                     row.put("consumerKey", row, dto.getConsumerKey());


### PR DESCRIPTION
this is a small bugfix for https://github.com/wso2/carbon-apimgt/pull/43