### PR TITLE
Unit tests for AbstractAPIManager

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/AbstractAPIManager.java
@@ -105,7 +105,7 @@ public abstract class AbstractAPIManager implements APIManager {
         } catch (APIMgtDAOException e) {
             String errorMsg = "Error occurred while retrieving API with id " + uuid;
             log.error(errorMsg, e);
-            throw new APIMgtDAOException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
+            throw new APIManagementException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
         }
         return api;
     }
@@ -121,7 +121,7 @@ public abstract class AbstractAPIManager implements APIManager {
         } catch (APIMgtDAOException e) {
             String errorMsg = "Error occurred while retrieving the last update time of API with id " + apiId;
             log.error(errorMsg, e);
-            throw new APIMgtDAOException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
+            throw new APIManagementException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
         }
         
         return lastUpdatedTime;
@@ -141,7 +141,7 @@ public abstract class AbstractAPIManager implements APIManager {
                     "Error occurred while retrieving the last update time of the swagger definition of API with id "
                             + apiId;
             log.error(errorMsg, e);
-            throw new APIMgtDAOException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
+            throw new APIManagementException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
         }
 
         return lastUpdatedTime;
@@ -174,7 +174,7 @@ public abstract class AbstractAPIManager implements APIManager {
             } catch (APIMgtDAOException e) {
                 String errorMsg = "Couldn't check API Context " + context + "Exists";
                 log.error(errorMsg, e);
-                throw new APIMgtDAOException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
+                throw new APIManagementException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
             }
         } else {
             return false;
@@ -195,7 +195,7 @@ public abstract class AbstractAPIManager implements APIManager {
         } catch (APIMgtDAOException e) {
             String errorMsg = "Couldn't check API Name " + apiName + "Exists";
             log.error(errorMsg, e);
-            throw new APIMgtDAOException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
+            throw new APIManagementException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
         }
     }
 
@@ -226,7 +226,7 @@ public abstract class AbstractAPIManager implements APIManager {
         } catch (APIMgtDAOException e) {
             String errorMsg = "Couldn't retrieve swagger definition for apiId " + api;
             log.error(errorMsg + api, e);
-            throw new APIMgtDAOException(errorMsg + api, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
+            throw new APIManagementException(errorMsg + api, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
         }
 
     }
@@ -246,7 +246,7 @@ public abstract class AbstractAPIManager implements APIManager {
         } catch (APIMgtDAOException e) {
             String errorMsg = "Error occurred while retrieving documents";
             log.error(errorMsg, e);
-            throw new APIMgtDAOException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
+            throw new APIManagementException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
         }
     }
 
@@ -304,7 +304,7 @@ public abstract class AbstractAPIManager implements APIManager {
         } catch (APIMgtDAOException e) {
             String errorMsg = "Error occurred while retrieving document content";
             log.error(errorMsg, e);
-            throw new APIMgtDAOException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
+            throw new APIManagementException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
         }
     }
 
@@ -323,7 +323,7 @@ public abstract class AbstractAPIManager implements APIManager {
         } catch (APIMgtDAOException e) {
             String errorMsg = "Error occurred while retrieving application - ";
             log.error(errorMsg, e);
-            throw new APIMgtDAOException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
+            throw new APIManagementException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
         }
         return application;
     }
