### PR TITLE
APIMANAGER-3416 - Use the TrustStore to verify the Thrift connection to the KeyManager.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/thrift/ThriftUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/thrift/ThriftUtils.java
@@ -47,8 +47,8 @@ public class ThriftUtils {
 
             ServerConfiguration serverConfiguration = ServerConfiguration.getInstance();
             //read configuration
-            trustStorePath = serverConfiguration.getFirstProperty("Security.KeyStore.Location");
-            trustStorePassword = serverConfiguration.getFirstProperty("Security.KeyStore.Password");
+            trustStorePath = serverConfiguration.getFirstProperty("Security.TrustStore.Location");
+            trustStorePassword = serverConfiguration.getFirstProperty("Security.TrustStore.Password");
             String webContextRoot = serverConfiguration.getFirstProperty("WebContextRoot");
 
             APIManagerConfiguration config = ServiceReferenceHolder.getInstance().getAPIManagerConfiguration();


### PR DESCRIPTION

In our deployment we store the server key in the keystore and certificates in the truststore. We get the following error when the API Gateway sets up a Thrift connection to the KeyManager (running on WSO2 Identity Server). 

```javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target```
