### PR TITLE
remove default configuratons for BPS

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin-dashboard/site/conf/site.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin-dashboard/site/conf/site.json
@@ -9,10 +9,10 @@
     "allowedRole":"admin",
     "allowedRoles":"admin,subscriber",
     "workflows":{
-     "applicationWorkFlowServerURL": "https://localhost:9445/services/",
-     "subscriptionWorkFlowServerURL": "https://localhost:9445/services/",
-     "signupWorkFlowServerURL": "https://localhost:9445/services/",
-     "appRegistrationWorkFlowServerURL": "https://localhost:9445/services/"
+     "applicationWorkFlowServerURL": "https://<BPSHost>:<BPSPort>/services/",
+     "subscriptionWorkFlowServerURL": "https://<BPSHost>:<BPSPort>/services/",
+     "signupWorkFlowServerURL": "https://<BPSHost>:<BPSPort>/services/",
+     "appRegistrationWorkFlowServerURL": "https://<BPSHost>:<BPSPort>/services/"
 
     },
     "ssoConfiguration" : {


### PR DESCRIPTION
Default config for BPS has 9445 as the port. If AM is configured to have port offset of 2, then errors are thrown when loging to the admin-dashboard