@@ -460,7 +460,7 @@ public abstract class AbstractAPIManager implements APIManager {
         } catch (APIMgtDAOException e) {
             String errorMsg = "Couldn't find subscriptions for apiId " + apiId;
             log.error(errorMsg, e);
-            throw new APIMgtDAOException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
+            throw new APIManagementException(errorMsg, e, ExceptionCodes.APIMGT_DAO_EXCEPTION);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/impl/AbstractAPIManagerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/impl/AbstractAPIManagerTestCase.java
@@ -18,6 +18,7 @@ package org.wso2.carbon.apimgt.core.impl;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.apimgt.core.SampleTestObjectCreator;
+import org.wso2.carbon.apimgt.core.dao.APISubscriptionDAO;
 import org.wso2.carbon.apimgt.core.dao.ApiDAO;
 import org.wso2.carbon.apimgt.core.dao.ApplicationDAO;
 import org.wso2.carbon.apimgt.core.exception.APIManagementException;
@@ -25,7 +26,12 @@ import org.wso2.carbon.apimgt.core.exception.APIMgtDAOException;
 import org.wso2.carbon.apimgt.core.models.API;
 import org.wso2.carbon.apimgt.core.models.Application;
 import org.wso2.carbon.apimgt.core.models.DocumentInfo;
+import org.wso2.carbon.apimgt.core.models.Subscription;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Mockito.atLeastOnce;
@@ -41,10 +47,13 @@ public class AbstractAPIManagerTestCase {
     private static final String API_VERSION = "1.0.0";
     private static final String PROVIDER_NAME = "provider";
     private static final String API_NAME = "api_name";
+    private static final String API_CONTEXT = "/testapi";
     private static final String APP_NAME = "app_name";
+    private static final String LAST_UPDATED_TIME = "2017-03-19T13:45:30";
     public static final String UUID = "7a2298c4-c905-403f-8fac-38c73301631f";
+    public static final String DOC_ID = "docId";
 
-    @Test
+    @Test(description = "Search API by UUID")
     public void testSearchAPIByUUID() throws APIManagementException {
         ApiDAO apiDAO = mock(ApiDAO.class);
         AbstractAPIManager apiStore = new APIStoreImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
@@ -88,6 +97,136 @@ public class AbstractAPIManagerTestCase {
         verify(apiDAO, times(1)).getDocumentsInfoList(UUID);
     }
 
+    @Test(description = "Getting last updated time of API")
+    public void testGetLastUpdatedTimeOfAPI() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getLastUpdatedTimeOfAPI(UUID)).thenReturn(LAST_UPDATED_TIME);
+        apiPublisher.getLastUpdatedTimeOfAPI(UUID);
+        verify(apiDAO, times(1)).getLastUpdatedTimeOfAPI(UUID);
+    }
+
+    @Test(description = "Getting last updated time of Swagger Definition")
+    public void testGetLastUpdatedTimeOfSwaggerDefinition() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getLastUpdatedTimeOfSwaggerDefinition(UUID)).thenReturn(LAST_UPDATED_TIME);
+        apiPublisher.getLastUpdatedTimeOfSwaggerDefinition(UUID);
+        verify(apiDAO, times(1)).getLastUpdatedTimeOfSwaggerDefinition(UUID);
+    }
+
+    @Test(description = "Check if context exist when context is null")
+    public void testIsContextExistWhenContextNull() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        Boolean isExists = apiPublisher.isContextExist("");
+        Assert.assertEquals(isExists, Boolean.FALSE);
+    }
+
+    @Test(description = "Get swagger definition for API")
+    public void testGetSwagger20Definition() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        String swaggerDefinition = SampleTestObjectCreator.apiDefinition;
+        when(apiDAO.getSwaggerDefinition(UUID)).thenReturn(swaggerDefinition);
+        apiPublisher.getSwagger20Definition(UUID);
+        verify(apiDAO, times(1)).getSwaggerDefinition(UUID);
+    }
+
+    @Test(description = "Get subscription by UUID")
+    public void testGetSubscriptionByUUID() throws APIManagementException {
+        APISubscriptionDAO apiSubscriptionDAO = mock(APISubscriptionDAO.class);
+        AbstractAPIManager apiStore = new APIStoreImpl(USER_NAME, null, null, apiSubscriptionDAO, null, null, null,
+                null);
+        when(apiSubscriptionDAO.getAPISubscription(UUID)).thenReturn(new Subscription(UUID, null, null, null));
+        apiStore.getSubscriptionByUUID(UUID);
+        verify(apiSubscriptionDAO, times(1)).getAPISubscription(UUID);
+    }
+
+    @Test(description = "Getting last updated time of Document")
+    public void testGetLastUpdatedTimeOfDocument() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getLastUpdatedTimeOfDocument(DOC_ID)).thenReturn(LAST_UPDATED_TIME);
+        apiPublisher.getLastUpdatedTimeOfDocument(DOC_ID);
+        verify(apiDAO, times(1)).getLastUpdatedTimeOfDocument(DOC_ID);
+    }
+
+    @Test(description = "Getting last updated time of Document content")
+    public void testGetLastUpdatedTimeOfDocumentContent() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getLastUpdatedTimeOfDocumentContent(UUID, DOC_ID)).thenReturn(LAST_UPDATED_TIME);
+        apiPublisher.getLastUpdatedTimeOfDocumentContent(UUID, DOC_ID);
+        verify(apiDAO, times(1)).getLastUpdatedTimeOfDocumentContent(UUID, DOC_ID);
+    }
+
+    @Test(description = "Getting last updated time of API Thumbnail Image")
+    public void testGetLastUpdatedTimeOfAPIThumbnailImage() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getLastUpdatedTimeOfAPIThumbnailImage(UUID)).thenReturn(LAST_UPDATED_TIME);
+        apiPublisher.getLastUpdatedTimeOfAPIThumbnailImage(UUID);
+        verify(apiDAO, times(1)).getLastUpdatedTimeOfAPIThumbnailImage(UUID);
+    }
+
+    @Test(description = "Getting last updated time of Application")
+    public void testGetLastUpdatedTimeOfApplication() throws APIManagementException {
+        ApplicationDAO applicationDAO = mock(ApplicationDAO.class);
+        AbstractAPIManager apiStore = new APIStoreImpl(USER_NAME, null, applicationDAO, null, null, null, null, null);
+        when(applicationDAO.getLastUpdatedTimeOfApplication(UUID)).thenReturn(LAST_UPDATED_TIME);
+        apiStore.getLastUpdatedTimeOfApplication(UUID);
+        verify(applicationDAO, times(1)).getLastUpdatedTimeOfApplication(UUID);
+    }
+
+    @Test(description = "Getting last updated time of Subscription")
+    public void testGetLastUpdatedTimeOfSubscription() throws APIManagementException {
+        APISubscriptionDAO apiSubscriptionDAO = mock(APISubscriptionDAO.class);
+        AbstractAPIManager apiStore = new APIStoreImpl(USER_NAME, null, null, apiSubscriptionDAO, null, null, null,
+                null);
+        when(apiSubscriptionDAO.getLastUpdatedTimeOfSubscription(UUID)).thenReturn(LAST_UPDATED_TIME);
+        apiStore.getLastUpdatedTimeOfSubscription(UUID);
+        verify(apiSubscriptionDAO, times(1)).getLastUpdatedTimeOfSubscription(UUID);
+    }
+
+    @Test(description = "Getting subscriptions by API")
+    public void testGetSubscriptionsByAPI() throws APIManagementException {
+        APISubscriptionDAO apiSubscriptionDAO = mock(APISubscriptionDAO.class);
+        AbstractAPIManager apiStore = new APIStoreImpl(USER_NAME, null, null, apiSubscriptionDAO, null, null, null,
+                null);
+        when(apiSubscriptionDAO.getAPISubscriptionsByAPI(UUID)).thenReturn(new ArrayList<Subscription>());
+        apiStore.getSubscriptionsByAPI(UUID);
+        verify(apiSubscriptionDAO, times(1)).getAPISubscriptionsByAPI(UUID);
+    }
+
+    @Test(description = "Getting Documentation content when source type is FILE")
+    public void testGetDocumentationContentFile() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        DocumentInfo.Builder builder = new DocumentInfo.Builder();
+        builder.name("CalculatorDoc");
+        builder.sourceType(DocumentInfo.SourceType.FILE);
+        DocumentInfo documentInfo = builder.build();
+        when(apiDAO.getDocumentInfo(DOC_ID)).thenReturn(documentInfo);
+        String stream = "This is sample file content";
+        InputStream inputStream = new ByteArrayInputStream(stream.getBytes());
+        when(apiDAO.getDocumentFileContent(DOC_ID)).thenReturn(inputStream);
+        apiPublisher.getDocumentationContent(DOC_ID);
+        verify(apiDAO, times(1)).getDocumentFileContent(DOC_ID);
+    }
+
+    @Test(description = "Getting Documentation content when source type is INLINE")
+    public void testGetDocumentationContentInline() throws APIManagementException, IOException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        DocumentInfo documentInfo = SampleTestObjectCreator.createDefaultDocumentationInfo();
+        when(apiDAO.getDocumentInfo(DOC_ID)).thenReturn(documentInfo);
+        when(apiDAO.getDocumentInlineContent(DOC_ID))
+                .thenReturn(SampleTestObjectCreator.createDefaultInlineDocumentationContent());
+        apiPublisher.getDocumentationContent(DOC_ID);
+        verify(apiDAO, times(1)).getDocumentInlineContent(DOC_ID);
+    }
+
     /**
      * Test cases for exceptions
      */
