### PR TITLE
Loganalyzer admin dashboard fixes.

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/jaggery.conf
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/jaggery.conf
@@ -121,10 +121,33 @@
           "path":"/site/pages/global-policy-manage.jag"
         },
         {
-          "url": "/loganalyzer/*",
+          "url": "/loganalyzer/overview",
           "path": "/site/pages/loganalyzer.jag"
+        },
+        {
+          "url": "/loganalyzer/application-errors",
+          "path": "/site/pages/loganalyzer.jag"
+        },
+        {
+          "url": "/loganalyzer/api-deployment-stats",
+          "path": "/site/pages/loganalyzer.jag"
+        },
+        {
+          "url": "/loganalyzer/login-errors",
+          "path": "/site/pages/loganalyzer.jag"
+        },
+        {
+          "url": "/loganalyzer/number-of-api-failures",
+          "path": "/site/pages/loganalyzer.jag"
+        },
+        {
+          "url": "/loganalyzer/access-token-errors",
+          "path": "/site/pages/loganalyzer.jag"
+        },
+        {
+         "url": "/loganalyzer/live-log-viewer",
+         "path": "/site/pages/loganalyzer.jag"
         }
     ]
-    
 
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/loganalyzer/css/custom.css
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/loganalyzer/css/custom.css
@@ -36,15 +36,7 @@ body > .page-content-wrapper > .container, body > .page-content-wrapper > .conta
     max-height: auto;
 }
 
