### PR TITLE
[C5] Adding new bundle to mock key manager APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymanager/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymanager/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>org.wso2.carbon.apimgt.keymanager</artifactId>
     <packaging>bundle</packaging>
 
-    <name>Sample: Stockquote microservice (OSGi Bundle)</name>
+    <name>Key Manager Backend module</name>
     <dependencies>
         <dependency>
             <groupId>org.wso2.eclipse.osgi</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.keymanager/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymanager/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>apimgt</artifactId>
+        <groupId>org.wso2.carbon.apimgt</groupId>
+        <version>7.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.wso2.carbon.apimgt.keymanager</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Sample: Stockquote microservice (OSGi Bundle)</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.msf4j</groupId>
+            <artifactId>msf4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <private.package>org.wso2.carbon.apimgt.keymanager.*</private.package>
+        <import.package>
+            org.osgi.framework.*;version="${osgi.framework.import.version.range}",
+            org.wso2.msf4j.*,
+            javax.ws.rs.*,
+            javax.xml.bind*,
+            org.slf4j.*,
+            io.swagger.annotations.*
+        </import.package>
+        <carbon.component>
+            osgi.service; objectClass="org.wso2.msf4j.Microservice"
+        </carbon.component>
+    </properties>
+</project>
+

--- a/components/apimgt/org.wso2.carbon.apimgt.keymanager/src/main/java/org/wso2/carbon/apimgt/keymanager/KeymanagerService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymanager/src/main/java/org/wso2/carbon/apimgt/keymanager/KeymanagerService.java
@@ -1,0 +1,39 @@
+package org.wso2.carbon.apimgt.keymanager;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.wso2.msf4j.Microservice;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * This method authenticate the user.
+ *
+ */
+@Component (
+        name = "org.wso2.carbon.apimgt.keymanager.KeymanagerService",
+        service = Microservice.class,
+        immediate = true
+)
+@Path("/oauth2")
+public class KeymanagerService implements Microservice {
+
+    @Activate
+    protected void activate(BundleContext bundleContext) {
+        // Nothing to do
+    }
+
+    @Deactivate
+    protected void deactivate(BundleContext bundleContext) {
+        // Nothing to do
+    }
+
+    @GET
+    @Path ("/token")
+    public String getNewAccessToken() {
+        return "";
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.keymanager/src/main/java/org/wso2/carbon/apimgt/keymanager/KeymanagerService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymanager/src/main/java/org/wso2/carbon/apimgt/keymanager/KeymanagerService.java
@@ -10,7 +10,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 /**
- * This method authenticate the user.
+ * This class is used to mock the key manager apis.
  *
  */
 @Component (

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.commons/src/main/java/org/wso2/carbon/apimgt/rest/api/common/interceptors/RESTAPISecurityInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.commons/src/main/java/org/wso2/carbon/apimgt/rest/api/common/interceptors/RESTAPISecurityInterceptor.java
@@ -113,7 +113,7 @@ public class RESTAPISecurityInterceptor implements Interceptor {
                 return false;
             }
             return true;
-        } else if (requestURI.contains("/editor")) {
+        } else if (requestURI.contains("/editor") || requestURI.contains("oauth2")) {
             return true;
         }
         try {

--- a/components/apimgt/pom.xml
+++ b/components/apimgt/pom.xml
@@ -40,6 +40,7 @@
         <module>org.wso2.carbon.apimgt.rest.api.admin</module>
         <module>org.wso2.carbon.apimgt.indexing</module>
         <module>org.wso2.carbon.apimgt.gateway.extension</module>
+        <module>org.wso2.carbon.apimgt.keymanager</module>
 
     </modules>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.commons.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.commons.feature/pom.xml
@@ -19,6 +19,11 @@
 			<groupId>org.wso2.carbon.apimgt</groupId>
 			<artifactId>org.wso2.carbon.apimgt.rest.api.commons</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.keymanager</artifactId>
+            <version>7.0.0-SNAPSHOT</version>
+        </dependency>
 	</dependencies>
 
 	<build>
@@ -52,6 +57,11 @@
 									<symbolicName>org.wso2.carbon.apimgt.rest.api.commons</symbolicName>
 									<version>${carbon.apimgt.version}</version>
 								</bundle>
+                                <!-- Remove following bundle ones keymanager mock interface is removed-->
+                                <bundle>
+                                    <symbolicName>org.wso2.carbon.apimgt.keymanager</symbolicName>
+                                    <version>${carbon.apimgt.version}</version>
+                                </bundle>
 							</bundles>
 							<importFeatures>
 								<feature>


### PR DESCRIPTION
This micro service bundle is introduced to mock the key manager services. Ones the key manager services are available we can remove this bundle.