### PR TITLE
Support Extended API details when listing apis via publisher rest API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/api/APIPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/api/APIPublisher.java
@@ -254,10 +254,11 @@ public interface APIPublisher extends APIManager {
      * @param limit  Number of search results returned
      * @param offset Starting index of the search results
      * @param query  Search query
+     * @param expand specify whether to return detailed API instead of summary of API
      * @return List of APIs
      * @throws APIManagementException If failed to search for apis with given query.
      */
-    List<API> searchAPIs(Integer limit, Integer offset, String query) throws APIManagementException;
+    List<API> searchAPIs(Integer limit, Integer offset, String query, boolean expand) throws APIManagementException;
 
     /**
      * Update the subscription status

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/dao/ApiDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/dao/ApiDAO.java
@@ -225,12 +225,13 @@ public interface ApiDAO {
      * @param attributeMap Map containing the attributes and search queries for those attributes
      * @param offset  The starting point of the formatApiSearch results.
      * @param limit   Number of formatApiSearch results that will be returned.
+     * @param expand specify whether to return detailed API instead of summary of API
      * @return {@code List<API>} matching results
      * @throws APIMgtDAOException if error occurs while accessing data layer
      *
      */
-    List<API> attributeSearchAPIs(Set<String> roles, String user, Map<SearchType, String> attributeMap,
-                                  int offset, int limit) throws APIMgtDAOException;
+    List<API> attributeSearchAPIs(Set<String> roles, String user, Map<SearchType, String> attributeMap, int offset,
+            int limit, boolean expand) throws APIMgtDAOException;
 
     /**
      * Retrieves summary of paginated data of APIs based on visibility (in store), that match the

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/dao/impl/ApiFileDAOImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/dao/impl/ApiFileDAOImpl.java
@@ -689,11 +689,11 @@ public class ApiFileDAOImpl implements ApiDAO {
     }
 
     /**
-     * @see ApiDAO#attributeSearchAPIs(Set, String, Map, int, int)
+     * @see ApiDAO#attributeSearchAPIs(Set, String, Map, int, int, boolean)
      */
     @Override
     public List<API> attributeSearchAPIs(Set<String> roles, String user, Map<SearchType, String> attributeMap,
-                                         int offset, int limit) throws APIMgtDAOException {
+                                         int offset, int limit, boolean expand) throws APIMgtDAOException {
         throw new UnsupportedOperationException();
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/APIPublisherImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/APIPublisherImpl.java
@@ -1454,11 +1454,13 @@ public class APIPublisherImpl extends AbstractAPIManager implements APIPublisher
      * @param limit  Limit
      * @param offset Offset
      * @param query  Search query
+     * @param expand specify whether to return detailed API instead of summary of API
      * @return List of APIS.
      * @throws APIManagementException If failed to formatApiSearch APIs.
      */
     @Override
-    public List<API> searchAPIs(Integer limit, Integer offset, String query) throws APIManagementException {
+    public List<API> searchAPIs(Integer limit, Integer offset, String query, boolean expand) throws
+            APIManagementException {
 
         List<API> apiResults;
         String user = getUsername();
@@ -1494,7 +1496,7 @@ public class APIPublisherImpl extends AbstractAPIManager implements APIPublisher
                     apiResults = getApiDAO().searchAPIs(roles, user, query, offset, limit);
                 } else {
                     log.debug("Attributes:", attributeMap.toString());
-                    apiResults = getApiDAO().attributeSearchAPIs(roles, user, attributeMap, offset, limit);
+                    apiResults = getApiDAO().attributeSearchAPIs(roles, user, attributeMap, offset, limit, expand);
                 }
 
             } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImplIT.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImplIT.java
@@ -1136,7 +1136,7 @@ public class ApiDAOImplIT extends DAOIntegrationTestBase {
         Set<String> roles = new HashSet<>();
         Map<SearchType, String> attributeMap = new EnumMap<>(SearchType.class);
         attributeMap.put(SearchType.fromString("name"), api.getName());
-        List<API> apiList = apiDAO.attributeSearchAPIs(roles, api.getProvider(), attributeMap, 0, 2);
+        List<API> apiList = apiDAO.attributeSearchAPIs(roles, api.getProvider(), attributeMap, 0, 2, false);
         Assert.assertTrue(apiList.size() > 0);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/impl/APIPublisherImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/impl/APIPublisherImplTestCase.java
@@ -713,7 +713,7 @@ public class APIPublisherImplTestCase {
                 thenReturn(apimResultsFromDAO);
         Mockito.when(identityProvider.getIdOfUser(ALTERNATIVE_USER)).thenReturn(USER_ID);
         Mockito.when(identityProvider.getRoleIdsOfUser(USER_ID)).thenReturn(roleIdsOfUser);
-        List<API> apis = apiPublisher.searchAPIs(2, 1, api1.getName());
+        List<API> apis = apiPublisher.searchAPIs(2, 1, api1.getName(), false);
         Assert.assertNotNull(apis);
         Mockito.verify(apiDAO, Mockito.atLeastOnce())
                 .searchAPIs(new HashSet<>(roleIdsOfUser), ALTERNATIVE_USER, api1.getName(), 1, 2);
@@ -727,7 +727,7 @@ public class APIPublisherImplTestCase {
         APIPublisherImpl apiPublisher = getApiPublisherImpl(daoFactory);
         List<API> apimResultsFromDAO = new ArrayList<>();
         Mockito.when(apiDAO.searchAPIs(new HashSet<>(), USER, null, 1, 2)).thenReturn(apimResultsFromDAO);
-        apiPublisher.searchAPIs(2, 1, null);
+        apiPublisher.searchAPIs(2, 1, null, false);
         Mockito.verify(apiDAO, Mockito.times(1)).getAPIs(new HashSet<String>(), USER);
     }
 
@@ -744,7 +744,7 @@ public class APIPublisherImplTestCase {
         Mockito.when(apiDAO.searchAPIs(new HashSet<>(), ALTERNATIVE_USER, QUERY_STRING, 1, 2))
                 .thenThrow(APIMgtDAOException.class);
         try {
-            apiPublisher.searchAPIs(2, 1, QUERY_STRING);
+            apiPublisher.searchAPIs(2, 1, QUERY_STRING, false);
         } catch (APIManagementException e) {
             Assert.assertEquals(e.getMessage(), "Error occurred while Searching the API with query " + QUERY_STRING);
         }
@@ -753,7 +753,7 @@ public class APIPublisherImplTestCase {
         //IdentityProviderException
         Mockito.when(identityProvider.getIdOfUser(ALTERNATIVE_USER)).thenThrow(IdentityProviderException.class);
         try {
-            apiPublisher.searchAPIs(2, 1, QUERY_STRING);
+            apiPublisher.searchAPIs(2, 1, QUERY_STRING, false);
         } catch (APIManagementException e) {
             Assert.assertEquals(e.getMessage(),
                     "Error occurred while calling SCIM endpoint to retrieve user " + ALTERNATIVE_USER

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApi.java
@@ -953,12 +953,14 @@ public class ApisApi implements Microservice  {
 ,@ApiParam(value = "Starting point within the complete list of items qualified. ", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset
 ,@ApiParam(value = "**Search condition**.  You can search in attributes by using an **\"<attribute>:\"** modifier.  Eg. \"provider:wso2\" will match an API if the provider of the API is exactly \"wso2\".  Additionally you can use wildcards.  Eg. \"provider:wso2*\" will match an API if the provider of the API starts with \"wso2\".  Supported attribute modifiers are [**version, context, lifeCycleStatus, description, subcontext, doc, provider**]  If no advanced attribute modifier has been specified, search will match the given query string against API Name. ") @QueryParam("query") String query
 ,@ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved variant of the resourec. " )@HeaderParam("If-None-Match") String ifNoneMatch
+,@ApiParam(value = "Defines whether the returned response should contain full details of API ", defaultValue="false") @DefaultValue("false") @QueryParam("expand") Boolean expand
  ,@Context Request request)
     throws NotFoundException {
         limit=limit==null?Integer.valueOf("25"):limit;
         offset=offset==null?Integer.valueOf("0"):offset;
+        expand=expand==null?Boolean.valueOf("false"):expand;
         
-        return delegate.apisGet(limit,offset,query,ifNoneMatch,request);
+        return delegate.apisGet(limit,offset,query,ifNoneMatch,expand,request);
     }
     @OPTIONS
     @HEAD

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApiService.java
@@ -181,6 +181,7 @@ public abstract class ApisApiService {
  ,Integer offset
  ,String query
  ,String ifNoneMatch
+ ,Boolean expand
   ,Request request) throws NotFoundException;
     public abstract Response apisHead(String query
  ,String ifNoneMatch

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APIDTO.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.wso2.carbon.apimgt.rest.api.publisher.dto.APIInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.API_businessInformationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.API_corsConfigurationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.API_endpointDTO;
@@ -17,33 +18,9 @@ import java.util.Objects;
 /**
  * APIDTO
  */
-public class APIDTO   {
-  @SerializedName("id")
-  private String id = null;
-
-  @SerializedName("name")
-  private String name = null;
-
-  @SerializedName("description")
-  private String description = null;
-
-  @SerializedName("context")
-  private String context = null;
-
-  @SerializedName("version")
-  private String version = null;
-
-  @SerializedName("provider")
-  private String provider = null;
-
+public class APIDTO extends APIInfoDTO  {
   @SerializedName("wsdlUri")
   private String wsdlUri = null;
-
-  @SerializedName("lifeCycleStatus")
-  private String lifeCycleStatus = null;
-
-  @SerializedName("workflowStatus")
-  private String workflowStatus = null;
 
   @SerializedName("createdTime")
   private String createdTime = null;
@@ -147,9 +124,6 @@ public class APIDTO   {
   @SerializedName("endpoint")
   private List<API_endpointDTO> endpoint = new ArrayList<API_endpointDTO>();
 
-  @SerializedName("securityScheme")
-  private List<String> securityScheme = new ArrayList<String>();
-
   @SerializedName("scopes")
   private List<String> scopes = new ArrayList<String>();
 
@@ -158,114 +132,6 @@ public class APIDTO   {
 
   @SerializedName("threatProtectionPolicies")
   private API_threatProtectionPoliciesDTO threatProtectionPolicies = null;
-
-  public APIDTO id(String id) {
-    this.id = id;
-    return this;
-  }
-
-   /**
-   * UUID of the api registry artifact 
-   * @return id
-  **/
-  @ApiModelProperty(example = "01234567-0123-0123-0123-012345678901", value = "UUID of the api registry artifact ")
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public APIDTO name(String name) {
-    this.name = name;
-    return this;
-  }
-
-   /**
-   * Get name
-   * @return name
-  **/
-  @ApiModelProperty(example = "CalculatorAPI", required = true, value = "")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public APIDTO description(String description) {
-    this.description = description;
-    return this;
-  }
-
-   /**
-   * Get description
-   * @return description
-  **/
-  @ApiModelProperty(example = "A calculator API that supports basic operations", value = "")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public APIDTO context(String context) {
-    this.context = context;
-    return this;
-  }
-
-   /**
-   * Get context
-   * @return context
-  **/
-  @ApiModelProperty(example = "CalculatorAPI", required = true, value = "")
-  public String getContext() {
-    return context;
-  }
-
-  public void setContext(String context) {
-    this.context = context;
-  }
-
-  public APIDTO version(String version) {
-    this.version = version;
-    return this;
-  }
-
-   /**
-   * Get version
-   * @return version
-  **/
-  @ApiModelProperty(example = "1.0.0", required = true, value = "")
-  public String getVersion() {
-    return version;
-  }
-
-  public void setVersion(String version) {
-    this.version = version;
-  }
-
-  public APIDTO provider(String provider) {
-    this.provider = provider;
-    return this;
-  }
-
-   /**
-   * If the provider value is not given user invoking the api will be used as the provider. 
-   * @return provider
-  **/
-  @ApiModelProperty(example = "admin", value = "If the provider value is not given user invoking the api will be used as the provider. ")
-  public String getProvider() {
-    return provider;
-  }
-
-  public void setProvider(String provider) {
-    this.provider = provider;
-  }
 
   public APIDTO wsdlUri(String wsdlUri) {
     this.wsdlUri = wsdlUri;
@@ -283,42 +149,6 @@ public class APIDTO   {
 
   public void setWsdlUri(String wsdlUri) {
     this.wsdlUri = wsdlUri;
-  }
-
-  public APIDTO lifeCycleStatus(String lifeCycleStatus) {
-    this.lifeCycleStatus = lifeCycleStatus;
-    return this;
-  }
-
-   /**
-   * Get lifeCycleStatus
-   * @return lifeCycleStatus
-  **/
-  @ApiModelProperty(example = "CREATED", value = "")
-  public String getLifeCycleStatus() {
-    return lifeCycleStatus;
-  }
-
-  public void setLifeCycleStatus(String lifeCycleStatus) {
-    this.lifeCycleStatus = lifeCycleStatus;
-  }
-
-  public APIDTO workflowStatus(String workflowStatus) {
-    this.workflowStatus = workflowStatus;
-    return this;
-  }
-
-   /**
-   * Get workflowStatus
-   * @return workflowStatus
-  **/
-  @ApiModelProperty(example = "APPROVED", value = "")
-  public String getWorkflowStatus() {
-    return workflowStatus;
-  }
-
-  public void setWorkflowStatus(String workflowStatus) {
-    this.workflowStatus = workflowStatus;
   }
 
   public APIDTO createdTime(String createdTime) {
@@ -438,7 +268,7 @@ public class APIDTO   {
    * Get isDefaultVersion
    * @return isDefaultVersion
   **/
-  @ApiModelProperty(example = "false", required = true, value = "")
+  @ApiModelProperty(example = "false", value = "")
   public Boolean getIsDefaultVersion() {
     return isDefaultVersion;
   }
@@ -461,7 +291,7 @@ public class APIDTO   {
    * Supported transports for the API (http and/or https). 
    * @return transport
   **/
-  @ApiModelProperty(example = "[\"http\",\"https\"]", required = true, value = "Supported transports for the API (http and/or https). ")
+  @ApiModelProperty(example = "[\"http\",\"https\"]", value = "Supported transports for the API (http and/or https). ")
   public List<String> getTransport() {
     return transport;
   }
@@ -571,7 +401,7 @@ public class APIDTO   {
    * Get policies
    * @return policies
   **/
-  @ApiModelProperty(example = "[\"Unlimited\"]", required = true, value = "")
+  @ApiModelProperty(example = "[\"Unlimited\"]", value = "")
   public List<String> getPolicies() {
     return policies;
   }
@@ -589,7 +419,7 @@ public class APIDTO   {
    * Get visibility
    * @return visibility
   **/
-  @ApiModelProperty(example = "PUBLIC", required = true, value = "")
+  @ApiModelProperty(example = "PUBLIC", value = "")
   public VisibilityEnum getVisibility() {
     return visibility;
   }
@@ -785,29 +615,6 @@ public class APIDTO   {
     this.endpoint = endpoint;
   }
 
-  public APIDTO securityScheme(List<String> securityScheme) {
-    this.securityScheme = securityScheme;
-    return this;
-  }
-
-  public APIDTO addSecuritySchemeItem(String securitySchemeItem) {
-    this.securityScheme.add(securitySchemeItem);
-    return this;
-  }
-
-   /**
-   * Get securityScheme
-   * @return securityScheme
-  **/
-  @ApiModelProperty(value = "")
-  public List<String> getSecurityScheme() {
-    return securityScheme;
-  }
-
-  public void setSecurityScheme(List<String> securityScheme) {
-    this.securityScheme = securityScheme;
-  }
-
   public APIDTO scopes(List<String> scopes) {
     this.scopes = scopes;
     return this;
@@ -882,15 +689,7 @@ public class APIDTO   {
       return false;
     }
     APIDTO API = (APIDTO) o;
-    return Objects.equals(this.id, API.id) &&
-        Objects.equals(this.name, API.name) &&
-        Objects.equals(this.description, API.description) &&
-        Objects.equals(this.context, API.context) &&
-        Objects.equals(this.version, API.version) &&
-        Objects.equals(this.provider, API.provider) &&
-        Objects.equals(this.wsdlUri, API.wsdlUri) &&
-        Objects.equals(this.lifeCycleStatus, API.lifeCycleStatus) &&
-        Objects.equals(this.workflowStatus, API.workflowStatus) &&
+    return Objects.equals(this.wsdlUri, API.wsdlUri) &&
         Objects.equals(this.createdTime, API.createdTime) &&
         Objects.equals(this.apiPolicy, API.apiPolicy) &&
         Objects.equals(this.lastUpdatedTime, API.lastUpdatedTime) &&
@@ -914,31 +713,23 @@ public class APIDTO   {
         Objects.equals(this.businessInformation, API.businessInformation) &&
         Objects.equals(this.corsConfiguration, API.corsConfiguration) &&
         Objects.equals(this.endpoint, API.endpoint) &&
-        Objects.equals(this.securityScheme, API.securityScheme) &&
         Objects.equals(this.scopes, API.scopes) &&
         Objects.equals(this.operations, API.operations) &&
-        Objects.equals(this.threatProtectionPolicies, API.threatProtectionPolicies);
+        Objects.equals(this.threatProtectionPolicies, API.threatProtectionPolicies) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, context, version, provider, wsdlUri, lifeCycleStatus, workflowStatus, createdTime, apiPolicy, lastUpdatedTime, responseCaching, cacheTimeout, destinationStatsEnabled, isDefaultVersion, transport, tags, hasOwnGateway, gatewayLabels, storeLabels, policies, visibility, visibleRoles, permission, userPermissionsForApi, visibleTenants, gatewayEnvironments, sequences, businessInformation, corsConfiguration, endpoint, securityScheme, scopes, operations, threatProtectionPolicies);
+    return Objects.hash(wsdlUri, createdTime, apiPolicy, lastUpdatedTime, responseCaching, cacheTimeout, destinationStatsEnabled, isDefaultVersion, transport, tags, hasOwnGateway, gatewayLabels, storeLabels, policies, visibility, visibleRoles, permission, userPermissionsForApi, visibleTenants, gatewayEnvironments, sequences, businessInformation, corsConfiguration, endpoint, scopes, operations, threatProtectionPolicies, super.hashCode());
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class APIDTO {\n");
-    
-    sb.append("    id: ").append(toIndentedString(id)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("    context: ").append(toIndentedString(context)).append("\n");
-    sb.append("    version: ").append(toIndentedString(version)).append("\n");
-    sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    wsdlUri: ").append(toIndentedString(wsdlUri)).append("\n");
-    sb.append("    lifeCycleStatus: ").append(toIndentedString(lifeCycleStatus)).append("\n");
-    sb.append("    workflowStatus: ").append(toIndentedString(workflowStatus)).append("\n");
     sb.append("    createdTime: ").append(toIndentedString(createdTime)).append("\n");
     sb.append("    apiPolicy: ").append(toIndentedString(apiPolicy)).append("\n");
     sb.append("    lastUpdatedTime: ").append(toIndentedString(lastUpdatedTime)).append("\n");
@@ -962,7 +753,6 @@ public class APIDTO   {
     sb.append("    businessInformation: ").append(toIndentedString(businessInformation)).append("\n");
     sb.append("    corsConfiguration: ").append(toIndentedString(corsConfiguration)).append("\n");
     sb.append("    endpoint: ").append(toIndentedString(endpoint)).append("\n");
-    sb.append("    securityScheme: ").append(toIndentedString(securityScheme)).append("\n");
     sb.append("    scopes: ").append(toIndentedString(scopes)).append("\n");
     sb.append("    operations: ").append(toIndentedString(operations)).append("\n");
     sb.append("    threatProtectionPolicies: ").append(toIndentedString(threatProtectionPolicies)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
@@ -1451,13 +1451,15 @@ public class ApisApiServiceImpl extends ApisApiService {
      * @throws NotFoundException When the particular resource does not exist in the system
      */
     @Override
-    public Response apisGet(Integer limit, Integer offset, String query, String ifNoneMatch, Request request)
+    public Response apisGet(Integer limit, Integer offset, String query, String ifNoneMatch, Boolean expand,
+            Request request)
             throws NotFoundException {
         String username = RestApiUtil.getLoggedInUsername(request);
         APIListDTO apiListDTO = null;
         try {
             apiListDTO = MappingUtil
-                    .toAPIListDTO(RestAPIPublisherUtil.getApiPublisher(username).searchAPIs(limit, offset, query));
+                    .toAPIListDTO(RestAPIPublisherUtil.getApiPublisher(username).searchAPIs(limit, offset, query,
+                            expand), expand);
             return Response.ok().entity(apiListDTO).build();
         } catch (APIManagementException e) {
             String errorMessage = "Error while retrieving APIs";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/ApiImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/ApiImportExportManager.java
@@ -74,7 +74,7 @@ public class ApiImportExportManager {
 
         Set<APIDetails> apiDetailSet = new HashSet<>();
         // search for APIs
-        List<API> apis = apiPublisher.searchAPIs(limit, offset, query);
+        List<API> apis = apiPublisher.searchAPIs(limit, offset, query, false);
         if (apis == null || apis.isEmpty()) {
             // no APIs found, return
             return apiDetailSet;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/FileBasedApiImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/FileBasedApiImportExportManager.java
@@ -228,7 +228,7 @@ public class FileBasedApiImportExportManager extends ApiImportExportManager {
             throw new APIMgtEntityImportExportException(errorMsg, ExceptionCodes.API_IMPORT_ERROR);
         }
 
-        return MappingUtil.toAPIListDTO(apis);
+        return MappingUtil.toAPIListDTO(apis, false);
     }
 
     /**
@@ -282,7 +282,7 @@ public class FileBasedApiImportExportManager extends ApiImportExportManager {
             throw new APIMgtEntityImportExportException(errorMsg, ExceptionCodes.API_IMPORT_ERROR);
         }
 
-        return MappingUtil.toAPIListDTO(apis);
+        return MappingUtil.toAPIListDTO(apis, false);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/MappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/MappingUtil.java
@@ -23,7 +23,6 @@
 package org.wso2.carbon.apimgt.rest.api.publisher.utils;
 
 import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.apimgt.core.api.WorkflowResponse;
 import org.wso2.carbon.apimgt.core.models.API;
@@ -330,17 +329,36 @@ public class MappingUtil {
     }
 
     /**
+     * Converts {@link API} List to an {@link APIDTO} List.
+     *
+     * @param apiSummaryList
+     * @return
+     */
+    private static List<APIInfoDTO> toAPI(List<API> apiSummaryList) {
+        List<APIInfoDTO> apiInfoList = new ArrayList<>();
+        for (API api : apiSummaryList) {
+            apiInfoList.add(toAPIDto(api));
+        }
+        return apiInfoList;
+    }
+
+    /**
      * Converts API list to APIListDTO list.
      *
      * @param apisResult List of APIs
+     * @param expand Specify whether to get detail API or summary API
      * @return APIListDTO object
      */
-    public static APIListDTO toAPIListDTO(List<API> apisResult) {
+    public static APIListDTO toAPIListDTO(List<API> apisResult, boolean expand) {
         APIListDTO apiListDTO = new APIListDTO();
         apiListDTO.setCount(apisResult.size());
         // apiListDTO.setNext(next);
         // apiListDTO.setPrevious(previous);
-        apiListDTO.setList(toAPIInfo(apisResult));
+        if (expand) {
+            apiListDTO.setList(toAPI(apisResult));
+        } else {
+            apiListDTO.setList(toAPIInfo(apisResult));
+        }
         return apiListDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml
@@ -120,6 +120,7 @@ paths:
 
           type: string
         - $ref : "#/parameters/If-None-Match"
+        - $ref : "#/parameters/expand"
       tags:
         - API (Collection)
       responses:
@@ -3784,6 +3785,14 @@ parameters:
     schema: {
       $ref: '#/definitions/ThreatProtectionPolicy'
     }
+# Specifies whether full details of APIs should be returned on apisGet call
+  expand:
+    name: expand
+    in: query
+    description: |
+      Defines whether the returned response should contain full details of API
+    default: false
+    type: boolean
 
 ######################################################
 # The resources used by some of the APIs above within the message body
@@ -3822,6 +3831,7 @@ definitions:
 # The API Info resource
 #-----------------------------------------------------
   APIInfo:
+    discriminator: id
     title: API Info object with basic API details.
     properties:
       id:
@@ -3868,203 +3878,138 @@ definitions:
       - isDefaultVersion
       - transport
       - visibility
-    properties:
-      id:
-        type: string
-        description: |
-          UUID of the api registry artifact
-        example: 01234567-0123-0123-0123-012345678901
-      name:
-        type: string
-        example: CalculatorAPI
-      description:
-        type: string
-        example: A calculator API that supports basic operations
-      context:
-        type: string
-        example: CalculatorAPI
-      version:
-        type: string
-        example: 1.0.0
-      provider:
-        description: |
-          If the provider value is not given user invoking the api will be used as the provider.
-        type: string
-        example: admin
-      wsdlUri:
-        description: |
-          WSDL URL if the API is based on a WSDL endpoint
-        type: string
-        example: "http://www.webservicex.com/globalweather.asmx?wsdl"
-      lifeCycleStatus:
-        type: string
-        example: CREATED
-      workflowStatus:
-        type: string
-        example: APPROVED
-      createdTime:
-        type: string
-        example: 2017-02-20T13:57:16.229
-      apiPolicy:
-        type: string
-        example: UNLIMITED
-      lastUpdatedTime:
-        type: string
-        example: 2017-02-20T13:57:16.229
-      responseCaching:
-        type: string
-        example: Disabled
-      cacheTimeout:
-        type: integer
-        example: 300
-      destinationStatsEnabled:
-        type: string
-        example: Disabled
-      isDefaultVersion:
-        type: boolean
-        example: false
-      transport:
-        description: |
-          Supported transports for the API (http and/or https).
-        type: array
-        items:
-          type: string
-        example: ["http","https"]
-      tags:
-        type: array
-        items:
-          type: string
-        example: ["substract","add"]
-      hasOwnGateway:
-        type: boolean
-        example : false
-      gatewayLabels:
-        type: array
-        items:
-          type: string
-        example: ["public","private"]
-      storeLabels:
-        type: array
-        items:
-          type: string
-        example: ["public","private"]
-      policies:
-        type: array
-        items:
-          type: string
-        example: ["Unlimited"]
-      visibility:
-        type: string
-        enum:
-          - PUBLIC
-          - PRIVATE
-          - RESTRICTED
-        example: PUBLIC
-      visibleRoles:
-        type: array
-        items:
-          type: string
-        example: []
-      permission:
-        type: string
-        example: "[{\"groupId\" : 1000, \"permission\" : [\"READ\",\"UPDATE\"]},{\"groupId\" : 1001, \"permission\" : [\"READ\",\"UPDATE\"]}]"
-      userPermissionsForApi:
-        type: array
-        description: |
-          LoggedIn user permissions for the API
-        items:
-          type: string
-        example: ["READ","UPDATE"]
-      visibleTenants:
-        type: array
-        items:
-          type: string
-        example: []
-      gatewayEnvironments:
-        description: |
-          Comma separated list of gateway environments.
-        type: string
-        example: Production and Sandbox
-      sequences:
-        type: array
-        items:
-          $ref: '#/definitions/Sequence'
-        example: []
-      businessInformation:
-        properties:
-          businessOwner:
+    allOf:
+      - $ref: '#/definitions/APIInfo'
+      - properties:
+          wsdlUri:
+            description: |
+              WSDL URL if the API is based on a WSDL endpoint
             type: string
-            example: businessowner
-          businessOwnerEmail:
+            example: "http://www.webservicex.com/globalweather.asmx?wsdl"
+          createdTime:
             type: string
-            example: businessowner@wso2.com
-          technicalOwner:
+            example: 2017-02-20T13:57:16.229
+          apiPolicy:
             type: string
-            example: technicalowner
-          technicalOwnerEmail:
+            example: UNLIMITED
+          lastUpdatedTime:
             type: string
-            example: technicalowner@wso2.com
-      corsConfiguration:
-        description: |
-          CORS configuration for the API
-        properties:
-          corsConfigurationEnabled:
+            example: 2017-02-20T13:57:16.229
+          responseCaching:
+            type: string
+            example: Disabled
+          cacheTimeout:
+            type: integer
+            example: 300
+          destinationStatsEnabled:
+            type: string
+            example: Disabled
+          isDefaultVersion:
             type: boolean
-            default: false
-          accessControlAllowOrigins:
-            type: array
-            items:
-               type: string
-          accessControlAllowCredentials:
-            type: boolean
-            default: false
-          accessControlAllowHeaders:
+            example: false
+          transport:
+            description: |
+              Supported transports for the API (http and/or https).
             type: array
             items:
               type: string
-          accessControlAllowMethods:
+            example: ["http","https"]
+          tags:
             type: array
             items:
               type: string
-      endpoint:
-        type: array
-        items:
-         properties:
-          key:
-           type: string
-           example: "01234567-0123-0123-0123-012345678901"
-          inline:
-           $ref: '#/definitions/EndPoint'
-          type:
+            example: ["substract","add"]
+          hasOwnGateway:
+            type: boolean
+            example : false
+          gatewayLabels:
+            type: array
+            items:
+              type: string
+            example: ["public","private"]
+          storeLabels:
+            type: array
+            items:
+              type: string
+            example: ["public","private"]
+          policies:
+            type: array
+            items:
+              type: string
+            example: ["Unlimited"]
+          visibility:
             type: string
-            example: "Production"
-      securityScheme:
-        type: array
-        items:
-          type: string
-      scopes:
-        type: array
-        items:
-          type: string
-      operations:
-       type: array
-       items:
-        properties:
-          id:
-           type: string
-           example: "postapiresource"
-          uritemplate:
+            enum:
+              - PUBLIC
+              - PRIVATE
+              - RESTRICTED
+            example: PUBLIC
+          visibleRoles:
+            type: array
+            items:
+              type: string
+            example: []
+          permission:
             type: string
-            default: "/*"
-          httpVerb:
+            example: "[{\"groupId\" : 1000, \"permission\" : [\"READ\",\"UPDATE\"]},{\"groupId\" : 1001, \"permission\" : [\"READ\",\"UPDATE\"]}]"
+          userPermissionsForApi:
+            type: array
+            description: |
+              LoggedIn user permissions for the API
+            items:
+              type: string
+            example: ["READ","UPDATE"]
+          visibleTenants:
+            type: array
+            items:
+              type: string
+            example: []
+          gatewayEnvironments:
+            description: |
+              Comma separated list of gateway environments.
             type: string
-            default: "GET"
-          authType:
-            type: string
-            default: "Any"
-          policy:
-            type: string
-            example: "Unlimited"
+            example: Production and Sandbox
+          sequences:
+            type: array
+            items:
+              $ref: '#/definitions/Sequence'
+            example: []
+          businessInformation:
+            properties:
+              businessOwner:
+                type: string
+                example: businessowner
+              businessOwnerEmail:
+                type: string
+                example: businessowner@wso2.com
+              technicalOwner:
+                type: string
+                example: technicalowner
+              technicalOwnerEmail:
+                type: string
+                example: technicalowner@wso2.com
+          corsConfiguration:
+            description: |
+              CORS configuration for the API
+            properties:
+              corsConfigurationEnabled:
+                type: boolean
+                default: false
+              accessControlAllowOrigins:
+                type: array
+                items:
+                   type: string
+              accessControlAllowCredentials:
+                type: boolean
+                default: false
+              accessControlAllowHeaders:
+                type: array
+                items:
+                  type: string
+              accessControlAllowMethods:
+                type: array
+                items:
+                  type: string
           endpoint:
             type: array
             items:
@@ -4081,16 +4026,51 @@ definitions:
             type: array
             items:
               type: string
-      threatProtectionPolicies:
-        properties:
-          list:
-            type: array
-            items:
-              properties:
-                policyId:
+          operations:
+           type: array
+           items:
+            properties:
+              id:
+               type: string
+               example: "postapiresource"
+              uritemplate:
+                type: string
+                default: "/*"
+              httpVerb:
+                type: string
+                default: "GET"
+              authType:
+                type: string
+                default: "Any"
+              policy:
+                type: string
+                example: "Unlimited"
+              endpoint:
+                type: array
+                items:
+                 properties:
+                  key:
+                   type: string
+                   example: "01234567-0123-0123-0123-012345678901"
+                  inline:
+                   $ref: '#/definitions/EndPoint'
+                  type:
+                    type: string
+                    example: "Production"
+              scopes:
+                type: array
+                items:
                   type: string
-                priority:
-                  type: integer
+          threatProtectionPolicies:
+            properties:
+              list:
+                type: array
+                items:
+                  properties:
+                    policyId:
+                      type: string
+                    priority:
+                      type: integer
 
 #-----------------------------------------------------
 # The Application resource

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImplTestCase.java
@@ -1265,8 +1265,8 @@ public class ApisApiServiceImplTestCase {
         PowerMockito.when(RestAPIPublisherUtil.getApiPublisher(USER)).
                 thenReturn(apiPublisher);
         Mockito.doReturn(apis).doThrow(new IllegalArgumentException())
-                .when(apiPublisher).searchAPIs(10, 0, "");
-        Response response = apisApiService.apisGet(10, 0, "", null, getRequest());
+                .when(apiPublisher).searchAPIs(10, 0, "", false);
+        Response response = apisApiService.apisGet(10, 0, "", null, false, getRequest());
         assertEquals(response.getStatus(), 200);
         assertTrue(response.getEntity().toString().contains("newAPI1"));
         assertTrue(response.getEntity().toString().contains("newAPI2"));
@@ -1282,8 +1282,8 @@ public class ApisApiServiceImplTestCase {
         PowerMockito.when(RestAPIPublisherUtil.getApiPublisher(USER)).
                 thenReturn(apiPublisher);
         Mockito.doThrow(new APIManagementException("Error occurred", ExceptionCodes.API_TYPE_INVALID))
-                .when(apiPublisher).searchAPIs(10, 0, "");
-        Response response = apisApiService.apisGet(10, 0, "", null, getRequest());
+                .when(apiPublisher).searchAPIs(10, 0, "", false);
+        Response response = apisApiService.apisGet(10, 0, "", null, false, getRequest());
         assertEquals(response.getStatus(), 400);
         assertTrue(response.getEntity().toString().contains("API Type specified is invalid"));
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/TestMappingUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/TestMappingUtilTestCase.java
@@ -207,7 +207,7 @@ public class TestMappingUtilTestCase {
         List<API> apis = new ArrayList<>();
         apis.add(api1);
         apis.add(api2);
-        APIListDTO apiListDTO = MappingUtil.toAPIListDTO(apis);
+        APIListDTO apiListDTO = MappingUtil.toAPIListDTO(apis, false);
         assertEquals((Integer) apis.size(), apiListDTO.getCount());
         assertEquals(api1.getId(), apiListDTO.getList().get(0).getId());
         assertEquals(api1.getName(), apiListDTO.getList().get(0).getName());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/APIImportExportTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/APIImportExportTestCase.java
@@ -127,7 +127,7 @@ public class APIImportExportTestCase {
                 ("api1_thumbnail.png"));
         List<API> apis = new ArrayList<>();
         apis.add(api1);
-        Mockito.when(apiPublisher.searchAPIs(Integer.MAX_VALUE, 0, "*")).thenReturn(apis);
+        Mockito.when(apiPublisher.searchAPIs(Integer.MAX_VALUE, 0, "*", false)).thenReturn(apis);
 
         ApiImportExportManager importExportManager = new ApiImportExportManager(apiPublisher);
         Set<APIDetails> apiDetailsSet = importExportManager.getAPIDetails(Integer.MAX_VALUE, 0, "*");
@@ -214,7 +214,7 @@ public class APIImportExportTestCase {
         List<API> apis = new ArrayList<>();
         apis.add(api4);
         apis.add(api5);
-        Mockito.when(apiPublisher.searchAPIs(Integer.MAX_VALUE, 0, "*")).thenReturn(apis);
+        Mockito.when(apiPublisher.searchAPIs(Integer.MAX_VALUE, 0, "*", false)).thenReturn(apis);
 
         ApiImportExportManager importExportManager = new ApiImportExportManager(apiPublisher);
         Set<APIDetails> apiDetailsSet = importExportManager.getAPIDetails(Integer.MAX_VALUE, 0, "*");
@@ -300,7 +300,7 @@ public class APIImportExportTestCase {
         List<API> apis = new ArrayList<>();
         apis.add(api6);
         apis.add(api7);
-        Mockito.when(apiPublisher.searchAPIs(Integer.MAX_VALUE, 0, "*")).thenReturn(apis);
+        Mockito.when(apiPublisher.searchAPIs(Integer.MAX_VALUE, 0, "*", false)).thenReturn(apis);
 
         ApiImportExportManager importExportManager = new ApiImportExportManager(apiPublisher);
         Set<APIDetails> apiDetailsSet = importExportManager.getAPIDetails(Integer.MAX_VALUE, 0, "*");


### PR DESCRIPTION
## Purpose
> /apis rest API of the publisher currently provided API list with summary of details for each API. The response json array contains few of the meta data of each api.
> With this PR we have introduced new parameter *expand* , so when we invoke the rest api with this parameter it will give api list, where each api have all meta data.

> sample curl command would be as follows
`curl -k -h "Authorization:Bearer <TOKEN> "https://localhost:9443/api/am/publisher/v1.0/apis?query=name:Sample&limit=25&offset=0&expand=true`

## Goals
> This enables the micro gateway to fetch all the API data and to create a micro gateway project

