### PR TITLE
Fix web socket API issue in validating keys for handshake

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -10986,7 +10986,7 @@ public class ApiMgtDAO {
             ps.setString(1, context);
 
             rs = ps.executeQuery();
-            if (rs.first()) {
+            if (rs.next()) {
                 apiName = rs.getString("API_NAME");
                 apiProvider = rs.getString("API_PROVIDER");
             }


### PR DESCRIPTION
When using rs.first() PostgreSql and MsSql Dbs throw an exception
saying it requires a scrollable Resultset. Hence fixed this by
using a rs.next().