### PR TITLE
Adding label-info API in Store

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.commons/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.commons/src/main/resources/store-api.yaml
@@ -1130,6 +1130,61 @@ paths:
             $ref: '#/definitions/Error'
 
 ######################################################
+# The "Label Collection" resource API
+######################################################
+  /label-info:
+
+#-----------------------------------------------------
+# Retrieve the label information
+#-----------------------------------------------------
+    get:
+      summary: Get label information based on the label name
+      description: |
+        This operation can be used to retrieve the information of the labels
+      parameters:
+        - in: body
+          name: body
+          description: |
+            Label names to get information.
+          required: true
+          schema:
+            $ref: '#/definitions/LabelInfoList'
+        - $ref: '#/parameters/Content-Type'
+        - $ref: '#/parameters/Accept'
+        - $ref: '#/parameters/If-None-Match'
+        - $ref: '#/parameters/If-Modified-Since'
+        - $ref: '#/parameters/Minor-Version'
+      tags:
+        - Label (Collection)
+      responses:
+        200:
+          description: |
+            OK.
+            Label list is returned.
+          schema:
+             $ref: '#/definitions/LabelList'
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              type: string
+            ETag:
+              description: |
+                Entity Tag of the response resource.
+                Used by caches, or in conditional requests (Will be supported in future).
+              type: string
+        304:
+          description: |
+            Not Modified.
+            Empty body because the client has already the latest version of the requested resource (Will be supported in future).
+        404:
+          description: |
+            Not Found.
+            Requested API does not exist.
+          schema:
+            $ref: '#/definitions/Error'
+
+######################################################
 # Parameters - required by some of the APIs above
 ######################################################
 parameters:
@@ -1686,12 +1741,18 @@ definitions:
       - applicationId
       - apiIdentifier
       - policy
+      - apiName
+      - apiVersion
     properties:
       subscriptionId:
         type: string
       applicationId:
         type: string
       apiIdentifier:
+        type: string
+      apiName:
+        type: string
+      apiVersion:
         type: string
       policy:
         type: string
@@ -1868,6 +1929,58 @@ definitions:
         items: 
           type: string
         description: Allowed scopes for the access token
+
+#-----------------------------------------------------
+# The Label resource
+#-----------------------------------------------------
+  Label:
+    title: Label
+    required:
+      - name
+      - access_url
+    properties:
+      name:
+        type: string
+      access_url:
+        type: string
+
+#-----------------------------------------------------
+# The Label Info List resource
+#-----------------------------------------------------
+  LabelInfoList:
+    title: Label Info List
+    required:
+      - labels
+    properties:
+      labels:
+        type: array
+        items:
+          type: string
+
+#-----------------------------------------------------
+# The Label List resource
+#-----------------------------------------------------
+  LabelList:
+    title: Label List
+    properties:
+      count:
+        type: integer
+        description: |
+          Number of Labels returned.
+      next:
+        type: string
+        description: |
+          Link to the next subset of resources qualified.
+          Empty if no more resources are to be returned.
+      previous:
+        type: string
+        description: |
+          Link to the previous subset of resources qualified.
+          Empty if current subset is the first subset returned.
+      list:
+        type: array
+        items:
+          $ref: '#/definitions/Label'
 
 #-----------------------------------------------------
 # END-OF-FILE

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/pom.xml
@@ -158,7 +158,7 @@
             org.wso2.carbon.apimgt.rest.api.store.*; version="${carbon.apimgt.version}"
         </export.package>
         <carbon.component>
-            osgi.service; objectClass="org.wso2.msf4j.Microservice"; serviceCount="5"
+            osgi.service; objectClass="org.wso2.msf4j.Microservice"; serviceCount="6"
         </carbon.component>
     </properties>
 </project>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApiException.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApiException.java
