### PR TITLE
[JWT Grant] Multi-Environment Authentication with login to one environment

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/auth/OAuth2ServiceStubs.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/auth/OAuth2ServiceStubs.java
@@ -89,10 +89,11 @@ public class OAuth2ServiceStubs {
                                      @Param("username") String username,
                                      @Param("password") String password,
                                      @Param("scope") String scopes,
-                                     @Param("validity_period") long validityPeriod);
+                                     @Param("validity_period") long validityPeriod,
+                                     @Param("assertion") String assertion);
 
         /**
-         * Get a access token by Client Credentials grant type
+         * Get an access token by Client Credentials grant type
          *
          * @param scopes         Required scopes (space separated) for the access token
          * @param validityPeriod Validity period of the token
@@ -105,11 +106,11 @@ public class OAuth2ServiceStubs {
             String credentials = clientId + ':' + clientSecret;
             String authToken = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
             return generateAccessToken(authToken, KeyManagerConstants.CLIENT_CREDENTIALS_GRANT_TYPE,
-                    null, null, null, null, null, scopes, validityPeriod);
+                    null, null, null, null, null, scopes, validityPeriod, null);
         }
 
         /**
-         * Get a access token by Password grant type
+         * Get an access token by Password grant type
          *
          * @param username       Username of the user
          * @param password       Password of the user
@@ -125,11 +126,11 @@ public class OAuth2ServiceStubs {
             String credentials = clientId + ':' + clientSecret;
             String authToken = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
             return generateAccessToken(authToken, KeyManagerConstants.PASSWORD_GRANT_TYPE, null, null, null,
-                    username, password, scopes, validityPeriod);
+                    username, password, scopes, validityPeriod, null);
         }
 
         /**
-         * Get a access token by Authorization Code grant type
+         * Get an access token by Authorization Code grant type
          *
          * @param code           Authorization Code
          * @param redirectUri    Callback URL
@@ -145,11 +146,11 @@ public class OAuth2ServiceStubs {
             String credentials = clientId + ':' + clientSecret;
             String authToken = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
             return generateAccessToken(authToken, KeyManagerConstants.AUTHORIZATION_CODE_GRANT_TYPE, code, redirectUri,
-                    null, null, null, scopes, validityPeriod);
+                    null, null, null, scopes, validityPeriod, null);
         }
 
         /**
-         * Get a access token by Refresh grant type
+         * Get an access token by Refresh grant type
          *
          * @param refreshToken   Refresh Token
          * @param scopes         Required scopes (space separated) for the access token
@@ -164,7 +165,27 @@ public class OAuth2ServiceStubs {
             String credentials = clientId + ':' + clientSecret;
             String authToken = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
             return generateAccessToken(authToken, KeyManagerConstants.REFRESH_GRANT_TYPE, null,
-                    null, refreshToken, null, null, scopes, validityPeriod);
+                    null, refreshToken, null, null, scopes, validityPeriod, null);
+        }
+
+        /**
+         * Get an access token by JWT grant type (or custom grant type works as JWT grant type)
+         *
+         * @param assertion       JWT token or the custom token
+         * @param customGrantType JWT Grant Type (urn:ietf:params:oauth:grant-type:jwt-bearer) or the custom grant type
+         * @param scopes          Required scopes (space separated) for the access token
+         * @param validityPeriod  Validity period of the token
+         * @param clientId        Consumer Key of the application
+         * @param clientSecret    Consumer Secret of the application
+         * @return Feign Response Object
+         */
+        public default Response generateJWTGrantAccessToken(String assertion, String customGrantType, String scopes,
+                                                            long validityPeriod,
+                                                            String clientId, String clientSecret) {
+            String credentials = clientId + ':' + clientSecret;
+            String authToken = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+            return generateAccessToken(authToken, customGrantType, null, null, null,
+                    null, null, scopes, validityPeriod, assertion);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/APIMConfigurationService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/APIMConfigurationService.java
@@ -16,6 +16,7 @@
 package org.wso2.carbon.apimgt.core.configuration;
 
 import org.wso2.carbon.apimgt.core.configuration.models.APIMConfigurations;
+import org.wso2.carbon.apimgt.core.configuration.models.EnvironmentConfigurations;
 import org.wso2.carbon.apimgt.core.internal.ServiceReferenceHolder;
 
 /**
@@ -24,9 +25,11 @@ import org.wso2.carbon.apimgt.core.internal.ServiceReferenceHolder;
 public class APIMConfigurationService {
     private static APIMConfigurationService apimConfigurationService = new APIMConfigurationService();
     private APIMConfigurations apimConfigurations;
+    private EnvironmentConfigurations environmentConfigurations;
 
     private APIMConfigurationService() {
         apimConfigurations = ServiceReferenceHolder.getInstance().getAPIMConfiguration();
+        environmentConfigurations = ServiceReferenceHolder.getInstance().getEnvironmentConfigurations();
     }
 
     public static APIMConfigurationService getInstance() {
@@ -35,5 +38,9 @@ public class APIMConfigurationService {
 
     public APIMConfigurations getApimConfigurations() {
         return apimConfigurations;
+    }
+
+    public EnvironmentConfigurations getEnvironmentConfigurations() {
+        return environmentConfigurations;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/APIMConfigurations.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/APIMConfigurations.java
@@ -90,9 +90,6 @@ public class APIMConfigurations {
             "org.wso2.carbon.apimgt.core.impl.WSDL11ProcessorImpl",
             "org.wso2.carbon.apimgt.core.impl.WSDL20ProcessorImpl");
 
-    @Element(description = "Environment Configurations")
-    private EnvironmentConfigurations environmentConfigurations = new EnvironmentConfigurations();
-
     @Element(description = "SDK Generation Language Configurations")
     private SdkLanguageConfigurations sdkLanguageConfigurations = new SdkLanguageConfigurations();
 
@@ -273,13 +270,5 @@ public class APIMConfigurations {
 
     public void setWsdlProcessors(List<String> wsdlProcessors) {
         this.wsdlProcessors = wsdlProcessors;
-    }
-
-    public EnvironmentConfigurations getEnvironmentConfigurations() {
-        return environmentConfigurations;
-    }
-
-    public void setEnvironmentConfigurations(EnvironmentConfigurations environmentConfigurations) {
-        this.environmentConfigurations = environmentConfigurations;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/EnvironmentConfigurations.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/EnvironmentConfigurations.java
@@ -28,7 +28,8 @@ import java.util.List;
 /**
  * Class to hold Environment configurations
  */
-@Configuration(description = "Environment Configurations")
+@Configuration(namespace = "wso2.carbon.apimgt.environment",
+        description = "APIM Environment Configuration Parameters")
 public class EnvironmentConfigurations {
     //Unique name for environment to set cookies by backend
     @Element(description = "current environment's label from the list of environments")

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/EnvironmentConfigurations.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/EnvironmentConfigurations.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * Class to hold Environment configurations
  */
-@Configuration(namespace = "wso2.carbon.apimgt.environment",
+@Configuration(namespace = "wso2.carbon.apimgt.environments",
         description = "APIM Environment Configuration Parameters")
 public class EnvironmentConfigurations {
     //Unique name for environment to set cookies by backend

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/EnvironmentConfigurations.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/EnvironmentConfigurations.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.apimgt.core.configuration.models;
 
 import org.wso2.carbon.apimgt.core.util.APIMgtConstants;
@@ -22,6 +40,9 @@ public class EnvironmentConfigurations {
     //If the first host is an empty string, use "wso2.carbon.apimgt.application: apimBaseUrl" as UI-Service
     private List<String> allowedHosts = Collections.singletonList("");
 
+    @Element(description = "Multi-Environment Overview Configurations")
+    private MultiEnvironmentOverview multiEnvironmentOverview = new MultiEnvironmentOverview();
+
     public String getEnvironmentLabel() {
         return environmentLabel;
     }
@@ -36,5 +57,13 @@ public class EnvironmentConfigurations {
 
     public void setAllowedHosts(List<String> allowedHosts) {
         this.allowedHosts = allowedHosts;
+    }
+
+    public MultiEnvironmentOverview getMultiEnvironmentOverview() {
+        return multiEnvironmentOverview;
+    }
+
+    public void setMultiEnvironmentOverview(MultiEnvironmentOverview multiEnvironmentOverview) {
+        this.multiEnvironmentOverview = multiEnvironmentOverview;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/MultiEnvironmentOverview.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/MultiEnvironmentOverview.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.core.configuration.models;
+
+import org.wso2.carbon.apimgt.core.util.KeyManagerConstants;
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Class to hold Environment configurations
+ */
+@Configuration(description = "Multi-Environment Overview Configurations")
+public class MultiEnvironmentOverview {
+    @Element(description = "Multi-Environment Overview feature enabled or not")
+    private boolean enabled = false;
+
+    @Element(description = "Authentication Grant Type to authenticate user to other environments")
+    private String authenticationGrantType = KeyManagerConstants.JWT_GRANT_TYPE;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getAuthenticationGrantType() {
+        return authenticationGrantType;
+    }
+
+    public void setAuthenticationGrantType(String authenticationGrantType) {
+        this.authenticationGrantType = authenticationGrantType;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/MultiEnvironmentOverview.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/MultiEnvironmentOverview.java
@@ -30,22 +30,11 @@ public class MultiEnvironmentOverview {
     @Element(description = "Multi-Environment Overview feature enabled or not")
     private boolean enabled = false;
 
-    @Element(description = "Authentication Grant Type to authenticate user to other environments")
-    private String authenticationGrantType = KeyManagerConstants.JWT_GRANT_TYPE;
-
     public boolean isEnabled() {
         return enabled;
     }
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
-    }
-
-    public String getAuthenticationGrantType() {
-        return authenticationGrantType;
-    }
-
-    public void setAuthenticationGrantType(String authenticationGrantType) {
-        this.authenticationGrantType = authenticationGrantType;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/MultiEnvironmentOverview.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/configuration/models/MultiEnvironmentOverview.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.apimgt.core.configuration.models;
 
-import org.wso2.carbon.apimgt.core.util.KeyManagerConstants;
 import org.wso2.carbon.config.annotation.Configuration;
 import org.wso2.carbon.config.annotation.Element;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/exception/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/exception/ExceptionCodes.java
@@ -177,6 +177,7 @@ public enum ExceptionCodes implements ErrorHandler {
     MISSING_CREDENTIALS(900902, "Missing Credentials", 401, " Please provide an active access token to proceed"),
     ACCESS_TOKEN_EXPIRED(900903, "Invalid Credentials", 401, " Access token is expired."),
     ACCESS_TOKEN_INACTIVE(900904, "Access Token Error", 401, " Access token is inactive."),
+    USER_NOT_AUTHENTICATED(900905, "User is not Authenticated", 401, " User is not authenticated."),
     INVALID_SCOPE(900910, "Invalid Scope", 403, " You are not authorized to access the resource."),
     INVALID_AUTHORIZATION_HEADER(900911, "Invalid Authorization header", 401,
             " Please provide the Authorization : Bearer <> token to proceed."),

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/DefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/DefaultKeyManagerImpl.java
@@ -302,6 +302,8 @@ public class DefaultKeyManagerImpl implements KeyManager {
                     throw new KeyManagementException("Error occurred while parsing token endpoint", e,
                             ExceptionCodes.ACCESS_TOKEN_GENERATION_FAILED);
                 }
+            } else if (KeyManagerConstants.JWT_GRANT_TYPE.equals(tokenRequest.getGrantType())) {
+                //todo: implement
             } else {
                 throw new KeyManagementException(
                         "Invalid access token request. Unsupported grant type: " + tokenRequest.getGrantType(),

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/WSO2ISKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/WSO2ISKeyManagerImpl.java
@@ -299,6 +299,10 @@ public class WSO2ISKeyManagerImpl implements KeyManager {
                 response = oAuth2ServiceStubs.getTokenServiceStub().generateRefreshGrantAccessToken(
                         tokenRequest.getRefreshToken(), tokenRequest.getScopes(), tokenRequest.getValidityPeriod(),
                         tokenRequest.getClientId(), tokenRequest.getClientSecret());
+            } else if (KeyManagerConstants.JWT_GRANT_TYPE.equals(tokenRequest.getGrantType())) {
+                response = oAuth2ServiceStubs.getTokenServiceStub().generateJWTGrantAccessToken(
+                        tokenRequest.getAssertion(), KeyManagerConstants.JWT_GRANT_TYPE, tokenRequest.getScopes(),
+                        tokenRequest.getValidityPeriod(), tokenRequest.getClientId(), tokenRequest.getClientSecret());
             } else {
                 throw new KeyManagementException("Invalid access token request. Unsupported grant type: "
                         + tokenRequest.getGrantType(), ExceptionCodes.INVALID_TOKEN_REQUEST);

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/internal/ServiceReferenceHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/internal/ServiceReferenceHolder.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.core.internal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.apimgt.core.configuration.models.APIMConfigurations;
+import org.wso2.carbon.apimgt.core.configuration.models.EnvironmentConfigurations;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.secvault.SecureVault;
@@ -33,7 +34,8 @@ public class ServiceReferenceHolder {
     private static final Logger log = LoggerFactory.getLogger(ServiceReferenceHolder.class);
     private static ServiceReferenceHolder instance = new ServiceReferenceHolder();
     private ConfigProvider configProvider;
-    private APIMConfigurations config;
+    private APIMConfigurations apimConfigurations;
+    private EnvironmentConfigurations environmentConfigurations;
     private SecureVault secureVault;
 
     private ServiceReferenceHolder() {}
@@ -59,7 +61,7 @@ public class ServiceReferenceHolder {
     public APIMConfigurations getAPIMConfiguration() {
         try {
             if (configProvider != null) {
-                config = configProvider.getConfigurationObject(APIMConfigurations.class);
+                apimConfigurations = configProvider.getConfigurationObject(APIMConfigurations.class);
             } else {
                 log.error("Configuration provider is null");
             }
@@ -67,12 +69,35 @@ public class ServiceReferenceHolder {
             log.error("error getting config : org.wso2.carbon.apimgt.core.internal.APIMConfiguration", e);
         }
 
-        if (config == null) {
-            config = new APIMConfigurations();
-            log.info("Setting default configurations...");
+        if (apimConfigurations == null) {
+            apimConfigurations = new APIMConfigurations();
+            log.info("APIMConfiguration: Setting default configurations...");
         }
 
-        return config;
+        return apimConfigurations;
+    }
+
+    /**
+     * Gives the EnvironmentConfigurations explicitly set in the deployment yaml or the default configurations
+     *
+     * @return EnvironmentConfigurations
+     */
+    public EnvironmentConfigurations getEnvironmentConfigurations() {
+        try {
+            if (configProvider != null) {
+                environmentConfigurations = configProvider.getConfigurationObject(EnvironmentConfigurations.class);
+            } else {
+                log.error("Configuration provider is null");
+            }
+        } catch (ConfigurationException e) {
+            log.error("error getting config : org.wso2.carbon.apimgt.core.internal.EnvironmentConfigurations", e);
+        }
+
+        if (environmentConfigurations == null) {
+            environmentConfigurations = new EnvironmentConfigurations();
+            log.info("EnvironmentConfigurations: Setting default configurations...");
+        }
+        return environmentConfigurations;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/models/AccessTokenRequest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/models/AccessTokenRequest.java
@@ -35,6 +35,7 @@ public class AccessTokenRequest {
     private long validityPeriod;
     private String tokenToRevoke;
     private String authorizationCode;
+    private String assertion;
 
     // This map can be used to store additional properties not captured by above list of fields.
     private HashMap<String, Object> requestParameters = new HashMap<String, Object>();
@@ -134,6 +135,14 @@ public class AccessTokenRequest {
 
     public void setAuthorizationCode(String authorizationCode) {
         this.authorizationCode = authorizationCode;
+    }
+
+    public String getAssertion() {
+        return assertion;
+    }
+
+    public void setAssertion(String assertion) {
+        this.assertion = assertion;
     }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/util/EnvironmentUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/util/EnvironmentUtils.java
@@ -20,8 +20,8 @@ public class EnvironmentUtils {
         }
 
         String host = origin.split(APIMgtConstants.WEB_PROTOCOL_SUFFIX)[1];
-        List<String> allowedOrigins = APIMConfigurationService.getInstance().getApimConfigurations()
-                .getEnvironmentConfigurations().getAllowedHosts();
+        List<String> allowedOrigins = APIMConfigurationService.getInstance().getEnvironmentConfigurations()
+                .getAllowedHosts();
         if (allowedOrigins.contains(APIMgtConstants.CORSAllowOriginConstants.ALLOW_ALL_ORIGINS) ||
                 allowedOrigins.contains(host)) {
             return origin;

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/util/KeyManagerConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/util/KeyManagerConstants.java
@@ -78,6 +78,7 @@ public class KeyManagerConstants {
     public static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
     public static final String PASSWORD_GRANT_TYPE = "password";
     public static final String AUTHORIZATION_CODE_GRANT_TYPE = "authorization_code";
+    public static final String JWT_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
     public static final String REFRESH_GRANT_TYPE = "refresh_token";
     public static final String GRANT_TYPE_PARAM_VALIDITY = "validity_period";
     public static final String AUTHORIZATION_HEADER = "Authorization";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/pom.xml
@@ -106,6 +106,16 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorAPI.java
@@ -272,7 +272,7 @@ public class AuthenticatorAPI implements Microservice {
      * This is the API which IDP redirects the user after authentication.
      *
      * @param request Request to call /callback api
-     * @param appName Name of the applicatoin (publisher/store/admin)
+     * @param appName Name of the application (publisher/store/admin)
      * @param authorizationCode Authorization-Code
      * @return Response - Response with redirect URL
      */

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorAPI.java
@@ -83,7 +83,8 @@ public class AuthenticatorAPI implements Microservice {
     @Consumes({MediaType.APPLICATION_FORM_URLENCODED, MediaType.MULTIPART_FORM_DATA})
     public Response authenticate(@Context Request request, @PathParam("appName") String appName,
                                  @FormDataParam("username") String userName, @FormDataParam("password") String password,
-                                 @FormDataParam("grant_type") String grantType, @FormDataParam("validity_period") String validityPeriod,
+                                 @FormDataParam("assertion") String assertion, @FormDataParam("grant_type") String grantType,
+                                 @FormDataParam("validity_period") String validityPeriod,
                                  @FormDataParam("remember_me") boolean isRememberMe, @FormDataParam("scopes") String scopesList) {
         try {
             KeyManager keyManager = APIManagerFactory.getInstance().getKeyManager();
@@ -115,7 +116,7 @@ public class AuthenticatorAPI implements Microservice {
                 }
             }
             AccessTokenInfo accessTokenInfo = authenticatorService.getTokens(appContext.substring(1),
-                    grantType, userName, password, refToken, Long.parseLong(validityPeriod), null);
+                    grantType, userName, password, refToken, Long.parseLong(validityPeriod), null, assertion);
             authenticatorService.setAccessTokenData(authResponseBean, accessTokenInfo);
             String accessToken = accessTokenInfo.getAccessToken();
             String refreshToken = accessTokenInfo.getRefreshToken();
@@ -300,7 +301,7 @@ public class AuthenticatorAPI implements Microservice {
             SystemApplicationDao systemApplicationDao = DAOFactory.getSystemApplicationDao();
             AuthenticatorService authenticatorService = new AuthenticatorService(keyManager, systemApplicationDao);
             AccessTokenInfo accessTokenInfo = authenticatorService.getTokens(appName, grantType,
-                    null, null, null, 0, authorizationCode);
+                    null, null, null, 0, authorizationCode, null);
             if (StringUtils.isEmpty(accessTokenInfo.toString())) {
                 return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                         .entity("Access token generation failed!").build();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorAPI.java
@@ -331,8 +331,8 @@ public class AuthenticatorAPI implements Microservice {
                 // Redirect to the store/apis page (redirect URL)
                 String uiServiceUrl;
                 //The first host in the list "allowedHosts" is the host of UI-Service
-                String uiServiceHost = APIMConfigurationService.getInstance().getApimConfigurations()
-                        .getEnvironmentConfigurations().getAllowedHosts().get(0);
+                String uiServiceHost = APIMConfigurationService.getInstance().getEnvironmentConfigurations()
+                        .getAllowedHosts().get(0);
                 if (StringUtils.isEmpty(uiServiceHost)) {
                     if (log.isDebugEnabled()) {
                         log.debug("The first string in the list " +

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorService.java
@@ -298,7 +298,7 @@ public class AuthenticatorService {
      * @throws APIManagementException When retrieving scopes from swagger definition fails
      */
     private String getApplicationScopes(String appName) throws APIManagementException {
-        String scopes = "";
+        String scopes;
         String applicationRestAPI = null;
         if (AuthenticatorConstants.STORE_APPLICATION.equals(appName)) {
             applicationRestAPI = RestApiUtil.getStoreRestAPIResource();
@@ -341,7 +341,7 @@ public class AuthenticatorService {
      * @return OAUthApplicationInfo - An object with DCR Application information
      * @throws APIManagementException When creating DCR application fails
      */
-    private OAuthApplicationInfo createDCRApplication(String clientName, String callBackURL, List grantTypes)
+    private OAuthApplicationInfo createDCRApplication(String clientName, String callBackURL, List<String> grantTypes)
             throws APIManagementException {
         OAuthApplicationInfo oAuthApplicationInfo;
         try {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorService.java
@@ -92,8 +92,10 @@ public class AuthenticatorService {
         List<String> grantTypes = new ArrayList<>();
         grantTypes.add(KeyManagerConstants.PASSWORD_GRANT_TYPE);
         grantTypes.add(KeyManagerConstants.AUTHORIZATION_CODE_GRANT_TYPE);
-        grantTypes.add(envOverviewConfigs.getAuthenticationGrantType());
         grantTypes.add(KeyManagerConstants.REFRESH_GRANT_TYPE);
+        if (isMultiEnvironmentOverviewEnabled) {
+            grantTypes.add(envOverviewConfigs.getAuthenticationGrantType());
+        }
         APIMAppConfigurations appConfigs = ServiceReferenceHolder.getInstance().getAPIMAppConfiguration();
         String callBackURL = appConfigs.getApimBaseUrl() + AuthenticatorConstants.AUTHORIZATION_CODE_CALLBACK_URL + appName;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorService.java
@@ -119,7 +119,7 @@ public class AuthenticatorService {
                 oAuthData.addProperty(KeyManagerConstants.AUTHORIZATION_ENDPOINT,
                         appConfigs.getAuthorizationEndpoint());
                 oAuthData.addProperty(AuthenticatorConstants.SSO_ENABLED, appConfigs.isSsoEnabled());
-                oAuthData.addProperty(AuthenticatorConstants.AUTO_LOGIN_ENABLED, isMultiEnvironmentOverviewEnabled);
+                oAuthData.addProperty(AuthenticatorConstants.MULTI_ENVIRONMENT_OVERVIEW_ENABLED, isMultiEnvironmentOverviewEnabled);
             } else {
                 String errorMsg = "No information available in OAuth application.";
                 log.error(errorMsg, ExceptionCodes.OAUTH2_APP_CREATION_FAILED);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorService.java
@@ -94,7 +94,7 @@ public class AuthenticatorService {
         grantTypes.add(KeyManagerConstants.AUTHORIZATION_CODE_GRANT_TYPE);
         grantTypes.add(KeyManagerConstants.REFRESH_GRANT_TYPE);
         if (isMultiEnvironmentOverviewEnabled) {
-            grantTypes.add(envOverviewConfigs.getAuthenticationGrantType());
+            grantTypes.add(KeyManagerConstants.JWT_GRANT_TYPE);
         }
         APIMAppConfigurations appConfigs = ServiceReferenceHolder.getInstance().getAPIMAppConfiguration();
         String callBackURL = appConfigs.getApimBaseUrl() + AuthenticatorConstants.AUTHORIZATION_CODE_CALLBACK_URL + appName;
@@ -156,7 +156,6 @@ public class AuthenticatorService {
         MultiEnvironmentOverview envOverviewConfigs = APIMConfigurationService.getInstance()
                 .getEnvironmentConfigurations().getMultiEnvironmentOverview();
         boolean isMultiEnvironmentOverviewEnabled = envOverviewConfigs.isEnabled();
-        String customGrantType = envOverviewConfigs.getAuthenticationGrantType();
 
         // Get scopes of the application
         String scopes = getApplicationScopes(appName);
@@ -207,7 +206,8 @@ public class AuthenticatorService {
                 accessTokenRequest.setClientId(consumerKeySecretMap.get("CONSUMER_KEY"));
                 accessTokenRequest.setClientSecret(consumerKeySecretMap.get("CONSUMER_SECRET"));
                 accessTokenRequest.setAssertion(assertion);
-                accessTokenRequest.setGrantType(customGrantType);
+                // Pass grant type to extend a custom grant instead of JWT grant in the future
+                accessTokenRequest.setGrantType(KeyManagerConstants.JWT_GRANT_TYPE);
                 accessTokenRequest.setScopes(scopes);
                 accessTokenRequest.setValidityPeriod(validityPeriod);
                 accessTokenInfo = getKeyManager().getNewAccessToken(accessTokenRequest);
@@ -217,7 +217,7 @@ public class AuthenticatorService {
                     APIManagerFactory.getInstance().getIdentityProvider().getIdOfUser(usernameFromJWT);
                 } catch (IdentityProviderException e) {
                     String errorMsg = "User " + usernameFromJWT + " dose not exists in this environment.";
-                    throw new KeyManagementException(errorMsg, e, ExceptionCodes.USER_DOES_NOT_EXIST);
+                    throw new APIManagementException(errorMsg, e, ExceptionCodes.USER_NOT_AUTHENTICATED);
                 }
             }
         } catch (KeyManagementException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorService.java
@@ -86,7 +86,7 @@ public class AuthenticatorService {
             throws APIManagementException {
         JsonObject oAuthData = new JsonObject();
         // Authentication details for Multi-Environment Overview
-        MultiEnvironmentOverview envOverviewConfigs = APIMConfigurationService.getInstance().getApimConfigurations()
+        MultiEnvironmentOverview envOverviewConfigs = APIMConfigurationService.getInstance()
                 .getEnvironmentConfigurations().getMultiEnvironmentOverview();
         boolean isMultiEnvironmentOverviewEnabled = envOverviewConfigs.isEnabled();
         List<String> grantTypes = new ArrayList<>();
@@ -151,7 +151,7 @@ public class AuthenticatorService {
         AccessTokenRequest accessTokenRequest = new AccessTokenRequest();
 
         // Authentication details for Multi-Environment Overview
-        MultiEnvironmentOverview envOverviewConfigs = APIMConfigurationService.getInstance().getApimConfigurations()
+        MultiEnvironmentOverview envOverviewConfigs = APIMConfigurationService.getInstance()
                 .getEnvironmentConfigurations().getMultiEnvironmentOverview();
         boolean isMultiEnvironmentOverviewEnabled = envOverviewConfigs.isEnabled();
         String customGrantType = envOverviewConfigs.getAuthenticationGrantType();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/constants/AuthenticatorConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/constants/AuthenticatorConstants.java
@@ -33,7 +33,6 @@ public class AuthenticatorConstants {
     public static final String SECURE_COOKIE = "Secure";
     public static final String PASSWORD_GRANT = "password";
     public static final String REFRESH_GRANT = "refresh_token";
-    public static final String JWT_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
     public static final String COOKIE_HEADER = "Cookie";
     public static final String AUTHORIZATION_HTTP_HEADER = "Authorization";
     public static final String BEARER_PREFIX = "bearer";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/constants/AuthenticatorConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/constants/AuthenticatorConstants.java
@@ -33,6 +33,7 @@ public class AuthenticatorConstants {
     public static final String SECURE_COOKIE = "Secure";
     public static final String PASSWORD_GRANT = "password";
     public static final String REFRESH_GRANT = "refresh_token";
+    public static final String JWT_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
     public static final String COOKIE_HEADER = "Cookie";
     public static final String AUTHORIZATION_HTTP_HEADER = "Authorization";
     public static final String BEARER_PREFIX = "bearer";
@@ -42,6 +43,7 @@ public class AuthenticatorConstants {
     public static final String CONSUMER_KEY = "CONSUMER_KEY";
     public static final String CONSUMER_SECRET = "CONSUMER_SECRET";
     public static final String SSO_ENABLED = "is_sso_enabled";
+    public static final String AUTO_LOGIN_ENABLED = "is_auto_login_enabled";
     public static final String APPLICATION_KEY_TYPE = "Application";
     public static final String REQUEST_URL = "REQUEST_URL";
     public static final String STORE_APPLICATION = "store";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/constants/AuthenticatorConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/constants/AuthenticatorConstants.java
@@ -42,7 +42,7 @@ public class AuthenticatorConstants {
     public static final String CONSUMER_KEY = "CONSUMER_KEY";
     public static final String CONSUMER_SECRET = "CONSUMER_SECRET";
     public static final String SSO_ENABLED = "is_sso_enabled";
-    public static final String AUTO_LOGIN_ENABLED = "is_auto_login_enabled";
+    public static final String MULTI_ENVIRONMENT_OVERVIEW_ENABLED = "is_multi_environment_overview_enabled";
     public static final String APPLICATION_KEY_TYPE = "Application";
     public static final String REQUEST_URL = "REQUEST_URL";
     public static final String STORE_APPLICATION = "store";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/utils/AuthUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/main/java/org/wso2/carbon/apimgt/rest/api/authenticator/utils/AuthUtil.java
@@ -132,7 +132,7 @@ public class AuthUtil {
         }
 
         //Append unique environment name in deployment.yaml
-        String environmentName = APIMConfigurationService.getInstance().getApimConfigurations()
+        String environmentName = APIMConfigurationService.getInstance()
                 .getEnvironmentConfigurations().getEnvironmentLabel();
         String cookie = request.getHeader(AuthenticatorConstants.COOKIE_HEADER);
         if (cookie != null) {
@@ -176,7 +176,7 @@ public class AuthUtil {
         }
 
         //Append unique environment name in deployment.yaml
-        String environmentName = APIMConfigurationService.getInstance().getApimConfigurations()
+        String environmentName = APIMConfigurationService.getInstance()
                 .getEnvironmentConfigurations().getEnvironmentLabel();
         return new NewCookie(name + "_" + environmentName, stringBuilder.toString());
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/test/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorServiceTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/test/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorServiceTestCase.java
@@ -154,7 +154,7 @@ public class AuthenticatorServiceTestCase {
         Mockito.when(keyManager.getNewAccessToken(Mockito.any())).thenReturn(tokenInfo);
         AccessTokenInfo tokenInfoResponseForValidAuthCode = authenticatorService.getTokens("store",
                 "authorization_code", null, null, null, 0,
-                "xxx-auth-code-xxx");
+                "xxx-auth-code-xxx", null);
         Assert.assertEquals(tokenInfoResponseForValidAuthCode, tokenInfo);
 
         // Error Path - 500 - Authorization code grant type
@@ -164,7 +164,7 @@ public class AuthenticatorServiceTestCase {
         AccessTokenInfo tokenInfoResponseForInvalidAuthCode = new AccessTokenInfo();
         try {
             tokenInfoResponseForInvalidAuthCode = authenticatorService.getTokens("store",
-                    "authorization_code", null, null, null, 0, null);
+                    "authorization_code", null, null, null, 0, null, null);
         } catch (APIManagementException e) {
             Assert.assertEquals(e.getMessage(), "No Authorization Code available.");
             Assert.assertEquals(tokenInfoResponseForInvalidAuthCode, emptyTokenInfo);
@@ -173,14 +173,14 @@ public class AuthenticatorServiceTestCase {
         // Happy Path - 200 - Password grant type
         Mockito.when(keyManager.getNewAccessToken(Mockito.any())).thenReturn(tokenInfo);
         AccessTokenInfo tokenInfoResponseForPasswordGrant = authenticatorService.getTokens("store", "password",
-                "admin", "admin", null, 0, null);
+                "admin", "admin", null, 0, null, null);
         Assert.assertEquals(tokenInfoResponseForPasswordGrant, tokenInfo);
 
         // Error Path - When token generation fails and throws APIManagementException
         Mockito.when(keyManager.getNewAccessToken(Mockito.any())).thenThrow(KeyManagementException.class);
         try {
             authenticatorService.getTokens("store", "password",
-                    "admin", "admin", null, 0, null);
+                    "admin", "admin", null, 0, null, null);
         } catch (APIManagementException e) {
             Assert.assertEquals(e.getMessage(), "Error while receiving tokens for OAuth application : store");
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/test/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorServiceTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/test/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorServiceTestCase.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.apimgt.core.api.KeyManager;
+import org.wso2.carbon.apimgt.core.configuration.APIMConfigurationService;
 import org.wso2.carbon.apimgt.core.dao.SystemApplicationDao;
 import org.wso2.carbon.apimgt.core.exception.APIManagementException;
 import org.wso2.carbon.apimgt.core.exception.KeyManagementException;
@@ -57,6 +58,8 @@ public class AuthenticatorServiceTestCase {
         oAuthData.addProperty(KeyManagerConstants.AUTHORIZATION_ENDPOINT, "https://localhost:9443/oauth2/authorize");
         oAuthData.addProperty(AuthenticatorConstants.SSO_ENABLED, ServiceReferenceHolder.getInstance()
                 .getAPIMAppConfiguration().isSsoEnabled());
+        oAuthData.addProperty(AuthenticatorConstants.AUTO_LOGIN_ENABLED, APIMConfigurationService.getInstance().getApimConfigurations()
+                .getEnvironmentConfigurations().getMultiEnvironmentOverview().isEnabled());
 
         KeyManager keyManager = Mockito.mock(KeyManager.class);
         AuthenticatorService authenticatorService = new AuthenticatorService(keyManager, systemApplicationDao);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/test/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorServiceTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/test/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorServiceTestCase.java
@@ -58,7 +58,7 @@ public class AuthenticatorServiceTestCase {
         oAuthData.addProperty(KeyManagerConstants.AUTHORIZATION_ENDPOINT, "https://localhost:9443/oauth2/authorize");
         oAuthData.addProperty(AuthenticatorConstants.SSO_ENABLED, ServiceReferenceHolder.getInstance()
                 .getAPIMAppConfiguration().isSsoEnabled());
-        oAuthData.addProperty(AuthenticatorConstants.AUTO_LOGIN_ENABLED, APIMConfigurationService.getInstance().getApimConfigurations()
+        oAuthData.addProperty(AuthenticatorConstants.AUTO_LOGIN_ENABLED, APIMConfigurationService.getInstance()
                 .getEnvironmentConfigurations().getMultiEnvironmentOverview().isEnabled());
 
         KeyManager keyManager = Mockito.mock(KeyManager.class);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/test/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorServiceTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.authenticator/src/test/java/org/wso2/carbon/apimgt/rest/api/authenticator/AuthenticatorServiceTestCase.java
@@ -66,7 +66,7 @@ public class AuthenticatorServiceTestCase {
         oAuthData.addProperty(KeyManagerConstants.AUTHORIZATION_ENDPOINT, "https://localhost:9443/oauth2/authorize");
         oAuthData.addProperty(AuthenticatorConstants.SSO_ENABLED, ServiceReferenceHolder.getInstance()
                 .getAPIMAppConfiguration().isSsoEnabled());
-        oAuthData.addProperty(AuthenticatorConstants.AUTO_LOGIN_ENABLED, APIMConfigurationService.getInstance()
+        oAuthData.addProperty(AuthenticatorConstants.MULTI_ENVIRONMENT_OVERVIEW_ENABLED, APIMConfigurationService.getInstance()
                 .getEnvironmentConfigurations().getMultiEnvironmentOverview().isEnabled());
 
         KeyManager keyManager = Mockito.mock(KeyManager.class);
@@ -200,7 +200,6 @@ public class AuthenticatorServiceTestCase {
         // Multi-Environment Overview configuration
         MultiEnvironmentOverview multiEnvironmentOverview = new MultiEnvironmentOverview();
         multiEnvironmentOverview.setEnabled(true);
-        multiEnvironmentOverview.setAuthenticationGrantType("urn:ietf:params:oauth:grant-type:jwt-bearer");
 
         // APIMConfigurations
         EnvironmentConfigurations environmentConfigurations = new EnvironmentConfigurations();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.commons/src/main/java/org/wso2/carbon/apimgt/rest/api/common/impl/OAuth2Authenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.commons/src/main/java/org/wso2/carbon/apimgt/rest/api/common/impl/OAuth2Authenticator.java
@@ -177,7 +177,7 @@ public class OAuth2Authenticator implements RESTAPIAuthenticator {
      */
     private String extractPartialAccessTokenFromCookie(String cookie) {
         //Append unique environment name in deployment.yaml
-        String environmentName = APIMConfigurationService.getInstance().getApimConfigurations()
+        String environmentName = APIMConfigurationService.getInstance()
                 .getEnvironmentConfigurations().getEnvironmentLabel();
 
         if (cookie != null) {
@@ -200,7 +200,7 @@ public class OAuth2Authenticator implements RESTAPIAuthenticator {
         String token2 = null;
 
         //Append unique environment name in deployment.yaml
-        String environmentName = APIMConfigurationService.getInstance().getApimConfigurations()
+        String environmentName = APIMConfigurationService.getInstance()
                 .getEnvironmentConfigurations().getEnvironmentLabel();
         if (cookie != null) {
             cookie = cookie.trim();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.commons/src/main/java/org/wso2/carbon/apimgt/rest/api/common/interceptors/RESTAPISecurityInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.commons/src/main/java/org/wso2/carbon/apimgt/rest/api/common/interceptors/RESTAPISecurityInterceptor.java
@@ -100,7 +100,7 @@ public class RESTAPISecurityInterceptor implements Interceptor {
         }
 
         /* TODO: Following string contains check is done to avoid checking security headers in non API requests.
-         * Consider this as a tempory fix until MSF4J support context based interceptor registration */
+         * Consider this as a temporary fix until MSF4J support context based interceptor registration */
         String requestURI = request.getUri().toLowerCase(Locale.ENGLISH);
         if (!requestURI.contains("/api/am/")) {
             return true;
@@ -262,7 +262,7 @@ public class RESTAPISecurityInterceptor implements Interceptor {
      * @param responder    HttpResponder instance which is used send error messages back to the client
      */
     private void handleSecurityError(ErrorHandler errorHandler, Response responder) {
-        HashMap<String, String> paramList = new HashMap<String, String>();
+        HashMap<String, String> paramList = new HashMap<>();
         ErrorDTO errorDTO = RestApiUtil.getErrorDTO(errorHandler, paramList);
         responder.setStatus(errorHandler.getHttpStatusCode());
         responder.setHeader(javax.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE, RestApiConstants.AUTH_TYPE_OAUTH2);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.configurations/src/main/java/org/wso2/carbon/apimgt/rest/api/configurations/ConfigurationsAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.configurations/src/main/java/org/wso2/carbon/apimgt/rest/api/configurations/ConfigurationsAPI.java
@@ -33,7 +33,7 @@ import javax.ws.rs.core.Response;
  * This class provides configurations information for UI
  */
 @Component(
-        name = "org.wso2.carbon.apimgt.rest.api.configurations.ConfiguratoinsAPI",
+        name = "org.wso2.carbon.apimgt.rest.api.configurations.ConfigurationsAPI",
         service = Microservice.class,
         immediate = true
 )
@@ -41,7 +41,7 @@ import javax.ws.rs.core.Response;
 public class ConfigurationsAPI implements Microservice {
 
     /**
-     * Get environment configurations from deployement.yaml and returns the list of environments
+     * Get environment configurations from deployment.yaml and returns the list of environments
      *
      * @return Response List of environments: {"environments":[
      *     {"host":"localhost:9292","loginTokenPath":"/login/token","label":"Development"},

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.configurations/src/main/java/org/wso2/carbon/apimgt/rest/api/configurations/utils/bean/EnvironmentConfigBean.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.configurations/src/main/java/org/wso2/carbon/apimgt/rest/api/configurations/utils/bean/EnvironmentConfigBean.java
@@ -26,7 +26,7 @@ import java.util.List;
  */
 public class EnvironmentConfigBean {
 
-    private List<EnvironmentConfigurations> environments = new ArrayList<EnvironmentConfigurations>();
+    private List<EnvironmentConfigurations> environments = new ArrayList<>();
 
     public List<EnvironmentConfigurations> getEnvironments() {
         return environments;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/App.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/App.js
@@ -48,7 +48,6 @@ class Protected extends Component {
         super(props);
         this.state = {
             showLeftMenu: false,
-            authConfigs: null,
             environments: [],
         };
         this.environmentName = "";

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/Swagger/ApiCreateSwagger.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/Swagger/ApiCreateSwagger.js
@@ -78,7 +78,7 @@ class ApiCreateSwagger extends React.Component {
             let data = {};
             data.url = url;
             data.type = 'swagger-url';
-            let new_api = new API('');
+            let new_api = new API();
             new_api.create(data)
                 .then(this.createAPICallback)
                 .catch(
@@ -97,7 +97,7 @@ class ApiCreateSwagger extends React.Component {
                 return;
             }
             let swagger = this.state.files[0];
-            let new_api = new API('');
+            let new_api = new API();
             new_api.create(swagger)
                 .then(this.createAPICallback)
                 .catch(

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.js
@@ -139,7 +139,7 @@ class ApiCreateWSDL extends Component {
     }
 
     createWSDLAPI() {
-        let new_api = new API('');
+        let new_api = new API();
         const {wsdlBean, apiFields} = this.state;
         const {apiName, apiVersion, apiContext, apiEndpoint, implementationType} = apiFields;
         const uploadMethod = wsdlBean.url ? 'url' : 'file';

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.js
@@ -60,7 +60,7 @@ class ProvideWSDL extends Component {
         // do not invoke callback in case of React SyntheticMouseEvent
         updateWSDLValidity = updateWSDLValidity.constructor.name === 'SyntheticMouseEvent' ? false : updateWSDLValidity;
         const {uploadMethod, url, file} = this.state;
-        let new_api = new API('');
+        let new_api = new API();
         let promised_validation;
         let wsdlBean = {};
         if (uploadMethod === 'file') {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NavBar.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NavBar.js
@@ -80,7 +80,7 @@ class NavBar extends Component {
         }
 
         return (
-            <Drawer type="persistent" classes={{paper: classes.drawerPaper,}} anchor={anchor} open={open}>
+            // <Drawer type="persistent" classes={{paper: classes.drawerPaper,}} anchor={anchor} open={open}>
                 <List className={classes.list}>
                     <ListItem>
                         <ListItemIcon>
@@ -99,7 +99,7 @@ class NavBar extends Component {
                         </ListItem>)
                     )}
                 </List>
-            </Drawer>
+            // </Drawer>
         )
     }
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Overview.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Overview.js
@@ -218,7 +218,7 @@ class Overview extends Component {
                             {api.lifeCycleStatus}
 
                             <Button dense color="primary">
-                                <a href={`/store/apis/${this.api_uuid}/overview?environment=${Utils.getEnvironment().label}`}
+                                <a href={`/store/apis/${this.api_uuid}/overview?environment=${Utils.getCurrentEnvironment().label}`}
                                    target="_blank" title="Store">
                                     View in store
                                 </a>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/Header.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/Header.js
@@ -231,7 +231,7 @@ class Header extends React.Component {
                                 </Menu>
                                 {/* Environment menu */}
                                 <EnvironmentMenu environments={this.state.environments}
-                                                 environmentLabel={Utils.getEnvironment().label}
+                                                 environmentLabel={Utils.getCurrentEnvironment().label}
                                                  handleEnvironmentChange={this.handleEnvironmentChange}/>
                                 {/* User menu */}
                                 <Button aria-owns="simple-menu" aria-haspopup="true" onClick={this.handleClickUserMenu}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Login/Login.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Login/Login.js
@@ -98,7 +98,7 @@ class Login extends Component {
             user.setPartialToken(WSO2_AM_TOKEN_1, validityPeriod, "/publisher");
             user.scopes = params.scopes.split(" ");
             AuthManager.setUser(user);
-            AuthManager.handleAutoLoginEnvironments(
+            this.authManager.handleAutoLoginEnvironments(
                 params.id_token,
                 this.state.environments,
                 this.state.authConfigs
@@ -116,7 +116,7 @@ class Login extends Component {
     fetch_DCRappInfo(environments) {
         //Array of promises
         let promised_ssoData = environments.map(
-            environment => Utils.getPromised_DCRappInfo(environment)
+            environment => Utils.getPromised_DCRAppInfo(environment)
         );
 
         Promise.all(promised_ssoData).then(responses => {
@@ -169,7 +169,7 @@ class Login extends Component {
         let loginPromise = this.authManager.authenticateUser(username, password, environment);
         loginPromise.then((response) => {
             this.setState({isLogin: AuthManager.getUser(), loading: false});
-            AuthManager.handleAutoLoginEnvironments(
+            this.authManager.handleAutoLoginEnvironments(
                 response.data.idToken,
                 this.state.environments,
                 this.state.authConfigs

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Logout.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Logout.js
@@ -20,6 +20,7 @@ import React, {Component} from 'react'
 import AuthManager from '../data/AuthManager'
 import {Redirect} from 'react-router-dom';
 import qs from 'qs'
+import ConfigManager from "../data/ConfigManager";
 
 class Logout extends Component {
     constructor(props) {
@@ -33,24 +34,27 @@ class Logout extends Component {
     }
 
     componentDidMount() {
-        const promisedLogout = this.authManager.logout();
-        promisedLogout.then(() => {
-            let newState = {logoutSuccess: true};
-            let queryString = this.props.location.search;
-            queryString = queryString.replace(/^\?/, '');
-            /* With QS version up we can directly use {ignoreQueryPrefix: true} option */
-            let params = qs.parse(queryString);
-            if (params.referrer) {
-                newState['referrer'] = params.referrer;
-            }
-            this.setState(newState);
+        ConfigManager.getConfigs().environments.then(response => {
+            const environments = response.data.environments;
+            const promisedLogout = this.authManager.logoutFromEnvironments(environments);
+            promisedLogout.then(() => {
+                let newState = {logoutSuccess: true};
+                let queryString = this.props.location.search;
+                queryString = queryString.replace(/^\?/, '');
+                /* With QS version up we can directly use {ignoreQueryPrefix: true} option */
+                let params = qs.parse(queryString);
+                if (params.referrer) {
+                    newState['referrer'] = params.referrer;
+                }
+                this.setState(newState);
 
-        }).catch((error) => {
-                let message = "Error while logging out";
-                console.log(message);
-                this.setState({logoutFail: error});
-            }
-        );
+            }).catch((error) => {
+                    let message = "Error while logging out";
+                    console.log(message);
+                    this.setState({logoutFail: error});
+                }
+            );
+        });
     }
 
     render() {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIClient.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIClient.js
@@ -126,7 +126,7 @@ class APIClient {
 
     _getRequestInterceptor() {
         return (request) => {
-            AuthManager.refreshTokenOnExpire(request);
+            AuthManager.refreshTokenOnExpire(request, this.environment);
             if (APIClient.getETag(request.url) && (request.method === "PUT" || request.method === "DELETE" || request.method === "POST")) {
                 request.headers["If-Match"] = APIClient.getETag(request.url);
             }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIClient.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIClient.js
@@ -27,16 +27,16 @@ import Utils from "./Utils";
  */
 class APIClient {
     /**
-     * @param {String} host : Host of apis. Host for the swagger-client's spec property.
+     * @param {Object} environment : Environment to get host for the swagger-client's spec property.
      * @param {{}} args : Accept as an optional argument for APIClient constructor.Merge the given args with default args.
      * @returns {APIClient|*|null}
      */
-    constructor(host, args = {}) {
-        this.host = host || location.host;
+    constructor(environment, args = {}) {
+        this.environment = environment || Utils.getCurrentEnvironment();
 
         const authorizations = {
             OAuth2Security: {
-                token: { access_token: AuthManager.getUser().getPartialToken() }
+                token: {access_token: AuthManager.getUser(environment.label).getPartialToken()}
             }
         };
 
@@ -111,7 +111,7 @@ class APIClient {
      * @private
      */
     _fixSpec(spec) {
-        spec.host = this.host;
+        spec.host = this.environment.host;
         return spec;
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIClient.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIClient.js
@@ -27,9 +27,9 @@ import Utils from "./Utils";
  */
 class APIClient {
     /**
-     * @param {Object} environment : Environment to get host for the swagger-client's spec property.
-     * @param {{}} args : Accept as an optional argument for APIClient constructor.Merge the given args with default args.
-     * @returns {APIClient|*|null}
+     * @param {Object} environment - Environment to get host for the swagger-client's spec property.
+     * @param {{}} args - Accept as an optional argument for APIClient constructor.Merge the given args with default args.
+     * @returns {APIClient}
      */
     constructor(environment, args = {}) {
         this.environment = environment || Utils.getCurrentEnvironment();
@@ -68,8 +68,8 @@ class APIClient {
 
     /**
      * Get the ETag of a given resource key from the session storage
-     * @param key {string} key of resource.
-     * @returns {string} ETag value for the given key
+     * @param {String} key - key of resource.
+     * @returns {String} ETag value for the given key
      */
     static getETag(key) {
         return sessionStorage.getItem("etag_" + key);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIClientFactory.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIClientFactory.js
@@ -29,18 +29,27 @@ class APIClientFactory {
         APIClientFactory._instance = this;
     }
 
-    getAPIClient(environmentLabel) {
-        let api_Client = this._APIClientMap.get(environmentLabel);
+    /**
+     *
+     * @param {Object} environment
+     * @returns {APIClient} APIClient object for the environment
+     */
+    getAPIClient(environment) {
+        let api_Client = this._APIClientMap.get(environment.label);
 
         if (api_Client) {
             return api_Client;
         }
 
-        api_Client = new APIClient(Utils.getEnvironment().host);
-        this._APIClientMap.set(environmentLabel, api_Client);
+        api_Client = new APIClient(environment);
+        this._APIClientMap.set(environment.label, api_Client);
         return api_Client;
     }
 
+    /**
+     * Remove an APIClient object from the environment
+     * @param {String} environmentLabel
+     */
     destroyAPIClient(environmentLabel) {
         this._APIClientMap.delete(environmentLabel);
     }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIClientFactory.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIClientFactory.js
@@ -17,9 +17,15 @@
  */
 "use strict";
 import APIClient from "./APIClient";
-import Utils from "./Utils";
 
+/**
+ * Class representing a Factory of APIClients
+ */
 class APIClientFactory {
+    /**
+     * Initialize a single instance of APIClientFactory
+     * @returns {APIClientFactory}
+     */
     constructor() {
         if (APIClientFactory._instance) {
             return APIClientFactory._instance;
@@ -53,8 +59,21 @@ class APIClientFactory {
     destroyAPIClient(environmentLabel) {
         this._APIClientMap.delete(environmentLabel);
     }
+
+    /**
+     * Get an instance of APIClientFactory
+     * @returns {APIClientFactory} An instance of APIClientFactory
+     */
+    static getInstance() {
+        return new APIClientFactory();
+    }
 }
 
+/**
+ * Single instance of APIClientFactory
+ * @type {APIClientFactory}
+ * @private
+ */
 APIClientFactory._instance = null;
 
 export default APIClientFactory;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/AuthManager.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/AuthManager.js
@@ -289,7 +289,7 @@ class AuthManager {
         const currentEnvName = Utils.getCurrentEnvironment().label;
 
         environments.forEach((environment, environmentID) => {
-            const isAutoLoginEnabled = configs[environmentID].is_auto_login_enabled;
+            const isAutoLoginEnabled = configs[environmentID].is_multi_environment_overview_enabled;
             const isAlreadyLoggedIn = AuthManager.getUser(environment.label); //Already logged in by any user
             const isCurrentEnvironment = environment.label === currentEnvName;
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/AuthManager.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/AuthManager.js
@@ -114,8 +114,7 @@ class AuthManager {
      * @param {User} user - An instance of the {User} class
      * @param {string} environmentName - label of the environment to be set the user
      */
-    static setUser(user, environmentName) {
-        environmentName = environmentName || Utils.getCurrentEnvironment().label;
+    static setUser(user, environmentName = Utils.getCurrentEnvironment().label) {
         if (!user instanceof User) {
             throw new Error("Invalid user object");
         }
@@ -197,8 +196,7 @@ class AuthManager {
      * @param {String} environmentName - Name of the environment to be logged out. Default current environment.
      * @returns {AxiosPromise}
      */
-    logout(environmentName) {
-        environmentName = environmentName || Utils.getCurrentEnvironment().label;
+    logout(environmentName = Utils.getCurrentEnvironment().label) {
         let authHeader = "Bearer " + AuthManager.getUser(environmentName).getPartialToken();
         //TODO Will have to change the logout end point url to contain the app context(i.e. publisher/store, etc.)
         let url = Utils.getAppLogoutURL();
@@ -286,8 +284,7 @@ class AuthManager {
         const data = {
             assertion: idToken,
             validity_period: -1,
-            scopes: 'apim:api_view apim:api_create apim:api_publish apim:tier_view apim:tier_manage '
-            + 'apim:subscription_view apim:subscription_block apim:subscribe apim:external_services_discover'
+            scopes: AuthManager.CONST.USER_SCOPES
         };
         const currentEnvName = Utils.getCurrentEnvironment().label;
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/ConfigManager.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/ConfigManager.js
@@ -23,7 +23,7 @@ class ConfigManager {
     /**
      * get promised config and update the configMap
      * @param configPath: Path to read configs from
-     * @returns {Promise Object}: promised config
+     * @returns {Promise}: promised config
      * @private
      */
     static _getPromisedConfigs(configPath) {
@@ -51,7 +51,8 @@ class ConfigManager {
 }
 
 /**
- * @type {{ConstPath: StringPath}} ConfigRequestPaths: Configuration requesting url paths
+ * ConfigRequestPaths: Configuration requesting url paths
+ * @type {{ENVIRONMENT_CONFIG_PATH: string}}
  */
 const ConfigRequestPaths = {
     ENVIRONMENT_CONFIG_PATH: "/configService/environments"

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/LifeCycle.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/LifeCycle.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+"use strict";
+
+
+const LifeCycleStatus = [
+    {name: "Created", color: "#0000ff"},
+    {name: "Prototyped", color: "#42dfff"},
+    {name: "Published", color: "#41830A"},
+    {name: "Maintenance", color: "#cecece"},
+    {name: "Deprecated", color: "#D7C850"},
+    {name: "Retired", color: "#000000"},
+];
+
+module.exports = {
+    LifeCycleStatus: LifeCycleStatus
+};

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/ScopeValidation.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/ScopeValidation.js
@@ -85,4 +85,4 @@ module.exports = {
     ScopeValidation,
     resourceMethod,
     resourcePath
-}
+};

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/User.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/User.js
@@ -26,8 +26,8 @@ import Utils from './Utils'
 export default class User {
     /**
      * Create a user for the given environment
-     * @param {string} environment : name of the environment
-     * @param {string} name : name of the cookie
+     * @param {string} environment - name of the environment
+     * @param {string} name - name of the cookie
      * @param {boolean} remember
      * @returns {User|null} user object
      */
@@ -79,6 +79,14 @@ export default class User {
     }
 
     /**
+     * Remove the user from static in-memory user map
+     * @param {String} environmentName - Name of the environment the user to be removed
+     */
+    static destroyInMemoryUser(environmentName){
+        User._userMap.delete(environmentName);
+    }
+
+    /**
      * Get the JS accessible access token fragment from cookie storage.
      * @returns {String|null}
      */
@@ -96,9 +104,9 @@ export default class User {
 
     /**
      * Store the JavaScript accessible access token segment in cookie storage
-     * @param {String} newToken : Part of the access token which needs when accessing REST API
-     * @param {Number} validityPeriod : Validity period of the cookie in seconds
-     * @param path Path which need to be set to cookie
+     * @param {String} newToken - Part of the access token which needs when accessing REST API
+     * @param {Number} validityPeriod - Validity period of the cookie in seconds
+     * @param {String} path - Path which need to be set to cookie
      */
     setPartialToken(newToken, validityPeriod, path) {
         Utils.delete_cookie(User.CONST.WSO2_AM_TOKEN_1, path, this._environment);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/User.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/User.js
@@ -26,13 +26,12 @@ import Utils from './Utils'
 export default class User {
     /**
      * Create a user for the given environment
-     * @param {string} environment
-     * @param {string} name
-     * @param {string} id_token
+     * @param {string} environment : name of the environment
+     * @param {string} name : name of the cookie
      * @param {boolean} remember
      * @returns {User|null} user object
      */
-    constructor(environment, name, id_token, remember = false) {
+    constructor(environment, name, remember = false) {
         const user = User._userMap.get(environment);
         if (user) {
             return user;
@@ -40,8 +39,8 @@ export default class User {
         this.name = name;
         this.environment = environment;
         this._scopes = [];
-        this._idToken = id_token;
         this._remember = remember;
+        this._environment = environment || Utils.getEnvironment().label;
         User._userMap.set(environment, this);
     }
 
@@ -72,7 +71,6 @@ export default class User {
         }
         const _user = new User(Utils.getEnvironment().label, userJson.name);
         _user.scopes = userJson.scopes;
-        _user.idToken = userJson.idToken;
         _user.rememberMe = userJson.remember;
         return _user;
     }
@@ -82,9 +80,7 @@ export default class User {
      * @returns {String|null}
      */
     getPartialToken() {
-        //Append environment name to cookie
-        const environmentName = "_" + Utils.getEnvironment().label;
-        return Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1 + environmentName);
+        return Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1, this._environment);
     }
 
     /**
@@ -92,9 +88,7 @@ export default class User {
      * @returns {String|null}
      */
     getRefreshPartialToken() {
-        //Append environment name to cookie
-        const environmentName = "_" + Utils.getEnvironment().label;
-        return Utils.getCookie(User.CONST.WSO2_AM_REFRESH_TOKEN_1 + environmentName);
+        return Utils.getCookie(User.CONST.WSO2_AM_REFRESH_TOKEN_1, this._environment);
     }
 
     /**
@@ -104,9 +98,8 @@ export default class User {
      * @param path Path which need to be set to cookie
      */
     setPartialToken(newToken, validityPeriod, path) {
-        Utils.delete_cookie(User.CONST.WSO2_AM_TOKEN_1, path);
-        const cookieName = `${User.CONST.WSO2_AM_TOKEN_1}_${Utils.getEnvironment().label}`;
-        Utils.setCookie(cookieName, newToken, validityPeriod, path);
+        Utils.delete_cookie(User.CONST.WSO2_AM_TOKEN_1, path, this._environment);
+        Utils.setCookie(User.CONST.WSO2_AM_TOKEN_1, newToken, validityPeriod, path, this._environment);
     }
 
     /**
@@ -146,7 +139,6 @@ export default class User {
         return {
             name: this.name,
             scopes: this._scopes,
-            idToken: this._idToken,
             remember: this._remember,
             expiryTime: this.getExpiryTime(),
             environment: this.environment

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/User.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/User.js
@@ -21,7 +21,7 @@ import Utils from './Utils'
 
 /**
  * Represent an user logged in to the application, There will be allays one user per session and
- * this user details will be persist in browser localstorage.
+ * this user details will be persist in browser local-storage.
  */
 export default class User {
     /**
@@ -46,7 +46,7 @@ export default class User {
 
     /**
      * OAuth scopes which are available for use by this user
-     * @returns {Array} : An array of scopes
+     * @returns {Array} - An array of scopes
      */
     get scopes() {
         return this._scopes;
@@ -54,7 +54,7 @@ export default class User {
 
     /**
      * Set OAuth scopes available to be used by this user
-     * @param {Array} newScopes :  An array of scopes
+     * @param {Array} newScopes - An array of scopes
      */
     set scopes(newScopes) {
         Object.assign(this.scopes, newScopes);
@@ -62,9 +62,9 @@ export default class User {
 
     /**
      * User utility method to create an user from JSON object.
-     * @param {JSON} userJson : Need to provide user information in JSON structure to create an user object
-     * @param {String} environmentName : Name of the environment to be assigned to the user
-     * @returns {User} : An instance of User(this) class.
+     * @param {JSON} userJson - Need to provide user information in JSON structure to create an user object
+     * @param {String} environmentName - Name of the environment to be assigned to the user
+     * @returns {User} - An instance of User(this) class.
      */
     static fromJson(userJson, environmentName) {
         if (!userJson.name) {
@@ -144,7 +144,7 @@ export default class User {
 
     /**
      * Provide user data in JSON structure.
-     * @returns {JSON} : JSON representation of the user object
+     * @returns {JSON} - JSON representation of the user object
      */
     toJson() {
         return {
@@ -161,7 +161,7 @@ User.CONST = {
     WSO2_AM_TOKEN_MSF4J: "WSO2_AM_TOKEN_MSF4J",
     WSO2_AM_TOKEN_1: "WSO2_AM_TOKEN_1",
     WSO2_AM_REFRESH_TOKEN_1: "WSO2_AM_REFRESH_TOKEN_1",
-    LOCALSTORAGE_USER: "wso2_user_publisher",
+    LOCAL_STORAGE_USER: "wso2_user_publisher",
     USER_EXPIRY_TIME: "user_expiry_time"
 };
 /**

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/User.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/User.js
@@ -40,7 +40,7 @@ export default class User {
         this.environment = environment;
         this._scopes = [];
         this._remember = remember;
-        this._environment = environment || Utils.getEnvironment().label;
+        this._environment = environment || Utils.getCurrentEnvironment().label;
         User._userMap.set(environment, this);
     }
 
@@ -63,13 +63,16 @@ export default class User {
     /**
      * User utility method to create an user from JSON object.
      * @param {JSON} userJson : Need to provide user information in JSON structure to create an user object
+     * @param {String} environmentName : Name of the environment to be assigned to the user
      * @returns {User} : An instance of User(this) class.
      */
-    static fromJson(userJson) {
+    static fromJson(userJson, environmentName) {
         if (!userJson.name) {
             throw "Need to provide user `name` key in the JSON object, to create an user";
         }
-        const _user = new User(Utils.getEnvironment().label, userJson.name);
+
+        environmentName = environmentName || Utils.getCurrentEnvironment().label;
+        const _user = new User(environmentName, userJson.name);
         _user.scopes = userJson.scopes;
         _user.rememberMe = userJson.remember;
         return _user;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/User.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/User.js
@@ -26,22 +26,21 @@ import Utils from './Utils'
 export default class User {
     /**
      * Create a user for the given environment
-     * @param {string} environment - name of the environment
+     * @param {string} environmentName - name of the environment
      * @param {string} name - name of the cookie
      * @param {boolean} remember
      * @returns {User|null} user object
      */
-    constructor(environment, name, remember = false) {
-        const user = User._userMap.get(environment);
+    constructor(environmentName, name, remember = false) {
+        const user = User._userMap.get(environmentName);
         if (user) {
             return user;
         }
         this.name = name;
-        this.environment = environment;
         this._scopes = [];
         this._remember = remember;
-        this._environment = environment || Utils.getCurrentEnvironment().label;
-        User._userMap.set(environment, this);
+        this._environmentName = environmentName;
+        User._userMap.set(environmentName, this);
     }
 
     /**
@@ -66,12 +65,11 @@ export default class User {
      * @param {String} environmentName - Name of the environment to be assigned to the user
      * @returns {User} - An instance of User(this) class.
      */
-    static fromJson(userJson, environmentName) {
+    static fromJson(userJson, environmentName = Utils.getCurrentEnvironment().label) {
         if (!userJson.name) {
             throw "Need to provide user `name` key in the JSON object, to create an user";
         }
 
-        environmentName = environmentName || Utils.getCurrentEnvironment().label;
         const _user = new User(environmentName, userJson.name);
         _user.scopes = userJson.scopes;
         _user.rememberMe = userJson.remember;
@@ -91,7 +89,7 @@ export default class User {
      * @returns {String|null}
      */
     getPartialToken() {
-        return Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1, this._environment);
+        return Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1, this._environmentName);
     }
 
     /**
@@ -99,7 +97,7 @@ export default class User {
      * @returns {String|null}
      */
     getRefreshPartialToken() {
-        return Utils.getCookie(User.CONST.WSO2_AM_REFRESH_TOKEN_1, this._environment);
+        return Utils.getCookie(User.CONST.WSO2_AM_REFRESH_TOKEN_1, this._environmentName);
     }
 
     /**
@@ -109,8 +107,8 @@ export default class User {
      * @param {String} path - Path which need to be set to cookie
      */
     setPartialToken(newToken, validityPeriod, path) {
-        Utils.delete_cookie(User.CONST.WSO2_AM_TOKEN_1, path, this._environment);
-        Utils.setCookie(User.CONST.WSO2_AM_TOKEN_1, newToken, validityPeriod, path, this._environment);
+        Utils.delete_cookie(User.CONST.WSO2_AM_TOKEN_1, path, this._environmentName);
+        Utils.setCookie(User.CONST.WSO2_AM_TOKEN_1, newToken, validityPeriod, path, this._environmentName);
     }
 
     /**
@@ -151,8 +149,7 @@ export default class User {
             name: this.name,
             scopes: this._scopes,
             remember: this._remember,
-            expiryTime: this.getExpiryTime(),
-            environment: this.environment
+            expiryTime: this.getExpiryTime()
         };
     }
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
@@ -25,9 +25,9 @@ class Utils {
 
     /**
      * Get JavaScript accessible cookies saved in browser, by giving the cooke name.
-     * @param {String} name : Name of the cookie which need to be retrived
-     * @param {String} environmentName : label of the environment of the cookie
-     * @returns {String|null} : If found a cookie with given name , return its value,Else null value is returned
+     * @param {String} name - Name of the cookie which need to be retrieved
+     * @param {String} environmentName - label of the environment of the cookie
+     * @returns {String|null} - If found a cookie with given name , return its value,Else null value is returned
      */
     static getCookie(name, environmentName) {
         environmentName = environmentName || Utils.getCurrentEnvironment().label;
@@ -83,7 +83,7 @@ class Utils {
 
     /**
      * Given an object returns whether the object is empty or not
-     * @param {Object} object : Any JSON object
+     * @param {Object} object - Any JSON object
      * @returns {boolean}
      */
     static isEmptyObject(object) {
@@ -92,14 +92,14 @@ class Utils {
 
     /**
      * Get the current environment from local-storage
-     * @returns {Object} environment: {label, host, loginTokenPath}
+     * @returns {Object}
      */
     static getCurrentEnvironment() {
         if (Utils._environment) {
             return Utils._environment;
         }
 
-        let environmentData = localStorage.getItem(Utils.CONST.LOCALSTORAGE_ENVIRONMENT);
+        let environmentData = localStorage.getItem(Utils.CONST.LOCAL_STORAGE_ENVIRONMENT);
         if (!environmentData) {
             return Utils._getDefaultEnvironment();
         }
@@ -109,8 +109,8 @@ class Utils {
 
     /**
      * Get current environment's index from the given environment array
-     * @param {Array} environments
-     * @param {string} name: name of the environment [default]: current environment name
+     * @param {Array} environments - Array of environments
+     * @param {string} name - name of the environment
      * @returns {number}
      */
     static getEnvironmentID(environments, name = Utils.getCurrentEnvironment().label) {
@@ -140,14 +140,14 @@ class Utils {
         }
         //Store environment.
         Utils._environment = environment;
-        localStorage.setItem(Utils.CONST.LOCALSTORAGE_ENVIRONMENT, JSON.stringify(environment));
+        localStorage.setItem(Utils.CONST.LOCAL_STORAGE_ENVIRONMENT, JSON.stringify(environment));
     }
 
-    static getPromised_DCRappInfo(environment) {
-        return Axios.get(Utils.getDCRappInfoRequestURL(environment));
+    static getPromised_DCRAppInfo(environment) {
+        return Axios.get(Utils.getDCRAppInfoRequestURL(environment));
     }
 
-    static getDCRappInfoRequestURL(environment = Utils.getCurrentEnvironment()) {
+    static getDCRAppInfoRequestURL(environment = Utils.getCurrentEnvironment()) {
         return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.DCR_APP_INFO}${Utils.CONST.CONTEXT_PATH}`;
     }
 
@@ -179,12 +179,12 @@ class Utils {
      * @private
      */
     static _getDefaultEnvironment() {
-        return { label: 'Default', host: window.location.host, loginTokenPath: '/login/token' };
+        return {label: 'Default', host: window.location.host, loginTokenPath: '/login/token'};
     }
 }
 
 Utils.CONST = {
-    LOCALSTORAGE_ENVIRONMENT: 'environment_publisher',
+    LOCAL_STORAGE_ENVIRONMENT: 'environment_publisher',
     DCR_APP_INFO: '/login/login',
     LOGOUT: '/login/logout',
     LOGIN_TOKEN_PATH: '/login/token',

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
@@ -25,12 +25,13 @@ class Utils {
 
     /**
      * Get JavaScript accessible cookies saved in browser, by giving the cooke name.
-     * @param {String} cookieName : Name of the cookie which need to be retrived
+     * @param {String} name : Name of the cookie which need to be retrived
      * @param {String} environmentName : label of the environment of the cookie
      * @returns {String|null} : If found a cookie with given name , return its value,Else null value is returned
      */
-    static getCookie(cookieName, environmentName) {
+    static getCookie(name, environmentName) {
         environmentName = environmentName || Utils.getCurrentEnvironment().label;
+        name = `${name}_${environmentName}`;
 
         let pairs = document.cookie.split(";");
         let cookie = null;
@@ -48,9 +49,9 @@ class Utils {
 
     /**
      * Delete a browser cookie given its name
-     * @param {String} name : Name of the cookie which need to be deleted
-     * @param {String} path : Path of the cookie which need to be deleted
-     * @param {String} environmentName: label of the environment of the cookie
+     * @param {String} name - Name of the cookie which need to be deleted
+     * @param {String} path - Path of the cookie which need to be deleted
+     * @param {String} environmentName - label of the environment of the cookie
      */
     static delete_cookie(name, path, environmentName) {
         environmentName = environmentName || Utils.getCurrentEnvironment().label;
@@ -64,6 +65,7 @@ class Utils {
      * @param {String} value - Value of the cookie, expect it to be URLEncoded
      * @param {number} validityPeriod -  (Optional) Validity period of the cookie in seconds
      * @param {String} path - Path which needs to set the given cookie
+     * @param {String} environmentName - Name of the environment to be appended to cookie name
      * @param {boolean} secured - secured parameter is set
      */
     static setCookie(name, value, validityPeriod, path = "/", environmentName, secured = true) {
@@ -76,7 +78,7 @@ class Utils {
             expiresDirective = "; expires=" + date.toUTCString();
         }
 
-        document.cookie = `${name}=${value}; path=${path}${expiresDirective}${securedDirective}`;
+        document.cookie = `${name}_${environmentName}=${value}; path=${path}${expiresDirective}${securedDirective}`;
     }
 
     /**

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
@@ -29,7 +29,9 @@ class Utils {
      * @param {String} environmentName : label of the environment of the cookie
      * @returns {String|null} : If found a cookie with given name , return its value,Else null value is returned
      */
-    static getCookie(name) {
+    static getCookie(cookieName, environmentName) {
+        environmentName = environmentName || Utils.getCurrentEnvironment().label;
+
         let pairs = document.cookie.split(";");
         let cookie = null;
         for (let pair of pairs) {
@@ -51,7 +53,7 @@ class Utils {
      * @param {String} environmentName: label of the environment of the cookie
      */
     static delete_cookie(name, path, environmentName) {
-        environmentName = environmentName || Utils.getEnvironment().label;
+        environmentName = environmentName || Utils.getCurrentEnvironment().label;
         document.cookie = `${name}_${environmentName}=; path=${path}; expires=Thu, 01 Jan 1970 00:00:01 GMT`;
     }
 
@@ -65,7 +67,7 @@ class Utils {
      * @param {boolean} secured - secured parameter is set
      */
     static setCookie(name, value, validityPeriod, path = "/", environmentName, secured = true) {
-        environmentName = environmentName || Utils.getEnvironment().label;
+        environmentName = environmentName || Utils.getCurrentEnvironment().label;
         let expiresDirective = "";
         const securedDirective = secured ? "; Secure" : "";
         if (validityPeriod) {
@@ -90,7 +92,7 @@ class Utils {
      * Get the current environment from local-storage
      * @returns {Object} environment: {label, host, loginTokenPath}
      */
-    static getEnvironment() {
+    static getCurrentEnvironment() {
         if (Utils._environment) {
             return Utils._environment;
         }
@@ -109,7 +111,7 @@ class Utils {
      * @param {string} name: name of the environment [default]: current environment name
      * @returns {number}
      */
-    static getEnvironmentID(environments, name = Utils.getEnvironment().label) {
+    static getEnvironmentID(environments, name = Utils.getCurrentEnvironment().label) {
         if (!name) {
             return 0;
         }
@@ -143,20 +145,20 @@ class Utils {
         return Axios.get(Utils.getDCRappInfoRequestURL(environment));
     }
 
-    static getDCRappInfoRequestURL(environment = Utils.getEnvironment()) {
+    static getDCRappInfoRequestURL(environment = Utils.getCurrentEnvironment()) {
         return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.DCR_APP_INFO}${Utils.CONST.CONTEXT_PATH}`;
     }
 
     static getAppLogoutURL() {
-        return Utils.CONST.PROTOCOL + Utils.getEnvironment().host + Utils.CONST.LOGOUT + Utils.CONST.CONTEXT_PATH;
+        return Utils.CONST.PROTOCOL + Utils.getCurrentEnvironment().host + Utils.CONST.LOGOUT + Utils.CONST.CONTEXT_PATH;
     }
 
-    static getLoginTokenPath(environment = Utils.getEnvironment()) {
+    static getLoginTokenPath(environment = Utils.getCurrentEnvironment()) {
         return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.LOGIN_TOKEN_PATH}${Utils.CONST.CONTEXT_PATH}`;
     }
 
     static getSwaggerURL() {
-        return "https://" + Utils.getEnvironment().host + Utils.CONST.SWAGGER_YAML;
+        return "https://" + Utils.getCurrentEnvironment().host + Utils.CONST.SWAGGER_YAML;
     }
 
     /**

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
@@ -29,8 +29,7 @@ class Utils {
      * @param {String} environmentName - label of the environment of the cookie
      * @returns {String|null} - If found a cookie with given name , return its value,Else null value is returned
      */
-    static getCookie(name, environmentName) {
-        environmentName = environmentName || Utils.getCurrentEnvironment().label;
+    static getCookie(name, environmentName = Utils.getCurrentEnvironment().label) {
         name = `${name}_${environmentName}`;
 
         let pairs = document.cookie.split(";");
@@ -53,8 +52,7 @@ class Utils {
      * @param {String} path - Path of the cookie which need to be deleted
      * @param {String} environmentName - label of the environment of the cookie
      */
-    static delete_cookie(name, path, environmentName) {
-        environmentName = environmentName || Utils.getCurrentEnvironment().label;
+    static delete_cookie(name, path, environmentName = Utils.getCurrentEnvironment().label) {
         document.cookie = `${name}_${environmentName}=; path=${path}; expires=Thu, 01 Jan 1970 00:00:01 GMT`;
     }
 
@@ -68,8 +66,7 @@ class Utils {
      * @param {String} environmentName - Name of the environment to be appended to cookie name
      * @param {boolean} secured - secured parameter is set
      */
-    static setCookie(name, value, validityPeriod, path = "/", environmentName, secured = true) {
-        environmentName = environmentName || Utils.getCurrentEnvironment().label;
+    static setCookie(name, value, validityPeriod, path = "/", environmentName = Utils.getCurrentEnvironment().label, secured = true) {
         let expiresDirective = "";
         const securedDirective = secured ? "; Secure" : "";
         if (validityPeriod) {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
@@ -139,12 +139,12 @@ class Utils {
         localStorage.setItem(Utils.CONST.LOCALSTORAGE_ENVIRONMENT, JSON.stringify(environment));
     }
 
-    static getPromised_ssoData(environment) {
-        return Axios.get(Utils.getAppSSORequestURL(environment));
+    static getPromised_DCRappInfo(environment) {
+        return Axios.get(Utils.getDCRappInfoRequestURL(environment));
     }
 
-    static getAppSSORequestURL(environment = Utils.getEnvironment()) {
-        return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.SSO_LOGIN}${Utils.CONST.CONTEXT_PATH}`;
+    static getDCRappInfoRequestURL(environment = Utils.getEnvironment()) {
+        return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.DCR_APP_INFO}${Utils.CONST.CONTEXT_PATH}`;
     }
 
     static getAppLogoutURL() {
@@ -181,7 +181,7 @@ class Utils {
 
 Utils.CONST = {
     LOCALSTORAGE_ENVIRONMENT: 'environment_publisher',
-    SSO_LOGIN: '/login/login',
+    DCR_APP_INFO: '/login/login',
     LOGOUT: '/login/logout',
     LOGIN_TOKEN_PATH: '/login/token',
     SWAGGER_YAML: '/api/am/publisher/v1.0/apis/swagger.yaml',

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/api.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/api.js
@@ -26,9 +26,8 @@ class API {
      * @constructor
      * @param {Object} environment - Environment object - Default current environment.
      */
-    constructor(environment) {
-        this.environment = environment || Utils.getCurrentEnvironment();
-        this.client = APIClientFactory.getInstance().getAPIClient(this.environment).client;
+    constructor(environment = Utils.getCurrentEnvironment()) {
+        this.client = APIClientFactory.getInstance().getAPIClient(environment).client;
     }
 
     /**

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/api.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/api.js
@@ -28,7 +28,7 @@ class API {
      */
     constructor(environment) {
         this.environment = environment || Utils.getCurrentEnvironment();
-        this.client = new APIClientFactory().getAPIClient(this.environment).client;
+        this.client = APIClientFactory.getInstance().getAPIClient(this.environment).client;
     }
 
     /**
@@ -59,8 +59,8 @@ class API {
             "version": null,
             "endpoint": []
         };
-        var user_keys = Object.keys(api_data);
-        for (var index in user_keys) {
+        const user_keys = Object.keys(api_data);
+        for (let index in user_keys) {
             if (!(user_keys[index] in template)) {
                 throw 'Invalid key provided, Valid keys are `' + Object.keys(template) + '`';
             }
@@ -151,7 +151,7 @@ class API {
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
     getAll(params, callback = null) {
-        var promise_get_all = this.client.then(
+        const promise_get_all = this.client.then(
             (client) => {
                 return client.apis["API (Collection)"].get_apis(params, this._requestMetaData());
             }
@@ -170,7 +170,7 @@ class API {
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
     get(id, callback = null) {
-        var promise_get = this.client.then(
+        const promise_get = this.client.then(
             (client) => {
                 return client.apis["API (Individual)"].get_apis__apiId_(
                     {apiId: id}, this._requestMetaData());
@@ -191,7 +191,7 @@ class API {
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
     createNewAPIVersion(id, version, callback = null) {
-        var promise_copy_api = this.client.then(
+        const promise_copy_api = this.client.then(
             (client) => {
                 return client.apis["API (Individual)"].post_apis_copy_api(
                     {apiId: id, newVersion: version},
@@ -212,7 +212,7 @@ class API {
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
     getSwagger(id, callback = null) {
-        var promise_get = this.client.then(
+        const promise_get = this.client.then(
             (client) => {
                 return client.apis["API (Individual)"].get_apis__apiId__swagger(
                     {apiId: id}, this._requestMetaData());
@@ -232,7 +232,7 @@ class API {
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
     getScopes(id, callback = null) {
-        var promise_get = this.client.then(
+        const promise_get = this.client.then(
             (client) => {
                 return client.apis["Scope (Collection)"].get_apis__apiId__scopes(
                     {apiId: id}, this._requestMetaData());
@@ -247,16 +247,17 @@ class API {
 
     /**
      * Get the detail of scope of an API
-     * @param id {String} UUID of the API in which the scopes is needed
-     * @param callback {function} Function which needs to be called upon success of the API deletion
+     * @param {String} api_id - UUID of the API in which the scopes is needed
+     * @param {String} scopeName - Name of the scope
+     * @param {function} callback - Function which needs to be called upon success of the API deletion
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
-    getScopeDetail(api_id, name, callback = null) {
-        var promise_get_Scope_detail = this.client.then(
+    getScopeDetail(api_id, scopeName, callback = null) {
+        const promise_get_Scope_detail = this.client.then(
             (client) => {
                 return client.apis["Scope (Individual)"].get_apis__apiId__scopes__name_({
                         apiId: api_id,
-                        name: name
+                        name: scopeName
                     },
                     this._requestMetaData());
             }
@@ -268,8 +269,14 @@ class API {
         }
     }
 
+    /**
+     * Update a scope of an API
+     * @param {String} api_id - UUID of the API in which the scopes is needed
+     * @param {String} scopeName - Name of the scope
+     * @param {Object} body - Scope details
+     */
     updateScope(api_id, scopeName, body) {
-        var promised_updateScope = this.client.then(
+        const promised_updateScope = this.client.then(
             (client) => {
                 let payload = {
                     apiId: api_id,
@@ -285,7 +292,7 @@ class API {
     }
 
     addScope(api_id, body) {
-        var promised_addScope = this.client.then(
+        const promised_addScope = this.client.then(
             (client) => {
                 let payload = {
                     apiId: api_id,
@@ -300,7 +307,7 @@ class API {
     }
 
     deleteScope(api_id, scope_name) {
-        var promise_deleteScope = this.client.then(
+        const promise_deleteScope = this.client.then(
             (client) => {
                 return client.apis["Scope (Individual)"].delete_apis__apiId__scopes__name_({
                         apiId: api_id,
@@ -317,7 +324,7 @@ class API {
      * @param api {Object} Updated API object(JSON) which needs to be updated
      */
     updateSwagger(id, swagger) {
-        var promised_update = this.client.then(
+        const promised_update = this.client.then(
             (client) => {
                 let payload = {
                     "apiId": id,
@@ -337,7 +344,7 @@ class API {
      * @returns {Promise.<TResult>}
      */
     policies(tier_level) {
-        var promise_policies = this.client.then(
+        const promise_policies = this.client.then(
             (client) => {
                 return client.apis["Throttling Tier (Collection)"].get_policies__tierLevel_(
                     {tierLevel: 'subscription'}, this._requestMetaData());
@@ -353,7 +360,7 @@ class API {
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
     deleteAPI(id) {
-        var promised_delete = this.client.then(
+        const promised_delete = this.client.then(
             (client) => {
                 return client.apis["API (Individual)"].delete_apis__apiId_(
                     {apiId: id}, this._requestMetaData());
@@ -368,7 +375,7 @@ class API {
      * @param callback {function} Callback function which needs to be executed in the success call
      */
     getLcState(id, callback = null) {
-        var promise_lc_get = this.client.then(
+        const promise_lc_get = this.client.then(
             (client) => {
                 return client.apis["API (Individual)"].get_apis__apiId__lifecycle(
                     {apiId: id}, this._requestMetaData());
@@ -387,7 +394,7 @@ class API {
      * @param callback {function} Callback function which needs to be executed in the success call
      */
     getLcHistory(id, callback = null) {
-        var promise_lc_history_get = this.client.then(
+        const promise_lc_history_get = this.client.then(
             (client) => {
                 return client.apis["API (Individual)"].get_apis__apiId__lifecycle_history(
                     {apiId: id}, this._requestMetaData());
@@ -407,8 +414,13 @@ class API {
      * @param callback {function} Callback function which needs to be executed in the success call
      */
     updateLcState(id, state, checkedItems, callback = null) {
-        var payload = {action: state, apiId: id, lifecycleChecklist: checkedItems, "Content-Type": "application/json"};
-        var promise_lc_update = this.client.then(
+        const payload = {
+            action: state,
+            apiId: id,
+            lifecycleChecklist: checkedItems,
+            "Content-Type": "application/json"
+        };
+        const promise_lc_update = this.client.then(
             (client) => {
                 return client.apis["API (Individual)"].post_apis_change_lifecycle(
                     payload, this._requestMetaData());
@@ -427,7 +439,7 @@ class API {
      * @param callback {function} Callback function which needs to be executed in the success call
      */
     cleanupPendingTask(id, callback = null) {
-        var promise_deletePendingTask = this.client.then(
+        const promise_deletePendingTask = this.client.then(
             (client) => {
                 return client.apis["API (Individual)"].delete_apis_apiId_lifecycle_lifecycle_pending_task({apiId: id},
                     this._requestMetaData());
@@ -441,7 +453,7 @@ class API {
      * @param api {Object} Updated API object(JSON) which needs to be updated
      */
     update(api) {
-        var promised_update = this.client.then(
+        const promised_update = this.client.then(
             (client) => {
                 let payload = {apiId: api.id, body: api};
                 return client.apis["API (Individual)"].put_apis__apiId_(payload);
@@ -456,7 +468,7 @@ class API {
      * @returns {Promise} With given callback attached to the success chain else API invoke promise.
      */
     subscriptions(id, callback = null) {
-        var promise_subscription = this.client.then(
+        const promise_subscription = this.client.then(
             (client) => {
                 return client.apis["Subscription (Collection)"].get_subscriptions(
                     {apiId: id},
@@ -478,7 +490,7 @@ class API {
      * @returns {Promise} With given callback attached to the success chain else API invoke promise.
      */
     blockSubscriptions(id, state, callback = null) {
-        var promise_subscription = this.client.then(
+        const promise_subscription = this.client.then(
             (client) => {
                 return client.apis["Subscription (Individual)"].post_subscriptions_block_subscription(
                     {subscriptionId: id, blockState: state},
@@ -499,7 +511,7 @@ class API {
      * @returns {Promise} With given callback attached to the success chain else API invoke promise.
      */
     unblockSubscriptions(id, callback = null) {
-        var promise_subscription = this.client.then(
+        const promise_subscription = this.client.then(
             (client) => {
                 return client.apis["Subscription (Individual)"].post_subscriptions_unblock_subscription(
                     {subscriptionId: id},
@@ -517,10 +529,9 @@ class API {
     /**
      * Add endpoint via POST HTTP method, need to provided endpoint properties and callback function as argument
      * @param body {Object} Endpoint to be added
-     * @param callback {function} Callback function
      */
     addEndpoint(body) {
-        var promised_addEndpoint = this.client.then(
+        const promised_addEndpoint = this.client.then(
             (client) => {
                 let payload = {body: body, "Content-Type": "application/json"};
                 return client.apis["Endpoint (Collection)"].post_endpoints(
@@ -537,7 +548,7 @@ class API {
      * @returns {promise}
      */
     deleteEndpoint(id) {
-        var promised_delete = this.client.then(
+        const promised_delete = this.client.then(
             (client) => {
                 return client.apis["Endpoint (individual)"].delete_endpoints__endpointId_(
                     {
@@ -599,8 +610,8 @@ class API {
 
     /**
      * Check if an endpoint name already exists.
-     * @param name {String} Name of the Endpoint
-     * @returns {Promise.<TResult>}
+     * @param {String} endpointName - Name of the Endpoint
+     * @return {Promise}
      */
     checkIfEndpointExists(endpointName) {
         return this.client.then(
@@ -629,7 +640,7 @@ class API {
 
     addDocument(api_id, body) {
 
-        var promised_addDocument = this.client.then(
+        const promised_addDocument = this.client.then(
             (client) => {
                 let payload = {apiId: api_id, body: body, "Content-Type": "application/json"};
                 return client.apis["Document (Collection)"].post_apis__apiId__documents(
@@ -643,7 +654,7 @@ class API {
      Add a File resource to a document
      */
     addFileToDocument(api_id, docId, fileToDocument) {
-        var promised_addFileToDocument = this.client.then(
+        const promised_addFileToDocument = this.client.then(
             (client) => {
                 let payload = {
                     apiId: api_id,
@@ -663,7 +674,7 @@ class API {
      Add inline content to a INLINE type document
      */
     addInlineContentToDocument(api_id, doc_id, inline_content) {
-        var promised_addInlineContentToDocument = this.client.then(
+        const promised_addInlineContentToDocument = this.client.then(
             (client) => {
                 let payload = {
                     apiId: api_id,
@@ -679,7 +690,7 @@ class API {
     }
 
     getFileForDocument(api_id, docId) {
-        var promised_getDocContent = this.client.then(
+        const promised_getDocContent = this.client.then(
             (client) => {
                 let payload = {apiId: api_id, documentId: docId, "Accept": "application/octet-stream"};
                 return client.apis["Document (Individual)"].get_apis__apiId__documents__documentId__content(
@@ -693,7 +704,7 @@ class API {
      Get the inline content of a given document
      */
     getInlineContentOfDocument(api_id, docId) {
-        var promised_getDocContent = this.client.then(
+        const promised_getDocContent = this.client.then(
             (client) => {
                 let payload = {apiId: api_id, documentId: docId};
                 return client.apis["Document (Individual)"].get_apis__apiId__documents__documentId__content(
@@ -704,7 +715,7 @@ class API {
     }
 
     getDocuments(api_id, callback) {
-        var promise_get_all = this.client.then(
+        const promise_get_all = this.client.then(
             (client) => {
                 return client.apis["Document (Collection)"].get_apis__apiId__documents({apiId: api_id}, this._requestMetaData());
             }
@@ -717,7 +728,7 @@ class API {
     }
 
     updateDocument(api_id, docId, body) {
-        var promised_updateDocument = this.client.then(
+        const promised_updateDocument = this.client.then(
             (client) => {
                 let payload = {
                     apiId: api_id,
@@ -733,7 +744,7 @@ class API {
     }
 
     getDocument(api_id, docId, callback) {
-        var promise_get = this.client.then(
+        const promise_get = this.client.then(
             (client) => {
                 return client.apis["Document (Individual)"].get_apis__apiId__documents__documentId_({
                         apiId: api_id,
@@ -747,7 +758,7 @@ class API {
 
 
     deleteDocument(api_id, document_id) {
-        var promise_deleteDocument = this.client.then(
+        const promise_deleteDocument = this.client.then(
             (client) => {
                 return client.apis["Document (Individual)"].delete_apis__apiId__documents__documentId_({
                         apiId: api_id,
@@ -764,7 +775,7 @@ class API {
      * @returns {Promise.<TResult>}
      */
     labels() {
-        var promise_labels = this.client.then(
+        const promise_labels = this.client.then(
             (client) => {
                 return client.apis["Label (Collection)"].get_labels({},
                     this._requestMetaData());

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/api.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/api.js
@@ -15,7 +15,6 @@
  */
 
 "use strict";
-import AuthManager from './AuthManager'
 import APIClientFactory from "./APIClientFactory";
 import Utils from "./Utils";
 
@@ -25,10 +24,11 @@ import Utils from "./Utils";
 class API {
     /**
      * @constructor
-     * @param {string} access_key - Access key for invoking the backend REST API call.
+     * @param {Object} environment - Environment object - Default current environment.
      */
-    constructor() {
-        this.client = new APIClientFactory().getAPIClient(Utils.getEnvironment().label).client;
+    constructor(environment) {
+        this.environment = environment || Utils.getCurrentEnvironment();
+        this.client = new APIClientFactory().getAPIClient(this.environment).client;
     }
 
     /**
@@ -146,13 +146,14 @@ class API {
     /**
      * Get list of all the available APIs, If the call back is given (TODO: need to ask for fallback sequence as well tmkb)
      * It will be invoked upon receiving the response from REST service.Else will return a promise.
-     * @param callback {function} A callback function to invoke after receiving successful response.
+     * @param {Object} params - Parameters to filter APIs.
+     * @param {function} callback - A callback function to invoke after receiving successful response.
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
-    getAll(callback = null) {
+    getAll(params, callback = null) {
         var promise_get_all = this.client.then(
             (client) => {
-                return client.apis["API (Collection)"].get_apis({}, this._requestMetaData());
+                return client.apis["API (Collection)"].get_apis(params, this._requestMetaData());
             }
         );
         if (callback) {
@@ -243,13 +244,14 @@ class API {
             return promise_get;
         }
     }
+
     /**
      * Get the detail of scope of an API
      * @param id {String} UUID of the API in which the scopes is needed
      * @param callback {function} Function which needs to be called upon success of the API deletion
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
-    getScopeDetail(api_id,name,callback = null) {
+    getScopeDetail(api_id, name, callback = null) {
         var promise_get_Scope_detail = this.client.then(
             (client) => {
                 return client.apis["Scope (Individual)"].get_apis__apiId__scopes__name_({
@@ -281,6 +283,7 @@ class API {
         );
         return promised_updateScope;
     }
+
     addScope(api_id, body) {
         var promised_addScope = this.client.then(
             (client) => {
@@ -295,6 +298,7 @@ class API {
         );
         return promised_addScope;
     }
+
     deleteScope(api_id, scope_name) {
         var promise_deleteScope = this.client.then(
             (client) => {
@@ -307,6 +311,7 @@ class API {
         );
         return promise_deleteScope;
     }
+
     /**
      * Update an api via PUT HTTP method, Need to give the updated API object as the argument.
      * @param api {Object} Updated API object(JSON) which needs to be updated
@@ -833,8 +838,10 @@ class API {
     addThreatProtectionPolicyToApi(apiId, policyId) {
         let promisedPolicies = this.client.then(
             (client) => {
-                return client.apis["API (Individual)"].
-                    post_apis__apiId__threat_protection_policies({apiId: apiId, policyId: policyId});
+                return client.apis["API (Individual)"].post_apis__apiId__threat_protection_policies({
+                    apiId: apiId,
+                    policyId: policyId
+                });
             }
         );
         return promisedPolicies;
@@ -850,8 +857,10 @@ class API {
         let promisedDelete = this.client.then(
             (client) => {
                 console.log(client.apis);
-                return client.apis["API (Individual)"].
-                delete_apis__apiId__threat_protection_policies({apiId: apiId, policyId: policyId});
+                return client.apis["API (Individual)"].delete_apis__apiId__threat_protection_policies({
+                    apiId: apiId,
+                    policyId: policyId
+                });
             }
         );
         return promisedDelete;

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.configurations.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.configurations.feature/pom.xml
@@ -115,6 +115,32 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wso2.carbon.apimgt</groupId>
+                                    <artifactId>org.wso2.carbon.apimgt.rest.api.configurations</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>bundle</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/docs</outputDirectory>
+                                    <includes>config-docs/**</includes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Login/Login.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/components/Login/Login.js
@@ -58,7 +58,7 @@ class Login extends Component {
             authConfigs: [],
             redirectToIS: false
         };
-        this.fetch_ssoData = this.fetch_ssoData.bind(this);
+        this.fetch_DCRappInfo = this.fetch_DCRappInfo.bind(this);
     }
 
     componentDidMount() {
@@ -81,7 +81,7 @@ class Login extends Component {
             this.setLoginStatusOfEnvironments(environments);
 
             //Fetch SSO data and render
-            this.fetch_ssoData(environments);
+            this.fetch_DCRappInfo(environments);
         });
 
         let queryString = this.props.location.search;
@@ -109,10 +109,10 @@ class Login extends Component {
         this.setState({loginStatusEnvironments});
     }
 
-    fetch_ssoData(environments) {
+    fetch_DCRappInfo(environments) {
         //Array of promises
         let promised_ssoData = environments.map(
-            environment => Utils.getPromised_ssoData(environment)
+            environment => Utils.getPromised_DCRappInfo(environment)
         );
 
         Promise.all(promised_ssoData).then(responses => {

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/source/src/app/data/Utils.js
@@ -142,12 +142,12 @@ class Utils {
         localStorage.setItem(Utils.CONST.LOCALSTORAGE_ENVIRONMENT, JSON.stringify(environment));
     }
 
-    static getPromised_ssoData(environment) {
-        return Axios.get(Utils.getAppSSORequestURL(environment));
+    static getPromised_DCRappInfo(environment) {
+        return Axios.get(Utils.getDCRappInfoRequestURL(environment));
     }
 
-    static getAppSSORequestURL(environment = Utils.getEnvironment()) {
-        return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.SSO_LOGIN}${Utils.CONST.CONTEXT_PATH}`;
+    static getDCRappInfoRequestURL(environment = Utils.getEnvironment()) {
+        return `${Utils.CONST.PROTOCOL}${environment.host}${Utils.CONST.DCR_APP_INFO}${Utils.CONST.CONTEXT_PATH}`;
     }
 
     static getAppLogoutURL() {
@@ -174,7 +174,7 @@ class Utils {
 
 Utils.CONST = {
     LOCALSTORAGE_ENVIRONMENT: 'environment_store',
-    SSO_LOGIN: '/login/login',
+    DCR_APP_INFO: '/login/login',
     LOGOUT: '/login/logout',
     LOGIN_TOKEN_PATH: '/login/token',
     SWAGGER_YAML: '/api/am/store/v1.0/apis/swagger.yaml',


### PR DESCRIPTION
### Proposed changes in this pull request
#### Changes in the backend
- Create DCR app with JWT grant type.
- Add `assertion` form param to the token endpoint.
- Implement `WSO2ISKeyManagerImpl` to support JWT from WSO2-IS.
- Testcase for the `AuthenticatorService` and `WSO2ISKeyManagerImpl`
- Change environment configuration to the new namespace `wso2.carbon.apimgt.environment`.
sample configuration
```yaml
  # APIM Environment Configuration Parameters
wso2.carbon.apimgt.environments:
    # current environment's label from the list of environments
  environmentLabel: Production
    # UI Service URL
  allowedHosts:
  - 10.100.4.247:9292
  - 10.100.4.177:9292
  - localhost:9292

    # Multi-Environment Overview Configurations
  multiEnvironmentOverview:
      # Multi-Environment Overview feature enabled or not
    enabled: true
```
#### Changes in the frontend
- Remove `idToken` from local-storage.
- Authenticate the user to all other environments.

Fix https://github.com/wso2/product-apim/issues/2629
Fix https://github.com/wso2/product-apim/issues/2694