### PR TITLE
Fix https://github.com/wso2/product-apim/issues/3786

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/wso2/templates/api/api-info/js/api-info.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/wso2/templates/api/api-info/js/api-info.js
@@ -40,6 +40,7 @@ function triggerSubscribe() {
                 $('#messageModal a.btn-primary').click(function() {
                     window.location.reload();
                 });
+                $('#messageModal').modal();
             } else {
                 var jsonPayload = result.status.workflowResponse.jsonPayload;
                 if(jsonPayload != null && jsonPayload != ""){


### PR DESCRIPTION
## Purpose

In the case of on-the-fly subscription rejection, this fix allows deletion of subscription entry. 
The workflow response should have `{"Status":"REJECTED"}` in the json payload for this to work.
