### PR TITLE
Fixing APIMANAGER-2280 and APIMANAGER-4064

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/default/templates/item-add/js/jsonform.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/default/templates/item-add/js/jsonform.js
@@ -338,7 +338,7 @@ jsonform.elementTypes = {
       '<div class="input-append">'+
       '<input type="text" ' +
       '<%= (fieldHtmlClass ? "class=\'" + fieldHtmlClass + "\' " : "") %>' +
-      ' class="validateEndpoints" '+
+      ' class="validateEndpoints validateUrl" '+
       'name="<%= node.name %>" value="<%= escape(value) %>" id="<%= id %>"' +
       '<%= (node.disabled? " disabled" : "")%>' +
       '<%= (node.readOnly ? " readonly=\'readonly\'" : "") %>' +

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/default/templates/item-implement/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/default/templates/item-implement/template.jag
@@ -310,7 +310,7 @@
                         <label class="control-label">Prototype Endpoint:</label>
                         <div class="controls">
                             <div class="input-append">
-                            <input type="text" id="prototype_endpoint" value="http://localhost" name="prototype_endpoint" class="required">
+                            <input type="text" id="prototype_endpoint" value="http://localhost" name="prototype_endpoint" class="required validateUrl">
                             <button type="button" class="btn check_url_valid" id="prototype_test" providerName="<%= api.provider %>" apiName="<%= api.name %>" apiVersion="<%= api.version %>">Test</button>
 
                             <a style="margin-left:3px" class="icon-question-sign help_popup" help_data="endpoint_test_help"></a>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/default/templates/utils/custom-validation/custom-validation.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/default/templates/utils/custom-validation/custom-validation.js
@@ -43,6 +43,15 @@ $(document).ready(function() {
         return value.indexOf("{}") == -1
     }, 'Empty curly brackets "{}" are not allowed in context field.');
 
+    $.validator.addMethod('validateUrl', function(value, element){
+        var validUrlRegex = /^(http|https):\/\/(.)+/g;
+        value = value.replace(/^\s+|\s+$/g, "");
+        if(value != ""){
+            return validUrlRegex.test(value);
+        }
+        return true;
+    }, 'Please provide a valid URL.');
+
     $.validator.addMethod('noSpace', function(value, element) {
         return !/\s/g.test(value);
     },'Name contains white spaces.');


### PR DESCRIPTION
This is a simple fix for the above issues. (A basic check to see whether it is a url) So this prevents the user entering text like 'aaaaaa' for example, in the respective fields.