### PR TITLE
Fix for the APIMANAGER-4877

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -5479,6 +5479,13 @@ public class ApiMgtDAO {
                 prepStmt.addBatch();
                 if (uriTemplate.getScope() != null) {
                     scopePrepStmt.setString(1, APIUtil.getResourceKey(api, uriTemplate));
+                    String scopeKey = uriTemplate.getScope().getKey();
+                    Scope scopeByKey = APIUtil.findScopeByKey(api.getScopes(), scopeKey);
+                    if(scopeByKey != null) {
+                        if(scopeByKey.getId() > 0) {
+                            uriTemplate.getScopes().setId(scopeByKey.getId());
+                        }
+                    }
                     scopePrepStmt.setInt(2, uriTemplate.getScope().getId());
                     scopePrepStmt.addBatch();
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -5479,13 +5479,17 @@ public class ApiMgtDAO {
                 prepStmt.addBatch();
                 if (uriTemplate.getScope() != null) {
                     scopePrepStmt.setString(1, APIUtil.getResourceKey(api, uriTemplate));
-                    String scopeKey = uriTemplate.getScope().getKey();
-                    Scope scopeByKey = APIUtil.findScopeByKey(api.getScopes(), scopeKey);
-                    if(scopeByKey != null) {
-                        if(scopeByKey.getId() > 0) {
-                            uriTemplate.getScopes().setId(scopeByKey.getId());
+
+                    if(uriTemplate.getScope().getId() == 0){
+                        String scopeKey = uriTemplate.getScope().getKey();
+                        Scope scopeByKey = APIUtil.findScopeByKey(api.getScopes(), scopeKey);
+                        if (scopeByKey != null) {
+                            if (scopeByKey.getId() > 0) {
+                                uriTemplate.getScopes().setId(scopeByKey.getId());
+                            }
                         }
                     }
+
                     scopePrepStmt.setInt(2, uriTemplate.getScope().getId());
                     scopePrepStmt.addBatch();
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
@@ -359,6 +359,7 @@ public class ApisApiServiceImpl extends ApisApiService {
             }
             API apiToUpdate = APIMappingUtil.fromDTOtoAPI(body, apiIdentifier.getProviderName());
             apiProvider.updateAPI(apiToUpdate);
+			apiProvider.saveSwagger20Definition(apiToUpdate.getId(), body.getApiDefinition());
             API updatedApi = apiProvider.getAPI(apiIdentifier);
             updatedApiDTO = APIMappingUtil.fromAPItoDTO(updatedApi);
             return Response.ok().entity(updatedApiDTO).build();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
@@ -359,7 +359,7 @@ public class ApisApiServiceImpl extends ApisApiService {
             }
             API apiToUpdate = APIMappingUtil.fromDTOtoAPI(body, apiIdentifier.getProviderName());
             apiProvider.updateAPI(apiToUpdate);
-			apiProvider.saveSwagger20Definition(apiToUpdate.getId(), body.getApiDefinition());
+            apiProvider.saveSwagger20Definition(apiToUpdate.getId(), body.getApiDefinition());
             API updatedApi = apiProvider.getAPI(apiIdentifier);
             updatedApiDTO = APIMappingUtil.fromAPItoDTO(updatedApi);
             return Response.ok().entity(updatedApiDTO).build();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/mappings/APIMappingUtil.java
@@ -358,10 +358,6 @@ public class APIMappingUtil {
             //this means the provided gatewayEnvironments is "" (empty)
             model.setEnvironments(APIUtil.extractEnvironmentsForAPI(APIConstants.API_GATEWAY_NONE));
         }
-
-        if(dto.getThumbnailUrl() != null) {
-            model.setThumbnailUrl(dto.getThumbnailUrl());
-        }
         return model;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/mappings/APIMappingUtil.java
@@ -358,6 +358,10 @@ public class APIMappingUtil {
             //this means the provided gatewayEnvironments is "" (empty)
             model.setEnvironments(APIUtil.extractEnvironmentsForAPI(APIConstants.API_GATEWAY_NONE));
         }
+
+        if(dto.getThumbnailUrl() != null) {
+            model.setThumbnailUrl(dto.getThumbnailUrl());
+        }
         return model;
     }
 


### PR DESCRIPTION
When API's are added to the API Manager via REST API, the scopes and uri-templates doesn't get added. Same happens when updating the API.

This fix addresses it. 