### PR TITLE
Swagger definition download in publisher

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/jaggery.conf
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/jaggery.conf
@@ -64,6 +64,9 @@
         },{
             "url":"/inline-editor",
             "path":"/site/pages/inline-editor.jag"
+        },{
+            "url":"/api-docs/*",
+            "path":"/site/blocks/api-doc/ajax/get.jag"
         }
     ],
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/blocks/api-doc/ajax/get.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/blocks/api-doc/ajax/get.jag
@@ -1,0 +1,94 @@
+<%
+response.addHeader('Cache-Control', 'no-cache, no-store, must-revalidate'); // HTTP 1.1.
+response.addHeader('Pragma', 'no-cache'); // HTTP 1.0.
+response.addHeader('Expires', '0');
+include("/jagg/jagg.jag");
+
+// Jaggery API for retrieving API Definition
+var log = new Log();
+
+(function () {
+    response.contentType = "application/json; charset=UTF-8";
+    var action = request.getParameter("action");
+    var site = require("/site/conf/site.json");
+    var carbon = require('carbon');
+    var uri = request.getRequestURI();
+    var callPath = uri.replace(site.context + "/api-docs", "");
+    var action;
+
+    if (uri != null) {
+        // replacing @ signs for matcher to work with reverse proxies
+        if (callPath.indexOf("@") > -1) {
+            callPath = callPath.replace("@", "%40");
+        }
+        var uriMatcher = new URIMatcher(callPath);
+        var providerVal, apiNameVal, apiVersionVal;
+        providerVal = apiNameVal = apiVersionVal = "";
+
+        if (uriMatcher.match("/{providerVal}/{apiNameVal}/{apiVersionVal}")) {
+            providerVal = uriMatcher.elements().providerVal;
+            apiNameVal = uriMatcher.elements().apiNameVal;
+            apiVersionVal = uriMatcher.elements().apiVersionVal;
+        } else if (request.getParameter("provider") != null) {
+            providerVal = request.getParameter("provider");
+            apiNameVal = request.getParameter("name");
+            apiVersionVal = request.getParameter("version");
+        } else {
+            // Invalid URL
+            action = "exit";
+        }
+
+        if (action == "exit") {
+            response.sendError(404);
+        } else {
+            var url = request.getRequestURL();
+            var tenantDomain;
+            var tenantID = -1234;
+            var isTenantFlowStarted = false;
+            var MultitenantUtils = Packages.org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+            var APIUtil = Packages.org.wso2.carbon.apimgt.impl.utils.APIUtil;
+            var data;
+
+            if (providerVal.indexOf("@") > -1) {
+                providerVal = APIUtil.replaceEmailDomain(providerVal);
+            }
+
+            tenantDomain = MultitenantUtils.getTenantDomain(APIUtil.replaceEmailDomainBack(providerVal));
+
+            if (tenantDomain) {
+                tenantID = carbon.server.osgiService('org.wso2.carbon.user.core.service.RealmService').
+                getTenantManager().getTenantId(tenantDomain);
+            }
+
+            if (providerVal.indexOf("-DOM-") > -1) {
+                providerVal = providerVal.replace("-DOM-", "/");
+            }
+
+            try {
+                //start tenant flow before fetching swagger resource from the registry
+                if (tenantDomain != "" && tenantDomain != 'carbon.super') {
+                    var PrivilegedCarbonContext = Packages.org.wso2.carbon.context.PrivilegedCarbonContext;
+                    isTenantFlowStarted = true;
+                    PrivilegedCarbonContext.startTenantFlow();
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+                }
+
+                var APIUtil = Packages.org.wso2.carbon.apimgt.impl.utils.APIUtil;
+                var apiUtil = new APIUtil();
+                var swaggerPath = apiUtil.getSwagger20DefinitionFilePath(apiNameVal, apiVersionVal, providerVal);
+                var registry = carbon.server.osgiService('org.wso2.carbon.registry.core.service.RegistryService').
+                getGovernanceUserRegistry("wso2.anonymous.user", tenantID);
+                url = swaggerPath + "swagger.json";
+                data = registry.get(url);
+            } finally {
+                if (isTenantFlowStarted) {
+                    PrivilegedCarbonContext.endTenantFlow();
+                }
+            }
+            var output = new Packages.java.lang.String(data.content);
+            var jsonObj = JSON.parse(output);
+            print(JSON.stringify(jsonObj));
+        }
+    }
+}());
+%>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/blocks/api-doc/block.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/blocks/api-doc/block.jag
@@ -1,0 +1,6 @@
+<%
+jagg.block("api-doc", {
+    initializer:function (data) {
+    }
+});
+%>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/conf/locales/jaggery/locale_default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/conf/locales/jaggery/locale_default.json
@@ -192,6 +192,7 @@
     "Error occurred while updating API": "Error occurred while updating API",
     "Execute fault sequence": "Execute fault sequence",
     "Existing API Definition will be overwritten by the imported definition.": "Existing API Definition will be overwritten by the imported definition.",
