### PR TITLE
[C5][environment] Render the application back when selecting an already logged in environment in the login page.

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Login/Login.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Login/Login.js
@@ -49,7 +49,8 @@ class Login extends Component {
             messageOpen: false,
             message: '',
             environments: [],
-            environmentId: 0
+            environmentId: 0,
+            loginStatusEnvironments: []
         };
     }
 
@@ -69,7 +70,16 @@ class Login extends Component {
             // Update environment to discard default environment configuration
             const environment = environments[environmentId];
             Utils.setEnvironment(environment);
+
+            // Set authentication status of environments
+            this.setLoginStatusOfEnvironments(environments);
         });
+    }
+
+    setLoginStatusOfEnvironments(environments) {
+        this.state.loginStatusEnvironments = environments.map(
+            environment => AuthManager.getUser(environment.label) !== null
+        );
     }
 
     handleSubmit = (e) => {
@@ -120,6 +130,7 @@ class Login extends Component {
             environmentId
         });
         Utils.setEnvironment(environment);
+        this.setState({environmentId, isLogin});
     };
 
     handleRequestClose = () => {

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Login/Login.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Login/Login.js
@@ -77,9 +77,10 @@ class Login extends Component {
     }
 
     setLoginStatusOfEnvironments(environments) {
-        this.state.loginStatusEnvironments = environments.map(
+        let loginStatusEnvironments = environments.map(
             environment => AuthManager.getUser(environment.label) !== null
         );
+        this.setState({loginStatusEnvironments});
     }
 
     handleSubmit = (e) => {

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/data/AuthManager.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/data/AuthManager.js
@@ -104,11 +104,13 @@ class AuthManager {
      * An user object is return in present of user logged in user info in browser local storage, at the same time checks for partialToken in the cookie as well.
      * This may give a partial indication(passive check not actually check the token validity via an API) of whether the user has logged in or not, The actual API call may get denied
      * if the cookie stored access token is invalid/expired
+     * @param {string} environmentName: label of the environment, the user to be retrieved from
      * @returns {User | null} Is any user has logged in or not
      */
-    static getUser() {
-        const userData = localStorage.getItem(`${User.CONST.LOCALSTORAGE_USER}_${Utils.getEnvironment().label}`);
-        const partialToken = Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1);
+    static getUser(environmentName) {
+        environmentName = environmentName || Utils.getEnvironment().label;
+        const userData = localStorage.getItem(`${User.CONST.LOCALSTORAGE_USER}_${environmentName}`);
+        const partialToken = Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1, environmentName);
         if (!(userData && partialToken)) {
             return null;
         }
@@ -120,14 +122,16 @@ class AuthManager {
      * Persist an user in browser local storage and in-memory, Since only one use can be logged into the application at a time,
      * This method will override any previously persist user data.
      * @param {User} user : An instance of the {User} class
+     * @param {string} environmentName: label of the environment to be set the user
      */
-    static setUser(user) {
+    static setUser(user, environmentName) {
+        environmentName = environmentName || Utils.getEnvironment().label;
         if (!user instanceof User) {
             throw new Error("Invalid user object");
         }
 
         if (user) {
-            localStorage.setItem(`${User.CONST.LOCALSTORAGE_USER}_${Utils.getEnvironment().label}`, JSON.stringify(user.toJson()));
+            localStorage.setItem(`${User.CONST.LOCALSTORAGE_USER}_${environmentName}`, JSON.stringify(user.toJson()));
         }
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/data/AuthManager.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/data/AuthManager.js
@@ -105,22 +105,15 @@ class AuthManager {
      * This may give a partial indication(passive check not actually check the token validity via an API) of whether the user has logged in or not, The actual API call may get denied
      * if the cookie stored access token is invalid/expired
      * @returns {User | null} Is any user has logged in or not
-     * @param {boolean} readFromLocalStorage: read from local-storage
      */
-    static getUser(readFromLocalStorage) {
-        if (!readFromLocalStorage && AuthManager._user) {
-            return AuthManager._user;
-        }
-
+    static getUser() {
         const userData = localStorage.getItem(`${User.CONST.LOCALSTORAGE_USER}_${Utils.getEnvironment().label}`);
         const partialToken = Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1);
         if (!(userData && partialToken)) {
             return null;
         }
 
-        //Update user in memory.
-        AuthManager._user = User.fromJson(JSON.parse(userData));
-        return AuthManager._user;
+        return User.fromJson(JSON.parse(userData));
     }
 
     /**
@@ -136,7 +129,6 @@ class AuthManager {
         if (user) {
             localStorage.setItem(`${User.CONST.LOCALSTORAGE_USER}_${Utils.getEnvironment().label}`, JSON.stringify(user.toJson()));
         }
-        AuthManager._user = user;
     }
 
     /**
@@ -227,10 +219,4 @@ class AuthManager {
 
 }
 
-/**
- * Current User
- * @type {object} User Object
- * @private
- */
-AuthManager._user = undefined;
 export default AuthManager;

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/data/Utils.js
@@ -135,11 +135,6 @@ class Utils {
         //Store environment.
         Utils._environment = environment;
         localStorage.setItem(Utils.CONST.LOCALSTORAGE_ENVIRONMENT, JSON.stringify(environment));
-
-        //Read the user of stored environment.
-        let user = AuthManager.getUser(true);
-        //If user is null store only in memory.
-        AuthManager.setUser(user);
     }
 
     static getPromised_ssoData(environment) {

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/data/Utils.js
@@ -26,12 +26,12 @@ class Utils {
 
     /**
      * Get JavaScript accessible cookies saved in browser, by giving the cooke name.
-     * @param {String} name : Name of the cookie which need to be retrived
+     * @param {String} cookieName : Name of the cookie which need to be retrived
+     * @param {String} environmentName : label of the environment of the cookie
      * @returns {String|null} : If found a cookie with given name , return its value,Else null value is returned
      */
-    static getCookie(name) {
-        //Append environment name to cookie
-        let environmentName = "_" + Utils.getEnvironment().label;
+    static getCookie(cookieName, environmentName) {
+        environmentName = environmentName || Utils.getEnvironment().label;
 
         let pairs = document.cookie.split(";");
         let cookie = null;
@@ -39,7 +39,7 @@ class Utils {
             pair = pair.split("=");
             let cookie_name = pair[0].trim();
             let value = encodeURIComponent(pair[1]);
-            if (cookie_name === name + environmentName) {
+            if (cookie_name === `${cookieName}_${environmentName}`) {
                 cookie = value;
                 break;
             }
@@ -51,10 +51,11 @@ class Utils {
      * Delete a browser cookie given its name
      * @param {String} name : Name of the cookie which need to be deleted
      * @param {String} path : Path of the cookie which need to be deleted
+     * @param {String} environmentName: label of the environment of the cookie
      */
-    static delete_cookie(name, path) {
-        //Environment name is appended to the cookie name
-        document.cookie = `${name}_${Utils.getEnvironment().label}=; path=${path}; expires=Thu, 01 Jan 1970 00:00:01 GMT`;
+    static delete_cookie(name, path, environmentName) {
+        environmentName = environmentName || Utils.getEnvironment().label;
+        document.cookie = `${name}_${environmentName}=; path=${path}; expires=Thu, 01 Jan 1970 00:00:01 GMT`;
     }
 
     /**
@@ -66,7 +67,8 @@ class Utils {
      * @param {String} path : Path which needs to set the given cookie
      * @param {boolean} secured : secured parameter is set
      */
-    static setCookie(name, value, validityPeriod, path = "/", secured = true) {
+    static setCookie(name, value, validityPeriod, path = "/", environmentName, secured = true) {
+        environmentName = environmentName || Utils.getEnvironment().label;
         let expiresDirective = "";
         const securedDirective = secured ? "; Secure" : "";
         if (validityPeriod) {
@@ -75,7 +77,7 @@ class Utils {
             expiresDirective = "; expires=" + date.toUTCString();
         }
 
-        document.cookie = `${name}_${Utils.getEnvironment().label}=${value}; path=${path}${expiresDirective}${securedDirective}`;
+        document.cookie = `${name}_${environmentName}=${value}; path=${path}${expiresDirective}${securedDirective}`;
     }
 
     /**

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Login/Login.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Login/Login.js
@@ -67,10 +67,7 @@ class Login extends Component {
         ConfigManager.getConfigs().environments.then(response => {
             const environments = response.data.environments;
             const environmentId = Utils.getEnvironmentID(environments);
-
-            // Do not need to render before fetch sso data
-            this.state.environments = environments;
-            this.state.environmentId = environmentId;
+            this.setState({environments, environmentId});
 
             // Update environment to discard default environment configuration
             const environment = environments[environmentId];
@@ -102,9 +99,10 @@ class Login extends Component {
     }
 
     setLoginStatusOfEnvironments(environments) {
-        this.state.loginStatusEnvironments = environments.map(
+        let loginStatusEnvironments = environments.map(
             environment => AuthManager.getUser(environment.label) !== null
         );
+        this.setState({loginStatusEnvironments});
     }
 
     fetch_ssoData(environments) {
@@ -133,7 +131,7 @@ class Login extends Component {
     };
 
     handleSsoLogin = (e) => {
-        if(e){
+        if (e) {
             e.preventDefault();
         }
         const authConfigs = this.state.authConfigs[this.state.environmentId];

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Login/Login.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Login/Login.js
@@ -55,6 +55,7 @@ class Login extends Component {
             message: '',
             environments: [],
             environmentId: 0,
+            loginStatusEnvironments: [],
             authConfigs: [],
             redirectToIS: false
         };
@@ -74,6 +75,9 @@ class Login extends Component {
             // Update environment to discard default environment configuration
             const environment = environments[environmentId];
             Utils.setEnvironment(environment);
+
+            // Set authentication status of environments
+            this.setLoginStatusOfEnvironments(environments);
 
             //Fetch SSO data and render
             this.fetch_ssoData(environments);
@@ -95,6 +99,12 @@ class Login extends Component {
             user.scopes = params.scopes.split(" ");
             AuthManager.setUser(user);
         }
+    }
+
+    setLoginStatusOfEnvironments(environments) {
+        this.state.loginStatusEnvironments = environments.map(
+            environment => AuthManager.getUser(environment.label) !== null
+        );
     }
 
     fetch_ssoData(environments) {
@@ -175,7 +185,11 @@ class Login extends Component {
     handleEnvironmentChange = (event) => {
         const environmentId = event.target.value;
         let environment = this.state.environments[environmentId];
-        this.setState({environmentId});
+        let isLogin = this.state.loginStatusEnvironments[environmentId];
+        if (isLogin) {
+            Utils.setEnvironment(environment);
+        }
+        this.setState({environmentId, isLogin});
     };
 
     handleRequestClose = () => {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/AuthManager.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/AuthManager.js
@@ -105,11 +105,13 @@ class AuthManager {
      * An user object is return in present of user logged in user info in browser local storage, at the same time checks for partialToken in the cookie as well.
      * This may give a partial indication(passive check not actually check the token validity via an API) of whether the user has logged in or not, The actual API call may get denied
      * if the cookie stored access token is invalid/expired
+     * @param {string} environmentName: label of the environment, the user to be retrieved from
      * @returns {User | null} Is any user has logged in or not
      */
-    static getUser() {
-        const userData = localStorage.getItem(`${User.CONST.LOCALSTORAGE_USER}_${Utils.getEnvironment().label}`);
-        const partialToken = Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1);
+    static getUser(environmentName) {
+        environmentName = environmentName || Utils.getEnvironment().label;
+        const userData = localStorage.getItem(`${User.CONST.LOCALSTORAGE_USER}_${environmentName}`);
+        const partialToken = Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1, environmentName);
         if (!(userData && partialToken)) {
             return null;
         }
@@ -121,14 +123,16 @@ class AuthManager {
      * Persist an user in browser local storage and in-memory, Since only one use can be logged into the application at a time,
      * This method will override any previously persist user data.
      * @param {User} user : An instance of the {User} class
+     * @param {string} environmentName: label of the environment to be set the user
      */
-    static setUser(user) {
+    static setUser(user, environmentName) {
+        environmentName = environmentName || Utils.getEnvironment().label;
         if (!user instanceof User) {
             throw new Error("Invalid user object");
         }
 
         if (user) {
-            localStorage.setItem(`${User.CONST.LOCALSTORAGE_USER}_${Utils.getEnvironment().label}`, JSON.stringify(user.toJson()));
+            localStorage.setItem(`${User.CONST.LOCALSTORAGE_USER}_${environmentName}`, JSON.stringify(user.toJson()));
         }
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/AuthManager.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/AuthManager.js
@@ -106,22 +106,15 @@ class AuthManager {
      * This may give a partial indication(passive check not actually check the token validity via an API) of whether the user has logged in or not, The actual API call may get denied
      * if the cookie stored access token is invalid/expired
      * @returns {User | null} Is any user has logged in or not
-     * @param {boolean} readFromLocalStorage: read from local-storage
      */
-    static getUser(readFromLocalStorage) {
-        if (!readFromLocalStorage && AuthManager._user) {
-            return AuthManager._user;
-        }
-
+    static getUser() {
         const userData = localStorage.getItem(`${User.CONST.LOCALSTORAGE_USER}_${Utils.getEnvironment().label}`);
         const partialToken = Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1);
         if (!(userData && partialToken)) {
             return null;
         }
 
-        //Update user in memory.
-        AuthManager._user = User.fromJson(JSON.parse(userData));
-        return AuthManager._user;
+        return User.fromJson(JSON.parse(userData));
     }
 
     /**
@@ -137,7 +130,6 @@ class AuthManager {
         if (user) {
             localStorage.setItem(`${User.CONST.LOCALSTORAGE_USER}_${Utils.getEnvironment().label}`, JSON.stringify(user.toJson()));
         }
-        AuthManager._user = user;
     }
 
     static hasScopes(resourcePath, resourceMethod) {
@@ -234,10 +226,4 @@ class AuthManager {
 
 }
 
-/**
- * Current User
- * @type {object} User Object
- * @private
- */
-AuthManager._user = undefined;
 export default AuthManager;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
@@ -135,14 +135,9 @@ class Utils {
         //Store environment.
         Utils._environment = environment;
         localStorage.setItem(Utils.CONST.LOCALSTORAGE_ENVIRONMENT, JSON.stringify(environment));
-
-        //Read the user of stored environment.
-        let user = AuthManager.getUser(true);
-        //If user is null store only in memory.
-        AuthManager.setUser(user);
     }
 
-    static getPromised_ssoData(environment){
+    static getPromised_ssoData(environment) {
         return Axios.get(Utils.getAppSSORequestURL(environment));
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
@@ -26,12 +26,12 @@ class Utils {
 
     /**
      * Get JavaScript accessible cookies saved in browser, by giving the cooke name.
-     * @param {String} name : Name of the cookie which need to be retrived
+     * @param {String} cookieName : Name of the cookie which need to be retrived
+     * @param {String} environmentName : label of the environment of the cookie
      * @returns {String|null} : If found a cookie with given name , return its value,Else null value is returned
      */
-    static getCookie(name) {
-        //Append environment name to cookie
-        let environmentName = "_" + Utils.getEnvironment().label;
+    static getCookie(cookieName, environmentName) {
+        environmentName = environmentName || Utils.getEnvironment().label;
 
         let pairs = document.cookie.split(";");
         let cookie = null;
@@ -39,7 +39,7 @@ class Utils {
             pair = pair.split("=");
             let cookie_name = pair[0].trim();
             let value = encodeURIComponent(pair[1]);
-            if (cookie_name === name + environmentName) {
+            if (cookie_name === `${cookieName}_${environmentName}`) {
                 cookie = value;
                 break;
             }
@@ -51,10 +51,11 @@ class Utils {
      * Delete a browser cookie given its name
      * @param {String} name : Name of the cookie which need to be deleted
      * @param {String} path : Path of the cookie which need to be deleted
+     * @param {String} environmentName: label of the environment of the cookie
      */
-    static delete_cookie(name, path) {
-        //Environment name is appended to the cookie name
-        document.cookie = `${name}_${Utils.getEnvironment().label}=; path=${path}; expires=Thu, 01 Jan 1970 00:00:01 GMT`;
+    static delete_cookie(name, path, environmentName) {
+        environmentName = environmentName || Utils.getEnvironment().label;
+        document.cookie = `${name}_${environmentName}=; path=${path}; expires=Thu, 01 Jan 1970 00:00:01 GMT`;
     }
 
     /**
@@ -66,7 +67,8 @@ class Utils {
      * @param {String} path : Path which needs to set the given cookie
      * @param {boolean} secured : secured parameter is set
      */
-    static setCookie(name, value, validityPeriod, path = "/", secured = true) {
+    static setCookie(name, value, validityPeriod, path = "/", environmentName, secured = true) {
+        environmentName = environmentName || Utils.getEnvironment().label;
         let expiresDirective = "";
         const securedDirective = secured ? "; Secure" : "";
         if (validityPeriod) {
@@ -75,7 +77,7 @@ class Utils {
             expiresDirective = "; expires=" + date.toUTCString();
         }
 
-        document.cookie = `${name}_${Utils.getEnvironment().label}=${value}; path=${path}${expiresDirective}${securedDirective}`;
+        document.cookie = `${name}_${environmentName}=${value}; path=${path}${expiresDirective}${securedDirective}`;
     }
 
     /**

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Login/Login.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Login/Login.js
@@ -18,7 +18,7 @@
 
 import React, {Component} from 'react'
 import './login.css'
-import {Redirect, Switch} from 'react-router-dom'
+import {Redirect, Switch, withRouter} from 'react-router-dom'
 import AuthManager from '../../data/AuthManager'
 import qs from 'qs'
 import TextField from 'material-ui/TextField';
@@ -34,9 +34,7 @@ import Input, {InputLabel} from 'material-ui/Input';
 import Select from 'material-ui/Select';
 import {FormControl} from 'material-ui/Form';
 import {MenuItem} from 'material-ui/Menu';
-import {CircularProgress} from "material-ui/Progress";
 import Grid from 'material-ui/Grid';
-import {withRouter} from 'react-router-dom';
 import Loading from "../Base/Loading/Loading";
 import Redirecting from "../Shared/Redirecting";
 
@@ -56,6 +54,7 @@ class Login extends Component {
             message: '',
             environments: [],
             environmentId: 0,
+            loginStatusEnvironments: [],
             authConfigs: [],
             redirectToIS: false
         };
@@ -78,6 +77,9 @@ class Login extends Component {
             const environment = environments[environmentId];
             Utils.setEnvironment(environment);
 
+            // Set authentication status of environments
+            this.setLoginStatusOfEnvironments(environments);
+
             //Fetch SSO data and render
             this.fetch_ssoData(environments);
         });
@@ -98,6 +100,12 @@ class Login extends Component {
             user.scopes = params.scopes.split(" ");
             AuthManager.setUser(user);
         }
+    }
+
+    setLoginStatusOfEnvironments(environments) {
+        this.state.loginStatusEnvironments = environments.map(
+            environment => AuthManager.getUser(environment.label) !== null
+        );
     }
 
     fetch_ssoData(environments) {
@@ -178,7 +186,11 @@ class Login extends Component {
     handleEnvironmentChange = (event) => {
         const environmentId = event.target.value;
         let environment = this.state.environments[environmentId];
-        this.setState({environmentId});
+        let isLogin = this.state.loginStatusEnvironments[environmentId];
+        if (isLogin) {
+            Utils.setEnvironment(environment);
+        }
+        this.setState({environmentId, isLogin});
     };
 
     handleRequestClose = () => {
@@ -190,7 +202,8 @@ class Login extends Component {
         const isSsoUpdated = this.state.authConfigs.length !== 0;
         const isSsoEnabled = isSsoUpdated && this.state.authConfigs[this.state.environmentId].is_sso_enabled.value;
         const {appName, appLabel} = this.props;
-        //Redirect to IS
+
+        //Redirect to Identity Provider
         if (this.state.redirectToIS) {
             return (
                 <Redirecting message={"You are now being redirected to Identity Provider."}/>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Login/Login.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Login/Login.js
@@ -68,10 +68,7 @@ class Login extends Component {
         ConfigManager.getConfigs().environments.then(response => {
             const environments = response.data.environments;
             const environmentId = Utils.getEnvironmentID(environments);
-
-            // Do not need to render before fetch sso data
-            this.state.environments = environments;
-            this.state.environmentId = environmentId;
+            this.setState({environments, environmentId});
 
             // Update environment to discard default environment configuration
             const environment = environments[environmentId];
@@ -103,9 +100,10 @@ class Login extends Component {
     }
 
     setLoginStatusOfEnvironments(environments) {
-        this.state.loginStatusEnvironments = environments.map(
+        let loginStatusEnvironments = environments.map(
             environment => AuthManager.getUser(environment.label) !== null
         );
+        this.setState({loginStatusEnvironments});
     }
 
     fetch_ssoData(environments) {
@@ -134,7 +132,7 @@ class Login extends Component {
     };
 
     handleSsoLogin = (e) => {
-        if(e){
+        if (e) {
             e.preventDefault();
         }
         const authConfigs = this.state.authConfigs[this.state.environmentId];

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/AuthManager.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/AuthManager.js
@@ -105,22 +105,15 @@ class AuthManager {
      * This may give a partial indication(passive check not actually check the token validity via an API) of whether the user has logged in or not, The actual API call may get denied
      * if the cookie stored access token is invalid/expired
      * @returns {User | null} Is any user has logged in or not
-     * @param {boolean} readFromLocalStorage: read from local-storage
      */
-    static getUser(readFromLocalStorage) {
-        if (!readFromLocalStorage && AuthManager._user) {
-            return AuthManager._user;
-        }
-
+    static getUser() {
         const userData = localStorage.getItem(`${User.CONST.LOCALSTORAGE_USER}_${Utils.getEnvironment().label}`);
         const partialToken = Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1);
         if (!(userData && partialToken)) {
             return null;
         }
 
-        //Update user in memory.
-        AuthManager._user = User.fromJson(JSON.parse(userData));
-        return AuthManager._user;
+        return User.fromJson(JSON.parse(userData));
     }
 
     /**
@@ -136,7 +129,6 @@ class AuthManager {
         if (user) {
             localStorage.setItem(`${User.CONST.LOCALSTORAGE_USER}_${Utils.getEnvironment().label}`, JSON.stringify(user.toJson()));
         }
-        AuthManager._user = user;
     }
 
     /**
@@ -190,7 +182,7 @@ class AuthManager {
     logout() {
         let authHeader = "Bearer " + AuthManager.getUser().getPartialToken();
         //TODO Will have to change the logout end point url to contain the app context(i.e. publisher/store, etc.)
-        let url = Utils.getAppLogoutURL()
+        let url = Utils.getAppLogoutURL();
         let headers = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
@@ -224,10 +216,4 @@ class AuthManager {
 
 }
 
-/**
- * Current User
- * @type {object} User Object
- * @private
- */
-AuthManager._user = undefined;
 export default AuthManager;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/AuthManager.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/AuthManager.js
@@ -104,11 +104,13 @@ class AuthManager {
      * An user object is return in present of user logged in user info in browser local storage, at the same time checks for partialToken in the cookie as well.
      * This may give a partial indication(passive check not actually check the token validity via an API) of whether the user has logged in or not, The actual API call may get denied
      * if the cookie stored access token is invalid/expired
+     * @param {string} environmentName: label of the environment, the user to be retrieved from
      * @returns {User | null} Is any user has logged in or not
      */
-    static getUser() {
-        const userData = localStorage.getItem(`${User.CONST.LOCALSTORAGE_USER}_${Utils.getEnvironment().label}`);
-        const partialToken = Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1);
+    static getUser(environmentName) {
+        environmentName = environmentName || Utils.getEnvironment().label;
+        const userData = localStorage.getItem(`${User.CONST.LOCALSTORAGE_USER}_${environmentName}`);
+        const partialToken = Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1, environmentName);
         if (!(userData && partialToken)) {
             return null;
         }
@@ -120,14 +122,16 @@ class AuthManager {
      * Persist an user in browser local storage and in-memory, Since only one use can be logged into the application at a time,
      * This method will override any previously persist user data.
      * @param {User} user : An instance of the {User} class
+     * @param {string} environmentName: label of the environment to be set the user
      */
-    static setUser(user) {
+    static setUser(user, environmentName) {
+        environmentName = environmentName || Utils.getEnvironment().label;
         if (!user instanceof User) {
             throw new Error("Invalid user object");
         }
 
         if (user) {
-            localStorage.setItem(`${User.CONST.LOCALSTORAGE_USER}_${Utils.getEnvironment().label}`, JSON.stringify(user.toJson()));
+            localStorage.setItem(`${User.CONST.LOCALSTORAGE_USER}_${environmentName}`, JSON.stringify(user.toJson()));
         }
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/Utils.js
@@ -135,14 +135,9 @@ class Utils {
         //Store environment.
         Utils._environment = environment;
         localStorage.setItem(Utils.CONST.LOCALSTORAGE_ENVIRONMENT, JSON.stringify(environment));
-
-        //Read the user of stored environment.
-        let user = AuthManager.getUser(true);
-        //If user is null store only in memory.
-        AuthManager.setUser(user);
     }
 
-    static getPromised_ssoData(environment){
+    static getPromised_ssoData(environment) {
         return Axios.get(Utils.getAppSSORequestURL(environment));
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/Utils.js
@@ -26,12 +26,12 @@ class Utils {
 
     /**
      * Get JavaScript accessible cookies saved in browser, by giving the cooke name.
-     * @param {String} name : Name of the cookie which need to be retrived
+     * @param {String} cookieName : Name of the cookie which need to be retrived
+     * @param {String} environmentName : label of the environment of the cookie
      * @returns {String|null} : If found a cookie with given name , return its value,Else null value is returned
      */
-    static getCookie(name) {
-        //Append environment name to cookie
-        let environmentName = "_" + Utils.getEnvironment().label;
+    static getCookie(cookieName, environmentName) {
+        environmentName = environmentName || Utils.getEnvironment().label;
 
         let pairs = document.cookie.split(";");
         let cookie = null;
@@ -39,7 +39,7 @@ class Utils {
             pair = pair.split("=");
             let cookie_name = pair[0].trim();
             let value = encodeURIComponent(pair[1]);
-            if (cookie_name === name + environmentName) {
+            if (cookie_name === `${cookieName}_${environmentName}`) {
                 cookie = value;
                 break;
             }
@@ -51,10 +51,11 @@ class Utils {
      * Delete a browser cookie given its name
      * @param {String} name : Name of the cookie which need to be deleted
      * @param {String} path : Path of the cookie which need to be deleted
+     * @param {String} environmentName: label of the environment of the cookie
      */
-    static delete_cookie(name, path) {
-        //Environment name is appended to the cookie name
-        document.cookie = `${name}_${Utils.getEnvironment().label}=; path=${path}; expires=Thu, 01 Jan 1970 00:00:01 GMT`;
+    static delete_cookie(name, path, environmentName) {
+        environmentName = environmentName || Utils.getEnvironment().label;
+        document.cookie = `${name}_${environmentName}=; path=${path}; expires=Thu, 01 Jan 1970 00:00:01 GMT`;
     }
 
     /**
@@ -66,7 +67,8 @@ class Utils {
      * @param {String} path : Path which needs to set the given cookie
      * @param {boolean} secured : secured parameter is set
      */
-    static setCookie(name, value, validityPeriod, path = "/", secured = true) {
+    static setCookie(name, value, validityPeriod, path = "/", environmentName, secured = true) {
+        environmentName = environmentName || Utils.getEnvironment().label;
         let expiresDirective = "";
         const securedDirective = secured ? "; Secure" : "";
         if (validityPeriod) {
@@ -75,7 +77,7 @@ class Utils {
             expiresDirective = "; expires=" + date.toUTCString();
         }
 
-        document.cookie = `${name}_${Utils.getEnvironment().label}=${value}; path=${path}${expiresDirective}${securedDirective}`;
+        document.cookie = `${name}_${environmentName}=${value}; path=${path}${expiresDirective}${securedDirective}`;
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request
- Render the application back when selecting an environment that is already logged in.
Eg:
  - Two environment: Development and Production
  - User already logged-in to Development environment and switch the environment.
  - Prompt the login page
  - When selecting the Development environment go back to the application.
- Remove in-memory user AuthManager._user
- Add `environmentName` parameter to `getUser` and `setUser` methods in `AuthManager.js`
- Fix https://github.com/wso2/product-apim/issues/2530