### PR TITLE
added a new admin service operation - revokeTokensOfUserByApp

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/AccessTokenInfo.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/AccessTokenInfo.java
@@ -36,6 +36,8 @@ public class AccessTokenInfo {
 
     private String consumerKey;
 
+    private String consumerSecret;
+
     private String[] scope;
 
     private String tokenState;
@@ -98,6 +100,22 @@ public class AccessTokenInfo {
 
     public void setConsumerKey(String consumerKey) {
         this.consumerKey = consumerKey;
+    }
+
+    /**
+     * Get consumer secret corresponding to the access token
+     * @return consumer secret
+     */
+    public String getConsumerSecret() {
+        return consumerSecret;
+    }
+
+    /**
+     * Set consumer secret corresponding to the access token
+     * @param consumerSecret consumer secret to set
+     */
+    public void setConsumerSecret(String consumerSecret) {
+        this.consumerSecret = consumerSecret;
     }
 
     public void setIssuedTime(long issuedTime) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -431,7 +431,6 @@ public final class APIConstants {
     public static final String API_KEY_VALIDATOR_THRIFT_SERVER_PORT = API_KEY_VALIDATOR + "ThriftServerPort";
     public static final String API_KEY_VALIDATOR_THRIFT_SERVER_HOST = API_KEY_VALIDATOR + "ThriftServerHost";
     public static final String API_KEY_VALIDATOR_CONNECTION_TIMEOUT = API_KEY_VALIDATOR + "ThriftClientConnectionTimeOut";
-    public static final String API_KEY_VALIDATOR_REVOKE_URL  = API_KEY_VALIDATOR + "RevokeAPIURL";
 
     // Constants needed for KeyManager section
     public static final String API_KEY_MANAGER = "APIKeyManager.";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -431,6 +431,7 @@ public final class APIConstants {
     public static final String API_KEY_VALIDATOR_THRIFT_SERVER_PORT = API_KEY_VALIDATOR + "ThriftServerPort";
     public static final String API_KEY_VALIDATOR_THRIFT_SERVER_HOST = API_KEY_VALIDATOR + "ThriftServerHost";
     public static final String API_KEY_VALIDATOR_CONNECTION_TIMEOUT = API_KEY_VALIDATOR + "ThriftClientConnectionTimeOut";
+    public static final String API_KEY_VALIDATOR_REVOKE_URL  = API_KEY_VALIDATOR + "RevokeAPIURL";
 
     // Constants needed for KeyManager section
     public static final String API_KEY_MANAGER = "APIKeyManager.";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.apimgt.impl.dao;
 
 
-import org.apache.axis2.util.JavaUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -33,6 +32,7 @@ import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIKey;
 import org.wso2.carbon.apimgt.api.model.APIStatus;
 import org.wso2.carbon.apimgt.api.model.APIStore;
+import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
 import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.ApplicationConstants;
 import org.wso2.carbon.apimgt.api.model.BlockConditionsDTO;
@@ -10824,5 +10824,41 @@ public class ApiMgtDAO {
          }
          return status;
     	
+    }
+
+
+    /**
+     * Get a list of access tokens issued for given user under the given app. Returned object carries consumer key
+     * and secret information related to the access token
+     *
+     * @param userName end user name
+     * @param appName application name
+     * @return list of tokens
+     * @throws SQLException in case of a DB issue
+     */
+    public static List<AccessTokenInfo> getAccessTokenListForUser(String userName, String appName) throws SQLException {
+
+        List<AccessTokenInfo> accessTokens = new ArrayList<AccessTokenInfo>(5);
+        Connection connection = APIMgtDBUtil.getConnection();
+        PreparedStatement consumerSecretIDPS = connection.prepareStatement(SQLConstants.GET_ACCESS_TOKENS_BY_USER_SQL);
+        consumerSecretIDPS.setString(1, userName);
+        consumerSecretIDPS.setString(2, appName);
+
+        ResultSet consumerSecretIDResult = consumerSecretIDPS.executeQuery();
+
+        while (consumerSecretIDResult.next()) {
+            String consumerKey = consumerSecretIDResult.getString(1);
+            String consumerSecret = consumerSecretIDResult.getString(2);
+            String accessToken = consumerSecretIDResult.getString(3);
+
+            AccessTokenInfo accessTokenInfo = new AccessTokenInfo();
+            accessTokenInfo.setConsumerKey(consumerKey);
+            accessTokenInfo.setConsumerSecret(consumerSecret);
+            accessTokenInfo.setAccessToken(accessToken);
+
+            accessTokens.add(accessTokenInfo);
+        }
+
+        return accessTokens;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -2455,6 +2455,16 @@ public class SQLConstants {
 
     public static final String GET_API_DETAILS_SQL = "SELECT * FROM AM_API ";
 
+    public static final String GET_ACCESS_TOKENS_BY_USER_SQL = "SELECT AKM.CONSUMER_KEY, CON_APP.CONSUMER_SECRET, TOKEN.ACCESS_TOKEN " +
+            "FROM " +
+            "IDN_OAUTH_CONSUMER_APPS CON_APP, AM_APPLICATION APP, IDN_OAUTH2_ACCESS_TOKEN  TOKEN, AM_APPLICATION_KEY_MAPPING AKM " +
+            "WHERE TOKEN.AUTHZ_USER =? " +
+            "AND APP.NAME=? " +
+            "AND TOKEN.TOKEN_STATE = 'ACTIVE' " +
+            "AND TOKEN.CONSUMER_KEY_ID = CON_APP.ID " +
+            "AND CON_APP.CONSUMER_KEY=AKM.CONSUMER_KEY " +
+            "AND AKM.APPLICATION_ID = APP.APPLICATION_ID";
+
     /** Throttle related constants**/
 
     public static class ThrottleSQLConstants{

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyMgtSubscriberService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyMgtSubscriberService.java
@@ -727,7 +727,7 @@ public class APIKeyMgtSubscriberService extends AbstractAdmin {
                 if(apiGatewayURL.length()> 1) {
                     //get https url
                     String apiHTTPSURL = apiGatewayURLs[1];
-                    String revokeURL = apiHTTPSURL + "/" + getRevokeURLPath();
+                    String revokeURL = apiHTTPSURL + getRevokeURLPath();
                     APIRevokeURLs.add(revokeURL);
                 }
             }
@@ -772,7 +772,7 @@ public class APIKeyMgtSubscriberService extends AbstractAdmin {
     private String getRevokeURLPath() {
         APIManagerConfiguration apiConfig = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                 .getAPIManagerConfiguration();
-        String revokeURL = apiConfig.getFirstProperty(APIConstants.API_KEY_VALIDATOR_REVOKE_URL);
+        String revokeURL = apiConfig.getFirstProperty(APIConstants.REVOKE_API_URL);
         URL revokeEndpointURL = new URL(revokeURL);
         return revokeEndpointURL.getFileName();
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyMgtSubscriberService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyMgtSubscriberService.java
@@ -66,6 +66,9 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -697,6 +700,141 @@ public class APIKeyMgtSubscriberService extends AbstractAdmin {
             oauthCache = OAuthCache.getInstance();
             oauthCache.clearCacheEntry(cacheKey);
         }
+    }
+
+
+    /**
+     * Service method to revoke all access tokens issued for given user under the given application. This will change
+     * access token status to revoked and remove cached access tokens from memory of all gateway nodes.
+     * @param userName end user name
+     * @param appName application name
+     * @return if operation is success
+     * @throws APIManagementException in case of revoke failure.
+     */
+    public boolean revokeTokensOfUserByApp(String userName, String appName)
+            throws APIManagementException {
+
+        try {
+
+            //find access tokens for user
+            List<AccessTokenInfo> accessTokens = ApiMgtDAO.getAccessTokenListForUser(userName,appName);
+            //find revoke urls
+            List<String> APIGatewayURLs = getAPIGatewayURLs();
+            List<String> APIRevokeURLs = new ArrayList<String>(APIGatewayURLs.size());
+
+            for (String apiGatewayURL : APIGatewayURLs) {
+                String [] apiGatewayURLs = apiGatewayURL.split(",");
+                if(apiGatewayURL.length()> 1) {
+                    //get https url
+                    String apiHTTPSURL = apiGatewayURLs[1];
+                    String revokeURL = apiHTTPSURL + "/" + getRevokeURLPath();
+                    APIRevokeURLs.add(revokeURL);
+                }
+            }
+
+            //for each access token call revoke
+            for (AccessTokenInfo accessToken : accessTokens) {
+                for (String apiRevokeURL : APIRevokeURLs) {
+                    revokeAccessToken(accessToken.getAccessToken(), accessToken.getConsumerKey(), accessToken
+                            .getConsumerSecret(), apiRevokeURL);
+                }
+            }
+
+            log.info("Successfully revoked all tokens issued for user=" + userName + "for application " + appName);
+            return true;
+
+        } catch (SQLException e) {
+            throw new APIManagementException("Error while revoking token for user=" + userName + " app="+ appName, e);
+        }
+
+    }
+
+    /**
+     * Get API gateway URLs defined on apiManager.xml
+     * @return list of gateway urls
+     */
+    private  List<String> getAPIGatewayURLs() {
+        APIManagerConfiguration apiConfig = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                .getAPIManagerConfiguration();
+        Map<String, Environment> APIEnvironments = apiConfig.getApiGatewayEnvironments();
+        List<String> gatewayURLs = new ArrayList<String>(2);
+        for (Environment environment : APIEnvironments.values()) {
+            gatewayURLs.add(environment.getApiGatewayEndpoint());
+        }
+        return gatewayURLs;
+    }
+
+    /**
+     * Get file name part of revoke url configured in APIMgt.xml file.
+     * (i.e revoke in https://${carbon.local.ip}:${https.nio.port}/revoke)
+     * @return file name part as a string
+     */
+    private String getRevokeURLPath() {
+        APIManagerConfiguration apiConfig = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                .getAPIManagerConfiguration();
+        String revokeURL = apiConfig.getFirstProperty(APIConstants.API_KEY_VALIDATOR_REVOKE_URL);
+        URL revokeEndpointURL = new URL(revokeURL);
+        return revokeEndpointURL.getFileName();
+    }
+
+    /**
+     * Revoke the given access token. This call will reach gateway and clear token caches there as well
+     * @param accessToken access token to revoke
+     * @param consumerKey consumer key
+     * @param consumerSecret consumer secret
+     * @param revokeEndpoint revoke endpoint of the gateway
+     * @throws APIManagementException
+     */
+    private void revokeAccessToken(String accessToken, String consumerKey, String consumerSecret, String
+            revokeEndpoint) throws APIManagementException {
+        try {
+            if (accessToken != null) {
+                URL revokeEndpointURL = new URL(revokeEndpoint);
+                String revokeEndpointProtocol = revokeEndpointURL.getProtocol();
+                int revokeEndpointPort = revokeEndpointURL.getPort();
+
+                HttpClient revokeEPClient = APIUtil.getHttpClient(revokeEndpointPort, revokeEndpointProtocol);
+
+                HttpPost httpRevokePost = new HttpPost(revokeEndpoint);
+
+                // Request parameters.
+                List<NameValuePair> revokeParams = new ArrayList<NameValuePair>(3);
+                revokeParams.add(new BasicNameValuePair(OAuth.OAUTH_CLIENT_ID, consumerKey));
+                revokeParams.add(new BasicNameValuePair(OAuth.OAUTH_CLIENT_SECRET, consumerSecret));
+                revokeParams.add(new BasicNameValuePair("token", accessToken));
+
+
+                //Revoke the Old Access Token
+                httpRevokePost.setEntity(new UrlEncodedFormEntity(revokeParams, "UTF-8"));
+                HttpResponse revokeResponse = revokeEPClient.execute(httpRevokePost);
+
+                if (revokeResponse.getStatusLine().getStatusCode() != 200) {
+                    throw new RuntimeException("Token revoke failed : HTTP error code : " +
+                            revokeResponse.getStatusLine().getStatusCode());
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Successfully submitted revoke request for user token " + accessToken+ ". HTTP " +
+                                "status : 200");
+                    }
+                }
+            }
+        } catch (UnsupportedEncodingException e) {
+            handleException("Error while preparing request for token/revoke APIs", e);
+        } catch (IOException e) {
+            handleException("Error while creating tokens - " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * common method to throw exceptions.
+     *
+     * @param msg this parameter contain error message that we need to throw.
+     * @param e   Exception object.
+     * @throws org.wso2.carbon.apimgt.api.APIManagementException
+     */
+    private void handleException(String msg, Exception e) throws APIManagementException {
+        log.error(msg, e);
+        throw new APIManagementException(msg, e);
     }
 
     /**

--- a/service-stubs/apimgt/org.wso2.carbon.apimgt.keymgt.stub/src/main/resources/APIKeyMgtSubscriberService.wsdl
+++ b/service-stubs/apimgt/org.wso2.carbon.apimgt.keymgt.stub/src/main/resources/APIKeyMgtSubscriberService.wsdl
@@ -1,18 +1,8 @@
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax296="http://dto.impl.apimgt.carbon.wso2.org/xsd" xmlns:ax288="http://api.apimgt.carbon.wso2.org/xsd" xmlns:ax297="http://util.java/xsd" xmlns:ax292="http://keymgt.apimgt.carbon.wso2.org/xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ax294="http://base.identity.carbon.wso2.org/xsd" xmlns:ax290="http://model.api.apimgt.carbon.wso2.org/xsd" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:tns="http://service.keymgt.apimgt.carbon.wso2.org" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" targetNamespace="http://service.keymgt.apimgt.carbon.wso2.org">
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax2106="http://model.api.apimgt.carbon.wso2.org/xsd" xmlns:ax2108="http://base.identity.carbon.wso2.org/xsd" xmlns:ax2102="http://keymgt.apimgt.carbon.wso2.org/xsd" xmlns:ax2104="http://api.apimgt.carbon.wso2.org/xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ax2111="http://util.java/xsd" xmlns:ax2110="http://dto.impl.apimgt.carbon.wso2.org/xsd" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:tns="http://service.keymgt.apimgt.carbon.wso2.org" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" targetNamespace="http://service.keymgt.apimgt.carbon.wso2.org">
    <wsdl:documentation>APIKeyMgtSubscriberService</wsdl:documentation>
    <wsdl:types>
-      <xs:schema xmlns:ax2100="http://util.java/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://model.api.apimgt.carbon.wso2.org/xsd">
+      <xs:schema xmlns:ax2114="http://util.java/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://model.api.apimgt.carbon.wso2.org/xsd">
          <xs:import namespace="http://util.java/xsd"/>
-         <xs:complexType name="Subscriber">
-            <xs:sequence>
-               <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
-               <xs:element minOccurs="0" name="email" nillable="true" type="xs:string"/>
-               <xs:element minOccurs="0" name="id" type="xs:int"/>
-               <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-               <xs:element minOccurs="0" name="subscribedDate" nillable="true" type="xs:date"/>
-               <xs:element minOccurs="0" name="tenantId" type="xs:int"/>
-            </xs:sequence>
-         </xs:complexType>
          <xs:complexType name="OAuthApplicationInfo">
             <xs:sequence>
                <xs:element minOccurs="0" name="appOwner" nillable="true" type="xs:string"/>
@@ -22,7 +12,6 @@
                <xs:element minOccurs="0" name="clientSecret" nillable="true" type="xs:string"/>
                <xs:element minOccurs="0" name="isSaasApplication" type="xs:boolean"/>
                <xs:element minOccurs="0" name="jsonString" nillable="true" type="xs:string"/>
-               <xs:element minOccurs="0" name="saasApplication" type="xs:boolean"/>
             </xs:sequence>
          </xs:complexType>
          <xs:complexType name="Application">
@@ -33,12 +22,23 @@
                <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
                <xs:element minOccurs="0" name="groupId" nillable="true" type="xs:string"/>
                <xs:element minOccurs="0" name="id" type="xs:int"/>
+               <xs:element minOccurs="0" name="isBlackListed" nillable="true" type="xs:boolean"/>
                <xs:element minOccurs="0" name="keys" nillable="true" type="xs:anyType"/>
                <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
                <xs:element minOccurs="0" name="status" nillable="true" type="xs:string"/>
-               <xs:element minOccurs="0" name="subscribedAPIs" nillable="true" type="ax297:Set"/>
-               <xs:element minOccurs="0" name="subscriber" nillable="true" type="ax290:Subscriber"/>
+               <xs:element minOccurs="0" name="subscribedAPIs" nillable="true" type="ax2114:Set"/>
+               <xs:element minOccurs="0" name="subscriber" nillable="true" type="ax2106:Subscriber"/>
                <xs:element minOccurs="0" name="tier" nillable="true" type="xs:string"/>
+            </xs:sequence>
+         </xs:complexType>
+         <xs:complexType name="Subscriber">
+            <xs:sequence>
+               <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
+               <xs:element minOccurs="0" name="email" nillable="true" type="xs:string"/>
+               <xs:element minOccurs="0" name="id" type="xs:int"/>
+               <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
+               <xs:element minOccurs="0" name="subscribedDate" nillable="true" type="xs:date"/>
+               <xs:element minOccurs="0" name="tenantId" type="xs:int"/>
             </xs:sequence>
          </xs:complexType>
       </xs:schema>
@@ -49,51 +49,37 @@
             </xs:sequence>
          </xs:complexType>
       </xs:schema>
-      <xs:schema xmlns:ax293="http://keymgt.apimgt.carbon.wso2.org/xsd" xmlns:ns="http://org.apache.axis2/xsd" xmlns:ax289="http://api.apimgt.carbon.wso2.org/xsd" xmlns:ax295="http://base.identity.carbon.wso2.org/xsd" xmlns:ax291="http://model.api.apimgt.carbon.wso2.org/xsd" xmlns:ax299="http://dto.impl.apimgt.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.axis2/xsd">
+      <xs:schema xmlns:ax2107="http://model.api.apimgt.carbon.wso2.org/xsd" xmlns:ns="http://org.apache.axis2/xsd" xmlns:ax2109="http://base.identity.carbon.wso2.org/xsd" xmlns:ax2113="http://dto.impl.apimgt.carbon.wso2.org/xsd" xmlns:ax2103="http://keymgt.apimgt.carbon.wso2.org/xsd" xmlns:ax2105="http://api.apimgt.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.axis2/xsd">
+         <xs:import namespace="http://keymgt.apimgt.carbon.wso2.org/xsd"/>
          <xs:import namespace="http://api.apimgt.carbon.wso2.org/xsd"/>
          <xs:import namespace="http://model.api.apimgt.carbon.wso2.org/xsd"/>
-         <xs:import namespace="http://keymgt.apimgt.carbon.wso2.org/xsd"/>
          <xs:import namespace="http://base.identity.carbon.wso2.org/xsd"/>
          <xs:import namespace="http://dto.impl.apimgt.carbon.wso2.org/xsd"/>
-         <xs:element name="APIKeyMgtSubscriberServiceAPIManagementException">
-            <xs:complexType>
-               <xs:sequence>
-                  <xs:element minOccurs="0" name="APIManagementException" nillable="true" type="ax289:APIManagementException"/>
-               </xs:sequence>
-            </xs:complexType>
-         </xs:element>
-         <xs:element name="revokeAccessTokenBySubscriber">
-            <xs:complexType>
-               <xs:sequence>
-                  <xs:element minOccurs="0" name="subscriber" nillable="true" type="ax290:Subscriber"/>
-               </xs:sequence>
-            </xs:complexType>
-         </xs:element>
-         <xs:element name="revokeKeysByTier">
-            <xs:complexType>
-               <xs:sequence>
-                  <xs:element minOccurs="0" name="tierName" nillable="true" type="xs:string"/>
-               </xs:sequence>
-            </xs:complexType>
-         </xs:element>
          <xs:element name="APIKeyMgtSubscriberServiceAPIKeyMgtException">
             <xs:complexType>
                <xs:sequence>
-                  <xs:element minOccurs="0" name="APIKeyMgtException" nillable="true" type="ax292:APIKeyMgtException"/>
+                  <xs:element minOccurs="0" name="APIKeyMgtException" nillable="true" type="ax2103:APIKeyMgtException"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="APIKeyMgtSubscriberServiceAPIManagementException">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element minOccurs="0" name="APIManagementException" nillable="true" type="ax2105:APIManagementException"/>
                </xs:sequence>
             </xs:complexType>
          </xs:element>
          <xs:element name="createOAuthApplicationByApplicationInfo">
             <xs:complexType>
                <xs:sequence>
-                  <xs:element minOccurs="0" name="oauthApplicationInfo" nillable="true" type="ax290:OAuthApplicationInfo"/>
+                  <xs:element minOccurs="0" name="oauthApplicationInfo" nillable="true" type="ax2107:OAuthApplicationInfo"/>
                </xs:sequence>
             </xs:complexType>
          </xs:element>
          <xs:element name="createOAuthApplicationByApplicationInfoResponse">
             <xs:complexType>
                <xs:sequence>
-                  <xs:element minOccurs="0" name="return" nillable="true" type="ax290:OAuthApplicationInfo"/>
+                  <xs:element minOccurs="0" name="return" nillable="true" type="ax2107:OAuthApplicationInfo"/>
                </xs:sequence>
             </xs:complexType>
          </xs:element>
@@ -109,14 +95,14 @@
          <xs:element name="createOAuthApplicationResponse">
             <xs:complexType>
                <xs:sequence>
-                  <xs:element minOccurs="0" name="return" nillable="true" type="ax290:OAuthApplicationInfo"/>
+                  <xs:element minOccurs="0" name="return" nillable="true" type="ax2107:OAuthApplicationInfo"/>
                </xs:sequence>
             </xs:complexType>
          </xs:element>
          <xs:element name="APIKeyMgtSubscriberServiceIdentityException">
             <xs:complexType>
                <xs:sequence>
-                  <xs:element minOccurs="0" name="IdentityException" nillable="true" type="ax294:IdentityException"/>
+                  <xs:element minOccurs="0" name="IdentityException" nillable="true" type="ax2109:IdentityException"/>
                </xs:sequence>
             </xs:complexType>
          </xs:element>
@@ -134,7 +120,7 @@
          <xs:element name="updateOAuthApplicationResponse">
             <xs:complexType>
                <xs:sequence>
-                  <xs:element minOccurs="0" name="return" nillable="true" type="ax290:OAuthApplicationInfo"/>
+                  <xs:element minOccurs="0" name="return" nillable="true" type="ax2107:OAuthApplicationInfo"/>
                </xs:sequence>
             </xs:complexType>
          </xs:element>
@@ -148,7 +134,7 @@
          <xs:element name="retrieveOAuthApplicationResponse">
             <xs:complexType>
                <xs:sequence>
-                  <xs:element minOccurs="0" name="return" nillable="true" type="ax290:OAuthApplicationInfo"/>
+                  <xs:element minOccurs="0" name="return" nillable="true" type="ax2107:OAuthApplicationInfo"/>
                </xs:sequence>
             </xs:complexType>
          </xs:element>
@@ -169,7 +155,7 @@
          <xs:element name="getSubscribedAPIsOfUserResponse">
             <xs:complexType>
                <xs:sequence>
-                  <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax296:APIInfoDTO"/>
+                  <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2113:APIInfoDTO"/>
                </xs:sequence>
             </xs:complexType>
          </xs:element>
@@ -208,7 +194,7 @@
             <xs:complexType>
                <xs:sequence>
                   <xs:element minOccurs="0" name="userId" nillable="true" type="xs:string"/>
-                  <xs:element minOccurs="0" name="apiInfoDTO" nillable="true" type="ax296:APIInfoDTO"/>
+                  <xs:element minOccurs="0" name="apiInfoDTO" nillable="true" type="ax2113:APIInfoDTO"/>
                </xs:sequence>
             </xs:complexType>
          </xs:element>
@@ -224,7 +210,21 @@
          <xs:element name="revokeAccessTokenForApplication">
             <xs:complexType>
                <xs:sequence>
-                  <xs:element minOccurs="0" name="application" nillable="true" type="ax290:Application"/>
+                  <xs:element minOccurs="0" name="application" nillable="true" type="ax2107:Application"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="revokeAccessTokenBySubscriber">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element minOccurs="0" name="subscriber" nillable="true" type="ax2107:Subscriber"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="revokeKeysByTier">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element minOccurs="0" name="tierName" nillable="true" type="xs:string"/>
                </xs:sequence>
             </xs:complexType>
          </xs:element>
@@ -236,13 +236,28 @@
                </xs:sequence>
             </xs:complexType>
          </xs:element>
+         <xs:element name="revokeTokensOfUserByApp">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element minOccurs="0" name="userName" nillable="true" type="xs:string"/>
+                  <xs:element minOccurs="0" name="appName" nillable="true" type="xs:string"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="revokeTokensOfUserByAppResponse">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
       </xs:schema>
       <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://keymgt.apimgt.carbon.wso2.org/xsd">
          <xs:complexType name="APIKeyMgtException">
             <xs:sequence/>
          </xs:complexType>
       </xs:schema>
-      <xs:schema xmlns:ax298="http://util.java/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://dto.impl.apimgt.carbon.wso2.org/xsd">
+      <xs:schema xmlns:ax2112="http://util.java/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://dto.impl.apimgt.carbon.wso2.org/xsd">
          <xs:import namespace="http://util.java/xsd"/>
          <xs:complexType name="APIInfoDTO">
             <xs:sequence>
@@ -250,14 +265,17 @@
                <xs:element minOccurs="0" name="apiName" nillable="true" type="xs:string"/>
                <xs:element minOccurs="0" name="context" nillable="true" type="xs:string"/>
                <xs:element minOccurs="0" name="providerId" nillable="true" type="xs:string"/>
-               <xs:element minOccurs="0" name="resources" nillable="true" type="ax297:Set"/>
+               <xs:element minOccurs="0" name="resources" nillable="true" type="ax2112:Set"/>
                <xs:element minOccurs="0" name="version" nillable="true" type="xs:string"/>
             </xs:sequence>
          </xs:complexType>
       </xs:schema>
       <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://base.identity.carbon.wso2.org/xsd">
          <xs:complexType name="IdentityException">
-            <xs:sequence/>
+            <xs:sequence>
+               <xs:element minOccurs="0" name="code" nillable="true" type="xs:string"/>
+               <xs:element minOccurs="0" name="errorInfoList" nillable="true" type="xs:anyType"/>
+            </xs:sequence>
          </xs:complexType>
       </xs:schema>
       <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://api.apimgt.carbon.wso2.org/xsd">
@@ -316,6 +334,12 @@
    </wsdl:message>
    <wsdl:message name="createOAuthApplicationByApplicationInfoResponse">
       <wsdl:part name="parameters" element="ns1:createOAuthApplicationByApplicationInfoResponse"/>
+   </wsdl:message>
+   <wsdl:message name="revokeTokensOfUserByAppRequest">
+      <wsdl:part name="parameters" element="ns1:revokeTokensOfUserByApp"/>
+   </wsdl:message>
+   <wsdl:message name="revokeTokensOfUserByAppResponse">
+      <wsdl:part name="parameters" element="ns1:revokeTokensOfUserByAppResponse"/>
    </wsdl:message>
    <wsdl:message name="deleteOAuthApplicationRequest">
       <wsdl:part name="parameters" element="ns1:deleteOAuthApplication"/>
@@ -376,6 +400,11 @@
          <wsdl:output message="tns:createOAuthApplicationByApplicationInfoResponse" wsaw:Action="urn:createOAuthApplicationByApplicationInfoResponse"/>
          <wsdl:fault message="tns:APIKeyMgtSubscriberServiceAPIKeyMgtException" name="APIKeyMgtSubscriberServiceAPIKeyMgtException" wsaw:Action="urn:createOAuthApplicationByApplicationInfoAPIKeyMgtSubscriberServiceAPIKeyMgtException"/>
          <wsdl:fault message="tns:APIKeyMgtSubscriberServiceAPIManagementException" name="APIKeyMgtSubscriberServiceAPIManagementException" wsaw:Action="urn:createOAuthApplicationByApplicationInfoAPIKeyMgtSubscriberServiceAPIManagementException"/>
+      </wsdl:operation>
+      <wsdl:operation name="revokeTokensOfUserByApp">
+         <wsdl:input message="tns:revokeTokensOfUserByAppRequest" wsaw:Action="urn:revokeTokensOfUserByApp"/>
+         <wsdl:output message="tns:revokeTokensOfUserByAppResponse" wsaw:Action="urn:revokeTokensOfUserByAppResponse"/>
+         <wsdl:fault message="tns:APIKeyMgtSubscriberServiceAPIManagementException" name="APIKeyMgtSubscriberServiceAPIManagementException" wsaw:Action="urn:revokeTokensOfUserByAppAPIKeyMgtSubscriberServiceAPIManagementException"/>
       </wsdl:operation>
       <wsdl:operation name="deleteOAuthApplication">
          <wsdl:input message="tns:deleteOAuthApplicationRequest" wsaw:Action="urn:deleteOAuthApplication"/>
@@ -503,6 +532,18 @@
          <wsdl:fault name="APIKeyMgtSubscriberServiceAPIKeyMgtException">
             <soap:fault use="literal" name="APIKeyMgtSubscriberServiceAPIKeyMgtException"/>
          </wsdl:fault>
+         <wsdl:fault name="APIKeyMgtSubscriberServiceAPIManagementException">
+            <soap:fault use="literal" name="APIKeyMgtSubscriberServiceAPIManagementException"/>
+         </wsdl:fault>
+      </wsdl:operation>
+      <wsdl:operation name="revokeTokensOfUserByApp">
+         <soap:operation soapAction="urn:revokeTokensOfUserByApp" style="document"/>
+         <wsdl:input>
+            <soap:body use="literal"/>
+         </wsdl:input>
+         <wsdl:output>
+            <soap:body use="literal"/>
+         </wsdl:output>
          <wsdl:fault name="APIKeyMgtSubscriberServiceAPIManagementException">
             <soap:fault use="literal" name="APIKeyMgtSubscriberServiceAPIManagementException"/>
          </wsdl:fault>
@@ -669,6 +710,18 @@
             <soap12:fault use="literal" name="APIKeyMgtSubscriberServiceAPIManagementException"/>
          </wsdl:fault>
       </wsdl:operation>
+      <wsdl:operation name="revokeTokensOfUserByApp">
+         <soap12:operation soapAction="urn:revokeTokensOfUserByApp" style="document"/>
+         <wsdl:input>
+            <soap12:body use="literal"/>
+         </wsdl:input>
+         <wsdl:output>
+            <soap12:body use="literal"/>
+         </wsdl:output>
+         <wsdl:fault name="APIKeyMgtSubscriberServiceAPIManagementException">
+            <soap12:fault use="literal" name="APIKeyMgtSubscriberServiceAPIManagementException"/>
+         </wsdl:fault>
+      </wsdl:operation>
       <wsdl:operation name="deleteOAuthApplication">
          <soap12:operation soapAction="urn:deleteOAuthApplication" style="document"/>
          <wsdl:input>
@@ -789,6 +842,15 @@
             <mime:content type="text/xml" part="parameters"/>
          </wsdl:output>
       </wsdl:operation>
+      <wsdl:operation name="revokeTokensOfUserByApp">
+         <http:operation location="revokeTokensOfUserByApp"/>
+         <wsdl:input>
+            <mime:content type="text/xml" part="parameters"/>
+         </wsdl:input>
+         <wsdl:output>
+            <mime:content type="text/xml" part="parameters"/>
+         </wsdl:output>
+      </wsdl:operation>
       <wsdl:operation name="deleteOAuthApplication">
          <http:operation location="deleteOAuthApplication"/>
          <wsdl:input>
@@ -828,13 +890,13 @@
    </wsdl:binding>
    <wsdl:service name="APIKeyMgtSubscriberService">
       <wsdl:port name="APIKeyMgtSubscriberServiceHttpsSoap11Endpoint" binding="tns:APIKeyMgtSubscriberServiceSoap11Binding">
-         <soap:address location="https://shani-ThinkPad-T530:8243/services/APIKeyMgtSubscriberService.APIKeyMgtSubscriberServiceHttpsSoap11Endpoint"/>
+         <soap:address location="https://hasitha-macbook-pro.local:8243/services/APIKeyMgtSubscriberService.APIKeyMgtSubscriberServiceHttpsSoap11Endpoint"/>
       </wsdl:port>
       <wsdl:port name="APIKeyMgtSubscriberServiceHttpsSoap12Endpoint" binding="tns:APIKeyMgtSubscriberServiceSoap12Binding">
-         <soap12:address location="https://shani-ThinkPad-T530:8243/services/APIKeyMgtSubscriberService.APIKeyMgtSubscriberServiceHttpsSoap12Endpoint"/>
+         <soap12:address location="https://hasitha-macbook-pro.local:8243/services/APIKeyMgtSubscriberService.APIKeyMgtSubscriberServiceHttpsSoap12Endpoint"/>
       </wsdl:port>
       <wsdl:port name="APIKeyMgtSubscriberServiceHttpsEndpoint" binding="tns:APIKeyMgtSubscriberServiceHttpBinding">
-         <http:address location="https://shani-ThinkPad-T530:8243/services/APIKeyMgtSubscriberService.APIKeyMgtSubscriberServiceHttpsEndpoint"/>
+         <http:address location="https://hasitha-macbook-pro.local:8243/services/APIKeyMgtSubscriberService.APIKeyMgtSubscriberServiceHttpsEndpoint"/>
       </wsdl:port>
    </wsdl:service>
 </wsdl:definitions>


### PR DESCRIPTION
This contains a feature for API manager for revoking access tokens issued for a given user (user tokens) under a given application. Key Manager server's admin service [1] should be called and it will revoke all the tokens and call gateway server so that key caches are invalidated.