@@ -129,6 +268,189 @@ public class AbstractAPIManagerTestCase {
         when(apiDAO.getAPI(UUID))
                 .thenThrow(new APIMgtDAOException("Error occurred while retrieving API with id " + UUID));
         apiStore.getAPIbyUUID(UUID);
+    }
+
+    @Test(description = "Exception when getting last updated time of API",
+            expectedExceptions = APIManagementException.class)
+    public void testGetLastUpdatedTimeOfAPIException() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getLastUpdatedTimeOfAPI(UUID)).thenThrow(
+                new APIMgtDAOException("Error occurred while retrieving the last update time of API with id " + UUID));
+        apiPublisher.getLastUpdatedTimeOfAPI(UUID);
+        verify(apiDAO, times(0)).getLastUpdatedTimeOfAPI(UUID);
+    }
+
+    @Test(description = "Exception when getting last updated time of Swagger Definition",
+            expectedExceptions = APIManagementException.class)
+    public void testGetLastUpdatedTimeOfSwaggerDefinitionException() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getLastUpdatedTimeOfSwaggerDefinition(UUID)).thenThrow(new APIMgtDAOException(
+                "Error occurred while retrieving the last update time of the swagger definition of API with id "
+                        + UUID));
+        apiPublisher.getLastUpdatedTimeOfSwaggerDefinition(UUID);
+        verify(apiDAO, times(0)).getLastUpdatedTimeOfSwaggerDefinition(UUID);
+    }
+
+    @Test(description = "Exception when checking for context exist", expectedExceptions = APIManagementException.class)
+    public void testIsContextExistException() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.isAPIContextExists(API_CONTEXT))
+                .thenThrow(new APIMgtDAOException("Couldn't check API Context " + API_CONTEXT + " Exists."));
+        apiPublisher.isContextExist(API_CONTEXT);
+    }
+
+    @Test(description = "Exception when checking for api name exists",
+            expectedExceptions = APIManagementException.class)
+    public void testIsApiNameExistException() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.isAPINameExists(API_NAME, USER_NAME))
+                .thenThrow(new APIMgtDAOException("Couldn't check API Name " + API_NAME + " Exists."));
+        apiPublisher.isApiNameExist(API_NAME);
+    }
+
+    @Test(description = "Exception when getting swagger definition for API",
+            expectedExceptions = APIManagementException.class)
+    public void testGetSwagger20DefinitionException() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getSwaggerDefinition(UUID))
+                .thenThrow(new APIMgtDAOException("Couldn't retrieve swagger definition for apiId " + UUID));
+        apiPublisher.getSwagger20Definition(UUID);
+        verify(apiDAO, times(0)).getSwaggerDefinition(UUID);
+    }
+
+    @Test(description = "Exception when getting subscription by UUID",
+            expectedExceptions = APIManagementException.class)
+    public void testGetSubscriptionByUUIDException() throws APIManagementException {
+        APISubscriptionDAO apiSubscriptionDAO = mock(APISubscriptionDAO.class);
+        AbstractAPIManager apiStore = new APIStoreImpl(USER_NAME, null, null, apiSubscriptionDAO, null, null, null,
+                null);
+        when(apiSubscriptionDAO.getAPISubscription(UUID))
+                .thenThrow(new APIMgtDAOException("Couldn't retrieve subscription for id " + UUID));
+        apiStore.getSubscriptionByUUID(UUID);
+        verify(apiSubscriptionDAO, times(0)).getAPISubscription(UUID);
+    }
+
+    @Test(description = "Exception when getting last updated time of Document",
+            expectedExceptions = APIManagementException.class)
+    public void testGetLastUpdatedTimeOfDocumentException() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getLastUpdatedTimeOfDocument(DOC_ID)).thenThrow(
+                new APIMgtDAOException("Error occurred while retrieving the last updated time of document " + DOC_ID));
+        apiPublisher.getLastUpdatedTimeOfDocument(DOC_ID);
+        verify(apiDAO, times(0)).getLastUpdatedTimeOfDocument(DOC_ID);
+    }
+
+    @Test(description = "Exception when getting last updated time of Document Content",
+            expectedExceptions = APIManagementException.class)
+    public void testGetLastUpdatedTimeOfDocumentContentException() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getLastUpdatedTimeOfDocumentContent(UUID, DOC_ID)).thenThrow(new APIMgtDAOException(
+                "Error occurred while retrieving the last updated time of the document's content " + DOC_ID));
+        apiPublisher.getLastUpdatedTimeOfDocumentContent(UUID, DOC_ID);
+        verify(apiDAO, times(0)).getLastUpdatedTimeOfDocumentContent(UUID, DOC_ID);
+    }
+
+    @Test(description = "Exception when getting last updated time of API Thumbnail Image",
+            expectedExceptions = APIManagementException.class)
+    public void testGetLastUpdatedTimeOfAPIThumbnailImageException() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getLastUpdatedTimeOfAPIThumbnailImage(UUID)).thenThrow(new APIMgtDAOException(
+                "Error occurred while retrieving the last updated time of the thumbnail image of the API " + UUID));
+        apiPublisher.getLastUpdatedTimeOfAPIThumbnailImage(UUID);
+        verify(apiDAO, times(0)).getLastUpdatedTimeOfAPIThumbnailImage(UUID);
+    }
+
+    @Test(description = "Exception when getting last updated time of Application",
+            expectedExceptions = APIManagementException.class)
+    public void testGetLastUpdatedTimeOfApplicationException() throws APIManagementException {
+        ApplicationDAO applicationDAO = mock(ApplicationDAO.class);
+        AbstractAPIManager apiStore = new APIStoreImpl(USER_NAME, null, applicationDAO, null, null, null, null, null);
+        when(applicationDAO.getLastUpdatedTimeOfApplication(UUID)).thenThrow(new APIMgtDAOException(
+                "Error occurred while retrieving the last updated time of the application " + UUID));
+        apiStore.getLastUpdatedTimeOfApplication(UUID);
+        verify(applicationDAO, times(0)).getLastUpdatedTimeOfApplication(UUID);
+    }
+
+    @Test(description = "Exception when getting last updated time of Subscription",
+            expectedExceptions = APIManagementException.class)
+    public void testGetLastUpdatedTimeOfSubscriptionException() throws APIManagementException {
+        APISubscriptionDAO apiSubscriptionDAO = mock(APISubscriptionDAO.class);
+        AbstractAPIManager apiStore = new APIStoreImpl(USER_NAME, null, null, apiSubscriptionDAO, null, null, null,
+                null);
+        when(apiSubscriptionDAO.getLastUpdatedTimeOfSubscription(UUID)).thenThrow(new APIMgtDAOException(
+                "Error occurred while retrieving the last updated time of the subscription " + UUID));
+        apiStore.getLastUpdatedTimeOfSubscription(UUID);
+        verify(apiSubscriptionDAO, times(0)).getLastUpdatedTimeOfSubscription(UUID);
+    }
+
+    @Test(description = "Exception when getting subscriptions by API",
+            expectedExceptions = APIManagementException.class)
+    public void testGetSubscriptionsByAPIException() throws APIManagementException {
+        APISubscriptionDAO apiSubscriptionDAO = mock(APISubscriptionDAO.class);
+        AbstractAPIManager apiStore = new APIStoreImpl(USER_NAME, null, null, apiSubscriptionDAO, null, null, null,
+                null);
+        when(apiSubscriptionDAO.getAPISubscriptionsByAPI(UUID))
+                .thenThrow(new APIMgtDAOException("Couldn't find subscriptions for apiId " + UUID));
+        apiStore.getSubscriptionsByAPI(UUID);
+        verify(apiSubscriptionDAO, times(0)).getAPISubscriptionsByAPI(UUID);
+    }
+
+    @Test(description = "Getting Documentation content when source type is FILE and the input stream is null",
+            expectedExceptions = APIManagementException.class)
+    public void testGetDocumentationContentFileWithNullStream() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        DocumentInfo.Builder builder = new DocumentInfo.Builder();
+        builder.name("CalculatorDoc");
+        builder.sourceType(DocumentInfo.SourceType.FILE);
+        DocumentInfo documentInfo = builder.build();
+        when(apiDAO.getDocumentInfo(DOC_ID)).thenReturn(documentInfo);
+        when(apiDAO.getDocumentFileContent(DOC_ID)).thenReturn(null);
+        apiPublisher.getDocumentationContent(DOC_ID);
+        verify(apiDAO, times(0)).getDocumentFileContent(DOC_ID);
+    }
+
+    @Test(description = "Getting Documentation content when source type is INLINE and inline content is null",
+            expectedExceptions = APIManagementException.class)
+    public void testGetDocumentationContentInlineWithNullContent() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        DocumentInfo documentInfo = SampleTestObjectCreator.createDefaultDocumentationInfo();
+        when(apiDAO.getDocumentInfo(DOC_ID)).thenReturn(documentInfo);
+        when(apiDAO.getDocumentInlineContent(DOC_ID)).thenReturn(null);
+        apiPublisher.getDocumentationContent(DOC_ID);
+        verify(apiDAO, times(0)).getDocumentInlineContent(DOC_ID);
+    }
+
+    @Test(description = "Getting Documentation content when document cannot be found",
+            expectedExceptions = APIManagementException.class)
+    public void testGetDocumentationContentWhenDocumentNotFound() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getDocumentInfo(DOC_ID)).thenReturn(null);
+        apiPublisher.getDocumentationContent(DOC_ID);
+        verify(apiDAO, times(0)).getDocumentFileContent(DOC_ID);
+        verify(apiDAO, times(0)).getDocumentInlineContent(DOC_ID);
+    }
+
+    @Test(description = "Exception when getting Documentation content due to error retrieving document content",
+            expectedExceptions = APIManagementException.class)
+    public void testGetDocumentationContentErrorOnRetrieval() throws APIManagementException {
+        ApiDAO apiDAO = mock(ApiDAO.class);
+        AbstractAPIManager apiPublisher = new APIPublisherImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
+        when(apiDAO.getDocumentInfo(DOC_ID))
+                .thenThrow(new APIMgtDAOException("Error occurred while retrieving document content"));
+        apiPublisher.getDocumentationContent(DOC_ID);
+        verify(apiDAO, times(0)).getDocumentFileContent(DOC_ID);
+        verify(apiDAO, times(0)).getDocumentInlineContent(DOC_ID);
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/impl/AbstractAPIManagerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/impl/AbstractAPIManagerTestCase.java
@@ -232,7 +232,7 @@ public class AbstractAPIManagerTestCase {
      */
 
     @Test(description = "Exception when retrieving an application by uuid",
-            expectedExceptions = APIMgtDAOException.class)
+            expectedExceptions = APIManagementException.class)
     public void testGetApplicationByUuidException() throws APIManagementException {
         ApplicationDAO applicationDAO = mock(ApplicationDAO.class);
         AbstractAPIManager apiStore = new APIStoreImpl(USER_NAME, null, applicationDAO, null, null, null, null, null);
@@ -252,7 +252,7 @@ public class AbstractAPIManagerTestCase {
     }
 
     @Test(description = "Exception when retrieving list of documentations",
-            expectedExceptions = APIMgtDAOException.class)
+            expectedExceptions = APIManagementException.class)
     public void testAllDocumentationException() throws APIManagementException {
         ApiDAO apiDAO = mock(ApiDAO.class);
         AbstractAPIManager apiStore = new APIStoreImpl(USER_NAME, apiDAO, null, null, null, null, null, null);
@@ -261,7 +261,7 @@ public class AbstractAPIManagerTestCase {
         apiStore.getAllDocumentation(UUID, 1, 10);
     }
 
-    @Test(description = "Exception when getting API by UUID", expectedExceptions = APIMgtDAOException.class)
+    @Test(description = "Exception when getting API by UUID", expectedExceptions = APIManagementException.class)
     public void testSearchAPIByUUIDException() throws APIManagementException {
         ApiDAO apiDAO = mock(ApiDAO.class);
         AbstractAPIManager apiStore = new APIStoreImpl(USER_NAME, apiDAO, null, null, null, null, null, null);


### PR DESCRIPTION
This PR contains 
1. Unit tests for  carbon-apimgt/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/AbstractAPIManager.java class. 
2. Modifications to methods in AbstractAPIManager to prevent catching and throwing the same exception - APIMgtDAOException.