### PR TITLE
Renaming Execution Manger to Template Manager

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/pom.xml
@@ -91,7 +91,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.analytics-common</groupId>
-            <artifactId>org.wso2.carbon.event.execution.manager.stub</artifactId>
+            <artifactId>org.wso2.carbon.event.template.manager.stub</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.org.apache.commons</groupId>
@@ -194,7 +194,7 @@
                                 <bundleDef>com.google.code.gson:gson:${google.code.gson.version}</bundleDef>
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>org.json.wso2:json:${orbit.version.json}</bundleDef>
-                                <bundleDef>org.wso2.carbon.analytics-common:org.wso2.carbon.event.execution.manager.stub:${carbon.analytics.common.version}</bundleDef>
+                                <bundleDef>org.wso2.carbon.analytics-common:org.wso2.carbon.event.template.manager.stub:${carbon.analytics.common.version}</bundleDef>
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.core.server:4.4.0</importFeatureDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/modules/configure-alerts/alerts-domain-edit.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/modules/configure-alerts/alerts-domain-edit.jag
@@ -17,7 +17,7 @@ var getDomain = function (domainName) {
         password = conf.*::['Analytics'].*::['DASPassword'].text();
 
 
-        var stub = new org.wso2.carbon.event.execution.manager.stub.ExecutionManagerAdminServiceStub(dasUrl + "/services/ExecutionManagerAdminService");
+        var stub = new org.wso2.carbon.event.template.manager.stub.TemplateManagerAdminServiceStub(dasUrl + "/services/TemplateManagerAdminService");
         var client = stub._getServiceClient();
         var options = client.getOptions();
         var authenticator = new org.apache.axis2.transport.http.HttpTransportProperties.Authenticator();
@@ -54,7 +54,7 @@ var getDomainConfiguration = function (domainName, configurationName) {
         username = conf.*::['Analytics'].*::['DASUsername'].text();
         password = conf.*::['Analytics'].*::['DASPassword'].text();
 
-        var stub = new org.wso2.carbon.event.execution.manager.stub.ExecutionManagerAdminServiceStub(dasUrl + "/services/ExecutionManagerAdminService");
+        var stub = new org.wso2.carbon.event.template.manager.stub.TemplateManagerAdminServiceStub(dasUrl + "/services/TemplateManagerAdminService");
         var client = stub._getServiceClient();
         var options = client.getOptions();
         var authenticator = new org.apache.axis2.transport.http.HttpTransportProperties.Authenticator();
@@ -83,9 +83,9 @@ var saveConfiguration = function (domainName, templateType, configurationName, d
         var valueSeparator = "::";
         
        
-        var ScenarioConfigurationDTO = Packages.org.wso2.carbon.event.execution.manager.admin.dto.configuration.xsd.ScenarioConfigurationDTO;
+        var ScenarioConfigurationDTO = Packages.org.wso2.carbon.event.template.manager.admin.dto.configuration.xsd.ScenarioConfigurationDTO;
         
-        var ParameterDTO = Packages.org.wso2.carbon.event.execution.manager.admin.dto.configuration.xsd.ConfigurationParameterDTO;
+        var ParameterDTO = Packages.org.wso2.carbon.event.template.manager.admin.dto.configuration.xsd.ConfigurationParameterDTO;
         
         var scenarioConfigurationDTO = new ScenarioConfigurationDTO();
 
@@ -123,7 +123,7 @@ var saveConfiguration = function (domainName, templateType, configurationName, d
         password = conf.*::['Analytics'].*::['DASPassword'].text();
 
 
-        var stub = new org.wso2.carbon.event.execution.manager.stub.ExecutionManagerAdminServiceStub(dasUrl + "/services/ExecutionManagerAdminService");
+        var stub = new org.wso2.carbon.event.template.manager.stub.TemplateManagerAdminServiceStub(dasUrl + "/services/TemplateManagerAdminService");
         var client = stub._getServiceClient();
         var options = client.getOptions();
         var authenticator = new org.apache.axis2.transport.http.HttpTransportProperties.Authenticator();

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/modules/configure-alerts/alerts-domain-list.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/modules/configure-alerts/alerts-domain-list.jag
@@ -17,7 +17,7 @@ var carbon = require('carbon'),
         password = conf.*::['Analytics'].*::['DASPassword'].text();
 
 
-          var stub = new org.wso2.carbon.event.execution.manager.stub.ExecutionManagerAdminServiceStub(dasUrl + "/services/ExecutionManagerAdminService");
+          var stub = new org.wso2.carbon.event.template.manager.stub.TemplateManagerAdminServiceStub(dasUrl + "/services/TemplateManagerAdminService");
 
         var client = stub._getServiceClient();
         var options = client.getOptions();

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/modules/configure-alerts/alerts-domain-manage.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/modules/configure-alerts/alerts-domain-manage.jag
@@ -17,7 +17,7 @@ var getDomainSpecificConfigurationsInfo = function (domainName) {
         password = conf.*::['Analytics'].*::['DASPassword'].text();
 
 
-        var stub = new org.wso2.carbon.event.execution.manager.stub.ExecutionManagerAdminServiceStub(dasUrl + "/services/ExecutionManagerAdminService");
+        var stub = new org.wso2.carbon.event.template.manager.stub.TemplateManagerAdminServiceStub(dasUrl + "/services/TemplateManagerAdminService");
 
         var client = stub._getServiceClient();
         var options = client.getOptions();
@@ -58,7 +58,7 @@ var getDomainTemplates = function (domainName) {
         password = conf.*::['Analytics'].*::['DASPassword'].text();
 
 
-        var stub = new org.wso2.carbon.event.execution.manager.stub.ExecutionManagerAdminServiceStub(dasUrl + "/services/ExecutionManagerAdminService");
+        var stub = new org.wso2.carbon.event.template.manager.stub.TemplateManagerAdminServiceStub(dasUrl + "/services/TemplateManagerAdminService");
 
         var client = stub._getServiceClient();
         var options = client.getOptions();
@@ -98,7 +98,7 @@ var deleteConfiguration = function (domainName, configurationName) {
         username = conf.*::['Analytics'].*::['DASUsername'].text();
         password = conf.*::['Analytics'].*::['DASPassword'].text();
 
-        var stub = new org.wso2.carbon.event.execution.manager.stub.ExecutionManagerAdminServiceStub(dasUrl + "/services/ExecutionManagerAdminService");
+        var stub = new org.wso2.carbon.event.template.manager.stub.TemplateManagerAdminServiceStub(dasUrl + "/services/TemplateManagerAdminService");
 
         var client = stub._getServiceClient();
         var options = client.getOptions();

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
 
             <dependency>
                 <groupId>org.wso2.carbon.analytics-common</groupId>
-                <artifactId>org.wso2.carbon.event.execution.manager.stub</artifactId>
+                <artifactId>org.wso2.carbon.event.template.manager.stub</artifactId>
                 <version>${carbon.analytics.common.version}</version>
             </dependency>
 


### PR DESCRIPTION
This pull contains changes w.r.t renaming of Execution Manger component to Template Manager. 

Please note that these changes are incorporated in following versions;
carbon.analytics.common: 5.1.0-SNAPSHOT
carbon.analytics: 1.0.6-SNAPSHOT
carbon.event.processing: 2.1.0-SNAPSHOT

Please review and merge
