### PR TITLE
Adding version annotation for ballerina services

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway.annotations/src/main/ballerina/wso2/gateway/annotation.bal
+++ b/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway.annotations/src/main/ballerina/wso2/gateway/annotation.bal
@@ -24,4 +24,14 @@ public type TierConfiguration {
 @Description {value:"Resource level tier annaotation"}
 public annotation <resource> ResourceTier TierConfiguration;
 
+@Description {value:"Configuration used for api version annotation"}
+@Field {value:"apiVersion: version specified for the API"}
+public type VersionConfiguration {
+    string apiVersion;
+
+};
+
+@Description {value:"API version annotation"}
+public annotation <service> Version VersionConfiguration;
+
 

--- a/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway.annotations/src/main/java/org/wso2/carbon/apimgt/ballerina/gateway/annotations/GatewayAnnotationPlugin.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway.annotations/src/main/java/org/wso2/carbon/apimgt/ballerina/gateway/annotations/GatewayAnnotationPlugin.java
@@ -16,16 +16,18 @@
  * under the License.
  */
 
-package org.wso2.carbon.apimgt.ballerina.gateway.annotations.plugins;
+package org.wso2.carbon.apimgt.ballerina.gateway.annotations;
 
 import org.ballerinalang.compiler.plugins.AbstractCompilerPlugin;
 import org.ballerinalang.compiler.plugins.SupportedAnnotationPackages;
 import org.ballerinalang.model.tree.AnnotationAttachmentNode;
 import org.ballerinalang.model.tree.ResourceNode;
+import org.ballerinalang.model.tree.ServiceNode;
 import org.ballerinalang.util.diagnostic.DiagnosticLog;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 import org.wso2.carbon.apimgt.ballerina.gateway.annotations.models.TierModel;
+import org.wso2.carbon.apimgt.ballerina.gateway.annotations.models.VersionModel;
 
 import java.util.List;
 
@@ -34,34 +36,59 @@ import java.util.List;
  */
 @SupportedAnnotationPackages(
         // Tell compiler we are only interested in gateway.tier annotations.
-        value = "gateway.tier"
+        value = "wso2.gateway"
 )
 
-public class ResourceTierPlugin extends AbstractCompilerPlugin {
+public class GatewayAnnotationPlugin extends AbstractCompilerPlugin {
 
     public static final String TIER_LEVEL = "tierLevel";
+    public static final String VERSION = "version";
     private DiagnosticLog dlog;
 
-    @Override public void init(DiagnosticLog diagnosticLog) {
+    @Override
+    public void init(DiagnosticLog diagnosticLog) {
         // Initialize the logger.
         this.dlog = diagnosticLog;
     }
 
-    // ResourceTier annotation is attached to resource<> objects
-    @Override public void process(ResourceNode resourceNode, List<AnnotationAttachmentNode> annotations) {
+    // Extract annotations attached to resource<> objects
+    @Override
+    public void process(ResourceNode resourceNode, List<AnnotationAttachmentNode> annotations) {
 
         //Iterate through the annotation Attachment Node List
         for (AnnotationAttachmentNode attachmentNode : annotations) {
-            List<BLangRecordLiteral.BLangRecordKeyValue> keyValues = ((BLangRecordLiteral) ((BLangAnnotationAttachment) attachmentNode).expr)
-                    .getKeyValuePairs();
+            List<BLangRecordLiteral.BLangRecordKeyValue> keyValues =
+                    ((BLangRecordLiteral) ((BLangAnnotationAttachment) attachmentNode).expr).getKeyValuePairs();
             //Iterate through the annotations
             for (BLangRecordLiteral.BLangRecordKeyValue keyValue : keyValues) {
                 String annotationValue = keyValue.getValue().toString();
                 switch (keyValue.getKey().toString()) {
                 //Match annotation key and assign the value to model class
-                case TIER_LEVEL:
-                    TierModel.getInstance().setTier(annotationValue);
-                    break;
+                    case TIER_LEVEL:
+                        TierModel.getInstance().setTier(annotationValue);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+
+    // Extract annotations attached  to service<> objects
+    @Override
+    public void process(ServiceNode serviceNode, List<AnnotationAttachmentNode> annotations) {
+
+        //Iterate through the annotation Attachment Node List
+        for (AnnotationAttachmentNode attachmentNode : annotations) {
+            List<BLangRecordLiteral.BLangRecordKeyValue> keyValues =
+                    ((BLangRecordLiteral) ((BLangAnnotationAttachment) attachmentNode).expr).getKeyValuePairs();
+            //Iterate through the annotations
+            for (BLangRecordLiteral.BLangRecordKeyValue keyValue : keyValues) {
+                String annotationValue = keyValue.getValue().toString();
+                switch (keyValue.getKey().toString()) {
+                //Match annotation key and assign the value to model class
+                case VERSION:
+                    VersionModel.getInstance().setApiVersion(annotationValue);
                 default:
                     break;
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway.annotations/src/main/java/org/wso2/carbon/apimgt/ballerina/gateway/annotations/GatewayExtensionProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway.annotations/src/main/java/org/wso2/carbon/apimgt/ballerina/gateway/annotations/GatewayExtensionProvider.java
@@ -27,7 +27,7 @@ import org.wso2.ballerinalang.compiler.packaging.repo.Repo;
  * This represents the resource tier extension package repository provider.
  */
 @JavaSPIService("org.ballerinalang.spi.SystemPackageRepositoryProvider")
-public class ResourceTierExtensionProvider implements SystemPackageRepositoryProvider {
+public class GatewayExtensionProvider implements SystemPackageRepositoryProvider {
 
     @Override
     public Repo loadRepository() {

--- a/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway.annotations/src/main/java/org/wso2/carbon/apimgt/ballerina/gateway/annotations/models/VersionModel.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway.annotations/src/main/java/org/wso2/carbon/apimgt/ballerina/gateway/annotations/models/VersionModel.java
@@ -15,32 +15,31 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.wso2.carbon.apimgt.ballerina.gateway.annotations.models;
 
-/**
- * Model class to store tier value.
- */
-public class TierModel {
-    private static TierModel instance;
-    private String tierLevel;
+public class VersionModel {
 
-    private TierModel() {
+    private static VersionModel instance;
+    private String apiVersion;
+
+    private VersionModel() {
     }
 
-    public static TierModel getInstance() {
-        synchronized (TierModel.class) {
+    public static VersionModel getInstance() {
+        synchronized (VersionModel.class) {
             if (instance == null) {
-                instance = new TierModel();
+                instance = new VersionModel();
             }
         }
         return instance;
     }
 
-    public String getTier() {
-        return tierLevel;
+    public String getApiVersion() {
+        return apiVersion;
     }
 
-    public void setTier(String tier) {
-        this.tierLevel = tier;
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway.annotations/src/main/resources/META-INF/services/org.ballerinalang.compiler.plugins.CompilerPlugin
+++ b/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway.annotations/src/main/resources/META-INF/services/org.ballerinalang.compiler.plugins.CompilerPlugin
@@ -1,1 +1,1 @@
-org.wso2.carbon.apimgt.ballerina.gateway.annotations.plugins.ResourceTierPlugin
+org.wso2.carbon.apimgt.ballerina.gateway.annotations.GatewayAnnotationPlugin

--- a/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway/src/main/ballerina/org.wso2.carbon.apimgt.gateway.sample.services/pizza_shack_api.bal
+++ b/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway/src/main/ballerina/org.wso2.carbon.apimgt.gateway.sample.services/pizza_shack_api.bal
@@ -16,6 +16,7 @@
 
 import ballerina/http;
 import org.wso2.carbon.apimgt.gateway.listeners as listeners;
+//import wso2/gateway;
 
 endpoint listeners:APIGatewayListener apiListener {
     host:"localhost",
@@ -35,6 +36,7 @@ endpoint http:Client pizzaShackEP {
     }
 
 }
+//@gateway:Version { apiVersion: "1.0.0" }
 service<http:Service> pizzashack bind apiListener {
     @http:ResourceConfig {
         methods:["GET"],
@@ -45,7 +47,7 @@ service<http:Service> pizzashack bind apiListener {
             scopes:["default"]
         }
     }
-    //@tier:ResourceTier{tierLevel : "Gold"}
+    //@gateway:ResourceTier{tierLevel : "Gold"}
     getMenu (endpoint conn, http:Request req) {
         var result = pizzaShackEP -> get("/menu", request = req);
         match result {


### PR DESCRIPTION
### Proposed changes in this pull request

- We can support ballerina services with following annotation at service level

@gateway:Version { apiVersion: "1.0.0" }

### When should this PR be merged

ASAP

