### PR TITLE
Remove the use of old lifecycle constant

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/ApplicationImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/ApplicationImportExportManager.java
@@ -149,7 +149,7 @@ public class ApplicationImportExportManager {
                     Tier tier = subscribedAPI.getTier();
                     //checking whether the target tier is available
                     if (isTierAvailable(tier, api) && api.getStatus() != null &&
-                            APIStatus.PUBLISHED == APIStatus.valueOf(api.getStatus())) {
+                            APIConstants.PUBLISHED.equals(api.getStatus())) {
                         apiId.setTier(tier.getName());
                         apiConsumer.addSubscription(apiId, userId, appId);
                     } else {


### PR DESCRIPTION
## Purpose
Use of ENUM constant for API lifecycle was removed with an earlier fix.