### PR TITLE
Add default validity period to empty token

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -643,7 +643,9 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                 tokenInfo.setValidityPeriod(apiKey.getValidityPeriod());
                 tokenInfo.setScope(apiKey.getTokenScope().split("\\s"));
             } else {
-                tokenInfo.setAccessToken("");      
+                tokenInfo.setAccessToken("");
+                //set default validity period
+                tokenInfo.setValidityPeriod(3600);
             }
             tokenInfo.setConsumerKey(consumerKey);
 


### PR DESCRIPTION
### Proposed changes in this pull request

When client credential grant type disabled and generated token and refreshed the page, the validity period become 0. It has to be fixed as 3600
