### PR TITLE
Improvements to Publisher OpenAPI support

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1081,6 +1081,7 @@ public final class APIConstants {
     public static final String SWAGGER_SCOPE_KEY = "key";
     public static final String SWAGGER_NAME = "name";
     public static final String SWAGGER_DESCRIPTION = "description";
+    public static final String SWAGGER_SUMMARY = "summary";
     public static final String SWAGGER_ROLES = "roles";
     public static final String SWAGGER_TITLE = "title";
     public static final String SWAGGER_EMAIL = "email";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromOpenAPISpec.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromOpenAPISpec.java
@@ -94,6 +94,13 @@ public class APIDefinitionFromOpenAPISpec extends APIDefinition {
 
                         if (APIConstants.PARAMETERS.equals(httpVerb.toLowerCase())) {
                             isGlobalParameterDefined = true;
+                        } else if (APIConstants.SWAGGER_SUMMARY.equals(httpVerb.toLowerCase())
+                                || APIConstants.SWAGGER_DESCRIPTION.equals(httpVerb.toLowerCase())
+                                || httpVerb.startsWith("x-")
+                                || httpVerb.startsWith("X-")) {
+                            // openapi 3.x allow 'summary', 'description' and extensions in PathItem Object.
+                            // which we are not interested at this point
+                            continue;
                         }
                         //Only continue for supported operations
                         else if (APIConstants.SUPPORTED_METHODS.contains(httpVerb.toLowerCase())) {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/blocks/item-design/ajax/add.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/blocks/item-design/ajax/add.jag
@@ -50,6 +50,11 @@ var parseSwaggerDefinition = function (swagger) {
     return swaggerJson;
 }
 
+var isSupportedOpenAPIVersion = function (version) {
+    // support for 3.0.x versions
+    return /^3\.0\.\d{1,}$/.test(version);
+}
+
 if(jagg.isCSRFTokenValid())
 (function () {
     response.contentType = "text/plain; charset=UTF-8";
@@ -62,7 +67,7 @@ if(jagg.isCSRFTokenValid())
     msg = require("/site/conf/ui-messages.jag"),
     parser = new SwaggerParser(),
     supportedSwaggerVersion = "2.0",
-    supportedOpenAPIVersion = "3.0.0",
+    supportedOpenAPIVersion = "3.0.x",
     supportedHTTPMethods = ["get", "put", "post", "delete", "patch", "head", "options"];
 
     if(jagg.getUser() == null){
@@ -92,7 +97,7 @@ if(jagg.isCSRFTokenValid())
                         //released yet.
                         var apiDefinition = parseSwaggerDefinition(swagger);
                         if (apiDefinition.openapi) {
-                            if (apiDefinition.openapi != supportedOpenAPIVersion) {
+                            if (!isSupportedOpenAPIVersion(apiDefinition.openapi.trim())) {
                                 print({
                                     error: true,
                                     message: "Unsupported OpenAPI version provided. Please re-import with OpenAPI " +
@@ -150,7 +155,7 @@ if(jagg.isCSRFTokenValid())
                         if (apiDefinition.openapi) {
 
                             //Supported Open API Version check
-                            if (apiDefinition.openapi != supportedOpenAPIVersion) {
+                            if (!isSupportedOpenAPIVersion(apiDefinition.openapi.trim())) {
                                 print({
                                     error: true,
                                     message: "Unsupported OpenAPI version provided. Please re-import with OpenAPI " +
@@ -866,7 +871,7 @@ if(jagg.isCSRFTokenValid())
                 }
             } else if (apiDefinition.openapi){
                 //Supported Open API Version check
-                if (apiDefinition.openapi.trim() != supportedOpenAPIVersion) {
+                if (!isSupportedOpenAPIVersion(apiDefinition.openapi.trim())) {
                     print({
                         error: true,
                         message: "Unsupported OpenAPI version provided. Please re-import with OpenAPI " +

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/item-design/js/api-design.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/item-design/js/api-design.js
@@ -289,7 +289,7 @@ APIDesigner.prototype.check_if_resource_exist = function(path, method){
 }
 
 APIDesigner.prototype.load_api_base_document = function (api_doc_version) {
-    if (api_doc_version == supportedOpenAPI3Version){
+    if (this.is_supported_openapi_version(api_doc_version)){
         this.load_api_document(openapi3_api_doc);
     } else{
         this.load_api_document(swagger2_api_doc);
@@ -298,7 +298,7 @@ APIDesigner.prototype.load_api_base_document = function (api_doc_version) {
 
 APIDesigner.prototype.is_openapi3 = function () {
     var isOpenAPI3 = false;
-    if (this.api_doc.openapi != undefined && this.api_doc.openapi.trim() == supportedOpenAPI3Version) {
+    if (this.api_doc.openapi != undefined && this.is_supported_openapi_version(this.api_doc.openapi.trim())) {
         isOpenAPI3 = true;
     }
     return isOpenAPI3;
@@ -330,6 +330,11 @@ APIDesigner.prototype.add_default_resource = function(){
     $(".http_verb_select:lt(5)").attr("checked","checked");
     $("#inputResource").val("Default");
     $("#add_resource").trigger('click');
+}
+
+APIDesigner.prototype.is_supported_openapi_version = function (version) {
+    // support for 3.0.x versions
+    return /^3\.0\.\d{1,}$/.test(version);
 }
 
 APIDesigner.prototype.get_scopes = function() {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/item-design/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/item-design/template.jag
@@ -838,20 +838,22 @@
 <table style="width:100%">                       
 {{#each doc.paths}}
     {{# each this}}
-        <tr class="resource_container" data-path="$.paths.['{{ path }}'].{{@key}}">
-            <td class="resource-method-td resource_expand" data-path="$.paths.['{{ path }}'].{{ @key }}">
-                <span class=" resource-method resource-method-{{ @key }}">{{ @key }}</span>
-            </td>
-            <td class="resource_expand"><a class="resource-path" title="resource-path">{{ path }}</a></td>
-            <td><span class="operation-summary change_summary" data-path="$.paths.['{{ path }}'].{{@key}}" data-attr="summary" >{{ summary }}</span></td>
-            <td class="delete_resource_td "><a class='operation-summary delete_resource' data-operation="{{ @key }}" data-path-name="{{ path }}" data-path="$.paths.['{{ path }}'].{{@key}}" data-index="{{ @index }}">
-		<span class="fw-stack" style="font-size:10px">
-                                <i class="fw fw-delete fw-stack-1x"></i>
-                                <i class="fw fw-circle-outline fw-stack-2x"></i>
-                </span>
-	    </a></td>
-        </tr>
-        <tr><td colspan="4" class="resource_body" style="display:none" data-path="$.paths.{{ path }}.{{@key}}"></td></tr>
+		{{#if this.responses}}
+            <tr class="resource_container" data-path="$.paths.['{{ path }}'].{{@key}}">
+                <td class="resource-method-td resource_expand" data-path="$.paths.['{{ path }}'].{{ @key }}">
+                    <span class=" resource-method resource-method-{{ @key }}">{{ @key }}</span>
+                </td>
+                <td class="resource_expand"><a class="resource-path" title="resource-path">{{ path }}</a></td>
+                <td><span class="operation-summary change_summary" data-path="$.paths.['{{ path }}'].{{@key}}" data-attr="summary" >{{ summary }}</span></td>
+                <td class="delete_resource_td "><a class='operation-summary delete_resource' data-operation="{{ @key }}" data-path-name="{{ path }}" data-path="$.paths.['{{ path }}'].{{@key}}" data-index="{{ @index }}">
+            <span class="fw-stack" style="font-size:10px">
+                                    <i class="fw fw-delete fw-stack-1x"></i>
+                                    <i class="fw fw-circle-outline fw-stack-2x"></i>
+                    </span>
+            </a></td>
+            </tr>
+            <tr><td colspan="4" class="resource_body" style="display:none" data-path="$.paths.{{ path }}.{{@key}}"></td></tr>
+		{{/if}}
     {{/each}}
 {{/each}}
 </table>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/item-implement/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/item-implement/template.jag
@@ -1151,14 +1151,16 @@
 <table style="width:100%; table-layout:fixed">
 {{#each doc.paths}}
     {{# each this}}
-        <tr class="resource_container" data-path="$.paths.{{ path }}.{{@key}}">
-            <td class="resource-method-td resource_expand" data-path="$.paths.{{ path}}.{{ @key }}">
-                <span class=" resource-method resource-method-{{ @key }}">{{ @key }}</span>
-            </td>
-            <td class="resource_expand"><a class="resource-path" title="{{ path }}">{{ path }}</a></td>
-            <td  width="99%"><span class="operation-summary change_summary" data-path="$.paths.{{ path }}.{{@key}}" data-attr="summary" >{{ summary }}</span></td>
-        </tr>
-        <tr><td colspan="3" class="resource_body " data-path="$.paths.{{ path }}.{{@key}}"></td></tr>
+		{{#if this.responses}}
+            <tr class="resource_container" data-path="$.paths.{{ path }}.{{@key}}">
+                <td class="resource-method-td resource_expand" data-path="$.paths.{{ path}}.{{ @key }}">
+                    <span class=" resource-method resource-method-{{ @key }}">{{ @key }}</span>
+                </td>
+                <td class="resource_expand"><a class="resource-path" title="{{ path }}">{{ path }}</a></td>
+                <td  width="99%"><span class="operation-summary change_summary" data-path="$.paths.{{ path }}.{{@key}}" data-attr="summary" >{{ summary }}</span></td>
+            </tr>
+            <tr><td colspan="3" class="resource_body " data-path="$.paths.{{ path }}.{{@key}}"></td></tr>
+        {{/if}}
     {{/each}}
 {{/each}}
 </table>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/item-manage/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/item-manage/template.jag
@@ -758,19 +758,21 @@
                                                                             </tr>
                                                                             {{#each doc.paths}}
                                                                                 {{#each this}}
-                                                                                <tr class="resource_container" data-path="">
-                                                                                    <td class="resource-method-td resource_expand" data-path="$.paths.{{ @../key}}.{{ @key }}">
-                                                                                        <span class=" resource-method resource-method-{{ @key }}">{{ @key }}</span>
-                                                                                    </td>
-                                                                                    <td><a class="resource-path" title="resource_path">{{ @../key}}</a></td>
-                                                                                    <td>
-                                                                                        <select class="form-control selected input-sm select_resource_policy" data-path="{{ @../key }}" data-method="{{@key}}" data-attr="x-throttling-tier">
-                                                                                            {{#each ../../tiers}}
-                                                                                                <option value="{{ this.value }}" {{#ifCond this.value '==' ../x-throttling-tier }}selected="selected"{{/ifCond}}>{{ this.text }}</option>
-                                                                                            {{/each}}
-                                                                                        </select>
-                                                                                    </td>
-                                                                                </tr>
+		                                                                            {{#if this.responses}}
+                                                                                        <tr class="resource_container" data-path="">
+                                                                                            <td class="resource-method-td resource_expand" data-path="$.paths.{{ @../key}}.{{ @key }}">
+                                                                                                <span class=" resource-method resource-method-{{ @key }}">{{ @key }}</span>
+                                                                                            </td>
+                                                                                            <td><a class="resource-path" title="resource_path">{{ @../key}}</a></td>
+                                                                                            <td>
+                                                                                                <select class="form-control selected input-sm select_resource_policy" data-path="{{ @../key }}" data-method="{{@key}}" data-attr="x-throttling-tier">
+                                                                                                    {{#each ../../tiers}}
+                                                                                                        <option value="{{ this.value }}" {{#ifCond this.value '==' ../x-throttling-tier }}selected="selected"{{/ifCond}}>{{ this.text }}</option>
+                                                                                                    {{/each}}
+                                                                                                </select>
+                                                                                            </td>
+                                                                                        </tr>
+                                                                                {{/if}}
                                                                                 {{/each}}
                                                                             {{/each}}
                                                                         </table>
@@ -1376,16 +1378,18 @@
 <table style="width:100%">
 {{#each doc.paths}}
     {{# each this}}
-        <tr class="resource_container" data-path="$.paths.['{{ path }}'].{{@key}}">
-            <td class="resource-method-td resource_expand" data-path="$.paths.['{{ path }}'].{{ @key }}">
-                <span class=" resource-method resource-method-{{ @key }}">{{ @key }}</span>
-            </td>
-            <td class="resource_expand"><a class="resource-path" title="resource_path">{{ path }}</a></td>
-            <td><span class="operation-summary change_summary" data-path="$.paths.['{{ path }}'].{{@key}}" data-attr="summary" >{{ summary }}</span></td>
-            <td><a class="operation-summary auth_type_select"  data-type="select" data-path="$.paths.['{{ path }}'].{{@key}}" data-attr="x-auth-type" data-value="{{ x-auth-type }}" title="x-auth-type"></a></td>
-            <td><a class='operation-summary throttling_select'  data-type="select" data-path="$.paths.['{{ path }}'].{{@key}}" data-attr="x-throttling-tier" title="x-throttling-tier">{{ x-throttling-tier }}</a></td>
-            <td><a class="operation-summary scope_select"  data-type="select" data-path="$.paths.['{{ path }}'].{{@key}}" data-attr="x-scope" title="x-scope">{{ x-scope }}</a></td>        </tr>
-        <tr><td colspan="6" class="resource_body " data-path="$.paths.['{{ path }}'].{{@key}}"></td></tr>
+		{{#if this.responses}}
+            <tr class="resource_container" data-path="$.paths.['{{ path }}'].{{@key}}">
+                <td class="resource-method-td resource_expand" data-path="$.paths.['{{ path }}'].{{ @key }}">
+                    <span class=" resource-method resource-method-{{ @key }}">{{ @key }}</span>
+                </td>
+                <td class="resource_expand"><a class="resource-path" title="resource_path">{{ path }}</a></td>
+                <td><span class="operation-summary change_summary" data-path="$.paths.['{{ path }}'].{{@key}}" data-attr="summary" >{{ summary }}</span></td>
+                <td><a class="operation-summary auth_type_select"  data-type="select" data-path="$.paths.['{{ path }}'].{{@key}}" data-attr="x-auth-type" data-value="{{ x-auth-type }}" title="x-auth-type"></a></td>
+                <td><a class='operation-summary throttling_select'  data-type="select" data-path="$.paths.['{{ path }}'].{{@key}}" data-attr="x-throttling-tier" title="x-throttling-tier">{{ x-throttling-tier }}</a></td>
+                <td><a class="operation-summary scope_select"  data-type="select" data-path="$.paths.['{{ path }}'].{{@key}}" data-attr="x-scope" title="x-scope">{{ x-scope }}</a></td>        </tr>
+            <tr><td colspan="6" class="resource_body " data-path="$.paths.['{{ path }}'].{{@key}}"></td></tr>
+        {{/if}}
     {{/each}}
 {{/each}}
 </table>


### PR DESCRIPTION
## Purpose

Fix: wso2/product-apim#3873

Having 'summary', 'description' and extensions in PathObject of openapi definition is supported by OpenAPI spec. But APIM doesn't support it.
Several patch releases has gone out for openapi spec after 3.0.0 release. Supporting 3.0.x is possible as we only expect issue fixes through a patch release. It shouldn't break anything.

## Goals
- Improve openapi path object support
- Make 3.0.x as supported range