### PR TITLE
[C5][environment][sso] Replace uiService query parameter with a configuration

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/EnvironmentConfigurations.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/EnvironmentConfigurations.java
@@ -16,8 +16,8 @@ public class EnvironmentConfigurations {
     @Element(description = "current environment's label from the list of environments")
     private String environmentLabel = "Default";
 
-    @Element(description = "list of web clients (eg: 127.0.0.1:9292) to allow make requests"
-            + "to current environment\n(use '" + APIMgtConstants.CORSAllowOriginConstants.ALLOW_ALL_ORIGINS +
+    @Element(description = "list of web clients (eg: 127.0.0.1:9292) to allow make requests" +
+            " to current environment\n(use '" + APIMgtConstants.CORSAllowOriginConstants.ALLOW_ALL_ORIGINS +
             "' to allow any web client)\nthe first host is used as UI-Service")
     //If the first host is an empty string, use "wso2.carbon.apimgt.application: apimBaseUrl" as UI-Service
     private List<String> allowedHosts = Collections.singletonList("");

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/EnvironmentConfigurations.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/EnvironmentConfigurations.java
@@ -12,23 +12,15 @@ import java.util.List;
  */
 @Configuration(description = "Environment Configurations")
 public class EnvironmentConfigurations {
-    @Element(description = "list of web clients (eg: 127.0.0.1:9292) to allow make requests"
-            + "to current environment\n(use '" + APIMgtConstants.CORSAllowOriginConstants.ALLOW_ALL_ORIGINS +
-            "' to allow any web client)")
-    private List<String> allowedHosts = Collections.singletonList(
-            APIMgtConstants.CORSAllowOriginConstants.ALLOW_ALL_ORIGINS);
-
     //Unique name for environment to set cookies by backend
     @Element(description = "current environment's label from the list of environments")
     private String environmentLabel = "Default";
 
-    public List<String> getAllowedHosts() {
-        return allowedHosts;
-    }
-
-    public void setAllowedHosts(List<String> allowedHosts) {
-        this.allowedHosts = allowedHosts;
-    }
+    @Element(description = "list of web clients (eg: 127.0.0.1:9292) to allow make requests"
+            + "to current environment\n(use '" + APIMgtConstants.CORSAllowOriginConstants.ALLOW_ALL_ORIGINS +
+            "' to allow any web client)\nthe first host is used as UI-Service")
+    //If the first host is an empty string, use "wso2.carbon.apimgt.application: apimBaseUrl" as UI-Service
+    private List<String> allowedHosts = Collections.singletonList("");
 
     public String getEnvironmentLabel() {
         return environmentLabel;
@@ -36,5 +28,13 @@ public class EnvironmentConfigurations {
 
     public void setEnvironmentLabel(String environmentLabel) {
         this.environmentLabel = environmentLabel;
+    }
+
+    public List<String> getAllowedHosts() {
+        return allowedHosts;
+    }
+
+    public void setAllowedHosts(List<String> allowedHosts) {
+        this.allowedHosts = allowedHosts;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorAPI.java
@@ -272,13 +272,14 @@ public class AuthenticatorAPI implements Microservice {
     @Produces(MediaType.APPLICATION_JSON)
     public Response callback(@Context Request request, @PathParam("appName") String appName,
                              @QueryParam("code") String authorizationCode) {
-        String appContext = "/" + appName;
+        String appContext = AuthenticatorConstants.URL_PATH_SEPERATOR + appName;
         String logoutContext =
                 AuthenticatorConstants.LOGOUT_SERVICE_CONTEXT + AuthenticatorConstants.URL_PATH_SEPERATOR + appName;
         String restAPIContext;
         if (AuthenticatorConstants.EDITOR_APPLICATION.equals(appName) ||
                 request.getUri().contains(AuthenticatorConstants.PUBLISHER_APPLICATION)) {
-            restAPIContext = AuthenticatorConstants.REST_CONTEXT + "/" + AuthenticatorConstants.PUBLISHER_APPLICATION;
+            restAPIContext = AuthenticatorConstants.REST_CONTEXT + AuthenticatorConstants.URL_PATH_SEPERATOR +
+                    AuthenticatorConstants.PUBLISHER_APPLICATION;
         } else {
             restAPIContext = AuthenticatorConstants.REST_CONTEXT + appContext;
         }
@@ -322,10 +323,22 @@ public class AuthenticatorAPI implements Microservice {
                 //The first host in the list "allowedHosts" is the host of UI-Service
                 String uiServiceHost = APIMConfigurationService.getInstance().getApimConfigurations()
                         .getEnvironmentConfigurations().getAllowedHosts().get(0);
-                if (uiServiceHost.isEmpty()) {
+                if (StringUtils.isEmpty(uiServiceHost)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("The first string in the list " +
+                                "'wso2.carbon.apimgt:environmentConfigurations:allowedHosts' configuration is empty.");
+                        log.debug("Read UI Service from 'wso2.carbon.apimgt.application:apimBaseUrl' configuration.");
+                    }
                     uiServiceUrl = ServiceReferenceHolder.getInstance().getAPIMAppConfiguration().getApimBaseUrl();
                 } else {
-                    uiServiceUrl = "https://" + uiServiceHost + "/";
+                    if (log.isDebugEnabled()) {
+                        log.debug("The first string in the list " +
+                                "'wso2.carbon.apimgt:environmentConfigurations:allowedHosts' configuration" +
+                                " is not empty. value: " + uiServiceHost);
+                    }
+                    uiServiceUrl = AuthenticatorConstants.HTTPS_PROTOCOL + AuthenticatorConstants.PROTOCOL_SEPERATOR +
+                            uiServiceHost + AuthenticatorConstants.URL_PATH_SEPERATOR;
+                    log.info("UI Service: {}", uiServiceUrl);
                 }
 
                 URI targetURIForRedirection = new URI(uiServiceUrl + appName);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorAPI.java
@@ -24,6 +24,7 @@ import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.apimgt.core.api.KeyManager;
+import org.wso2.carbon.apimgt.core.configuration.APIMConfigurationService;
 import org.wso2.carbon.apimgt.core.dao.SystemApplicationDao;
 import org.wso2.carbon.apimgt.core.dao.impl.DAOFactory;
 import org.wso2.carbon.apimgt.core.exception.APIManagementException;
@@ -33,6 +34,7 @@ import org.wso2.carbon.apimgt.core.models.AccessTokenInfo;
 import org.wso2.carbon.apimgt.core.util.KeyManagerConstants;
 import org.wso2.carbon.apimgt.rest.api.authenticator.constants.AuthenticatorConstants;
 import org.wso2.carbon.apimgt.rest.api.authenticator.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.authenticator.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.rest.api.authenticator.utils.AuthUtil;
 import org.wso2.carbon.apimgt.rest.api.authenticator.utils.bean.AuthResponseBean;
 import org.wso2.carbon.apimgt.rest.api.common.APIConstants;
@@ -79,7 +81,7 @@ public class AuthenticatorAPI implements Microservice {
     @Path("/token/{appName}")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes({MediaType.APPLICATION_FORM_URLENCODED, MediaType.MULTIPART_FORM_DATA})
-    public Response authenticate(@Context Request request, @PathParam("appName") String appName, @QueryParam("uiService") String uiServiceUrl,
+    public Response authenticate(@Context Request request, @PathParam("appName") String appName,
                                  @FormDataParam("username") String userName, @FormDataParam("password") String password,
                                  @FormDataParam("grant_type") String grantType, @FormDataParam("validity_period") String validityPeriod,
                                  @FormDataParam("remember_me") boolean isRememberMe, @FormDataParam("scopes") String scopesList) {
@@ -111,8 +113,7 @@ public class AuthenticatorAPI implements Microservice {
                 }
             }
             AccessTokenInfo accessTokenInfo = authenticatorService.getTokens(appContext.substring(1),
-                    grantType, userName, password, refToken,
-                    Long.parseLong(validityPeriod), uiServiceUrl, null);
+                    grantType, userName, password, refToken, Long.parseLong(validityPeriod), null);
             authenticatorService.setAccessTokenData(authResponseBean, accessTokenInfo);
             String accessToken = accessTokenInfo.getAccessToken();
             String refreshToken = accessTokenInfo.getRefreshToken();
@@ -238,13 +239,12 @@ public class AuthenticatorAPI implements Microservice {
     @GET
     @Path("/login/{appName}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response redirect(@Context Request request, @PathParam("appName") String appName,
-                             @QueryParam("uiService") String uiServiceUrl) {
+    public Response redirect(@Context Request request, @PathParam("appName") String appName) {
         try {
             KeyManager keyManager = APIManagerFactory.getInstance().getKeyManager();
             SystemApplicationDao systemApplicationDao = DAOFactory.getSystemApplicationDao();
             AuthenticatorService authenticatorService = new AuthenticatorService(keyManager, systemApplicationDao);
-            JsonObject oAuthData = authenticatorService.getAuthenticationConfigurations(appName, uiServiceUrl);
+            JsonObject oAuthData = authenticatorService.getAuthenticationConfigurations(appName);
             if (oAuthData.size() == 0) {
                 return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                         .entity("Error while creating the OAuth application!").build();
@@ -263,7 +263,6 @@ public class AuthenticatorAPI implements Microservice {
      *
      * @param request Request to call /callback api
      * @param appName Name of the applicatoin (publisher/store/admin)
-     * @param uiServiceUrl URL of the UI-Service to redirect back
      * @param authorizationCode Authorization-Code
      * @return Response - Response with redirect URL
      */
@@ -272,7 +271,7 @@ public class AuthenticatorAPI implements Microservice {
     @Path("/callback/{appName}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response callback(@Context Request request, @PathParam("appName") String appName,
-                             @QueryParam("uiService") String uiServiceUrl, @QueryParam("code") String authorizationCode) {
+                             @QueryParam("code") String authorizationCode) {
         String appContext = "/" + appName;
         String logoutContext =
                 AuthenticatorConstants.LOGOUT_SERVICE_CONTEXT + AuthenticatorConstants.URL_PATH_SEPERATOR + appName;
@@ -291,7 +290,7 @@ public class AuthenticatorAPI implements Microservice {
             SystemApplicationDao systemApplicationDao = DAOFactory.getSystemApplicationDao();
             AuthenticatorService authenticatorService = new AuthenticatorService(keyManager, systemApplicationDao);
             AccessTokenInfo accessTokenInfo = authenticatorService.getTokens(appName, grantType,
-                    null, null, null, 0, uiServiceUrl, authorizationCode);
+                    null, null, null, 0, authorizationCode);
             if (StringUtils.isEmpty(accessTokenInfo.toString())) {
                 return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                         .entity("Access token generation failed!").build();
@@ -319,6 +318,16 @@ public class AuthenticatorAPI implements Microservice {
                     log.debug("Set cookies for " + appName + " application.");
                 }
                 // Redirect to the store/apis page (redirect URL)
+                String uiServiceUrl;
+                //The first host in the list "allowedHosts" is the host of UI-Service
+                String uiServiceHost = APIMConfigurationService.getInstance().getApimConfigurations()
+                        .getEnvironmentConfigurations().getAllowedHosts().get(0);
+                if (uiServiceHost.isEmpty()) {
+                    uiServiceUrl = ServiceReferenceHolder.getInstance().getAPIMAppConfiguration().getApimBaseUrl();
+                } else {
+                    uiServiceUrl = "https://" + uiServiceHost + "/";
+                }
+
                 URI targetURIForRedirection = new URI(uiServiceUrl + appName);
                 if (AuthenticatorConstants.PUBLISHER_APPLICATION.equals(appName) || AuthenticatorConstants.STORE_APPLICATION.equals(appName)) {
                     String authResponseBeanData = authResponseBean.getAuthUser() + "&id_token="

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorService.java
@@ -74,11 +74,10 @@ public class AuthenticatorService {
      * This method returns the details of a DCR application.
      *
      * @param appName Name of the application to be created
-     * @param uiServiceURL  URL of the UI Service to be appended to the callback URL
      * @return oAuthData - A JsonObject with DCR application details, scopes, auth endpoint, and SSO is enabled or not
      * @throws APIManagementException When creating DCR application fails
      */
-    public JsonObject getAuthenticationConfigurations(String appName, String uiServiceURL)
+    public JsonObject getAuthenticationConfigurations(String appName)
             throws APIManagementException {
         JsonObject oAuthData = new JsonObject();
         List<String> grantTypes = new ArrayList<>();
@@ -86,8 +85,7 @@ public class AuthenticatorService {
         grantTypes.add(KeyManagerConstants.AUTHORIZATION_CODE_GRANT_TYPE);
         grantTypes.add(KeyManagerConstants.REFRESH_GRANT_TYPE);
         APIMAppConfigurations appConfigs = ServiceReferenceHolder.getInstance().getAPIMAppConfiguration();
-        String callBackURL = appConfigs.getApimBaseUrl() + AuthenticatorConstants.AUTHORIZATION_CODE_CALLBACK_URL
-                + appName + "?uiService=" + uiServiceURL;
+        String callBackURL = appConfigs.getApimBaseUrl() + AuthenticatorConstants.AUTHORIZATION_CODE_CALLBACK_URL + appName;
         // Get scopes of the application
         String scopes = getApplicationScopes(appName);
         if (log.isDebugEnabled()) {
@@ -129,14 +127,13 @@ public class AuthenticatorService {
      * @param password Password of the user
      * @param refreshToken Refresh token
      * @param validityPeriod Validity period of tokens
-     * @param uiServiceURL URL of the UI-Service
      * @param authorizationCode Authorization Code
      * @return AccessTokenInfo - An object with the generated access token information
      * @throws APIManagementException When receiving access tokens fails
      */
     public AccessTokenInfo getTokens(String appName, String grantType,
                                      String userName, String password, String refreshToken,
-                                     long validityPeriod, String uiServiceURL, String authorizationCode)
+                                     long validityPeriod, String authorizationCode)
             throws APIManagementException {
         AccessTokenInfo accessTokenInfo = new AccessTokenInfo();
         AccessTokenRequest accessTokenRequest = new AccessTokenRequest();
@@ -155,8 +152,7 @@ public class AuthenticatorService {
                 // Access token for authorization code grant type
                 APIMAppConfigurations appConfigs = ServiceReferenceHolder.getInstance()
                         .getAPIMAppConfiguration();
-                String callBackURL = appConfigs.getApimBaseUrl() + AuthenticatorConstants.AUTHORIZATION_CODE_CALLBACK_URL + appName
-                        + "?uiService=" + uiServiceURL;
+                String callBackURL = appConfigs.getApimBaseUrl() + AuthenticatorConstants.AUTHORIZATION_CODE_CALLBACK_URL + appName;
 
                 if (authorizationCode != null) {
                     // Get Access & Refresh Tokens

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/constants/AuthenticatorConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/constants/AuthenticatorConstants.java
@@ -50,5 +50,7 @@ public class AuthenticatorConstants {
     public static final String EDITOR_APPLICATION = "editor";
     public static final String AUTHORIZATION_CODE_CALLBACK_URL = "login/callback/";
     public static final String URL_PATH_SEPERATOR = "/";
+    public static final String PROTOCOL_SEPERATOR = "://";
     public static final String LOGOUT_SERVICE_CONTEXT = "/login/logout";
+    public static final String HTTPS_PROTOCOL = "https";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/test/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorServiceTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/test/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorServiceTestCase.java
@@ -63,19 +63,19 @@ public class AuthenticatorServiceTestCase {
 
         //// Get data object to be passed to the front-end
         Mockito.when(keyManager.createApplication(Mockito.any())).thenReturn(oAuthApplicationInfo);
-        JsonObject responseOAuthDataObj = authenticatorService.getAuthenticationConfigurations("store", "https://localhost:9292/");
+        JsonObject responseOAuthDataObj = authenticatorService.getAuthenticationConfigurations("store");
         Assert.assertEquals(responseOAuthDataObj, oAuthData);
 
         // Error Path - 500 - When OAuthApplicationInfo is null
         JsonObject emptyOAuthDataObj = new JsonObject();
         Mockito.when(keyManager.createApplication(Mockito.any())).thenReturn(null);
-        JsonObject responseEmptyOAuthDataObj = authenticatorService.getAuthenticationConfigurations("store", "https://localhost:9292/");
+        JsonObject responseEmptyOAuthDataObj = authenticatorService.getAuthenticationConfigurations("store");
         Assert.assertEquals(responseEmptyOAuthDataObj, emptyOAuthDataObj);
 
         // Error Path - When DCR application creation fails and throws an APIManagementException
         Mockito.when(keyManager.createApplication(Mockito.any())).thenThrow(KeyManagementException.class);
         try {
-            authenticatorService.getAuthenticationConfigurations("store", "https://localhost:9292/");
+            authenticatorService.getAuthenticationConfigurations("store");
         } catch (APIManagementException e) {
             Assert.assertEquals(e.getMessage(), "Error while creating the keys for OAuth application : store");
         }
@@ -108,7 +108,7 @@ public class AuthenticatorServiceTestCase {
 
         //// Get data object to be passed to the front-end
         Mockito.when(keyManager.createApplication(Mockito.any())).thenReturn(oAuthApplicationInfo);
-        JsonObject responseOAuthDataObj = authenticatorService.getAuthenticationConfigurations("publisher", "https://localhost:9292/");
+        JsonObject responseOAuthDataObj = authenticatorService.getAuthenticationConfigurations("publisher");
         String[] scopesActual = responseOAuthDataObj.get(KeyManagerConstants.TOKEN_SCOPES).toString().split(" ");
         String[] scopesExpected = oAuthData.get(KeyManagerConstants.TOKEN_SCOPES).toString().split(" ");
         Assert.assertEquals(scopesActual.length, scopesExpected.length);
@@ -116,13 +116,13 @@ public class AuthenticatorServiceTestCase {
         // Error Path - 500 - When OAuthApplicationInfo is null
         JsonObject emptyOAuthDataObj = new JsonObject();
         Mockito.when(keyManager.createApplication(Mockito.any())).thenReturn(null);
-        JsonObject responseEmptyOAuthDataObj = authenticatorService.getAuthenticationConfigurations("publisher", "https://localhost:9292/");
+        JsonObject responseEmptyOAuthDataObj = authenticatorService.getAuthenticationConfigurations("publisher");
         Assert.assertEquals(responseEmptyOAuthDataObj, emptyOAuthDataObj);
 
         // Error Path - When DCR application creation fails and throws an APIManagementException
         Mockito.when(keyManager.createApplication(Mockito.any())).thenThrow(KeyManagementException.class);
         try {
-            authenticatorService.getAuthenticationConfigurations("publisher", "https://localhost:9292/");
+            authenticatorService.getAuthenticationConfigurations("publisher");
         } catch (APIManagementException e) {
             Assert.assertEquals(e.getMessage(), "Error while creating the keys for OAuth application : publisher");
         }
@@ -154,7 +154,7 @@ public class AuthenticatorServiceTestCase {
         Mockito.when(keyManager.getNewAccessToken(Mockito.any())).thenReturn(tokenInfo);
         AccessTokenInfo tokenInfoResponseForValidAuthCode = authenticatorService.getTokens("store",
                 "authorization_code", null, null, null, 0,
-                "https://localhost:9292/", "xxx-auth-code-xxx");
+                "xxx-auth-code-xxx");
         Assert.assertEquals(tokenInfoResponseForValidAuthCode, tokenInfo);
 
         // Error Path - 500 - Authorization code grant type
@@ -164,8 +164,7 @@ public class AuthenticatorServiceTestCase {
         AccessTokenInfo tokenInfoResponseForInvalidAuthCode = new AccessTokenInfo();
         try {
             tokenInfoResponseForInvalidAuthCode = authenticatorService.getTokens("store",
-                    "authorization_code",
-                    null, null, null, 0, "https://localhost:9292/", null);
+                    "authorization_code", null, null, null, 0, null);
         } catch (APIManagementException e) {
             Assert.assertEquals(e.getMessage(), "No Authorization Code available.");
             Assert.assertEquals(tokenInfoResponseForInvalidAuthCode, emptyTokenInfo);
@@ -174,14 +173,14 @@ public class AuthenticatorServiceTestCase {
         // Happy Path - 200 - Password grant type
         Mockito.when(keyManager.getNewAccessToken(Mockito.any())).thenReturn(tokenInfo);
         AccessTokenInfo tokenInfoResponseForPasswordGrant = authenticatorService.getTokens("store", "password",
-                "admin", "admin", null, 0, "https://localhost:9292/", null);
+                "admin", "admin", null, 0, null);
         Assert.assertEquals(tokenInfoResponseForPasswordGrant, tokenInfo);
 
         // Error Path - When token generation fails and throws APIManagementException
         Mockito.when(keyManager.getNewAccessToken(Mockito.any())).thenThrow(KeyManagementException.class);
         try {
             authenticatorService.getTokens("store", "password",
-                    "admin", "admin", null, 0, "https://localhost:9292/", null);
+                    "admin", "admin", null, 0, null);
         } catch (APIManagementException e) {
             Assert.assertEquals(e.getMessage(), "Error while receiving tokens for OAuth application : store");
         }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
@@ -147,9 +147,7 @@ class Utils {
     }
 
     static getAppSSORequestURL(environment = Utils.getEnvironment()) {
-        const uiService = encodeURIComponent(window.location.origin);
-        return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.SSO_LOGIN}${Utils.CONST.CONTEXT_PATH}`
-            + `?uiService=${uiService}/`;
+        return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.SSO_LOGIN}${Utils.CONST.CONTEXT_PATH}`;
     }
 
     static getAppLogoutURL() {
@@ -157,9 +155,7 @@ class Utils {
     }
 
     static getLoginTokenPath(environment = Utils.getEnvironment()) {
-        const uiService = encodeURIComponent(window.location.origin);
-        return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.LOGIN_TOKEN_PATH}${Utils.CONST.CONTEXT_PATH}`
-            + `?uiService=${uiService}/`;
+        return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.LOGIN_TOKEN_PATH}${Utils.CONST.CONTEXT_PATH}`;
     }
 
     static getSwaggerURL() {

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/Utils.js
@@ -147,9 +147,7 @@ class Utils {
     }
 
     static getAppSSORequestURL(environment = Utils.getEnvironment()) {
-        const uiService = encodeURIComponent(window.location.origin);
-        return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.SSO_LOGIN}${Utils.CONST.CONTEXT_PATH}`
-            + `?uiService=${uiService}/`;
+        return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.SSO_LOGIN}${Utils.CONST.CONTEXT_PATH}`;
     }
 
     static getAppLogoutURL() {
@@ -157,9 +155,7 @@ class Utils {
     }
 
     static getLoginTokenPath(environment = Utils.getEnvironment()) {
-        const uiService = encodeURIComponent(window.location.origin);
-        return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.LOGIN_TOKEN_PATH}${Utils.CONST.CONTEXT_PATH}`
-            + `?uiService=${uiService}/`;
+        return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.LOGIN_TOKEN_PATH}${Utils.CONST.CONTEXT_PATH}`;
     }
 
     static getSwaggerURL() {


### PR DESCRIPTION
### Proposed changes in this pull request
- Use the first host in the `allowedOrigins` list as UI Service.
- If the first host is empty use the `wso2.carbon.apimgt.application: apimBaseUrl` as UI Service
- Configurations are changed as below.

From:
```yaml
wso2.carbon.apimgt:
    # Environment Configurations
  environmentConfigurations:
      # list of web clients (eg: 127.0.0.1:9292) to allow make requests to current environment
      # (use '*' to allow any web client)
    allowedHosts:
    - 10.100.4.247:9292
    - localhost:9292
      # current environment's label from the list of environments
    environmentLabel: Development
```
To:
```yaml
wso2.carbon.apimgt:
    # Environment Configurations
  environmentConfigurations:
      # current environment's label from the list of environments
    environmentLabel: Default
      # list of web clients (eg: 127.0.0.1:9292) to allow make requeststo current environment
      # (use '*' to allow any web client)
      # the first host is used as UI-Service
    allowedHosts:
    - ''
```

- Remove the `uiService` query parameter from callback URL.
- Fix https://github.com/wso2/product-apim/issues/2205
  