### PR TITLE
Add new secure gateway listener for https connections

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway/src/main/ballerina/gateway/api_gateway_listener.bal
+++ b/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway/src/main/ballerina/gateway/api_gateway_listener.bal
@@ -65,11 +65,12 @@ public type EndpointConfiguration {
     http:RequestLimits? requestLimits,
     http:Filter[] filters,
     http:AuthProvider[]? authProviders,
+    boolean isSecured,
 };
 
 
 public function APIGatewayListener::init (EndpointConfiguration config) {
-    initiateGatewayConfigurations();
+    initiateGatewayConfigurations(config);
     addAuthFiltersForAPIGatewayListener(config);
     self.httpListener.init(config);
     initializeBlockConditions();
@@ -175,8 +176,13 @@ function createAuthHandler (http:AuthProvider authProvider) returns http:HttpAut
     }
 }
 
-function initiateGatewayConfigurations() {
+function initiateGatewayConfigurations(EndpointConfiguration config) {
+    if(!config.isSecured) {
+        config.port = getConfigIntValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_HTTP_PORT, 9090);
+    }
+    config.host = getConfigValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_HOST,"localhost");
     intitateKeyManagerConfigurations();
+
 }
 
 function intitateKeyManagerConfigurations() {
@@ -191,6 +197,10 @@ function intitateKeyManagerConfigurations() {
 
 function getConfigValue(string instanceId, string property, string defaultValue) returns string {
     return config:getAsString(instanceId + "." + property, default = defaultValue);
+}
+
+function getConfigIntValue(string instanceId, string property, int defaultValue) returns int {
+    return config:getAsInt(instanceId + "." + property, default = defaultValue);
 }
 
 @Description {value:"Gets called every time a service attaches itself to this endpoint. Also happens at package initialization."}

--- a/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway/src/main/ballerina/gateway/api_gateway_secure_listener.bal
+++ b/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway/src/main/ballerina/gateway/api_gateway_secure_listener.bal
@@ -1,0 +1,104 @@
+// Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/auth;
+import ballerina/cache;
+import ballerina/config;
+import ballerina/runtime;
+import ballerina/time;
+import ballerina/io;
+
+@Description {value:"Representation of an API gateway secure listener"}
+@Field {value:"apiGatewayListener: API Gateway listener instance"}
+public type APIGatewaySecureListener object {
+    public {
+        APIGatewayListener apiGatewayListener;
+    }
+    new () {
+        apiGatewayListener = new;
+    }
+
+    public function init(EndpointConfiguration config);
+
+    @Description {value:"Gets called when the endpoint is being initialize during package init time"}
+    @Return {value:"Error occured during initialization"}
+    public function initEndpoint() returns (error);
+
+    @Description {value:"Gets called every time a service attaches itself to this endpoint. Also happens at package initialization."}
+    @Param {value:"serviceType: The type of the service to be registered"}
+    public function register(typedesc serviceType);
+
+    @Description {value:"Starts the registered service"}
+    public function start();
+
+    @Description {value:"Returns the connector that client code uses"}
+    @Return {value:"The connector that client code uses"}
+    public function getCallerActions() returns (http:Connection);
+
+    @Description {value:"Stops the registered service"}
+    public function stop();
+};
+
+
+public function APIGatewaySecureListener::init (EndpointConfiguration config) {
+    initiateGatewaySecureConfigurations(config);
+    self.apiGatewayListener.init(config);
+
+}
+
+@Description {value:"Gets called when the endpoint is being initialize during package init time"}
+@Return {value:"Error occured during initialization"}
+public function APIGatewaySecureListener::initEndpoint() returns (error) {
+    return self.apiGatewayListener.initEndpoint();
+}
+
+@Description {value:"Gets called every time a service attaches itself to this endpoint. Also happens at package initialization."}
+@Param {value:"ep: The endpoint to which the service should be registered to"}
+@Param {value:"serviceType: The type of the service to be registered"}
+public function APIGatewaySecureListener::register (typedesc serviceType) {
+    self.apiGatewayListener.register(serviceType);
+}
+
+@Description {value:"Starts the registered service"}
+public function APIGatewaySecureListener::start () {
+    self.apiGatewayListener.start();
+}
+
+@Description {value:"Returns the connector that client code uses"}
+@Return {value:"The connector that client code uses"}
+public function APIGatewaySecureListener::getCallerActions () returns (http:Connection) {
+    return self.apiGatewayListener.getCallerActions();
+}
+
+@Description {value:"Stops the registered service"}
+public function APIGatewaySecureListener::stop () {
+    self.apiGatewayListener.stop();
+}
+
+function initiateGatewaySecureConfigurations(EndpointConfiguration config) {
+    config.port = getConfigIntValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_HTTPS_PORT, 9095);
+    string keyStorePath = getConfigValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_KEY_STORE_PATH,
+        "${ballerina.home}/bre/security/ballerinaKeystore.p12");
+    string keyStorePassword = getConfigValue(LISTENER_CONF_INSTANCE_ID,
+        LISTENER_CONF_KEY_STORE_PASSWORD, "ballerina");
+    http:KeyStore keyStore = { path: keyStorePath, password: keyStorePassword };
+    http:ServiceSecureSocket secureSocket = { keyStore: keyStore };
+    config.secureSocket = secureSocket;
+    config.isSecured = true;
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway/src/main/ballerina/gateway/constants.bal
+++ b/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway/src/main/ballerina/gateway/constants.bal
@@ -69,4 +69,17 @@
 @Description { value: "Block Condition Value"}
 @final public string BLOCKING_CONDITION_VALUE = "conditionValue";
 
+@Description { value: "Listener endpoint related configs"}
+@final public string LISTENER_CONF_INSTANCE_ID = "listenerConfig";
+@Description { value: "Listener endpoint host"}
+@final public string LISTENER_CONF_HOST = "host";
+@Description { value: "Listener endpoint http port"}
+@final public string LISTENER_CONF_HTTP_PORT = "httpPort";
+@Description { value: "Listener endpoint https port"}
+@final public string LISTENER_CONF_HTTPS_PORT = "httpsPort";
+@Description { value: "Listener endpoint key store path"}
+@final public string LISTENER_CONF_KEY_STORE_PATH = "keyStore.path";
+@Description { value: "Listener endpoint key store password"}
+@final public string LISTENER_CONF_KEY_STORE_PASSWORD = "keyStore.password";
+
 @final string TRUE = "true";

--- a/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway/src/main/ballerina/gateway/subscription_filter.bal
+++ b/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway/src/main/ballerina/gateway/subscription_filter.bal
@@ -54,6 +54,8 @@ public type SubscriptionFilter object {
                                     authenticationContext.apiTier = decodedPayload.apiTier.toString();
                                     authenticationContext.subscriberTenantDomain = decodedPayload
                                                                                     .subscriberTenantDomain.toString();
+                                    authenticationContext.isContentAwareTierPresent = check <boolean> decodedPayload
+                                    .isContentAware;
                                     json policiesList = decodedPayload.subscriptionPolicies;
                                     int numOfPolicies = lengthof policiesList;
                                     int i =0;

--- a/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway/src/main/resources/ballerina.conf
+++ b/components/apimgt/org.wso2.carbon.apimgt.ballerina.gateway/src/main/resources/ballerina.conf
@@ -1,3 +1,9 @@
+[listenerConfig]
+host="localhost"
+httpPort=9090
+httpsPort=9095
+keyStore.path="${ballerina.home}/bre/security/ballerinaKeystore.p12"
+keyStore.password="ballerina"
 [keyManager]
 serverUrl="https://localhost:9443"
 username="admin"


### PR DESCRIPTION
### Proposed changes in this pull request
- Added new secure gateway listener which wraps the gateway listener, which is used for https connections
- We can define two endpoints (http and https) and bind them to services as below

`endpoint gateway:APIGatewaySecureListener apiSecureListener {
	authProviders:[gateway:basicAuthProvider,jwtAuthProvider]
};`

`endpoint gateway:APIGatewayListener apiListener {
    authProviders:[gateway:basicAuthProvider,jwtAuthProvider]
};`

` @http:ServiceConfig {
    basePath:"/pizzashack/1.0.0",
    authConfig:{
        authProviders:["oauth2"],
        authentication:{enabled:true}
      
    }

}`
` @gateway:Version { apiVersion: "1.0.0" }
service<http:Service> pizzashack bind apiListener,apiSecureListener {
}`

### When should this PR be merged
ASAP


