### PR TITLE
Fix for APIMANAGER-3797

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
@@ -99,6 +99,17 @@ public interface APIManager {
             throws APIManagementException;
 
     /**
+     * Checks whether the given document already exists for the given api
+     *
+     * @param identifier API Identifier
+     * @param docName Name of the document
+     * @return true if document already exists for the given api
+     * @throws APIManagementException if failed to check existence of the documentation
+     */
+    public boolean isDocumentationExist(APIIdentifier identifier, String docName)
+            throws APIManagementException;
+
+    /**
      * Returns a list of documentation attached to a particular API
      *
      * @param apiId APIIdentifier

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
@@ -2864,6 +2864,14 @@ public class APIProviderHostObject extends ScriptableObject {
 
         APIIdentifier apiId = new APIIdentifier(APIUtil.replaceEmailDomain(providerName), apiName, version);
         Documentation doc = new Documentation(getDocType(docType), docName);
+        APIProvider apiProvider = getAPIProvider(thisObj);
+
+        //add documentation is allowed only if document name does not already exist for this api
+        if (apiProvider.isDocumentationExist(apiId, docName)) {
+            handleException("Error occurred while adding the document. " + docName +
+                    " already exists for API " + apiName + "-" + version);
+        }
+
         if (doc.getType() == DocumentationType.OTHER) {
             doc.setOtherTypeName(args[9].toString());
         }
@@ -2888,7 +2896,6 @@ public class APIProviderHostObject extends ScriptableObject {
         } else {
             doc.setVisibility(Documentation.DocumentVisibility.OWNER_ONLY);
         }
-        APIProvider apiProvider = getAPIProvider(thisObj);
         try {
 
             if (fileHostObject != null && fileHostObject.getJavaScriptFile().getLength() != 0) {
@@ -3915,6 +3922,13 @@ public class APIProviderHostObject extends ScriptableObject {
 
         APIIdentifier apiId = new APIIdentifier(providerName, apiName, version);
         Documentation doc = new Documentation(getDocType(docType), docName);
+        APIProvider apiProvider = getAPIProvider(thisObj);
+
+        //update documentation is allowed only if documentation name already exists for this api
+        if (!apiProvider.isDocumentationExist(apiId, docName)) {
+            handleException("Error occurred while updating the document. " + docName +
+                    " does not exist for API " + apiName + "-" + version);
+        }
 
         if (doc.getType() == DocumentationType.OTHER) {
             doc.setOtherTypeName(args[9].toString());
@@ -3939,8 +3953,7 @@ public class APIProviderHostObject extends ScriptableObject {
         } else {
             doc.setVisibility(Documentation.DocumentVisibility.OWNER_ONLY);
         }
-        APIProvider apiProvider = getAPIProvider(thisObj);
-        
+
         Documentation oldDoc = apiProvider.getDocumentation(apiId, doc.getType(), doc.getName());
 
         try {

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
@@ -2858,7 +2858,8 @@ public class APIStoreHostObject extends ScriptableObject {
             }
 
             //check whether application exist prior to get subscriptions
-            if (!(appName == null || appName.isEmpty()) && !APIUtil.isApplicationExist(username, appName, groupingId)) {
+            if (!(appName == null || appName.isEmpty()) &&
+                    !APIUtil.isApplicationExist(username, appName, groupingId)) {
                 String message = "Application " + appName + " does not exist for user " +
                         "" + username;
                 log.error(message);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -416,6 +416,21 @@ public abstract class AbstractAPIManager implements APIManager {
         return null;
     }
 
+    public boolean isDocumentationExist(APIIdentifier identifier, String docName)
+            throws APIManagementException {
+        String docPath = APIConstants.API_ROOT_LOCATION + RegistryConstants.PATH_SEPARATOR +
+                identifier.getProviderName() + RegistryConstants.PATH_SEPARATOR +
+                identifier.getApiName() + RegistryConstants.PATH_SEPARATOR +
+                identifier.getVersion() + RegistryConstants.PATH_SEPARATOR +
+                APIConstants.DOC_DIR + RegistryConstants.PATH_SEPARATOR + docName;
+        try {
+            return registry.resourceExists(docPath);
+        } catch (RegistryException e) {
+            handleException("Failed to check existence of the document :" + docPath, e);
+            return false;
+        }
+    }
+
     public List<Documentation> getAllDocumentation(APIIdentifier apiId) throws APIManagementException {
         List<Documentation> documentationList = new ArrayList<Documentation>();
         String apiResourcePath = APIUtil.getAPIPath(apiId);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -416,6 +416,14 @@ public abstract class AbstractAPIManager implements APIManager {
         return null;
     }
 
+    /**
+     * Checks whether the given document already exists for the given api
+     *
+     * @param identifier API Identifier
+     * @param docName Name of the document
+     * @return true if document already exists for the given api
+     * @throws APIManagementException if failed to check existence of the documentation
+     */
     public boolean isDocumentationExist(APIIdentifier identifier, String docName)
             throws APIManagementException {
         String docPath = APIConstants.API_ROOT_LOCATION + RegistryConstants.PATH_SEPARATOR +

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/default/css/styles-layout.css
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/default/css/styles-layout.css
@@ -73,6 +73,9 @@ a{
     display:block;
     margin-top:11px;
 }
+.doc-content{
+    color:#0088cc;
+}
 .row-fluid div.special-link-box1{
     background: #f0f0f0;
     padding:10px 20px;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/default/templates/api/documentation/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/default/templates/api/documentation/template.jag
@@ -42,21 +42,21 @@ if(tenant!=null) {urlPrefix="&tenant="+tenant;}else{urlPrefix='';}
                     <%}%>
                     <%if(doc.sourceUrl&& doc.sourceUrl!=""){
                         %>
-                    <p><a href="<%=doc.sourceUrl%>" target="_blank">
+                    <p><a href="<%=doc.sourceUrl%>" class="doc-content" target="_blank">
                     <% if(doc.sourceType=="URL"){%>
                      <%=doc.sourceUrl%></a></p>
                     <%}else{%>
                     <%=i18n.localize("viewDoc")%></a></p>
                     <%}}else if(doc.filePath && doc.filePath!=""){%>
-                    <p><a href="/store/site/themes/default/templates/api/documentation/download.jag?resourceUrl=<%=doc.filePath%>" target="_blank" download><%=i18n.localize("download")%></a></p>
+                    <p><a href="/store/site/themes/default/templates/api/documentation/download.jag?resourceUrl=<%=doc.filePath%>" class="doc-content" target="_blank" download><%=i18n.localize("download")%></a></p>
 
                     <%}else{
                     %>
                     <div>
                      <%if(reqUrl.indexOf(".jag")>=0){%>
-                     <a href="doc-viewer.jag?docName=<%= encode.forUriComponent(doc.name)%>&name=<%= encode.forUriComponent(name) %>&version=<%= encode.forUriComponent(version)%>&provider=<%= encode.forUriComponent(provider)%>&<%=urlPrefix%>"  target="_blank"><%=i18n.localize("viewDoc")%></a>
+                     <a href="doc-viewer.jag?docName=<%= encode.forUriComponent(doc.name)%>&name=<%= encode.forUriComponent(name) %>&version=<%= encode.forUriComponent(version)%>&provider=<%= encode.forUriComponent(provider)%>&<%=urlPrefix%>" class="doc-content"  target="_blank"><%=i18n.localize("viewDoc")%></a>
                      <%}else{%>
-                     <a href="../site/pages/doc-viewer.jag?docName=<%= encode.forUriComponent(doc.name) %>&name=<%= encode.forUriComponent(name)%>&version=<%= encode.forUriComponent(version) %>&provider=<%=encode.forUriComponent(provider)%>&<%=urlPrefix%>"  target="_blank"><%=i18n.localize("viewDoc")%></a>
+                     <a href="../site/pages/doc-viewer.jag?docName=<%= encode.forUriComponent(doc.name) %>&name=<%= encode.forUriComponent(name)%>&version=<%= encode.forUriComponent(version) %>&provider=<%=encode.forUriComponent(provider)%>&<%=urlPrefix%>" class="doc-content"  target="_blank"><%=i18n.localize("viewDoc")%></a>
                      <%}%>
                     </div>
                      <%}%>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/css/styles-layout.css
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/css/styles-layout.css
@@ -49,6 +49,7 @@ p{
 }
 a{
     cursor:pointer;
+    color:#444;
 }
 .noborder-table tr td{
     border-top:none;
@@ -71,6 +72,9 @@ a{
     height:26px;
     display:block;
     margin-top:11px;
+}
+.doc-content{
+    color:#0088cc;
 }
 .row-fluid div.special-link-box1{
     background: #f0f0f0;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/subthemes/dark/css/styles-layout.css
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/subthemes/dark/css/styles-layout.css
@@ -67,6 +67,7 @@ p{
 }
 a{
     cursor:pointer;
+    color:#444;
 }
 a.link-to-api, a.title{
     font-weight: bold;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/api/documentation/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/fancy/templates/api/documentation/template.jag
@@ -42,21 +42,21 @@ if(tenant!=null) {urlPrefix="&tenant="+tenant;}else{urlPrefix='';}
                     <%}%>
                     <%if(doc.sourceUrl&& doc.sourceUrl!=""){
                         %>
-                    <p><a href="<%=doc.sourceUrl%>" target="_blank">
+                    <p><a href="<%=doc.sourceUrl%>" class="doc-content" target="_blank">
                     <% if(doc.sourceType=="URL"){%>
                      <%=doc.sourceUrl%></a></p>
                     <%}else{%>
                     <%=i18n.localize("viewDoc")%></a></p>
                     <%}}else if(doc.filePath && doc.filePath!=""){%>
-                    <p><a href="/store/site/themes/fancy/templates/api/documentation/download.jag?resourceUrl=<%=doc.filePath%>" target="_blank" download><%=i18n.localize("download")%></a></p>
+                    <p><a href="/store/site/themes/fancy/templates/api/documentation/download.jag?resourceUrl=<%=doc.filePath%>" class="doc-content" target="_blank" download><%=i18n.localize("download")%></a></p>
 
                     <%}else{
                     %>
                     <div>
                      <%if(reqUrl.indexOf(".jag")>=0){%>
-                     <a href="doc-viewer.jag?docName=<%= encode.forUriComponent(doc.name)%>&name=<%= encode.forUriComponent(name) %>&version=<%= encode.forUriComponent(version)%>&provider=<%= encode.forUriComponent(provider)%>&<%=urlPrefix%>"  target="_blank"><%=i18n.localize("viewDoc")%></a>
+                     <a href="doc-viewer.jag?docName=<%= encode.forUriComponent(doc.name)%>&name=<%= encode.forUriComponent(name) %>&version=<%= encode.forUriComponent(version)%>&provider=<%= encode.forUriComponent(provider)%>&<%=urlPrefix%>" class="doc-content"  target="_blank"><%=i18n.localize("viewDoc")%></a>
                      <%}else{%>
-                     <a href="../site/pages/doc-viewer.jag?docName=<%= encode.forUriComponent(doc.name) %>&name=<%= encode.forUriComponent(name)%>&version=<%= encode.forUriComponent(version) %>&provider=<%=encode.forUriComponent(provider)%>&<%=urlPrefix%>"  target="_blank"><%=i18n.localize("viewDoc")%></a>
+                     <a href="../site/pages/doc-viewer.jag?docName=<%= encode.forUriComponent(doc.name) %>&name=<%= encode.forUriComponent(name)%>&version=<%= encode.forUriComponent(version) %>&provider=<%=encode.forUriComponent(provider)%>&<%=urlPrefix%>" class="doc-content"  target="_blank"><%=i18n.localize("viewDoc")%></a>
                      <%}%>
                     </div>
                      <%}%>


### PR DESCRIPTION
Fix for APIMANAGER-3797 : When adding and updating existing documents via Publisher Rest api, proper message should be returned to the client and the backend exception should be handled