### PR TITLE
Add support for API serach by labelName attribute

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1391,6 +1391,8 @@ public final class APIConstants {
             API_STATUS.toLowerCase() };
     // Prefix for registry attributes.
     public static final String OVERVIEW_PREFIX = "overview_";
+    public static final String LABEL_PREFIX = "labels_";
+    public static final String LABELNAME = "labelName";
     /**
      * Parameter for enabling tenant load notifications to members in the same HZ cluster
      */
@@ -1411,4 +1413,7 @@ public final class APIConstants {
     public static final String USER = "user";
     public static final String IS_SUPER_TENANT = "isSuperTenant";
     public static final String NULL_GROUPID_LIST = "null";
+
+    public static final String APPLICATION_GZIP = "application/gzip";
+    public static final String JAVA_IO_TMPDIR = "java.io.tmpdir";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1416,4 +1416,6 @@ public final class APIConstants {
 
     public static final String APPLICATION_GZIP = "application/gzip";
     public static final String JAVA_IO_TMPDIR = "java.io.tmpdir";
+    public static final String JSON_FILENAME_EXTENSION = ".json";
+    public static final String JSON_GZIP_FILENAME_EXTENSION = ".json.gz";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -1908,7 +1908,17 @@ public abstract class AbstractAPIManager implements APIManager {
             // If the query does not contains "=" then it is an errornous scenario.
             if (query.contains("=")) {
                 String[] searchKeys = query.split("=");
-                if (!Arrays.asList(APIConstants.API_SEARCH_PREFIXES).contains(searchKeys[0].toLowerCase())) {
+
+                //prevent api-meta. getting prefixed to labelName and restrict label serach to exact match only
+                if (APIConstants.LABELNAME.equals(searchKeys[0])) {
+                    searchKeys[0] = APIConstants.LABEL_PREFIX + searchKeys[0];
+                    if (searchKeys[1].startsWith("*")) {
+                        searchKeys[1] = searchKeys[1].substring(1, searchKeys[1].length());
+                    }
+                    if (searchKeys[1].endsWith("*")) {
+                        searchKeys[1] = searchKeys[1].substring(0, searchKeys[1].length() - 1);
+                    }
+                } else if (!Arrays.asList(APIConstants.API_SEARCH_PREFIXES).contains(searchKeys[0].toLowerCase())) {
                     if (log.isDebugEnabled()) {
                         log.debug(searchKeys[0] + " does not match with any of the reserved key words. Hence"
                                 + " appending " + APIConstants.API_RELATED_CUSTOM_PROPERTIES_PREFIX + " as prefix");

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/GZIPUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/GZIPUtils.java
@@ -47,13 +47,13 @@ public class GZIPUtils {
             gzipOutputStream = new GZIPOutputStream(fileOutputStream);
             fileInputStream = new FileInputStream(sourcePath);
 
-            int length;
+            int length = 0;
             while ((length = fileInputStream.read(buffer)) > 0) {
                 gzipOutputStream.write(buffer, 0, length);
             }
             gzipOutputStream.finish();
         } catch (IOException e) {
-            throw new APIManagementException("Error while compressing file at" + sourcePath + "to" + destinationPath, e);
+            throw new APIManagementException("Error while compressing file at " + sourcePath + " to" + destinationPath, e);
         } finally {
             IOUtils.closeQuietly(fileInputStream);
             IOUtils.closeQuietly(fileOutputStream);
@@ -62,14 +62,14 @@ public class GZIPUtils {
     }
 
     public static File constructZippedResponse(Object data) throws APIManagementException {
-        String tmpSourceFileName = System.currentTimeMillis() + ".json";
-        String tmpDestinationFileName = System.currentTimeMillis() + ".json.gz";
+        String tmpSourceFileName = System.currentTimeMillis() + APIConstants.JSON_FILE_EXTENSION;
+        String tmpDestinationFileName = System.currentTimeMillis() + APIConstants.JSON_GZIP_FILENAME_EXTENSION;
         String sourcePath = System.getProperty(APIConstants.JAVA_IO_TMPDIR) + File.separator  + tmpSourceFileName;
         String destinationPath = System.getProperty(APIConstants.JAVA_IO_TMPDIR) + File.separator + tmpDestinationFileName;
         File zippedResponse;
 
         File file = new File(sourcePath);
-        FileWriter fileWriter;
+        FileWriter fileWriter = null;
         try {
             file.createNewFile();
             fileWriter = new FileWriter(file);
@@ -79,6 +79,8 @@ public class GZIPUtils {
             zippedResponse = new File(destinationPath);
         } catch (IOException e) {
             throw new APIManagementException("Error while constructing zipped response..", e);
+        } finally {
+            IOUtils.closeQuietly(fileWriter);
         }
         return zippedResponse;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/GZIPUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/GZIPUtils.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
+
+public class GZIPUtils {
+    private static final Log log = LogFactory.getLog(GZIPUtils.class);
+    private static final int BUFFER_SIZE = 1028;
+
+    public static void compressFile(String sourcePath, String destinationPath) throws APIManagementException{
+        if (log.isDebugEnabled()) {
+            log.debug("Compressing file : " + sourcePath + " to : " + destinationPath);
+        }
+        byte[] buffer = new byte[BUFFER_SIZE];
+        GZIPOutputStream gzipOutputStream = null;
+        FileOutputStream fileOutputStream = null;
+        FileInputStream fileInputStream = null;
+
+        try {
+            fileOutputStream = new FileOutputStream(destinationPath);
+            gzipOutputStream = new GZIPOutputStream(fileOutputStream);
+            fileInputStream = new FileInputStream(sourcePath);
+
+            int length;
+            while ((length = fileInputStream.read(buffer)) > 0) {
+                gzipOutputStream.write(buffer, 0, length);
+            }
+            gzipOutputStream.finish();
+        } catch (IOException e) {
+            throw new APIManagementException("Error while compressing file at" + sourcePath + "to" + destinationPath, e);
+        } finally {
+            IOUtils.closeQuietly(fileInputStream);
+            IOUtils.closeQuietly(fileOutputStream);
+            IOUtils.closeQuietly(gzipOutputStream);
+        }
+    }
+
+    public static File constructZippedResponse(Object data) throws APIManagementException {
+        String tmpSourceFileName = System.currentTimeMillis() + ".json";
+        String tmpDestinationFileName = System.currentTimeMillis() + ".json.gz";
+        String sourcePath = System.getProperty(APIConstants.JAVA_IO_TMPDIR) + File.separator  + tmpSourceFileName;
+        String destinationPath = System.getProperty(APIConstants.JAVA_IO_TMPDIR) + File.separator + tmpDestinationFileName;
+        File zippedResponse;
+
+        File file = new File(sourcePath);
+        FileWriter fileWriter;
+        try {
+            file.createNewFile();
+            fileWriter = new FileWriter(file);
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.writeValue(fileWriter, data);
+            compressFile(sourcePath, destinationPath);
+            zippedResponse = new File(destinationPath);
+        } catch (IOException e) {
+            throw new APIManagementException("Error while constructing zipped response..", e);
+        }
+        return zippedResponse;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApi.java
@@ -541,7 +541,7 @@ public class ApisApi  {
     @GET
     
     @Consumes({ "application/json" })
-    @Produces({ "application/json" })
+    @Produces({ "application/json", "application/gzip" })
     @io.swagger.annotations.ApiOperation(value = "Retrieve/Search APIs\n", notes = "This operation provides you a list of available APIs qualifying under a given search condition.\n\nEach retrieved API is represented with a minimal amount of attributes. If you want to get complete details of an API, you need to use **Get details of an API** operation.\n", response = APIListDTO.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "OK.\nList of qualifying APIs is returned.\n"),
@@ -554,9 +554,10 @@ public class ApisApi  {
     @ApiParam(value = "Starting point within the complete list of items qualified.\n", defaultValue="0") @QueryParam("offset")  Integer offset,
     @ApiParam(value = "**Search condition**.\n\nYou can search in attributes by using an **\"<attribute>:\"** modifier.\n\nEg.\n\"provider:wso2\" will match an API if the provider of the API is exactly \"wso2\".\n\nAdditionally you can use wildcards.\n\nEg.\n\"provider:wso2*\" will match an API if the provider of the API starts with \"wso2\".\n\nSupported attribute modifiers are [**version, context, status,\ndescription, subcontext, doc, provider**]\n\nIf no advanced attribute modifier has been specified,  the API names containing\nthe search term will be returned as a result.\n") @QueryParam("query")  String query,
     @ApiParam(value = "Media types acceptable for the response. Default is application/json.\n"  , defaultValue="application/json")@HeaderParam("Accept") String accept,
-    @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resource (Will be supported in future).\n"  )@HeaderParam("If-None-Match") String ifNoneMatch)
+    @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resource (Will be supported in future).\n"  )@HeaderParam("If-None-Match") String ifNoneMatch,
+    @ApiParam(value = "Whether the returned response should contain full details of API\n") @QueryParam("expand")  Boolean expand)
     {
-    return delegate.apisGet(limit,offset,query,accept,ifNoneMatch);
+    return delegate.apisGet(limit,offset,query,accept,ifNoneMatch,expand);
     }
     @POST
     

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApiService.java
@@ -45,7 +45,7 @@ public abstract class ApisApiService {
     public abstract Response apisApiIdWsdlPost(String apiId,WsdlDTO body,String contentType,String ifMatch,String ifUnmodifiedSince);
     public abstract Response apisChangeLifecyclePost(String action,String apiId,String lifecycleChecklist,String ifMatch,String ifUnmodifiedSince);
     public abstract Response apisCopyApiPost(String newVersion,String apiId);
-    public abstract Response apisGet(Integer limit,Integer offset,String query,String accept,String ifNoneMatch);
+    public abstract Response apisGet(Integer limit,Integer offset,String query,String accept,String ifNoneMatch,Boolean expand);
     public abstract Response apisPost(APIDTO body,String contentType);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APIBusinessInformationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APIBusinessInformationDTO.java
@@ -15,27 +15,27 @@ public class APIBusinessInformationDTO  {
   
   
   
-  private String technicalOwnerEmail = null;
+  private String businessOwner = null;
   
   
   private String businessOwnerEmail = null;
   
   
-  private String businessOwner = null;
-  
-  
   private String technicalOwner = null;
+  
+  
+  private String technicalOwnerEmail = null;
 
   
   /**
    **/
   @ApiModelProperty(value = "")
-  @JsonProperty("technicalOwnerEmail")
-  public String getTechnicalOwnerEmail() {
-    return technicalOwnerEmail;
+  @JsonProperty("businessOwner")
+  public String getBusinessOwner() {
+    return businessOwner;
   }
-  public void setTechnicalOwnerEmail(String technicalOwnerEmail) {
-    this.technicalOwnerEmail = technicalOwnerEmail;
+  public void setBusinessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
   }
 
   
@@ -54,18 +54,6 @@ public class APIBusinessInformationDTO  {
   /**
    **/
   @ApiModelProperty(value = "")
-  @JsonProperty("businessOwner")
-  public String getBusinessOwner() {
-    return businessOwner;
-  }
-  public void setBusinessOwner(String businessOwner) {
-    this.businessOwner = businessOwner;
-  }
-
-  
-  /**
-   **/
-  @ApiModelProperty(value = "")
   @JsonProperty("technicalOwner")
   public String getTechnicalOwner() {
     return technicalOwner;
@@ -75,16 +63,28 @@ public class APIBusinessInformationDTO  {
   }
 
   
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("technicalOwnerEmail")
+  public String getTechnicalOwnerEmail() {
+    return technicalOwnerEmail;
+  }
+  public void setTechnicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+  }
+
+  
 
   @Override
   public String toString()  {
     StringBuilder sb = new StringBuilder();
     sb.append("class APIBusinessInformationDTO {\n");
     
-    sb.append("  technicalOwnerEmail: ").append(technicalOwnerEmail).append("\n");
-    sb.append("  businessOwnerEmail: ").append(businessOwnerEmail).append("\n");
     sb.append("  businessOwner: ").append(businessOwner).append("\n");
+    sb.append("  businessOwnerEmail: ").append(businessOwnerEmail).append("\n");
     sb.append("  technicalOwner: ").append(technicalOwner).append("\n");
+    sb.append("  technicalOwnerEmail: ").append(technicalOwnerEmail).append("\n");
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APICorsConfigurationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APICorsConfigurationDTO.java
@@ -21,19 +21,31 @@ public class APICorsConfigurationDTO  {
   
   
   
+  private Boolean corsConfigurationEnabled = false;
+  
+  
   private List<String> accessControlAllowOrigins = new ArrayList<String>();
   
   
   private Boolean accessControlAllowCredentials = false;
   
   
-  private Boolean corsConfigurationEnabled = false;
-  
-  
   private List<String> accessControlAllowHeaders = new ArrayList<String>();
   
   
   private List<String> accessControlAllowMethods = new ArrayList<String>();
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("corsConfigurationEnabled")
+  public Boolean getCorsConfigurationEnabled() {
+    return corsConfigurationEnabled;
+  }
+  public void setCorsConfigurationEnabled(Boolean corsConfigurationEnabled) {
+    this.corsConfigurationEnabled = corsConfigurationEnabled;
+  }
 
   
   /**
@@ -57,18 +69,6 @@ public class APICorsConfigurationDTO  {
   }
   public void setAccessControlAllowCredentials(Boolean accessControlAllowCredentials) {
     this.accessControlAllowCredentials = accessControlAllowCredentials;
-  }
-
-  
-  /**
-   **/
-  @ApiModelProperty(value = "")
-  @JsonProperty("corsConfigurationEnabled")
-  public Boolean getCorsConfigurationEnabled() {
-    return corsConfigurationEnabled;
-  }
-  public void setCorsConfigurationEnabled(Boolean corsConfigurationEnabled) {
-    this.corsConfigurationEnabled = corsConfigurationEnabled;
   }
 
   
@@ -102,9 +102,9 @@ public class APICorsConfigurationDTO  {
     StringBuilder sb = new StringBuilder();
     sb.append("class APICorsConfigurationDTO {\n");
     
+    sb.append("  corsConfigurationEnabled: ").append(corsConfigurationEnabled).append("\n");
     sb.append("  accessControlAllowOrigins: ").append(accessControlAllowOrigins).append("\n");
     sb.append("  accessControlAllowCredentials: ").append(accessControlAllowCredentials).append("\n");
-    sb.append("  corsConfigurationEnabled: ").append(corsConfigurationEnabled).append("\n");
     sb.append("  accessControlAllowHeaders: ").append(accessControlAllowHeaders).append("\n");
     sb.append("  accessControlAllowMethods: ").append(accessControlAllowMethods).append("\n");
     sb.append("}\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APIDTO.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.APIBusinessInformationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.APICorsConfigurationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.APIEndpointSecurityDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.dto.APIInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.APIMaxTpsDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.LabelDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.SequenceDTO;
@@ -21,35 +22,14 @@ import javax.validation.constraints.NotNull;
 
 
 @ApiModel(description = "")
-public class APIDTO  {
+public class APIDTO extends APIInfoDTO {
   
-  
-  
-  private String id = null;
-  
-  @NotNull
-  private String name = null;
-  
-  
-  private String description = null;
-  
-  @NotNull
-  private String context = null;
-  
-  @NotNull
-  private String version = null;
-  
-  
-  private String provider = null;
   
   
   private String apiDefinition = null;
   
   
   private String wsdlUri = null;
-  
-  
-  private String status = null;
   
   
   private String responseCaching = null;
@@ -60,22 +40,22 @@ public class APIDTO  {
   
   private String destinationStatsEnabled = null;
   
-  @NotNull
+  
   private Boolean isDefaultVersion = null;
   
   public enum TypeEnum {
      HTTP,  WS, 
   };
-  @NotNull
+  
   private TypeEnum type = TypeEnum.HTTP;
   
-  @NotNull
+  
   private List<String> transport = new ArrayList<String>();
   
   
   private List<String> tags = new ArrayList<String>();
   
-  @NotNull
+  
   private List<String> tiers = new ArrayList<String>();
   
   
@@ -84,13 +64,10 @@ public class APIDTO  {
   
   private APIMaxTpsDTO maxTps = null;
   
-  
-  private String thumbnailUri = null;
-  
   public enum VisibilityEnum {
      PUBLIC,  PRIVATE,  RESTRICTED,  CONTROLLED, 
   };
-  @NotNull
+  
   private VisibilityEnum visibility = null;
   
   
@@ -99,7 +76,7 @@ public class APIDTO  {
   
   private List<String> visibleTenants = new ArrayList<String>();
   
-  @NotNull
+  
   private String endpointConfig = null;
   
   
@@ -143,84 +120,6 @@ public class APIDTO  {
 
   
   /**
-   * UUID of the api registry artifact\n
-   **/
-  @ApiModelProperty(value = "UUID of the api registry artifact\n")
-  @JsonProperty("id")
-  public String getId() {
-    return id;
-  }
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  
-  /**
-   * Name of the API
-   **/
-  @ApiModelProperty(required = true, value = "Name of the API")
-  @JsonProperty("name")
-  public String getName() {
-    return name;
-  }
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  
-  /**
-   * A brief description about the API
-   **/
-  @ApiModelProperty(value = "A brief description about the API")
-  @JsonProperty("description")
-  public String getDescription() {
-    return description;
-  }
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  
-  /**
-   * A string that represents the context of the user's request
-   **/
-  @ApiModelProperty(required = true, value = "A string that represents the context of the user's request")
-  @JsonProperty("context")
-  public String getContext() {
-    return context;
-  }
-  public void setContext(String context) {
-    this.context = context;
-  }
-
-  
-  /**
-   * The version of the API
-   **/
-  @ApiModelProperty(required = true, value = "The version of the API")
-  @JsonProperty("version")
-  public String getVersion() {
-    return version;
-  }
-  public void setVersion(String version) {
-    this.version = version;
-  }
-
-  
-  /**
-   * If the provider value is not given user invoking the api will be used as the provider.\n
-   **/
-  @ApiModelProperty(value = "If the provider value is not given user invoking the api will be used as the provider.\n")
-  @JsonProperty("provider")
-  public String getProvider() {
-    return provider;
-  }
-  public void setProvider(String provider) {
-    this.provider = provider;
-  }
-
-  
-  /**
    * Swagger definition of the API which contains details about URI templates and scopes\n
    **/
   @ApiModelProperty(value = "Swagger definition of the API which contains details about URI templates and scopes\n")
@@ -243,19 +142,6 @@ public class APIDTO  {
   }
   public void setWsdlUri(String wsdlUri) {
     this.wsdlUri = wsdlUri;
-  }
-
-  
-  /**
-   * This describes in which status of the lifecycle the API is
-   **/
-  @ApiModelProperty(value = "This describes in which status of the lifecycle the API is")
-  @JsonProperty("status")
-  public String getStatus() {
-    return status;
-  }
-  public void setStatus(String status) {
-    this.status = status;
   }
 
   
@@ -297,7 +183,7 @@ public class APIDTO  {
   
   /**
    **/
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("isDefaultVersion")
   public Boolean getIsDefaultVersion() {
     return isDefaultVersion;
@@ -310,7 +196,7 @@ public class APIDTO  {
   /**
    * The transport to be set. Accepted values are HTTP, WS
    **/
-  @ApiModelProperty(required = true, value = "The transport to be set. Accepted values are HTTP, WS")
+  @ApiModelProperty(value = "The transport to be set. Accepted values are HTTP, WS")
   @JsonProperty("type")
   public TypeEnum getType() {
     return type;
@@ -323,7 +209,7 @@ public class APIDTO  {
   /**
    * Supported transports for the API (http and/or https).\n
    **/
-  @ApiModelProperty(required = true, value = "Supported transports for the API (http and/or https).\n")
+  @ApiModelProperty(value = "Supported transports for the API (http and/or https).\n")
   @JsonProperty("transport")
   public List<String> getTransport() {
     return transport;
@@ -349,7 +235,7 @@ public class APIDTO  {
   /**
    * The subscription tiers selected for the particular API
    **/
-  @ApiModelProperty(required = true, value = "The subscription tiers selected for the particular API")
+  @ApiModelProperty(value = "The subscription tiers selected for the particular API")
   @JsonProperty("tiers")
   public List<String> getTiers() {
     return tiers;
@@ -385,21 +271,9 @@ public class APIDTO  {
 
   
   /**
-   **/
-  @ApiModelProperty(value = "")
-  @JsonProperty("thumbnailUri")
-  public String getThumbnailUri() {
-    return thumbnailUri;
-  }
-  public void setThumbnailUri(String thumbnailUri) {
-    this.thumbnailUri = thumbnailUri;
-  }
-
-  
-  /**
    * The visibility level of the API. Accepts one of the following. PUBLIC, PRIVATE, RESTRICTED OR CONTROLLED.
    **/
-  @ApiModelProperty(required = true, value = "The visibility level of the API. Accepts one of the following. PUBLIC, PRIVATE, RESTRICTED OR CONTROLLED.")
+  @ApiModelProperty(value = "The visibility level of the API. Accepts one of the following. PUBLIC, PRIVATE, RESTRICTED OR CONTROLLED.")
   @JsonProperty("visibility")
   public VisibilityEnum getVisibility() {
     return visibility;
@@ -436,7 +310,7 @@ public class APIDTO  {
   
   /**
    **/
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("endpointConfig")
   public String getEndpointConfig() {
     return endpointConfig;
@@ -589,16 +463,9 @@ public class APIDTO  {
   public String toString()  {
     StringBuilder sb = new StringBuilder();
     sb.append("class APIDTO {\n");
-    
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  name: ").append(name).append("\n");
-    sb.append("  description: ").append(description).append("\n");
-    sb.append("  context: ").append(context).append("\n");
-    sb.append("  version: ").append(version).append("\n");
-    sb.append("  provider: ").append(provider).append("\n");
+    sb.append("  " + super.toString()).append("\n");
     sb.append("  apiDefinition: ").append(apiDefinition).append("\n");
     sb.append("  wsdlUri: ").append(wsdlUri).append("\n");
-    sb.append("  status: ").append(status).append("\n");
     sb.append("  responseCaching: ").append(responseCaching).append("\n");
     sb.append("  cacheTimeout: ").append(cacheTimeout).append("\n");
     sb.append("  destinationStatsEnabled: ").append(destinationStatsEnabled).append("\n");
@@ -609,7 +476,6 @@ public class APIDTO  {
     sb.append("  tiers: ").append(tiers).append("\n");
     sb.append("  apiLevelPolicy: ").append(apiLevelPolicy).append("\n");
     sb.append("  maxTps: ").append(maxTps).append("\n");
-    sb.append("  thumbnailUri: ").append(thumbnailUri).append("\n");
     sb.append("  visibility: ").append(visibility).append("\n");
     sb.append("  visibleRoles: ").append(visibleRoles).append("\n");
     sb.append("  visibleTenants: ").append(visibleTenants).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APIEndpointSecurityDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APIEndpointSecurityDTO.java
@@ -14,9 +14,6 @@ import javax.validation.constraints.NotNull;
 public class APIEndpointSecurityDTO  {
   
   
-  
-  private String password = null;
-  
   public enum TypeEnum {
      basic,  digest, 
   };
@@ -25,18 +22,9 @@ public class APIEndpointSecurityDTO  {
   
   
   private String username = null;
-
   
-  /**
-   **/
-  @ApiModelProperty(value = "")
-  @JsonProperty("password")
-  public String getPassword() {
-    return password;
-  }
-  public void setPassword(String password) {
-    this.password = password;
-  }
+  
+  private String password = null;
 
   
   /**
@@ -64,15 +52,27 @@ public class APIEndpointSecurityDTO  {
   }
 
   
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("password")
+  public String getPassword() {
+    return password;
+  }
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  
 
   @Override
   public String toString()  {
     StringBuilder sb = new StringBuilder();
     sb.append("class APIEndpointSecurityDTO {\n");
     
-    sb.append("  password: ").append(password).append("\n");
     sb.append("  type: ").append(type).append("\n");
     sb.append("  username: ").append(username).append("\n");
+    sb.append("  password: ").append(password).append("\n");
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APIInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APIInfoDTO.java
@@ -40,8 +40,9 @@ public class APIInfoDTO  {
 
   
   /**
+   * UUID of the api registry artifact\n
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "UUID of the api registry artifact\n")
   @JsonProperty("id")
   public String getId() {
     return id;
@@ -52,8 +53,9 @@ public class APIInfoDTO  {
 
   
   /**
+   * Name of the API
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "Name of the API")
   @JsonProperty("name")
   public String getName() {
     return name;
@@ -64,8 +66,9 @@ public class APIInfoDTO  {
 
   
   /**
+   * A brief description about the API
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "A brief description about the API")
   @JsonProperty("description")
   public String getDescription() {
     return description;
@@ -76,8 +79,9 @@ public class APIInfoDTO  {
 
   
   /**
+   * A string that represents the context of the user's request
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "A string that represents the context of the user's request")
   @JsonProperty("context")
   public String getContext() {
     return context;
@@ -88,8 +92,9 @@ public class APIInfoDTO  {
 
   
   /**
+   * The version of the API
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "The version of the API")
   @JsonProperty("version")
   public String getVersion() {
     return version;
@@ -113,8 +118,9 @@ public class APIInfoDTO  {
 
   
   /**
+   * This describes in which status of the lifecycle the API is
    **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "This describes in which status of the lifecycle the API is")
   @JsonProperty("status")
   public String getStatus() {
     return status;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/mappings/APIMappingUtil.java
@@ -261,7 +261,7 @@ public class APIMappingUtil {
             dto.setType(APIDTO.TypeEnum.valueOf(model.getType()));
         }
 
-        if (!model.getType().equals(APIConstants.APIType.WS)) {
+        if (!APIConstants.APIType.WS.equals(model.getType())) {
             dto.setTransport(Arrays.asList(model.getTransports().split(",")));
         }
         dto.setVisibility(mapVisibilityFromAPItoDTO(model.getVisibility()));
@@ -577,14 +577,19 @@ public class APIMappingUtil {
      * Converts a List object of APIs into a DTO
      *
      * @param apiList List of APIs
+     * @param expand defines whether APIListDTO should contain APIINFODTOs or APIDTOs
      * @return APIListDTO object containing APIDTOs
      */
-    public static APIListDTO fromAPIListToDTO(List<API> apiList) {
+    public static APIListDTO fromAPIListToDTO(List<API> apiList, boolean expand) throws APIManagementException {
         APIListDTO apiListDTO = new APIListDTO();
         List<APIInfoDTO> apiInfoDTOs = apiListDTO.getList();
-        if (apiList != null) {
+        if (apiList != null && !expand) {
             for (API api : apiList) {
                 apiInfoDTOs.add(fromAPIToInfoDTO(api));
+            }
+        } else if (apiList != null && expand) {
+            for (API api : apiList) {
+                apiInfoDTOs.add(fromAPItoDTO(api));
             }
         }
         apiListDTO.setCount(apiInfoDTOs.size());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml
@@ -3657,6 +3657,9 @@ definitions:
         type: string
         example: "Approve workflow request."
 
+#-----------------------------------------------------
+# API maxTPs resource
+#-----------------------------------------------------
   APIMaxTps:
     properties:
       production:
@@ -3668,6 +3671,9 @@ definitions:
         format: int64
         example: 1000
 
+#-----------------------------------------------------
+# API Endpoint Security resource
+#-----------------------------------------------------
   APIEndpointSecurity:
     properties:
       type:
@@ -3684,6 +3690,9 @@ definitions:
         type: string
         example: password
 
+#-----------------------------------------------------
+# API Business Information resource
+#-----------------------------------------------------
   APIBusinessInformation:
     properties:
       businessOwner:
@@ -3699,6 +3708,9 @@ definitions:
         type: string
         example: technicalowner@wso2.com
 
+#-----------------------------------------------------
+# API CORS configuration resource
+#-----------------------------------------------------
   APICorsConfiguration:
     description: |
       CORS configuration for the API

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml
@@ -105,6 +105,9 @@ paths:
 #-----------------------------------------------------
     get:
       x-scope: apim:api_view
+      produces:
+        - application/json
+        - application/gzip
       x-wso2-curl: "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/publisher/v0.12/apis"
       x-wso2-request: |
         GET https://localhost:9443/api/am/publisher/v0.12/apis
@@ -143,6 +146,7 @@ paths:
           type: string
         - $ref : "#/parameters/Accept"
         - $ref : "#/parameters/If-None-Match"
+        - $ref : "#/parameters/expand"
       tags:
         - API (Collection)
       responses:
@@ -2832,6 +2836,14 @@ parameters:
     required: true
     type: string
 
+# Specifies whether full details of APIs should be returned on apisGet call
+  expand:
+    name: expand
+    in: query
+    description: |
+      Whether the returned response should contain full details of API
+    type: boolean
+
 ######################################################
 # The resources used by some of the APIs above within the message body
 ######################################################
@@ -2884,49 +2896,6 @@ definitions:
     properties:
       id:
         type: string
-        example: 01234567-0123-0123-0123-012345678901
-      name:
-        type: string
-        example: CalculatorAPI
-      description:
-        type: string
-        example: A calculator API that supports basic operations
-      context:
-        type: string
-        example: CalculatorAPI
-      version:
-        type: string
-        example: 1.0.0
-      provider:
-        description: |
-          If the provider value is not given, the user invoking the API will be used as the provider.
-        type: string
-        example: admin
-      status:
-        type: string
-        example: CREATED
-      thumbnailUri:
-        type: string
-        example: /apis/01234567-0123-0123-0123-012345678901/thumbnail
-
-#-----------------------------------------------------
-# The API resource
-#-----------------------------------------------------
-  API:
-    title: API object
-    required:
-      - name
-      - context
-      - version
-      - tiers
-      - isDefaultVersion
-      - transport
-      - endpointConfig
-      - visibility
-      - type
-    properties:
-      id:
-        type: string
         description: |
           UUID of the api registry artifact
         example: 01234567-0123-0123-0123-012345678901
@@ -2948,207 +2917,173 @@ definitions:
         example: 1.0.0
       provider:
         description: |
-          If the provider value is not given user invoking the api will be used as the provider.
+          If the provider value is not given, the user invoking the API will be used as the provider.
         type: string
         example: admin
-      apiDefinition:
-        description: |
-          Swagger definition of the API which contains details about URI templates and scopes
-        type: string
-        example: "{\"paths\":{\"/substract\":{\"get\":{\"x-auth-type\":\"Application & Application User\",\"x-throttling-tier\":\"Unlimited\",\"parameters\":[{\"name\":\"x\",\"required\":true,\"type\":\"string\",\"in\":\"query\"},{\"name\":\"y\",\"required\":true,\"type\":\"string\",\"in\":\"query\"}],\"responses\":{\"200\":{}}}},\"/add\":{\"get\":{\"x-auth-type\":\"Application & Application User\",\"x-throttling-tier\":\"Unlimited\",\"parameters\":[{\"name\":\"x\",\"required\":true,\"type\":\"string\",\"in\":\"query\"},{\"name\":\"y\",\"required\":true,\"type\":\"string\",\"in\":\"query\"}],\"responses\":{\"200\":{}}}}},\"swagger\":\"2.0\",\"info\":{\"title\":\"CalculatorAPI\",\"version\":\"1.0.0\"}}"
-      wsdlUri:
-        description: |
-          WSDL URL if the API is based on a WSDL endpoint
-        type: string
-        example: "http://www.webservicex.com/globalweather.asmx?wsdl"
       status:
         type: string
         description: This describes in which status of the lifecycle the API is
         example: CREATED
-      responseCaching:
-        type: string
-        example: Disabled
-      cacheTimeout:
-        type: integer
-        example: 300
-      destinationStatsEnabled:
-        type: string
-        example: Disabled
-      isDefaultVersion:
-        type: boolean
-        example: false
-      type:
-        type: string
-        description: The transport to be set. Accepted values are HTTP, WS
-        enum:
-          - HTTP
-          - WS
-        example: HTTP
-        default: HTTP
-      transport:
-        description: |
-          Supported transports for the API (http and/or https).
-        type: array
-        items:
-          type: string
-        example: ["http","https"]
-      tags:
-        type: array
-        description: Search keywords related to the API
-        items:
-          type: string
-        example: ["substract","add"]
-      tiers:
-        type: array
-        description: The subscription tiers selected for the particular API
-        items:
-          type: string
-        example: ["Unlimited"]
-      apiLevelPolicy:
-        description: The policy selected for the particular API
-        type: string
-        example: "Unlimited"
-      maxTps:
-        properties:
-          production:
-            type: integer
-            format: int64
-            example: 1000
-          sandbox:
-            type: integer
-            format: int64
-            example: 1000
       thumbnailUri:
         type: string
-        example: "/apis/01234567-0123-0123-0123-012345678901/thumbnail"
-      visibility:
-        type: string
-        description: The visibility level of the API. Accepts one of the following. PUBLIC, PRIVATE, RESTRICTED OR CONTROLLED.
-        enum:
-          - PUBLIC
-          - PRIVATE
-          - RESTRICTED
-          - CONTROLLED
-        example: PUBLIC
-      visibleRoles:
-        type: array
-        description: The user roles that are able to access the API
-        items:
-          type: string
-        example: []
-      visibleTenants:
-        type: array
-        items:
-          type: string
-      endpointConfig:
-        type: string
-        example: "{\"production_endpoints\":{\"url\":\"https://localhost:9443/am/sample/pizzashack/v1/api/\",\"config\":{\"suspendErrorCode\":\"101000\",\"suspendDuration\":\"2000\",\"suspendMaxDuration\":\"3\",\"factor\":\"2\",\"retryErroCode\":\"101000\",\"retryTimeOut\":\"4\",\"retryDelay\":\"1000\",\"actionSelect\":\"fault\",\"actionDuration\":\"3000\"}},\"sandbox_endpoints\":{\"url\":\"https://localhost:9443/am/sample/pizzashack/v1/api/\",\"config\":null},\"endpoint_type\":\"http\"}"
-      endpointSecurity:
-        properties:
+        example: /apis/01234567-0123-0123-0123-012345678901/thumbnail
+
+#-----------------------------------------------------
+# The API resource
+#-----------------------------------------------------
+  API:
+    title: API object
+    required:
+      - name
+      - context
+      - version
+      - tiers
+      - isDefaultVersion
+      - transport
+      - endpointConfig
+      - visibility
+      - type
+    allOf:
+      - $ref: '#/definitions/APIInfo'
+      - properties:
+          apiDefinition:
+            description: |
+              Swagger definition of the API which contains details about URI templates and scopes
+            type: string
+            example: "{\"paths\":{\"/substract\":{\"get\":{\"x-auth-type\":\"Application & Application User\",\"x-throttling-tier\":\"Unlimited\",\"parameters\":[{\"name\":\"x\",\"required\":true,\"type\":\"string\",\"in\":\"query\"},{\"name\":\"y\",\"required\":true,\"type\":\"string\",\"in\":\"query\"}],\"responses\":{\"200\":{}}}},\"/add\":{\"get\":{\"x-auth-type\":\"Application & Application User\",\"x-throttling-tier\":\"Unlimited\",\"parameters\":[{\"name\":\"x\",\"required\":true,\"type\":\"string\",\"in\":\"query\"},{\"name\":\"y\",\"required\":true,\"type\":\"string\",\"in\":\"query\"}],\"responses\":{\"200\":{}}}}},\"swagger\":\"2.0\",\"info\":{\"title\":\"CalculatorAPI\",\"version\":\"1.0.0\"}}"
+          wsdlUri:
+            description: |
+              WSDL URL if the API is based on a WSDL endpoint
+            type: string
+            example: "http://www.webservicex.com/globalweather.asmx?wsdl"
+          responseCaching:
+            type: string
+            example: Disabled
+          cacheTimeout:
+            type: integer
+            example: 300
+          destinationStatsEnabled:
+            type: string
+            example: Disabled
+          isDefaultVersion:
+            type: boolean
+            example: false
           type:
             type: string
-            example: basic
-            description: Accepts one of the following, basic or digest.
+            description: The transport to be set. Accepted values are HTTP, WS
             enum:
-              - basic
-              - digest
-          username:
-            type: string
-            example: admin
-          password:
-            type: string
-            example: password
-      gatewayEnvironments:
-        description: |
-          Comma separated list of gateway environments.
-        type: string
-        example: Production and Sandbox
-      labels:
-        description: |
-          Labels of micro-gateway environments attached to the API.
-        type: array
-        items:
-          $ref: '#/definitions/Label'
-      sequences:
-        type: array
-        items:
-          $ref: '#/definitions/Sequence'
-        example: "\"sequences\":
-        [
-          {\"name\": \"json_to_xml_in_message\",\"config\": null,\"type\": \"in\"},
-          {\"name\": \"xml_to_json_out_message\",\"config\": null,\"type\": \"out\"},
-          {\"name\": \"json_fault\",\"config\": null,\"type\": \"fault\"}
-        ],"
-      subscriptionAvailability:
-        type: string
-        description: The subscription availability. Accepts one of the following. current_tenant, all_tenants or specific_tenants.
-        enum:
-          - current_tenant
-          - all_tenants
-          - specific_tenants
-        example: current_tenant
-      subscriptionAvailableTenants:
-        type: array
-        items:
-          type: string
-        example: ["tenant1", "tenant2"]
-      additionalProperties:
-        type: object
-        additionalProperties:
-            type: string
-        description : Map of custom properties of API
-      accessControl:
-        type: string
-        description: |
-          Is the API is restricted to certain set of publishers or creators or is it visible to all the
-          publishers and creators. If the accessControl restriction is none, this API can be modified by all the
-          publishers and creators, if not it can only be viewable/modifiable by certain set of publishers and creators,
-           based on the restriction.
-        enum:
-          - NONE
-          - RESTRICTED
-      accessControlRoles:
-            type: array
-            description: The user roles that are able to view/modify as API publisher or creator.
-            items:
-              type: string
-            example: [admin]
-      businessInformation:
-        properties:
-          businessOwner:
-            type: string
-            example: businessowner
-          businessOwnerEmail:
-            type: string
-            example: businessowner@wso2.com
-          technicalOwner:
-            type: string
-            example: technicalowner
-          technicalOwnerEmail:
-            type: string
-            example: technicalowner@wso2.com
-      corsConfiguration:
-        description: |
-          CORS configuration for the API
-        properties:
-          corsConfigurationEnabled:
-            type: boolean
-            default: false
-          accessControlAllowOrigins:
-            type: array
-            items:
-               type: string
-          accessControlAllowCredentials:
-            type: boolean
-            default: false
-          accessControlAllowHeaders:
+              - HTTP
+              - WS
+            example: HTTP
+            default: HTTP
+          transport:
+            description: |
+              Supported transports for the API (http and/or https).
             type: array
             items:
               type: string
-          accessControlAllowMethods:
+            example: ["http","https"]
+          tags:
+            type: array
+            description: Search keywords related to the API
+            items:
+              type: string
+            example: ["substract","add"]
+          tiers:
+            type: array
+            description: The subscription tiers selected for the particular API
+            items:
+              type: string
+            example: ["Unlimited"]
+          apiLevelPolicy:
+            description: The policy selected for the particular API
+            type: string
+            example: "Unlimited"
+          maxTps:
+            $ref: '#/definitions/APIMaxTps'
+          visibility:
+            type: string
+            description: The visibility level of the API. Accepts one of the following. PUBLIC, PRIVATE, RESTRICTED OR CONTROLLED.
+            enum:
+              - PUBLIC
+              - PRIVATE
+              - RESTRICTED
+              - CONTROLLED
+            example: PUBLIC
+          visibleRoles:
+            type: array
+            description: The user roles that are able to access the API
+            items:
+              type: string
+            example: []
+          visibleTenants:
             type: array
             items:
               type: string
+          endpointConfig:
+            type: string
+            example: "{\"production_endpoints\":{\"url\":\"https://localhost:9443/am/sample/pizzashack/v1/api/\",\"config\":{\"suspendErrorCode\":\"101000\",\"suspendDuration\":\"2000\",\"suspendMaxDuration\":\"3\",\"factor\":\"2\",\"retryErroCode\":\"101000\",\"retryTimeOut\":\"4\",\"retryDelay\":\"1000\",\"actionSelect\":\"fault\",\"actionDuration\":\"3000\"}},\"sandbox_endpoints\":{\"url\":\"https://localhost:9443/am/sample/pizzashack/v1/api/\",\"config\":null},\"endpoint_type\":\"http\"}"
+          endpointSecurity:
+            $ref: '#/definitions/APIEndpointSecurity'
+          gatewayEnvironments:
+            description: |
+              Comma separated list of gateway environments.
+            type: string
+            example: Production and Sandbox
+          labels:
+            description: |
+              Labels of micro-gateway environments attached to the API.
+            type: array
+            items:
+              $ref: '#/definitions/Label'
+          sequences:
+            type: array
+            items:
+              $ref: '#/definitions/Sequence'
+            example: "\"sequences\":
+            [
+              {\"name\": \"json_to_xml_in_message\",\"config\": null,\"type\": \"in\"},
+              {\"name\": \"xml_to_json_out_message\",\"config\": null,\"type\": \"out\"},
+              {\"name\": \"json_fault\",\"config\": null,\"type\": \"fault\"}
+            ],"
+          subscriptionAvailability:
+            type: string
+            description: The subscription availability. Accepts one of the following. current_tenant, all_tenants or specific_tenants.
+            enum:
+              - current_tenant
+              - all_tenants
+              - specific_tenants
+            example: current_tenant
+          subscriptionAvailableTenants:
+            type: array
+            items:
+              type: string
+            example: ["tenant1", "tenant2"]
+          additionalProperties:
+            type: object
+            additionalProperties:
+                type: string
+            description : Map of custom properties of API
+          accessControl:
+            type: string
+            description: |
+              Is the API is restricted to certain set of publishers or creators or is it visible to all the
+              publishers and creators. If the accessControl restriction is none, this API can be modified by all the
+              publishers and creators, if not it can only be viewable/modifiable by certain set of publishers and creators,
+               based on the restriction.
+            enum:
+              - NONE
+              - RESTRICTED
+          accessControlRoles:
+                type: array
+                description: The user roles that are able to view/modify as API publisher or creator.
+                items:
+                  type: string
+                example: [admin]
+          businessInformation:
+            $ref: '#/definitions/APIBusinessInformation'
+          corsConfiguration:
+            $ref: '#/definitions/APICorsConfiguration'
 
 #-----------------------------------------------------
 # The Application resource
@@ -3721,3 +3656,68 @@ definitions:
       description:
         type: string
         example: "Approve workflow request."
+
+  APIMaxTps:
+    properties:
+      production:
+        type: integer
+        format: int64
+        example: 1000
+      sandbox:
+        type: integer
+        format: int64
+        example: 1000
+
+  APIEndpointSecurity:
+    properties:
+      type:
+        type: string
+        example: basic
+        description: Accepts one of the following, basic or digest.
+        enum:
+          - basic
+          - digest
+      username:
+        type: string
+        example: admin
+      password:
+        type: string
+        example: password
+
+  APIBusinessInformation:
+    properties:
+      businessOwner:
+        type: string
+        example: businessowner
+      businessOwnerEmail:
+        type: string
+        example: businessowner@wso2.com
+      technicalOwner:
+        type: string
+        example: technicalowner
+      technicalOwnerEmail:
+        type: string
+        example: technicalowner@wso2.com
+
+  APICorsConfiguration:
+    description: |
+      CORS configuration for the API
+    properties:
+      corsConfigurationEnabled:
+        type: boolean
+        default: false
+      accessControlAllowOrigins:
+        type: array
+        items:
+           type: string
+      accessControlAllowCredentials:
+        type: boolean
+        default: false
+      accessControlAllowHeaders:
+        type: array
+        items:
+          type: string
+      accessControlAllowMethods:
+        type: array
+        items:
+          type: string


### PR DESCRIPTION
### Proposed changes in this pull request

This PR contains publisher REST api changes to support api search by labelName attribute.

Other modifications to /apis GET resource

1. a parameter ‘expand’  was introduced to specify whether the returned response should contain APIDTOs or APIInfoDTOs.
Expand, true → APIDTO 
* APIDTO should be changed to APIDetailDTO, that change is not included in this PR for the moment.

2. added support for “Accept: application/gzip” header

sample curl to retrive API details of APIs under label1 as a gzip.

curl -k -H "Authorization: Bearer <access_token>" “https://localhost:9443/api/am/publisher/v0.12/apis?query=labelName:label1&expand=true” -H “Accept: application/gzip” > test.json.gz
