### PR TITLE
Add support for Access-Control-Max-Age

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -788,6 +788,7 @@ public final class APIConstants {
         public static final String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
         public static final String ACCESS_CONTROL_ALLOW_HEADERS = "Access-Control-Allow-Headers";
         public static final String ACCESS_CONTROL_ALLOW_METHODS = "Access-Control-Allow-Methods";
+        public static final String ACCESS_CONTROL_MAX_AGE = "Access-Control-Max-Age";
         public static final String ACCESS_CONTROL_ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials";
         public static final String ALLOW_HEADERS_HANDLER_VALUE = "allowHeaders";
         public static final String ALLOW_METHODS_HANDLER_VALUE = "allowedMethods";


### PR DESCRIPTION
Add the `Access-Control-Max-Age` header to avoid a lot of OPTIONS requests

The CORS headers can be cached by the browser accordingly to the `Access-Control-Max-Age` header. This will save dozen of OPTIONS request.

To enable this headers, simply set a property that defines the max age (in seconds) in the CORSRequestHandler: 

```xml
<handler class="org.wso2.carbon.apimgt.gateway.handlers.security.CORSRequestHandler">
    <property name="apiImplementationType" value="ENDPOINT"/>
    <property name="accessControlMaxAge" value="3600"/>
</handler>
```