### PR TITLE
Removed swagger2cxf-maven-plugin from rest.apit.store.pom.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/pom.xml
@@ -182,15 +182,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.wso2.maven.plugins</groupId>
-                <artifactId>swagger2cxf-maven-plugin</artifactId>
-                <version>1.0-SNAPSHOT</version>
-                <configuration>
-                    <inputSpec>${project.basedir}/src/main/resources/store-api.yaml</inputSpec>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
### Proposed changes in this pull request

Removed swagger2cxf-maven-plugin from rest.apit.store.pom.
