### PR TITLE
Refactoring throttle core dependent poms.

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/pom.xml
@@ -106,6 +106,10 @@
             <groupId>org.apache.woden.wso2</groupId>
             <artifactId>woden</artifactId>
         </dependency>
+	<dependency>
+	    <groupId>org.wso2.carbon</groupId>
+	    <artifactId>org.wso2.carbon.throttle.core</artifactId>
+	</dependency>
     </dependencies>
 
     <build>
@@ -285,7 +289,8 @@
                                 <importBundleDef>org.wso2.carbon.commons:org.wso2.carbon.ganalytics.publisher:${carbon.commons.version}</importBundleDef>
                                 <importBundleDef>org.wso2.carbon.deployment:org.wso2.carbon.bam.service.data.publisher:${carbon.deployment.version}</importBundleDef>
                                 <importBundleDef>org.wso2.carbon.mediation:org.wso2.carbon.mediation.security.stub:4.4.5</importBundleDef>
-                            </importBundles>
+                            	<importBundleDef>org.wso2.carbon:org.wso2.carbon.throttle.core:${carbon.throttle.module.version}</importBundleDef>
+			    </importBundles>
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.core.server:${carbon.platform.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.oauth.server:${carbon.identity.version}</importFeatureDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/pom.xml
@@ -97,7 +97,7 @@
                             <importBundles>
                                 <importBundleDef>org.wso2.carbon.hostobjects:org.wso2.carbon.hostobjects.sso</importBundleDef>
                                 <importBundleDef>org.wso2.carbon.mediation:org.wso2.carbon.rest.api.stub:${carbon.mediation.version}</importBundleDef>
-                                <importBundleDef>org.wso2.carbon:org.wso2.carbon.throttle.core:4.2.1</importBundleDef>
+                                <importBundleDef>org.wso2.carbon:org.wso2.carbon.throttle.core:${carbon.throttle.module.version}</importBundleDef>
                             </importBundles>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.throttle.core</artifactId>
-                <version>4.2.1</version>
+                <version>${carbon.throttle.module.version}</version>
             </dependency>
 
             <dependency>
@@ -954,6 +954,7 @@
         <imp.pkg.version.org.wso2.carbon.base>[1.0.0, 1.1.0)</imp.pkg.version.org.wso2.carbon.base>
         <imp.pkg.version.org.wso2.carbon.user.api>[1.0.1, 1.2.0)</imp.pkg.version.org.wso2.carbon.user.api>
 
+	<carbon.throttle.module.version>4.2.1</carbon.throttle.module.version>
     </properties>
     <distributionManagement>
         <repository>


### PR DESCRIPTION
…ndencies and making all throttle-consumer components to inherit the version of org.wso2.carbon.throttle.core from the top most parent of the repository