### PR TITLE
[APIM3 Publisher] Add global search capability

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/public/locales/en.json
@@ -4,9 +4,9 @@
   "create.new.api": "Create New API",
   "deploy.sample.api": "Deploy Sample API",
   "i.have.an.existing.api": "I Have an Existing API",
-  "use.an.existing.api.endpoint.or.the.api.swagger.definition.to.create.an.api" : "Use an existing API endpoint or the API Swagger definition to create an API",
-  "i.have.a.soap.endpoint" : "I Have a SOAP Endpoint",
-  "use.an.existing.soap.endpoint.to.create.a.managed.api.import.the.wsdl.of.the.soap.service" : "Use an existing SOAP endpoint to create a managed API. Import the WSDL of the SOAP service",
+  "use.an.existing.api.endpoint.or.the.api.swagger.definition.to.create.an.api": "Use an existing API endpoint or the API Swagger definition to create an API",
+  "i.have.a.soap.endpoint": "I Have a SOAP Endpoint",
+  "use.an.existing.soap.endpoint.to.create.a.managed.api.import.the.wsdl.of.the.soap.service": "Use an existing SOAP endpoint to create a managed API. Import the WSDL of the SOAP service",
   "designa.a.new.rest.api": "Design a New REST API",
   "design.and.prototype.a.new.rest.api": "Design and prototype a new REST API",
   "design.new.websocket.api": "Design New Websocket API",
@@ -18,5 +18,9 @@
   "service.url": "Service URL",
   "timeout": "Timeout",
   "max.tps": "Max TPS",
