### PR TITLE
Fix for APIMANAGER-5507: PR for master branch

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/conditions/manage/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/conditions/manage/template.jag
@@ -102,6 +102,7 @@
     }
 
     function deleteCondition(conditionId){
+    $("#messageModal div.modal-footer").html("");
     jagg.message({
         content:i18n.t('Are you sure you want to delete this current Block Condition'),
         title:i18n.t('Confirm Deletion'),

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/policy/app/manage/js/manage.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/policy/app/manage/js/manage.js
@@ -1,4 +1,5 @@
 var deleteAppPolicy = function (policyObject) {
+    $("#messageModal div.modal-footer").html("");
     jagg.message({
         content: i18n.t('Policy deletion might affect current subscriptions. Are you sure you want to delete this policy? '),
         title: i18n.t('Confirm Deletion'),

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/policy/resource/policy-list/js/policy-list.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/policy/resource/policy-list/js/policy-list.js
@@ -1,4 +1,5 @@
 var deleteAPIPolicy = function (policyObject) {
+    $("#messageModal div.modal-footer").html("");
     jagg.message({
         content: i18n.t('Policy deletion might affect current subscriptions. Are you sure you want to delete this policy? '),
         title: i18n.t('Confirm Deletion'),

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/policy/subscription/manage/js/manage.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/policy/subscription/manage/js/manage.js
@@ -1,4 +1,5 @@
 var deleteSubscriptionPolicy = function (policyObject) {
+    $("#messageModal div.modal-footer").html("");
     jagg.message({
         content:i18n.t('Policy deletion might affect current subscriptions. Are you sure you want to delete this policy?'),
         title:i18n.t('Confirm Deletion'),

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/tier/manage/js/manage.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/tier/manage/js/manage.js
@@ -1,4 +1,5 @@
 var deleteTier = function (tierObject) {
+    $("#messageModal div.modal-footer").html("");
     jagg.message({
         content: i18n.t('Tier deletion might affect current subscriptions. Are you sure you want to delete this tier? '),
         title: i18n.t('Confirm Deletion'),


### PR DESCRIPTION
In the admin dashboard, multiple 'No' buttons are getting added to the popup when trying to delete an item. This will not show up when trying to delete the item at the first time. This would happen if you click 'No' for the pop up for the first time and trying to delete the same item for the second time. This will keep adding 'No' buttons to the popup.