### PR TITLE
ETag feature for Store REST API 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.registry.api.Registry;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -75,4 +76,12 @@ public abstract class APIDefinition {
      */
     public abstract String generateAPIDefinition(API api) throws APIManagementException;
 
+    /**
+     * This method returns the timestamps for a given API
+     * @param apiIdentifier
+     * @param registry
+     * @return
+     * @throws APIManagementException
+     */
+    public abstract Map<String ,String> getAPISwaggerDefinitionTimeStamps(APIIdentifier apiIdentifier, Registry registry) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
@@ -435,4 +435,13 @@ public interface APIManager {
      */
     Map<String,Object> searchPaginatedAPIs(String searchQuery, String tenantDomain,int start,int end, 
                                            boolean limitAttributes) throws APIManagementException;
+
+    /**
+     * fetches the lastUpdated timestamp for the API swagger resource
+     * @param apiIdentifier
+     * @return long
+     * @throws APIManagementException
+     */
+    Map<String,String> getSwaggerDefinitionTimeStamps(APIIdentifier apiIdentifier) throws APIManagementException;
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
@@ -444,4 +444,11 @@ public interface APIManager {
      */
     Map<String,String> getSwaggerDefinitionTimeStamps(APIIdentifier apiIdentifier) throws APIManagementException;
 
+    /**
+     * gets the updated timestamp for the API swagger resource
+     * @param apiIdentifier
+     * @return long
+     * @throws APIManagementException
+     */
+    String getThumbnailLastUpdatedTime(APIIdentifier apiIdentifier) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
@@ -17,10 +17,13 @@
 */
 package org.wso2.carbon.apimgt.api.model;
 
-import java.io.Serializable;
-import java.util.*;
-
 import org.wso2.carbon.apimgt.api.model.policy.Policy;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Provider's & system's view of API
@@ -108,6 +111,8 @@ public class API implements Serializable{
     private boolean isPublishedDefaultVersion=false;
 
     private Set<String> environments;
+
+    private String createdTime;
 
     public Set<String> getEnvironments() {
         return environments;
@@ -663,5 +668,12 @@ public class API implements Serializable{
         } else {
             this.type = "HTTP";
         }
+    }
+    public String getCreatedTime() {
+        return createdTime;
+    }
+
+    public void setCreatedTime(String createdTime) {
+        this.createdTime = createdTime;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Application.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Application.java
@@ -17,8 +17,6 @@
 */
 package org.wso2.carbon.apimgt.api.model;
 
-import org.wso2.carbon.apimgt.api.APIManagementException;
-
 import java.util.*;
 
 /**
@@ -39,6 +37,25 @@ public class Application {
     private String status;
     private String groupId;
     private Boolean isBlackListed;
+
+    private String createdTime;
+    private String lastUpdatedTime;
+
+    public String getCreatedTime() {
+        return createdTime;
+    }
+
+    public void setCreatedTime(String createdTime) {
+        this.createdTime = createdTime;
+    }
+
+    public String getLastUpdatedTime() {
+        return lastUpdatedTime;
+    }
+
+    public void setLastUpdatedTime(String lastUpdatedTime) {
+        this.lastUpdatedTime = lastUpdatedTime;
+    }
 
     /**Holds workflow status**/
     private String applicationWorkFlowStatus; 

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Documentation.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Documentation.java
@@ -36,6 +36,7 @@ public class Documentation implements Serializable{
     private DocumentVisibility visibility;
     private Date lastUpdated;
     private String filePath;
+    private Date createdDate;
 
     public String getOtherTypeName() {
         return otherTypeName;
@@ -154,4 +155,13 @@ public class Documentation implements Serializable{
     public void setId(String id) {
         this.id = id;
     }
+
+    public Date getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Date createdDate) {
+        this.createdDate = createdDate;
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SubscribedAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SubscribedAPI.java
@@ -38,6 +38,9 @@ public class SubscribedAPI {
     private List<APIKey> keys = new ArrayList<APIKey>();
     private String uuid;
 
+    private String createdTime;
+    private String updatedTime;
+
     private boolean isBlocked;   //TODO: what is the difference & usage of revoking & blocking users
 
     public SubscribedAPI(Subscriber subscriber, APIIdentifier apiId) {
@@ -147,5 +150,21 @@ public class SubscribedAPI {
         result = 31 * result + apiId.hashCode();
         result = 31 * result + application.hashCode();
         return result;
+    }
+
+    public String getCreatedTime() {
+        return createdTime;
+    }
+
+    public void setCreatedTime(String createdTime) {
+        this.createdTime = createdTime;
+    }
+
+    public String getUpdatedTime() {
+        return updatedTime;
+    }
+
+    public void setUpdatedTime(String updatedTime) {
+        this.updatedTime = updatedTime;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
@@ -33,8 +33,6 @@ public class APIMgtLatencyStatsHandler extends AbstractHandler {
             messageContext.setProperty(APIMgtGatewayConstants.REQUEST_EXECUTION_START_TIME, Long.toString(System
                     .currentTimeMillis()));
         }
-        long currentTime = System.currentTimeMillis();
-        messageContext.setProperty("api.ut.requestTime", Long.toString(currentTime));
         return true;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
@@ -33,6 +33,8 @@ public class APIMgtLatencyStatsHandler extends AbstractHandler {
             messageContext.setProperty(APIMgtGatewayConstants.REQUEST_EXECUTION_START_TIME, Long.toString(System
                     .currentTimeMillis()));
         }
+        long currentTime = System.currentTimeMillis();
+        messageContext.setProperty("api.ut.requestTime", Long.toString(currentTime));
         return true;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -474,6 +474,10 @@ public final class APIConstants {
     public static final String API_RESTAPI_WHITELISTED_URI = API_RESTAPI + "WhiteListedURIs.WhiteListedURI.";
     public static final String API_RESTAPI_WHITELISTED_URI_URI = API_RESTAPI_WHITELISTED_URI + "URI";
     public static final String API_RESTAPI_WHITELISTED_URI_HTTPMethods = API_RESTAPI_WHITELISTED_URI + "HTTPMethods";
+    public static final String API_RESTAPI_ETAG_SKIP_LIST = API_RESTAPI + "ETagSkipList.";
+    public static final String API_RESTAPI_ETAG_SKIP_URI = API_RESTAPI_ETAG_SKIP_LIST + "ETagSkipURI.";
+    public static final String API_RESTAPI_ETAG_SKIP_URI_URI = API_RESTAPI_ETAG_SKIP_URI + "URI";
+    public static final String API_RESTAPI_ETAG_SKIP_URI_HTTPMETHOD = API_RESTAPI_ETAG_SKIP_URI + "HTTPMethods";
 
     public static final String API_KEY_MANAGER_THRIFT_SERVER_HOST = API_KEY_VALIDATOR + "ThriftServerHost";
     public static final String API_KEY_VALIDATOR_CLIENT_TYPE = API_KEY_VALIDATOR + "KeyValidatorClientType";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -840,6 +840,11 @@ public abstract class AbstractAPIManager implements APIManager {
             GenericArtifact artifact = artifactManager.getGenericArtifact(docId);
             if (null != artifact) {
                 documentation = APIUtil.getDocumentation(artifact);
+                documentation.setCreatedDate(registryType.get(artifact.getPath()).getCreatedTime());
+                Date lastModified = registryType.get(artifact.getPath()).getLastModified();
+                if (lastModified != null) {
+                    documentation.setLastUpdated(registryType.get(artifact.getPath()).getLastModified());
+                }
             }
         } catch (RegistryException e) {
             handleException("Failed to get documentation details", e);
@@ -1518,5 +1523,25 @@ public abstract class AbstractAPIManager implements APIManager {
             e.printStackTrace();
         }
         return null;
+    }
+
+    @Override
+    public String getThumbnailLastUpdatedTime(APIIdentifier apiIdentifier) throws APIManagementException {
+        String artifactPath = APIConstants.API_IMAGE_LOCATION + RegistryConstants.PATH_SEPARATOR +
+                apiIdentifier.getProviderName() + RegistryConstants.PATH_SEPARATOR +
+                apiIdentifier.getApiName() + RegistryConstants.PATH_SEPARATOR + apiIdentifier.getVersion();
+
+        String thumbPath = artifactPath + RegistryConstants.PATH_SEPARATOR + APIConstants.API_ICON_IMAGE;
+        try {
+            if (registry.resourceExists(thumbPath)) {
+                Resource res = registry.get(thumbPath);
+                Date lastModifiedTime = res.getLastModified();
+                return lastModifiedTime == null ? String.valueOf(res.getCreatedTime().getTime()) : String.valueOf(lastModifiedTime.getTime());
+            }
+        } catch (RegistryException e) {
+            handleException("Error while loading API icon from the registry", e);
+        }
+        return null;
+
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -1496,4 +1496,27 @@ public abstract class AbstractAPIManager implements APIManager {
         result.put("isMore", isMore);
         return result;
     }
+
+    public Map<String, String> getSwaggerDefinitionTimeStamps(APIIdentifier apiIdentifier) throws APIManagementException {
+        String apiTenantDomain = MultitenantUtils.getTenantDomain(
+                APIUtil.replaceEmailDomainBack(apiIdentifier.getProviderName()));
+        try {
+            Registry registryType;
+            //Tenant store anonymous mode if current tenant and the required tenant is not matching
+            if (this.tenantDomain == null || isTenantDomainNotMatching(apiTenantDomain)) {
+                int tenantId = ServiceReferenceHolder.getInstance().getRealmService().getTenantManager().getTenantId(
+                        apiTenantDomain);
+                registryType = ServiceReferenceHolder.getInstance().getRegistryService().getGovernanceUserRegistry(
+                        CarbonConstants.REGISTRY_ANONNYMOUS_USERNAME, tenantId);
+            } else {
+                registryType = registry;
+            }
+            return definitionFromSwagger20.getAPISwaggerDefinitionTimeStamps(apiIdentifier,registryType);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            e.printStackTrace();
+        } catch (RegistryException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -1502,6 +1502,12 @@ public abstract class AbstractAPIManager implements APIManager {
         return result;
     }
 
+    /**
+     * gets the swagger definition timestamps as a map
+     * @param apiIdentifier
+     * @return
+     * @throws APIManagementException
+     */
     public Map<String, String> getSwaggerDefinitionTimeStamps(APIIdentifier apiIdentifier) throws APIManagementException {
         String apiTenantDomain = MultitenantUtils.getTenantDomain(
                 APIUtil.replaceEmailDomainBack(apiIdentifier.getProviderName()));
@@ -1525,6 +1531,12 @@ public abstract class AbstractAPIManager implements APIManager {
         return null;
     }
 
+    /**
+     * get the thumbnailLastUpdatedTime for a thumbnail for a given api
+     * @param apiIdentifier
+     * @return
+     * @throws APIManagementException
+     */
     @Override
     public String getThumbnailLastUpdatedTime(APIIdentifier apiIdentifier) throws APIManagementException {
         String artifactPath = APIConstants.API_IMAGE_LOCATION + RegistryConstants.PATH_SEPARATOR +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -1436,6 +1436,11 @@ public class ApiMgtDAO {
                 subscribedAPI.setSubStatus(resultSet.getString("SUB_STATUS"));
                 subscribedAPI.setSubCreatedStatus(resultSet.getString("SUBS_CREATE_STATE"));
                 subscribedAPI.setTier(new Tier(resultSet.getString("TIER_ID")));
+
+                Timestamp createdTime = resultSet.getTimestamp("CREATED_TIME");
+                Timestamp updatedTime = resultSet.getTimestamp("UPDATED_TIME");
+                subscribedAPI.setCreatedTime(createdTime == null ? null : String.valueOf(createdTime.getTime()));
+                subscribedAPI.setUpdatedTime(updatedTime == null ? null : String.valueOf(updatedTime.getTime()));
                 subscribedAPI.setApplication(application);
             }
             return subscribedAPI;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -5956,6 +5956,11 @@ public class ApiMgtDAO {
                 application.setTier(rs.getString("APPLICATION_TIER"));
                 subscriber.setId(rs.getInt("SUBSCRIBER_ID"));
 
+                Timestamp updatedTime = rs.getTimestamp("UPDATED_TIME");
+                Timestamp createdTime = rs.getTimestamp("CREATED_TIME");
+                application.setLastUpdatedTime(updatedTime == null ? null : String.valueOf(updatedTime.getTime()));
+                application.setCreatedTime(createdTime == null ? null : String.valueOf(createdTime.getTime()));
+
                 Set<APIKey> keys = getApplicationKeys(subscriber.getName(), application.getId());
                 for (APIKey key : keys) {
                     application.addKey(key);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -1618,6 +1618,8 @@ public class SQLConstants {
             "   APP.SUBSCRIBER_ID," +
             "   APP.APPLICATION_STATUS, " +
             "   APP.GROUP_ID, " +
+            "   APP.UPDATED_TIME, "+
+            "   APP.CREATED_TIME, "+
             "   APP.UUID," +
             "   SUB.USER_ID " +
             " FROM " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -472,6 +472,8 @@ public class SQLConstants {
             "   SUBS.TIER_ID AS TIER_ID, " +
             "   SUBS.SUB_STATUS AS SUB_STATUS, " +
             "   SUBS.SUBS_CREATE_STATE AS SUBS_CREATE_STATE, " +
+            "   SUBS.CREATED_TIME AS CREATED_TIME, "+
+            "   SUBS.UPDATED_TIME AS UPDATED_TIME, "+
             "   SUBS.UUID AS UUID " +
             " FROM " +
             "   AM_SUBSCRIPTION SUBS," +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromSwagger12.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromSwagger12.java
@@ -24,9 +24,6 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIManagementException;
-import org.wso2.carbon.apimgt.api.doc.model.APIResource;
-import org.wso2.carbon.apimgt.api.doc.model.Operation;
-import org.wso2.carbon.apimgt.api.doc.model.Parameter;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.Scope;
@@ -420,5 +417,10 @@ public class APIDefinitionFromSwagger12 extends APIDefinition {
 
 
         return mainAPIJson.toJSONString();
+    }
+
+    @Override
+    public Map<String, String> getAPISwaggerDefinitionTimeStamps(APIIdentifier apiIdentifier, Registry registry) throws APIManagementException {
+        return null;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromSwagger20.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromSwagger20.java
@@ -382,6 +382,13 @@ public class APIDefinitionFromSwagger20 extends APIDefinition {
         return swaggerObject.toJSONString();
     }
 
+    /**
+     * gets the createdTime and updatedTime for the swagger definition
+     * @param apiIdentifier
+     * @param registry
+     * @return
+     * @throws APIManagementException
+     */
     @Override
     public Map<String, String> getAPISwaggerDefinitionTimeStamps(APIIdentifier apiIdentifier, Registry registry) throws APIManagementException {
         Map<String, String> timeStampMap = new HashMap<String, String>();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromSwagger20.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromSwagger20.java
@@ -26,7 +26,10 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIManagementException;
-import org.wso2.carbon.apimgt.api.model.*;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.Scope;
+import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.dto.Environment;
@@ -37,9 +40,7 @@ import org.wso2.carbon.registry.api.RegistryException;
 import org.wso2.carbon.registry.api.Resource;
 
 import java.nio.charset.Charset;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
 
 import static org.wso2.carbon.apimgt.impl.utils.APIUtil.handleException;
 
@@ -379,5 +380,32 @@ public class APIDefinitionFromSwagger20 extends APIDefinition {
         swaggerObject.put("securityDefinitions",securityDefinitionAttr);//++++++
 
         return swaggerObject.toJSONString();
+    }
+
+    @Override
+    public Map<String, String> getAPISwaggerDefinitionTimeStamps(APIIdentifier apiIdentifier, Registry registry) throws APIManagementException {
+        Map<String, String> timeStampMap = new HashMap<String, String>();
+        String resourcePath = APIUtil.getSwagger20DefinitionFilePath(apiIdentifier.getApiName(),
+                apiIdentifier.getVersion(), apiIdentifier.getProviderName());
+        try {
+            if (registry.resourceExists(resourcePath + SWAGGER_2_0_FILE_NAME)) {
+                Resource apiDocResource = registry.get(resourcePath + SWAGGER_2_0_FILE_NAME);
+                Date lastModified = apiDocResource.getLastModified();
+                Date createdTime = apiDocResource.getCreatedTime();
+                if (lastModified != null) {
+                    timeStampMap.put("UPDATED_TIME", String.valueOf(lastModified.getTime()));
+                } else {
+                    timeStampMap.put("CREATED_TIME", String.valueOf(createdTime.getTime()));
+                }
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Resource " + SWAGGER_2_0_FILE_NAME + " not found at " + resourcePath);
+                }
+            }
+        } catch (RegistryException e) {
+            handleException("Error while retrieving Swagger v2.0 updated time for " + apiIdentifier.getApiName() + '-' +
+                    apiIdentifier.getVersion(), e);
+        }
+        return timeStampMap;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -545,6 +545,7 @@ public final class APIUtil {
             }
             api.addTags(tags);
             api.setLastUpdated(registry.get(artifactPath).getLastModified());
+            api.setCreatedTime(String.valueOf(registry.get(artifactPath).getCreatedTime().getTime()));
             api.setImplementation(artifact.getAttribute(APIConstants.PROTOTYPE_OVERVIEW_IMPLEMENTATION));
             String environments = artifact.getAttribute(APIConstants.API_OVERVIEW_ENVIRONMENTS);
             api.setEnvironments(extractEnvironmentsForAPI(environments));
@@ -4173,9 +4174,15 @@ public final class APIUtil {
             String environments = artifact.getAttribute(APIConstants.API_OVERVIEW_ENVIRONMENTS);
             api.setEnvironments(extractEnvironmentsForAPI(environments));
             api.setCorsConfiguration(getCorsConfigurationFromArtifact(artifact));
+            String artifactPath = GovernanceUtils.getArtifactPath(registry, artifact.getId());
+            api.setLastUpdated(registry.get(artifactPath).getLastModified());
+            api.setCreatedTime(String.valueOf(registry.get(artifactPath).getCreatedTime().getTime()));
 
         } catch (GovernanceException e) {
-            String msg = "Failed to get API fro artifact ";
+            String msg = "Failed to get API from artifact ";
+            throw new APIManagementException(msg, e);
+        } catch (RegistryException e) {
+            String msg = "Failed to get LastAccess time or Rating";
             throw new APIManagementException(msg, e);
         }
         return api;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApisApi.java
@@ -1,25 +1,14 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-import org.wso2.carbon.apimgt.rest.api.store.dto.*;
-import org.wso2.carbon.apimgt.rest.api.store.ApisApiService;
-import org.wso2.carbon.apimgt.rest.api.store.factories.ApisApiServiceFactory;
-
 import io.swagger.annotations.ApiParam;
-
-import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.DocumentDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.DocumentListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.dto.APIDTO;
 import org.wso2.carbon.apimgt.rest.api.store.dto.APIListDTO;
+import org.wso2.carbon.apimgt.rest.api.store.dto.DocumentDTO;
+import org.wso2.carbon.apimgt.rest.api.store.dto.DocumentListDTO;
+import org.wso2.carbon.apimgt.rest.api.store.factories.ApisApiServiceFactory;
 
-import java.util.List;
-
-import java.io.InputStream;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
-import org.apache.cxf.jaxrs.ext.multipart.Multipart;
-
-import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
 
 @Path("/apis")
 @Consumes({ "application/json" })
@@ -54,6 +43,11 @@ public class ApisApi  {
     {
     return delegate.apisApiIdDocumentsDocumentIdContentGet(apiId,documentId,xWSO2Tenant,accept,ifNoneMatch,ifModifiedSince);
     }
+
+    public String apisApiIdDocumentsDocumentIdContentGetGetLastUpdatedTime(String apiId,String documentId,String xWSO2Tenant,String accept,String ifNoneMatch,String ifModifiedSince)
+    {
+        return delegate.apisApiIdDocumentsDocumentIdContentGetGetLastUpdatedTime(apiId,documentId,xWSO2Tenant,accept,ifNoneMatch,ifModifiedSince);
+    }
     @GET
     @Path("/{apiId}/documents/{documentId}")
     @Consumes({ "application/json" })
@@ -76,6 +70,11 @@ public class ApisApi  {
     @ApiParam(value = "Validator for conditional requests; based on Last Modified header of the\nformerly retrieved variant of the resource.\n"  )@HeaderParam("If-Modified-Since") String ifModifiedSince)
     {
     return delegate.apisApiIdDocumentsDocumentIdGet(apiId,documentId,xWSO2Tenant,accept,ifNoneMatch,ifModifiedSince);
+    }
+
+    public String apisApiIdDocumentsDocumentIdGetGetLastUpdatedTime(String apiId,String documentId,String xWSO2Tenant,String accept,String ifNoneMatch,String ifModifiedSince)
+    {
+        return delegate.apisApiIdDocumentsDocumentIdGetGetLastUpdatedTime(apiId,documentId,xWSO2Tenant,accept,ifNoneMatch,ifModifiedSince);
     }
     @GET
     @Path("/{apiId}/documents")
@@ -100,6 +99,11 @@ public class ApisApi  {
     {
     return delegate.apisApiIdDocumentsGet(apiId,limit,offset,xWSO2Tenant,accept,ifNoneMatch);
     }
+
+    public String apisApiIdDocumentsGetGetLastUpdatedTime(String apiId,Integer limit,Integer offset,String xWSO2Tenant,String accept,String ifNoneMatch)
+    {
+        return delegate.apisApiIdDocumentsGetGetLastUpdatedTime(apiId,limit,offset,xWSO2Tenant,accept,ifNoneMatch);
+    }
     @GET
     @Path("/{apiId}")
     @Consumes({ "application/json" })
@@ -121,6 +125,11 @@ public class ApisApi  {
     @ApiParam(value = "For cross-tenant invocations, this is used to specify the tenant domain, where the resource need to be\n  retirieved from.\n"  )@HeaderParam("X-WSO2-Tenant") String xWSO2Tenant)
     {
     return delegate.apisApiIdGet(apiId,accept,ifNoneMatch,ifModifiedSince,xWSO2Tenant);
+    }
+
+    public String apisApiIdGetGetLastUpdatedTime(String apiId,String accept,String ifNoneMatch,String ifModifiedSince,String xWSO2Tenant)
+    {
+        return delegate.apisApiIdGetGetLastUpdatedTime(apiId,accept,ifNoneMatch,ifModifiedSince,xWSO2Tenant);
     }
     @GET
     @Path("/{apiId}/swagger")
@@ -144,6 +153,11 @@ public class ApisApi  {
     {
     return delegate.apisApiIdSwaggerGet(apiId,accept,ifNoneMatch,ifModifiedSince,xWSO2Tenant);
     }
+
+    public String apisApiIdSwaggerGetGetLastUpdatedTime(String apiId,String accept,String ifNoneMatch,String ifModifiedSince,String xWSO2Tenant)
+    {
+        return delegate.apisApiIdSwaggerGetGetLastUpdatedTime(apiId,accept,ifNoneMatch,ifModifiedSince,xWSO2Tenant);
+    }
     @GET
     @Path("/{apiId}/thumbnail")
     @Consumes({ "application/json" })
@@ -165,6 +179,11 @@ public class ApisApi  {
     {
     return delegate.apisApiIdThumbnailGet(apiId,accept,ifNoneMatch,ifModifiedSince);
     }
+
+    public String apisApiIdThumbnailGetGetLastUpdatedTime(String apiId,String accept,String ifNoneMatch,String ifModifiedSince)
+    {
+        return delegate.apisApiIdThumbnailGetGetLastUpdatedTime(apiId,accept,ifNoneMatch,ifModifiedSince);
+    }
     @POST
     @Path("/generate-sdk/")
     @Consumes({ "application/json" })
@@ -184,6 +203,11 @@ public class ApisApi  {
     @ApiParam(value = "For cross-tenant invocations, this is used to specify the tenant domain, where the resource need to be\n  retirieved from.\n"  )@HeaderParam("X-WSO2-Tenant") String xWSO2Tenant)
     {
     return delegate.apisGenerateSdkPost(apiId,language,xWSO2Tenant);
+    }
+
+    public String apisGenerateSdkPostGetLastUpdatedTime(String apiId,String language,String xWSO2Tenant)
+    {
+        return delegate.apisGenerateSdkPostGetLastUpdatedTime(apiId,language,xWSO2Tenant);
     }
     @GET
     
@@ -205,6 +229,11 @@ public class ApisApi  {
     @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resourec.\n"  )@HeaderParam("If-None-Match") String ifNoneMatch)
     {
     return delegate.apisGet(limit,offset,xWSO2Tenant,query,accept,ifNoneMatch);
+    }
+
+    public String apisGetGetLastUpdatedTime(Integer limit,Integer offset,String xWSO2Tenant,String query,String accept,String ifNoneMatch)
+    {
+        return delegate.apisGetGetLastUpdatedTime(limit,offset,xWSO2Tenant,query,accept,ifNoneMatch);
     }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApisApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApisApiService.java
@@ -1,19 +1,5 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-import org.wso2.carbon.apimgt.rest.api.store.*;
-import org.wso2.carbon.apimgt.rest.api.store.dto.*;
-
-import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.DocumentDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.DocumentListDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.APIDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.APIListDTO;
-
-import java.util.List;
-
-import java.io.InputStream;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
-
 import javax.ws.rs.core.Response;
 
 public abstract class ApisApiService {
@@ -25,5 +11,14 @@ public abstract class ApisApiService {
     public abstract Response apisApiIdThumbnailGet(String apiId,String accept,String ifNoneMatch,String ifModifiedSince);
     public abstract Response apisGenerateSdkPost(String apiId,String language,String xWSO2Tenant);
     public abstract Response apisGet(Integer limit,Integer offset,String xWSO2Tenant,String query,String accept,String ifNoneMatch);
+
+    public abstract String apisApiIdDocumentsDocumentIdContentGetGetLastUpdatedTime(String apiId,String documentId,String xWSO2Tenant,String accept,String ifNoneMatch,String ifModifiedSince);
+    public abstract String apisApiIdDocumentsDocumentIdGetGetLastUpdatedTime(String apiId,String documentId,String xWSO2Tenant,String accept,String ifNoneMatch,String ifModifiedSince);
+    public abstract String apisApiIdDocumentsGetGetLastUpdatedTime(String apiId,Integer limit,Integer offset,String xWSO2Tenant,String accept,String ifNoneMatch);
+    public abstract String apisApiIdGetGetLastUpdatedTime(String apiId,String accept,String ifNoneMatch,String ifModifiedSince,String xWSO2Tenant);
+    public abstract String apisApiIdSwaggerGetGetLastUpdatedTime(String apiId,String accept,String ifNoneMatch,String ifModifiedSince,String xWSO2Tenant);
+    public abstract String apisApiIdThumbnailGetGetLastUpdatedTime(String apiId,String accept,String ifNoneMatch,String ifModifiedSince);
+    public abstract String apisGenerateSdkPostGetLastUpdatedTime(String apiId,String language,String xWSO2Tenant);
+    public abstract String apisGetGetLastUpdatedTime(Integer limit,Integer offset,String xWSO2Tenant,String query,String accept,String ifNoneMatch);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApplicationsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApplicationsApi.java
@@ -1,25 +1,14 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-import org.wso2.carbon.apimgt.rest.api.store.dto.*;
-import org.wso2.carbon.apimgt.rest.api.store.ApplicationsApiService;
-import org.wso2.carbon.apimgt.rest.api.store.factories.ApplicationsApiServiceFactory;
-
 import io.swagger.annotations.ApiParam;
-
-import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorDTO;
 import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationDTO;
 import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationKeyDTO;
 import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationKeyGenerateRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationListDTO;
+import org.wso2.carbon.apimgt.rest.api.store.factories.ApplicationsApiServiceFactory;
 
-import java.util.List;
-
-import java.io.InputStream;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
-import org.apache.cxf.jaxrs.ext.multipart.Multipart;
-
-import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
 
 @Path("/applications")
 @Consumes({ "application/json" })
@@ -41,11 +30,16 @@ public class ApplicationsApi  {
         
         @io.swagger.annotations.ApiResponse(code = 412, message = "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met (Will be supported in future).\n") })
 
-    public Response applicationsApplicationIdDelete(@ApiParam(value = "**Application Identifier** consisting of the UUID of the Application.\n",required=true ) @PathParam("applicationId") String applicationId,
+    public Response applicationsApplicationIdDelete(@ApiParam(value = "Application Identifier consisting of the UUID of the Application.\n",required=true ) @PathParam("applicationId") String applicationId,
     @ApiParam(value = "Validator for conditional requests; based on ETag.\n"  )@HeaderParam("If-Match") String ifMatch,
     @ApiParam(value = "Validator for conditional requests; based on Last Modified header.\n"  )@HeaderParam("If-Unmodified-Since") String ifUnmodifiedSince)
     {
     return delegate.applicationsApplicationIdDelete(applicationId,ifMatch,ifUnmodifiedSince);
+    }
+
+    public String applicationsApplicationIdDeleteGetLastUpdatedTime(String applicationId,String ifMatch,String ifUnmodifiedSince)
+    {
+        return delegate.applicationsApplicationIdDeleteGetLastUpdatedTime(applicationId,ifMatch,ifUnmodifiedSince);
     }
     @GET
     @Path("/{applicationId}")
@@ -61,12 +55,17 @@ public class ApplicationsApi  {
         
         @io.swagger.annotations.ApiResponse(code = 406, message = "Not Acceptable.\nThe requested media type is not supported\n") })
 
-    public Response applicationsApplicationIdGet(@ApiParam(value = "**Application Identifier** consisting of the UUID of the Application.\n",required=true ) @PathParam("applicationId") String applicationId,
+    public Response applicationsApplicationIdGet(@ApiParam(value = "Application Identifier consisting of the UUID of the Application.\n",required=true ) @PathParam("applicationId") String applicationId,
     @ApiParam(value = "Media types acceptable for the response. Default is application/json.\n"  , defaultValue="application/json")@HeaderParam("Accept") String accept,
     @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resourec.\n"  )@HeaderParam("If-None-Match") String ifNoneMatch,
     @ApiParam(value = "Validator for conditional requests; based on Last Modified header of the\nformerly retrieved variant of the resource.\n"  )@HeaderParam("If-Modified-Since") String ifModifiedSince)
     {
     return delegate.applicationsApplicationIdGet(applicationId,accept,ifNoneMatch,ifModifiedSince);
+    }
+
+    public String applicationsApplicationIdGetGetLastUpdatedTime(String applicationId,String accept,String ifNoneMatch,String ifModifiedSince)
+    {
+        return delegate.applicationsApplicationIdGetGetLastUpdatedTime(applicationId,accept,ifNoneMatch,ifModifiedSince);
     }
     @PUT
     @Path("/{applicationId}")
@@ -82,13 +81,18 @@ public class ApplicationsApi  {
         
         @io.swagger.annotations.ApiResponse(code = 412, message = "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met (Will be supported in future).\n") })
 
-    public Response applicationsApplicationIdPut(@ApiParam(value = "**Application Identifier** consisting of the UUID of the Application.\n",required=true ) @PathParam("applicationId") String applicationId,
+    public Response applicationsApplicationIdPut(@ApiParam(value = "Application Identifier consisting of the UUID of the Application.\n",required=true ) @PathParam("applicationId") String applicationId,
     @ApiParam(value = "Application object that needs to be updated\n" ,required=true ) ApplicationDTO body,
     @ApiParam(value = "Media type of the entity in the body. Default is application/json.\n" ,required=true , defaultValue="application/json")@HeaderParam("Content-Type") String contentType,
     @ApiParam(value = "Validator for conditional requests; based on ETag.\n"  )@HeaderParam("If-Match") String ifMatch,
     @ApiParam(value = "Validator for conditional requests; based on Last Modified header.\n"  )@HeaderParam("If-Unmodified-Since") String ifUnmodifiedSince)
     {
     return delegate.applicationsApplicationIdPut(applicationId,body,contentType,ifMatch,ifUnmodifiedSince);
+    }
+
+    public String applicationsApplicationIdPutGetLastUpdatedTime(String applicationId,ApplicationDTO body,String contentType,String ifMatch,String ifUnmodifiedSince)
+    {
+        return delegate.applicationsApplicationIdPutGetLastUpdatedTime(applicationId,body,contentType,ifMatch,ifUnmodifiedSince);
     }
     @POST
     @Path("/generate-keys")
@@ -104,13 +108,18 @@ public class ApplicationsApi  {
         
         @io.swagger.annotations.ApiResponse(code = 412, message = "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met (Will be supported in future).\n") })
 
-    public Response applicationsGenerateKeysPost(@ApiParam(value = "**Application Identifier** consisting of the UUID of the Application.\n",required=true) @QueryParam("applicationId") String applicationId,
+    public Response applicationsGenerateKeysPost(@ApiParam(value = "Application Identifier consisting of the UUID of the Application.\n",required=true) @QueryParam("applicationId") String applicationId,
     @ApiParam(value = "Application object the keys of which are to be generated\n" ,required=true ) ApplicationKeyGenerateRequestDTO body,
     @ApiParam(value = "Media type of the entity in the body. Default is application/json.\n" ,required=true , defaultValue="application/json")@HeaderParam("Content-Type") String contentType,
     @ApiParam(value = "Validator for conditional requests; based on ETag.\n"  )@HeaderParam("If-Match") String ifMatch,
     @ApiParam(value = "Validator for conditional requests; based on Last Modified header.\n"  )@HeaderParam("If-Unmodified-Since") String ifUnmodifiedSince)
     {
     return delegate.applicationsGenerateKeysPost(applicationId,body,contentType,ifMatch,ifUnmodifiedSince);
+    }
+
+    public String applicationsGenerateKeysPostGetLastUpdatedTime(String applicationId,ApplicationKeyGenerateRequestDTO body,String contentType,String ifMatch,String ifUnmodifiedSince)
+    {
+        return delegate.applicationsGenerateKeysPostGetLastUpdatedTime(applicationId,body,contentType,ifMatch,ifUnmodifiedSince);
     }
     @GET
     
@@ -135,6 +144,11 @@ public class ApplicationsApi  {
     {
     return delegate.applicationsGet(groupId,query,limit,offset,accept,ifNoneMatch);
     }
+
+    public String applicationsGetGetLastUpdatedTime(String groupId,String query,Integer limit,Integer offset,String accept,String ifNoneMatch)
+    {
+        return delegate.applicationsGetGetLastUpdatedTime(groupId,query,limit,offset,accept,ifNoneMatch);
+    }
     @POST
     
     @Consumes({ "application/json" })
@@ -153,6 +167,11 @@ public class ApplicationsApi  {
     @ApiParam(value = "Media type of the entity in the body. Default is application/json.\n" ,required=true , defaultValue="application/json")@HeaderParam("Content-Type") String contentType)
     {
     return delegate.applicationsPost(body,contentType);
+    }
+
+    public String applicationsPostGetLastUpdatedTime(ApplicationDTO body,String contentType)
+    {
+        return delegate.applicationsPostGetLastUpdatedTime(body,contentType);
     }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApplicationsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApplicationsApiService.java
@@ -1,18 +1,7 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-import org.wso2.carbon.apimgt.rest.api.store.*;
-import org.wso2.carbon.apimgt.rest.api.store.dto.*;
-
-import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorDTO;
 import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationKeyDTO;
 import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationKeyGenerateRequestDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationListDTO;
-
-import java.util.List;
-
-import java.io.InputStream;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 
 import javax.ws.rs.core.Response;
 
@@ -23,5 +12,12 @@ public abstract class ApplicationsApiService {
     public abstract Response applicationsGenerateKeysPost(String applicationId,ApplicationKeyGenerateRequestDTO body,String contentType,String ifMatch,String ifUnmodifiedSince);
     public abstract Response applicationsGet(String groupId,String query,Integer limit,Integer offset,String accept,String ifNoneMatch);
     public abstract Response applicationsPost(ApplicationDTO body,String contentType);
+
+    public abstract String applicationsApplicationIdDeleteGetLastUpdatedTime(String applicationId,String ifMatch,String ifUnmodifiedSince);
+    public abstract String applicationsApplicationIdGetGetLastUpdatedTime(String applicationId,String accept,String ifNoneMatch,String ifModifiedSince);
+    public abstract String applicationsApplicationIdPutGetLastUpdatedTime(String applicationId,ApplicationDTO body,String contentType,String ifMatch,String ifUnmodifiedSince);
+    public abstract String applicationsGenerateKeysPostGetLastUpdatedTime(String applicationId,ApplicationKeyGenerateRequestDTO body,String contentType,String ifMatch,String ifUnmodifiedSince);
+    public abstract String applicationsGetGetLastUpdatedTime(String groupId,String query,Integer limit,Integer offset,String accept,String ifNoneMatch);
+    public abstract String applicationsPostGetLastUpdatedTime(ApplicationDTO body,String contentType);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/SubscriptionsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/SubscriptionsApi.java
@@ -1,23 +1,12 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-import org.wso2.carbon.apimgt.rest.api.store.dto.*;
-import org.wso2.carbon.apimgt.rest.api.store.SubscriptionsApiService;
+import io.swagger.annotations.ApiParam;
+import org.wso2.carbon.apimgt.rest.api.store.dto.SubscriptionDTO;
+import org.wso2.carbon.apimgt.rest.api.store.dto.SubscriptionListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.factories.SubscriptionsApiServiceFactory;
 
-import io.swagger.annotations.ApiParam;
-
-import org.wso2.carbon.apimgt.rest.api.store.dto.SubscriptionListDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.SubscriptionDTO;
-
-import java.util.List;
-
-import java.io.InputStream;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
-import org.apache.cxf.jaxrs.ext.multipart.Multipart;
-
-import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
 
 @Path("/subscriptions")
 @Consumes({ "application/json" })
@@ -40,7 +29,7 @@ public class SubscriptionsApi  {
         @io.swagger.annotations.ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported\n") })
 
     public Response subscriptionsGet(@ApiParam(value = "**API ID** consisting of the **UUID** of the API.\nThe combination of the provider of the API, name of the API and the version is also accepted as a valid API I.\nShould be formatted as **provider-name-version**.\n",required=true) @QueryParam("apiId") String apiId,
-    @ApiParam(value = "**Application Identifier** consisting of the UUID of the Application.\n",required=true) @QueryParam("applicationId") String applicationId,
+    @ApiParam(value = "Application Identifier consisting of the UUID of the Application.\n",required=true) @QueryParam("applicationId") String applicationId,
     @ApiParam(value = "Application Group Id\n") @QueryParam("groupId") String groupId,
     @ApiParam(value = "Starting point within the complete list of items qualified.\n", defaultValue="0") @QueryParam("offset") Integer offset,
     @ApiParam(value = "Maximum size of resource array to return.\n", defaultValue="25") @QueryParam("limit") Integer limit,
@@ -48,6 +37,11 @@ public class SubscriptionsApi  {
     @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resourec.\n"  )@HeaderParam("If-None-Match") String ifNoneMatch)
     {
     return delegate.subscriptionsGet(apiId,applicationId,groupId,offset,limit,accept,ifNoneMatch);
+    }
+
+    public String subscriptionsGetGetLastUpdatedTime(String apiId,String applicationId,String groupId,Integer offset,Integer limit,String accept,String ifNoneMatch)
+    {
+        return delegate.subscriptionsGetGetLastUpdatedTime(apiId,applicationId,groupId,offset,limit,accept,ifNoneMatch);
     }
     @POST
     
@@ -65,6 +59,11 @@ public class SubscriptionsApi  {
     @ApiParam(value = "Media type of the entity in the body. Default is application/json.\n" ,required=true , defaultValue="application/json")@HeaderParam("Content-Type") String contentType)
     {
     return delegate.subscriptionsPost(body,contentType);
+    }
+
+    public String subscriptionsPostGetLastUpdatedTime(SubscriptionDTO body,String contentType)
+    {
+        return delegate.subscriptionsPostGetLastUpdatedTime(body,contentType);
     }
     @DELETE
     @Path("/{subscriptionId}")
@@ -84,6 +83,11 @@ public class SubscriptionsApi  {
     {
     return delegate.subscriptionsSubscriptionIdDelete(subscriptionId,ifMatch,ifUnmodifiedSince);
     }
+
+    public String subscriptionsSubscriptionIdDeleteGetLastUpdatedTime(String subscriptionId,String ifMatch,String ifUnmodifiedSince)
+    {
+        return delegate.subscriptionsSubscriptionIdDeleteGetLastUpdatedTime(subscriptionId,ifMatch,ifUnmodifiedSince);
+    }
     @GET
     @Path("/{subscriptionId}")
     @Consumes({ "application/json" })
@@ -102,6 +106,11 @@ public class SubscriptionsApi  {
     @ApiParam(value = "Validator for conditional requests; based on Last Modified header of the\nformerly retrieved variant of the resource.\n"  )@HeaderParam("If-Modified-Since") String ifModifiedSince)
     {
     return delegate.subscriptionsSubscriptionIdGet(subscriptionId,accept,ifNoneMatch,ifModifiedSince);
+    }
+
+    public String subscriptionsSubscriptionIdGetGetLastUpdatedTime(String subscriptionId,String accept,String ifNoneMatch,String ifModifiedSince)
+    {
+        return delegate.subscriptionsSubscriptionIdGetGetLastUpdatedTime(subscriptionId,accept,ifNoneMatch,ifModifiedSince);
     }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/SubscriptionsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/SubscriptionsApiService.java
@@ -1,16 +1,6 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-import org.wso2.carbon.apimgt.rest.api.store.*;
-import org.wso2.carbon.apimgt.rest.api.store.dto.*;
-
-import org.wso2.carbon.apimgt.rest.api.store.dto.SubscriptionListDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorDTO;
 import org.wso2.carbon.apimgt.rest.api.store.dto.SubscriptionDTO;
-
-import java.util.List;
-
-import java.io.InputStream;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 
 import javax.ws.rs.core.Response;
 
@@ -19,5 +9,10 @@ public abstract class SubscriptionsApiService {
     public abstract Response subscriptionsPost(SubscriptionDTO body,String contentType);
     public abstract Response subscriptionsSubscriptionIdDelete(String subscriptionId,String ifMatch,String ifUnmodifiedSince);
     public abstract Response subscriptionsSubscriptionIdGet(String subscriptionId,String accept,String ifNoneMatch,String ifModifiedSince);
+
+    public abstract String subscriptionsGetGetLastUpdatedTime(String apiId,String applicationId,String groupId,Integer offset,Integer limit,String accept,String ifNoneMatch);
+    public abstract String subscriptionsPostGetLastUpdatedTime(SubscriptionDTO body,String contentType);
+    public abstract String subscriptionsSubscriptionIdDeleteGetLastUpdatedTime(String subscriptionId,String ifMatch,String ifUnmodifiedSince);
+    public abstract String subscriptionsSubscriptionIdGetGetLastUpdatedTime(String subscriptionId,String accept,String ifNoneMatch,String ifModifiedSince);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/TagsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/TagsApi.java
@@ -1,22 +1,11 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-import org.wso2.carbon.apimgt.rest.api.store.dto.*;
-import org.wso2.carbon.apimgt.rest.api.store.TagsApiService;
+import io.swagger.annotations.ApiParam;
+import org.wso2.carbon.apimgt.rest.api.store.dto.TagListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.factories.TagsApiServiceFactory;
 
-import io.swagger.annotations.ApiParam;
-
-import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.TagListDTO;
-
-import java.util.List;
-
-import java.io.InputStream;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
-import org.apache.cxf.jaxrs.ext.multipart.Multipart;
-
-import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
 
 @Path("/tags")
 @Consumes({ "application/json" })
@@ -47,6 +36,11 @@ public class TagsApi  {
     @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resourec.\n"  )@HeaderParam("If-None-Match") String ifNoneMatch)
     {
     return delegate.tagsGet(limit,offset,xWSO2Tenant,accept,ifNoneMatch);
+    }
+
+    public String tagsGetGetLastUpdatedTime(Integer limit,Integer offset,String xWSO2Tenant,String accept,String ifNoneMatch)
+    {
+        return delegate.tagsGetGetLastUpdatedTime(limit,offset,xWSO2Tenant,accept,ifNoneMatch);
     }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/TagsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/TagsApiService.java
@@ -1,19 +1,10 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-import org.wso2.carbon.apimgt.rest.api.store.*;
-import org.wso2.carbon.apimgt.rest.api.store.dto.*;
-
-import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.TagListDTO;
-
-import java.util.List;
-
-import java.io.InputStream;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
-
 import javax.ws.rs.core.Response;
 
 public abstract class TagsApiService {
     public abstract Response tagsGet(Integer limit,Integer offset,String xWSO2Tenant,String accept,String ifNoneMatch);
+
+    public abstract String tagsGetGetLastUpdatedTime(Integer limit,Integer offset,String xWSO2Tenant,String accept,String ifNoneMatch);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/TiersApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/TiersApi.java
@@ -1,23 +1,12 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-import org.wso2.carbon.apimgt.rest.api.store.dto.*;
-import org.wso2.carbon.apimgt.rest.api.store.TiersApiService;
+import io.swagger.annotations.ApiParam;
+import org.wso2.carbon.apimgt.rest.api.store.dto.TierDTO;
+import org.wso2.carbon.apimgt.rest.api.store.dto.TierListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.factories.TiersApiServiceFactory;
 
-import io.swagger.annotations.ApiParam;
-
-import org.wso2.carbon.apimgt.rest.api.store.dto.TierListDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.TierDTO;
-
-import java.util.List;
-
-import java.io.InputStream;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
-import org.apache.cxf.jaxrs.ext.multipart.Multipart;
-
-import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
 
 @Path("/tiers")
 @Consumes({ "application/json" })
@@ -48,6 +37,11 @@ public class TiersApi  {
     {
     return delegate.tiersTierLevelGet(tierLevel,limit,offset,xWSO2Tenant,accept,ifNoneMatch);
     }
+
+    public String tiersTierLevelGetGetLastUpdatedTime(String tierLevel,Integer limit,Integer offset,String xWSO2Tenant,String accept,String ifNoneMatch)
+    {
+        return delegate.tiersTierLevelGetGetLastUpdatedTime(tierLevel,limit,offset,xWSO2Tenant,accept,ifNoneMatch);
+    }
     @GET
     @Path("/{tierLevel}/{tierName}")
     @Consumes({ "application/json" })
@@ -70,6 +64,11 @@ public class TiersApi  {
     @ApiParam(value = "Validator for conditional requests; based on Last Modified header of the\nformerly retrieved variant of the resource.\n"  )@HeaderParam("If-Modified-Since") String ifModifiedSince)
     {
     return delegate.tiersTierLevelTierNameGet(tierName,tierLevel,xWSO2Tenant,accept,ifNoneMatch,ifModifiedSince);
+    }
+
+    public String tiersTierLevelTierNameGetGetLastUpdatedTime(String tierName,String tierLevel,String xWSO2Tenant,String accept,String ifNoneMatch,String ifModifiedSince)
+    {
+        return delegate.tiersTierLevelTierNameGetGetLastUpdatedTime(tierName,tierLevel,xWSO2Tenant,accept,ifNoneMatch,ifModifiedSince);
     }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/TiersApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/TiersApiService.java
@@ -1,21 +1,12 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-import org.wso2.carbon.apimgt.rest.api.store.*;
-import org.wso2.carbon.apimgt.rest.api.store.dto.*;
-
-import org.wso2.carbon.apimgt.rest.api.store.dto.TierListDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.TierDTO;
-
-import java.util.List;
-
-import java.io.InputStream;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
-
 import javax.ws.rs.core.Response;
 
 public abstract class TiersApiService {
     public abstract Response tiersTierLevelGet(String tierLevel,Integer limit,Integer offset,String xWSO2Tenant,String accept,String ifNoneMatch);
     public abstract Response tiersTierLevelTierNameGet(String tierName,String tierLevel,String xWSO2Tenant,String accept,String ifNoneMatch,String ifModifiedSince);
+
+    public abstract String tiersTierLevelGetGetLastUpdatedTime(String tierLevel,Integer limit,Integer offset,String xWSO2Tenant,String accept,String ifNoneMatch);
+    public abstract String tiersTierLevelTierNameGetGetLastUpdatedTime(String tierName,String tierLevel,String xWSO2Tenant,String accept,String ifNoneMatch,String ifModifiedSince);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIBusinessInformationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIBusinessInformationDTO.java
@@ -3,7 +3,6 @@ package org.wso2.carbon.apimgt.rest.api.store.dto;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -26,7 +25,34 @@ public class APIBusinessInformationDTO  {
   
   private String businessOwner = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for APIBusinessInformationDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a APIBusinessInformationDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -38,8 +64,7 @@ public class APIBusinessInformationDTO  {
     this.businessOwnerEmail = businessOwnerEmail;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("technicalOwnerEmail")
@@ -50,8 +75,7 @@ public class APIBusinessInformationDTO  {
     this.technicalOwnerEmail = technicalOwnerEmail;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("technicalOwner")
@@ -62,8 +86,7 @@ public class APIBusinessInformationDTO  {
     this.technicalOwner = technicalOwner;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("businessOwner")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIDTO.java
@@ -1,14 +1,13 @@
 package org.wso2.carbon.apimgt.rest.api.store.dto;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.wso2.carbon.apimgt.rest.api.store.dto.APIBusinessInformationDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.APIEndpointURLsDTO;
-
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 
 
 
@@ -66,7 +65,34 @@ public class APIDTO  {
   
   private APIBusinessInformationDTO businessInformation = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for APIDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a APIDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    * UUID of the api registry artifact\n
    **/
@@ -79,8 +105,7 @@ public class APIDTO  {
     this.id = id;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
@@ -91,8 +116,7 @@ public class APIDTO  {
     this.name = name;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("description")
@@ -103,8 +127,7 @@ public class APIDTO  {
     this.description = description;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("context")
@@ -115,8 +138,7 @@ public class APIDTO  {
     this.context = context;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("version")
@@ -127,8 +149,7 @@ public class APIDTO  {
     this.version = version;
   }
 
-  
-  /**
+    /**
    * If the provider value is not given user invoking the api will be used as the provider.\n
    **/
   @ApiModelProperty(required = true, value = "If the provider value is not given user invoking the api will be used as the provider.\n")
@@ -140,8 +161,7 @@ public class APIDTO  {
     this.provider = provider;
   }
 
-  
-  /**
+    /**
    * Swagger definition of the API which contains details about URI templates and scopes\n
    **/
   @ApiModelProperty(required = true, value = "Swagger definition of the API which contains details about URI templates and scopes\n")
@@ -153,8 +173,7 @@ public class APIDTO  {
     this.apiDefinition = apiDefinition;
   }
 
-  
-  /**
+    /**
    * WSDL URL if the API is based on a WSDL endpoint\n
    **/
   @ApiModelProperty(value = "WSDL URL if the API is based on a WSDL endpoint\n")
@@ -166,8 +185,7 @@ public class APIDTO  {
     this.wsdlUri = wsdlUri;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("status")
@@ -178,8 +196,7 @@ public class APIDTO  {
     this.status = status;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("isDefaultVersion")
@@ -190,8 +207,7 @@ public class APIDTO  {
     this.isDefaultVersion = isDefaultVersion;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("transport")
@@ -202,8 +218,7 @@ public class APIDTO  {
     this.transport = transport;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("tags")
@@ -214,8 +229,7 @@ public class APIDTO  {
     this.tags = tags;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("tiers")
@@ -226,8 +240,7 @@ public class APIDTO  {
     this.tiers = tiers;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("thumbnailUrl")
@@ -238,8 +251,7 @@ public class APIDTO  {
     this.thumbnailUrl = thumbnailUrl;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("endpointURLs")
@@ -250,8 +262,7 @@ public class APIDTO  {
     this.endpointURLs = endpointURLs;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("businessInformation")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIEndpointURLsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIEndpointURLsDTO.java
@@ -4,7 +4,6 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.APIEnvironmentURLsDTO;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -24,7 +23,34 @@ public class APIEndpointURLsDTO  {
   
   private String environmentType = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for APIEndpointURLsDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a APIEndpointURLsDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -36,8 +62,7 @@ public class APIEndpointURLsDTO  {
     this.environmentURLs = environmentURLs;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("environmentName")
@@ -48,8 +73,7 @@ public class APIEndpointURLsDTO  {
     this.environmentName = environmentName;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("environmentType")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIEnvironmentURLsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIEnvironmentURLsDTO.java
@@ -3,7 +3,6 @@ package org.wso2.carbon.apimgt.rest.api.store.dto;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -20,7 +19,34 @@ public class APIEnvironmentURLsDTO  {
   
   private String http = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for APIEnvironmentURLsDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a APIEnvironmentURLsDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    * HTTPS environment URL
    **/
@@ -33,8 +59,7 @@ public class APIEnvironmentURLsDTO  {
     this.https = https;
   }
 
-  
-  /**
+    /**
    * HTTP environment URL
    **/
   @ApiModelProperty(value = "HTTP environment URL")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIInfoDTO.java
@@ -3,7 +3,6 @@ package org.wso2.carbon.apimgt.rest.api.store.dto;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -35,7 +34,34 @@ public class APIInfoDTO  {
   
   private String status = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for APIInfoDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a APIInfoDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -47,8 +73,7 @@ public class APIInfoDTO  {
     this.id = id;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("name")
@@ -59,8 +84,7 @@ public class APIInfoDTO  {
     this.name = name;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("description")
@@ -71,8 +95,7 @@ public class APIInfoDTO  {
     this.description = description;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("context")
@@ -83,8 +106,7 @@ public class APIInfoDTO  {
     this.context = context;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("version")
@@ -95,8 +117,7 @@ public class APIInfoDTO  {
     this.version = version;
   }
 
-  
-  /**
+    /**
    * If the provider value is not given, the user invoking the API will be used as the provider.\n
    **/
   @ApiModelProperty(value = "If the provider value is not given, the user invoking the API will be used as the provider.\n")
@@ -108,8 +129,7 @@ public class APIInfoDTO  {
     this.provider = provider;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("status")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIListDTO.java
@@ -6,7 +6,6 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.APIInfoDTO;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -29,7 +28,34 @@ public class APIListDTO  {
   
   private List<APIInfoDTO> list = new ArrayList<APIInfoDTO>();
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for APIListDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a APIListDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    * Number of APIs returned.\n
    **/
@@ -42,8 +68,7 @@ public class APIListDTO  {
     this.count = count;
   }
 
-  
-  /**
+    /**
    * Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n
    **/
   @ApiModelProperty(value = "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n")
@@ -55,8 +80,7 @@ public class APIListDTO  {
     this.next = next;
   }
 
-  
-  /**
+    /**
    * Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n
    **/
   @ApiModelProperty(value = "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n")
@@ -68,8 +92,7 @@ public class APIListDTO  {
     this.previous = previous;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("list")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationDTO.java
@@ -6,7 +6,6 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationKeyDTO;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -44,7 +43,34 @@ public class ApplicationDTO  {
   
   private List<ApplicationKeyDTO> keys = new ArrayList<ApplicationKeyDTO>();
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for ApplicationDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a ApplicationDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -56,8 +82,7 @@ public class ApplicationDTO  {
     this.applicationId = applicationId;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
@@ -68,8 +93,7 @@ public class ApplicationDTO  {
     this.name = name;
   }
 
-  
-  /**
+    /**
    * If subscriber is not given user invoking the API will be taken as the subscriber.\n
    **/
   @ApiModelProperty(value = "If subscriber is not given user invoking the API will be taken as the subscriber.\n")
@@ -81,8 +105,7 @@ public class ApplicationDTO  {
     this.subscriber = subscriber;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("throttlingTier")
@@ -93,8 +116,7 @@ public class ApplicationDTO  {
     this.throttlingTier = throttlingTier;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("callbackUrl")
@@ -105,8 +127,7 @@ public class ApplicationDTO  {
     this.callbackUrl = callbackUrl;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("description")
@@ -117,8 +138,7 @@ public class ApplicationDTO  {
     this.description = description;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("status")
@@ -129,8 +149,7 @@ public class ApplicationDTO  {
     this.status = status;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("groupId")
@@ -141,8 +160,7 @@ public class ApplicationDTO  {
     this.groupId = groupId;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("keys")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationInfoDTO.java
@@ -3,7 +3,6 @@ package org.wso2.carbon.apimgt.rest.api.store.dto;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -35,7 +34,34 @@ public class ApplicationInfoDTO  {
   
   private String groupId = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for ApplicationInfoDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a ApplicationInfoDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -47,8 +73,7 @@ public class ApplicationInfoDTO  {
     this.applicationId = applicationId;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("name")
@@ -59,8 +84,7 @@ public class ApplicationInfoDTO  {
     this.name = name;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("subscriber")
@@ -71,8 +95,7 @@ public class ApplicationInfoDTO  {
     this.subscriber = subscriber;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("throttlingTier")
@@ -83,8 +106,7 @@ public class ApplicationInfoDTO  {
     this.throttlingTier = throttlingTier;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("description")
@@ -95,8 +117,7 @@ public class ApplicationInfoDTO  {
     this.description = description;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("status")
@@ -107,8 +128,7 @@ public class ApplicationInfoDTO  {
     this.status = status;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("groupId")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationKeyDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationKeyDTO.java
@@ -6,7 +6,6 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.TokenDTO;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -38,7 +37,34 @@ public class ApplicationKeyDTO  {
   
   private TokenDTO token = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for ApplicationKeyDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a ApplicationKeyDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    * Consumer key of the application
    **/
@@ -51,8 +77,7 @@ public class ApplicationKeyDTO  {
     this.consumerKey = consumerKey;
   }
 
-  
-  /**
+    /**
    * Consumer secret of the application
    **/
   @ApiModelProperty(value = "Consumer secret of the application")
@@ -64,8 +89,7 @@ public class ApplicationKeyDTO  {
     this.consumerSecret = consumerSecret;
   }
 
-  
-  /**
+    /**
    * Supported grant types for the application
    **/
   @ApiModelProperty(value = "Supported grant types for the application")
@@ -77,8 +101,7 @@ public class ApplicationKeyDTO  {
     this.supportedGrantTypes = supportedGrantTypes;
   }
 
-  
-  /**
+    /**
    * State of the key generation of the application
    **/
   @ApiModelProperty(value = "State of the key generation of the application")
@@ -90,8 +113,7 @@ public class ApplicationKeyDTO  {
     this.keyState = keyState;
   }
 
-  
-  /**
+    /**
    * Key type
    **/
   @ApiModelProperty(value = "Key type")
@@ -103,8 +125,7 @@ public class ApplicationKeyDTO  {
     this.keyType = keyType;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("token")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationKeyGenerateRequestDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationKeyGenerateRequestDTO.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -34,7 +33,34 @@ public class ApplicationKeyGenerateRequestDTO  {
   
   private List<String> scopes = new ArrayList<String>();
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for ApplicationKeyGenerateRequestDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a ApplicationKeyGenerateRequestDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    **/
   @ApiModelProperty(required = true, value = "")
@@ -46,8 +72,7 @@ public class ApplicationKeyGenerateRequestDTO  {
     this.keyType = keyType;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("validityTime")
@@ -58,8 +83,7 @@ public class ApplicationKeyGenerateRequestDTO  {
     this.validityTime = validityTime;
   }
 
-  
-  /**
+    /**
    * Callback URL
    **/
   @ApiModelProperty(value = "Callback URL")
@@ -71,8 +95,7 @@ public class ApplicationKeyGenerateRequestDTO  {
     this.callbackUrl = callbackUrl;
   }
 
-  
-  /**
+    /**
    * Allowed domains for the access token
    **/
   @ApiModelProperty(required = true, value = "Allowed domains for the access token")
@@ -84,8 +107,7 @@ public class ApplicationKeyGenerateRequestDTO  {
     this.accessAllowDomains = accessAllowDomains;
   }
 
-  
-  /**
+    /**
    * Allowed scopes for the access token
    **/
   @ApiModelProperty(value = "Allowed scopes for the access token")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationListDTO.java
@@ -6,7 +6,6 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationInfoDTO;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -29,7 +28,34 @@ public class ApplicationListDTO  {
   
   private List<ApplicationInfoDTO> list = new ArrayList<ApplicationInfoDTO>();
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for ApplicationListDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a ApplicationListDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    * Number of applications returned.\n
    **/
@@ -42,8 +68,7 @@ public class ApplicationListDTO  {
     this.count = count;
   }
 
-  
-  /**
+    /**
    * Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n
    **/
   @ApiModelProperty(value = "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n")
@@ -55,8 +80,7 @@ public class ApplicationListDTO  {
     this.next = next;
   }
 
-  
-  /**
+    /**
    * Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n
    **/
   @ApiModelProperty(value = "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n")
@@ -68,8 +92,7 @@ public class ApplicationListDTO  {
     this.previous = previous;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("list")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/DocumentDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/DocumentDTO.java
@@ -3,7 +3,6 @@ package org.wso2.carbon.apimgt.rest.api.store.dto;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -41,7 +40,34 @@ public class DocumentDTO  {
   
   private String otherTypeName = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for DocumentDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a DocumentDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -53,8 +79,7 @@ public class DocumentDTO  {
     this.documentId = documentId;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
@@ -65,8 +90,7 @@ public class DocumentDTO  {
     this.name = name;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("type")
@@ -77,8 +101,7 @@ public class DocumentDTO  {
     this.type = type;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("summary")
@@ -89,8 +112,7 @@ public class DocumentDTO  {
     this.summary = summary;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("sourceType")
@@ -101,8 +123,7 @@ public class DocumentDTO  {
     this.sourceType = sourceType;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("sourceUrl")
@@ -113,8 +134,7 @@ public class DocumentDTO  {
     this.sourceUrl = sourceUrl;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("otherTypeName")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/DocumentListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/DocumentListDTO.java
@@ -6,7 +6,6 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.DocumentDTO;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -29,7 +28,34 @@ public class DocumentListDTO  {
   
   private List<DocumentDTO> list = new ArrayList<DocumentDTO>();
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for DocumentListDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a DocumentListDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    * Number of Documents returned.\n
    **/
@@ -42,8 +68,7 @@ public class DocumentListDTO  {
     this.count = count;
   }
 
-  
-  /**
+    /**
    * Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n
    **/
   @ApiModelProperty(value = "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n")
@@ -55,8 +80,7 @@ public class DocumentListDTO  {
     this.next = next;
   }
 
-  
-  /**
+    /**
    * Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n
    **/
   @ApiModelProperty(value = "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n")
@@ -68,8 +92,7 @@ public class DocumentListDTO  {
     this.previous = previous;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("list")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ErrorDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ErrorDTO.java
@@ -6,7 +6,6 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorListItemDTO;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -32,7 +31,34 @@ public class ErrorDTO  {
   
   private List<ErrorListItemDTO> error = new ArrayList<ErrorListItemDTO>();
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for ErrorDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a ErrorDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    **/
   @ApiModelProperty(required = true, value = "")
@@ -44,8 +70,7 @@ public class ErrorDTO  {
     this.code = code;
   }
 
-  
-  /**
+    /**
    * Error message.
    **/
   @ApiModelProperty(required = true, value = "Error message.")
@@ -57,8 +82,7 @@ public class ErrorDTO  {
     this.message = message;
   }
 
-  
-  /**
+    /**
    * A detail description about the error message.\n
    **/
   @ApiModelProperty(value = "A detail description about the error message.\n")
@@ -70,8 +94,7 @@ public class ErrorDTO  {
     this.description = description;
   }
 
-  
-  /**
+    /**
    * Preferably an url with more details about the error.\n
    **/
   @ApiModelProperty(value = "Preferably an url with more details about the error.\n")
@@ -83,8 +106,7 @@ public class ErrorDTO  {
     this.moreInfo = moreInfo;
   }
 
-  
-  /**
+    /**
    * If there are more than one error list them out.\nFor example, list out validation errors by each field.\n
    **/
   @ApiModelProperty(value = "If there are more than one error list them out.\nFor example, list out validation errors by each field.\n")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ErrorListItemDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ErrorListItemDTO.java
@@ -3,7 +3,6 @@ package org.wso2.carbon.apimgt.rest.api.store.dto;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -20,7 +19,34 @@ public class ErrorListItemDTO  {
   @NotNull
   private String message = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for ErrorListItemDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a ErrorListItemDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    **/
   @ApiModelProperty(required = true, value = "")
@@ -32,8 +58,7 @@ public class ErrorListItemDTO  {
     this.code = code;
   }
 
-  
-  /**
+    /**
    * Description about Individual errors occurred\n
    **/
   @ApiModelProperty(required = true, value = "Description about Individual errors occurred\n")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/SubscriptionDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/SubscriptionDTO.java
@@ -3,7 +3,6 @@ package org.wso2.carbon.apimgt.rest.api.store.dto;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -32,7 +31,34 @@ public class SubscriptionDTO  {
   
   private StatusEnum status = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for SubscriptionDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a SubscriptionDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -44,8 +70,7 @@ public class SubscriptionDTO  {
     this.subscriptionId = subscriptionId;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("applicationId")
@@ -56,8 +81,7 @@ public class SubscriptionDTO  {
     this.applicationId = applicationId;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("apiIdentifier")
@@ -68,8 +92,7 @@ public class SubscriptionDTO  {
     this.apiIdentifier = apiIdentifier;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("tier")
@@ -80,8 +103,7 @@ public class SubscriptionDTO  {
     this.tier = tier;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("status")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/SubscriptionListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/SubscriptionListDTO.java
@@ -6,7 +6,6 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.SubscriptionDTO;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -29,7 +28,34 @@ public class SubscriptionListDTO  {
   
   private List<SubscriptionDTO> list = new ArrayList<SubscriptionDTO>();
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for SubscriptionListDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a SubscriptionListDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    * Number of Subscriptions returned.\n
    **/
@@ -42,8 +68,7 @@ public class SubscriptionListDTO  {
     this.count = count;
   }
 
-  
-  /**
+    /**
    * Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n
    **/
   @ApiModelProperty(value = "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n")
@@ -55,8 +80,7 @@ public class SubscriptionListDTO  {
     this.next = next;
   }
 
-  
-  /**
+    /**
    * Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n
    **/
   @ApiModelProperty(value = "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n")
@@ -68,8 +92,7 @@ public class SubscriptionListDTO  {
     this.previous = previous;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("list")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TagDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TagDTO.java
@@ -3,7 +3,6 @@ package org.wso2.carbon.apimgt.rest.api.store.dto;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -20,7 +19,34 @@ public class TagDTO  {
   @NotNull
   private Integer weight = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for TagDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a TagDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    **/
   @ApiModelProperty(required = true, value = "")
@@ -32,8 +58,7 @@ public class TagDTO  {
     this.name = name;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("weight")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TagListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TagListDTO.java
@@ -6,7 +6,6 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.TagDTO;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -29,7 +28,34 @@ public class TagListDTO  {
   
   private List<TagDTO> list = new ArrayList<TagDTO>();
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for TagListDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a TagListDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    * Number of Tags returned.\n
    **/
@@ -42,8 +68,7 @@ public class TagListDTO  {
     this.count = count;
   }
 
-  
-  /**
+    /**
    * Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n
    **/
   @ApiModelProperty(value = "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n")
@@ -55,8 +80,7 @@ public class TagListDTO  {
     this.next = next;
   }
 
-  
-  /**
+    /**
    * Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n
    **/
   @ApiModelProperty(value = "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n")
@@ -68,8 +92,7 @@ public class TagListDTO  {
     this.previous = previous;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("list")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TierDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TierDTO.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -47,7 +46,34 @@ public class TierDTO  {
   @NotNull
   private Boolean stopOnQuotaReach = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for TierDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a TierDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    **/
   @ApiModelProperty(required = true, value = "")
@@ -59,8 +85,7 @@ public class TierDTO  {
     this.name = name;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("description")
@@ -71,8 +96,7 @@ public class TierDTO  {
     this.description = description;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("tierLevel")
@@ -83,8 +107,7 @@ public class TierDTO  {
     this.tierLevel = tierLevel;
   }
 
-  
-  /**
+    /**
    * Custom attributes added to the tier policy\n
    **/
   @ApiModelProperty(value = "Custom attributes added to the tier policy\n")
@@ -96,8 +119,7 @@ public class TierDTO  {
     this.attributes = attributes;
   }
 
-  
-  /**
+    /**
    * Maximum number of requests which can be sent within a provided unit time\n
    **/
   @ApiModelProperty(required = true, value = "Maximum number of requests which can be sent within a provided unit time\n")
@@ -109,8 +131,7 @@ public class TierDTO  {
     this.requestCount = requestCount;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("unitTime")
@@ -121,8 +142,7 @@ public class TierDTO  {
     this.unitTime = unitTime;
   }
 
-  
-  /**
+    /**
    * This attribute declares whether this tier is available under commercial or free\n
    **/
   @ApiModelProperty(required = true, value = "This attribute declares whether this tier is available under commercial or free\n")
@@ -134,8 +154,7 @@ public class TierDTO  {
     this.tierPlan = tierPlan;
   }
 
-  
-  /**
+    /**
    * If this attribute is set to false, you are capabale of sending requests\neven if the request count exceeded within a unit time\n
    **/
   @ApiModelProperty(required = true, value = "If this attribute is set to false, you are capabale of sending requests\neven if the request count exceeded within a unit time\n")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TierListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TierListDTO.java
@@ -6,7 +6,6 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.TierDTO;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -29,7 +28,34 @@ public class TierListDTO  {
   
   private List<TierDTO> list = new ArrayList<TierDTO>();
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for TierListDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a TierListDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    * Number of Tiers returned.\n
    **/
@@ -42,8 +68,7 @@ public class TierListDTO  {
     this.count = count;
   }
 
-  
-  /**
+    /**
    * Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n
    **/
   @ApiModelProperty(value = "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n")
@@ -55,8 +80,7 @@ public class TierListDTO  {
     this.next = next;
   }
 
-  
-  /**
+    /**
    * Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n
    **/
   @ApiModelProperty(value = "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n")
@@ -68,8 +92,7 @@ public class TierListDTO  {
     this.previous = previous;
   }
 
-  
-  /**
+    /**
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("list")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TokenDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TokenDTO.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
-
 import javax.validation.constraints.NotNull;
 
 
@@ -25,7 +24,34 @@ public class TokenDTO  {
   
   private Long validityTime = null;
 
-  
+
+  private String lastUpdatedTime = null;
+
+  private String createdTime = null;
+
+  /**
+  * gets and sets the lastUpdatedTime for TokenDTO
+  **/
+  @JsonIgnore
+  public String getLastUpdatedTime(){
+    return lastUpdatedTime;
+  }
+  public void setLastUpdatedTime(String lastUpdatedTime){
+    this.lastUpdatedTime=lastUpdatedTime;
+  }
+
+  /**
+  * gets and sets the createdTime for a TokenDTO
+  **/
+
+  @JsonIgnore
+  public String getCreatedTime(){
+    return createdTime;
+  }
+  public void setCreatedTime(String createdTime){
+    this.createdTime=createdTime;
+  }
+
   /**
    * Access token
    **/
@@ -38,8 +64,7 @@ public class TokenDTO  {
     this.accessToken = accessToken;
   }
 
-  
-  /**
+    /**
    * Valid scopes for the access token
    **/
   @ApiModelProperty(value = "Valid scopes for the access token")
@@ -51,8 +76,7 @@ public class TokenDTO  {
     this.tokenScopes = tokenScopes;
   }
 
-  
-  /**
+    /**
    * Maximum validity time for the access token
    **/
   @ApiModelProperty(value = "Maximum validity time for the access token")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImpl.java
@@ -28,7 +28,6 @@ import org.wso2.carbon.apimgt.api.model.ResourceFile;
 import org.wso2.carbon.apimgt.impl.APIClientGenerationException;
 import org.wso2.carbon.apimgt.impl.APIClientGenerationManager;
 import org.wso2.carbon.apimgt.impl.APIConstants;
-import org.wso2.carbon.apimgt.impl.APIManagerFactory;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.store.ApisApiService;
 import org.wso2.carbon.apimgt.rest.api.store.dto.APIDTO;
@@ -36,9 +35,9 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.APIListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.dto.DocumentDTO;
 import org.wso2.carbon.apimgt.rest.api.store.dto.DocumentListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.utils.RestAPIStoreUtils;
+import org.wso2.carbon.apimgt.rest.api.store.utils.mappings.APIMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.store.utils.mappings.DocumentationMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
-import org.wso2.carbon.apimgt.rest.api.store.utils.mappings.APIMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.user.api.UserStoreException;
 
@@ -51,8 +50,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /** This is the service implementation class for Store API related operations 
  *
@@ -512,6 +509,46 @@ public class ApisApiServiceImpl extends ApisApiService {
             String errorMessage = "SDK generation failed. Unable to fetch location of the SDK.";
             RestApiUtil.handleInternalServerError(errorMessage, log);
         }
+        return null;
+    }
+
+    @Override
+    public String apisApiIdDocumentsDocumentIdContentGetGetLastUpdatedTime(String apiId, String documentId, String xWSO2Tenant, String accept, String ifNoneMatch, String ifModifiedSince) {
+        return null;
+    }
+
+    @Override
+    public String apisApiIdDocumentsDocumentIdGetGetLastUpdatedTime(String apiId, String documentId, String xWSO2Tenant, String accept, String ifNoneMatch, String ifModifiedSince) {
+        return null;
+    }
+
+    @Override
+    public String apisApiIdDocumentsGetGetLastUpdatedTime(String apiId, Integer limit, Integer offset, String xWSO2Tenant, String accept, String ifNoneMatch) {
+        return null;
+    }
+
+    @Override
+    public String apisApiIdGetGetLastUpdatedTime(String apiId, String accept, String ifNoneMatch, String ifModifiedSince, String xWSO2Tenant) {
+        return null;
+    }
+
+    @Override
+    public String apisApiIdSwaggerGetGetLastUpdatedTime(String apiId, String accept, String ifNoneMatch, String ifModifiedSince, String xWSO2Tenant) {
+        return null;
+    }
+
+    @Override
+    public String apisApiIdThumbnailGetGetLastUpdatedTime(String apiId, String accept, String ifNoneMatch, String ifModifiedSince) {
+        return null;
+    }
+
+    @Override
+    public String apisGenerateSdkPostGetLastUpdatedTime(String apiId, String language, String xWSO2Tenant) {
+        return null;
+    }
+
+    @Override
+    public String apisGetGetLastUpdatedTime(Integer limit, Integer offset, String xWSO2Tenant, String query, String accept, String ifNoneMatch) {
         return null;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImpl.java
@@ -51,14 +51,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/** This is the service implementation class for Store API related operations 
+/** This is the service implementation class for Store API related operations
  *
  */
 public class ApisApiServiceImpl extends ApisApiService {
 
     private static final Log log = LogFactory.getLog(ApisApiServiceImpl.class);
 
-    /** Retrieves APIs qualifying under given search condition 
+    /** Retrieves APIs qualifying under given search condition
      *
      * @param limit maximum number of APIs returns
      * @param offset starting index
@@ -105,7 +105,7 @@ public class ApisApiServiceImpl extends ApisApiService {
                 }
             }
 
-            if (searchType.equalsIgnoreCase(APIConstants.API_STATUS) && 
+            if (searchType.equalsIgnoreCase(APIConstants.API_STATUS) &&
                     searchContent.equalsIgnoreCase(APIConstants.PROTOTYPED)) {
                 apisMap = apiConsumer.getAllPaginatedAPIsByStatus(requestedTenantDomain, offset, limit,
                         APIConstants.PROTOTYPED, false);
@@ -200,7 +200,7 @@ public class ApisApiServiceImpl extends ApisApiService {
 
     /**
      *  Returns all the documents of the given API identifier that matches to the search condition
-     *  
+     *
      * @param apiId API identifier
      * @param limit max number of records returned
      * @param offset starting index
@@ -252,7 +252,7 @@ public class ApisApiServiceImpl extends ApisApiService {
 
     /**
      * Returns a specific document by identifier that is belong to the given API identifier
-     * 
+     *
      * @param apiId API identifier
      * @param documentId document identifier
      * @param xWSO2Tenant requested tenant domain for cross tenant invocations
@@ -371,7 +371,7 @@ public class ApisApiServiceImpl extends ApisApiService {
 
     /**
      * Retrieves the swagger document of an API
-     * 
+     *
      * @param apiId API identifier
      * @param accept Accept header value
      * @param ifNoneMatch If-None-Match header value
@@ -379,7 +379,7 @@ public class ApisApiServiceImpl extends ApisApiService {
      * @param xWSO2Tenant requested tenant domain for cross tenant invocations
      * @return Swagger document of the API
      */
-    @Override 
+    @Override
     public Response apisApiIdSwaggerGet(String apiId, String accept, String ifNoneMatch, String ifModifiedSince,
             String xWSO2Tenant) {
         String requestedTenantDomain = RestApiUtil.getRequestedTenantDomain(xWSO2Tenant);
@@ -512,41 +512,120 @@ public class ApisApiServiceImpl extends ApisApiService {
         return null;
     }
 
+    /**
+     * Retrieves the lastUpdatedTime for the content of a document
+     *
+     * @param apiId API identifier
+     * @param documentId document identifier
+     * @param xWSO2Tenant requested tenant domain for cross tenant invocations
+     * @param accept Accept header value
+     * @param ifNoneMatch If-None-Match header value
+     * @param ifModifiedSince If-Modified-Since header value
+     * @return Content of the document/ either inline/file or source url as a redirection
+     */
     @Override
     public String apisApiIdDocumentsDocumentIdContentGetGetLastUpdatedTime(String apiId, String documentId, String xWSO2Tenant, String accept, String ifNoneMatch, String ifModifiedSince) {
         return RestAPIStoreUtils.apisApiIdDocumentIdGetLastUpdated(documentId, xWSO2Tenant);
     }
 
+    /**
+     * Returns the lastUpdatedTime for  a specific document by identifier that is belong to the given API identifier
+     *
+     * @param apiId API identifier
+     * @param documentId document identifier
+     * @param xWSO2Tenant requested tenant domain for cross tenant invocations
+     * @param accept Accept header value
+     * @param ifNoneMatch If-None-Match header value
+     * @param ifModifiedSince If-Modified-Since header value
+     * @return returns the matched document
+     */
     @Override
     public String apisApiIdDocumentsDocumentIdGetGetLastUpdatedTime(String apiId, String documentId, String xWSO2Tenant, String accept, String ifNoneMatch, String ifModifiedSince) {
         return RestAPIStoreUtils.apisApiIdDocumentIdGetLastUpdated(documentId, xWSO2Tenant);
     }
 
+    /**
+     *
+     *
+     * @param apiId API identifier
+     * @param limit max number of records returned
+     * @param offset starting index
+     * @param xWSO2Tenant requested tenant domain for cross tenant invocations
+     * @param accept Accept header value
+     * @param ifNoneMatch If-None-Match header value
+     * @return matched documents as a list if DocumentDTOs
+     */
     @Override
     public String apisApiIdDocumentsGetGetLastUpdatedTime(String apiId, Integer limit, Integer offset, String xWSO2Tenant, String accept, String ifNoneMatch) {
         return null;
     }
 
+    /**
+     * Get lastUpdatedTime for a API with a given ID
+     *
+     * @param apiId  API ID
+     * @param accept accept header value
+     * @param ifNoneMatch If-None-Match header value
+     * @param ifModifiedSince If-Modified-Since header value
+     * @param xWSO2Tenant requested tenant domain for cross tenant invocations
+     * @return API of the given ID
+     */
     @Override
     public String apisApiIdGetGetLastUpdatedTime(String apiId, String accept, String ifNoneMatch, String ifModifiedSince, String xWSO2Tenant) {
         return RestAPIStoreUtils.apisApiIdGetLastUpdated(apiId, xWSO2Tenant);
     }
 
+    /**
+     * Retrieves lastUpdatedTime for the Swagger document of an API
+     *
+     * @param apiId API identifier
+     * @param accept Accept header value
+     * @param ifNoneMatch If-None-Match header value
+     * @param ifModifiedSince If-Modified-Since header value
+     * @param xWSO2Tenant requested tenant domain for cross tenant invocations
+     * @return Swagger document of the API
+     */
     @Override
     public String apisApiIdSwaggerGetGetLastUpdatedTime(String apiId, String accept, String ifNoneMatch, String ifModifiedSince, String xWSO2Tenant) {
         return RestAPIStoreUtils.apisApiIdSwaggerGetLastUpdated(xWSO2Tenant,apiId);
     }
 
+    /**
+     * Retrieves the thumbnail image lastUpdatedTime of an API specified by API identifier
+     *
+     * @param apiId API Id
+     * @param accept Accept header value
+     * @param ifNoneMatch If-None-Match header value
+     * @param ifModifiedSince If-Modified-Since header value
+     * @return Thumbnail image of the API
+     */
     @Override
     public String apisApiIdThumbnailGetGetLastUpdatedTime(String apiId, String accept, String ifNoneMatch, String ifModifiedSince) {
         return RestAPIStoreUtils.apisApiIdThumbnailGetLastUpdated(apiId);
     }
 
+    /**
+     *
+     * @param apiId       API Id
+     * @param language    SDK language
+     * @param xWSO2Tenant requested tenant domain for cross tenant invocations
+     * @return SDK for the requested API in a given language
+     */
     @Override
     public String apisGenerateSdkPostGetLastUpdatedTime(String apiId, String language, String xWSO2Tenant) {
         return null;
     }
 
+    /**
+     *
+     * @param limit maximum number of APIs returns
+     * @param offset starting index
+     * @param xWSO2Tenant requested tenant domain for cross tenant invocations
+     * @param query search condition
+     * @param accept Accept header value
+     * @param ifNoneMatch If-None-Match header value
+     * @return matched APIs for the given search condition
+     */
     @Override
     public String apisGetGetLastUpdatedTime(Integer limit, Integer offset, String xWSO2Tenant, String query, String accept, String ifNoneMatch) {
         return null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImpl.java
@@ -514,12 +514,12 @@ public class ApisApiServiceImpl extends ApisApiService {
 
     @Override
     public String apisApiIdDocumentsDocumentIdContentGetGetLastUpdatedTime(String apiId, String documentId, String xWSO2Tenant, String accept, String ifNoneMatch, String ifModifiedSince) {
-        return null;
+        return RestAPIStoreUtils.apisApiIdDocumentIdGetLastUpdated(documentId, xWSO2Tenant);
     }
 
     @Override
     public String apisApiIdDocumentsDocumentIdGetGetLastUpdatedTime(String apiId, String documentId, String xWSO2Tenant, String accept, String ifNoneMatch, String ifModifiedSince) {
-        return null;
+        return RestAPIStoreUtils.apisApiIdDocumentIdGetLastUpdated(documentId, xWSO2Tenant);
     }
 
     @Override
@@ -529,17 +529,17 @@ public class ApisApiServiceImpl extends ApisApiService {
 
     @Override
     public String apisApiIdGetGetLastUpdatedTime(String apiId, String accept, String ifNoneMatch, String ifModifiedSince, String xWSO2Tenant) {
-        return null;
+        return RestAPIStoreUtils.apisApiIdGetLastUpdated(apiId, xWSO2Tenant);
     }
 
     @Override
     public String apisApiIdSwaggerGetGetLastUpdatedTime(String apiId, String accept, String ifNoneMatch, String ifModifiedSince, String xWSO2Tenant) {
-        return null;
+        return RestAPIStoreUtils.apisApiIdSwaggerGetLastUpdated(xWSO2Tenant,apiId);
     }
 
     @Override
     public String apisApiIdThumbnailGetGetLastUpdatedTime(String apiId, String accept, String ifNoneMatch, String ifModifiedSince) {
-        return null;
+        return RestAPIStoreUtils.apisApiIdThumbnailGetLastUpdated(apiId);
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApplicationsApiServiceImpl.java
@@ -38,14 +38,14 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationKeyGenerateRequestDT
 import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.utils.RestAPIStoreUtils;
 import org.wso2.carbon.apimgt.rest.api.store.utils.mappings.ApplicationKeyMappingUtil;
-import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.store.utils.mappings.ApplicationMappingUtil;
+import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
+import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
-import javax.ws.rs.core.Response;
 
 /**
  * This is the service implementation class for Store application related operations
@@ -323,4 +323,35 @@ public class ApplicationsApiServiceImpl extends ApplicationsApiService {
         }
         return null;
     }
+
+    @Override
+    public String applicationsApplicationIdDeleteGetLastUpdatedTime(String applicationId, String ifMatch, String ifUnmodifiedSince) {
+        return RestAPIStoreUtils.getLastUpdatedTimeByApplicationId(applicationId);
+    }
+
+    @Override
+    public String applicationsApplicationIdGetGetLastUpdatedTime(String applicationId, String accept, String ifNoneMatch, String ifModifiedSince) {
+        return RestAPIStoreUtils.getLastUpdatedTimeByApplicationId(applicationId);
+    }
+
+    @Override
+    public String applicationsApplicationIdPutGetLastUpdatedTime(String applicationId, ApplicationDTO body, String contentType, String ifMatch, String ifUnmodifiedSince) {
+        return RestAPIStoreUtils.getLastUpdatedTimeByApplicationId(applicationId);
+    }
+
+    @Override
+    public String applicationsGenerateKeysPostGetLastUpdatedTime(String applicationId, ApplicationKeyGenerateRequestDTO body, String contentType, String ifMatch, String ifUnmodifiedSince) {
+        return null;
+    }
+
+    @Override
+    public String applicationsGetGetLastUpdatedTime(String groupId, String query, Integer limit, Integer offset, String accept, String ifNoneMatch) {
+        return null;
+    }
+
+    @Override
+    public String applicationsPostGetLastUpdatedTime(ApplicationDTO body, String contentType) {
+        return null;
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApplicationsApiServiceImpl.java
@@ -67,7 +67,7 @@ public class ApplicationsApiServiceImpl extends ApplicationsApiService {
      */
     @Override
     public Response applicationsGet(String groupId, String query, Integer limit, Integer offset, String accept,
-            String ifNoneMatch) {
+                                    String ifNoneMatch) {
         String username = RestApiUtil.getLoggedInUsername();
 
         // currently groupId is taken from the user so that groupId coming as a query parameter is not honored.
@@ -172,7 +172,7 @@ public class ApplicationsApiServiceImpl extends ApplicationsApiService {
     @Override
     @SuppressWarnings("unchecked")
     public Response applicationsGenerateKeysPost(String applicationId, ApplicationKeyGenerateRequestDTO body,
-            String contentType, String ifMatch, String ifUnmodifiedSince) {
+                                                 String contentType, String ifMatch, String ifUnmodifiedSince) {
 
         String username = RestApiUtil.getLoggedInUsername();
         try {
@@ -225,7 +225,7 @@ public class ApplicationsApiServiceImpl extends ApplicationsApiService {
      */
     @Override
     public Response applicationsApplicationIdGet(String applicationId, String accept, String ifNoneMatch,
-            String ifModifiedSince) {
+                                                 String ifModifiedSince) {
         String username = RestApiUtil.getLoggedInUsername();
         try {
             APIConsumer apiConsumer = APIManagerFactory.getInstance().getAPIConsumer(username);
@@ -258,7 +258,7 @@ public class ApplicationsApiServiceImpl extends ApplicationsApiService {
      */
     @Override
     public Response applicationsApplicationIdPut(String applicationId, ApplicationDTO body, String contentType,
-            String ifMatch, String ifUnmodifiedSince) {
+                                                 String ifMatch, String ifUnmodifiedSince) {
         String username = RestApiUtil.getLoggedInUsername();
         try {
             APIConsumer apiConsumer = APIManagerFactory.getInstance().getAPIConsumer(username);
@@ -303,7 +303,7 @@ public class ApplicationsApiServiceImpl extends ApplicationsApiService {
     @Override
     @SuppressWarnings("unchecked")
     public Response applicationsApplicationIdDelete(String applicationId, String ifMatch,
-            String ifUnmodifiedSince) {
+                                                    String ifUnmodifiedSince) {
         String username = RestApiUtil.getLoggedInUsername();
         try {
             APIConsumer apiConsumer = APIManagerFactory.getInstance().getAPIConsumer(username);
@@ -324,16 +324,42 @@ public class ApplicationsApiServiceImpl extends ApplicationsApiService {
         return null;
     }
 
+    /**
+     * get the lastUpdatedTime for an application DELETE
+     *
+     * @param applicationId
+     * @param ifMatch
+     * @param ifUnmodifiedSince
+     * @return
+     */
     @Override
     public String applicationsApplicationIdDeleteGetLastUpdatedTime(String applicationId, String ifMatch, String ifUnmodifiedSince) {
         return RestAPIStoreUtils.getLastUpdatedTimeByApplicationId(applicationId);
     }
 
+    /**
+     * get the lastUpdatedTime for an application
+     *
+     * @param applicationId
+     * @param accept
+     * @param ifNoneMatch
+     * @param ifModifiedSince
+     * @return
+     */
     @Override
     public String applicationsApplicationIdGetGetLastUpdatedTime(String applicationId, String accept, String ifNoneMatch, String ifModifiedSince) {
         return RestAPIStoreUtils.getLastUpdatedTimeByApplicationId(applicationId);
     }
 
+    /**
+     * get the lastUpdatedTime for an application PUT
+     * @param applicationId
+     * @param body
+     * @param contentType
+     * @param ifMatch
+     * @param ifUnmodifiedSince
+     * @return
+     */
     @Override
     public String applicationsApplicationIdPutGetLastUpdatedTime(String applicationId, ApplicationDTO body, String contentType, String ifMatch, String ifUnmodifiedSince) {
         return RestAPIStoreUtils.getLastUpdatedTimeByApplicationId(applicationId);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/SubscriptionsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/SubscriptionsApiServiceImpl.java
@@ -25,28 +25,20 @@ import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIMgtAuthorizationFailedException;
 import org.wso2.carbon.apimgt.api.SubscriptionAlreadyExistingException;
-import org.wso2.carbon.apimgt.api.model.APIIdentifier;
-import org.wso2.carbon.apimgt.api.model.Application;
-import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
-import org.wso2.carbon.apimgt.api.model.Subscriber;
-import org.wso2.carbon.apimgt.api.model.SubscriptionResponse;
+import org.wso2.carbon.apimgt.api.model.*;
 import org.wso2.carbon.apimgt.rest.api.store.SubscriptionsApiService;
 import org.wso2.carbon.apimgt.rest.api.store.dto.SubscriptionDTO;
 import org.wso2.carbon.apimgt.rest.api.store.dto.SubscriptionListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.utils.RestAPIStoreUtils;
-import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.store.utils.mappings.APIMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.store.utils.mappings.SubscriptionMappingUtil;
+import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
+import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
-import javax.ws.rs.core.Response;
+import java.util.*;
 
 /**
  * This is the service implementation class for Store subscription related operations
@@ -292,4 +284,25 @@ public class SubscriptionsApiServiceImpl extends SubscriptionsApiService {
         }
         return null;
     }
+
+    @Override
+    public String subscriptionsGetGetLastUpdatedTime(String apiId, String applicationId, String groupId, Integer offset, Integer limit, String accept, String ifNoneMatch) {
+        return null;
+    }
+
+    @Override
+    public String subscriptionsPostGetLastUpdatedTime(SubscriptionDTO body, String contentType) {
+        return null;
+    }
+
+    @Override
+    public String subscriptionsSubscriptionIdDeleteGetLastUpdatedTime(String subscriptionId, String ifMatch, String ifUnmodifiedSince) {
+        return RestAPIStoreUtils.getLastUpdatedTimeBySubscriptionId(subscriptionId);
+    }
+
+    @Override
+    public String subscriptionsSubscriptionIdGetGetLastUpdatedTime(String subscriptionId, String accept, String ifNoneMatch, String ifModifiedSince) {
+        return RestAPIStoreUtils.getLastUpdatedTimeBySubscriptionId(subscriptionId);
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/SubscriptionsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/SubscriptionsApiServiceImpl.java
@@ -285,21 +285,53 @@ public class SubscriptionsApiServiceImpl extends SubscriptionsApiService {
         return null;
     }
 
+    /**
+     * Gets the lastUpdated time for subscription collection
+     * @param apiId         api identifier
+     * @param applicationId application identifier
+     * @param groupId       group id
+     * @param offset        starting index of the subscription list
+     * @param limit         max num of subscriptions returned
+     * @param accept        Accept header value
+     * @param ifNoneMatch   If-None-Match header value
+     * @return LastUpdated time for the resource in UNIX time as a {@link String}
+     */
     @Override
     public String subscriptionsGetGetLastUpdatedTime(String apiId, String applicationId, String groupId, Integer offset, Integer limit, String accept, String ifNoneMatch) {
         return null;
     }
 
+    /**
+     * placeholder method
+     * @param body        new subscription details
+     * @param contentType Content-Type header
+     * @return LastUpdated time for the resource in UNIX time as a {@link String}
+     */
     @Override
     public String subscriptionsPostGetLastUpdatedTime(SubscriptionDTO body, String contentType) {
         return null;
     }
 
+    /**
+     * placeholder method
+     * @param subscriptionId    subscription identifier
+     * @param ifMatch           If-Match header value
+     * @param ifUnmodifiedSince If-Unmodified-Since header value
+     * @return LastUpdated time for the resource in UNIX time as a {@link String}
+     */
     @Override
     public String subscriptionsSubscriptionIdDeleteGetLastUpdatedTime(String subscriptionId, String ifMatch, String ifUnmodifiedSince) {
         return RestAPIStoreUtils.getLastUpdatedTimeBySubscriptionId(subscriptionId);
     }
 
+    /**
+     * Gets the lastUpdated time for subscription ID.
+     * @param subscriptionId    {@link SubscribedAPI} identifier
+     * @param accept            accept header value
+     * @param ifNoneMatch       If-None-Match header value
+     * @param ifModifiedSince   If-Modified-Since header value
+     * @return  LastUpdated time for the resource in UNIX time as a {@link String}
+     */
     @Override
     public String subscriptionsSubscriptionIdGetGetLastUpdatedTime(String subscriptionId, String accept, String ifNoneMatch, String ifModifiedSince) {
         return RestAPIStoreUtils.getLastUpdatedTimeBySubscriptionId(subscriptionId);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/TagsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/TagsApiServiceImpl.java
@@ -25,15 +25,15 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.Tag;
 import org.wso2.carbon.apimgt.rest.api.store.TagsApiService;
 import org.wso2.carbon.apimgt.rest.api.store.dto.TagListDTO;
-import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.store.utils.mappings.TagMappingUtil;
+import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.user.api.UserStoreException;
 
+import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import javax.ws.rs.core.Response;
 
 /** 
  * This is the service implementation class for Store tag related operations
@@ -79,6 +79,11 @@ public class TagsApiServiceImpl extends TagsApiService {
             String errorMessage = "Error while checking availability of tenant " + requestedTenantDomain;
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
         }
+        return null;
+    }
+
+    @Override
+    public String tagsGetGetLastUpdatedTime(Integer limit, Integer offset, String xWSO2Tenant, String accept, String ifNoneMatch) {
         return null;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/TiersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/TiersApiServiceImpl.java
@@ -167,4 +167,14 @@ public class TiersApiServiceImpl extends TiersApiService {
         return null;
     }
 
+    @Override
+    public String tiersTierLevelGetGetLastUpdatedTime(String tierLevel, Integer limit, Integer offset, String xWSO2Tenant, String accept, String ifNoneMatch) {
+        return null;
+    }
+
+    @Override
+    public String tiersTierLevelTierNameGetGetLastUpdatedTime(String tierName, String tierLevel, String xWSO2Tenant, String accept, String ifNoneMatch, String ifModifiedSince) {
+        return null;
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/utils/RestAPIStoreUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/utils/RestAPIStoreUtils.java
@@ -21,29 +21,18 @@ package org.wso2.carbon.apimgt.rest.api.store.utils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.json.simple.JSONObject;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIMgtAuthorizationFailedException;
-import org.wso2.carbon.apimgt.api.model.API;
-import org.wso2.carbon.apimgt.api.model.APIIdentifier;
-import org.wso2.carbon.apimgt.api.model.Application;
-import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
-import org.wso2.carbon.apimgt.api.model.Tier;
+import org.wso2.carbon.apimgt.api.model.*;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerFactory;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.store.utils.mappings.APIMappingUtil;
-import org.wso2.carbon.apimgt.rest.api.util.exception.InternalServerErrorException;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
-import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -262,5 +251,22 @@ public class RestAPIStoreUtils {
             apiSwagger = apiSwagger.replace(matcher.group(), "");
         }
         return apiSwagger;
+    }
+
+    public static String getLastUpdatedTimeByApplicationId(String applicationId){
+        String username = RestApiUtil.getLoggedInUsername();
+        APIConsumer apiConsumer;
+        try {
+            apiConsumer = APIManagerFactory.getInstance().getAPIConsumer(username);
+            Application application = apiConsumer.getApplicationByUUID(applicationId);
+            String lastUpdated = application.getLastUpdatedTime();
+            return lastUpdated != null ? lastUpdated : application.getCreatedTime();
+        } catch (APIManagementException e) {
+            if(log.isDebugEnabled()){
+                log.debug("Error while retrieving resource timestamps due to " + e.getMessage(),e);
+            }
+            RestApiUtil.handleInternalServerError("Error while getting application with id " + applicationId, e, log);
+        }
+        return null;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/utils/RestAPIStoreUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/utils/RestAPIStoreUtils.java
@@ -43,9 +43,9 @@ public class RestAPIStoreUtils {
 
     private static final Log log = LogFactory.getLog(RestAPIStoreUtils.class);
 
-    /** 
+    /**
      * check whether current logged in user has access to the specified application
-     * 
+     *
      * @param application Application object
      * @return true if current logged in consumer has access to the specified application
      */
@@ -105,10 +105,10 @@ public class RestAPIStoreUtils {
 
     /**
      * Check whether the specified API exists and the current logged in user has access to it.
-     * 
-     * When it tries to retrieve the resource from the registry, it will fail with AuthorizationFailedException if user 
+     *
+     * When it tries to retrieve the resource from the registry, it will fail with AuthorizationFailedException if user
      * does not have enough privileges. If the API does not exist, this will throw a APIMgtResourceNotFoundException
-     * 
+     *
      * @param apiId API identifier
      * @throws APIManagementException
      */
@@ -136,7 +136,7 @@ public class RestAPIStoreUtils {
     /**
      * Check whether the specified API exists and the current logged in user has access to it.
      *
-     * When it tries to retrieve the resource from the registry, it will fail with AuthorizationFailedException if user 
+     * When it tries to retrieve the resource from the registry, it will fail with AuthorizationFailedException if user
      * does not have enough privileges. If the API does not exist, this will throw a APIMgtResourceNotFoundException
      *
      * @param apiId API identifier
@@ -166,7 +166,7 @@ public class RestAPIStoreUtils {
 
     /**
      * Check if the specified subscription is allowed for the logged in user
-     * 
+     *
      * @param apiIdentifier API identifier
      * @param tier the subscribing tier of the API
      * @throws APIManagementException if the subscription allow check was failed. If the user is not allowed to add the
@@ -233,7 +233,7 @@ public class RestAPIStoreUtils {
 
     /**
      * Removes x-mediation-scripts from swagger as they should not be provided to store consumers
-     * 
+     *
      * @param apiSwagger swagger definition of API
      * @return swagger which exclude x-mediation-script elements
      */
@@ -253,7 +253,7 @@ public class RestAPIStoreUtils {
         return apiSwagger;
     }
 
-    public static String getLastUpdatedTimeByApplicationId(String applicationId){
+    public static String getLastUpdatedTimeByApplicationId(String applicationId) {
         String username = RestApiUtil.getLoggedInUsername();
         APIConsumer apiConsumer;
         try {
@@ -262,8 +262,8 @@ public class RestAPIStoreUtils {
             String lastUpdated = application.getLastUpdatedTime();
             return lastUpdated != null ? lastUpdated : application.getCreatedTime();
         } catch (APIManagementException e) {
-            if(log.isDebugEnabled()){
-                log.debug("Error while retrieving resource timestamps due to " + e.getMessage(),e);
+            if (log.isDebugEnabled()) {
+                log.debug("Error while retrieving resource timestamps due to " + e.getMessage(), e);
             }
             RestApiUtil.handleInternalServerError("Error while getting application with id " + applicationId, e, log);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/webapp/WEB-INF/beans.xml
@@ -20,7 +20,7 @@
         </jaxrs:serviceBeans>
         <jaxrs:providers>
 
-            <bean class="org.codehaus.jackson.jaxrs.JacksonJsonProvider"/>
+            <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.util.exception.GlobalThrowableMapper" />
         </jaxrs:providers>
         <jaxrs:properties>
@@ -33,12 +33,18 @@
     <bean id="AuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.auth.OAuthAuthenticationInterceptor" />
     <bean id="PostAuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.PostAuthenticationInterceptor" />
     <bean id="ValidationInInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.validation.ValidationInInterceptor"/>
+    <bean id="ETagInInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.eTag.ETagInInterceptor"/>
+    <bean id="ETagOutInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.eTag.ETagOutInterceptor"/>
     <cxf:bus>
         <cxf:inInterceptors>
             <ref bean="PreAuthenticationInterceptor"/>
             <ref bean="AuthenticationInterceptor"/>
             <ref bean="PostAuthenticationInterceptor"/>
             <ref bean="ValidationInInterceptor"/>
+            <ref bean="ETagInInterceptor"/>
         </cxf:inInterceptors>
+        <cxf:outInterceptors>
+            <ref bean="ETagOutInterceptor"/>
+        </cxf:outInterceptors>
     </cxf:bus>
 </beans>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
@@ -154,7 +154,7 @@ public final class RestApiConstants {
     public static final String SANDBOX_ENDPOINTS = "sandbox_endpoints";
 
 
-    public static final String GET_LAST_UPDATED = "GetLastUpdated";
+    public static final String GET_LAST_UPDATED = "GetLastUpdatedTime";
     public static final String GET = "GET";
     public static final String ETAG = "ETag";
     public static final String PUT = "PUT";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
@@ -152,4 +152,11 @@ public final class RestApiConstants {
     // common attributes
     public static final String PRODUCTION_ENDPOINTS = "production_endpoints";
     public static final String SANDBOX_ENDPOINTS = "sandbox_endpoints";
+
+
+    public static final String GET_LAST_UPDATED = "GetLastUpdated";
+    public static final String GET = "GET";
+    public static final String ETAG = "ETag";
+    public static final String PUT = "PUT";
+    public static final String DELETE = "DELETE";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/interceptors/eTag/ETagInInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/interceptors/eTag/ETagInInterceptor.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.rest.api.util.interceptors.eTag;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.cxf.helpers.CastUtils;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.jaxrs.model.OperationResourceInfo;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageContentsList;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
+import org.wso2.carbon.apimgt.rest.api.util.utils.ETagGenerator;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil.checkETagSkipList;
+
+public class ETagInInterceptor extends AbstractPhaseInterceptor<Message> {
+    private static final Log log = LogFactory.getLog(ETagInInterceptor.class);
+
+    public ETagInInterceptor() {
+        super(Phase.PRE_INVOKE);
+    }
+
+    @Override
+    public void handleMessage(Message message) throws Fault {
+
+        if (checkETagSkipList(message.get(Message.PATH_INFO).toString(),
+                message.get(Message.HTTP_REQUEST_METHOD).toString())) {
+            log.info("Skipping ETagInInterceptor for URI : " + message.get(Message.PATH_INFO).toString());
+            return;
+        }
+
+        OperationResourceInfo operationResource = message.getExchange().get(OperationResourceInfo.class);
+        Map<String, List<String>> headers = CastUtils.cast((Map) message.get(Message.PROTOCOL_HEADERS));
+        List<Object> arguments = MessageContentsList.getContentsList(message);
+        try {
+            Class aClass = Class.forName(operationResource.getMethodToInvoke().getDeclaringClass().getName());
+            Method aClassMethod = aClass.getMethod(operationResource.getMethodToInvoke().getName() +
+                    RestApiConstants.GET_LAST_UPDATED, operationResource.getMethodToInvoke().getParameterTypes());
+            Object o = aClass.newInstance();
+            String lastUpdatedTime = String.valueOf(aClassMethod.invoke(o, arguments.toArray()));
+            if (message.get(Message.HTTP_REQUEST_METHOD).equals(RestApiConstants.GET)) {
+                if (!Objects.equals(lastUpdatedTime, "null")) {
+                    String eTag = ETagGenerator.getETag(lastUpdatedTime);
+                    if (headers.containsKey(HttpHeaders.IF_NONE_MATCH)) {
+                        String headerValue = headers.get(HttpHeaders.IF_NONE_MATCH).get(0);
+                        if (Objects.equals(eTag, headerValue)) {
+                            Response response = Response.notModified(eTag).build();
+                            message.getExchange().put(Response.class, response);
+                            return;
+                        }
+                    }
+                    message.getExchange().put(RestApiConstants.ETAG, eTag);
+                }
+            }
+            /*
+            If the request method is a PUT or a DELETE and the If-Match header is given then the ETag value for the
+            resource and the header value will be compared and if they do not match then the flow will be terminated
+            with 412 PRECONDITION FAILED
+             */
+            if (((RestApiConstants.PUT.equals(message.get(Message.HTTP_REQUEST_METHOD))
+                    || RestApiConstants.DELETE.equals(message.get(Message.HTTP_REQUEST_METHOD))))
+                    && headers.containsKey(HttpHeaders.IF_MATCH)) {
+                String ifMatchHeaderValue;
+                ifMatchHeaderValue = String.valueOf(headers.get(HttpHeaders.IF_MATCH).get(0));
+                if (!Objects.equals(lastUpdatedTime, "null")) {
+                    String eTag = ETagGenerator.getETag(lastUpdatedTime);
+                    if (!Objects.equals(ifMatchHeaderValue, eTag)) {
+                        Response response = Response.status(Response.Status.PRECONDITION_FAILED).build();
+                        message.getExchange().put(Response.class, response);
+                    }
+                }
+            }
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException |
+                InvocationTargetException | InstantiationException e) {
+            if (log.isDebugEnabled()) {
+                log.debug(" Error while retrieving the ETag Resource timestamps due to " + e.getMessage(), e);
+            }
+        }
+
+    }
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/interceptors/eTag/ETagOutInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/interceptors/eTag/ETagOutInterceptor.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.rest.api.util.interceptors.eTag;
+
+import org.apache.axis2.context.MessageContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.jaxrs.impl.MetadataMap;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import static org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil.checkETagSkipList;
+
+public class ETagOutInterceptor extends AbstractPhaseInterceptor<Message> {
+    private static final Log log = LogFactory.getLog(ETagOutInterceptor.class);
+    private static final String ETAG = "ETag";
+
+    public ETagOutInterceptor() {
+        super(Phase.PRE_PROTOCOL);
+    }
+
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        if (checkETagSkipList(message.getExchange().getInMessage().get(Message.PATH_INFO).toString(),
+                message.getExchange().getInMessage().get(Message.HTTP_REQUEST_METHOD).toString())) {
+            log.info("Skipping ETagOutInterceptor for URI : " + message.getExchange().getInMessage().get(Message.PATH_INFO).toString());
+            return;
+
+        }
+        MultivaluedMap<String, Object> headers = (MetadataMap<String, Object>) message.get(Message.PROTOCOL_HEADERS);
+        if (headers == null) {
+            headers = new MetadataMap<>();
+        }
+        MessageContext currentMessageContext = MessageContext.getCurrentMessageContext();
+
+        if (message.getExchange().containsKey(ETAG)) {
+            String eTag = (String) message.getExchange().get(ETAG);
+            setOutBoundHeaders(message, headers, eTag);
+        }
+    }
+
+    private void setOutBoundHeaders(Message message, MultivaluedMap<String, Object> headers, String eTag) {
+        headers.add(ETAG, "\"" + eTag + "\"");
+        message.put(Message.PROTOCOL_HEADERS, headers);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/ETagGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/ETagGenerator.java
@@ -1,0 +1,89 @@
+package org.wso2.carbon.apimgt.rest.api.util.utils;
+/*
+*  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * This class generates ETag hash value for the given timestamp of the resource
+ * using MD5 as the default hashing algorithm.
+ */
+public class ETagGenerator {
+    private static final Log log = LogFactory.getLog(ETagGenerator.class);
+    /**
+     * This generates the ETag value using the given algorithm
+     * @param updatedTimeInMillis the updated/created time of the resource in UNIX time
+     * @return String
+     */
+    private static String getETag(long updatedTimeInMillis) {
+        String eTagValue=null;
+        try {
+            eTagValue= getHash(updatedTimeInMillis) ;
+        } catch (NoSuchAlgorithmException e) {
+            log.error("Failed to generate E-Tag due to " + e.getMessage(), e);
+        }
+        return eTagValue;
+    }
+
+
+    /**
+     * If some other hashing algorithm is needed use this method.
+     * @param updatedTimeInMillis, the updated/created time of the resource in UNIX time
+     * @param algorithm the algorithm used for hashing
+     * @return String
+     * @throws NoSuchAlgorithmException if the given algorithm is invalid or not found in {@link MessageDigest}
+     */
+    private static String getHash(long updatedTimeInMillis, String algorithm) throws NoSuchAlgorithmException {
+        MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
+        messageDigest.update(String.valueOf(updatedTimeInMillis).getBytes());
+        byte[] digest = messageDigest.digest();
+
+        StringBuilder sb = new StringBuilder();
+        for (byte aDigest : digest) {
+            sb.append(Integer.toString((aDigest & 0xff) + 0x100, 16).substring(1)); // not quite necessary
+        }
+        if (log.isDebugEnabled()){
+            log.debug("ETag generated in HEX :: " + sb.toString());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Method returns the hashed value for the updatedTimeInMillis using MD5 hashing as default
+     * @param updatedTimeInMillis the updated/created time of the resource in UNIX time
+     * @return String
+     * @throws NoSuchAlgorithmException if the given algorithm is invalid or not found in {@link MessageDigest}
+     */
+    private static String getHash(long updatedTimeInMillis) throws NoSuchAlgorithmException {
+        return getHash(updatedTimeInMillis, "MD5");
+    }
+    public static String getETag(String lastUpdatedTimeInMillis){
+        try {
+            return getETag(Long.parseLong(lastUpdatedTimeInMillis));
+        }catch (NumberFormatException e){
+            log.error("Error in ETagGenerator due to "+ e.getMessage(),e);
+        }
+        return null;
+    }
+
+
+}

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
@@ -85,30 +85,33 @@
             <!-- api-console element specifies whether the environment should be listed in API Console or not -->
             <Environment type="hybrid" api-console="true">
                 <Name>Production and Sandbox</Name>
-                <Description>This is a hybrid gateway that handles both production and sandbox token traffic.</Description>
+                <Description>This is a hybrid gateway that handles both production and sandbox token traffic.
+                </Description>
                 <!-- Server URL of the API gateway -->
                 <ServerURL>https://localhost:${mgt.transport.https.port}${carbon.context}services/</ServerURL>
-		        <!-- Admin username for the API gateway. -->
+                <!-- Admin username for the API gateway. -->
                 <Username>${admin.username}</Username>
                 <!-- Admin password for the API gateway.-->
                 <Password>${admin.password}</Password>
                 <!-- Endpoint URLs for the APIs hosted in this API gateway.-->
-                <GatewayEndpoint>http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}</GatewayEndpoint>
+                <GatewayEndpoint>
+                    http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}
+                </GatewayEndpoint>
             </Environment>
         </Environments>
     </APIGateway>
 
     <CacheConfigurations>
-	    <!-- Enable/Disable token caching at the Gateway-->
+        <!-- Enable/Disable token caching at the Gateway-->
         <EnableGatewayTokenCache>true</EnableGatewayTokenCache>
-	    <!-- Enable/Disable API resource caching at the Gateway-->
+        <!-- Enable/Disable API resource caching at the Gateway-->
         <EnableGatewayResourceCache>true</EnableGatewayResourceCache>
         <!-- Enable/Disable API key validation information caching at key-management server -->
         <EnableKeyManagerTokenCache>false</EnableKeyManagerTokenCache>
         <!-- This parameter specifies whether Recently Added APIs will be loaded from the cache or not.
              If there are multiple API modification during a short time period, better to disable cache. -->
         <EnableRecentlyAddedAPICache>false</EnableRecentlyAddedAPICache>
-	    <!-- JWT claims Cache expiry in seconds -->
+        <!-- JWT claims Cache expiry in seconds -->
         <!--JWTClaimCacheExpiry>900</JWTClaimCacheExpiry-->
         <!-- Expiry time for the apim key mgt validation info cache -->
         <!--TokenCacheExpiry>900</TokenCacheExpiry-->
@@ -144,7 +147,8 @@
         <DASPassword>${admin.password}</DASPassword>
 
         <!-- For APIM implemented Statistic client for RDBMS -->
-        <StatsProviderImpl>org.wso2.carbon.apimgt.usage.client.impl.APIUsageStatisticsRdbmsClientImpl</StatsProviderImpl>
+        <StatsProviderImpl>org.wso2.carbon.apimgt.usage.client.impl.APIUsageStatisticsRdbmsClientImpl
+        </StatsProviderImpl>
 
         <!-- DAS REST API configuration -->
         <DASRestApiURL>https://localhost:9444</DASRestApiURL>
@@ -188,7 +192,7 @@
                 <Name>org.wso2.apimgt.statistics.execution.time</Name>
                 <Version>1.0.0</Version>
             </ExecutionTime>
-	    <AlertTypes>
+            <AlertTypes>
                 <Name>org.wso2.analytics.apim.alertStakeholderInfo</Name>
                 <Version>1.0.0</Version>
             </AlertTypes>
@@ -230,7 +234,8 @@
         </ConnectionPool-->
         <!-- Specifies the implementation to be used for KeyValidationHandler. Steps for validating a token can be controlled by plugging in a 
              custom KeyValidation Handler -->
-        <KeyValidationHandlerClassName>org.wso2.carbon.apimgt.keymgt.handlers.DefaultKeyValidationHandler</KeyValidationHandlerClassName>
+        <KeyValidationHandlerClassName>org.wso2.carbon.apimgt.keymgt.handlers.DefaultKeyValidationHandler
+        </KeyValidationHandlerClassName>
     </APIKeyValidator>
 
     <!-- Uncomment this section only if you are going to have an instance other than KeyValidator as your KeyManager.
@@ -390,14 +395,15 @@
         <Access-Control-Allow-Methods>GET,PUT,POST,DELETE,PATCH,OPTIONS</Access-Control-Allow-Methods>
 
         <!-- Configure Access-Control-Allow-Headers -->
-        <Access-Control-Allow-Headers>authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction</Access-Control-Allow-Headers>
+        <Access-Control-Allow-Headers>authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction
+        </Access-Control-Allow-Headers>
 
         <!-- Configure Access-Control-Allow-Credentials -->
         <!-- Specifying this header to true means that the server allows cookies (or other user credentials) to be included on cross-origin requests.
              It is false by default and if you set it to true then make sure that the Access-Control-Allow-Origin header does not contain the wildcard (*) -->
         <Access-Control-Allow-Credentials>false</Access-Control-Allow-Credentials>
     </CORSConfiguration>
-    
+
     <!-- This property is there to configure velocity log output into existing Log4j carbon Logger.
          You can enable this and set preferable Logger name. -->
     <!-- VelocityLogger>VELOCITY</VelocityLogger -->
@@ -458,6 +464,131 @@
                 <HTTPMethods>GET,HEAD</HTTPMethods>
             </WhiteListedURI>
         </WhiteListedURIs>
+        <ETagSkipList>
+            <ETagSkipURI>
+                <URI>/api/am/store/apis/generate-sdk</URI>
+                <HTTPMethods>POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/store/tiers/{tierLevel}</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/store/tiers/{tierLevel}/{tierName}</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipList>
+                <ETagSkipURI>
+                    <URI>/api/am/store/v0.10/apis</URI>
+                    <HTTPMethods>GET</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/store/v0.10/applications</URI>
+                    <HTTPMethods>GET</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/store/v0.10/applications/generate-keys</URI>
+                    <HTTPMethods>POST</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/store/v0.10/{apiId}/documents</URI>
+                    <HTTPMethods>GET</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/store/v0.10/subscriptions</URI>
+                    <HTTPMethods>GET</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/store/v0.10/tags</URI>
+                    <HTTPMethods>GET</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/store/v0.10/tiers/api</URI>
+                    <HTTPMethods>GET</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/store/v0.10/{tierLevel}</URI>
+                    <HTTPMethods>GET</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/store/v0.10/{tierLevel}/{tierName}</URI>
+                    <HTTPMethods>GET</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/apis</URI>
+                    <HTTPMethods>GET,POST</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/apis/{apiId}</URI>
+                    <HTTPMethods>GET,DELETE,PUT</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/apis/{apiId}/swagger</URI>
+                    <HTTPMethods>GET,PUT</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/apis/{apiId}/thumbnail</URI>
+                    <HTTPMethods>GET,POST</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/apis/{apiId}/change-lifecycle</URI>
+                    <HTTPMethods>POST</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/apis/{apiId}/copy-api</URI>
+                    <HTTPMethods>POST</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/applications/{applicationId}</URI>
+                    <HTTPMethods>GET</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/apis/{apiId}/documents</URI>
+                    <HTTPMethods>GET,POST</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/apis/{apiId}/documents/{documentId}/content</URI>
+                    <HTTPMethods>GET,POST</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/apis/{apiId}/documents/{documentId}</URI>
+                    <HTTPMethods>GET,PUT,DELETE</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/environments</URI>
+                    <HTTPMethods>GET</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/subscriptions</URI>
+                    <HTTPMethods>GET</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/subscriptions/block-subscription</URI>
+                    <HTTPMethods>POST</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/subscriptions/{subscriptionId}</URI>
+                    <HTTPMethods>GET</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/subscriptions/unblock-subscription</URI>
+                    <HTTPMethods>POST</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/tiers/{tierLevel}</URI>
+                    <HTTPMethods>GET,POST</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/tiers/{tierLevel}/{tierName}</URI>
+                    <HTTPMethods>GET,PUT,DELETE</HTTPMethods>
+                </ETagSkipURI>
+                <ETagSkipURI>
+                    <URI>/api/am/publisher/v0.10/tiers/update-permission</URI>
+                    <HTTPMethods>POST</HTTPMethods>
+                </ETagSkipURI>
+            </ETagSkipList>
+
+        </ETagSkipList>
     </RESTAPI>
     <ThrottlingConfigurations>
         <EnableAdvanceThrottling>true</EnableAdvanceThrottling>
@@ -496,10 +627,14 @@
             <Destination>throttleData</Destination>
             <!--InitDelay>300000</InitDelay-->
             <JMSConnectionParameters>
-                <transport.jms.ConnectionFactoryJNDIName>TopicConnectionFactory</transport.jms.ConnectionFactoryJNDIName>
+                <transport.jms.ConnectionFactoryJNDIName>TopicConnectionFactory
+                </transport.jms.ConnectionFactoryJNDIName>
                 <transport.jms.DestinationType>topic</transport.jms.DestinationType>
-                <java.naming.factory.initial>org.wso2.andes.jndi.PropertiesFileInitialContextFactory</java.naming.factory.initial>
-                <connectionfactory.TopicConnectionFactory>amqp://${jms.username}:${jms.password}@clientid/carbon?brokerlist='${jms.url}'</connectionfactory.TopicConnectionFactory>
+                <java.naming.factory.initial>org.wso2.andes.jndi.PropertiesFileInitialContextFactory
+                </java.naming.factory.initial>
+                <connectionfactory.TopicConnectionFactory>
+                    amqp://${jms.username}:${jms.password}@clientid/carbon?brokerlist='${jms.url}'
+                </connectionfactory.TopicConnectionFactory>
             </JMSConnectionParameters>
             <JMSTaskManager>
                 <MinThreadPoolSize>20</MinThreadPoolSize>
@@ -509,12 +644,13 @@
             </JMSTaskManager>
         </JMSConnectionDetails>
         <JMSEventPublisherParameters>
-                <java.naming.factory.initial>org.wso2.andes.jndi.PropertiesFileInitialContextFactory</java.naming.factory.initial>
-                <java.naming.provider.url>repository/conf/jndi.properties</java.naming.provider.url>
-                <transport.jms.DestinationType>topic</transport.jms.DestinationType>
-                <transport.jms.Destination>throttleData</transport.jms.Destination>
-                <transport.jms.ConcurrentPublishers>allow</transport.jms.ConcurrentPublishers>
-                <transport.jms.ConnectionFactoryJNDIName>TopicConnectionFactory</transport.jms.ConnectionFactoryJNDIName>
+            <java.naming.factory.initial>org.wso2.andes.jndi.PropertiesFileInitialContextFactory
+            </java.naming.factory.initial>
+            <java.naming.provider.url>repository/conf/jndi.properties</java.naming.provider.url>
+            <transport.jms.DestinationType>topic</transport.jms.DestinationType>
+            <transport.jms.Destination>throttleData</transport.jms.Destination>
+            <transport.jms.ConcurrentPublishers>allow</transport.jms.ConcurrentPublishers>
+            <transport.jms.ConnectionFactoryJNDIName>TopicConnectionFactory</transport.jms.ConnectionFactoryJNDIName>
         </JMSEventPublisherParameters>
         <!--DefaultLimits>
             <SubscriptionTierLimits>
@@ -539,13 +675,15 @@
         <EnableJWTClaimConditions>false</EnableJWTClaimConditions>
         <EnableQueryParamConditions>false</EnableQueryParamConditions>
     </ThrottlingConfigurations>
-    
+
     <WorkflowConfigurations>
         <Enabled>false</Enabled>
-    	<ServerUrl>https://localhost:9445/bpmn</ServerUrl>   		
-    	<ServerUser>${admin.username}</ServerUser>
-    	<ServerPassword>${admin.password}</ServerPassword>
-    	<WorkflowCallbackAPI>https://localhost:${mgt.transport.https.port}/api/am/publisher/v0.10/workflows/update-workflow-status</WorkflowCallbackAPI>
+        <ServerUrl>https://localhost:9445/bpmn</ServerUrl>
+        <ServerUser>${admin.username}</ServerUser>
+        <ServerPassword>${admin.password}</ServerPassword>
+        <WorkflowCallbackAPI>
+            https://localhost:${mgt.transport.https.port}/api/am/publisher/v0.10/workflows/update-workflow-status
+        </WorkflowCallbackAPI>
         <TokenEndPoint>https://localhost:${https.nio.port}/token</TokenEndPoint>
         <DCREndPoint>https://localhost:${mgt.transport.https.port}/client-registration/v0.10/register</DCREndPoint>
         <DCREndPointUser>${admin.username}</DCREndPointUser>


### PR DESCRIPTION
Added support for ETags in the REST API of the API Manager Store, All endpoints which are not collection resource endpoints are capable to handling ETags, however /tags and /tiers endpoints are excluded  