### PR TITLE
Fixed IDENTITY-4834

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/util/APIManagerOAuthCallbackHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/util/APIManagerOAuthCallbackHandler.java
@@ -50,6 +50,14 @@ public class APIManagerOAuthCallbackHandler extends AbstractOAuthCallbackHandler
             }
             if (OAuthCallback.OAuthCallbackType.SCOPE_VALIDATION_AUTHZ.equals(
                     oauthCallback.getCallbackType())){
+                String[] scopes = oauthCallback.getRequestedScope();
+                //If no scopes have been requested.
+                if(scopes == null || scopes.length == 0){
+                    //Issue a default scope. The default scope can only be used to access resources which are
+                    // not associated to a scope
+                    scopes = new String[]{APIConstants.OAUTH2_DEFAULT_SCOPE};
+                }
+                oauthCallback.setApprovedScope(scopes);
                 oauthCallback.setValidScope(true);
             }
             if (OAuthCallback.OAuthCallbackType.SCOPE_VALIDATION_TOKEN.equals(


### PR DESCRIPTION
When issuing access token in implicit grant type, validateScope() of the ResponseTypeHandler class will be invoked. There only the scope validation callback having SCOPE_VALIDATION_AUTHZ callback type will be handled, since we are calling for authorize endpoint. 

If you are invoking token endpoint, as in authorization code grant, validateScope() of the AuthorizationGrantHandler will be invoked. And there scope validation callback having SCOPE_VALIDATION_TOKEN callback type will be handled.

So in api manager side when handling callbacks(in custom OAuthCallbackHandler), in a scenario where we are calling for authorize endpoint(as in implicit grant type), if the scope parameter is not specified in the request, need to assign the oauth default scope.
