### PR TITLE
Fix for APIMANAGER-4488

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIStoreHostObject.java
@@ -3007,25 +3007,20 @@ public class APIStoreHostObject extends ScriptableObject {
 
     public static boolean jsFunction_removeApplication(Context cx, Scriptable thisObj, Object[] args, Function funObj)
             throws ScriptException, APIManagementException {
-
         if (args != null && args.length > 2 && isStringArray(args)) {
             String name = (String) args[0];
             String username = (String) args[1];
             String groupingId = (String) args[2];
-            Subscriber subscriber = new Subscriber(username);
             APIConsumer apiConsumer = getAPIConsumer(thisObj);
-            Application[] apps;
-           	apps = apiConsumer.getApplications(subscriber, groupingId);
-            
-            if (apps == null || apps.length == 0) {
-                return false;
+            Application app = apiConsumer.getApplicationsByName(username, name, groupingId);
+
+            if (app != null) {
+                apiConsumer.removeApplication(app);
+            } else {
+                handleException("Application " + name + " doesn't exists");
             }
-            for (Application app : apps) {
-                if (app.getName().equals(name)) {
-                    apiConsumer.removeApplication(app);
-                    return true;
-                }
-            }
+
+            return true;
         }
         return false;
     }
@@ -3082,10 +3077,8 @@ public class APIStoreHostObject extends ScriptableObject {
         return myn;
     }
 
-    public static boolean jsFunction_updateApplication(Context cx, Scriptable thisObj,
-                                                       Object[] args, Function funObj)
+    public static boolean jsFunction_updateApplication(Context cx, Scriptable thisObj, Object[] args, Function funObj)
             throws ScriptException, APIManagementException {
-
         if (args != null && args.length > 5 && isStringArray(args)) {
             String newName = (String) args[0];
             String oldName = (String) args[1];
@@ -3094,39 +3087,35 @@ public class APIStoreHostObject extends ScriptableObject {
             String callbackUrl = (String) args[4];
             String description = (String) args[5];
             String groupingId = null;
-            if(args.length > 6 && args[6] != null){
+            APIConsumer apiConsumer = getAPIConsumer(thisObj);
+
+            if (args.length > 6 && args[6] != null) {
                 groupingId = (String) args[6];
             }
-           
-            Subscriber subscriber = new Subscriber(username);
-            APIConsumer apiConsumer = getAPIConsumer(thisObj);
-            Application[] apps;
-           	apps = apiConsumer.getApplications(subscriber, groupingId);
-           if (apps == null || apps.length == 0) {
-                return false;
-            }
 
-            Map appsMap = new HashMap();
-            for (Application app : apps) {
-                appsMap.put(app.getName(), app);
-            }
-            
-            // check whether there is an app with same name
-            if (!newName.equals(oldName) && appsMap.containsKey(newName)) {
-                handleException("An application already exist by the name " + newName);
-            }
+            // get application with new name if exists
+            Application application = apiConsumer.getApplicationsByName(username, newName, groupingId);
+            if (!newName.equals(oldName)) {
 
-            for (Application app : apps) {
-                if (app.getName().equals(oldName)) {
-                    Application application = new Application(newName, subscriber);
-                    application.setId(app.getId());
-                    application.setTier(tier);
-                    application.setCallbackUrl(callbackUrl);
-                    application.setDescription(description);
-                    apiConsumer.updateApplication(application);
-                    return true;
+                // check whether there is an app with new name and throw error if exists
+                if (application != null) {
+                    handleException("An application already exist by the name " + newName);
+                } else {
+
+                    // get the application by old name
+                    application = apiConsumer.getApplicationsByName(username, oldName, groupingId);
                 }
             }
+
+            // update application details
+            Subscriber subscriber = new Subscriber(username);
+            Application updatedApplication = new Application(newName, subscriber);
+            updatedApplication.setId(application.getId());
+            updatedApplication.setTier(tier);
+            updatedApplication.setCallbackUrl(callbackUrl);
+            updatedApplication.setDescription(description);
+            apiConsumer.updateApplication(updatedApplication);
+            return true;
         }
 
         return false;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/application/application-remove/ajax/application-remove.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/application/application-remove/ajax/application-remove.jag
@@ -48,7 +48,7 @@ include("/jagg/jagg.jag");
 
         if (result.error) {
             obj = {
-                error:result.error,
+                error:true,
                 message:msg.error.authError(action, username)
             };
         } else {


### PR DESCRIPTION
*getApplications* method was used to get the correct application to
update. This method takes too much time to execute when number of
applications is high (fetches application key information per each
application from the database). Therefore *getApplicationByName*
was used to directly retrieve only the application required and
update/remove.