### PR TITLE
Add new dependency to APIM publisher commons component

### DIFF
--- a/components/web/apps/org.wso2.carbon.apimgt.editor.app/pom.xml
+++ b/components/web/apps/org.wso2.carbon.apimgt.editor.app/pom.xml
@@ -67,6 +67,11 @@
         </dependency>
         <!--Backend dependencies-->
         <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.authenticator</artifactId>
+            <version>${carbon.apimgt.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.uuf.sample</groupId>
             <artifactId>org.wso2.carbon.uuf.sample.simple-auth.bundle</artifactId>
             <version>${carbon.uuf.version}</version>

--- a/components/web/apps/org.wso2.carbon.apimgt.publisher/pom.xml
+++ b/components/web/apps/org.wso2.carbon.apimgt.publisher/pom.xml
@@ -43,13 +43,6 @@
             <classifier>uuf-component</classifier>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.apimgt</groupId>
-            <artifactId>org.wso2.carbon.apimgt.auth.ui</artifactId>
-            <version>${carbon.apimgt.version}</version>
-            <type>zip</type>
-            <classifier>uuf-component</classifier>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.uuf.common</groupId>
             <artifactId>org.wso2.carbon.uuf.common.foundation.ui</artifactId>
             <version>${carbon.uuf.common.version}</version>
@@ -65,11 +58,6 @@
             <classifier>uuf-theme</classifier>
         </dependency>
         <!--Backend dependencies-->
-        <dependency>
-            <groupId>org.wso2.carbon.uuf.sample</groupId>
-            <artifactId>org.wso2.carbon.uuf.sample.simple-auth.bundle</artifactId>
-            <version>${carbon.uuf.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.authenticator</artifactId>

--- a/components/web/components/org.wso2.carbon.apimgt.publisher.commons.ui/pom.xml
+++ b/components/web/components/org.wso2.carbon.apimgt.publisher.commons.ui/pom.xml
@@ -43,6 +43,13 @@
             <type>zip</type>
             <classifier>uuf-component</classifier>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.auth.ui</artifactId>
+            <version>${carbon.apimgt.version}</version>
+            <type>zip</type>
+            <classifier>uuf-component</classifier>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
In this PR:

- I have added `org.wso2.carbon.apimgt.auth` component as a dependency to `org.wso2.carbon.apimgt.publisher.commons` , so that js library fragments in auth component can be used in commons component context