### PR TITLE
Fix for APIMANAGER-5856 : Remove redundant getTenantAwareUsername util call

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/issuers/RoleBasedScopesIssuer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/issuers/RoleBasedScopesIssuer.java
@@ -34,7 +34,6 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
-import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -131,8 +130,7 @@ public class RoleBasedScopesIssuer extends AbstractScopesIssuer {
                     Assertion assertion = (Assertion) tokReqMsgCtx.getProperty(ResourceConstants.SAML2_ASSERTION);
                     userRoles = APIKeyMgtUtil.getRolesFromAssertion(assertion);
                 } else {
-                    userRoles = userStoreManager.getRoleListOfUser(MultitenantUtils.
-                            getTenantAwareUsername(endUsernameWithDomain));
+                    userRoles = userStoreManager.getRoleListOfUser(endUsernameWithDomain);
                 }
 
             } catch (UserStoreException e) {


### PR DESCRIPTION
### Proposed changes in this pull request

The issue was:
- We have used the `MultitenantUtils.getTenantAwareUsername` method on already tenant aware username

- The issue get highlighted when the user has both email usernames and default tenanted usernames, In such scenario when user present with an email username for a tenanted(this is valid for super tenant as well refer: [this](http://xacmlinfo.org/2014/10/07/email-username-with-identity-server/)) user, this redundant  `MultitenantUtils.getTenantAwareUsername` call removes the domain part from the email username which makes the username invalid.

- Before calling the `getTenantAwareUsername` util method, the developer should have prior knowledge about the username which is passed to that method, whether it's a tenant aware username or not, and use the util method only for strip out the tenant domain from the username.

Address the following issue : [APIMANAGER-5856](https://wso2.org/jira/browse/APIMANAGER-5856)
### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
