### PR TITLE
SSO improvements 

### DIFF
--- a/components/sso-hostobject/org.wso2.carbon.hostobjects.sso/src/main/java/org/wso2/carbon/hostobjects/sso/internal/SessionInfo.java
+++ b/components/sso-hostobject/org.wso2.carbon.hostobjects.sso/src/main/java/org/wso2/carbon/hostobjects/sso/internal/SessionInfo.java
@@ -16,11 +16,14 @@
 
 package org.wso2.carbon.hostobjects.sso.internal;
 
+import org.jaggeryjs.hostobjects.web.SessionHostObject;
+
 public class SessionInfo {
     private String sessionId;
     private String loggedInUser;
     private String sessionIndex;
     private String samlToken;
+    private SessionHostObject sessionHostObject;
 
     public SessionInfo(String sessionId) {
         this.sessionId = sessionId;
@@ -56,5 +59,13 @@ public class SessionInfo {
 
     public void setSamlToken(String samlToken) {
         this.samlToken = samlToken;
+    }
+
+    public void setSessionHostObject(SessionHostObject sessionHostObject) {
+        this.sessionHostObject = sessionHostObject;
+    }
+
+    public SessionHostObject getSessionHostObject() {
+        return sessionHostObject;
     }
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/conf/site.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/conf/site.json
@@ -15,6 +15,8 @@
         "responseSigningEnabled":"true",
         "assertionSigningEnabled":"true",
         "keyStoreName" :"",
+        "signRequests" : "true",
+        //"acsURL" : "https://localhost:9443/publisher/jagg/jaggery_acs.jag", //use only if Assertion Consumer Service URL needs to be sent along with SAML request 
         //"nameIdPolicy" : "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", //If not specified, 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified' will be used
     },
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/sso/filter/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/sso/filter/template.jag
@@ -19,29 +19,44 @@
 	}
 	if (checkSSO && !Boolean(isAuthenticated)) {
 
-	    var keyStorePassword = site.ssoConfiguration.keyStorePassword;
-            var keyStoreAlias = site.ssoConfiguration.identityAlias;
-            var keyStoreLocation = site.ssoConfiguration.keyStoreName;
-            var CarbonUtils = Packages.org.wso2.carbon.utils.CarbonUtils;
-            if(site.ssoConfiguration.keyStorePassword == null || site.ssoConfiguration.keyStorePassword == ""){
-                site.ssoConfiguration.keyStorePassword = CarbonUtils.getServerConfiguration().getFirstProperty("Security.KeyStore.Password");
-                }
-            if(site.ssoConfiguration.identityAlias == null || site.ssoConfiguration.identityAlias == ""){
-                site.ssoConfiguration.identityAlias = CarbonUtils.getServerConfiguration().getFirstProperty("Security.KeyStore.KeyAlias");
-                }
-            if(site.ssoConfiguration.keyStoreName == null || site.ssoConfiguration.keyStoreName == ""){
-                site.ssoConfiguration.keyStoreName = CarbonUtils.getServerConfiguration().getFirstProperty("Security.KeyStore.Location");
-                }
-            if(site.ssoConfiguration.nameIdPolicy == null){
-                site.ssoConfiguration.nameIdPolicy = "";
-            }
-            ssoRelyingParty.setProperty("identityProviderURL", site.ssoConfiguration.identityProviderURL);
-            ssoRelyingParty.setProperty("keyStorePassword", String(site.ssoConfiguration.keyStorePassword));
-            ssoRelyingParty.setProperty("identityAlias", String(site.ssoConfiguration.identityAlias));
-            ssoRelyingParty.setProperty("keyStoreName", String(site.ssoConfiguration.keyStoreName));
-            ssoRelyingParty.setProperty("nameIdPolicy", site.ssoConfiguration.nameIdPolicy);
+        var keyStorePassword = site.ssoConfiguration.keyStorePassword;
+        var acsURL = site.ssoConfiguration.acsURL;
+        var signRequests = site.ssoConfiguration.signRequests;
+        var keyStoreAlias = site.ssoConfiguration.identityAlias;
+        var keyStoreLocation = site.ssoConfiguration.keyStoreName;
+        var CarbonUtils = Packages.org.wso2.carbon.utils.CarbonUtils;
+        if(site.ssoConfiguration.keyStorePassword == null || site.ssoConfiguration.keyStorePassword == ""){
+            site.ssoConfiguration.keyStorePassword = CarbonUtils.getServerConfiguration().getFirstProperty("Security.KeyStore.Password");
+        }
+        if(site.ssoConfiguration.identityAlias == null || site.ssoConfiguration.identityAlias == ""){
+            site.ssoConfiguration.identityAlias = CarbonUtils.getServerConfiguration().getFirstProperty("Security.KeyStore.KeyAlias");
+        }
+        if(site.ssoConfiguration.keyStoreName == null || site.ssoConfiguration.keyStoreName == ""){
+            site.ssoConfiguration.keyStoreName = CarbonUtils.getServerConfiguration().getFirstProperty("Security.KeyStore.Location");
+        }
+        if(site.ssoConfiguration.signRequests == null || site.ssoConfiguration.signRequests == ""){
+            site.ssoConfiguration.signRequests = "false";
+        }
+        if(site.ssoConfiguration.nameIdPolicy == null){
+            site.ssoConfiguration.nameIdPolicy = "";
+        }
+        ssoRelyingParty.setProperty("identityProviderURL", site.ssoConfiguration.identityProviderURL);
+        ssoRelyingParty.setProperty("keyStorePassword", String(site.ssoConfiguration.keyStorePassword));
+        ssoRelyingParty.setProperty("identityAlias", String(site.ssoConfiguration.identityAlias));
+        ssoRelyingParty.setProperty("keyStoreName", String(site.ssoConfiguration.keyStoreName));
+        ssoRelyingParty.setProperty("nameIdPolicy", site.ssoConfiguration.nameIdPolicy);
+        ssoRelyingParty.setProperty("signRequests", String(site.ssoConfiguration.signRequests));
+        ssoRelyingParty.setProperty("nameIdPolicy", String(site.ssoConfiguration.nameIdPolicy));
 
-	    var samlAuthRequest = ssoRelyingParty.getSAMLAuthRequest();
+        var consumerUrl = "";
+        //if acsURL is provided in site.json, consumerUrl will be taken from that. Otherwise not sent with the request.
+        if (acsURL) {
+            consumerUrl = String(acsURL);
+            samlAuthRequest = ssoRelyingParty.getSAMLAuthRequest(consumerUrl);
+        } else {
+            samlAuthRequest = ssoRelyingParty.getSAMLAuthRequest();
+        }
+
 	    var encodedRequest = ssoRelyingParty.encode(samlAuthRequest);
 	    var relayState = ssoRelyingParty.getUUID();
 	    ssoRelyingParty.setRelayStateProperty(relayState, requestURI);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/sso/logout/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/sso/logout/template.jag
@@ -45,6 +45,9 @@
                             log.debug("doing logout request");
                         }
                         idpURL = ssoRelyingParty.getProperty("identityProviderURL");
+                        if (!Boolean(idpURL)) {
+                            idpURL = site.ssoConfiguration.identityProviderURL ;
+                        }
                 }
 
                 var encodedRequest = ssoRelyingParty.encode(samlLogoutRequest);

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/wso2/templates/sso/logout/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/wso2/templates/sso/logout/template.jag
@@ -44,6 +44,9 @@
                             log.debug("doing logout request");
                         }
                         idpURL = ssoRelyingParty.getProperty("identityProviderURL");
+                        if (!Boolean(idpURL)) {
+                            idpURL = site.ssoConfiguration.identityProviderURL ;
+                        }
                 }
 
                 var encodedRequest = ssoRelyingParty.encode(samlLogoutRequest);


### PR DESCRIPTION
1. Support SSO without SLO
2. Support sending signed SAML requests for Publisher.
New config is added to publisher site.json ssoConfiguration to enable/disable this.
"signRequests" : "true"
3. Support sending ACS url with SAML requests in Publisher.
New config is added to publisher site.json ssoConfiguration to specify this.
"acsURL" : "https://localhost:9443/publisher/jagg/jaggery_acs.jag", //use only if Assertion Consumer Service URL needs to be sent along with SAML request 