### PR TITLE
Fix interference of RESTAPISecurityInterceptor with UUF apps

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.commons/src/main/java/org/wso2/carbon/apimgt/rest/api/common/interceptors/RESTAPISecurityInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.commons/src/main/java/org/wso2/carbon/apimgt/rest/api/common/interceptors/RESTAPISecurityInterceptor.java
@@ -36,6 +36,7 @@ import org.wso2.msf4j.Response;
 import org.wso2.msf4j.ServiceMethodInfo;
 
 import java.util.HashMap;
+import java.util.Locale;
 
 /**
  * Security Interceptor that does basic authentication for REST ApI requests.
@@ -69,7 +70,10 @@ public class RESTAPISecurityInterceptor implements Interceptor {
             APIMgtSecurityException {
         ErrorHandler errorHandler = null;
         boolean isAuthenticated = false;
-
+        String requestURI = request.getUri().toLowerCase(Locale.ENGLISH);
+        if (requestURI.contains("/publisher") || requestURI.contains("/store")) {
+            return true;
+        }
         try {
             if (authenticatorImplClass == null) {
                 Class<?> implClass = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.commons/src/main/java/org/wso2/carbon/apimgt/rest/api/common/interceptors/RESTAPISecurityInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.commons/src/main/java/org/wso2/carbon/apimgt/rest/api/common/interceptors/RESTAPISecurityInterceptor.java
@@ -70,6 +70,8 @@ public class RESTAPISecurityInterceptor implements Interceptor {
             APIMgtSecurityException {
         ErrorHandler errorHandler = null;
         boolean isAuthenticated = false;
+        /* TODO: Following string contains check is done to avoid checking security headers in non API requests.
+         * Consider this as a tempory fix until MSF4J support context based interceptor registration */
         String requestURI = request.getUri().toLowerCase(Locale.ENGLISH);
         if (requestURI.contains("/publisher") || requestURI.contains("/store")) {
             return true;


### PR DESCRIPTION
In this PR:

- Fix checking for Authorize header in none API HTTP requests for APIM publisher and store UUF apps