### PR TITLE
Fixing incorrect URL on admin dashboard 

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin-dashboard/site/themes/wso2/templates/menu/left/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin-dashboard/site/themes/wso2/templates/menu/left/template.jag
@@ -4,7 +4,7 @@
 
     var reqUrl = request.getRequestURI();
     var listUrl=jagg.url("/site/pages/index.jag");
-    var listMappedUrl=jagg.url("/modules/la/log-viewer.jag");
+    var listMappedUrl=jagg.url("/site/pages/index.jag");
     var liveLogViewer=jagg.url("/log-viewer");
     var loganalyzer =jagg.url("/log-analyzer");
     var subsUrl=jagg.url("/site/pages/index.jag");


### PR DESCRIPTION
Fixing incorrect URL on admin dashboard "Subscription Creation" and "Application Registration".
Original issue was due to incorrect addition of URL while adding Log Analyzer links.