### PR TITLE
Fix version parameter in the event streams

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtFaultHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtFaultHandler.java
@@ -56,7 +56,7 @@ public class APIMgtFaultHandler extends APIMgtCommonExecutionPublisher {
             faultPublisherDTO.setApiContext((String) messageContext.getProperty(
                     APIMgtGatewayConstants.CONTEXT));
             faultPublisherDTO.setApiVersion(((String) messageContext.getProperty(
-                    APIMgtGatewayConstants.API_VERSION)).split(":")[1]);
+                    APIMgtGatewayConstants.API_VERSION)).split(":v")[1]);
             faultPublisherDTO.setApiName((String) messageContext.getProperty(
                     APIMgtGatewayConstants.API));
             faultPublisherDTO.setApiResourcePath((String) messageContext.getProperty(

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtResponseHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtResponseHandler.java
@@ -141,7 +141,7 @@ public class APIMgtResponseHandler extends APIMgtCommonExecutionPublisher {
                 creator = APIUtil.getAPIProviderFromRESTAPI(apiVersion, tenantDomain);
             }
             //get the version
-            apiVersion = apiVersion.split(":")[1];
+            apiVersion = apiVersion.split(":v")[1];
             String url = (String) mc.getProperty(RESTConstants.REST_URL_PREFIX);
 
             URL apiurl = new URL(url);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtThrottleUsageHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtThrottleUsageHandler.java
@@ -77,7 +77,7 @@ public class APIMgtThrottleUsageHandler extends APIMgtCommonExecutionPublisher {
                 throttlePublisherDTO.setApiname((String) messageContext.getProperty(
                         APIMgtGatewayConstants.API));
                 throttlePublisherDTO.setVersion(
-                        ((String) messageContext.getProperty(RESTConstants.SYNAPSE_REST_API)).split(":")[1]);
+                        ((String) messageContext.getProperty(RESTConstants.SYNAPSE_REST_API)).split(":v")[1]);
                 throttlePublisherDTO.setContext((String) messageContext.getProperty(
                         APIMgtGatewayConstants.CONTEXT));
                 throttlePublisherDTO.setApiCreator((String) messageContext.getProperty(


### PR DESCRIPTION
remove unnecessary parameter from the version value.  Version is extracted from synapse file. it is retrieved as `<apiprovider>--<apiname>:v<verison>` . modified the split character to get the exact version