-  "endpoint.type": "Endpoint Type"
+  "endpoint.type": "Endpoint Type",
+  "create.an.api": "Create an API",
+  "by": "by",
+  "context": "context",
+  "version": "version"
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/APIsNavigation.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/APIsNavigation.jsx
@@ -11,8 +11,8 @@ import NavItem from '../Base/container/navigation/NavItem';
  */
 const NavBar = () => {
     const items = [{ name: 'Alerts', linkTo: '/alerts', NavIcon: <AlertsIcon /> }];
-    const section = <NavItem name='APIs' NavIcon={<APIsIcon />} />;
-    const navItems = items.map(item => <NavItem {...item} />);
+    const navItems = items.map(item => <NavItem key={item.name} {...item} />);
+    const section = <NavItem name='APIs' linkTo='/apis' NavIcon={<APIsIcon />} />;
     return <PageNav section={section} navItems={navItems} />;
 };
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/CardView/CardView.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/CardView/CardView.jsx
@@ -8,14 +8,14 @@ const CardView = ({ apis, updateAPIsList }) => {
     return (
         <Grid container justify='flex-start' spacing={8}>
             {apis.list.map((api) => {
-                return <ApiThumb updateAPIsList={updateAPIsList} api={api} />;
+                return <ApiThumb key={api.id} updateAPIsList={updateAPIsList} api={api} />;
             })}
         </Grid>
     );
 };
 
 CardView.propTypes = {
-    apis: PropTypes.arrayOf(PropTypes.object).isRequired,
+    apis: PropTypes.shape({ list: PropTypes.array, count: PropTypes.number }).isRequired,
     updateAPIsList: PropTypes.func.isRequired,
 };
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Listing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Listing.jsx
@@ -164,8 +164,6 @@ class Listing extends React.Component {
 }
 
 Listing.propTypes = {
-    classes: PropTypes.shape({}).isRequired,
-    theme: PropTypes.shape({}).isRequired,
     history: PropTypes.shape({
         push: PropTypes.func,
     }).isRequired,

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/TableView/TableView.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/TableView/TableView.jsx
@@ -57,14 +57,13 @@ function createData(name, calories, fat, carbs, protein) {
 
 /**
  * Table view of the API listing
- *
- * @class TableView
- * @extends {React.Component}
+ * @class TableView @inheritdoc
+ * @extends {React.Component} @inheritdoc
  */
 class TableView extends React.Component {
     /**
      *Creates an instance of TableView.
-     * @param {*} props
+     * @param {Object} props @inheritdoc
      * @memberof TableView
      */
     constructor(props) {
@@ -81,6 +80,8 @@ class TableView extends React.Component {
         this.handleSelectAnAPI = this.handleSelectAnAPI.bind(this);
         this.handleSelectAllClick = this.handleSelectAllClick.bind(this);
         this.handleDeleteAPIs = this.handleDeleteAPIs.bind(this);
+        this.handleChangePage = this.handleChangePage.bind(this);
+        this.handleChangeRowsPerPage = this.handleChangeRowsPerPage.bind(this);
     }
 
     handleRequestSort = (event, property) => {
@@ -111,8 +112,8 @@ class TableView extends React.Component {
 
     /**
      *
-     *
-     * @param {*} event
+     * Handle onClick event of checkbox for single API (One row in the APIs listing table view)
+     * @param {React.SyntheticEvent} event onClick event
      * @memberof TableView
      */
     handleSelectAnAPI(event) {
@@ -134,17 +135,32 @@ class TableView extends React.Component {
         this.setState({ selected: newSelected });
     }
 
-    handleChangePage = (event, page) => {
+    /**
+     * Provide implementation for Material UI standard TablePagination callback prop
+     * Switch to the next/previous page from the current page according to the passed page number
+     *
+     * @param {React.SyntheticEvent} event
+     * @param {Number} page Next/Previous page number
+     * @memberof TableView
+     */
+    handleChangePage(event, page) {
         this.setState({ page });
-    };
-
-    handleChangeRowsPerPage = (event) => {
-        this.setState({ rowsPerPage: event.target.value });
-    };
+    }
 
     /**
      *
-     * Delete API in selected list
+     * Provide implementation for Material UI standard TablePagination callback prop
+     * Change the number of rows(APIs) shown in single page
+     * @param {React.SyntheticEvent} event Synthetic event for number of rows dropdown menu
+     * @memberof TableView
+     */
+    handleChangeRowsPerPage(event) {
+        this.setState({ rowsPerPage: event.target.value });
+    }
+
+    /**
+     *
+     * Delete API in `selected` list
      * @memberof TableView
      */
     handleDeleteAPIs() {
@@ -233,15 +249,14 @@ class TableView extends React.Component {
                                             <TableCell onClick={this.handleSelectAnAPI} id={id} padding='checkbox'>
                                                 <Checkbox checked={isSelected} />
                                             </TableCell>
-                                            <Link to={overviewPath} style={{ display: 'contents' }}>
-                                                <TableCell component='th' scope='row' padding='none'>
-                                                    {api.name}
-                                                </TableCell>
-                                                <TableCell numeric>{api.version}</TableCell>
-                                                <TableCell numeric>{api.context}</TableCell>
-                                                <TableCell numeric>{Math.floor(Math.random() * 20)}</TableCell>
-                                                <TableCell numeric>{api.provider}</TableCell>
-                                            </Link>
+
+                                            <TableCell component='th' scope='row' padding='none'>
+                                                <Link to={overviewPath}>{api.name}</Link>
+                                            </TableCell>
+                                            <TableCell numeric>{api.version}</TableCell>
+                                            <TableCell numeric>{api.context}</TableCell>
+                                            <TableCell numeric>{Math.floor(Math.random() * 20)}</TableCell>
+                                            <TableCell numeric>{api.provider}</TableCell>
                                         </TableRow>
                                     );
                                 })}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/components/ApiThumb.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/components/ApiThumb.jsx
@@ -110,7 +110,7 @@ class APIThumb extends Component {
                     component={ImageGenerator}
                     height='140'
                     title='Contemplative Reptile'
-                    name={api.name}
+                    apiName={api.name}
                     id={api.id}
                 />
                 <CardContent className={classes.apiDetails}>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/components/ImageGenerator.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/components/ImageGenerator.jsx
@@ -30,8 +30,8 @@ class ImageGenerator extends PureComponent {
      * @memberof ImageGenerator
      */
     render() {
-        const { classes, name, id } = this.props;
-        const str = name;
+        const { classes, apiName, id } = this.props;
+        const str = apiName;
         const overviewPath = `apis/${id}/overview`;
 
         const colorPairs = [

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/components/TopMenu.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/components/TopMenu.jsx
@@ -5,6 +5,7 @@ import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/icons/List';
 import GridIcon from '@material-ui/icons/GridOn';
 import { withStyles } from '@material-ui/core/styles';
+import { FormattedMessage } from 'react-intl';
 
 import APICreateMenu from '../components/APICreateMenu';
 
@@ -42,7 +43,7 @@ const TopMenu = ({ classes, isCardView, toggleView }) => {
                     </Typography>
                 </div>
                 <APICreateMenu buttonProps={{ size: 'medium', color: 'secondary', variant: 'contained' }}>
-                    Create API
+                    <FormattedMessage id='create.an.api' defaultMessage='Create API' />
                 </APICreateMenu>
             </div>
             <div className={classes.buttonRight}>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/headersearch/searchUtils.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/headersearch/searchUtils.jsx
@@ -2,48 +2,23 @@ import React from 'react';
 import match from 'autosuggest-highlight/match';
 import parse from 'autosuggest-highlight/parse';
 import TextField from '@material-ui/core/TextField';
-import Paper from '@material-ui/core/Paper';
 import MenuItem from '@material-ui/core/MenuItem';
+import Divider from '@material-ui/core/Divider';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import SearchOutlined from '@material-ui/icons/SearchOutlined';
+import { Link } from 'react-router-dom';
+import APIsIcon from '@material-ui/icons/SettingsApplicationsOutlined';
 
-const suggestions = [
-    { label: 'Afghanistan' },
-    { label: 'Aland Islands' },
-    { label: 'Albania' },
-    { label: 'Algeria' },
-    { label: 'American Samoa' },
-    { label: 'Andorra' },
-    { label: 'Angola' },
-    { label: 'Anguilla' },
-    { label: 'Antarctica' },
-    { label: 'Antigua and Barbuda' },
-    { label: 'Argentina' },
-    { label: 'Armenia' },
-    { label: 'Aruba' },
-    { label: 'Australia' },
-    { label: 'Austria' },
-    { label: 'Azerbaijan' },
-    { label: 'Bahamas' },
-    { label: 'Bahrain' },
-    { label: 'Bangladesh' },
-    { label: 'Barbados' },
-    { label: 'Belarus' },
-    { label: 'Belgium' },
-    { label: 'Belize' },
-    { label: 'Benin' },
-    { label: 'Bermuda' },
-    { label: 'Bhutan' },
-    { label: 'Bolivia, Plurinational State of' },
-    { label: 'Bonaire, Sint Eustatius and Saba' },
-    { label: 'Bosnia and Herzegovina' },
-    { label: 'Botswana' },
-    { label: 'Bouvet Island' },
-    { label: 'Brazil' },
-    { label: 'British Indian Ocean Territory' },
-    { label: 'Brunei Darussalam' },
-];
+import API from '../../../../data/api';
+/* Utility methods defined here are described in
+* react-autosuggest documentation https://github.com/moroshko/react-autosuggest
+*/
 
+/**
+ *
+ * @param {Object} inputProps Props given for the underline input element
+ * @returns {React.Component} @inheritdoc
+ */
 function renderInput(inputProps) {
     const { classes, ref, ...other } = inputProps;
     return (
@@ -63,59 +38,63 @@ function renderInput(inputProps) {
     );
 }
 
+/**
+ *
+ * Use your imagination to define how suggestions are rendered.
+ * @param {Object} suggestion This is an API object coming from APIS GET search API call
+ * @param {Object} { query, isHighlighted } query : User entered value
+ * @returns {React.Component} @inheritdoc
+ */
 function renderSuggestion(suggestion, { query, isHighlighted }) {
-    const matches = match(suggestion.label, query);
-    const parts = parse(suggestion.label, matches);
-
+    const matches = match(suggestion.name, query);
+    const parts = parse(suggestion.name, matches);
+    const path = `/apis/${suggestion.id}/overview`;
     return (
-        <MenuItem selected={isHighlighted} component='div'>
-            <div>
-                {parts.map((part, index) => {
-                    return part.highlight ? (
-                        <span key={String(index)} style={{ fontWeight: 500 }}>
-                            {part.text}
-                        </span>
-                    ) : (
-                        <strong key={String(index)} style={{ fontWeight: 300 }}>
-                            {part.text}
-                        </strong>
-                    );
-                })}
-            </div>
-        </MenuItem>
+        <React.Fragment>
+            <Link to={path}>
+                <MenuItem selected={isHighlighted} component='div'>
+                    <APIsIcon />
+
+                    {parts.map((part, index) => {
+                        return part.highlight ? (
+                            <span key={String(index)} style={{ fontWeight: 500 }}>
+                                {part.text}
+                            </span>
+                        ) : (
+                            <strong key={String(index)} style={{ fontWeight: 300 }}>
+                                {part.text}
+                            </strong>
+                        );
+                    })}
+                </MenuItem>
+            </Link>
+            <Divider />
+        </React.Fragment>
     );
 }
 
-function renderSuggestionsContainer(options) {
-    const { containerProps, children } = options;
-
-    return (
-        <Paper {...containerProps} square>
-            {children}
-        </Paper>
-    );
-}
-
+/**
+ * When suggestion is clicked, Autosuggest needs to populate the input
+ * based on the clicked suggestion. Teach Autosuggest how to calculate the input value for every given suggestion.
+ *
+ * @param {Object} suggestion API Object returned from APIS search api.list[]
+ * @returns {String} API Name
+ */
 function getSuggestionValue(suggestion) {
-    return suggestion.label;
+    return suggestion.name;
 }
 
+/**
+ * Called for any input change to get the results set
+ *
+ * @param {String} value current value in input element
+ * @returns {Promise} If no input text, return a promise which resolve to empty array, else return the API.all response
+ */
 function getSuggestions(value) {
     const inputValue = value.trim().toLowerCase();
     const inputLength = inputValue.length;
-    let count = 0;
-
-    return inputLength === 0
-        ? []
-        : suggestions.filter((suggestion) => {
-            const keep = count < 5 && suggestion.label.toLowerCase().slice(0, inputLength) === inputValue;
-
-            if (keep) {
-                count += 1;
-            }
-
-            return keep;
-        });
+    const promisedAPIs = API.all({ query: { name: inputValue }, limit: 8 });
+    return inputLength === 0 ? new Promise(resolve => resolve([])) : promisedAPIs;
 }
 
-export { renderInput, renderSuggestion, renderSuggestionsContainer, getSuggestions, getSuggestionValue };
+export { renderInput, renderSuggestion, getSuggestions, getSuggestionValue };

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/container/navigation/NavItem.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/container/navigation/NavItem.jsx
@@ -3,11 +3,15 @@ import PropTypes from 'prop-types';
 import { ListItem, ListItemIcon, ListItemText, withStyles } from '@material-ui/core/';
 import { Link } from 'react-router-dom';
 
-const styles = () => {};
+const styles = () => ({
+    navLink: {
+        display: 'contents',
+    },
+});
 
 const NavItem = (props) => {
     const {
-        listItemProps, listItemTextProps, iconProps, ...other
+        listItemProps, listItemTextProps, iconProps, classes, ...other
     } = props;
     const {
         name, onClick, linkTo, NavIcon,
@@ -19,23 +23,30 @@ const NavItem = (props) => {
             <ListItemText {...listItemTextProps} primary={name} />
         </ListItem>
     );
-    return linkTo ? <Link to={linkTo}> {listItem} </Link> : listItem;
+    return linkTo ? (
+        <Link className={classes.navLink} to={linkTo}>
+            {' '}
+            {listItem}{' '}
+        </Link>
+    ) : (
+        listItem
+    );
 };
 
 NavItem.defaultProps = {
     listItemProps: {},
     listItemTextProps: {},
     iconProps: {},
-    onClick: {},
+    onClick: () => {},
     linkTo: undefined,
 };
 
 NavItem.propTypes = {
-    listItemProps: PropTypes.string,
-    listItemTextProps: PropTypes.string,
-    iconProps: PropTypes.string,
+    listItemProps: PropTypes.shape({}),
+    listItemTextProps: PropTypes.shape({}),
+    iconProps: PropTypes.shape({}),
     name: PropTypes.string.isRequired,
-    onClick: PropTypes.string,
+    onClick: PropTypes.func,
     linkTo: PropTypes.string,
     classes: PropTypes.shape({}).isRequired,
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/api.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/api.js
@@ -922,6 +922,13 @@ class API extends Resource {
      * @memberof API
      */
     static all(params) {
+        let query = "";
+        if (params && 'query' in params) {
+            for (const [key, value] of Object.entries(params.query)) {
+                query += `${key}:${value},`;
+            }
+            params.query = query;
+        }
         const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment()).client;
         return apiClient.then((client) => {
             return client.apis['API (Collection)'].get_apis(params, Resource._requestMetaData());


### PR DESCRIPTION
### Proposed changes in this pull request

- The users can search for APIs or Endpoint(TODO) from the top app bar search input

![api_search](https://user-images.githubusercontent.com/3313885/44721153-9a233a00-aae6-11e8-8cba-5a9d3d409d14.gif)


### Follow up actions

- Can't search endpoint using its name like it's possible with [APIs](https://github.com/wso2/carbon-apimgt/blob/master/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml#L92)
- Improve global endpoint search and use it to suggest global endpoints in App bar search

