### PR TITLE
Fix an issue in importing subscriptions

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/ApplicationImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/ApplicationImportExportManager.java
@@ -148,8 +148,8 @@ public class ApplicationImportExportManager {
                     //tier of the imported subscription
                     Tier tier = subscribedAPI.getTier();
                     //checking whether the target tier is available
-                    if (isTierAvailable(tier, api) && api.getStatus() != null && api.getStatus()
-                            .equals(APIStatus.PUBLISHED)) {
+                    if (isTierAvailable(tier, api) && api.getStatus() != null &&
+                            APIStatus.PUBLISHED == APIStatus.valueOf(api.getStatus())) {
                         apiId.setTier(tier.getName());
                         apiConsumer.addSubscription(apiId, userId, appId);
                     } else {


### PR DESCRIPTION
## Purpose
Application import was broken due to an issue in subscription importing.
Cause of the issue was incorrectly comparing an ENUM with a String.