### PR TITLE
Fix https://github.com/wso2/product-apim/issues/2394

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/policy/resource/policy-add/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/policy/resource/policy-add/template.jag
@@ -185,6 +185,7 @@
             <div class="col-sm-3">
                 <select class="form-control select required" id="request-count-unit" name="request-count-unit">
                     <option value="min" <% if(defaultTimeUnit == "" || defaultTimeUnit == "min") {%>selected<%}%>>Minutes(s)</option>
+                    <option value="sec" <% if(defaultTimeUnit == "sec") {%>selected<%}%>>Second(s)</option>
                     <option value="hour" <% if(defaultTimeUnit == "hour") {%>selected<%}%>>Hour(s)</option>
                     <option value="days" <% if(defaultTimeUnit == "day") {%>selected<%}%>>Day(s)</option>
                     <option value="month" <% if(defaultTimeUnit == "month") {%>selected<%}%>>Month(s)</option>


### PR DESCRIPTION
### Proposed changes in this pull request

Showing 'seconds' in the unit time for advanced throttling. (https://github.com/wso2/product-apim/issues/2394)