+    "Download Source": "Download Source",
     "External API Stores": "External API Stores",
     "Failed to Publish Environments": "Failed to Publish Environments",
     "Failed to UnPublish Environments": "Failed to UnPublish Environments",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/menu/actions/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/menu/actions/template.jag
@@ -1,65 +1,86 @@
-<% jagg.template("menu/actions", function(inputs, outputs, jagg) { %>
+<% jagg.template("menu/actions", function (inputs, outputs, jagg) { %>
             <%
-                var encode = require('encode');
-                encode = new encode.Encode();
-                var tenantDomain = encode.forUriComponent(request.getParameter("tenant"));
-                var site = require("/site/conf/site.json");
-                var ssoEnabled = site.ssoConfiguration.enabled;
-                var urlPrefix = '', urlPostfix = '', isCreatePermitted, isPublishPermitted, api;
+    var encode = require('encode');
+    encode = new encode.Encode();
+    var tenantDomain = encode.forUriComponent(request.getParameter("tenant"));
+    var site = require("/site/conf/site.json");
+    var ssoEnabled = site.ssoConfiguration.enabled;
+    var urlPrefix = '', urlPostfix = '', isCreatePermitted, isPublishPermitted, api;
 
-                if(tenantDomain!='null'){
-                	urlPrefix = "?tenant=" + tenantDomain;
-                	urlPostfix = "&tenant=" + tenantDomain;
-                }
-                
-                api = outputs.api;
-                
-                var reqUrl = jagg.getAbsoluteReqUrl(request.getRequestURI()) + urlPrefix;       
-                
-                
-                var listUrl = jagg.getAbsoluteUrl("/site/pages/index.jag") + urlPrefix;
-                var listMappedUrl = jagg.getMappedUrl("/site/pages/index.jag") + urlPrefix;
-                
-                var infoUrl = jagg.getAbsoluteUrl("/site/pages/item-info.jag") + urlPrefix;;
-                var infoMappedUrl = jagg.getMappedUrl("/site/pages/item-info.jag") + urlPrefix;;
-                
-                var subsUrl = jagg.getAbsoluteUrl("/site/pages/subscriptions.jag") + urlPrefix;
-                var subsMappedUrl = jagg.getMappedUrl("/site/pages/subscriptions.jag") + urlPrefix;
-                
-                var infoUrl = jagg.getAbsoluteUrl("/site/pages/item-info.jag") + urlPrefix;
-                var infoMappedUrl = jagg.getMappedUrl("/site/pages/item-info.jag") + urlPrefix;
-                
-                var versionUrl = jagg.getAbsoluteUrl("/site/pages/version.jag") + urlPrefix;
-                var versionMappedUrl = jagg.getMappedUrl("/site/pages/version.jag") + urlPrefix;
-                                
-                var addUrl=jagg.getAbsoluteUrl("/site/pages/add.jag") + urlPrefix;
-                var addMappedUrl=jagg.getMappedUrl("/site/pages/add.jag") + urlPrefix;
-                
-                var addDesignUrl = jagg.getMappedUrl("/site/pages/design.jag") + urlPrefix;
-                var addImplementUrl = jagg.getMappedUrl("/site/pages/implement.jag") + urlPrefix;
-                var addManageUrl = jagg.getMappedUrl("/site/pages/manage.jag") + urlPrefix;
-                
-                var docViewerUrl = jagg.getAbsoluteUrl("/site/pages/doc-viewer.jag") + urlPrefix;
-                var docViewerMappedUrl = jagg.getMappedUrl("/site/pages/doc-viewer.jag") + urlPrefix;
+    if (tenantDomain != 'null') {
+        urlPrefix = "?tenant=" + tenantDomain;
+        urlPostfix = "&tenant=" + tenantDomain;
+    }
 
-		var allStaticUrl = jagg.getAbsoluteUrl("/site/pages/all-statistics.jag") + urlPrefix;
-		var allStaticMappedUrl = jagg.getMappedUrl("/site/pages/all-statistics.jag") + urlPrefix;
+    api = outputs.api;
 
-		var goBackStatsURL = jagg.getAbsoluteUrl("/site/pages/stats-menu-list.jag") + urlPrefix;
+    var reqUrl = jagg.getAbsoluteReqUrl(request.getRequestURI()) + urlPrefix;
 
-                isCreatePermitted = jagg.getCreatePermitted().permitted;
-                isPublishPermitted = jagg.getPublishPermitted().permitted;
-            %>
+    var listUrl = jagg.getAbsoluteUrl("/site/pages/index.jag") + urlPrefix;
+    var listMappedUrl = jagg.getMappedUrl("/site/pages/index.jag") + urlPrefix;
 
-        <div class="navbar-wrapper">
-		<nav class="navbar navbar-default" data-spy="affix"
-			data-offset-top="80" data-offset-bottom="40">
-			<div class="container-fluid">
-				<div class="navbar-header">
-					<button type="button" class="navbar-toggle collapsed"
-						data-toggle="collapse" data-target="#navbar" aria-expanded="false"
-						aria-controls="navbar">
-						<span class="sr-only"><%=i18n.localize("Toggle navigation")%></span> <span
+    var infoUrl = jagg.getAbsoluteUrl("/site/pages/item-info.jag") + urlPrefix;
+    ;
+    var infoMappedUrl = jagg.getMappedUrl("/site/pages/item-info.jag") + urlPrefix;
+    ;
+
+    var subsUrl = jagg.getAbsoluteUrl("/site/pages/subscriptions.jag") + urlPrefix;
+    var subsMappedUrl = jagg.getMappedUrl("/site/pages/subscriptions.jag") + urlPrefix;
+
+    var infoUrl = jagg.getAbsoluteUrl("/site/pages/item-info.jag") + urlPrefix;
+    var infoMappedUrl = jagg.getMappedUrl("/site/pages/item-info.jag") + urlPrefix;
+
+    var versionUrl = jagg.getAbsoluteUrl("/site/pages/version.jag") + urlPrefix;
+    var versionMappedUrl = jagg.getMappedUrl("/site/pages/version.jag") + urlPrefix;
+
+    var addUrl = jagg.getAbsoluteUrl("/site/pages/add.jag") + urlPrefix;
+    var addMappedUrl = jagg.getMappedUrl("/site/pages/add.jag") + urlPrefix;
+
+    var addDesignUrl = jagg.getMappedUrl("/site/pages/design.jag") + urlPrefix;
+    var addImplementUrl = jagg.getMappedUrl("/site/pages/implement.jag") + urlPrefix;
+    var addManageUrl = jagg.getMappedUrl("/site/pages/manage.jag") + urlPrefix;
+
+    var docViewerUrl = jagg.getAbsoluteUrl("/site/pages/doc-viewer.jag") + urlPrefix;
+    var docViewerMappedUrl = jagg.getMappedUrl("/site/pages/doc-viewer.jag") + urlPrefix;
+
+    var allStaticUrl = jagg.getAbsoluteUrl("/site/pages/all-statistics.jag") + urlPrefix;
+    var allStaticMappedUrl = jagg.getMappedUrl("/site/pages/all-statistics.jag") + urlPrefix;
+
+    var goBackStatsURL = jagg.getAbsoluteUrl("/site/pages/stats-menu-list.jag") + urlPrefix;
+
+    isCreatePermitted = jagg.getCreatePermitted().permitted;
+    isPublishPermitted = jagg.getPublishPermitted().permitted;
+
+    if(api) {
+        var provider = api.provider;
+        var APIUtil = Packages.org.wso2.carbon.apimgt.impl.utils.APIUtil;
+        provider = APIUtil.replaceEmailDomain(provider);
+
+        if (provider.indexOf("@") > -1) {
+            provider = provider.replace("@", "%40");
+        }
+        if (provider.indexOf("/") > -1) {
+            provider = provider.replace("/", "-DOM-");
+        }
+
+        var swaggerAPI;
+        if (provider.contains("/")) {
+            swaggerAPI = jagg.url("/api-docs" + "?provider=" + encodeURIComponent(provider) + "&name=" + encodeURIComponent(api.name) + "&version=" + encodeURIComponent(api.version));
+        } else {
+            swaggerAPI = jagg.url("/api-docs" + "/" + provider + "/" + api.name + "/" + api.version);
+        }
+    }
+    %>
+
+<div class="navbar-wrapper">
+<nav class="navbar navbar-default" data-spy="affix"
+    data-offset-top="80" data-offset-bottom="40">
+    <div class="container-fluid">
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed"
+                data-toggle="collapse" data-target="#navbar" aria-expanded="false"
+                aria-controls="navbar">
+                <span class="sr-only"><%=i18n.localize("Toggle navigation")%></span> <span
 							class="icon-bar"></span> <span class="icon-bar"></span> <span
 							class="icon-bar"></span>
 					</button>
@@ -136,6 +157,15 @@
 	                                    <i class="fw fw-circle-outline fw-stack-2x" title="<%=i18n.localize("Create New Version")%>"></i>
 	                                </span>
 	                                <%=i18n.localize("Create New Version")%>
+	                            </a>
+	                        </li>
+	                        <li>
+	                            <a download="swagger.json" href="<%=swaggerAPI%>" title="<%=i18n.localize("Download Source")%>">
+	                                <span class="icon fw-stack">
+	                                    <i class="fw fw-download fw-stack-1x" title="<%=i18n.localize("Download Source")%>"></i>
+	                                    <i class="fw fw-circle-outline fw-stack-2x" title="<%=i18n.localize("Download Source")%>"></i>
+	                                </span>
+	                                <%=i18n.localize("Download Source")%>
 	                            </a>
 	                        </li>
 	                        <%} else if(api && isPublishPermitted && api.endpointConfig) {%>	                        


### PR DESCRIPTION
API creators need api definition to create copies of same API.
This feature allows API creators to download swagger definition
of an API from the API overview.