@@ -1,6 +1,6 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class ApiException extends Exception{
     private int code;
     public ApiException (int code, String msg) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApiOriginFilter.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApiOriginFilter.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletResponse;
 
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class ApiOriginFilter implements javax.servlet.Filter {
     public void doFilter(ServletRequest request, ServletResponse response,
             FilterChain chain) throws IOException, ServletException {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApiResponseMessage.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApiResponseMessage.java
@@ -3,7 +3,7 @@ package org.wso2.carbon.apimgt.rest.api.store;
 import javax.xml.bind.annotation.XmlTransient;
 
 @javax.xml.bind.annotation.XmlRootElement
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class ApiResponseMessage {
     public static final int ERROR = 1;
     public static final int WARNING = 2;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApisApi.java
@@ -30,7 +30,7 @@ import javax.ws.rs.*;
 @Consumes({ "application/json" })
 @Produces({ "application/json" })
 @io.swagger.annotations.Api(description = "the apis API")
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class ApisApi implements Microservice  {
    private final ApisApiService delegate = ApisApiServiceFactory.getApisApi();
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApisApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApisApiService.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public abstract class ApisApiService {
     public abstract Response apisApiIdDocumentsDocumentIdContentGet(String apiId
  ,String documentId

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApplicationsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApplicationsApi.java
@@ -30,7 +30,7 @@ import javax.ws.rs.*;
 @Consumes({ "application/json" })
 @Produces({ "application/json" })
 @io.swagger.annotations.Api(description = "the applications API")
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class ApplicationsApi implements Microservice  {
    private final ApplicationsApiService delegate = ApplicationsApiServiceFactory.getApplicationsApi();
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApplicationsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/ApplicationsApiService.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public abstract class ApplicationsApiService {
     public abstract Response applicationsApplicationIdDelete(String applicationId
  ,String ifMatch

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/LabelInfoApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/LabelInfoApi.java
@@ -1,0 +1,56 @@
+package org.wso2.carbon.apimgt.rest.api.store;
+
+import org.wso2.carbon.apimgt.rest.api.store.factories.LabelInfoApiServiceFactory;
+
+import io.swagger.annotations.ApiParam;
+
+import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.store.dto.LabelInfoListDTO;
+import org.wso2.carbon.apimgt.rest.api.store.dto.LabelListDTO;
+
+import org.wso2.msf4j.Microservice;
+import org.osgi.service.component.annotations.Component;
+
+import java.io.InputStream;
+
+import org.wso2.msf4j.formparam.FormDataParam;
+import org.wso2.msf4j.formparam.FileInfo;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.*;
+
+@Component(
+    name = "org.wso2.carbon.apimgt.rest.api.store.LabelInfoApi",
+    service = Microservice.class,
+    immediate = true
+)
+@Path("/api/am/store/v1/label-info")
+@Consumes({ "application/json" })
+@Produces({ "application/json" })
+@io.swagger.annotations.Api(description = "the label-info API")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
+public class LabelInfoApi implements Microservice  {
+   private final LabelInfoApiService delegate = LabelInfoApiServiceFactory.getLabelInfoApi();
+
+    @GET
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Get label information based on the label name", notes = "This operation can be used to retrieve the information of the labels ", response = LabelListDTO.class, tags={ "Label (Collection)", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "OK. Label list is returned. ", response = LabelListDTO.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 304, message = "Not Modified. Empty body because the client has already the latest version of the requested resource (Will be supported in future). ", response = LabelListDTO.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Not Found. Requested API does not exist. ", response = LabelListDTO.class) })
+    public Response labelInfoGet(@ApiParam(value = "Label names to get information. " ,required=true) LabelInfoListDTO body
+,@ApiParam(value = "Media type of the entity in the body. Default is JSON. " ,required=true, defaultValue="JSON")@HeaderParam("Content-Type") String contentType
+,@ApiParam(value = "Media types acceptable for the response. Default is JSON. " , defaultValue="JSON")@HeaderParam("Accept") String accept
+,@ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved variant of the resourec. " )@HeaderParam("If-None-Match") String ifNoneMatch
+,@ApiParam(value = "Validator for conditional requests; based on Last Modified header of the formerly retrieved variant of the resource. " )@HeaderParam("If-Modified-Since") String ifModifiedSince
+,@ApiParam(value = "Validator for API Minor Version " , defaultValue="1.0")@HeaderParam("Minor-Version") String minorVersion
+)
+    throws NotFoundException {
+        return delegate.labelInfoGet(body,contentType,accept,ifNoneMatch,ifModifiedSince,minorVersion);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/LabelInfoApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/LabelInfoApiService.java
@@ -7,8 +7,8 @@ import org.wso2.msf4j.formparam.FormDataParam;
 import org.wso2.msf4j.formparam.FileInfo;
 
 import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.TierDTO;
-import org.wso2.carbon.apimgt.rest.api.store.dto.TierListDTO;
+import org.wso2.carbon.apimgt.rest.api.store.dto.LabelInfoListDTO;
+import org.wso2.carbon.apimgt.rest.api.store.dto.LabelListDTO;
 
 import java.util.List;
 import org.wso2.carbon.apimgt.rest.api.store.NotFoundException;
@@ -19,16 +19,9 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
 @javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
-public abstract class PoliciesApiService {
-    public abstract Response policiesTierLevelGet(String tierLevel
- ,Integer limit
- ,Integer offset
- ,String accept
- ,String ifNoneMatch
- ,String minorVersion
- ) throws NotFoundException;
-    public abstract Response policiesTierLevelTierNameGet(String tierName
- ,String tierLevel
+public abstract class LabelInfoApiService {
+    public abstract Response labelInfoGet(LabelInfoListDTO body
+ ,String contentType
  ,String accept
  ,String ifNoneMatch
  ,String ifModifiedSince

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/NotFoundException.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/NotFoundException.java
@@ -1,6 +1,6 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class NotFoundException extends ApiException {
     private int code;
     public NotFoundException (int code, String msg) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/PoliciesApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/PoliciesApi.java
@@ -28,7 +28,7 @@ import javax.ws.rs.*;
 @Consumes({ "application/json" })
 @Produces({ "application/json" })
 @io.swagger.annotations.Api(description = "the policies API")
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class PoliciesApi implements Microservice  {
    private final PoliciesApiService delegate = PoliciesApiServiceFactory.getPoliciesApi();
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/StringUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/StringUtil.java
@@ -1,6 +1,6 @@
 package org.wso2.carbon.apimgt.rest.api.store;
 
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/SubscriptionsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/SubscriptionsApi.java
@@ -28,7 +28,7 @@ import javax.ws.rs.*;
 @Consumes({ "application/json" })
 @Produces({ "application/json" })
 @io.swagger.annotations.Api(description = "the subscriptions API")
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class SubscriptionsApi implements Microservice  {
    private final SubscriptionsApiService delegate = SubscriptionsApiServiceFactory.getSubscriptionsApi();
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/SubscriptionsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/SubscriptionsApiService.java
@@ -18,7 +18,7 @@ import java.io.InputStream;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public abstract class SubscriptionsApiService {
     public abstract Response subscriptionsGet(String apiId
  ,String applicationId

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/TagsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/TagsApi.java
@@ -27,7 +27,7 @@ import javax.ws.rs.*;
 @Consumes({ "application/json" })
 @Produces({ "application/json" })
 @io.swagger.annotations.Api(description = "the tags API")
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class TagsApi implements Microservice  {
    private final TagsApiService delegate = TagsApiServiceFactory.getTagsApi();
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/TagsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/TagsApiService.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public abstract class TagsApiService {
     public abstract Response tagsGet(Integer limit
  ,Integer offset

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIDTO.java
@@ -12,7 +12,7 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.API_businessInformationDTO;
 /**
  * APIDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class APIDTO   {
   @JsonProperty("id")
   private String id = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/APIInfoDTO.java
@@ -9,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * APIInfoDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class APIInfoDTO   {
   @JsonProperty("id")
   private String id = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/API_businessInformationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/API_businessInformationDTO.java
@@ -9,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * API_businessInformationDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class API_businessInformationDTO   {
   @JsonProperty("businessOwner")
   private String businessOwner = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationDTO.java
@@ -12,7 +12,7 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationKeyDTO;
 /**
  * ApplicationDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class ApplicationDTO   {
   @JsonProperty("applicationId")
   private String applicationId = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationInfoDTO.java
@@ -9,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ApplicationInfoDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class ApplicationInfoDTO   {
   @JsonProperty("applicationId")
   private String applicationId = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationKeyDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationKeyDTO.java
@@ -13,7 +13,7 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.TokenDTO;
 /**
  * ApplicationKeyDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class ApplicationKeyDTO   {
   @JsonProperty("consumerKey")
   private String consumerKey = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationKeyGenerateRequestDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationKeyGenerateRequestDTO.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * ApplicationKeyGenerateRequestDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class ApplicationKeyGenerateRequestDTO   {
   /**
    * Gets or Sets keyType

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ApplicationListDTO.java
@@ -12,7 +12,7 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.ApplicationInfoDTO;
 /**
  * ApplicationListDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class ApplicationListDTO   {
   @JsonProperty("count")
   private Integer count = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/DocumentDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/DocumentDTO.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * DocumentDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class DocumentDTO   {
   @JsonProperty("documentId")
   private String documentId = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/DocumentListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/DocumentListDTO.java
@@ -12,7 +12,7 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.DocumentDTO;
 /**
  * DocumentListDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class DocumentListDTO   {
   @JsonProperty("count")
   private Integer count = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ErrorDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ErrorDTO.java
@@ -12,7 +12,7 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.ErrorListItemDTO;
 /**
  * ErrorDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class ErrorDTO   {
   @JsonProperty("code")
   private Long code = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ErrorListItemDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/ErrorListItemDTO.java
@@ -9,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ErrorListItemDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class ErrorListItemDTO   {
   @JsonProperty("code")
   private String code = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/LabelDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/LabelDTO.java
@@ -7,17 +7,17 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 /**
- * TagDTO
+ * LabelDTO
  */
 @javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
-public class TagDTO   {
+public class LabelDTO   {
   @JsonProperty("name")
   private String name = null;
 
-  @JsonProperty("weight")
-  private Integer weight = null;
+  @JsonProperty("access_url")
+  private String accessUrl = null;
 
-  public TagDTO name(String name) {
+  public LabelDTO name(String name) {
     this.name = name;
     return this;
   }
@@ -35,22 +35,22 @@ public class TagDTO   {
     this.name = name;
   }
 
-  public TagDTO weight(Integer weight) {
-    this.weight = weight;
+  public LabelDTO accessUrl(String accessUrl) {
+    this.accessUrl = accessUrl;
     return this;
   }
 
    /**
-   * Get weight
-   * @return weight
+   * Get accessUrl
+   * @return accessUrl
   **/
   @ApiModelProperty(required = true, value = "")
-  public Integer getWeight() {
-    return weight;
+  public String getAccessUrl() {
+    return accessUrl;
   }
 
-  public void setWeight(Integer weight) {
-    this.weight = weight;
+  public void setAccessUrl(String accessUrl) {
+    this.accessUrl = accessUrl;
   }
 
 
@@ -62,23 +62,23 @@ public class TagDTO   {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    TagDTO tag = (TagDTO) o;
-    return Objects.equals(this.name, tag.name) &&
-        Objects.equals(this.weight, tag.weight);
+    LabelDTO label = (LabelDTO) o;
+    return Objects.equals(this.name, label.name) &&
+        Objects.equals(this.accessUrl, label.accessUrl);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, weight);
+    return Objects.hash(name, accessUrl);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class TagDTO {\n");
+    sb.append("class LabelDTO {\n");
     
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    weight: ").append(toIndentedString(weight)).append("\n");
+    sb.append("    accessUrl: ").append(toIndentedString(accessUrl)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/LabelInfoListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/LabelInfoListDTO.java
@@ -5,52 +5,38 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * TagDTO
+ * LabelInfoListDTO
  */
 @javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
-public class TagDTO   {
-  @JsonProperty("name")
-  private String name = null;
+public class LabelInfoListDTO   {
+  @JsonProperty("labels")
+  private List<String> labels = new ArrayList<String>();
 
-  @JsonProperty("weight")
-  private Integer weight = null;
+  public LabelInfoListDTO labels(List<String> labels) {
+    this.labels = labels;
+    return this;
+  }
 
-  public TagDTO name(String name) {
-    this.name = name;
+  public LabelInfoListDTO addLabelsItem(String labelsItem) {
+    this.labels.add(labelsItem);
     return this;
   }
 
    /**
-   * Get name
-   * @return name
+   * Get labels
+   * @return labels
   **/
   @ApiModelProperty(required = true, value = "")
-  public String getName() {
-    return name;
+  public List<String> getLabels() {
+    return labels;
   }
 
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public TagDTO weight(Integer weight) {
-    this.weight = weight;
-    return this;
-  }
-
-   /**
-   * Get weight
-   * @return weight
-  **/
-  @ApiModelProperty(required = true, value = "")
-  public Integer getWeight() {
-    return weight;
-  }
-
-  public void setWeight(Integer weight) {
-    this.weight = weight;
+  public void setLabels(List<String> labels) {
+    this.labels = labels;
   }
 
 
@@ -62,23 +48,21 @@ public class TagDTO   {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    TagDTO tag = (TagDTO) o;
-    return Objects.equals(this.name, tag.name) &&
-        Objects.equals(this.weight, tag.weight);
+    LabelInfoListDTO labelInfoList = (LabelInfoListDTO) o;
+    return Objects.equals(this.labels, labelInfoList.labels);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, weight);
+    return Objects.hash(labels);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class TagDTO {\n");
+    sb.append("class LabelInfoListDTO {\n");
     
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    weight: ").append(toIndentedString(weight)).append("\n");
+    sb.append("    labels: ").append(toIndentedString(labels)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/LabelListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/LabelListDTO.java
@@ -7,13 +7,13 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
-import org.wso2.carbon.apimgt.rest.api.store.dto.APIInfoDTO;
+import org.wso2.carbon.apimgt.rest.api.store.dto.LabelDTO;
 
 /**
- * APIListDTO
+ * LabelListDTO
  */
 @javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
-public class APIListDTO   {
+public class LabelListDTO   {
   @JsonProperty("count")
   private Integer count = null;
 
@@ -24,18 +24,18 @@ public class APIListDTO   {
   private String previous = null;
 
   @JsonProperty("list")
-  private List<APIInfoDTO> list = new ArrayList<APIInfoDTO>();
+  private List<LabelDTO> list = new ArrayList<LabelDTO>();
 
-  public APIListDTO count(Integer count) {
+  public LabelListDTO count(Integer count) {
     this.count = count;
     return this;
   }
 
    /**
-   * Number of APIs returned. 
+   * Number of Labels returned. 
    * @return count
   **/
-  @ApiModelProperty(value = "Number of APIs returned. ")
+  @ApiModelProperty(value = "Number of Labels returned. ")
   public Integer getCount() {
     return count;
   }
@@ -44,7 +44,7 @@ public class APIListDTO   {
     this.count = count;
   }
 
-  public APIListDTO next(String next) {
+  public LabelListDTO next(String next) {
     this.next = next;
     return this;
   }
@@ -62,7 +62,7 @@ public class APIListDTO   {
     this.next = next;
   }
 
-  public APIListDTO previous(String previous) {
+  public LabelListDTO previous(String previous) {
     this.previous = previous;
     return this;
   }
@@ -80,12 +80,12 @@ public class APIListDTO   {
     this.previous = previous;
   }
 
-  public APIListDTO list(List<APIInfoDTO> list) {
+  public LabelListDTO list(List<LabelDTO> list) {
     this.list = list;
     return this;
   }
 
-  public APIListDTO addListItem(APIInfoDTO listItem) {
+  public LabelListDTO addListItem(LabelDTO listItem) {
     this.list.add(listItem);
     return this;
   }
@@ -95,11 +95,11 @@ public class APIListDTO   {
    * @return list
   **/
   @ApiModelProperty(value = "")
-  public List<APIInfoDTO> getList() {
+  public List<LabelDTO> getList() {
     return list;
   }
 
-  public void setList(List<APIInfoDTO> list) {
+  public void setList(List<LabelDTO> list) {
     this.list = list;
   }
 
@@ -112,11 +112,11 @@ public class APIListDTO   {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    APIListDTO apIList = (APIListDTO) o;
-    return Objects.equals(this.count, apIList.count) &&
-        Objects.equals(this.next, apIList.next) &&
-        Objects.equals(this.previous, apIList.previous) &&
-        Objects.equals(this.list, apIList.list);
+    LabelListDTO labelList = (LabelListDTO) o;
+    return Objects.equals(this.count, labelList.count) &&
+        Objects.equals(this.next, labelList.next) &&
+        Objects.equals(this.previous, labelList.previous) &&
+        Objects.equals(this.list, labelList.list);
   }
 
   @Override
@@ -127,7 +127,7 @@ public class APIListDTO   {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class APIListDTO {\n");
+    sb.append("class LabelListDTO {\n");
     
     sb.append("    count: ").append(toIndentedString(count)).append("\n");
     sb.append("    next: ").append(toIndentedString(next)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/SubscriptionDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/SubscriptionDTO.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * SubscriptionDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-20T12:49:23.977+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class SubscriptionDTO   {
   @JsonProperty("subscriptionId")
   private String subscriptionId = null;
@@ -21,14 +21,14 @@ public class SubscriptionDTO   {
   @JsonProperty("apiIdentifier")
   private String apiIdentifier = null;
 
-  @JsonProperty("policy")
-  private String policy = null;
-
   @JsonProperty("apiName")
   private String apiName = null;
 
   @JsonProperty("apiVersion")
   private String apiVersion = null;
+
+  @JsonProperty("policy")
+  private String policy = null;
 
   /**
    * Gets or Sets lifeCycleStatus
@@ -75,10 +75,10 @@ public class SubscriptionDTO   {
     return this;
   }
 
-  /**
+   /**
    * Get subscriptionId
    * @return subscriptionId
-   **/
+  **/
   @ApiModelProperty(value = "")
   public String getSubscriptionId() {
     return subscriptionId;
@@ -93,10 +93,10 @@ public class SubscriptionDTO   {
     return this;
   }
 
-  /**
+   /**
    * Get applicationId
    * @return applicationId
-   **/
+  **/
   @ApiModelProperty(required = true, value = "")
   public String getApplicationId() {
     return applicationId;
@@ -111,10 +111,10 @@ public class SubscriptionDTO   {
     return this;
   }
 
-  /**
+   /**
    * Get apiIdentifier
    * @return apiIdentifier
-   **/
+  **/
   @ApiModelProperty(required = true, value = "")
   public String getApiIdentifier() {
     return apiIdentifier;
@@ -124,33 +124,15 @@ public class SubscriptionDTO   {
     this.apiIdentifier = apiIdentifier;
   }
 
-  public SubscriptionDTO policy(String policy) {
-    this.policy = policy;
-    return this;
-  }
-
-  /**
-   * Get policy
-   * @return policy
-   **/
-  @ApiModelProperty(required = true, value = "")
-  public String getPolicy() {
-    return policy;
-  }
-
-  public void setPolicy(String policy) {
-    this.policy = policy;
-  }
-
   public SubscriptionDTO apiName(String apiName) {
     this.apiName = apiName;
     return this;
   }
 
-  /**
+   /**
    * Get apiName
    * @return apiName
-   **/
+  **/
   @ApiModelProperty(required = true, value = "")
   public String getApiName() {
     return apiName;
@@ -165,10 +147,10 @@ public class SubscriptionDTO   {
     return this;
   }
 
-  /**
+   /**
    * Get apiVersion
    * @return apiVersion
-   **/
+  **/
   @ApiModelProperty(required = true, value = "")
   public String getApiVersion() {
     return apiVersion;
@@ -178,15 +160,33 @@ public class SubscriptionDTO   {
     this.apiVersion = apiVersion;
   }
 
+  public SubscriptionDTO policy(String policy) {
+    this.policy = policy;
+    return this;
+  }
+
+   /**
+   * Get policy
+   * @return policy
+  **/
+  @ApiModelProperty(required = true, value = "")
+  public String getPolicy() {
+    return policy;
+  }
+
+  public void setPolicy(String policy) {
+    this.policy = policy;
+  }
+
   public SubscriptionDTO lifeCycleStatus(LifeCycleStatusEnum lifeCycleStatus) {
     this.lifeCycleStatus = lifeCycleStatus;
     return this;
   }
 
-  /**
+   /**
    * Get lifeCycleStatus
    * @return lifeCycleStatus
-   **/
+  **/
   @ApiModelProperty(value = "")
   public LifeCycleStatusEnum getLifeCycleStatus() {
     return lifeCycleStatus;
@@ -207,17 +207,17 @@ public class SubscriptionDTO   {
     }
     SubscriptionDTO subscription = (SubscriptionDTO) o;
     return Objects.equals(this.subscriptionId, subscription.subscriptionId) &&
-            Objects.equals(this.applicationId, subscription.applicationId) &&
-            Objects.equals(this.apiIdentifier, subscription.apiIdentifier) &&
-            Objects.equals(this.policy, subscription.policy) &&
-            Objects.equals(this.apiName, subscription.apiName) &&
-            Objects.equals(this.apiVersion, subscription.apiVersion) &&
-            Objects.equals(this.lifeCycleStatus, subscription.lifeCycleStatus);
+        Objects.equals(this.applicationId, subscription.applicationId) &&
+        Objects.equals(this.apiIdentifier, subscription.apiIdentifier) &&
+        Objects.equals(this.apiName, subscription.apiName) &&
+        Objects.equals(this.apiVersion, subscription.apiVersion) &&
+        Objects.equals(this.policy, subscription.policy) &&
+        Objects.equals(this.lifeCycleStatus, subscription.lifeCycleStatus);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(subscriptionId, applicationId, apiIdentifier, policy, apiName, apiVersion, lifeCycleStatus);
+    return Objects.hash(subscriptionId, applicationId, apiIdentifier, apiName, apiVersion, policy, lifeCycleStatus);
   }
 
   @Override
@@ -228,9 +228,9 @@ public class SubscriptionDTO   {
     sb.append("    subscriptionId: ").append(toIndentedString(subscriptionId)).append("\n");
     sb.append("    applicationId: ").append(toIndentedString(applicationId)).append("\n");
     sb.append("    apiIdentifier: ").append(toIndentedString(apiIdentifier)).append("\n");
-    sb.append("    policy: ").append(toIndentedString(policy)).append("\n");
     sb.append("    apiName: ").append(toIndentedString(apiName)).append("\n");
     sb.append("    apiVersion: ").append(toIndentedString(apiVersion)).append("\n");
+    sb.append("    policy: ").append(toIndentedString(policy)).append("\n");
     sb.append("    lifeCycleStatus: ").append(toIndentedString(lifeCycleStatus)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/SubscriptionListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/SubscriptionListDTO.java
@@ -12,7 +12,7 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.SubscriptionDTO;
 /**
  * SubscriptionListDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class SubscriptionListDTO   {
   @JsonProperty("count")
   private Integer count = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TagListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TagListDTO.java
@@ -12,7 +12,7 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.TagDTO;
 /**
  * TagListDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class TagListDTO   {
   @JsonProperty("count")
   private Integer count = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TierDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TierDTO.java
@@ -13,7 +13,7 @@ import java.util.Map;
 /**
  * TierDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class TierDTO   {
   @JsonProperty("name")
   private String name = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TierListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TierListDTO.java
@@ -12,7 +12,7 @@ import org.wso2.carbon.apimgt.rest.api.store.dto.TierDTO;
 /**
  * TierListDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class TierListDTO   {
   @JsonProperty("count")
   private Integer count = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TokenDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/TokenDTO.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * TokenDTO
  */
-@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-02-09T12:36:56.084+05:30")
+@javax.annotation.Generated(value = "org.wso2.maven.plugins.JavaMSF4JServerCodegen", date = "2017-03-08T11:10:07.219+05:30")
 public class TokenDTO   {
   @JsonProperty("accessToken")
   private String accessToken = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/factories/LabelInfoApiServiceFactory.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/factories/LabelInfoApiServiceFactory.java
@@ -1,0 +1,12 @@
+package org.wso2.carbon.apimgt.rest.api.store.factories;
+
+import org.wso2.carbon.apimgt.rest.api.store.LabelInfoApiService;
+import org.wso2.carbon.apimgt.rest.api.store.impl.LabelInfoApiServiceImpl;
+
+public class LabelInfoApiServiceFactory {
+    private static final LabelInfoApiService service = new LabelInfoApiServiceImpl();
+
+    public static LabelInfoApiService getLabelInfoApi() {
+        return service;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/LabelInfoApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/LabelInfoApiServiceImpl.java
@@ -1,0 +1,29 @@
+package org.wso2.carbon.apimgt.rest.api.store.impl;
+
+import org.wso2.carbon.apimgt.rest.api.store.*;
+import org.wso2.carbon.apimgt.rest.api.store.dto.*;
+
+
+import java.util.List;
+import org.wso2.carbon.apimgt.rest.api.store.NotFoundException;
+
+import java.io.InputStream;
+
+import org.wso2.msf4j.formparam.FormDataParam;
+import org.wso2.msf4j.formparam.FileInfo;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+
+public class LabelInfoApiServiceImpl extends LabelInfoApiService {
+    @Override
+    public Response labelInfoGet(LabelInfoListDTO body
+, String contentType
+, String accept
+, String ifNoneMatch
+, String ifModifiedSince
+, String minorVersion
+ ) throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/resources/store-api.yaml
@@ -1130,6 +1130,61 @@ paths:
             $ref: '#/definitions/Error'
 
 ######################################################
+# The "Label Collection" resource API
+######################################################
+  /label-info:
+
+#-----------------------------------------------------
+# Retrieve the label information
+#-----------------------------------------------------
+    get:
+      summary: Get label information based on the label name
+      description: |
+        This operation can be used to retrieve the information of the labels
+      parameters:
+        - in: body
+          name: body
+          description: |
+            Label names to get information.
+          required: true
+          schema:
+            $ref: '#/definitions/LabelInfoList'
+        - $ref: '#/parameters/Content-Type'
+        - $ref: '#/parameters/Accept'
+        - $ref: '#/parameters/If-None-Match'
+        - $ref: '#/parameters/If-Modified-Since'
+        - $ref: '#/parameters/Minor-Version'
+      tags:
+        - Label (Collection)
+      responses:
+        200:
+          description: |
+            OK.
+            Label list is returned.
+          schema:
+             $ref: '#/definitions/LabelList'
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              type: string
+            ETag:
+              description: |
+                Entity Tag of the response resource.
+                Used by caches, or in conditional requests (Will be supported in future).
+              type: string
+        304:
+          description: |
+            Not Modified.
+            Empty body because the client has already the latest version of the requested resource (Will be supported in future).
+        404:
+          description: |
+            Not Found.
+            Requested API does not exist.
+          schema:
+            $ref: '#/definitions/Error'
+
+######################################################
 # Parameters - required by some of the APIs above
 ######################################################
 parameters:
@@ -1686,12 +1741,18 @@ definitions:
       - applicationId
       - apiIdentifier
       - policy
+      - apiName
+      - apiVersion
     properties:
       subscriptionId:
         type: string
       applicationId:
         type: string
       apiIdentifier:
+        type: string
+      apiName:
+        type: string
+      apiVersion:
         type: string
       policy:
         type: string
@@ -1868,6 +1929,58 @@ definitions:
         items: 
           type: string
         description: Allowed scopes for the access token
+
+#-----------------------------------------------------
+# The Label resource
+#-----------------------------------------------------
+  Label:
+    title: Label
+    required:
+      - name
+      - access_url
+    properties:
+      name:
+        type: string
+      access_url:
+        type: string
+
+#-----------------------------------------------------
+# The Label Info List resource
+#-----------------------------------------------------
+  LabelInfoList:
+    title: Label Info List
+    required:
+      - labels
+    properties:
+      labels:
+        type: array
+        items:
+          type: string
+
+#-----------------------------------------------------
+# The Label List resource
+#-----------------------------------------------------
+  LabelList:
+    title: Label List
+    properties:
+      count:
+        type: integer
+        description: |
+          Number of Labels returned.
+      next:
+        type: string
+        description: |
+          Link to the next subset of resources qualified.
+          Empty if no more resources are to be returned.
+      previous:
+        type: string
+        description: |
+          Link to the previous subset of resources qualified.
+          Empty if current subset is the first subset returned.
+      list:
+        type: array
+        items:
+          $ref: '#/definitions/Label'
 
 #-----------------------------------------------------
 # END-OF-FILE


### PR DESCRIPTION
This PR adds a new API for Store to retrieve information about labels given. 

GET /label-info

Request - 
{  
   "labels":[  
      "public",
      "private"
   ]
}

Response - 
{  
   "count":2,
   "list":[  
      {  
         "name":"public",
         "access_url":"https://test.cloud.public"
      },
      {  
         "name":"private",
         "access_url":"https://test.cloud.private"
      }
   ]
}