### PR TITLE
Update store and publisher UI

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/App.css
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/App.css
@@ -121,7 +121,7 @@ div.horizontal{
     margin-bottom:20px;
 }
 .lifecycle-box{
-    background: transparent url(/publisher/public/images/lifecycle.svg) left top no-repeat;
+    background: transparent url(/publisher/public/app/images/lifecycle.svg) left top no-repeat;
     width: 438px;
     height: 281px;
     padding:100px 0 0 85px;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Overview.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Overview.js
@@ -178,10 +178,10 @@ class Overview extends Component {
 
                         <Card>
                             <CardMedia
-                                image="/publisher/public/images/api/api-default.png"
+                                image="/publisher/public/app/images/api/api-default.png"
                                 title="Contemplative Reptile"
                             >
-                                <img alt="API thumb" width="100%" src="/publisher/public/images/api/api-default.png"/>
+                                <img alt="API thumb" width="100%" src="/publisher/public/app/images/api/api-default.png"/>
                             </CardMedia>
                             <CardContent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Permission.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Permission.js
@@ -434,7 +434,7 @@ class Permission extends Component {
                     <Col span={4}>
                         <Card bodyStyle={{padding: 5}}>
                             <div className="custom-image">
-                                <img alt="API thumb" width="100%" src="/publisher/public/images/api/api-default.png"/>
+                                <img alt="API thumb" width="100%" src="/publisher/public/app/images/api/api-default.png"/>
                             </div>
                             <div className="custom-card">
                                 <Badge status="processing" text={api.lifeCycleStatus}/>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/ApiThumb.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/ApiThumb.js
@@ -74,8 +74,8 @@ class ApiThumb extends React.Component {
         return (
             <Grid item xs={12} sm={6} md={3} lg={2} xl={2}>
                 <Card>
-                    <CardMedia image="/publisher/public/images/api/api-default.png">
-                        <img src="/publisher/public/images/api/api-default.png" style={{width:"100%"}}/>
+                    <CardMedia image="/publisher/public/app/images/api/api-default.png">
+                        <img src="/publisher/public/app/images/api/api-default.png" style={{width:"100%"}}/>
                     </CardMedia>
                     <CardContent>
                         <Typography type="headline" component="h2">

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/ComposeHeader.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/ComposeHeader.js
@@ -32,7 +32,7 @@ const ComposeHeader = (props) => {
         <Header className='custom-header'>
             <div className="logo">
                 <Link to="/apis">
-                    <img className="brand" src="/publisher/public/images/logo.svg" alt="wso2-logo"/>
+                    <img className="brand" src="/publisher/public/app/images/logo.svg" alt="wso2-logo"/>
                     <span>API Publisher</span>
                 </Link>
             </div>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/Header.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/Header.js
@@ -174,7 +174,7 @@ class Header extends React.Component {
                         <Typography type="title" color="inherit" style={{flex: 1}}>
                             <Link to="/" style={{textDecoration: 'none'}}>
                                 <Button color="primary">
-                                    <img className="brand" src="/publisher/public/images/logo.svg" alt="wso2-logo"/>
+                                    <img className="brand" src="/publisher/public/app/images/logo.svg" alt="wso2-logo"/>
                                     <span color="contrast" style={{fontSize: "15px", color:"#fff"}}>APIM Publisher</span>
                                 </Button>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Login/Login.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Login/Login.js
@@ -146,7 +146,7 @@ class Login extends Component {
 
                             <form onSubmit={this.handleSubmit} className="login-form">
                                 <div>
-                                    <img className="brand" src="/publisher/public/images/logo.svg" alt="wso2-logo"/>
+                                    <img className="brand" src="/publisher/public/app/images/logo.svg" alt="wso2-logo"/>
                                     <Typography type="subheading" gutterBottom>
                                         API Publisher
                                     </Typography>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Login/LoginBase.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Login/LoginBase.js
@@ -26,7 +26,7 @@ const LoginBase = (props) => {
                     <div className="pull-left brand float-remove-xs text-center-xs">
                         <a href="/publisher/">
                             <img
-                                src="/publisher/public/images/logo.svg"
+                                src="/publisher/public/app/images/logo.svg"
 
                                 className="logo"/>
                             <h1>API Publisher</h1>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/pages/index.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/pages/index.html
@@ -133,8 +133,8 @@
             }
         }
     </style>
-    <link href="/store/public/css/animations.css" type="text/css" rel="stylesheet" />
-    <link href="/store/public/css/materialize_.css" type="text/css" rel="stylesheet" />
+    <link href="/store/public/app/css/animations.css" type="text/css" rel="stylesheet" />
+    <link href="/store/public/app/css/materialize_.css" type="text/css" rel="stylesheet" />
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Apis/Details/BasicInfo.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Apis/Details/BasicInfo.js
@@ -273,7 +273,7 @@ class BasicInfo extends Component {
                     <Grid item xs={12} sm={12} md={3} lg={3} xl={2} style={{paddingLeft:"40px"}}>
 
                         <Card>
-                            <CardMedia image="/store/public/images/api/api-default.png" >
+                            <CardMedia image="/store/public/app/images/api/api-default.png" >
                             </CardMedia>
                             <CardContent>
                                 <div className="custom-card">

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Apis/Details/Overview.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Apis/Details/Overview.js
@@ -250,23 +250,23 @@ class Overview extends Component {
                                     <a className="social_links" id="facebook"
                                        href="http://www.facebook.com/sharer.php?u=https%3A%2F%2F172.17.0.1%3A9444%2Fstore%2Fapis%2Finfo%3Fname%3Dfoo%26version%3D1.0.0%26provider%3Dadmin"
                                        target="_blank" title="facebook">
-                                        <img src="/store/public/images/social/facebook.png" alt="Facebook" />
+                                        <img src="/store/public/app/images/social/facebook.png" alt="Facebook" />
                                     </a>
                                     {/* Twitter */}
                                     <a className="social_links" id="twitter"
                                        href="http://twitter.com/share?url=https%3A%2F%2F172.17.0.1%3A9444%2Fstore%2Fapis%2Finfo%3Fname%3Dfoo%26version%3D1.0.0%26provider%3Dadmin&text=API%20Store%20-%20foo%20%3A%20try%20this%20API%20at%20https%3A%2F%2F172.17.0.1%3A9444%2Fstore%2Fapis%2Finfo%3Fname%3Dfoo%26version%3D1.0.0%26provider%3Dadmin"
                                        target="_blank" title="twitter">
-                                        <img src="/store/public/images/social/twitter.png" alt="Twitter" /></a>
+                                        <img src="/store/public/app/images/social/twitter.png" alt="Twitter" /></a>
                                     {/* Google+ */}
                                     <a className="social_links" id="googleplus"
                                        href="https://plus.google.com/share?url=https%3A%2F%2F172.17.0.1%3A9444%2Fstore%2Fapis%2Finfo%3Fname%3Dfoo%26version%3D1.0.0%26provider%3Dadmin"
                                        target="_blank" title="googleplus">
-                                        <img src="/store/public/images/social/google.png" alt="Google" /></a>
+                                        <img src="/store/public/app/images/social/google.png" alt="Google" /></a>
                                     {/* Digg */}
                                     <a className="social_links" id="digg"
                                        href="http://www.digg.com/submit?url=https%3A%2F%2F172.17.0.1%3A9444%2Fstore%2Fapis%2Finfo%3Fname%3Dfoo%26version%3D1.0.0%26provider%3Dadmin"
                                        target="_blank" title="digg">
-                                        <img src="/store/public/images/social/diggit.png" alt="Digg" /></a>
+                                        <img src="/store/public/app/images/social/diggit.png" alt="Digg" /></a>
                                     <div className="clearfix">
                                     </div>
                                 </div>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Apis/Details/Permission.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Apis/Details/Permission.js
@@ -351,7 +351,7 @@ class Permission extends Component {
                     <Col span={4}>
                         <Card bodyStyle={{padding: 5}}>
                             <div className="custom-image">
-                                <img alt="API thumb" width="100%" src="/store/public/images/api/api-default.png"/>
+                                <img alt="API thumb" width="100%" src="/store/public/app/images/api/api-default.png"/>
                             </div>
                             <div className="custom-card">
                                 <Badge status="processing" text={api.lifeCycleStatus}/>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Apis/Details/Sdk.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Apis/Details/Sdk.js
@@ -150,9 +150,9 @@ class Sdk extends React.Component {
                                             <Divider/>
                                             <CardMedia
                                                 title={language.toString().toUpperCase()}
-                                                src={"/store/public/images/sdks/"+new String(language)+".svg"}
+                                                src={"/store/public/app/images/sdks/"+new String(language)+".svg"}
                                             >
-                                                <img alt={language} src={"/store/public/images/sdks/"+new String(language)+".svg"} style={{width:"100px",height:"100px",margin:"15px"}}/>
+                                                <img alt={language} src={"/store/public/app/images/sdks/"+new String(language)+".svg"} style={{width:"100px",height:"100px",margin:"15px"}}/>
                                             </CardMedia>
                                             <CardActions>
                                                 <Grid container justify="center">

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Base/Header/Header.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Base/Header/Header.js
@@ -152,7 +152,7 @@ class Header extends React.Component {
                         </IconButton> : <span></span> }
                         <Typography type="title" color="inherit" style={{flex: 1}}>
                             <Link to="/" className="home">
-                                    <img className="brand" src="/store/public/images/logo-inverse.svg" alt="wso2-logo"/>
+                                    <img className="brand" src="/store/public/app/images/logo-inverse.svg" alt="wso2-logo"/>
                                     <span color="contrast" style={{fontSize: "15px", color:"#fff"}}>APIM Store</span>
                             </Link>
                         </Typography>
@@ -184,8 +184,9 @@ class Header extends React.Component {
                                 {/* User menu */}
                                 <Button aria-owns="simple-menu" aria-haspopup="true" onClick={this.handleClickUserMenu}
                                         color="contrast">
-                                        <Avatar alt="{user.name}" src="/store/public/images/users/user.png" style={{marginRight:"5px"}}></Avatar>
-                                        <span style={{textTransform:"none", marginLeft:"5px"}}>{user.name}</span>
+                                    <Avatar alt="{user.name}" src="/store/public/app/images/users/user.png"
+                                            style={{marginRight: "5px"}}></Avatar>
+                                    <span style={{textTransform: "none", marginLeft: "5px"}}>{user.name}</span>
                                 </Button>
                                 <Menu
                                     id="simple-menu"

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Login/Login.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Login/Login.js
@@ -120,7 +120,7 @@ class Login extends Component {
                 <div className="login-main-content">
                     <Paper elevation={0} square={true} className="branding">
                       <div>
-                          <img className="brand" src="/store/public/images/logo.svg" alt="wso2-logo"/>
+                          <img className="brand" src="/store/public/app/images/logo.svg" alt="wso2-logo"/>
                           <Typography type="headline" align="right" gutterBottom>
                               API STORE
                           </Typography>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Login/LoginBase.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Login/LoginBase.js
@@ -27,7 +27,7 @@ const LoginBase = (props) => {
                     <div className="pull-left brand float-remove-xs text-center-xs">
                         <a href="/store/">
                             <img
-                                src="/store/public/images/logo.svg"
+                                src="/store/public/app/images/logo.svg"
 
                                 className="logo"/>
                               <h1>API Store</h1>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/Application.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/Application.js
@@ -20,20 +20,87 @@ export default class Application {
     constructor(name, description, throttlingTier, kwargs) {
         this.id = kwargs ? kwargs.applicationId : null;
         this.client = new SingleClient().client;
+        this.keys = new Map();
+        this.tokens = new Map();
         for (let key in kwargs) {
             if (kwargs.hasOwnProperty(key)) {
+                if (key === "keys") {
+                    this._setKeys(kwargs[key]);
+                    continue;
+                }
                 this[key] = kwargs[key];
             }
         }
     }
 
-    getKeys(type) {
+    /***
+     * Set this.keys object by iterating the keys array received from REST API
+     * @param keys {Array} An array of keys object containing either PRODUCTION or/and SANDBOX key information
+     * @private
+     */
+    _setKeys(keys) {
+        for (let key_obj of keys) {
+            this.keys.set(key_obj.keyType, key_obj);
+        }
+    }
+
+    /***
+     * Get keys of the current instance of an application
+     * @param key_type {string} Key type either `Production` or `SandBox`
+     * @returns {promise} Set the fetched CS/CK into current instance and return keys array as Promise object
+     */
+    getKeys(key_type) {
         let promise_keys = this.client.then((client) => {
             return client.apis["Application (Individual)"].get_applications__applicationId__keys({applicationId: this.id});
         });
         return promise_keys.then(keys_response => {
-            this.keys = keys_response.obj;
+            this._setKeys(keys_response.obj);
             return this.keys;
+        });
+    }
+
+    /***
+     * Generate token for this application instance
+     * @returns {promise} Set the generated token into current instance and return tokenObject received as Promise object
+     */
+    generateToken(type) {
+        let promise_token = this.client.then((client) => {
+            let keys = this.keys.get(type);
+            let request_content = {
+                consumerKey: keys.consumerKey,
+                consumerSecret: keys.consumerSecret,
+                validityPeriod: 3600,
+                scopes: ""
+            };
+            let payload = {applicationId: this.id, body: request_content};
+            return client.apis["Application (Individual)"].post_applications__applicationId__generate_token(payload);
+        });
+        return promise_token.then(token_response => {
+            let token = token_response.obj;
+            this.tokens.set(type, token);
+            return token;
+        });
+    }
+
+    /***
+     * Generate Consumer Secret and Consumer Key for this application instance
+     * @param key_type {string} Key type either `Production` or `SandBox`
+     * @returns {promise} Set the generated token into current instance and return tokenObject received as Promise object
+     */
+    generateKeys(key_type) {
+        let promised_keys = this.client.then((client) => {
+            let request_content =
+                {
+                    keyType: key_type, /* TODO: need to support dynamic key types ~tmkb*/
+                    grantTypesToBeSupported: ["password", "client_credentials"], /* TODO: need to give UI checkboxes to get these information ~tmkb*/
+                    callbackUrl: ""
+                };
+            let payload = {applicationId: this.id, body: request_content};
+            return client.apis["Application (Individual)"].post_applications__applicationId__generate_keys(payload);
+        });
+        return promised_keys.then(keys_response => {
+            this.keys.set(key_type, keys_response.obj);
+            return this.keys.get(key_type);
         });
     }
 
@@ -49,3 +116,8 @@ export default class Application {
         });
     }
 }
+
+Application.KEY_TYPES = {
+    PRODUCTION: "PRODUCTION",
+    SANDBOX: "SANDBOX"
+};

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/api.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/api.js
@@ -332,6 +332,7 @@ class API {
      * @param request_content payload of generate key request
      * @param callback {function} Function which needs to be called upon success
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
+     * @deprecated Use Application.generateKeys() instead
      */
     generateKeys(applicationId, request_content, callback = null) {
         var promise_get = this.client.then(
@@ -354,6 +355,7 @@ class API {
      * @param request_content payload of generate token request
      * @param callback {function} Function which needs to be called upon success
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
+     * @deprecated Use Application.generateToken() instead
      */
     generateToken(applicationId, request_content, callback = null) {
         var promise_get = this.client.then(
@@ -375,6 +377,7 @@ class API {
      * @param applicationId id of the application that needs to get the keys
      * @param callback {function} Function which needs to be called upon success
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
+     * @deprecated Use Application.getKeys() instead
      */
     getKeys(applicationId, callback = null) {
         var promise_get = this.client.then(


### PR DESCRIPTION
### Proposed changes in this pull request
- Update Store and Publisher static files relative path (Append `/app` context) to make compatible with Carbon UI server URL pattern
- Update Store Production Key generation UI to preserve generated keys between page refresh
- Add new `Generate Token` button to re-generate access token and show it in UI, Since Access Token data does not come along with Application information

### Follow up actions

- Add notification to user actions in Store App Key Generation page
- Generalize Key Generation component to make DRY use with both SandBox and Production key generation UIs
