### PR TITLE
Changing the swagger-codegen version for iot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1202,7 +1202,7 @@
         <orbit.version.pdfbox>1.8.10.wso2v2</orbit.version.pdfbox>
 
         <event.processor.stub.version>2.1.6</event.processor.stub.version>
-        <swagger.codegen.version>2.2.0.wso2v2</swagger.codegen.version>
+        <swagger.codegen.version>2.2.0.wso2v3</swagger.codegen.version>
         <swagger.parser.version>1.0.21.wso2v1</swagger.parser.version>
         <swagger.core.version>1.5.10</swagger.core.version>
         <swagger.models.version>1.5.10</swagger.models.version>


### PR DESCRIPTION
This Fix will change swagger-codegen version, due to previous version having osgi class loading issues.