### PR TITLE
Changed commonly used ports to different ones in unit tests

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/APIKeyValidatorClientTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/APIKeyValidatorClientTest.java
@@ -67,7 +67,7 @@ public class APIKeyValidatorClientTest {
     public static void setTrustManager() throws KeyStoreException, IOException, CertificateException,
             NoSuchAlgorithmException, UnrecoverableKeyException, KeyManagementException {
         wireMockConfiguration.trustStoreType("JKS").keystoreType("JKS").keystorePath(KEYSTORE_FILE_PATH)
-                .trustStorePath(TRUSTSTORE_FILE_PATH).httpsPort(8082).trustStorePassword("wso2carbon")
+                .trustStorePath(TRUSTSTORE_FILE_PATH).httpsPort(18082).trustStorePassword("wso2carbon")
                 .keystorePassword("wso2carbon");
         ;
         InputStream inputStream = new FileInputStream("src/test/resources/jks/wso2carbon.jks");
@@ -126,7 +126,7 @@ public class APIKeyValidatorClientTest {
         ServiceReferenceHolder.getInstance().setAPIManagerConfigurationService(new APIManagerConfigurationServiceImpl
                 (apiManagerConfiguration));
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.API_KEY_VALIDATOR_URL)).thenReturn
-                ("https://localhost:" + 8082 + "/services/");
+                ("https://localhost:" + 18082 + "/services/");
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.API_KEY_VALIDATOR_USERNAME)).thenReturn
                 ("admin");
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.API_KEY_VALIDATOR_PASSWORD)).thenReturn
@@ -200,7 +200,7 @@ public class APIKeyValidatorClientTest {
         ServiceReferenceHolder.getInstance().setAPIManagerConfigurationService(new APIManagerConfigurationServiceImpl
                 (apiManagerConfiguration));
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.API_KEY_VALIDATOR_URL)).thenReturn
-                ("https://localhost:" + 8082 + "/services/");
+                ("https://localhost:" + 18082 + "/services/");
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.API_KEY_VALIDATOR_USERNAME)).thenReturn
                 ("admin");
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.API_KEY_VALIDATOR_PASSWORD)).thenReturn
@@ -274,7 +274,7 @@ public class APIKeyValidatorClientTest {
         ServiceReferenceHolder.getInstance().setAPIManagerConfigurationService(new APIManagerConfigurationServiceImpl
                 (apiManagerConfiguration));
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.API_KEY_VALIDATOR_URL)).thenReturn
-                ("https://localhost:" + 8082 + "/services/");
+                ("https://localhost:" + 18082 + "/services/");
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.API_KEY_VALIDATOR_USERNAME)).thenReturn
                 ("admin");
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.API_KEY_VALIDATOR_PASSWORD)).thenReturn
@@ -346,7 +346,7 @@ public class APIKeyValidatorClientTest {
         ServiceReferenceHolder.getInstance().setAPIManagerConfigurationService(new APIManagerConfigurationServiceImpl
                 (apiManagerConfiguration));
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.API_KEY_VALIDATOR_URL)).thenReturn
-                ("https://localhost:" + 8082 + "/services/");
+                ("https://localhost:" + 18082 + "/services/");
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.API_KEY_VALIDATOR_USERNAME)).thenReturn
                 ("admin");
         Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.API_KEY_VALIDATOR_PASSWORD)).thenReturn

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/util/BlockingConditionRetrieverTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/util/BlockingConditionRetrieverTest.java
@@ -56,7 +56,7 @@ public class BlockingConditionRetrieverTest {
         blockCondition.setUsername("admin");
         blockCondition.setPassword("admin");
         blockCondition.setEnabled(true);
-        blockCondition.setServiceUrl("http://localhost:8083/throttle/data/v1");
+        blockCondition.setServiceUrl("http://localhost:18083/throttle/data/v1");
         ThrottleDataHolder throttleDataHolder = new ThrottleDataHolder();
         throttleProperties.setBlockCondition(blockCondition);
         BlockingConditionRetriever blockingConditionRetriever = new BlockingConditionRetrieverWrapper

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/util/KeyTemplateRetrieverTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/util/KeyTemplateRetrieverTest.java
@@ -62,7 +62,7 @@ public class KeyTemplateRetrieverTest {
         blockCondition.setUsername("admin");
         blockCondition.setPassword("admin");
         blockCondition.setEnabled(true);
-        blockCondition.setServiceUrl("http://localhost:8084/throttle/data/v1");
+        blockCondition.setServiceUrl("http://localhost:18084/throttle/data/v1");
         ThrottleDataHolder throttleDataHolder = new ThrottleDataHolder();
         throttleProperties.setBlockCondition(blockCondition);
         KeyTemplateRetriever keyTemplateRetriever = new KeyTemplateRetrieverWrapper(throttleProperties,

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/test/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObjectTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/test/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObjectTest.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.wso2.carbon.apimgt.api.APIManagementException;
 
 import java.io.File;
 
@@ -62,7 +61,8 @@ public class APIProviderHostObjectTest {
     @Test
     public void testMutualSSLEnabledBackend() {
         wireMockRule = new WireMockRule(wireMockConfig()
-                .httpsPort(8081)
+                .port(18082)
+                .httpsPort(18081)
                 .needClientAuth(true)
                 .trustStoreType("JKS")
                 .keystoreType("JKS")
@@ -84,7 +84,7 @@ public class APIProviderHostObjectTest {
         System.setProperty("javax.net.ssl.trustStore", TRUSTSTORE_FILE_PATH_CLIENT);
         System.setProperty("javax.net.ssl.trustStorePassword", "wso2carbon");
         org.mozilla.javascript.NativeObject obj =
-                HostObjectUtils.sendHttpHEADRequest("https://localhost:8081/test",
+                HostObjectUtils.sendHttpHEADRequest("https://localhost:18081/test",
                         "404");
         Assert.assertEquals("success", obj.get("response"));
         wireMockRule.resetAll();

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/ResourceConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/ResourceConstants.java
@@ -36,7 +36,7 @@ public final class ResourceConstants {
     public static final String ATTRIBUTE_VALUE_SEPERATER = ",";
 
     public static final String RESOURCE_PARAMS = "keymgt_resource_params";
-    public static final String INTROSPECTURI = "http://localhost:8080/openid-connect-server-webapp/introspect";
+    public static final String INTROSPECTURI = "http://localhost:18080/openid-connect-server-webapp/introspect";
     public static final String AUTH_TOKEN_PARAM_NAME = "token";
     public static final String AUTHORIZATION_PARAM_NAME = "Authorization";
     public static final String BASIC_TOKEN_NAME = "Basic";

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/ResourceConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/ResourceConstants.java
@@ -36,7 +36,7 @@ public final class ResourceConstants {
     public static final String ATTRIBUTE_VALUE_SEPERATER = ",";
 
     public static final String RESOURCE_PARAMS = "keymgt_resource_params";
-    public static final String INTROSPECTURI = "http://localhost:18080/openid-connect-server-webapp/introspect";
+    public static final String INTROSPECTURI = "http://localhost:8080/openid-connect-server-webapp/introspect";
     public static final String AUTH_TOKEN_PARAM_NAME = "token";
     public static final String AUTHORIZATION_PARAM_NAME = "Authorization";
     public static final String BASIC_TOKEN_NAME = "Basic";


### PR DESCRIPTION
### Proposed changes in this pull request

This changes commonly used ports (eg. 8080, 8081 etc) to different ones in unit tests to avoid port conflicts.
