### PR TITLE
Add Host header for sanity

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
@@ -4765,7 +4765,7 @@ public class APIProviderHostObject extends ScriptableObject {
         HttpClient client = new DefaultHttpClient();
         HttpHead head = new HttpHead(urlVal);
         // extract the host name and add the Host http header for sanity
-        head.addHeader("Host", urlVal.replaceAll("https?://", "").replaceAll("(:[0-9]+)?(/.*)?", ""));
+        head.addHeader("Host", urlVal.replaceAll("https?://", "").replaceAll("(/.*)?", ""));
         client.getParams().setParameter("http.socket.timeout", 4000);
         client.getParams().setParameter("http.connection.timeout", 4000);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
@@ -4764,6 +4764,8 @@ public class APIProviderHostObject extends ScriptableObject {
 
         HttpClient client = new DefaultHttpClient();
         HttpHead head = new HttpHead(urlVal);
+        // extract the host name and add the Host http header for sanity
+        head.addHeader("Host", urlVal.replaceAll("https?://", "").replaceAll("(:[0-9]+)?(/.*)?", ""));
         client.getParams().setParameter("http.socket.timeout", 4000);
         client.getParams().setParameter("http.connection.timeout", 4000);
 


### PR DESCRIPTION
When the endpoint we are accessing is behind an haproxy or any system that is based on the Host header to dispatch to the proper backend, the Host header is kind of "mandatory".

Not setting the Host header can lead to invalid TLS certificate served or inconsistent behaviour.

Anyway, the header is properly set when running the api manager but was missing when clicking the "Test" button on the GUI. It ends to an error in the UI that is not blocking. 

This PR get rid of this error and simulate the HEAD request with something more similar to the production behaviour

Hope it is clear