### PR TITLE
Fix for APIMANAGER-4048

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.client/src/main/java/org/wso2/carbon/apimgt/usage/client/APIUsageStatisticsClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.client/src/main/java/org/wso2/carbon/apimgt/usage/client/APIUsageStatisticsClient.java
@@ -1297,16 +1297,18 @@ public class APIUsageStatisticsClient {
                     "dataTable.* " +
                     " FROM (" +
                     " SELECT " +
-                    APIUsageStatisticsClientConstants.API + "," +
+                    APIUsageStatisticsClientConstants.API + ",apiPublisher," +
                     "MAX(" + APIUsageStatisticsClientConstants.TIME + ") " + "AS maxTime " +
                     " FROM " + tableName +
-                    " GROUP BY " + APIUsageStatisticsClientConstants.API + ") maxTimesTable " +
+                    " GROUP BY " + APIUsageStatisticsClientConstants.API + ",apiPublisher) maxTimesTable " +
                     " INNER JOIN " +
                     "(SELECT * " +
                     " FROM " +
                     tableName + ") dataTable " +
                     " ON maxTimesTable." +
                     APIUsageStatisticsClientConstants.API + "=dataTable." + APIUsageStatisticsClientConstants.API +
+                    " AND " +
+                    "maxTimesTable.apiPublisher=dataTable.apiPublisher" +
                     " AND " +
                     "maxTimesTable.maxTime=dataTable." + APIUsageStatisticsClientConstants.TIME;
 


### PR DESCRIPTION
Fix for APIMANAGER-4048 : API Last Access Times Statistics retrieved incorrectly when APIs with same name reside in multiple tenants