-.page-header {
-    height: auto;
-    padding: 20px 40px;
-    border-bottom: none;
-    margin: 0;
-    background: #fff;
-}
-
-.dashboard .page-header {
+.dashboard{
     margin-left: -15px;
     margin-right: -15px;
     height: auto;
@@ -58,36 +50,36 @@ body > .page-content-wrapper > .container, body > .page-content-wrapper > .conta
     height: 0;
 }
 
-.dashboard .page-header .auth {
+.dashboard .auth {
     min-height: 20px;
     margin-bottom: 15px;
 }
 
-.dashboard .page-header .auth > div {
+.dashboard .auth > div {
     position: relative;
 }
 
-.dashboard .page-header .auth > div > span, .dashboard .page-header .auth > div > a {
+.dashboard .auth > div > span, .dashboard .page-header .auth > div > a {
     display: inline-block;
     vertical-align: middle;
     line-height: 20px;
     padding: 0 4px;
 }
 
-.dashboard .page-header .auth > div > a span i {
+.dashboard .auth > div > a span i {
     line-height: 20px;
 }
 
-.dashboard .page-header .auth > div .icon {
+.dashboard .auth > div .icon {
     height: 20px;
     width: 20px;
 }
 
-.dashboard .page-header .auth > div .caret {
+.dashboard .auth > div .caret {
     margin-left: -2px;
 }
 
-.dashboard .page-header .auth > div.pull-right:not(:first-child) {
+.dashboard .auth > div.pull-right:not(:first-child) {
     border-right: 1px solid #e4e4e4;
 }
 
@@ -97,37 +89,9 @@ body > .page-content-wrapper > .container, body > .page-content-wrapper > .conta
     font-weight: 400;
 }
 
-.dashboard .page-header > .page-title > h1 {
+.dashboard > .page-title > h1 {
     padding: 20px 0;
     font-size: 25px;
-}
-
-.page-header > .page-title > .lead {
-    margin-bottom: 0;
-    font-size: 16px;
-    color: #999;
-}
-
-.page-header > .page-title {
-    float: left;
-}
-
-.page-header > .page-actions {
-    float: right;
-    margin: 5px 0;
-}
-
-.page-header > .page-actions > * {
-    height: 34px;
-}
-
-.page-header > .page-actions button .icon {
-    padding: 3px;
-}
-
-.page-header > .page-actions button img {
-    width: 14px;
-    height: 14px;
 }
 
 .page-content {
@@ -535,9 +499,6 @@ html:not('.ie') .page-content-wrapper.fixed .sidebar-wrapper.sidebar-options {
     .page-content-wrapper.fixed {
         min-height: calc(100% - 130px);
         max-height: calc(100% - 130px);
-    }
-    .page-header {
-        height: 85px;
     }
 }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/loganalyzer/js/loganalyzer-dashboard.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/loganalyzer/js/loganalyzer-dashboard.js
@@ -26,7 +26,7 @@ var loganalyzerDashboard = {
     },
     "pages": [
         {
-            "id": "page0",
+            "id": "overview",
             "title": "Overview",
             "layout": {
                 "content": {
@@ -136,7 +136,7 @@ var loganalyzerDashboard = {
             }
         },
         {
-            "id": "page1",
+            "id": "application-errors",
             "title": "Application Errors",
             "layout": {
                 "content": {
@@ -356,7 +356,7 @@ var loganalyzerDashboard = {
             }
         },
         {
-            "id": "page2",
+            "id": "api-deployment-stats",
             "title": "API Deployment Stats",
             "layout": {
                 "content": {
@@ -516,7 +516,7 @@ var loganalyzerDashboard = {
             }
         },
         {
-            "id": "page3",
+            "id": "login-errors",
             "title": "Login Errors",
             "layout": {
                 "content": {
@@ -632,7 +632,7 @@ var loganalyzerDashboard = {
             }
         },
         {
-            "id": "page4",
+            "id": "number-of-api-failures",
             "title": "Number of API Failures",
             "layout": {
                 "content": {
@@ -736,7 +736,7 @@ var loganalyzerDashboard = {
             }
         },
         {
-            "id": "page5",
+            "id": "access-token-errors",
             "title": "Access Token Errors",
             "layout": {
                 "content": {
@@ -942,7 +942,7 @@ var loganalyzerDashboard = {
             }
         },
         {
-            "id": "page6",
+            "id": "live-log-viewer",
             "title": "Live Log Viewer",
             "layout": {
                 "content": {

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/loganalyzer/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/loganalyzer/template.jag
@@ -27,26 +27,26 @@ var httpPort;
 var httpsPort;
 
 if(hostName == null | hostName == ""){
-    if(hostURLMatcher.match('https://{hostname}:{port}/admin-dashboard/loganalyzer/{page}') |
-            hostURLMatcher.match('http://{hostname}:{port}/admin-dashboard/loganalyzer/{page}')){
+    if(hostURLMatcher.match('https://{hostname}:{port}/{admin}/loganalyzer/{page}') |
+            hostURLMatcher.match('http://{hostname}:{port}/{admin}/loganalyzer/{page}')){
         hostName = hostURLMatcher.elements().hostname;
     }else{
         hostName = "localhost";
     }
 }
 
-if(hostURLMatcher.match('http://{hostname}:{port}/admin-dashboard/loganalyzer/{page}')) {
+if(hostURLMatcher.match('http://{hostname}:{port}/{admin}/loganalyzer/{page}')) {
     httpPort = hostURLMatcher.elements().port;
 }else{
     httpPort = 9763;
 }
-if(hostURLMatcher.match('https://{hostname}:{port}/admin-dashboard/loganalyzer/{page}')) {
+if(hostURLMatcher.match('https://{hostname}:{port}/{admin}/loganalyzer/{page}')) {
     httpsPort = hostURLMatcher.elements().port;
 }else{
     httpsPort = 9443;
 }
 %>
-<div id ="title-section" class="title-section"></div>
+<div id ="title-section" class= "page-header"></div>
 <%
 var analyticsConfig = Packages.org.wso2.carbon.apimgt.impl.APIManagerAnalyticsConfiguration;
 var analyticsConfigInstance = analyticsConfig.getInstance();
@@ -277,7 +277,7 @@ if(analyticsConfigInstance.isAnalyticsEnabled()){%>
             var pages = ues.global.dashboard.pages;
             for(var i=0; i< pages.length; i++){
                 if(pages[i].id === "<%=page%>") {
-                    $("#title-section").append('<h2>'+pages[i].title+'</h2>');
+                    $("#title-section").append('<h1>'+pages[i].title+'</h1>');
                 }
             }
             //usage : in traverseMenu helper
@@ -293,7 +293,7 @@ if(analyticsConfigInstance.isAnalyticsEnabled()){%>
         var pages = loganalyzerDashboard.pages;
         for(var i=0; i< pages.length; i++){
         if(pages[i].id === "<%=page%>") {
-            $("#title-section").append('<h2>'+pages[i].title+'</h2>');
+            $("#title-section").append('<h1>'+pages[i].title+'</h1>');
             $("#message-section").append('<h3>'+pages[i].title+" is disabled."+'</h3>');
         }
     }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/loganalyzer/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/loganalyzer/template.jag
@@ -15,18 +15,35 @@ if(uriMatcher.match('/{admindashboard}/{loganalyzer}/{pageName}')) {
 if(page == null) {
     page = 'live-log-viewer';
 }
+
 var MultitenantUtils = Packages.org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 var tenantDomain = MultitenantUtils.getTenantDomain(username);
+
 var carbon = require('carbon');
-var httpUriMatcher = new URIMatcher(carbon.server.address('http'));
-var httpsUriMatcher = new URIMatcher(carbon.server.address('https'));
+var serverConfigService = carbon.server.osgiService('org.wso2.carbon.base.api.ServerConfigurationService');
+var hostName = serverConfigService.getFirstProperty("HostName");
+var hostURLMatcher = new URIMatcher(request.getRequestURL());
 var httpPort;
 var httpsPort;
-if(httpUriMatcher.match('/{hostname}:{port}')) {
-    httpPort = httpUriMatcher.elements().port;
+
+if(hostName == null | hostName == ""){
+    if(hostURLMatcher.match('https://{hostname}:{port}/admin-dashboard/loganalyzer/{page}') |
+            hostURLMatcher.match('http://{hostname}:{port}/admin-dashboard/loganalyzer/{page}')){
+        hostName = hostURLMatcher.elements().hostname;
+    }else{
+        hostName = "localhost";
+    }
 }
-if(httpsUriMatcher.match('/{hostname}:{port}')) {
-    httpsPort = httpsUriMatcher.elements().port;
+
+if(hostURLMatcher.match('http://{hostname}:{port}/admin-dashboard/loganalyzer/{page}')) {
+    httpPort = hostURLMatcher.elements().port;
+}else{
+    httpPort = 9763;
+}
+if(hostURLMatcher.match('https://{hostname}:{port}/admin-dashboard/loganalyzer/{page}')) {
+    httpsPort = hostURLMatcher.elements().port;
+}else{
+    httpsPort = 9443;
 }
 %>
 <div id ="title-section" class="title-section"></div>
@@ -189,7 +206,7 @@ if(analyticsConfigInstance.isAnalyticsEnabled()){%>
             ues.global.tenantPrefix = "/t";
             ues.global.type = 'default';
             ues.global.anon = false;
-            ues.global.host = {"hostname": "localhost", "port": "", "protocol": ""};
+            ues.global.host = {"hostname": "<%=hostName%>", "port": "", "protocol": ""};
             ues.global.context = "/portal";
             ues.global.server = {
                 httpPort: "<%=httpPort%>",

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/loganalyzer/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/loganalyzer/template.jag
@@ -7,13 +7,13 @@ var lenI=0,apps = outputs.applications; if(apps!=null){lenI = apps.length;}
 var uriMatcher = new URIMatcher(request.getRequestURI())
 var page;
 //Provide a pattern to be matched against the URL
-if(uriMatcher.match('/{admindashboard}/{loganalyzer}/{pageNo}')) {
+if(uriMatcher.match('/{admindashboard}/{loganalyzer}/{pageName}')) {
 //If pattern matches, elements can be accessed from their keys
-  page = uriMatcher.elements().pageNo;
+  page = uriMatcher.elements().pageName;
 }
 
 if(page == null) {
-    page = 'page6';
+    page = 'live-log-viewer';
 }
 var MultitenantUtils = Packages.org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 var tenantDomain = MultitenantUtils.getTenantDomain(username);
@@ -29,12 +29,12 @@ if(httpsUriMatcher.match('/{hostname}:{port}')) {
     httpsPort = httpsUriMatcher.elements().port;
 }
 %>
-
+<div id ="title-section" class="title-section"></div>
+<%
+var analyticsConfig = Packages.org.wso2.carbon.apimgt.impl.APIManagerAnalyticsConfiguration;
+var analyticsConfigInstance = analyticsConfig.getInstance();
+if(analyticsConfigInstance.isAnalyticsEnabled()){%>
 <div id="loganalyzer">
-
-    <div id ="title-section" class="page-header">
-    </div>
-
     <!-- page content -->
     <div class="container body-wrapper">
         <div class="page-content">
@@ -82,7 +82,7 @@ if(httpsUriMatcher.match('/{hostname}:{port}')) {
                  data-gs-height="{{height}}" data-banner="{{banner}}" {{#if banner}}
                  data-gs-no-resize="true"
                  {{/if}}>
-            <div class="grid-stack-item-content ues-component-box gadget-wrapper" id="{{id}}">
+            <div class="grid-stack-item-content ues-component-box gadget-wrapper" id="{{id}}" style="overflow-y: hidden">
             </div>
             </div>
             {{/each}}
@@ -174,9 +174,9 @@ if(httpsUriMatcher.match('/{hostname}:{port}')) {
             </div>
         </script>
 
-    <script id="ues-menu-list-hbs" type="text/x-handlebars-template">
-        //{{#traverseMenu menu false isAnonView user isHiddenMenu}}{{/traverseMenu}}
-    </script>
+        <script id="ues-menu-list-hbs" type="text/x-handlebars-template">
+            //{{#traverseMenu menu false isAnonView user isHiddenMenu}}{{/traverseMenu}}
+        </script>
 
         <script src="/shindig/gadgets/js/container:open-views:opensearch:rpc:xmlutil:pubsub-2.js?c=1&debug=1&container=default"></script>
         <script src="/portal/js/ues.js"></script>
@@ -263,9 +263,23 @@ if(httpsUriMatcher.match('/{hostname}:{port}')) {
                     $("#title-section").append('<h2>'+pages[i].title+'</h2>');
                 }
             }
-    //usage : in traverseMenu helper
-    var user = {}, isAnonView = null;
-    </script>
+            //usage : in traverseMenu helper
+            var user = {}, isAnonView = null;
+        </script>
     </div>
 </div>
+<%}else{%>
+
+    <div id="message-section"></div>
+    <script>
+        $("#title-section").empty();
+        var pages = loganalyzerDashboard.pages;
+        for(var i=0; i< pages.length; i++){
+        if(pages[i].id === "<%=page%>") {
+            $("#title-section").append('<h2>'+pages[i].title+'</h2>');
+            $("#message-section").append('<h3>'+pages[i].title+" is disabled."+'</h3>');
+        }
+    }
+    </script>
+<%}%>
 <% }); %>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/menu/left/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/menu/left/template.jag
@@ -5,13 +5,13 @@
   var reqUrl = request.getRequestURI();
   var listUrl=jagg.url("/site/pages/index.jag");
   var listMappedUrl=jagg.url("/site/pages/index.jag");
-  var liveLogViewer=jagg.url("/loganalyzer/page6");
-  var loganalyzerOverview = jagg.url("/loganalyzer/page0");
-  var loganalyzerApplicationErrors = jagg.url("/loganalyzer/page1");
-  var loganalyzerApiDeploymentStats = jagg.url("/loganalyzer/page2");
-  var loganalyzerLoginStats = jagg.url("/loganalyzer/page3");
-  var loganalyzerNumberOfAPIFailures = jagg.url("/loganalyzer/page4");
-  var loganalyzerAccessTokenErrors = jagg.url("/loganalyzer/page5");
+  var liveLogViewer=jagg.url("/loganalyzer/live-log-viewer");
+  var loganalyzerOverview = jagg.url("/loganalyzer/overview");
+  var loganalyzerApplicationErrors = jagg.url("/loganalyzer/application-errors");
+  var loganalyzerApiDeploymentStats = jagg.url("/loganalyzer/api-deployment-stats");
+  var loganalyzerLoginStats = jagg.url("/loganalyzer/login-errors");
+  var loganalyzerNumberOfAPIFailures = jagg.url("/loganalyzer/number-of-api-failures");
+  var loganalyzerAccessTokenErrors = jagg.url("/loganalyzer/access-token-errors");
   var subsUrl=jagg.url("/site/pages/index.jag");
   var subsMappedUrl=jagg.url("/site/pages/index.jag");
   var throttlePolicyUrl=jagg.getMappedUrl("/site/pages/policy-list.jag");
@@ -159,32 +159,32 @@
         <li class="nav-header">
           <a href="#"><i class="fw fw-blank-document fw-2x" style="font-size:22px;"></i>Log Analyzer<i class="fw fw-down fw-stack-1x toggle-icon-down toggle-caret remove-float"></i></a>
           <ul class="nav nav-pills secondary-nav collapse">
-            <li <%if (reqUrl.match("/admin/loganalyzer/page6")){%>class="active"<% } %>><a href="<%=liveLogViewer%>"
+            <li <%if (reqUrl.match("/admin/loganalyzer/live-log-viewer")){%>class="active"<% } %>><a href="<%=liveLogViewer%>"
               onclick="jagg.sessionAwareJS({redirect:'<%=liveLogViewer%>',e:event,ssoEnabled:<%=ssoEnabled%>})">
               <i class="fw fw-list"></i>Live log viewer</a>
             </li>
-            <li <%if (reqUrl.match("/admin/loganalyzer/page0")){%>class="active"<% } %>><a href="<%=loganalyzerOverview%>"
+            <li <%if (reqUrl.match("/admin/loganalyzer/overview")){%>class="active"<% } %>><a href="<%=loganalyzerOverview%>"
               onclick="jagg.sessionAwareJS({redirect:'<%=loganalyzerOverview%>',e:event,ssoEnabled:<%=ssoEnabled%>})">
               <i class="fw fw-view"></i>
               Overview</a>
             </li>
-            <li <%if (reqUrl.match("/admin/loganalyzer/page1")){%>class="active"<% } %>><a href="<%=loganalyzerApplicationErrors%>"
+            <li <%if (reqUrl.match("/admin/loganalyzer/application-errors")){%>class="active"<% } %>><a href="<%=loganalyzerApplicationErrors%>"
               onclick="jagg.sessionAwareJS({redirect:'<%=loganalyzerApplicationErrors%>',e:event,ssoEnabled:<%=ssoEnabled%>})">
               <i class="fw fw-alert"></i>Application Errors</a>
             </li>
-            <li <%if (reqUrl.match("/admin/loganalyzer/page2")){%>class="active"<% } %>><a href="<%=loganalyzerApiDeploymentStats%>"
+            <li <%if (reqUrl.match("/admin/loganalyzer/api-deployment-stats")){%>class="active"<% } %>><a href="<%=loganalyzerApiDeploymentStats%>"
               onclick="jagg.sessionAwareJS({redirect:'<%=loganalyzerApiDeploymentStats%>',e:event,ssoEnabled:<%=ssoEnabled%>})">
               <i class="fw fw-statistics"></i>Api Deployment Stats</a>
             </li>
-            <li <%if (reqUrl.match("/admin/loganalyzer/page3")){%>class="active"<% } %>><a href="<%=loganalyzerLoginStats%>"
+            <li <%if (reqUrl.match("/admin/loganalyzer/login-errors")){%>class="active"<% } %>><a href="<%=loganalyzerLoginStats%>"
               onclick="jagg.sessionAwareJS({redirect:'<%=loganalyzerLoginStats%>',e:event,ssoEnabled:<%=ssoEnabled%>})">
               <i class="fw fw-sign-in"></i>Login Errors</a>
             </li>
-            <li <%if (reqUrl.match("/admin/loganalyzer/page4")){%>class="active"<% } %>><a href="<%=loganalyzerNumberOfAPIFailures%>"
+            <li <%if (reqUrl.match("/admin/loganalyzer/number-of-api-failures")){%>class="active"<% } %>><a href="<%=loganalyzerNumberOfAPIFailures%>"
               onclick="jagg.sessionAwareJS({redirect:'<%=loganalyzerNumberOfAPIFailures%>',e:event,ssoEnabled:<%=ssoEnabled%>})">
               <i class="fw fw-info"></i>Number of API Failures</a>
             </li>
-            <li <%if (reqUrl.match("/admin/loganalyzer/page5")){%>class="active"<% } %>><a href="<%=loganalyzerAccessTokenErrors%>"
+            <li <%if (reqUrl.match("/admin/loganalyzer/access-token-errors")){%>class="active"<% } %>><a href="<%=loganalyzerAccessTokenErrors%>"
               onclick="jagg.sessionAwareJS({redirect:'<%=loganalyzerAccessTokenErrors%>',e:event,ssoEnabled:<%=ssoEnabled%>})">
               <i class="fw fw-depend"></i>Access Token Errors</a>
             </li>


### PR DESCRIPTION
- Adding loganalyzer dashboard pages.
- Refactoring loganalyzer dashboard pages names.
- Refactoring loganalyzer gadget dashboard pages names.
- Updating loganalyzer admin dashboard template by adding host name verification from the carbon configuration and request URL.
- Fixing loganalyzer page name headers styling and change **admin-dashboard** to **admin** in the loganalyzer dashboard template.
