### PR TITLE
Handling application post and put in the Store REST API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -5519,6 +5519,12 @@ public class ApiMgtDAO {
                 application.setTier(rs.getString("APPLICATION_TIER"));
                 application.setTokenType(rs.getString("TOKEN_TYPE"));
                 subscriber.setId(rs.getInt("SUBSCRIBER_ID"));
+
+                if (multiGroupAppSharingEnabled) {
+                    if (application.getGroupId().isEmpty()) {
+                        application.setGroupId(getGroupId(applicationId));
+                    }
+                }
             }
             if (application != null) {
                 Map<String,String> applicationAttributes = getApplicationAttributes(connection, applicationId);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApplicationsApiServiceImpl.java
@@ -174,10 +174,6 @@ public class ApplicationsApiServiceImpl extends ApplicationsApiService {
             //subscriber field of the body is not honored. It is taken from the context
             Application application = ApplicationMappingUtil.fromDTOtoApplication(body, username);
 
-            //setting the proper groupId. This is not honored for now.
-            // Later we can honor it by checking admin privileges of the user.
-            String groupId = RestApiUtil.getLoggedInUserGroupId();
-            application.setGroupId(groupId);
             int applicationId = apiConsumer.addApplication(application, username);
 
             //retrieves the created application and send as the response

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/utils/RestAPIStoreUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/utils/RestAPIStoreUtils.java
@@ -89,34 +89,31 @@ public class RestAPIStoreUtils {
      * @return true if current logged in consumer has access to the specified application
      */
     public static boolean isUserAccessAllowedForApplication(Application application) {
-        String username = RestApiUtil.getLoggedInUsername();
+        String groupId;
 
         if (application != null) {
-            //if groupId is null or empty, it is not a shared app 
-            if (StringUtils.isEmpty(application.getGroupId())) {
-                //if the application is not shared, its subscriber and the current logged in user must be same
-                if (application.getSubscriber() != null) {
-                    if (application.getSubscriber().getName().equals(username)) {
-                        return true;
-                    } else if (application.getSubscriber().getName().toLowerCase().equals(username.toLowerCase())) {
-                        APIManagerConfiguration configuration = ServiceReferenceHolder.getInstance()
-                                .getAPIManagerConfigurationService().getAPIManagerConfiguration();
-                        String comparisonConfig = configuration
-                                .getFirstProperty(APIConstants.API_STORE_FORCE_CI_COMPARISIONS);
-                        if (StringUtils.isNotEmpty(comparisonConfig) && Boolean.valueOf(comparisonConfig)) {
+            groupId = application.getGroupId();
+            //If application  subscriber and the current logged in user  same then user can retrieve application
+            // irrespective of the groupId
+            if (application.getSubscriber() != null && isUserOwnerOfApplication(application)) {
+                return true;
+            }
+            // Check for shared apps
+            if (!StringUtils.isEmpty(groupId)) {
+                String userGroupId = RestApiUtil.getLoggedInUserGroupId();
+                //Check whether there is a common groupId between user and application
+                if (userGroupId != null) {
+                    List<String> groupIdList = new ArrayList<>(
+                            Arrays.asList(groupId.split(APIConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT)));
+                    for (String id : userGroupId.split(APIConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT)) {
+                        if (groupIdList.contains(id)) {
                             return true;
                         }
                     }
-                }
-            } else {
-                String userGroupId = RestApiUtil.getLoggedInUserGroupId();
-                //if the application is a shared one, application's group id and the user's group id should be same
-                if (application.getGroupId().equals(userGroupId)) {
-                    return true;
+
                 }
             }
         }
-
         //user don't have access
         return false;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/utils/mappings/ApplicationMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/utils/mappings/ApplicationMappingUtil.java
@@ -78,8 +78,7 @@ public class ApplicationMappingUtil {
         Object applicationAttributes = applicationDTO.getAttributes();
         Map appAttributes = new ObjectMapper().convertValue(applicationAttributes,Map.class);
         application.setApplicationAttributes(appAttributes);
-        //groupId is not honored for now. Later we can improve by checking admin privileges of the user.
-        //application.setGroupId(applicationDTO.getGroupId());
+        application.setGroupId(applicationDTO.getGroupId());
         return application;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/resources/store-api.yaml
@@ -712,7 +712,7 @@ paths:
     post:
       x-scope: apim:subscribe
       x-wso2-curl: "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json \"https://localhost:9443/api/am/store/v0.14/applications\""
-      x-wso2-request: "POST https://localhost:9443/api/am/store/v0.14/applications\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\n    \"throttlingTier\": \"Unlimited\",\n    \"description\": \"sample app description\",\n    \"name\": \"sampleapp\",\n    \"callbackUrl\": \"http://my.server.com/callback\"\n}"
+      x-wso2-request: "POST https://localhost:9443/api/am/store/v0.14/applications\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\n    \"throttlingTier\": \"Unlimited\",\n    \"description\": \"sample app description\",\n    \"name\": \"sampleapp\",\n    \"callbackUrl\": \"http://my.server.com/callback\"\n \"groupId\": \"org1\"\n}"
       x-wso2-response: "HTTP/1.1 201 Created\nLocation: https://localhost:9443/api/am/store/v0.14/applications/c30f3a6e-ffa4-4ae7-afce-224d1f820524\nContent-Type: application/json\n\n{\n   \"groupId\": null,\n   \"callbackUrl\": \"http://my.server.com/callback\",\n   \"subscriber\": \"admin\",\n   \"throttlingTier\": \"Unlimited\",\n   \"applicationId\": \"c30f3a6e-ffa4-4ae7-afce-224d1f820524\",\n   \"description\": \"sample app description\",\n   \"status\": \"APPROVED\",\n   \"name\": \"sampleapp\",\n   \"keys\": []\n}"
       summary: |
         Create a new application
@@ -839,7 +839,7 @@ paths:
     put:
       x-scope: apim:subscribe
       x-wso2-curl: "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X PUT -d @data.json \"https://localhost:9443/api/am/store/v0.14/applications/c30f3a6e-ffa4-4ae7-afce-224d1f820524\""
-      x-wso2-request: "PUT https://localhost:9443/api/am/store/v0.14/applications/c30f3a6e-ffa4-4ae7-afce-224d1f820524\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\n   \"callbackUrl\": \"\",\n   \"throttlingTier\": \"Bronze\",\n   \"description\": \"sample app description updated\",\n   \"name\": \"sampleapp\"\n}"
+      x-wso2-request: "PUT https://localhost:9443/api/am/store/v0.14/applications/c30f3a6e-ffa4-4ae7-afce-224d1f820524\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\n   \"callbackUrl\": \"\",\n   \"throttlingTier\": \"Bronze\",\n   \"description\": \"sample app description updated\",\n   \"name\": \"sampleapp\",\n    \"groupId\": \"org1\"\n}"
       x-wso2-response: "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"groupId\": null,\n   \"callbackUrl\": \"\",\n   \"subscriber\": \"admin\",\n   \"throttlingTier\": \"Bronze\",\n   \"applicationId\": \"c30f3a6e-ffa4-4ae7-afce-224d1f820524\",\n   \"description\": \"sample app description updated\",\n   \"status\": \"APPROVED\",\n   \"name\": \"sampleapp\",\n   \"keys\": []\n}"
       summary: |
         Update an application


### PR DESCRIPTION
## Purpose
To fix https://github.com/wso2/product-apim/issues/3863 : When adding an app from the Store REST API where sharing apps between multiple groups are enabled, it adds the group id of the user irrespective of the input groupId value, in the payload. Due to this, when user1 adds a private app from the REST API, it is shared with user2 when both are in the same group (org is the claim). This PR fixes this issue.

## Approach
When an application via Store REST API, groupId parsed in the body was not honored. So, as the fix, the parsed groupId is set to be honored, hence will be added in to the DB.

## Automation tests
 - Integration tests
         Added via https://github.com/wso2/product-apim/pull/3884