### PR TITLE
Implement creating an API from swagger url 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/MappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/MappingUtil.java
@@ -126,18 +126,22 @@ public class MappingUtil {
     public static API.APIBuilder toAPI(APIDTO apidto) {
         BusinessInformation businessInformation = new BusinessInformation();
         API_businessInformationDTO apiBusinessInformationDTO = apidto.getBusinessInformation();
-        businessInformation.setBusinessOwner(apiBusinessInformationDTO.getBusinessOwner());
-        businessInformation.setBusinessOwnerEmail(apiBusinessInformationDTO.getBusinessOwnerEmail());
-        businessInformation.setTechnicalOwner(apiBusinessInformationDTO.getTechnicalOwner());
-        businessInformation.setTechnicalOwnerEmail(apiBusinessInformationDTO.getTechnicalOwnerEmail());
+        if(apiBusinessInformationDTO != null) {
+            businessInformation.setBusinessOwner(apiBusinessInformationDTO.getBusinessOwner());
+            businessInformation.setBusinessOwnerEmail(apiBusinessInformationDTO.getBusinessOwnerEmail());
+            businessInformation.setTechnicalOwner(apiBusinessInformationDTO.getTechnicalOwner());
+            businessInformation.setTechnicalOwnerEmail(apiBusinessInformationDTO.getTechnicalOwnerEmail());
+        }
 
         API_corsConfigurationDTO apiCorsConfigurationDTO = apidto.getCorsConfiguration();
         CorsConfiguration corsConfiguration = new CorsConfiguration();
-        corsConfiguration.setAllowCredentials(apiCorsConfigurationDTO.getAccessControlAllowCredentials());
-        corsConfiguration.setAllowHeaders(apiCorsConfigurationDTO.getAccessControlAllowHeaders());
-        corsConfiguration.setAllowMethods(apiCorsConfigurationDTO.getAccessControlAllowMethods());
-        corsConfiguration.setAllowOrigins(apiCorsConfigurationDTO.getAccessControlAllowOrigins());
-        corsConfiguration.setEnabled(apiCorsConfigurationDTO.getCorsConfigurationEnabled());
+        if(apiCorsConfigurationDTO != null) {
+            corsConfiguration.setAllowCredentials(apiCorsConfigurationDTO.getAccessControlAllowCredentials());
+            corsConfiguration.setAllowHeaders(apiCorsConfigurationDTO.getAccessControlAllowHeaders());
+            corsConfiguration.setAllowMethods(apiCorsConfigurationDTO.getAccessControlAllowMethods());
+            corsConfiguration.setAllowOrigins(apiCorsConfigurationDTO.getAccessControlAllowOrigins());
+            corsConfiguration.setEnabled(apiCorsConfigurationDTO.getCorsConfigurationEnabled());
+        }
         List<API_operationsDTO> operationList = apidto.getOperations();
         Map<String,UriTemplate> uriTemplateList = new HashMap();
         for (API_operationsDTO operationsDTO : operationList){
@@ -166,17 +170,22 @@ public class MappingUtil {
                 lifeCycleStatus(apidto.getLifeCycleStatus()).
                 endpoint(fromEndpointListToMap(apidto.getEndpoint())).
                 visibleRoles(apidto.getVisibleRoles()).
-                visibility(API.Visibility.valueOf(apidto.getVisibility().toString())).
                 policies(apidto.getPolicies()).
                 permission(apidto.getPermission()).
                 tags(apidto.getTags()).
                 transport(apidto.getTransport()).
-                cacheTimeout(apidto.getCacheTimeout()).
                 isResponseCachingEnabled(Boolean.valueOf(apidto.getResponseCaching())).
                 policies(apidto.getPolicies()).
                 businessInformation(businessInformation).
                 uriTemplates(uriTemplateList).
                 corsConfiguration(corsConfiguration);
+        if(apidto.getVisibility() != null) {
+            apiBuilder.visibility(API.Visibility.valueOf(apidto.getVisibility().toString()));
+        }
+        if(apidto.getCacheTimeout() != null) {
+            apiBuilder.cacheTimeout(apidto.getCacheTimeout());
+
+        }
         return apiBuilder;
     }
 

--- a/components/web/apps/org.wso2.carbon.apimgt.editor.app/src/main/component.yaml
+++ b/components/web/apps/org.wso2.carbon.apimgt.editor.app/src/main/component.yaml
@@ -10,5 +10,3 @@ config:
   title : "API Editor Tool"
   appName : API Editor
   loginRedirectUri: "/api"
-  swaggerURL: "http://localhost:9090/swagger?path=/api/am/publisher/v0.10/apis"
-

--- a/components/web/apps/org.wso2.carbon.apimgt.editor.app/src/main/pages/apis/create.hbs
+++ b/components/web/apps/org.wso2.carbon.apimgt.editor.app/src/main/pages/apis/create.hbs
@@ -16,7 +16,7 @@
                 </div>
                 <div class="col-md-10">
                     <!-- Name version context input fields-->
-                    <div class="row">
+                    <div class="row basic-inputs ">
                         <div class="col-xsm-12 col-lg-4">
                             <div class="input-group input-wrap res-wrap">
                                 <label class="control-label">Name</label>
@@ -46,21 +46,26 @@
                             <h4>Implementation Method</h4>
                             <div class="col-sm-12 col-md-12">
                                 <div class="col-sm-12 col-md-12">
-                                    <label class="radio apim-pub-new-api">
-                                        <input type="radio" name="options" value="endpoint-option" checked="checked">
-                                        <span class="helper">Endpoint</span>
-                                    </label>
-                                    <label class="radio apim-pub-new-api no-border">
-                                        <input type="radio" name="options" value="swagger-option">
-                                        <span class="helper">Import Swagger</span>
-                                    </label>
-                                    <label class="radio apim-pub-new-api no-border">
-                                        <input type="radio" name="options" value="mock-option">
-                                        <span class="helper">Mock</span>
-                                    </label>
+                                    <form class="form-horizontal" id="implementation-option-form">
+                                        <div class="form-group">
+                                            <label class="radio apim-pub-new-api">
+                                                <input type="radio" name="implementation-options" value="endpoint-option"
+                                                       checked="checked">
+                                                <span class="helper">Endpoint</span>
+                                            </label>
+                                            <label class="radio apim-pub-new-api no-border">
+                                                <input type="radio" name="implementation-options" value="swagger-option">
+                                                <span class="helper">Import Swagger</span>
+                                            </label>
+                                            <label class="radio apim-pub-new-api no-border">
+                                                <input type="radio" name="implementation-options" value="mock-option">
+                                                <span class="helper">Mock</span>
+                                            </label>
+                                        </div>
+                                    </form>
                                 </div>
                                 <div class="col-sm-12 col-md-12" style="margin-left: 10%;">
-                                    <form class="form-horizontal" id="endpoint-option-form">
+                                    <form class="form-horizontal sub-implementation-option" id="endpoint-option-form">
                                         <div class="form-group">
                                             <div class="col-sm-12">
                                                 <input id="wsdl-url" name="wsdl-url" class="form-control input-small"
@@ -68,11 +73,12 @@
                                             </div>
                                         </div>
                                     </form>
-                                    <form class="form-horizontal" id="swagger-option-form" style="display: none">
+                                    <form class="form-horizontal sub-implementation-option" id="swagger-option-form" style="display: none">
                                         <div class="form-group">
                                             <div class="col-sm-12 toggleRadios">
                                                 <label class="radio sub-labels urlSelect-label"> <input
                                                         type="radio"
+                                                        checked="checked"
                                                         name="import-definition"
                                                         value="swagger-url">
                                                     <span

--- a/components/web/apps/org.wso2.carbon.apimgt.editor.app/src/main/pages/apis/create.js
+++ b/components/web/apps/org.wso2.carbon.apimgt.editor.app/src/main/pages/apis/create.js
@@ -15,6 +15,5 @@
  */
 
 function onGet(env) {
-    sendToClient("swaggerURL", env.config.swaggerURL);
     return {};
 }

--- a/components/web/apps/org.wso2.carbon.apimgt.editor.app/src/main/pages/apis/index.js
+++ b/components/web/apps/org.wso2.carbon.apimgt.editor.app/src/main/pages/apis/index.js
@@ -21,6 +21,5 @@ function onGet(env) {
         vars = env.request.queryParams;
     }
     vars['contextPath'] = env.contextPath;
-    sendToClient("swaggerURL", env.config.swaggerURL);
     return vars;
 }

--- a/components/web/apps/org.wso2.carbon.apimgt.editor.app/src/main/public/js/api/create.js
+++ b/components/web/apps/org.wso2.carbon.apimgt.editor.app/src/main/public/js/api/create.js
@@ -15,30 +15,77 @@
  */
 $(
     function () {
-        $('#api-create-submit').on('click',
-            function (event) {
-                event.preventDefault();
-                var api_data = {
-                    name: $("#new-api-name").val(),
-                    context: $('#new-api-context').val(),
-                    version: $('#new-api-version').val()
-                };
-                var new_api = new API('');
-                new_api.create(api_data, createAPICallback);
-            }
-        );
-        $("input[name$='options']").on("change", function () {
-            // debugger;
-            var test = $(this).val();
-            $(".form-horizontal").hide();
-            $("#" + test + "-form").show();
-        });
+        $('#api-create-submit').on('click', createAPIHandler);
+        $('input[type=radio][name=implementation-options]').on('change', implementationOptionsHandler);
     }
 );
 
-
+/**
+ * This callback function is called after the success response from API creation
+ * @param response {object} Response object receiving from swagger-js client
+ */
 function createAPICallback(response) {
     // Grab the template script
     var responseObject = JSON.parse(response.data);
     window.location.replace("/editor/apis?create_success=true&id=" + responseObject.id + "&name=" + encodeURI(responseObject.name));
+}
+
+/**
+ * Jquery event handler for options element for switch between implementation types
+ * @param event
+ */
+function implementationOptionsHandler(event) {
+    var selected_value = this.value;
+    $(".sub-implementation-option").hide();
+    $("#" + selected_value + "-form").fadeIn();
+    if (selected_value == 'swagger-option') {
+        $('.basic-inputs :input').prop("disabled", true);
+    } else {
+        $('.basic-inputs :input').prop("disabled", false);
+    }
+}
+/**
+ * Jquery event handler on click event for api create submit button
+ * @param event
+ */
+function createAPIHandler(event) {
+    event.preventDefault();
+    let implementation_method = $('input[name=implementation-options]:checked', '#implementation-option-form').val();
+    let input_type = $('input[name=import-definition]:checked', '#swagger-option-form').val();
+
+    switch (implementation_method) {
+        case "endpoint-option":
+            break;
+        case "swagger-option":
+            createAPIFromSwagger(input_type);
+            break;
+        case "mock-option":
+            var api_data = {
+                name: $("#new-api-name").val(),
+                context: $('#new-api-context').val(),
+                version: $('#new-api-version').val()
+            };
+            var new_api = new API('');
+            new_api.create(api_data, createAPICallback);
+            break;
+    }
+}
+/**
+ * Do create API from either swagger URL or swagger file upload.In case of URL pre fetch the swagger file and make a blob
+ * and the send it over REST API.
+ * @param input_type
+ */
+function createAPIFromSwagger(input_type) {
+    if (input_type === "swagger-url") {
+        var url = $('#swagger-url').val();
+        var fetch_data = $.get(url);
+        fetch_data.then(
+            (swagger_json) => {
+                let data = new Blob([JSON.stringify(swagger_json)], {type: 'application/json'});
+                var new_api = new API('');
+                new_api.create(data, createAPICallback);
+            });
+    } else if (input_type === "swagger-file") {
+        /* TODO: Implement swagger file  upload support ~tmkb*/
+    }
 }

--- a/components/web/components/org.wso2.carbon.apimgt.publisher.commons.ui/src/main/component.yaml
+++ b/components/web/components/org.wso2.carbon.apimgt.publisher.commons.ui/src/main/component.yaml
@@ -17,5 +17,5 @@ config:
   scopes: "apim:api_view"
   tokenEndpoint: "https://localhost:8243/token"
   keyAndSecret: "dmRNdk05d1R4NkZ5NjNXa2xfb0FEaTdMQXZnYTp3UHNIQkJFS1FPbWU0bGZxYlJRZW1GY3ZqSUlh=="
-  swaggerURL: "http://localhost:9090/swagger?path=/api/am/publisher/v0.10/apis"
+  swaggerURL: "http://localhost:9090/api/am/publisher/v0.10/apis/swagger.json"
   nonSecureUrl: "/test1,/test2"


### PR DESCRIPTION
In this PR:

- Add null checks in `Mappingutils` to avoid adding null values for optional parameters when creating an API
- Switch to swagger file exposed by APIM service rather than consuming the MSF4J Swagger service
- Implement API creation by giving a swagger URL