### PR TITLE
Fixing "Can access another domains' API information even visibility is set to domain only"

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -278,10 +278,14 @@ public abstract class AbstractAPIManager implements APIManager {
 
     public API getAPI(APIIdentifier identifier) throws APIManagementException {
         String apiPath = APIUtil.getAPIPath(identifier);
+        API api;
         try {
             String tenantDomain = MultitenantUtils.getTenantDomain(APIUtil.replaceEmailDomainBack(identifier.getProviderName()));
             Registry registry;
-            if (!tenantDomain.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            if(isTenantDomainNotMatching(tenantDomain)){
+                throw new APIManagementException("Invalid Operation: Cannot access " +  apiPath);
+            }
+            else if (!tenantDomain.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
                 int id = ServiceReferenceHolder.getInstance().getRealmService().getTenantManager().getTenantId(tenantDomain);
                 registry = ServiceReferenceHolder.getInstance().
                         getRegistryService().getGovernanceSystemRegistry(id);
@@ -301,7 +305,7 @@ public abstract class AbstractAPIManager implements APIManager {
                 throw new APIManagementException("artifact id is null for : " + apiPath);
             }
             GenericArtifact apiArtifact = artifactManager.getGenericArtifact(artifactId);
-            return APIUtil.getAPIForPublishing(apiArtifact, registry);
+            api =  APIUtil.getAPIForPublishing(apiArtifact, registry);
 
         } catch (RegistryException e) {
             handleException("Failed to get API from : " + apiPath, e);
@@ -310,6 +314,7 @@ public abstract class AbstractAPIManager implements APIManager {
             handleException("Failed to get API from : " + apiPath, e);
             return null;
         }
+        return api;
     }
 
     public API getAPI(String apiPath) throws APIManagementException {


### PR DESCRIPTION
Mail Received From sanethd

API information of another domain can be accessed through  "getAPI" action in  "/publisher/site/blocks/listing/ajax/item-list.jag" if the API name, version and provider is known.

Steps to re-create:

    create 2 tenants :  admin@tenant1.com and admin@tenant2.com
    create a API in tenant1 using admin@tenant1.com, visibility level should be domain only.
        curl -X POST -c cookies http://localhost:9763/publisher/site/blocks/user/login/ajax/login.jag -d 'action=login&username=admin@tenant1.com&password=adminadmin'
        curl -X POST -b cookies http://localhost:9763/publisher/site/blocks/item-add/ajax/add.jag -d "action=addAPI&name=YoutubeFeeds&visibility=private&version=1.0.0&description=Youtube Live Feeds&endpointType=nonsecured&http_checked=http&https_checked=https&&wsdl=&tags=youtube,gdata,multimedia&tier=Silver&thumbUrl=http://www.10bigideas.com.au/www/573/files/pf-thumbnail-youtube_logo.jpg&context=/youtube&tiersCollection=Gold&resourceCount=0&resourceMethod-0=GET&resourceMethodAuthType-0=Application&resourceMethodThrottlingTier-0=Unlimited&uriTemplate-0=/*"  -d'endpoint_config={"production_endpoints":{"url":"http://gdata.youtube.com/feeds/api/standardfeeds","config":null},"endpoint_type":"http"}';
    Login to tenant2
        curl -X POST -c cookies http://localhost:9763/publisher/site/blocks/user/login/ajax/login.jag -d 'action=login&username=admin@tenant2.com&password=adminadmin'
    Access  API information of tenant1 using tenant2 session cookie.
         curl -X POST -b cookies http://localhost:9763/publisher/site/blocks/listing/ajax/item-list.jag -d "action=getAPI&name=APILifeCycleTestAPI1&version=1.0.0&provider=admin"
    All the information about API can be retrieved
        {"error" : false, "api" : {"name" : "APILifeCycleTestAPI1", "version" : "1.0.0", "description" : "This is test API create by API manager integration test", "endpoint" : "", "wsdl" : "", "tags" : "youtube,media,video", "availableTiers" : "Gold", "status" : "PUBLISHED", "thumb" : null, "context" : "/testAPI1", "lastUpdated" : "1426569756676", "subs" : 1, "templates" : [["/*", "GET,POST", "Application,,None", "Unlimited,null"]], "sandbox" : "", "tierDescs" : "Allows 20 request(s) per minute.", "bizOwner" : "", "bizOwnerMail" : "", "techOwner" : "", "techOwnerMail" : "", "wadl" : "", "visibility" : "public", "roles" : "", "tenants" : "", "epUsername" : "", "epPassword" : "", "endpointTypeSecured" : "false", "provider" : "admin", "transport_http" : "checked", "transport_https" : "checked", "apiStores" : null, "inSequence" : "", "outSequence" : "", "subscriptionAvailability" : "", "subscriptionTenants" : "", "endpointConfig" : "{\"production_endpoints\":{\"config\":null,\"url\":\"http://gdata.youtube.com/feeds/api/standardfeeds\"},\"endpoint_type\":\"http\"}", "responseCache" : "Disabled", "cacheTimeout" : "300", "availableTiersDisplayNames" : "Gold", "faultSequence" : "", "destinationStats" : "Disabled", "resources" : "[{\"http_verbs\":{\"POST\":{\"auth_type\":\"None\",\"throttling_tier\":\"null\"},\"GET\":{\"auth_type\":\"Application \",\"throttling_tier\":\"Unlimited\"}},\"url_pattern\":\"\\/*\"}]", "scopes" : "[]", "isDefaultVersion" : "false", "implementation" : "ENDPOINT", "hasDefaultVersion" : false, "currentDefaultVersion" : null}}

Return information contains sensitive information as highlighted above(Ex: endpoint URL).

but if we call "curl -b cookies  http://localhost:9763/publisher/site/blocks/listing/ajax/item-list.jag?action=getAllAPIs" from tenant2  it will not return any information since it docent have any visible APIs.
action=getAPI should have the same security level as the getAllAPIs.

Same issue can be seen in 1.9.0 SNAPSHOT.

Thanks and Best Regards,

Saneth Dharmakeerthi
Senior Software Engineer
WSO2, Inc.
Mobile: +94772325511
