### PR TITLE
Fix for APIMANAGER-5509: Adding changes to the master branch

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -335,7 +335,8 @@ public class SQLConstants {
                     "   AND APP.SUBSCRIBER_ID = SUBS.SUBSCRIBER_ID" +
                     "   AND API.API_ID = SUB.API_ID" +
                     "   AND AKM.APPLICATION_ID=APP.APPLICATION_ID" +
-                    "   AND APS.NAME = SUB.TIER_ID";
+                    "   AND APS.NAME = SUB.TIER_ID" +
+                    "   AND SUBS.TENANT_ID = APS.TENANT_ID";
 
     public static final String ADVANCED_VALIDATE_SUBSCRIPTION_KEY_VERSION_SQL =
             " SELECT " +
@@ -369,7 +370,8 @@ public class SQLConstants {
                     "   AND APP.SUBSCRIBER_ID = SUBS.SUBSCRIBER_ID" +
                     "   AND API.API_ID = SUB.API_ID" +
                     "   AND AKM.APPLICATION_ID=APP.APPLICATION_ID" +
-                    "   AND APS.NAME = SUB.TIER_ID";
+                    "   AND APS.NAME = SUB.TIER_ID" +
+                    "   AND SUBS.TENANT_ID = APS.TENANT_ID";
 
     public static final String UPDATE_TOKEN_PREFIX = "UPDATE ";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/amConfig.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/amConfig.xml
@@ -55,4 +55,8 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </APIKeyValidator>
 
+    <ThrottlingConfigurations>
+        <EnableAdvanceThrottling>true</EnableAdvanceThrottling>
+    </ThrottlingConfigurations>
+
 </APIManager>


### PR DESCRIPTION
Spike arrest limits are not properly retrieved in tenant basis. The underlying query does not filter out the tiers by tenant from subscription policy table. As a result, spike arrest limit of the very first tier with the same name is retrieved irrespective of the tenant.