### PR TITLE
Add test case for openapi validation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromOpenAPISpecTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromOpenAPISpecTest.java
@@ -239,6 +239,43 @@ public class APIDefinitionFromOpenAPISpecTest {
 
     }
 
+    @Test
+    public void testOpenApi3WithNonVerbElementHttpVerbInPathItem() throws APIManagementException {
+        APIDefinitionFromOpenAPISpec apiDef = new APIDefinitionFromOpenAPISpec();
+        String openApi =
+                "{\n"
+                        + "  \"openapi\": \"3.0.0\",\n"
+                        + "  \"info\": {\n"
+                        + "    \"title\": \"OAPI\",\n"
+                        + "    \"version\": \"1.0.0\"\n"
+                        + "  },\n"
+                        + "  \"paths\": {\n"
+                        + "    \"/item\": {\n"
+                        + "      \"parameters\": {},\n"
+                        + "      \"servers\": {},\n"
+                        + "      \"summary\": \"Valid summary but invalid in WSO2\",\n"
+                        + "      \"description\": \"Valid description but invalid in WSO2\",\n"
+                        + "      \"x-custom-field\": \"Valid custom field but invalid in WSO2\",\n"
+                        + "      \"get\": {\n"
+                        + "        \"responses\": {\n"
+                        + "          \"200\": {\n"
+                        + "            \"description\": \"OK\"\n"
+                        + "          }\n"
+                        + "        },\n"
+                        + "        \"x-auth-type\":\"Application\",\n"
+                        + "        \"x-throttling-tier\":\"Unlimited\"\n"
+                        + "      }\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}";
+
+        Set<URITemplate> expectedTemplates = new LinkedHashSet<URITemplate>();
+        expectedTemplates.add(getUriTemplate("GET", "Application", "/item"));
+        API api = new API(new APIIdentifier("admin", "OAPI", "1.0.0"));
+        Set<URITemplate> actualTemplates = apiDef.getURITemplates(api, openApi);
+        Assert.assertEquals(actualTemplates, expectedTemplates);
+    }
+
     protected URITemplate getUriTemplate(String httpVerb, String authType, String uriTemplateString) {
         URITemplate uriTemplate = new URITemplate();
         uriTemplate.setAuthTypes(authType);


### PR DESCRIPTION
## Purpose
Verifies the fix for wso2/product-apim#3873

OpenApi definitions provided with additional elements in Path Item Object should be correctly parsed when building URITemplates


## Automation tests
 - Unit tests

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/5837