### PR TITLE
Add TravisCI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+---
+# Use Ubuntu Trusty with sudo instead of new default Trusty because of higher resources
+sudo: required
+dist: trusty
+language: java
+
+install:
+  - . $HOME/.nvm/nvm.sh
+  - nvm install 8.9.0
+  - nvm use 8.9.0
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+
+cache:
+  directories:
+  - $HOME/.m2
+  - /home/tmkasun/Documents/wso2/dev/products/team/apim/carbon-apimgt-forked/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/node_modules
+  - /home/tmkasun/Documents/wso2/dev/products/team/apim/carbon-apimgt-forked/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/node_modules
+  - /home/tmkasun/Documents/wso2/dev/products/team/apim/carbon-apimgt-forked/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ install:
   - . $HOME/.nvm/nvm.sh
   - nvm install 8.9.0
   - nvm use 8.9.0
-  # Using -q Quiet output which only show errors, to overcome TravisCI log limit issue
-  - travis_wait 60 mvn install -DskipTests=true -Dmaven.javadoc.skip=true -q -B -V
+
+# Using -q Quiet output which only show errors, to overcome TravisCI log limit issue
+script: travis_wait 100 mvn clean install -q -B -V
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-# Use Ubuntu Trusty with sudo instead of new default Trusty because of higher resources
+# Use Ubuntu Trusty with sudo instead of new default Trusty because of higher resources availability
 sudo: required
 dist: trusty
 language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - nvm install 8.9.0
   - nvm use 8.9.0
   # Using -q Quiet output which only show errors, to overcome TravisCI log limit issue
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -q -B -V
+  - travis_wait 60 mvn install -DskipTests=true -Dmaven.javadoc.skip=true -q -B -V
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ install:
   - . $HOME/.nvm/nvm.sh
   - nvm install 8.9.0
   - nvm use 8.9.0
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  # Using -q Quiet output which only show errors, to overcome TravisCI log limit issue
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -q -B -V
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ script: travis_wait 100 mvn clean install -q -B -V
 cache:
   directories:
   - $HOME/.m2
-  - /home/tmkasun/Documents/wso2/dev/products/team/apim/carbon-apimgt-forked/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/node_modules
-  - /home/tmkasun/Documents/wso2/dev/products/team/apim/carbon-apimgt-forked/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/node_modules
-  - /home/tmkasun/Documents/wso2/dev/products/team/apim/carbon-apimgt-forked/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/node_modules
+  - features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/node_modules
+  - features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/node_modules
+  - features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/node_modules

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # About this repository
  This repository contains major components which are used to build the API Manager product.
 
+|  Branch | Build Status(jenkins) | Build Status(TravisCI) |
+| :------------ |:------------- |:-------------
+| master      | [![Build Status](https://wso2.org/jenkins/job/platform-builds/job/carbon-apimgt/badge/icon)](https://wso2.org/jenkins/job/platform-builds/job/carbon-apimgt/) | [![Build Status](https://api.travis-ci.org/wso2/carbon-apimgt.svg?branch=master)](https://api.travis-ci.org/tmkasun/react-samples) |
+
+
 ## Building from the source
 
 If you want to build carbon-apimgt from the source code:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # About this repository
- This repository contains major components which are used to build the API Manager product.
 
-|  Branch | Build Status(jenkins) | Build Status(TravisCI) |
+|  Branch | Build Status(Jenkins) | Build Status(TravisCI) |
 | :------------ |:------------- |:-------------
 | master      | [![Build Status](https://wso2.org/jenkins/job/platform-builds/job/carbon-apimgt/badge/icon)](https://wso2.org/jenkins/job/platform-builds/job/carbon-apimgt/) | [![Build Status](https://api.travis-ci.org/wso2/carbon-apimgt.svg?branch=master)](https://api.travis-ci.org/tmkasun/react-samples) |
 
+ This repository contains major components which are used to build the API Manager product.
 
 ## Building from the source
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |  Branch | Build Status(Jenkins) | Build Status(TravisCI) |
 | :------------ |:------------- |:-------------
-| master      | [![Build Status](https://wso2.org/jenkins/job/platform-builds/job/carbon-apimgt/badge/icon)](https://wso2.org/jenkins/job/platform-builds/job/carbon-apimgt/) | [![Build Status](https://api.travis-ci.org/wso2/carbon-apimgt.svg?branch=master)](https://api.travis-ci.org/tmkasun/react-samples) |
+| master      | [![Build Status](https://wso2.org/jenkins/job/platform-builds/job/carbon-apimgt/badge/icon)](https://wso2.org/jenkins/job/platform-builds/job/carbon-apimgt/) | [![Build Status](https://api.travis-ci.org/wso2/carbon-apimgt.svg?branch=master)](https://api.travis-ci.org/wso2/carbon-apimgt) |
 
  This repository contains major components which are used to build the API Manager product.
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Address the following issue https://github.com/wso2/product-apim/issues/2020

### When should this PR be merged

- ***There is a log size limitation in TravisCI which terminate the build job if the stdout log exceeds `4MB`
- In [this ](https://twitter.com/travisci/status/174904509754118144) Twitter post and 
- In TravisCI [documentation](https://github.com/travis-ci/docs-travis-ci-com/blob/master/user/common-build-problems.md#log-length-exceeded)
they have mentioned about this limitation

### Follow up actions

- Need to activate TravisCI build for `carbon-apimgt` repo in https://travis-ci.org/wso2
@rumeshbandara 
