### PR TITLE
Omitting the access token being sent in the error response when an aut…

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
@@ -215,8 +215,7 @@ public class OAuthAuthenticator implements Authenticator {
                 log.debug("User is NOT authorized to access the Resource");
             }
             throw new APISecurityException(info.getValidationStatus(),
-                    "Access failure for API: " + apiContext + ", version: " + apiVersion +
-                            " with key: " + apiKey);
+                    "Access failure for API: " + apiContext + ", version: " + apiVersion);
         }
     }
 


### PR DESCRIPTION
…h failure occurs during API invocation