### PR TITLE
Fix for APIMANAGER-5443: Add new endpoint to store api

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/modules/api/api.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/modules/api/api.jag
@@ -150,4 +150,89 @@ var getAllPaginatedAPIs = function (tenantDomain, start, end, returnAPITags,stat
         };
     }
 };
+
+
+var getAPI = function (api) {
+    var api, result, defaultVersion,
+            log = new Log(),
+            provider = jagg.module("manager").getAPIProviderObj();
+
+    try {
+        result = provider.getAPI(api.provider, api.name, api.version);
+        defaultVersion=provider.getDefaultAPIVersion(api.provider, api.name);
+        hasDefaultVersion=(defaultVersion!=null);
+        if (log.isDebugEnabled()) {
+            log.debug("getAPI : " + stringify(result));
+        }
+
+        api = {
+            name:result[0],
+            version:result[4],
+            description:result[1],
+            endpoint:result[2],
+            wsdl:result[3],
+            tags:result[5],
+            availableTiers:result[6],
+            status:result[7],
+            thumb:result[8],
+            context:result[9],
+            lastUpdated:result[10],
+            subs:result[11],
+            templates:result[12],
+            sandbox:result[13],
+            tierDescs:result[14],
+            bizOwner:result[15],
+            bizOwnerMail:result[16],
+            techOwner:result[17],
+            techOwnerMail:result[18],
+            wadl:result[19],
+            visibility:result[20],
+            roles:result[21],
+            tenants:result[22],
+            epUsername:result[23],
+            epPassword:result[24],
+            endpointTypeSecured:result[25],
+            provider:result[26],
+            transport_http:result[27],
+            transport_https:result[28],
+            apiStores:result[29],
+            inSequence:result[30],
+            outSequence:result[31],
+            subscriptionAvailability:result[32],
+            subscriptionTenants:result[33],
+            endpointConfig:result[34],
+            responseCache:result[35],
+            cacheTimeout:result[36],
+            availableTiersDisplayNames:result[37],
+            faultSequence:result[38],
+            destinationStats:result[39],
+            resources:result[40],
+            scopes:result[41],
+            isDefaultVersion:result[42],
+            implementation:result[43],
+            environments:result[44],
+            productionTps:result[46],
+            sandboxTps:result[47],
+            endpointAuthTypeDigest:result[48],
+            corsConfiguration:result[49],
+            hasDefaultVersion:hasDefaultVersion,
+            currentDefaultVersion:defaultVersion,
+            availableSubscriptionPolicy:result[50],
+            apiLevelPolicy:result[51]
+        };
+        return {
+            error:false,
+            api:api
+        };
+    } catch (e) {
+        log.error(e.message);
+        return {
+            error:e,
+            api:null,
+            message:e.message.split(":")[1]
+        };
+    }
+};
+
+
 %>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/modules/api/module.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/modules/api/module.jag
@@ -52,6 +52,9 @@ jagg.module("api", {
     },
     getAllPaginatedAPIs:function () {
         return jagg.require(jagg.getModulesDir() + "api/api.jag").getAllPaginatedAPIs.apply(this, arguments);
+    },
+    getAPI:function () {
+        return jagg.require(jagg.getModulesDir() + "api/api.jag").getAPI.apply(this, arguments);
     }
 });
 %>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/modules/manager/manager.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/modules/manager/manager.jag
@@ -169,4 +169,16 @@ var isForumEnabled = function() {
     return org.wso2.carbon.apimgt.impl.utils.APIUtil.isStoreForumEnabled();
 }
 
+var getAPIProviderObj = function() {
+    var user = jagg.getUser();
+    var store;
+    if (user == null) {
+        store = require('apipublisher');
+        return new store.APIProvider();
+    } else {
+        store = require('apipublisher');
+        return new store.APIProvider(user.username);
+    }
+};
+
 %>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/modules/manager/module.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/modules/manager/module.jag
@@ -47,6 +47,9 @@ jagg.module("manager", {
     },
     isForumEnabled:function () {
         return jagg.require(jagg.getModulesDir() + "manager/manager.jag").isForumEnabled.apply(this, arguments);
-    }
+    },
+    getAPIProviderObj:function () {
+        return jagg.require(jagg.getModulesDir() + "manager/manager.jag").getAPIProviderObj.apply(this, arguments);
+     }
  });
  %>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/listing/ajax/item-list.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/listing/ajax/item-list.jag
