### PR TITLE
Improve the fix for : APIMANAGER-5384

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/modules/statistics/module.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/modules/statistics/module.jag
@@ -71,6 +71,8 @@ jagg.module("statistics", {
         return jagg.require(jagg.getModulesDir() + "statistics/usage.jag").getApisList.apply(this, arguments);
     },getTopApiUsers:function () {
         return jagg.require(jagg.getModulesDir() + "statistics/usage.jag").getTopApiUsers.apply(this, arguments);
+    },checkTenants:function () {
+        return jagg.require(jagg.getModulesDir() + "statistics/usage.jag").checkTenants.apply(this, arguments);
     }
 });
 %>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/modules/statistics/usage.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/modules/statistics/usage.jag
@@ -1009,4 +1009,14 @@ function getTopApiUsers(apiName, version, tenantDomain, fromDate, toDate, start,
         };
     }
 }
+
+function checkTenants () {
+    var APIUtil = Packages.org.wso2.carbon.apimgt.impl.utils.APIUtil;
+    var tenantList = APIUtil.getAllTenantsWithSuperTenant();
+    if(tenantList.size() > 1){
+        return true;
+    } else {
+        return false;
+    }
+}
 %>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/stats/api-top-users/js/stats.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/stats/api-top-users/js/stats.js
@@ -143,7 +143,11 @@ var drawTopAPIUsersTable = function () {
         "columnDefs": [{
             "targets": 0,
             "render": function (data, type, full, meta) {
-                return '<a href="#" class="show-model-user" data-user="' + data + '">' + data + '</a>';
+                if (hasTenants) {
+                    return data;
+                } else {
+                    return '<a href="#" class="show-model-user" data-user="' + data + '">' + data + '</a>';
+                }
             }
         },{
             "targets": 1,

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/stats/api-top-users/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/stats/api-top-users/template.jag
@@ -6,6 +6,19 @@
         window.requestedVersion = '<%=outputs.version%>';
     </script>
 <%}%>        
+
+<%
+    var mod = jagg.module("statistics");
+    if (mod.checkTenants() == true) { %>
+        <script>
+            var hasTenants = true;
+        </script>
+    <%} else { %>
+        <script>
+            var hasTenants = false;
+        </script>
+<%}%>
+
 <style>
     .modal-dialog{ position: relative; display: table; overflow-y: auto; overflow-x: auto; width: auto; min-width: 500px; }
 </style>


### PR DESCRIPTION
This will prevent the error in APIMANAGER-5384, when there are multiple tenants. It will disable the hyperlink for the user profile so that it prevents viewing profile information across tenants.