### PR TITLE
APIMANAGER-3413 fixed

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/conf/locales/jaggery/locale_default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/conf/locales/jaggery/locale_default.json
@@ -306,6 +306,7 @@
     "viewDoc" : "View Content",
     "download" : "Download",
     "defaultAPIHelpMsg" : "Marks one API version in a group as the default, so that it can be invoked without specifying the version number in the URL. For example, if you mark http://host:port/youtube/2.0 as the default API, requests made to http://host:port/youtube/ are automatically routed to version 2.0. If you mark an unpublished API as the default, the previous default, published API will still be used as the default until the new default API is published",
+    "httpHelpMsg" : "HTTP is less secure than HTTPS and makes your API vulnerable to security threats.",
 	"transportHelpMsg" : "The transport protocol/s on which the API is exposed.",
 	"endpointSecHelpMsg" : "To connect to secured endpoints, you need to pass the credentials of the backend service.",
    "versionCopyHelpMsg" : "Marks one API version in a group as the default one, so that it can be invoked without specifying the version number in the URL. For example, if you mark http://host:port/youtube/2.0 as the default API, requests made to http://host:port/youtube/ gets automatically routed to version 2.0. If you mark an unpublished API as the default while the previously default API was a published one, the users who invoke the default API will still be routed to the previous default version rather than the new one. This is because the new version is not published yet.",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/conf/locales/jaggery/locale_en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/conf/locales/jaggery/locale_en.json
@@ -300,6 +300,7 @@
     "viewDoc" : "View Content",
     "download" : "Download",
     "defaultAPIHelpMsg" : "Marks one API version in a group as the default, so that it can be invoked without specifying the version number in the URL. For example, if you mark http://host:port/youtube/2.0 as the default API, requests made to http://host:port/youtube/ are automatically routed to version 2.0. If you mark an unpublished API as the default, the previous default, published API will still be used as the default until the new default API is published",
+    "httpHelpMsg" : "HTTP is less secure than HTTPS and makes your API vulnerable to security threats.",
 	"transportHelpMsg" : "The transport protocol/s on which the API is exposed.",
 	"endpointSecHelpMsg" : "To connect to secured endpoints, you need to pass the credentials of the backend service.",
 	"versionCopyHelpMsg" : "Marks one API version in a group as the default one, so that it can be invoked without specifying the version number in the URL. For example, if you mark http://host:port/youtube/2.0 as the default API, requests made to http://host:port/youtube/ gets automatically routed to version 2.0. If you mark an unpublished API as the default while the previously default API was a published one, the users who invoke the default API will still be routed to the previous default version rather than the new one. This is because the new version is not published yet.",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/default/templates/item-manage/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/default/templates/item-manage/template.jag
@@ -134,16 +134,18 @@
                 <label class="control-label" for="transports"><%=i18n.localize("transports")%>:<span class="requiredAstrix">*</span></label>
                 <div class="controls">
                     <div class="checkbox">
+                        <label  class="checkbox inline" >
+                            <input type="checkbox" id="transport_https" name="transport_https"  value="https" <%if(api.transport_https=="checked"){%>checked<%}%>/>
+
+                            <%=i18n.localize("httpsTransport")%>
+                        </label>
                         <label  class="checkbox inline " >
-                            <input type="checkbox"  id="transport_http" name="transport_http"  value="http" <%if(api.transport_http=="checked"){%>checked<%}%> />
+                            <input type="checkbox"  id="transport_http" name="transport_http"  value="http"/>
                          
                             <%=i18n.localize("httpTransport")%>
                         </label>
-                        <label  class="checkbox inline" >
-                            <input type="checkbox" id="transport_https" name="transport_https"  value="https" <%if(api.transport_https=="checked"){%>checked<%}%>/>
-                            
-                            <%=i18n.localize("httpsTransport")%>
-                        </label>
+                        <a class="icon-question-sign help_popup" help_data="http_help"></a>
+                        <p id="http_help" class="hide"><%=i18n.localize("httpHelpMsg")%></p>
                     </div>
                 </div>
              </div> 


### PR DESCRIPTION
removed the default "checked" status for HTTP checkbox and added a tool-tip stating the security vulnerabilities an API would face if HTTP is used. 