@@ -1,0 +1,62 @@
+<%
+include("/jagg/jagg.jag");
+
+(function () {
+    response.contentType = "application/json; charset=UTF-8";
+    var mod, obj, result,
+            action = request.getParameter("action"),
+            site = require("/site/conf/site.json"),
+            msg = require("/site/conf/ui-messages.jag");
+
+    if (jagg.getUser() == null) {
+        print({
+                  error:true,
+                  message:'AuthenticateError'
+              });
+    } else {
+        if (action === "getAllAPIs") {
+            mod = jagg.module("api");
+            result = mod.getAllAPIs();
+            if (result.error) {
+                obj = {
+                    error:true,
+                    message:result.message
+                };
+            } else {
+                obj = {
+                    error:false,
+                    apis:result.apis
+                }
+            }
+            print(obj);
+
+        } else if (action === "getAPI") {
+            mod = jagg.module("api");
+            var apiData = {};
+            apiData.name = request.getParameter("name");
+            apiData.version = request.getParameter("version");
+            apiData.provider = request.getParameter("provider");
+            result = mod.getAPI(apiData);
+            if (result.error) {
+                obj = {
+                    error:true,
+                    message:result.message
+                };
+            } else {
+                obj = {
+                    error:false,
+                    api:result.api
+                }
+            }
+            print(obj);
+
+        } else {
+            print({
+                      error:true,
+                      message:msg.error.invalidAction(action)
+                  });
+        }
+    }
+
+}());
+%>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/listing/block.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/listing/block.jag
@@ -1,0 +1,80 @@
+<%
+include("/jagg/jagg.jag");
+
+jagg.block("listing", {
+    initializer:function (data) {
+
+    },
+
+    getInputs:function () {
+        return {
+            "apis":null,
+            "currentPage":null,
+            "numberOfPages":null
+        };
+    },
+
+    getOutputs:function () {
+        var apis, result,query,error,message, mod,mode,length,user = jagg.getUser();
+
+        query = request.getParameter("query");
+        var page = request.getParameter("page");
+        var tenantDomain = String(jagg.getTenantDomain());
+        if (page == null) {
+            page = 1;
+        }
+        var itemsPerPage = 12;
+        var currentPage = page;
+        var start = itemsPerPage*(page-1);
+        if (query) {
+            mod = jagg.module("search");
+            result = mod.searchAPIs(null,query,String(start),String(itemsPerPage));
+            apis = result.response.apis;
+            length = result.response.totalLength;
+            error=result.error,
+            message=result.message,
+            mode="search"
+        } else {
+            mod = jagg.module("api");
+            result = mod.getAllPaginatedAPIs(tenantDomain,String(start),String(itemsPerPage));
+            apis = result.response.apis;
+            length = result.response.totalLength;
+            error=result.error,
+            message=result.message
+            mode="listing"
+        }
+        var itemCount;
+        if (apis != null) {
+            itemCount = result.totalLength;
+            var numberOfPages = itemCount / itemsPerPage;
+            if (itemCount % itemsPerPage != 0) {
+                numberOfPages++;
+            }
+            if (numberOfPages < currentPage || currentPage <= 0) {
+                currentPage = 1;
+            }
+        }
+        var isCreatePermitted = jagg.getCreatePermitted().permitted;
+	var isPublishPermitted = jagg.getPublishPermitted().permitted;
+        return {
+            "apis":apis,
+            "error":error,
+            "message":message,
+            "currentPage":currentPage,
+            "numberOfPages":parseInt(numberOfPages),
+            "isCreatePermitted":isCreatePermitted,
+	        "isPublishPermitted":isPublishPermitted,
+            "mode":mode,
+            "totalLength" : parseInt(length)
+        }
+    },
+
+
+    getStaticBlocks:function() {
+        return [
+            "search/api-search"
+        ];
+    }
+
+});
+%>


### PR DESCRIPTION
In this PR:

- Add a new endpoint to store jaggery REST API named `listing/ajax/item-list.jag`

- Thorugh the above API users can retrieve API information by giving 
   *action*, *API name*, *API version*, and *provider* information through POST data.

Address the following issue :  [APIMANAGER-5443](https://wso2.org/jira/browse/APIMANAGER-5443) 
