### PR TITLE
Fixed APIMANAGER-3462 + improvements.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
@@ -2744,9 +2744,9 @@ public class APIStoreHostObject extends ScriptableObject {
 //                                    OAUTH_CLIENT_SECRET);
                             appObj.put("prodKey", appObj, prodKey.getAccessToken());
 
-	                        appObj.put("prodKeyScope", appObj, prodKeyScope);
+			                appObj.put("prodKeyScope", appObj, prodKeyScope);
 	                        appObj.put("prodKeyScopeValue", appObj, prodKey.getTokenScope());
-	                        appObj.put("prodConsumerKey", appObj, prodConsumerKey);
+                            appObj.put("prodConsumerKey", appObj, prodConsumerKey);
                             appObj.put("prodConsumerSecret", appObj, prodConsumerSecret);
                             appObj.put("prodJsonString", appObj, jsonString);
 
@@ -2764,9 +2764,9 @@ public class APIStoreHostObject extends ScriptableObject {
                             }
                         } else if (prodKey != null) {
                             appObj.put("prodKey", appObj, null);
-	                        appObj.put("prodKeyScope", appObj, null);
+                            appObj.put("prodKeyScope", appObj, null);
 	                        appObj.put("prodKeyScopeValue", appObj, null);
-	                        appObj.put("prodConsumerKey", appObj, null);
+                            appObj.put("prodConsumerKey", appObj, null);
                             appObj.put("prodConsumerSecret", appObj, null);
                             appObj.put("prodRegenarateOption", appObj, prodEnableRegenarateOption);
                             appObj.put("prodAuthorizedDomains", appObj, null);
@@ -2781,9 +2781,9 @@ public class APIStoreHostObject extends ScriptableObject {
                             appObj.put("prodKeyState", appObj, prodKey.getState());
                         } else {
                             appObj.put("prodKey", appObj, null);
-	                        appObj.put("prodKeyScope", appObj, null);
+                            appObj.put("prodKeyScope", appObj, null);
 	                        appObj.put("prodKeyScopeValue", appObj, null);
-	                        appObj.put("prodConsumerKey", appObj, null);
+                            appObj.put("prodConsumerKey", appObj, null);
                             appObj.put("prodConsumerSecret", appObj, null);
                             appObj.put("prodRegenarateOption", appObj, prodEnableRegenarateOption);
                             appObj.put("prodAuthorizedDomains", appObj, null);
@@ -2820,9 +2820,9 @@ public class APIStoreHostObject extends ScriptableObject {
 //                                    get(ApplicationConstants.OAUTH_CLIENT_SECRET);
                             appObj.put("sandboxKey", appObj, sandboxKey.getAccessToken());
 
-	                        appObj.put("sandKeyScope", appObj, sandKeyScope);
+                            appObj.put("sandKeyScope", appObj, sandKeyScope);
 	                        appObj.put("sandKeyScopeValue", appObj, sandboxKey.getTokenScope());
-	                        appObj.put("sandboxConsumerKey", appObj, sandboxConsumerKey);
+                            appObj.put("sandboxConsumerKey", appObj, sandboxConsumerKey);
                             appObj.put("sandboxConsumerSecret", appObj, sandboxConsumerSecret);
                             appObj.put("sandboxKeyState", appObj, sandboxKey.getState());
                             appObj.put("sandboxJsonString", appObj, jsonString);
@@ -2846,9 +2846,9 @@ public class APIStoreHostObject extends ScriptableObject {
                             }
                         } else if (sandboxKey != null) {
                             appObj.put("sandboxKey", appObj, null);
-	                        appObj.put("sandKeyScope", appObj, null);
+                            appObj.put("sandKeyScope", appObj, null);
 	                        appObj.put("sandKeyScopeValue", appObj, null);
-	                        appObj.put("sandboxConsumerKey", appObj, null);
+                            appObj.put("sandboxConsumerKey", appObj, null);
                             appObj.put("sandboxConsumerSecret", appObj, null);
                             appObj.put("sandRegenarateOption", appObj, sandEnableRegenarateOption);
                             appObj.put("sandboxAuthorizedDomains", appObj, null);
@@ -2863,9 +2863,9 @@ public class APIStoreHostObject extends ScriptableObject {
                             }
                         } else {
                             appObj.put("sandboxKey", appObj, null);
-	                        appObj.put("sandKeyScope", appObj, null);
+                            appObj.put("sandKeyScope", appObj, null);
 	                        appObj.put("sandKeyScopeValue", appObj, null);
-	                        appObj.put("sandboxConsumerKey", appObj, null);
+                            appObj.put("sandboxConsumerKey", appObj, null);
                             appObj.put("sandboxConsumerSecret", appObj, null);
                             appObj.put("sandRegenarateOption", appObj, sandEnableRegenarateOption);
                             appObj.put("sandboxAuthorizedDomains", appObj, null);
@@ -3857,7 +3857,7 @@ public class APIStoreHostObject extends ScriptableObject {
             row.put("consumerKey", row, response.getConsumerKey());
             row.put("consumerSecret", row, response.getConsumerKey());
             row.put("validityTime", row, response.getValidityPeriod());
-	        row.put("responseParams", row, response.getJSONString());
+            row.put("responseParams", row, response.getJSONString());
 	        row.put("tokenScope", row, response.getScopes());
 
             boolean isRegenarateOptionEnabled = true;

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
@@ -2745,7 +2745,7 @@ public class APIStoreHostObject extends ScriptableObject {
                             appObj.put("prodKey", appObj, prodKey.getAccessToken());
 
 			                appObj.put("prodKeyScope", appObj, prodKeyScope);
-	                        appObj.put("prodKeyScopeValue", appObj, prodKey.getTokenScope());
+                            appObj.put("prodKeyScopeValue", appObj, prodKey.getTokenScope());
                             appObj.put("prodConsumerKey", appObj, prodConsumerKey);
                             appObj.put("prodConsumerSecret", appObj, prodConsumerSecret);
                             appObj.put("prodJsonString", appObj, jsonString);
@@ -2765,7 +2765,7 @@ public class APIStoreHostObject extends ScriptableObject {
                         } else if (prodKey != null) {
                             appObj.put("prodKey", appObj, null);
                             appObj.put("prodKeyScope", appObj, null);
-	                        appObj.put("prodKeyScopeValue", appObj, null);
+                            appObj.put("prodKeyScopeValue", appObj, null);
                             appObj.put("prodConsumerKey", appObj, null);
                             appObj.put("prodConsumerSecret", appObj, null);
                             appObj.put("prodRegenarateOption", appObj, prodEnableRegenarateOption);
@@ -2782,7 +2782,7 @@ public class APIStoreHostObject extends ScriptableObject {
                         } else {
                             appObj.put("prodKey", appObj, null);
                             appObj.put("prodKeyScope", appObj, null);
-	                        appObj.put("prodKeyScopeValue", appObj, null);
+                            appObj.put("prodKeyScopeValue", appObj, null);
                             appObj.put("prodConsumerKey", appObj, null);
                             appObj.put("prodConsumerSecret", appObj, null);
                             appObj.put("prodRegenarateOption", appObj, prodEnableRegenarateOption);
@@ -2821,7 +2821,7 @@ public class APIStoreHostObject extends ScriptableObject {
                             appObj.put("sandboxKey", appObj, sandboxKey.getAccessToken());
 
                             appObj.put("sandKeyScope", appObj, sandKeyScope);
-	                        appObj.put("sandKeyScopeValue", appObj, sandboxKey.getTokenScope());
+                            appObj.put("sandKeyScopeValue", appObj, sandboxKey.getTokenScope());
                             appObj.put("sandboxConsumerKey", appObj, sandboxConsumerKey);
                             appObj.put("sandboxConsumerSecret", appObj, sandboxConsumerSecret);
                             appObj.put("sandboxKeyState", appObj, sandboxKey.getState());
@@ -2847,7 +2847,7 @@ public class APIStoreHostObject extends ScriptableObject {
                         } else if (sandboxKey != null) {
                             appObj.put("sandboxKey", appObj, null);
                             appObj.put("sandKeyScope", appObj, null);
-	                        appObj.put("sandKeyScopeValue", appObj, null);
+                            appObj.put("sandKeyScopeValue", appObj, null);
                             appObj.put("sandboxConsumerKey", appObj, null);
                             appObj.put("sandboxConsumerSecret", appObj, null);
                             appObj.put("sandRegenarateOption", appObj, sandEnableRegenarateOption);
@@ -2864,7 +2864,7 @@ public class APIStoreHostObject extends ScriptableObject {
                         } else {
                             appObj.put("sandboxKey", appObj, null);
                             appObj.put("sandKeyScope", appObj, null);
-	                        appObj.put("sandKeyScopeValue", appObj, null);
+                            appObj.put("sandKeyScopeValue", appObj, null);
                             appObj.put("sandboxConsumerKey", appObj, null);
                             appObj.put("sandboxConsumerSecret", appObj, null);
                             appObj.put("sandRegenarateOption", appObj, sandEnableRegenarateOption);
@@ -3858,7 +3858,7 @@ public class APIStoreHostObject extends ScriptableObject {
             row.put("consumerSecret", row, response.getConsumerKey());
             row.put("validityTime", row, response.getValidityPeriod());
             row.put("responseParams", row, response.getJSONString());
-	        row.put("tokenScope", row, response.getScopes());
+            row.put("tokenScope", row, response.getScopes());
 
             boolean isRegenarateOptionEnabled = true;
             if (getApplicationAccessTokenValidityPeriodInSeconds() < 0) {

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
@@ -2746,6 +2746,7 @@ public class APIStoreHostObject extends ScriptableObject {
                             appObj.put("prodKey", appObj, prodKey.getAccessToken());
 
 			                appObj.put("prodKeyScope", appObj, prodKeyScope);
+	                        appObj.put("prodKeyScopeValue", appObj, prodKey.getTokenScope());
                             appObj.put("prodConsumerKey", appObj, prodConsumerKey);
                             appObj.put("prodConsumerSecret", appObj, prodConsumerSecret);
                             appObj.put("prodJsonString", appObj, jsonString);
@@ -2765,6 +2766,7 @@ public class APIStoreHostObject extends ScriptableObject {
                         } else if (prodKey != null) {
                             appObj.put("prodKey", appObj, null);
                             appObj.put("prodKeyScope", appObj, null);
+	                        appObj.put("prodKeyScopeValue", appObj, null);
                             appObj.put("prodConsumerKey", appObj, null);
                             appObj.put("prodConsumerSecret", appObj, null);
                             appObj.put("prodRegenarateOption", appObj, prodEnableRegenarateOption);
@@ -2781,6 +2783,7 @@ public class APIStoreHostObject extends ScriptableObject {
                         } else {
                             appObj.put("prodKey", appObj, null);
                             appObj.put("prodKeyScope", appObj, null);
+	                        appObj.put("prodKeyScopeValue", appObj, null);
                             appObj.put("prodConsumerKey", appObj, null);
                             appObj.put("prodConsumerSecret", appObj, null);
                             appObj.put("prodRegenarateOption", appObj, prodEnableRegenarateOption);
@@ -2819,6 +2822,7 @@ public class APIStoreHostObject extends ScriptableObject {
                             appObj.put("sandboxKey", appObj, sandboxKey.getAccessToken());
 
                             appObj.put("sandKeyScope", appObj, sandKeyScope);
+	                        appObj.put("sandKeyScopeValue", appObj, sandboxKey.getTokenScope());
                             appObj.put("sandboxConsumerKey", appObj, sandboxConsumerKey);
                             appObj.put("sandboxConsumerSecret", appObj, sandboxConsumerSecret);
                             appObj.put("sandboxKeyState", appObj, sandboxKey.getState());
@@ -2844,6 +2848,7 @@ public class APIStoreHostObject extends ScriptableObject {
                         } else if (sandboxKey != null) {
                             appObj.put("sandboxKey", appObj, null);
                             appObj.put("sandKeyScope", appObj, null);
+	                        appObj.put("sandKeyScopeValue", appObj, null);
                             appObj.put("sandboxConsumerKey", appObj, null);
                             appObj.put("sandboxConsumerSecret", appObj, null);
                             appObj.put("sandRegenarateOption", appObj, sandEnableRegenarateOption);
@@ -2860,6 +2865,7 @@ public class APIStoreHostObject extends ScriptableObject {
                         } else {
                             appObj.put("sandboxKey", appObj, null);
                             appObj.put("sandKeyScope", appObj, null);
+	                        appObj.put("sandKeyScopeValue", appObj, null);
                             appObj.put("sandboxConsumerKey", appObj, null);
                             appObj.put("sandboxConsumerSecret", appObj, null);
                             appObj.put("sandRegenarateOption", appObj, sandEnableRegenarateOption);
@@ -3873,6 +3879,7 @@ public class APIStoreHostObject extends ScriptableObject {
             row.put("consumerSecret", row, response.getConsumerKey());
             row.put("validityTime", row, response.getValidityPeriod());
             row.put("responseParams", row, response.getJSONString());
+	        row.put("tokenScope", row, response.getScopes());
 
             boolean isRegenarateOptionEnabled = true;
             if (getApplicationAccessTokenValidityPeriodInSeconds() < 0) {

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
@@ -2744,9 +2744,9 @@ public class APIStoreHostObject extends ScriptableObject {
 //                                    OAUTH_CLIENT_SECRET);
                             appObj.put("prodKey", appObj, prodKey.getAccessToken());
 
-			                appObj.put("prodKeyScope", appObj, prodKeyScope);
+	                        appObj.put("prodKeyScope", appObj, prodKeyScope);
 	                        appObj.put("prodKeyScopeValue", appObj, prodKey.getTokenScope());
-                            appObj.put("prodConsumerKey", appObj, prodConsumerKey);
+	                        appObj.put("prodConsumerKey", appObj, prodConsumerKey);
                             appObj.put("prodConsumerSecret", appObj, prodConsumerSecret);
                             appObj.put("prodJsonString", appObj, jsonString);
 
@@ -2764,9 +2764,9 @@ public class APIStoreHostObject extends ScriptableObject {
                             }
                         } else if (prodKey != null) {
                             appObj.put("prodKey", appObj, null);
-                            appObj.put("prodKeyScope", appObj, null);
+	                        appObj.put("prodKeyScope", appObj, null);
 	                        appObj.put("prodKeyScopeValue", appObj, null);
-                            appObj.put("prodConsumerKey", appObj, null);
+	                        appObj.put("prodConsumerKey", appObj, null);
                             appObj.put("prodConsumerSecret", appObj, null);
                             appObj.put("prodRegenarateOption", appObj, prodEnableRegenarateOption);
                             appObj.put("prodAuthorizedDomains", appObj, null);
@@ -2781,9 +2781,9 @@ public class APIStoreHostObject extends ScriptableObject {
                             appObj.put("prodKeyState", appObj, prodKey.getState());
                         } else {
                             appObj.put("prodKey", appObj, null);
-                            appObj.put("prodKeyScope", appObj, null);
+	                        appObj.put("prodKeyScope", appObj, null);
 	                        appObj.put("prodKeyScopeValue", appObj, null);
-                            appObj.put("prodConsumerKey", appObj, null);
+	                        appObj.put("prodConsumerKey", appObj, null);
                             appObj.put("prodConsumerSecret", appObj, null);
                             appObj.put("prodRegenarateOption", appObj, prodEnableRegenarateOption);
                             appObj.put("prodAuthorizedDomains", appObj, null);
@@ -2820,9 +2820,9 @@ public class APIStoreHostObject extends ScriptableObject {
 //                                    get(ApplicationConstants.OAUTH_CLIENT_SECRET);
                             appObj.put("sandboxKey", appObj, sandboxKey.getAccessToken());
 
-                            appObj.put("sandKeyScope", appObj, sandKeyScope);
+	                        appObj.put("sandKeyScope", appObj, sandKeyScope);
 	                        appObj.put("sandKeyScopeValue", appObj, sandboxKey.getTokenScope());
-                            appObj.put("sandboxConsumerKey", appObj, sandboxConsumerKey);
+	                        appObj.put("sandboxConsumerKey", appObj, sandboxConsumerKey);
                             appObj.put("sandboxConsumerSecret", appObj, sandboxConsumerSecret);
                             appObj.put("sandboxKeyState", appObj, sandboxKey.getState());
                             appObj.put("sandboxJsonString", appObj, jsonString);
@@ -2846,9 +2846,9 @@ public class APIStoreHostObject extends ScriptableObject {
                             }
                         } else if (sandboxKey != null) {
                             appObj.put("sandboxKey", appObj, null);
-                            appObj.put("sandKeyScope", appObj, null);
+	                        appObj.put("sandKeyScope", appObj, null);
 	                        appObj.put("sandKeyScopeValue", appObj, null);
-                            appObj.put("sandboxConsumerKey", appObj, null);
+	                        appObj.put("sandboxConsumerKey", appObj, null);
                             appObj.put("sandboxConsumerSecret", appObj, null);
                             appObj.put("sandRegenarateOption", appObj, sandEnableRegenarateOption);
                             appObj.put("sandboxAuthorizedDomains", appObj, null);
@@ -2863,9 +2863,9 @@ public class APIStoreHostObject extends ScriptableObject {
                             }
                         } else {
                             appObj.put("sandboxKey", appObj, null);
-                            appObj.put("sandKeyScope", appObj, null);
+	                        appObj.put("sandKeyScope", appObj, null);
 	                        appObj.put("sandKeyScopeValue", appObj, null);
-                            appObj.put("sandboxConsumerKey", appObj, null);
+	                        appObj.put("sandboxConsumerKey", appObj, null);
                             appObj.put("sandboxConsumerSecret", appObj, null);
                             appObj.put("sandRegenarateOption", appObj, sandEnableRegenarateOption);
                             appObj.put("sandboxAuthorizedDomains", appObj, null);
@@ -3857,7 +3857,7 @@ public class APIStoreHostObject extends ScriptableObject {
             row.put("consumerKey", row, response.getConsumerKey());
             row.put("consumerSecret", row, response.getConsumerKey());
             row.put("validityTime", row, response.getValidityPeriod());
-            row.put("responseParams", row, response.getJSONString());
+	        row.put("responseParams", row, response.getJSONString());
 	        row.put("tokenScope", row, response.getScopes());
 
             boolean isRegenarateOptionEnabled = true;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/conf/locales/jaggery/locale_default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/conf/locales/jaggery/locale_default.json
@@ -232,7 +232,9 @@
     "forum.topicEdit.description" : "Edit Topic Description",
 
     "forum.addReply.title" : "Add reply",
-    "forum.addReply.replyToThread" : "Reply to Thread"
+    "forum.addReply.replyToThread" : "Reply to Thread",
+    
+    "scope" : "Scope"
   
     
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/conf/locales/jaggery/locale_en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/conf/locales/jaggery/locale_en.json
@@ -236,7 +236,8 @@
 
 	"forum.addReply.title" : "Add reply",
 	"forum.addReply.replyToThread" : "Reply to Thread",
-    "selectScopes" : "Select Scopes"
+    "selectScopes" : "Select Scopes",
+    "scope" : "Scope"
 
    
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/conf/locales/jaggery/locale_es.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/conf/locales/jaggery/locale_es.json
@@ -151,5 +151,6 @@
     "ShareonGoogle":"Share on Google +",
     "ShareonLinkedIn":"Share on LinkedIn",
     "ShareonFacebook":"Share on Facebook",
-    "selectScopes" : "Select Scopes"
+    "selectScopes" : "Select Scopes",
+    "scope" : "Scope"
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list-element/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list-element/template.jag
@@ -99,22 +99,25 @@
 
                         <div class="row-fluid keys">
 							<div class="span3">
-		                        <b><%=i18n.localize("scope")%>:</b> 
-	                        </div>
-	                        <div class="span9">
-	                        	
-	                        	<% if(lenS > 0){ %>
-								    <div class="token">
-									    <% if(app.prodKeyScope != null && app.prodKeyScope.length > 60){ %>
-										    <textarea class="tokenTextarea accessTokenScopeDisplayPro keyValues" data-value="<%=app.prodKeyScope%>"><%=app.prodKeyScope%></textarea>
-										<% } else  { %>
-										    <span class="accessTokenScopeDisplayPro keyValues" id="prodAccessScope" data-value="<%=app.prodKeyScope%>"><%=app.prodKeyScope%></span>
-										<% } %>
-									</div>
-								<% } %>
-	                        	
-	                        </div>
-                        </div>
+								<b><%=i18n.localize("scope")%>:</b>
+							</div>
+							<div class="span9">
+			
+								<% if(lenS > 0){ %>
+								<div class="token">
+									<% if(app.prodKeyScope != null && app.prodKeyScope.length > 60){ %>
+									<textarea
+										class="tokenTextarea accessTokenScopeDisplayPro keyValues"
+										data-value="<%=app.prodKeyScope%>"><%=app.prodKeyScope%></textarea>
+									<% } else  { %>
+									<span class="accessTokenScopeDisplayPro keyValues"
+										id="prodAccessScope" data-value="<%=app.prodKeyScope%>"><%=app.prodKeyScope%>
+									</span>
+									<% } %>
+								</div>
+								<% } %>			
+							</div>
+						</div>
 
                         <div class="row-fluid keys">
 							<div class="span12">
@@ -324,20 +327,22 @@
 
                         <div class="row-fluid keys">
 							<div class="span3">
-		                        <b><%=i18n.localize("scope")%>:</b>
-	                        </div>
-	                        <div class="span9">
-	                        	<% if(lenS > 0){ %>
-                                	<div class="token">
-                                    	<% if(app.sandKeyScope != null && app.sandKeyScope.length > 60){ %>
-                                        	<textarea class="tokenTextarea sandScopeDisplayPro keyValues" data-value="<%=app.sandKeyScope%>"><%=app.sandKeyScope%></textarea>
-                                        <% } else { %>
-                                        	<span class="sandScopeDisplayPro keyValues" id="sandAccessScope" data-value="<%=app.sandKeyScope%>"><%=app.sandKeyScope%></span>
-                                        <% } %>                                                
-                                	</div>
-                                <% } %>	
-	                        </div>
-                        </div>
+								<b><%=i18n.localize("scope")%>:</b>
+							</div>
+							<div class="span9">
+								<% if(lenS > 0){ %>
+								<div class="token">
+									<% if(app.sandKeyScope != null && app.sandKeyScope.length > 60){ %>
+									<textarea class="tokenTextarea sandScopeDisplayPro keyValues"
+										data-value="<%=app.sandKeyScope%>"><%=app.sandKeyScope%></textarea>
+									<% } else { %>
+									<span class="sandScopeDisplayPro keyValues" id="sandAccessScope"
+										data-value="<%=app.sandKeyScope%>"><%=app.sandKeyScope%> </span>
+									<% } %>
+								</div>
+								<% } %>
+							</div>
+						</div>
 
                         <div class="row-fluid keys">
 							<div class="span12">

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list-element/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list-element/template.jag
@@ -19,7 +19,8 @@
 
         <input type="hidden"  class="prodAccessTokenHidden" id="prodAccessTokenHiddenID" value="<%=app.prodKey%>" >
         <input type="hidden"  class="sandAccessTokenHidden" id="sandAccessTokenHiddenID" value="<%=app.sandboxKey%>" >
-        <input type="hidden" type="text"  id="scopeInput" value='<%=app.prodKeyScope %>'/>
+        <input type="hidden" type="text"  id="prodScopeInput" value='<%=app.prodKeyScopeValue %>'/>
+        <input type="hidden" type="text"  id="sandScopeInput" value='<%=app.sandKeyScopeValue %>'/>
         <h3 data-section="key-prod" class="js_toggle"><%=i18n.localize("keysPro")%> <i class="icon-chevron-down icon-keys"></i></h3>
         <div class="keyBoxOut">
             <div class="container-fluid">

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list-element/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list-element/template.jag
@@ -117,7 +117,7 @@
 
                                         <% if(lenS > 0){ %>
 										<div class="token">
-											<% if(app.prodKeyScope != null && lenS<0 && app.prodKeyScope.length > 60){ %>
+											<% if(app.prodKeyScope != null && app.prodKeyScope.length > 60){ %>
 											   <textarea class="tokenTextarea accessTokenScopeDisplayPro keyValues" data-value="<%=app.prodKeyScope%>"><%=app.prodKeyScope%></textarea>
 											<% } else  { %>
 											   <span class="accessTokenScopeDisplayPro keyValues" id="prodAccessScope" data-value="<%=app.prodKeyScope%>"><%=app.prodKeyScope%></span>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list-element/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list-element/template.jag
@@ -98,6 +98,25 @@
                         </div>
 
                         <div class="row-fluid keys">
+							<div class="span3">
+		                        <b><%=i18n.localize("scope")%>:</b> 
+	                        </div>
+	                        <div class="span9">
+	                        	
+	                        	<% if(lenS > 0){ %>
+								    <div class="token">
+									    <% if(app.prodKeyScope != null && app.prodKeyScope.length > 60){ %>
+										    <textarea class="tokenTextarea accessTokenScopeDisplayPro keyValues" data-value="<%=app.prodKeyScope%>"><%=app.prodKeyScope%></textarea>
+										<% } else  { %>
+										    <span class="accessTokenScopeDisplayPro keyValues" id="prodAccessScope" data-value="<%=app.prodKeyScope%>"><%=app.prodKeyScope%></span>
+										<% } %>
+									</div>
+								<% } %>
+	                        	
+	                        </div>
+                        </div>
+
+                        <div class="row-fluid keys">
 							<div class="span12">
 								<h5 class="special-colored"><b><%=i18n.localize("accessToken")%>: </b></h5>
 								<div class="show-hide-key processing-msg" style="display:none;"><%=i18n.localize("generating")%></div>
@@ -114,20 +133,6 @@
                 								<button id="prodAccessCopy" data-clipboard-target="prodAccessTokenHiddenID" title="Copy to clipboard" class="curl-copybtn"><i class="fa fa-clipboard"></i></button>
                 							</div>
 										</div>
-
-                                        <% if(lenS > 0){ %>
-										<div class="token">
-											<% if(app.prodKeyScope != null && app.prodKeyScope.length > 60){ %>
-											   <textarea class="tokenTextarea accessTokenScopeDisplayPro keyValues" data-value="<%=app.prodKeyScope%>"><%=app.prodKeyScope%></textarea>
-											<% } else  { %>
-											   <span class="accessTokenScopeDisplayPro keyValues" id="prodAccessScope" data-value="<%=app.prodKeyScope%>"><%=app.prodKeyScope%></span>
-											<% } %>
-			  								<div class="copybtn-wrapper">
-                    							<span class="curl-copyinfo">Copied!</span>
-                								<button id="prodAccessCopy" data-clipboard-target="prodAccessScope" title="Copy to clipboard" class="curl-copybtn"><i class="fa fa-clipboard"></i></button>
-                							</div>
-										</div>
-										<% } %>
 
 										<div class="regenerate-wrapper">
 											<div class="span2">
@@ -318,6 +323,23 @@
                         </div>
 
                         <div class="row-fluid keys">
+							<div class="span3">
+		                        <b><%=i18n.localize("scope")%>:</b>
+	                        </div>
+	                        <div class="span9">
+	                        	<% if(lenS > 0){ %>
+                                	<div class="token">
+                                    	<% if(app.sandKeyScope != null && app.sandKeyScope.length > 60){ %>
+                                        	<textarea class="tokenTextarea sandScopeDisplayPro keyValues" data-value="<%=app.sandKeyScope%>"><%=app.sandKeyScope%></textarea>
+                                        <% } else { %>
+                                        	<span class="sandScopeDisplayPro keyValues" id="sandAccessScope" data-value="<%=app.sandKeyScope%>"><%=app.sandKeyScope%></span>
+                                        <% } %>                                                
+                                	</div>
+                                <% } %>	
+	                        </div>
+                        </div>
+
+                        <div class="row-fluid keys">
 							<div class="span12">
 								<h5 class="special-colored"><b><%=i18n.localize("accessToken")%>: </b></h5>
 								<div class="show-hide-key processing-msg" style="display:none;"><%=i18n.localize("generating")%></div>
@@ -334,20 +356,6 @@
                 								<button id="sandAccessCopy" data-clipboard-target="sandAccessTokenHiddenID" title="Copy to clipboard" class="curl-copybtn"><i class="fa fa-clipboard"></i></button>
                 							</div>
 										</div>
-
-										<% if(lenS > 0){ %>
-                                            <div class="token">
-                                                <% if(app.sandKeyScope != null && app.sandKeyScope.length > 60){ %>
-                                                   <textarea class="tokenTextarea sandScopeDisplayPro keyValues" data-value="<%=app.sandKeyScope%>"><%=app.sandKeyScope%></textarea>
-                                                <% } else { %>
-                                                   <span class="sandScopeDisplayPro keyValues" id="sandAccessScope" data-value="<%=app.sandKeyScope%>"><%=app.sandKeyScope%></span>
-                                                <% } %>
-                                                <div class="copybtn-wrapper">
-                                                    <span class="curl-copyinfo">Copied!</span>
-                                                    <button id="sandScopeCopy" data-clipboard-target="sandAccessScope" title="Copy to clipboard" class="curl-copybtn"><i class="fa fa-clipboard"></i></button>
-                                                </div>
-                                            </div>
-                                        <% } %>
 
 										<div class="regenerate-wrapper">
 											<div class="span2">

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list/js/subscription-list.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list/js/subscription-list.js
@@ -364,13 +364,15 @@ var regenerate=function(appName,keyType,i,btn,div,clientId,clientSecret) {
                 //generating comma seperated string of scope names.
                 var generatedScopesArr = result.data.key.tokenScope;
                 for(var i = 0; i<generatedScopesArr.length; i++){
-                    if(generatedScopesArr[i] == "am_application_scope"){
-                        continue;
-                    }
                     var scopeId = "#"+generatedScopesArr[i];
-                    generatedScopesNames+=$(scopeId).attr('name');
-                    if(i<generatedScopesArr.length - 1){
-                        generatedScopesNames+=", ";
+                    var attr = $(scopeId).attr('name');
+                    // For some browsers, `attr` is undefined; for others,
+                    // `attr` is false.  Check for both.
+                    if (typeof attr !== typeof undefined && attr !== false) {
+                        generatedScopesNames+=$(scopeId).attr('name');
+                        if(i<generatedScopesArr.length - 1){
+                            generatedScopesNames+=", ";
+                        }
                     }
                 }
             }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list/js/subscription-list.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/subscription/subscription-list/js/subscription-list.js
@@ -18,8 +18,8 @@ $(document).ready(function () {
     	var selected = ($('.Checkbox:checked').map(function() {
     	    return this.value;
     	}).get().join(' '));
-    	$('#scopeInput').attr('value', selected);
-    	$('#scopeInput').attr('value', selected);
+    	$('#prodScopeInput').attr('value', selected);
+    	$('#sandScopeInput').attr('value', selected);
     	});
     
     /*$("select[name='scope']").change(function() {
@@ -97,19 +97,22 @@ $(document).ready(function () {
         var userName = elem.attr("data-username");
         var validityTime;
         var applicationId=$('option:selected','#appListSelected').attr('appId');
+        var tokenScope;
         if (keyType == 'PRODUCTION') {
             authoDomains = $('#allowedDomainsPro').val();
             validityTime = $('#refreshProdValidityTime').val();
+            tokenScope = $('#prodScopeInput').val();
         } else {
             authoDomains = $('#allowedDomainsSand').val();
             validityTime = $('#refreshSandValidityTime').val();
+            tokenScope = $('#sandScopeInput').val();
         }
 
         /*
          if we have additional parameters we can pass them as a json object.
          */
 
-	    var tokenScope = $('#scopeInput').val();
+
 
         jagg.post("/site/blocks/subscription/subscription-add/ajax/subscription-add.jag", {
 
@@ -330,15 +333,16 @@ var regenerate=function(appName,keyType,i,btn,div,clientId,clientSecret) {
         authorizedDomainsTemp = $('#allowedDomainsPro').val();
         if(authorizedDomainsTemp == ''){$('#allowedDomainsPro').val('ALL')}
         validityTime=$('#refreshProdValidityTime').val();
+        tokenScope=$('#prodScopeInput').val();
     } else {
         oldAccessToken = $('.sandAccessTokenHidden').val();
         authorizedDomainsTemp = $('#allowedDomainsSand').val();
         if(authorizedDomainsTemp == ''){$('#allowedDomainsSand').val('ALL')}
         validityTime=$('#refreshSandValidityTime').val();
+        tokenScope=$('#sandScopeInput').val();
     }
-    
-    tokenScope=$('#scopeInput').val();
-    
+
+
     jagg.post("/site/blocks/subscription/subscription-add/ajax/subscription-add.jag", {
         action:"refreshToken",
         application:appName,
@@ -354,17 +358,34 @@ var regenerate=function(appName,keyType,i,btn,div,clientId,clientSecret) {
             $(btn).parent().show();
             $(btn).parent().prev().hide();
             var regenerateOption=result.data.key.enableRegenarate;
+            var generatedScopesNames = "";
+
+            if(result.data.key.tokenScope.length > 1){
+                //generating comma seperated string of scope names.
+                var generatedScopesArr = result.data.key.tokenScope;
+                for(var i = 0; i<generatedScopesArr.length; i++){
+                    if(generatedScopesArr[i] == "am_application_scope"){
+                        continue;
+                    }
+                    var scopeId = "#"+generatedScopesArr[i];
+                    generatedScopesNames+=$(scopeId).attr('name');
+                    if(i<generatedScopesArr.length - 1){
+                        generatedScopesNames+=", ";
+                    }
+                }
+            }
+
             if(keyType == "PRODUCTION"){
                 $('.prodAccessTokenHidden').val(result.data.key.accessToken);
                 if(!regenerateOption){ $('.proRegenerateForm').hide(); }
                 $('.accessTokenDisplayPro').html(result.data.key.accessToken).attr('data-value',result.data.key.accessToken);
-                $('.accessTokenScopeDisplayPro').html(result.data.key.tokenScope).attr('data-value',result.data.key.tokenScope);
+                $('.accessTokenScopeDisplayPro').html(generatedScopesNames).attr('data-value',generatedScopesNames);
                 showHideKeys();
             } else{
                 $('.sandAccessTokenHidden').val(result.data.key.accessToken);
                 if(!regenerateOption){ $('.sandRegenerateForm').hide(); }
                 $('.accessTokenDisplaySand').html(result.data.key.accessToken).attr('data-value',result.data.key.accessToken);
-                $('.sandScopeDisplayPro').html(result.data.key.tokenScope).attr('data-value',result.data.key.tokenScope);
+                $('.sandScopeDisplayPro').html(generatedScopesNames).attr('data-value',generatedScopesNames);
                 //change sandScopeDisplayPro name
                 showHideKeys();
             }


### PR DESCRIPTION
- fixed the scope specific access token generation issue where user had to select scopes each time they regenerate keys. (APIMANAGER-3462)
- fixed generated scopes not showing up until the page is refreshed.
- added a label to scopes for clarity in viewing.
- removed the copy button for scope names. 