### PR TITLE
Remove unused dependency

### DIFF
--- a/components/web/apps/org.wso2.carbon.apimgt.store/pom.xml
+++ b/components/web/apps/org.wso2.carbon.apimgt.store/pom.xml
@@ -35,13 +35,6 @@
 
     <dependencies>
         <!--UUF Components-->
-        <dependency>
-            <groupId>org.wso2.carbon.apimgt.web</groupId>
-            <artifactId>org.wso2.carbon.apimgt.web.store.utils</artifactId>
-            <version>${carbon.apimgt.version}</version>
-            <type>zip</type>
-            <classifier>uuf-component</classifier>
-        </dependency>
         <!--UUF Themes-->
         <dependency>
             <groupId>org.wso2.carbon.apimgt.web</groupId>


### PR DESCRIPTION
In this PR:

- Remove previously used store utils component, It is no longer been used and instead we have renamed it to publisher.commons