### PR TITLE
Improve openapi validation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1081,6 +1081,7 @@ public final class APIConstants {
     public static final String SWAGGER_SCOPE_KEY = "key";
     public static final String SWAGGER_NAME = "name";
     public static final String SWAGGER_DESCRIPTION = "description";
+    public static final String SWAGGER_SERVERS = "servers";
     public static final String SWAGGER_SUMMARY = "summary";
     public static final String SWAGGER_ROLES = "roles";
     public static final String SWAGGER_TITLE = "title";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromOpenAPISpec.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromOpenAPISpec.java
@@ -86,16 +86,15 @@ public class APIDefinitionFromOpenAPISpec extends APIDefinition {
                         continue;
                     }
 
-                    boolean isGlobalParameterDefined = false;
                     boolean isHttpVerbDefined = false;
 
                     for (Object o1 : path.keySet()) {
                         String httpVerb = (String) o1;
 
-                        if (APIConstants.PARAMETERS.equals(httpVerb.toLowerCase())) {
-                            isGlobalParameterDefined = true;
-                        } else if (APIConstants.SWAGGER_SUMMARY.equals(httpVerb.toLowerCase())
+                        if (APIConstants.SWAGGER_SUMMARY.equals(httpVerb.toLowerCase())
                                 || APIConstants.SWAGGER_DESCRIPTION.equals(httpVerb.toLowerCase())
+                                || APIConstants.SWAGGER_SERVERS.equals(httpVerb.toLowerCase())
+                                || APIConstants.PARAMETERS.equals(httpVerb.toLowerCase())
                                 || httpVerb.startsWith("x-")
                                 || httpVerb.startsWith("X-")) {
                             // openapi 3.x allow 'summary', 'description' and extensions in PathItem Object.
@@ -142,7 +141,7 @@ public class APIDefinitionFromOpenAPISpec extends APIDefinition {
                         }
                     }
 
-                    if (isGlobalParameterDefined && !isHttpVerbDefined) {
+                    if (!isHttpVerbDefined) {
                         handleException("Resource '" + uriTempVal + "' has global parameters without " +
                                 "HTTP methods");
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromOpenAPISpecTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromOpenAPISpecTest.java
@@ -240,7 +240,7 @@ public class APIDefinitionFromOpenAPISpecTest {
     }
 
     @Test
-    public void testOpenApi3WithNonVerbElementHttpVerbInPathItem() throws APIManagementException {
+    public void testOpenApi3WithNonHttpVerbElementInPathItem() throws APIManagementException {
         APIDefinitionFromOpenAPISpec apiDef = new APIDefinitionFromOpenAPISpec();
         String openApi =
                 "{\n"


### PR DESCRIPTION
## Purpose
OpenAPI allow 'parameters' and 'servers' elements in PathItem Object. These two items needs to be skipped when building URI Templates using the openapi definition.