### PR TITLE
Add datacenter id support though system property for analytics stats events

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtFaultHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtFaultHandler.java
@@ -73,8 +73,7 @@ public class APIMgtFaultHandler extends APIMgtCommonExecutionPublisher {
             faultPublisherDTO.setUsername((String) messageContext.getProperty(
                     APIMgtGatewayConstants.USER_ID));
             faultPublisherDTO.setUserTenantDomain(MultitenantUtils.getTenantDomain(faultPublisherDTO.getUsername()));
-            faultPublisherDTO.setHostname((String) messageContext.getProperty(
-                    APIMgtGatewayConstants.HOST_NAME));
+            faultPublisherDTO.setHostname(GatewayUtils.getHostName(messageContext));
             String apiPublisher = (String) messageContext.getProperty(
                     APIMgtGatewayConstants.API_PUBLISHER);
             if (apiPublisher == null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtResponseHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtResponseHandler.java
@@ -173,7 +173,7 @@ public class APIMgtResponseHandler extends APIMgtCommonExecutionPublisher {
 
             RequestResponseStreamDTO stream = new RequestResponseStreamDTO();
             stream.setApiContext((String) mc.getProperty(APIMgtGatewayConstants.CONTEXT));
-            stream.setApiHostname((String) mc.getProperty(APIMgtGatewayConstants.HOST_NAME));
+            stream.setApiHostname(GatewayUtils.getHostName(mc));
             stream.setApiMethod((String) mc.getProperty(APIMgtGatewayConstants.HTTP_METHOD));
             stream.setApiName((String) mc.getProperty(APIMgtGatewayConstants.API));
             stream.setApiCreatorTenantDomain(MultitenantUtils.getTenantDomain(creator));

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -37,12 +37,14 @@ import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.security.AuthenticationContext;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.threatprotection.utils.ThreatProtectorConstants;
+import org.wso2.carbon.apimgt.usage.publisher.DataPublisherUtil;
 import org.wso2.carbon.apimgt.usage.publisher.dto.ExecutionTimeDTO;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.mediation.registry.RegistryServiceHolder;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.session.UserRegistry;
+import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.InputStream;
@@ -418,5 +420,13 @@ public class GatewayUtils {
             resource = matcher.group(1);
         }
         return resource;
+    }
+    
+    public static String getHostName(org.apache.synapse.MessageContext messageContext) {
+        String hostname = DataPublisherUtil.getApiManagerAnalyticsConfiguration().getDatacenterId();
+        if (hostname == null) {
+            hostname = (String) messageContext.getProperty(APIMgtGatewayConstants.HOST_NAME);
+        }
+        return hostname;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerAnalyticsConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerAnalyticsConfiguration.java
@@ -48,6 +48,7 @@ public class APIManagerAnalyticsConfiguration {
     private String alertTypeStreamName;
     private String alertTypeStreamVersion;
     private boolean skipWorkFlowEventReceiverConnection;
+    private String datacenterId;
     
     private APIManagerAnalyticsConfiguration() {
     }
@@ -114,6 +115,7 @@ public class APIManagerAnalyticsConfiguration {
             dasServerPassword = config.getFirstProperty(APIConstants.API_USAGE_DAS_REST_API_PASSWORD);
             String build = config.getFirstProperty(APIConstants.API_USAGE_BUILD_MSG);
             buildMsg = build != null && JavaUtils.isTrueExplicitly(build);
+            datacenterId = System.getProperty("datacenterId");
         }
     }
 
@@ -244,4 +246,13 @@ public class APIManagerAnalyticsConfiguration {
     public boolean isSkipWorkFlowEventReceiverConnection() {
         return skipWorkFlowEventReceiverConnection;
     }
+
+    public String getDatacenterId() {
+        return datacenterId;
+    }
+
+    public void setDatacenterId(String datacenterId) {
+        this.datacenterId = datacenterId;
+    }
+    
 }


### PR DESCRIPTION
This supports providing a specific value to the hostname property in the gateway generated event. this would help to group events based on a specific group of hosts (say to identify requests handled all the gateways in a datacenter )

Following is the method to provide this value (as a system property)

`./wso2server.sh -DdatacenterId=datacenter1`