### PR TITLE
Added logic to check gateway type before loading custom sequences

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -126,8 +126,18 @@ public abstract class AbstractAPIManager implements APIManager {
                 //load resources for each tenants.
                 APIUtil.loadloadTenantAPIRXT( tenantUserName, tenantId);
                 APIUtil.loadTenantAPIPolicy( tenantUserName, tenantId);
-                APIUtil.writeDefinedSequencesToTenantRegistry(tenantId);
-                ServiceReferenceHolder.setUserRealm((UserRealm)(ServiceReferenceHolder.getInstance().
+
+                //Check whether GatewayType is "Synapse" before attempting to load Custom-Sequences into registry
+                APIManagerConfiguration configuration = ServiceReferenceHolder.getInstance()
+                        .getAPIManagerConfigurationService().getAPIManagerConfiguration();
+
+                String gatewayType = configuration.getFirstProperty(APIConstants.API_GATEWAY_TYPE);
+
+                if (APIConstants.API_GATEWAY_TYPE_SYNAPSE.equalsIgnoreCase(gatewayType)) {
+                    APIUtil.writeDefinedSequencesToTenantRegistry(tenantId);
+                }
+
+                ServiceReferenceHolder.setUserRealm((UserRealm) (ServiceReferenceHolder.getInstance().
                         getRealmService().getTenantUserRealm(tenantId)));
             }
             ServiceReferenceHolder.setUserRealm(ServiceReferenceHolder.getInstance().

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/observers/CommonConfigDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/observers/CommonConfigDeployer.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerAnalyticsConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -53,7 +54,15 @@ public class CommonConfigDeployer extends AbstractAxis2ConfigurationContextObser
         }
 
         try {
-            APIUtil.writeDefinedSequencesToTenantRegistry(tenantId);
+            //Check whether GatewayType is "Synapse" before attempting to load Custom-Sequences into registry
+            APIManagerConfiguration configuration = ServiceReferenceHolder.getInstance()
+                    .getAPIManagerConfigurationService().getAPIManagerConfiguration();
+
+            String gatewayType = configuration.getFirstProperty(APIConstants.API_GATEWAY_TYPE);
+
+            if (APIConstants.API_GATEWAY_TYPE_SYNAPSE.equalsIgnoreCase(gatewayType)) {
+                APIUtil.writeDefinedSequencesToTenantRegistry(tenantId);
+            }
         }
         // Need to continue the execution even if we encounter an error.
         catch (Exception e) {


### PR DESCRIPTION
The logic for checking whether the gatewayType was "Synapse" before attempting to load custom sequences was missing in two classes. The changes were made to these classes