### PR TITLE
Fixing APIMANAGER-5637

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
@@ -72,7 +72,7 @@ public class ApisApiServiceImpl extends ApisApiService {
             DocumentInfo documentInfo = documentationContent.getDocumentInfo();
             if (DocumentInfo.SourceType.FILE.equals(documentInfo.getSourceType())) {
                 String filename = documentInfo.getFileName();
-                return Response.ok(documentInfo)
+                return Response.ok(documentationContent.getFileContent())
                         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_TYPE)
                         .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
                         .build();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImpl.java
@@ -44,7 +44,7 @@ public class ApisApiServiceImpl extends ApisApiService {
             DocumentInfo documentInfo = documentationContent.getDocumentInfo();
             if (DocumentInfo.SourceType.FILE.equals(documentInfo.getSourceType())) {
                 String filename = documentInfo.getFileName();
-                return Response.ok(documentInfo)
+                return Response.ok(documentationContent.getFileContent())
                         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_TYPE)
                         .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
                         .build();


### PR DESCRIPTION
Fixing File Content Download for FILE type document Download Resource API in both Publisher and Store