### PR TITLE
Improvements to latency graphs and Alerts

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/modules/configure-alert/alerts.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/modules/configure-alert/alerts.jag
@@ -98,8 +98,9 @@ var addOrUpdatePublisherAlertConfigs  = function (apiName, apiVersion, type, val
     }
 };
 
-var deletePublisherAlertConfigs = function (apiName, apiVersion) {
+var deletePublisherAlertConfigs = function (apiName, apiVersion, type) {
     var log = new Log();
+    var typeColName = alertTypeMap[type];
 
     try {
         var APIUtil = org.wso2.carbon.apimgt.impl.utils.APIUtil;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/blocks/configure-alert/ajax/configure-alert.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/blocks/configure-alert/ajax/configure-alert.jag
@@ -57,7 +57,8 @@ include("/jagg/jagg.jag");
                 mod = jagg.module("configure-alert");
                 var apiName= request.getParameter("apiName");
                 var apiVersion= request.getParameter("apiVersion");
-                var result = mod.deletePublisherAlertConfigs(apiName, apiVersion);
+                var type = request.getParameter("alertType");
+                var result = mod.deletePublisherAlertConfigs(apiName, apiVersion, type);
 
                 if (result.error) {
                     obj = {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/blocks/manage-alerts/block.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/blocks/manage-alerts/block.jag
@@ -16,9 +16,11 @@ jagg.block("manage-alerts", {
         };
     },
     getOutputs: function () {
-
         var log = new Log()
         var mod = jagg.module("manage-alerts");
+        var configMod = jagg.module("configure-alert");
+        var responseConfigs = configMod.getPublisherAlertConfigs("AbnormalResponseTime");
+        var backendConfigs = configMod.getPublisherAlertConfigs("AbnormalBackendTime");
 
 
         var savedAlertTypes = mod.retrieveSavedAlertsTypes();
@@ -26,7 +28,9 @@ jagg.block("manage-alerts", {
 
         return {
             "alertTypesInformations": savedAlertTypes,
-            "emailList": savedEmaillList
+            "emailList": savedEmaillList,
+            "backendConfigs": backendConfigs,
+            "responseConfigs": responseConfigs
         };
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/conf/locales/js/i18nResources.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/conf/locales/js/i18nResources.json
@@ -36,6 +36,7 @@
     "Could not save. You have entered an invalid email address.": "API Not saved. Invalid email address.",
     "Count": "Count",
     "Created API Count": "Created API Count",
+    "Data for this selection is already purged": "Data for this selection is already purged",
     "Data publishing is enabled": "Data publishing is enabled",
     "Delete Certificate for Alias": "Delete certificate for alias",
     "Delete certificate for endpoint": "Delete certificate for endpoint",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/configure-alert/js/configure-alert.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/configure-alert/js/configure-alert.js
@@ -30,6 +30,7 @@ $(function() {
             action:"removeAlertConfig",
             apiName: apiName,
             apiVersion: apiVersion,
+            alertType: alertType
         }, function (result) {
             if (!result.error) {
                 window.location.reload(true);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/manage-alerts/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/manage-alerts/template.jag
@@ -10,13 +10,23 @@
                 if(error == false){
                     var allAlertType = outputs.alertTypesInformations.allAlertTypeJson;
                     var savedAlertTypes = outputs.alertTypesInformations.savedAlertTypeJson;
+                    var backendConfigs = outputs.backendConfigs;
+                    var responseConfigs = outputs.responseConfigs;
                     %>
                         <div class="form-horizontal">
                     <%
                     for (var key in allAlertType) {
                         if (allAlertType.hasOwnProperty(key)) {
                             var isChecked;
+                            var isDisabled = "";
                             var alertType = allAlertType[key];
+
+                            // if configurable alert type is not configured, We disabled it until it is configured
+                            if ("AbnormalResponseTime" == alertType) {
+                                isDisabled = responseConfigs.length > 0 ? "" : "disabled";
+                            } else if ("AbnormalBackendTime" == alertType) {
+                                isDisabled = backendConfigs.length > 0 ? "" : "disabled";
+                            }
 
                             for (var savedAlertTypesKey in savedAlertTypes) {
                                 if (savedAlertTypes.hasOwnProperty(savedAlertTypesKey)) {
@@ -35,7 +45,7 @@
                                     <div class="row">
                                         <div class="col-xs-10 col-sm-10 col-lg-11">
                                             <label class="checkbox">
-                                                <input type="checkbox" id="<%=allAlertType[key]%>" value="<%=encode.forHtml(key)%>" <%=encode.forHtml(isChecked) %>>
+                                                <input type="checkbox" id="<%=allAlertType[key]%>" value="<%=encode.forHtml(key)%>" <%=encode.forHtml(isChecked) %> <%=isDisabled %>>
                                                 <span class="helper"><strong><%= i18n.localize(encode.forHtml(allAlertType[key])) %></strong></span>
                                                 <p><%= i18n.localize(encode.forHtml(allAlertType[key]) + "_Desc") %></p>
                                             </label>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/stats/api-latencytime/js/stats.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/stats/api-latencytime/js/stats.js
@@ -348,7 +348,6 @@ nv.addGraph(function() {
             var purgedDate = new Date();
             purgedDate = purgedDate.setDate(purgedDate.getDate() - 1);
 
-
             // Prevent loading seconds drill down view if
             // requested date is older than 1 day. 1 day is the
             // default data purge config for seconds table

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/stats/api-latencytime/js/stats.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/stats/api-latencytime/js/stats.js
@@ -284,7 +284,7 @@ function renderCompareGraph(fromDate,toDate,drillDown,mediationName){
         }, "json");
 }
 
-function drawGraphInArea(rdata,drilldown){
+function drawGraphInArea(rdata,drilldown) {
     $('#chartContainer').show();
     $('#chartContainer').empty();
     $('#noData').empty();
@@ -329,33 +329,39 @@ nv.addGraph(function() {
       .datum(renderdata)         //Populate the <svg> element with chart data...
       .call(chart);          //Finally, render the chart!
 
-  //Update the chart when window resizes.
-  nv.utils.windowResize(function() { chart.update() });
- d3.selectAll(".nv-point").on("click", function (e) {
-    var date = new Date(e.x);
-    if (depth == "DAY"){
-     from = new Date(e.x).setDate(date.getDate()-1);
-     to = new Date(e.x).setDate(date.getDate()+1);
-    depth = "HOUR";
-    }else if (depth == "HOUR"){
-     from = new Date(e.x).setHours(date.getHours()-1);
-     to = new Date(e.x).setHours(date.getHours()+1);
-    depth = "MINUTES";
-    }else if (depth == "MINUTES"){
-     from = new Date(e.x).setMinutes(date.getMinutes()-1);
-     to = new Date(e.x).setMinutes(date.getMinutes()+1);
-    depth = "SECONDS";
-    }else if (depth == "SECONDS"){
-    depth = "HOUR";
-     from = new Date(e.x).setHours(date.getHours()-1);
-     to = new Date(e.x).setHours(date.getHours()+1);
-    }
-    if (versionComparison) {
-       renderCompareGraph(from,to,depth,encodeURIComponent(mediationName));
-    }else{
-    renderGraph(from,to,depth);
-    }
-  });
+    //Update the chart when window resizes.
+    nv.utils.windowResize(function() { chart.update() });
+
+    d3.selectAll(".nv-point").on("click", function (e) {
+        var date = new Date(e.x);
+
+        if (depth == "DAY") {
+            from = new Date(e.x).setDate(date.getDate() - 1);
+            to = new Date(e.x).setDate(date.getDate() + 1);
+            btnActiveToggle($('#hour-btn'));
+            depth = "HOUR";
+        } else if (depth == "HOUR") {
+            from = new Date(e.x).setHours(date.getHours() - 1);
+            to = new Date(e.x).setHours(date.getHours() + 1);
+            $("#dateRangePickerContainer .btn-group").children().removeClass('active');
+            depth = "MINUTES";
+        } else if (depth == "MINUTES") {
+            from = new Date(e.x).setMinutes(date.getMinutes() - 1);
+            to = new Date(e.x).setMinutes(date.getMinutes() + 1);
+            $("#dateRangePickerContainer .btn-group").children().removeClass('active');
+            depth = "SECONDS";
+        } else if (depth == "SECONDS") {
+            depth = "HOUR";
+            from = new Date(e.x).setHours(date.getHours() - 1);
+            to = new Date(e.x).setHours(date.getHours() + 1);
+        }
+
+        if (versionComparison) {
+            renderCompareGraph(from,to,depth,encodeURIComponent(mediationName));
+        } else {
+            renderGraph(from,to,depth);
+        }
+    });
 });
 $('#chartContainer').append($('<div id="latencytTime"><svg style="height:600px;"></svg></div>'));
 $('#latencytTime svg').show();

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/stats/api-latencytime/js/stats.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/stats/api-latencytime/js/stats.js
@@ -251,9 +251,7 @@ function renderGraph(fromDate,toDate,drillDown){
                     $('#noData').append('<div class="center-wrapper"><div class="col-sm-4"/><div class="col-sm-4 message message-info"><h4><i class="icon fw fw-info" title="No Data Available"></i>'+i18n.t("No Data Available")+'</h4>'+ "<p> " + i18n.t('Generate some traffic to see statistics') + "</p>" +'</div></div>');
                     $('#chartContainer').hide();
                     $('#apiLatencyTimeNote').addClass('hide');
-
-                }
-                else{
+                } else {
                     $('.stat-page').html("");
                     $('#apiLatencyTimeNote').addClass('hide');
                     showEnableAnalyticsMsg();
@@ -346,14 +344,38 @@ nv.addGraph(function() {
             $("#dateRangePickerContainer .btn-group").children().removeClass('active');
             depth = "MINUTES";
         } else if (depth == "MINUTES") {
-            from = new Date(e.x).setMinutes(date.getMinutes() - 1);
-            to = new Date(e.x).setMinutes(date.getMinutes() + 1);
+            var selDate = new Date(e.x);
+            var purgedDate = new Date();
+            purgedDate = purgedDate.setDate(purgedDate.getDate() - 1);
+
+
+            // Prevent loading seconds drill down view if
+            // requested date is older than 1 day. 1 day is the
+            // default data purge config for seconds table
+            if (selDate < purgedDate) {
+                $('#noData').html('');
+                $('#noData').append('<div class="center-wrapper">' +
+                        '<div class="col-sm-4"/>' +
+                            '<div class="col-sm-4 message message-info">' +
+                            '<h4>' +
+                                '<i class="icon fw fw-info" title="No Data Available"></i>' +
+                                i18n.t("No Data Available") +
+                            '</h4>' +
+                            '<p>' + i18n.t("Data for this selection is already purged") + '</p>' +
+                        '</div>' +
+                    '</div>');
+                $('#chartContainer').hide();
+                $('#apiLatencyTimeNote').addClass('hide');
+
+                return;
+            }
+
+            from = selDate.setMinutes(date.getMinutes() - 1);
+            to = selDate.setMinutes(date.getMinutes() + 1);
             $("#dateRangePickerContainer .btn-group").children().removeClass('active');
             depth = "SECONDS";
-        } else if (depth == "SECONDS") {
-            depth = "HOUR";
-            from = new Date(e.x).setHours(date.getHours() - 1);
-            to = new Date(e.x).setHours(date.getHours() + 1);
+        } else {
+            return;
         }
 
         if (versionComparison) {

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/manage-alerts/block.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/manage-alerts/block.jag
@@ -12,12 +12,15 @@ jagg.block("manage-alerts", {
     getOutputs: function () {
         var log = new Log()
         var mod = jagg.module("manage-alerts");
+        var configMod = jagg.module("configure-alert");
+        var reqCountAlert = configMod.getStoreAlertConfigs();
         var savedAlertTypes = mod.retrieveSavedAlertsTypes();
         var savedEmaillList = mod.retrieveSavedEmailList();
 
         return {
             "alertTypesInformations": savedAlertTypes,
-            "emailList": savedEmaillList
+            "emailList": savedEmaillList,
+            "reqCountConfigs": reqCountAlert
         };
     }
 });

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/wso2/templates/manage-alerts/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/wso2/templates/manage-alerts/template.jag
@@ -5,18 +5,26 @@
             <h2><%=i18n.localize("Manage Alert Types")%></h2>
         </div>
         <div class="white-wrapper add-padding-4x">
-           <%
-            var error = outputs.alertTypesInformations.error;
-            if(error == false){
-                var allAlertType = outputs.alertTypesInformations.allAlertTypeJson;
-                var savedAlertTypes = outputs.alertTypesInformations.savedAlertTypeJson;
-                %>
+            <%
+                var error = outputs.alertTypesInformations.error;
+                if(error == false){
+                    var allAlertType = outputs.alertTypesInformations.allAlertTypeJson;
+                    var savedAlertTypes = outputs.alertTypesInformations.savedAlertTypeJson;
+                    var configs = outputs.reqCountConfigs;
+            %>
                     <div class="form-horizontal">
                 <%
                 for (var key in allAlertType) {
                     if (allAlertType.hasOwnProperty(key)) {
                         var isChecked;
+                        var isDisabled = "";
                         var alertType = allAlertType[key];
+
+                        // if configurable alert type is not configured, We disabled it until it is configured
+                        if ("AbnormalRequestsPerMin" == alertType) {
+                            isDisabled = configs.length > 0 ? "" : "disabled";
+                        }
+
                         for (var savedAlertTypesKey in savedAlertTypes) {
                             if (savedAlertTypes.hasOwnProperty(savedAlertTypesKey)) {
                                 if(savedAlertTypes[savedAlertTypesKey] == key) {
@@ -33,7 +41,8 @@
                                     <div class="row">
                                         <div class="col-xs-10 col-sm-10 col-lg-11">
                                             <label class="checkbox">
-                                                <input type="checkbox" title="alertTypes" id="<%=allAlertType[key]%>" value="<%=encode.forHtml(key)%>" <%=encode.forHtml(isChecked) %>>
+                                                <input type="checkbox" title="alertTypes" id="<%=allAlertType[key]%>" value="<%=encode.forHtml(key)%>" <%=encode.forHtml(isChecked)%> <%=isDisabled%>>
+
                                                 <span class="helper"><strong><%= i18n.localize(encode.forHtml(allAlertType[key])) %></strong></span>
                                                 <p><%= i18n.localize(encode.forHtml(allAlertType[key]) + "_Desc") %></p>
                                             </label>


### PR DESCRIPTION
## Purpose
Minor UX improvements to alert configurations.
Publisher Latency graph's second drill down will only show up if the selected date is within 1day (seconds table data, older than 1day is purged by default). 

After merging this PR, siddhi query for alert config delete need be changed with alert type as a filter variable.

## Goals
* Disable selecting unconfigured alerts
* Activate correct button on drilldown
* Improve latency graph drilldown
* Add alert type to delete request 