### PR TITLE
Upgrade P2 plugin, C4 and Metrics versions to support Java 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1405,7 +1405,7 @@
         <analytics.shared.version>1.0.4</analytics.shared.version>
         <carbon.analytics.common.version>5.1.42</carbon.analytics.common.version>
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.4.35</carbon.kernel.version>
+        <carbon.kernel.version>4.4.37-SNAPSHOT</carbon.kernel.version> <!-- carbon-kernel branch: 4.4.x_java10 -->
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
 
         <carbon.commons.version>4.6.49</carbon.commons.version>
@@ -1455,7 +1455,7 @@
         <libthrift.import.version.range>[0.8.0.wso2v1,0.9.0)</libthrift.import.version.range>
 
         <!-- P2 Plugin Version -->
-        <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
+        <carbon.p2.plugin.version>1.6.1-SNAPSHOT</carbon.p2.plugin.version> <!-- maven-tools branch: master_java10 -->
 
         <maven-scr-plugin.version>1.7.2</maven-scr-plugin.version>
         <maven-bundle-plugin.version>2.5.3</maven-bundle-plugin.version>
@@ -1543,7 +1543,7 @@
         <!-- apache cxf version -->
         <cxf.version>3.2.2</cxf.version>
 
-        <carbon.metrics.version>1.2.3</carbon.metrics.version>
+        <carbon.metrics.version>1.2.4-SNAPSHOT</carbon.metrics.version> <!-- carbon-metrics branch: 1.x.x_java10 -->
         <!-- apache pdfbox version -->
         <pdfbox.version>1.8.13</pdfbox.version>
 


### PR DESCRIPTION
## Purpose
To support APIM to be able to run on Java 10

## Approach
Upgraded P2 Plugin, Carbon Kernel and Carbon Metrics dependencies

## Prerequisites
Please checkout and locally build following branches:
    master_java10 branch in maven-tools repo
    4.4.x_java10 branch in carbon-kernel repo
    1.x.x_java10 branch in carbon-metrics repo

## Note
Please build with java 8. Built products can be run on java 10.
