### PR TITLE
Adding the missing required notation

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/wso2/templates/user/sign-up/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/wso2/templates/user/sign-up/template.jag
@@ -96,7 +96,7 @@
 								<%if (required == true) {%>
 									 <div class="form-group">
                                         <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
-                                            <label class="control-label"><%=i18n.localize(field.name, field.name)%> </label>
+                                            <label class="control-label"><%=i18n.localize(field.name, field.name)%> *</label>
                                             <div class="input-group input-wrap">
                                                 <input type="text" id="<%=i%>cliamUri" name="<%=i%>cliamUri" title="<%=i%>cliamUri" class="<%=inputClass%> form-control">
                                             </div>


### PR DESCRIPTION
Following three fields of user sign up page are required, but has not denoted by the required (*) notification. This fix is to add it to improve the user convenience.

1. First Name
2. Last Name
3. Email