### PR TITLE
Improves the back-end to retrieve nested comments

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImpl.java
@@ -75,6 +75,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1438,7 +1439,7 @@ public class ApiDAOImpl implements ApiDAO {
     @Override
     public List<Comment> getCommentsForApi(String apiId) throws APIMgtDAOException {
         List<Comment> commentList;
-        Map commentListMap = new HashMap();
+        Map commentListMap = new LinkedHashMap();
         final String getCommentsQuery = "SELECT UUID, COMMENT_TEXT, USER_IDENTIFIER, API_ID, CATEGORY,"
                 + " PARENT_COMMENT_ID, ENTRY_POINT, CREATED_BY, CREATED_TIME, UPDATED_BY, LAST_UPDATED_TIME "
                 + "FROM AM_API_COMMENTS WHERE API_ID = ? ORDER BY CREATED_TIME";

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImpl.java
@@ -1441,7 +1441,7 @@ public class ApiDAOImpl implements ApiDAO {
         Map commentListMap = new HashMap();
         final String getCommentsQuery = "SELECT UUID, COMMENT_TEXT, USER_IDENTIFIER, API_ID, CATEGORY,"
                 + " PARENT_COMMENT_ID, ENTRY_POINT, CREATED_BY, CREATED_TIME, UPDATED_BY, LAST_UPDATED_TIME "
-                + "FROM AM_API_COMMENTS WHERE API_ID = ?";
+                + "FROM AM_API_COMMENTS WHERE API_ID = ? ORDER BY CREATED_TIME";
         try (Connection connection = DAOUtil.getConnection();
              PreparedStatement statement = connection.prepareStatement(getCommentsQuery)) {
             try {
@@ -1453,12 +1453,11 @@ public class ApiDAOImpl implements ApiDAO {
                         Comment comment = constructCommentFromResultSet(rs);
                         String commentId = comment.getUuid();
                         String parentCommentId = comment.getParentCommentId();
-                        if (commentListMap.containsKey(parentCommentId)) {
+                        if (parentCommentId == null) {
+                            commentListMap.put(commentId, comment);
+                        } else {
                             Comment existingComment = (Comment) commentListMap.get(parentCommentId);
                             existingComment.getReplies().add(comment);
-                            commentListMap.put(parentCommentId, existingComment);
-                        } else {
-                            commentListMap.put(commentId, comment);
                         }
                     }
                     commentList = new ArrayList<Comment>(commentListMap.values());

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImpl.java
@@ -1312,7 +1312,7 @@ public class ApiDAOImpl implements ApiDAO {
 
         comment.setUuid(rs.getString("UUID"));
         comment.setCommentText(IOUtils.toString(rs.getBinaryStream("COMMENT_TEXT")));
-        comment.setCommentedUser(rs.getString("USER_IDENTIFIER"));
+        comment.setCommentOwner(rs.getString("USER_IDENTIFIER"));
         comment.setApiId(rs.getString("API_ID"));
         comment.setCategory(rs.getString("CATEGORY"));
         comment.setParentCommentId(rs.getString("PARENT_COMMENT_ID"));
@@ -1339,7 +1339,7 @@ public class ApiDAOImpl implements ApiDAO {
                 connection.setAutoCommit(false);
                 statement.setString(1, comment.getUuid());
                 statement.setBinaryStream(2, IOUtils.toInputStream(comment.getCommentText()));
-                statement.setString(3, comment.getCommentedUser());
+                statement.setString(3, comment.getCommentOwner());
                 statement.setString(4, apiId);
                 statement.setString(5, comment.getCreatedUser());
                 statement.setTimestamp(6, Timestamp.valueOf(LocalDateTime.now()));

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImpl.java
@@ -1313,7 +1313,7 @@ public class ApiDAOImpl implements ApiDAO {
 
         comment.setUuid(rs.getString("UUID"));
         comment.setCommentText(IOUtils.toString(rs.getBinaryStream("COMMENT_TEXT")));
-        comment.setCommentOwner(rs.getString("USER_IDENTIFIER"));
+        comment.setOwner(rs.getString("USER_IDENTIFIER"));
         comment.setApiId(rs.getString("API_ID"));
         comment.setCategory(rs.getString("CATEGORY"));
         comment.setParentCommentId(rs.getString("PARENT_COMMENT_ID"));
@@ -1340,7 +1340,7 @@ public class ApiDAOImpl implements ApiDAO {
                 connection.setAutoCommit(false);
                 statement.setString(1, comment.getUuid());
                 statement.setBinaryStream(2, IOUtils.toInputStream(comment.getCommentText()));
-                statement.setString(3, comment.getCommentOwner());
+                statement.setString(3, comment.getOwner());
                 statement.setString(4, apiId);
                 statement.setString(5, comment.getCreatedUser());
                 statement.setTimestamp(6, Timestamp.valueOf(LocalDateTime.now()));

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/APIPublisherImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/APIPublisherImpl.java
@@ -2609,7 +2609,7 @@ public class APIPublisherImpl extends AbstractAPIManager implements APIPublisher
             if (comment != null) {
                  /*if the delete operation is done by a user who isn't the owner of the comment
                   and with a different end point*/
-                if (!(comment.getCommentedUser().equals(username) &&
+                if (!(comment.getCommentOwner().equals(username) &&
                         ENTRY_POINT_PUBLISHER.equals(comment.getEntryPoint()))) {
                     checkIfUserIsAdmin(username);
                 }
@@ -2637,7 +2637,7 @@ public class APIPublisherImpl extends AbstractAPIManager implements APIPublisher
             if (oldComment != null) {
                 /*if the update operation is done by a user who isn't the owner of the comment
                   and with a different end point*/
-                if (!(oldComment.getCommentedUser().equals(username) &&
+                if (!(oldComment.getCommentOwner().equals(username) &&
                         ENTRY_POINT_PUBLISHER.equals(oldComment.getEntryPoint()))) {
                     String errorMsg = "The user " + username + " does not have permission to update this comment";
                     log.error(errorMsg);

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/APIPublisherImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/APIPublisherImpl.java
@@ -2609,7 +2609,7 @@ public class APIPublisherImpl extends AbstractAPIManager implements APIPublisher
             if (comment != null) {
                  /*if the delete operation is done by a user who isn't the owner of the comment
                   and with a different end point*/
-                if (!(comment.getCommentOwner().equals(username) &&
+                if (!(comment.getOwner().equals(username) &&
                         ENTRY_POINT_PUBLISHER.equals(comment.getEntryPoint()))) {
                     checkIfUserIsAdmin(username);
                 }
@@ -2637,7 +2637,7 @@ public class APIPublisherImpl extends AbstractAPIManager implements APIPublisher
             if (oldComment != null) {
                 /*if the update operation is done by a user who isn't the owner of the comment
                   and with a different end point*/
-                if (!(oldComment.getCommentOwner().equals(username) &&
+                if (!(oldComment.getOwner().equals(username) &&
                         ENTRY_POINT_PUBLISHER.equals(oldComment.getEntryPoint()))) {
                     String errorMsg = "The user " + username + " does not have permission to update this comment";
                     log.error(errorMsg);

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/APIStoreImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/APIStoreImpl.java
@@ -881,7 +881,7 @@ public class APIStoreImpl extends AbstractAPIManager implements APIStore, APIMOb
                /*if the update operation is done by a user who isn't the owner of the comment
                   and with a different end point*/
                 if (!(oldComment.getCommentedUser().equals(username) &&
-                        ENTRY_POINT_STORE.equals(comment.getEntryPoint()))) {
+                        ENTRY_POINT_STORE.equals(oldComment.getEntryPoint()))) {
                     String errorMsg = "The user " + username + " does not have permission to update this comment";
                     log.error(errorMsg);
                     throw new APICommentException(errorMsg, ExceptionCodes.COULD_NOT_UPDATE_COMMENT);

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/APIStoreImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/APIStoreImpl.java
@@ -853,7 +853,7 @@ public class APIStoreImpl extends AbstractAPIManager implements APIStore, APIMOb
             if (comment != null) {
                   /*if the delete operation is done by a user who isn't the owner of the comment
                   and with a different end point*/
-                if (!(comment.getCommentOwner().equals(username) &&
+                if (!(comment.getOwner().equals(username) &&
                         ENTRY_POINT_STORE.equals(comment.getEntryPoint()))) {
                     checkIfUserIsAdmin(username);
                 }
@@ -880,7 +880,7 @@ public class APIStoreImpl extends AbstractAPIManager implements APIStore, APIMOb
             if (oldComment != null) {
                /*if the update operation is done by a user who isn't the owner of the comment
                   and with a different end point*/
-                if (!(oldComment.getCommentOwner().equals(username) &&
+                if (!(oldComment.getOwner().equals(username) &&
                         ENTRY_POINT_STORE.equals(oldComment.getEntryPoint()))) {
                     String errorMsg = "The user " + username + " does not have permission to update this comment";
                     log.error(errorMsg);

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/APIStoreImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/impl/APIStoreImpl.java
@@ -853,7 +853,7 @@ public class APIStoreImpl extends AbstractAPIManager implements APIStore, APIMOb
             if (comment != null) {
                   /*if the delete operation is done by a user who isn't the owner of the comment
                   and with a different end point*/
-                if (!(comment.getCommentedUser().equals(username) &&
+                if (!(comment.getCommentOwner().equals(username) &&
                         ENTRY_POINT_STORE.equals(comment.getEntryPoint()))) {
                     checkIfUserIsAdmin(username);
                 }
@@ -880,7 +880,7 @@ public class APIStoreImpl extends AbstractAPIManager implements APIStore, APIMOb
             if (oldComment != null) {
                /*if the update operation is done by a user who isn't the owner of the comment
                   and with a different end point*/
-                if (!(oldComment.getCommentedUser().equals(username) &&
+                if (!(oldComment.getCommentOwner().equals(username) &&
                         ENTRY_POINT_STORE.equals(oldComment.getEntryPoint()))) {
                     String errorMsg = "The user " + username + " does not have permission to update this comment";
                     log.error(errorMsg);

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/models/Comment.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/models/Comment.java
@@ -20,6 +20,7 @@
 package org.wso2.carbon.apimgt.core.models;
 
 import java.time.Instant;
+import java.util.ArrayList;
 
 /**
  * Represents an instance of a Comment. Comments can be associated with APIs.
@@ -37,6 +38,7 @@ public final class Comment {
     private Instant createdTime;
     private String updatedUser;
     private Instant updatedTime;
+    private ArrayList<Comment> replies;
 
     public String getApiId() {
         return apiId;
@@ -124,6 +126,14 @@ public final class Comment {
 
     public void setUpdatedTime(Instant updatedTime) {
         this.updatedTime = updatedTime;
+    }
+
+    public ArrayList<Comment> getReplies() {
+        return replies;
+    }
+
+    public void setReplies(ArrayList<Comment> replies) {
+        this.replies = replies;
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/models/Comment.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/models/Comment.java
@@ -32,7 +32,7 @@ public final class Comment {
     private String category;
     private String parentCommentId;
     private String entryPoint;
-    private String commentedUser;
+    private String commentOwner;
     private String commentText;
     private String createdUser;
     private Instant createdTime;
@@ -80,12 +80,12 @@ public final class Comment {
         this.entryPoint = entryPoint;
     }
 
-    public String getCommentedUser() {
-        return commentedUser;
+    public String getCommentOwner() {
+        return commentOwner;
     }
 
-    public void setCommentedUser(String commentedUser) {
-        this.commentedUser = commentedUser;
+    public void setCommentOwner(String commentOwner) {
+        this.commentOwner = commentOwner;
     }
 
     public String getCommentText() {

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/models/Comment.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/main/java/org/wso2/carbon/apimgt/core/models/Comment.java
@@ -32,7 +32,7 @@ public final class Comment {
     private String category;
     private String parentCommentId;
     private String entryPoint;
-    private String commentOwner;
+    private String owner;
     private String commentText;
     private String createdUser;
     private Instant createdTime;
@@ -80,12 +80,12 @@ public final class Comment {
         this.entryPoint = entryPoint;
     }
 
-    public String getCommentOwner() {
-        return commentOwner;
+    public String getOwner() {
+        return owner;
     }
 
-    public void setCommentOwner(String commentOwner) {
-        this.commentOwner = commentOwner;
+    public void setOwner(String owner) {
+        this.owner = owner;
     }
 
     public String getCommentText() {

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/SampleTestObjectCreator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/SampleTestObjectCreator.java
@@ -1131,7 +1131,7 @@ public class SampleTestObjectCreator {
         comment.setCategory("sample category");
         comment.setParentCommentId(UUID.randomUUID().toString());
         comment.setEntryPoint(entryPoint);
-        comment.setCommentedUser("admin");
+        comment.setCommentOwner("admin");
         comment.setUpdatedUser("admin");
         comment.setCreatedTime(time);
         comment.setUpdatedTime(time);
@@ -1147,7 +1147,7 @@ public class SampleTestObjectCreator {
         comment.setCategory("sample alt category");
         comment.setParentCommentId(UUID.randomUUID().toString());
         comment.setEntryPoint(entryPoint);
-        comment.setCommentedUser("admin");
+        comment.setCommentOwner("admin");
         comment.setUpdatedUser("admin");
         comment.setCreatedTime(time);
         comment.setUpdatedTime(time);
@@ -1163,7 +1163,7 @@ public class SampleTestObjectCreator {
         comment.setCategory("sample category");
         comment.setParentCommentId(parentCommentId);
         comment.setEntryPoint(entryPoint);
-        comment.setCommentedUser("admin");
+        comment.setCommentOwner("admin");
         comment.setUpdatedUser("admin");
         comment.setCreatedTime(time);
         comment.setUpdatedTime(time);

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/SampleTestObjectCreator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/SampleTestObjectCreator.java
@@ -1131,7 +1131,7 @@ public class SampleTestObjectCreator {
         comment.setCategory("sample category");
         comment.setParentCommentId(UUID.randomUUID().toString());
         comment.setEntryPoint(entryPoint);
-        comment.setCommentOwner("admin");
+        comment.setOwner("admin");
         comment.setUpdatedUser("admin");
         comment.setCreatedTime(time);
         comment.setUpdatedTime(time);
@@ -1147,7 +1147,7 @@ public class SampleTestObjectCreator {
         comment.setCategory("sample alt category");
         comment.setParentCommentId(UUID.randomUUID().toString());
         comment.setEntryPoint(entryPoint);
-        comment.setCommentOwner("admin");
+        comment.setOwner("admin");
         comment.setUpdatedUser("admin");
         comment.setCreatedTime(time);
         comment.setUpdatedTime(time);
@@ -1163,7 +1163,7 @@ public class SampleTestObjectCreator {
         comment.setCategory("sample category");
         comment.setParentCommentId(parentCommentId);
         comment.setEntryPoint(entryPoint);
-        comment.setCommentOwner("admin");
+        comment.setOwner("admin");
         comment.setUpdatedUser("admin");
         comment.setCreatedTime(time);
         comment.setUpdatedTime(time);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/EndpointsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/EndpointsApi.java
@@ -2,20 +2,28 @@ package org.wso2.carbon.apimgt.rest.api.publisher;
 
 
 import io.swagger.annotations.ApiParam;
-import org.osgi.service.component.annotations.Component;
+
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.EndPointDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.EndPointListDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.dto.ErrorDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.factories.EndpointsApiServiceFactory;
+
 import org.wso2.msf4j.Microservice;
 import org.wso2.msf4j.Request;
+import org.wso2.msf4j.formparam.FileInfo;
+import org.wso2.msf4j.formparam.FormDataParam;
+import org.osgi.service.component.annotations.Component;
 
+import java.io.InputStream;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
-import javax.ws.rs.HeaderParam;
 import javax.ws.rs.OPTIONS;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/API_additionalPropertiesDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/API_additionalPropertiesDTO.java
@@ -28,20 +28,20 @@ public class API_additionalPropertiesDTO   {
 
 
 
-    public API_additionalPropertiesDTO(String key, String value) {
-        this.key = key;
-        this.value = value;
-    }
+  public API_additionalPropertiesDTO(String key, String value) {
+    this.key = key;
+    this.value = value;
+  }
 
   public API_additionalPropertiesDTO key(String key) {
     this.key = key;
     return this;
   }
 
-   /**
+  /**
    * Get key
    * @return key
-  **/
+   **/
   @ApiModelProperty(example = "environment", value = "")
   public String getKey() {
     return key;
@@ -56,10 +56,10 @@ public class API_additionalPropertiesDTO   {
     return this;
   }
 
-   /**
+  /**
    * Get value
    * @return value
-  **/
+   **/
   @ApiModelProperty(example = "preprod", value = "")
   public String getValue() {
     return value;
@@ -80,7 +80,7 @@ public class API_additionalPropertiesDTO   {
     }
     API_additionalPropertiesDTO apIAdditionalProperties = (API_additionalPropertiesDTO) o;
     return Objects.equals(this.key, apIAdditionalProperties.key) &&
-        Objects.equals(this.value, apIAdditionalProperties.value);
+            Objects.equals(this.value, apIAdditionalProperties.value);
   }
 
   @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/CommentDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/CommentDTO.java
@@ -4,6 +4,9 @@ package org.wso2.carbon.apimgt.rest.api.publisher.dto;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.apimgt.rest.api.publisher.dto.CommentDTO;
 import java.util.Objects;
 
 /**
@@ -42,6 +45,9 @@ public class CommentDTO   {
 
   @SerializedName("lastUpdatedBy")
   private String lastUpdatedBy = null;
+
+  @SerializedName("replies")
+  private List<CommentDTO> replies = new ArrayList<CommentDTO>();
 
   public CommentDTO commentId(String commentId) {
     this.commentId = commentId;
@@ -241,6 +247,29 @@ public class CommentDTO   {
     this.lastUpdatedBy = lastUpdatedBy;
   }
 
+  public CommentDTO replies(List<CommentDTO> replies) {
+    this.replies = replies;
+    return this;
+  }
+
+  public CommentDTO addRepliesItem(CommentDTO repliesItem) {
+    this.replies.add(repliesItem);
+    return this;
+  }
+
+   /**
+   * Get replies
+   * @return replies
+  **/
+  @ApiModelProperty(value = "")
+  public List<CommentDTO> getReplies() {
+    return replies;
+  }
+
+  public void setReplies(List<CommentDTO> replies) {
+    this.replies = replies;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -261,12 +290,13 @@ public class CommentDTO   {
         Objects.equals(this.createdTime, comment.createdTime) &&
         Objects.equals(this.createdBy, comment.createdBy) &&
         Objects.equals(this.lastUpdatedTime, comment.lastUpdatedTime) &&
-        Objects.equals(this.lastUpdatedBy, comment.lastUpdatedBy);
+        Objects.equals(this.lastUpdatedBy, comment.lastUpdatedBy) &&
+        Objects.equals(this.replies, comment.replies);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(commentId, apiId, category, parentCommentId, entryPoint, username, commentText, createdTime, createdBy, lastUpdatedTime, lastUpdatedBy);
+    return Objects.hash(commentId, apiId, category, parentCommentId, entryPoint, username, commentText, createdTime, createdBy, lastUpdatedTime, lastUpdatedBy, replies);
   }
 
   @Override
@@ -285,6 +315,7 @@ public class CommentDTO   {
     sb.append("    createdBy: ").append(toIndentedString(createdBy)).append("\n");
     sb.append("    lastUpdatedTime: ").append(toIndentedString(lastUpdatedTime)).append("\n");
     sb.append("    lastUpdatedBy: ").append(toIndentedString(lastUpdatedBy)).append("\n");
+    sb.append("    replies: ").append(toIndentedString(replies)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtil.java
@@ -49,7 +49,7 @@ public class CommentMappingUtil {
         CommentDTO commentDTO = new CommentDTO();
         commentDTO.setCommentId(comment.getUuid());
         String realName = APIManagerFactory.getInstance().getUserNameMapper().getLoggedInUserIDFromPseudoName(comment
-                .getCommentOwner());
+                .getOwner());
         commentDTO.setUsername(realName);
         commentDTO.setCommentText(comment.getCommentText());
         commentDTO.setCategory(comment.getCategory());
@@ -80,7 +80,7 @@ public class CommentMappingUtil {
         comment.setCategory(body.getCategory());
         comment.setParentCommentId(body.getParentCommentId());
         comment.setEntryPoint(body.getEntryPoint());
-        comment.setCommentOwner(username);
+        comment.setOwner(username);
         comment.setApiId(body.getApiId());
         comment.setCreatedUser(username);
         comment.setUpdatedUser(username);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtil.java
@@ -59,6 +59,9 @@ public class CommentMappingUtil {
         commentDTO.setLastUpdatedBy(comment.getUpdatedUser());
         commentDTO.setCreatedTime(comment.getCreatedTime().toString());
         commentDTO.setLastUpdatedTime(comment.getUpdatedTime().toString());
+        for (Comment commentItem : comment.getReplies()) {
+            commentDTO.addRepliesItem(fromCommentToDTO(commentItem));
+        }
 
         return commentDTO;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtil.java
@@ -49,7 +49,7 @@ public class CommentMappingUtil {
         CommentDTO commentDTO = new CommentDTO();
         commentDTO.setCommentId(comment.getUuid());
         String realName = APIManagerFactory.getInstance().getUserNameMapper().getLoggedInUserIDFromPseudoName(comment
-                .getCommentedUser());
+                .getCommentOwner());
         commentDTO.setUsername(realName);
         commentDTO.setCommentText(comment.getCommentText());
         commentDTO.setCategory(comment.getCategory());
@@ -80,7 +80,7 @@ public class CommentMappingUtil {
         comment.setCategory(body.getCategory());
         comment.setParentCommentId(body.getParentCommentId());
         comment.setEntryPoint(body.getEntryPoint());
-        comment.setCommentedUser(username);
+        comment.setCommentOwner(username);
         comment.setApiId(body.getApiId());
         comment.setCreatedUser(username);
         comment.setUpdatedUser(username);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml
@@ -5195,6 +5195,10 @@ definitions:
         example: 2017-02-20T13:57:16.229
       lastUpdatedBy:
         type: string
+      replies:
+        type: array
+        items:
+          $ref: '#/definitions/Comment'
 
   #-----------------------------------------------------
   # The Comments List resource

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImplTestCase.java
@@ -2236,7 +2236,7 @@ public class ApisApiServiceImplTestCase {
         Comment comment = new Comment();
         comment.setUuid(commentId);
         comment.setApiId(apiId);
-        comment.setCommentedUser("commentedUser");
+        comment.setCommentOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
         comment.setParentCommentId("");
@@ -2294,7 +2294,7 @@ public class ApisApiServiceImplTestCase {
         Comment comment = new Comment();
         comment.setUuid(commentId);
         comment.setApiId(apiId);
-        comment.setCommentedUser("commentedUser");
+        comment.setCommentOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
         comment.setParentCommentId("");
@@ -2339,7 +2339,7 @@ public class ApisApiServiceImplTestCase {
         Instant time = APIUtils.getCurrentUTCTime();
         Comment comment1 = new Comment();
         comment1.setUuid(UUID.randomUUID().toString());
-        comment1.setCommentedUser("commentedUser1");
+        comment1.setCommentOwner("commentedUser1");
         comment1.setCommentText("this is a comment 1");
         comment1.setCategory("testCategory1");
         comment1.setParentCommentId("");
@@ -2352,7 +2352,7 @@ public class ApisApiServiceImplTestCase {
         time = APIUtils.getCurrentUTCTime();
         Comment comment2 = new Comment();
         comment2.setUuid(UUID.randomUUID().toString());
-        comment2.setCommentedUser("commentedUser2");
+        comment2.setCommentOwner("commentedUser2");
         comment2.setCommentText("this is a comment 2");
         comment2.setCategory("testCategory2");
         comment2.setParentCommentId("");
@@ -2410,7 +2410,7 @@ public class ApisApiServiceImplTestCase {
         Instant time = APIUtils.getCurrentUTCTime();
         ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
-        comment.setCommentedUser("commentedUser");
+        comment.setCommentOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
         comment.setParentCommentId("");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImplTestCase.java
@@ -2236,7 +2236,7 @@ public class ApisApiServiceImplTestCase {
         Comment comment = new Comment();
         comment.setUuid(commentId);
         comment.setApiId(apiId);
-        comment.setCommentOwner("commentedUser");
+        comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
         comment.setParentCommentId("");
@@ -2294,7 +2294,7 @@ public class ApisApiServiceImplTestCase {
         Comment comment = new Comment();
         comment.setUuid(commentId);
         comment.setApiId(apiId);
-        comment.setCommentOwner("commentedUser");
+        comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
         comment.setParentCommentId("");
@@ -2339,7 +2339,7 @@ public class ApisApiServiceImplTestCase {
         Instant time = APIUtils.getCurrentUTCTime();
         Comment comment1 = new Comment();
         comment1.setUuid(UUID.randomUUID().toString());
-        comment1.setCommentOwner("commentedUser1");
+        comment1.setOwner("commentedUser1");
         comment1.setCommentText("this is a comment 1");
         comment1.setCategory("testCategory1");
         comment1.setParentCommentId("");
@@ -2352,7 +2352,7 @@ public class ApisApiServiceImplTestCase {
         time = APIUtils.getCurrentUTCTime();
         Comment comment2 = new Comment();
         comment2.setUuid(UUID.randomUUID().toString());
-        comment2.setCommentOwner("commentedUser2");
+        comment2.setOwner("commentedUser2");
         comment2.setCommentText("this is a comment 2");
         comment2.setCategory("testCategory2");
         comment2.setParentCommentId("");
@@ -2410,7 +2410,7 @@ public class ApisApiServiceImplTestCase {
         Instant time = APIUtils.getCurrentUTCTime();
         ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
-        comment.setCommentOwner("commentedUser");
+        comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
         comment.setParentCommentId("");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImplTestCase.java
@@ -2290,6 +2290,7 @@ public class ApisApiServiceImplTestCase {
         PowerMockito.when(RestApiUtil.getLoggedInUsername(request)).thenReturn(USER);
 
         Instant time = APIUtils.getCurrentUTCTime();
+        ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
         comment.setUuid(commentId);
         comment.setApiId(apiId);
@@ -2302,6 +2303,7 @@ public class ApisApiServiceImplTestCase {
         comment.setUpdatedUser("updatedUser");
         comment.setCreatedTime(time);
         comment.setUpdatedTime(time);
+        comment.setReplies(comments);
 
         Mockito.when(apiPublisher.getCommentByUUID(commentId, apiId)).thenReturn(comment);
 
@@ -2406,6 +2408,7 @@ public class ApisApiServiceImplTestCase {
         commentDTO.setLastUpdatedBy("updater");
 
         Instant time = APIUtils.getCurrentUTCTime();
+        ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
         comment.setCommentedUser("commentedUser");
         comment.setCommentText("this is a comment");
@@ -2416,6 +2419,8 @@ public class ApisApiServiceImplTestCase {
         comment.setUpdatedUser("updatedUser");
         comment.setCreatedTime(time);
         comment.setUpdatedTime(time);
+        comment.setReplies(comments);
+
 
         Mockito.doNothing().doThrow(new IllegalArgumentException()).when(apiPublisher)
                 .updateComment(comment, commentId, apiId, USER);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtilTestCase.java
@@ -56,6 +56,7 @@ public class CommentMappingUtilTestCase {
         String commentUUID = UUID.randomUUID().toString();
         Instant time = APIUtils.getCurrentUTCTime();
 
+        ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
         comment.setUuid(commentUUID);
         comment.setCommentedUser("commentedUser");
@@ -67,6 +68,7 @@ public class CommentMappingUtilTestCase {
         comment.setUpdatedUser("updatedUser");
         comment.setCreatedTime(time);
         comment.setUpdatedTime(time);
+        comment.setReplies(comments);
 
         CommentDTO commentDTO = CommentMappingUtil.fromCommentToDTO(comment);
 
@@ -98,6 +100,7 @@ public class CommentMappingUtilTestCase {
     public void testFromCommentListToDTO() throws APIManagementException {
         Mockito.when(userNameMapper.getLoggedInUserIDFromPseudoName(Mockito.anyString())).thenReturn(Mockito.anyString());
         Instant time = APIUtils.getCurrentUTCTime();
+        ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment1 = new Comment();
         comment1.setUuid(UUID.randomUUID().toString());
         comment1.setCommentedUser("commentedUser1");
@@ -109,6 +112,7 @@ public class CommentMappingUtilTestCase {
         comment1.setUpdatedUser("updatedUser1");
         comment1.setCreatedTime(time);
         comment1.setUpdatedTime(time);
+        comment1.setReplies(comments);
 
         time = APIUtils.getCurrentUTCTime();
         Comment comment2 = new Comment();
@@ -122,6 +126,7 @@ public class CommentMappingUtilTestCase {
         comment2.setUpdatedUser("updatedUser2");
         comment2.setCreatedTime(time);
         comment2.setUpdatedTime(time);
+        comment2.setReplies(comments);
 
         List<Comment> commentList = new ArrayList<>();
         commentList.add(comment1);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtilTestCase.java
@@ -59,7 +59,7 @@ public class CommentMappingUtilTestCase {
         ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
         comment.setUuid(commentUUID);
-        comment.setCommentOwner("commentedUser");
+        comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testingCategory");
         comment.setParentCommentId("");
@@ -103,7 +103,7 @@ public class CommentMappingUtilTestCase {
         ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment1 = new Comment();
         comment1.setUuid(UUID.randomUUID().toString());
-        comment1.setCommentOwner("commentedUser1");
+        comment1.setOwner("commentedUser1");
         comment1.setCommentText("this is a comment 1");
         comment1.setCategory("testingCategory1");
         comment1.setParentCommentId("");
@@ -117,7 +117,7 @@ public class CommentMappingUtilTestCase {
         time = APIUtils.getCurrentUTCTime();
         Comment comment2 = new Comment();
         comment2.setUuid(UUID.randomUUID().toString());
-        comment2.setCommentOwner("commentedUser2");
+        comment2.setOwner("commentedUser2");
         comment2.setCommentText("this is a comment 2");
         comment2.setCategory("testingCategory1");
         comment2.setParentCommentId("");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtilTestCase.java
@@ -59,7 +59,7 @@ public class CommentMappingUtilTestCase {
         ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
         comment.setUuid(commentUUID);
-        comment.setCommentedUser("commentedUser");
+        comment.setCommentOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testingCategory");
         comment.setParentCommentId("");
@@ -103,7 +103,7 @@ public class CommentMappingUtilTestCase {
         ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment1 = new Comment();
         comment1.setUuid(UUID.randomUUID().toString());
-        comment1.setCommentedUser("commentedUser1");
+        comment1.setCommentOwner("commentedUser1");
         comment1.setCommentText("this is a comment 1");
         comment1.setCategory("testingCategory1");
         comment1.setParentCommentId("");
@@ -117,7 +117,7 @@ public class CommentMappingUtilTestCase {
         time = APIUtils.getCurrentUTCTime();
         Comment comment2 = new Comment();
         comment2.setUuid(UUID.randomUUID().toString());
-        comment2.setCommentedUser("commentedUser2");
+        comment2.setCommentOwner("commentedUser2");
         comment2.setCommentText("this is a comment 2");
         comment2.setCategory("testingCategory1");
         comment2.setParentCommentId("");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/CommentDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/dto/CommentDTO.java
@@ -4,6 +4,9 @@ package org.wso2.carbon.apimgt.rest.api.store.dto;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.apimgt.rest.api.store.dto.CommentDTO;
 import java.util.Objects;
 
 /**
@@ -42,6 +45,9 @@ public class CommentDTO   {
 
   @SerializedName("lastUpdatedBy")
   private String lastUpdatedBy = null;
+
+  @SerializedName("replies")
+  private List<CommentDTO> replies = new ArrayList<CommentDTO>();
 
   public CommentDTO commentId(String commentId) {
     this.commentId = commentId;
@@ -241,6 +247,29 @@ public class CommentDTO   {
     this.lastUpdatedBy = lastUpdatedBy;
   }
 
+  public CommentDTO replies(List<CommentDTO> replies) {
+    this.replies = replies;
+    return this;
+  }
+
+  public CommentDTO addRepliesItem(CommentDTO repliesItem) {
+    this.replies.add(repliesItem);
+    return this;
+  }
+
+   /**
+   * Get replies
+   * @return replies
+  **/
+  @ApiModelProperty(value = "")
+  public List<CommentDTO> getReplies() {
+    return replies;
+  }
+
+  public void setReplies(List<CommentDTO> replies) {
+    this.replies = replies;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -261,12 +290,13 @@ public class CommentDTO   {
         Objects.equals(this.createdTime, comment.createdTime) &&
         Objects.equals(this.createdBy, comment.createdBy) &&
         Objects.equals(this.lastUpdatedTime, comment.lastUpdatedTime) &&
-        Objects.equals(this.lastUpdatedBy, comment.lastUpdatedBy);
+        Objects.equals(this.lastUpdatedBy, comment.lastUpdatedBy) &&
+        Objects.equals(this.replies, comment.replies);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(commentId, apiId, category, parentCommentId, entryPoint, username, commentText, createdTime, createdBy, lastUpdatedTime, lastUpdatedBy);
+    return Objects.hash(commentId, apiId, category, parentCommentId, entryPoint, username, commentText, createdTime, createdBy, lastUpdatedTime, lastUpdatedBy, replies);
   }
 
   @Override
@@ -285,6 +315,7 @@ public class CommentDTO   {
     sb.append("    createdBy: ").append(toIndentedString(createdBy)).append("\n");
     sb.append("    lastUpdatedTime: ").append(toIndentedString(lastUpdatedTime)).append("\n");
     sb.append("    lastUpdatedBy: ").append(toIndentedString(lastUpdatedBy)).append("\n");
+    sb.append("    replies: ").append(toIndentedString(replies)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtil.java
@@ -48,7 +48,7 @@ public class CommentMappingUtil {
         CommentDTO commentDTO = new CommentDTO();
         commentDTO.setCommentId(comment.getUuid());
         String realName = APIManagerFactory.getInstance().getUserNameMapper().getLoggedInUserIDFromPseudoName(comment
-                .getCommentedUser());
+                .getCommentOwner());
         commentDTO.setUsername(realName);
         commentDTO.setCommentText(comment.getCommentText());
         commentDTO.setCategory(comment.getCategory());
@@ -79,7 +79,7 @@ public class CommentMappingUtil {
         comment.setCategory(body.getCategory());
         comment.setParentCommentId(body.getParentCommentId());
         comment.setEntryPoint(body.getEntryPoint());
-        comment.setCommentedUser(username);
+        comment.setCommentOwner(username);
         comment.setApiId(body.getApiId());
         comment.setCreatedUser(username);
         comment.setUpdatedUser(username);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtil.java
@@ -48,7 +48,7 @@ public class CommentMappingUtil {
         CommentDTO commentDTO = new CommentDTO();
         commentDTO.setCommentId(comment.getUuid());
         String realName = APIManagerFactory.getInstance().getUserNameMapper().getLoggedInUserIDFromPseudoName(comment
-                .getCommentOwner());
+                .getOwner());
         commentDTO.setUsername(realName);
         commentDTO.setCommentText(comment.getCommentText());
         commentDTO.setCategory(comment.getCategory());
@@ -79,7 +79,7 @@ public class CommentMappingUtil {
         comment.setCategory(body.getCategory());
         comment.setParentCommentId(body.getParentCommentId());
         comment.setEntryPoint(body.getEntryPoint());
-        comment.setCommentOwner(username);
+        comment.setOwner(username);
         comment.setApiId(body.getApiId());
         comment.setCreatedUser(username);
         comment.setUpdatedUser(username);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtil.java
@@ -58,6 +58,9 @@ public class CommentMappingUtil {
         commentDTO.setLastUpdatedBy(comment.getUpdatedUser());
         commentDTO.setCreatedTime(comment.getCreatedTime().toString());
         commentDTO.setLastUpdatedTime(comment.getUpdatedTime().toString());
+        for (Comment commentItem : comment.getReplies()) {
+            commentDTO.addRepliesItem(fromCommentToDTO(commentItem));
+        }
 
         return commentDTO;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/resources/store-api.yaml
@@ -3832,8 +3832,13 @@ definitions:
         example: 2017-02-20T13:57:16.229
       lastUpdatedBy:
         type: string
+      replies:
+        type: array
+        items:
+          $ref: '#/definitions/Comment'
 
-#-----------------------------------------------------
+
+  #-----------------------------------------------------
 # The Comments List resource
 #-----------------------------------------------------
   CommentList:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImplTestCase.java
@@ -188,7 +188,7 @@ public class ApisApiServiceImplTestCase {
         Comment comment = new Comment();
         comment.setUuid(commentId);
         comment.setApiId(apiId);
-        comment.setCommentedUser("commentedUser");
+        comment.setCommentOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
         comment.setParentCommentId("");
@@ -244,7 +244,7 @@ public class ApisApiServiceImplTestCase {
         Comment comment = new Comment();
         comment.setUuid(commentId);
         comment.setApiId(apiId);
-        comment.setCommentedUser("commentedUser");
+        comment.setCommentOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
         comment.setParentCommentId("");
@@ -288,7 +288,7 @@ public class ApisApiServiceImplTestCase {
         Instant time = APIUtils.getCurrentUTCTime();
         Comment comment1 = new Comment();
         comment1.setUuid(UUID.randomUUID().toString());
-        comment1.setCommentedUser("commentedUser1");
+        comment1.setCommentOwner("commentedUser1");
         comment1.setCommentText("this is a comment 1");
         comment1.setCategory("testCategory1");
         comment1.setParentCommentId("");
@@ -301,7 +301,7 @@ public class ApisApiServiceImplTestCase {
         time = APIUtils.getCurrentUTCTime();
         Comment comment2 = new Comment();
         comment2.setUuid(UUID.randomUUID().toString());
-        comment2.setCommentedUser("commentedUser2");
+        comment2.setCommentOwner("commentedUser2");
         comment2.setCommentText("this is a comment 2");
         comment2.setCategory("testCategory2");
         comment2.setParentCommentId("");
@@ -358,7 +358,7 @@ public class ApisApiServiceImplTestCase {
         Instant time = APIUtils.getCurrentUTCTime();
         ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
-        comment.setCommentedUser("commentedUser");
+        comment.setCommentOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
         comment.setParentCommentId("");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImplTestCase.java
@@ -188,7 +188,7 @@ public class ApisApiServiceImplTestCase {
         Comment comment = new Comment();
         comment.setUuid(commentId);
         comment.setApiId(apiId);
-        comment.setCommentOwner("commentedUser");
+        comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
         comment.setParentCommentId("");
@@ -244,7 +244,7 @@ public class ApisApiServiceImplTestCase {
         Comment comment = new Comment();
         comment.setUuid(commentId);
         comment.setApiId(apiId);
-        comment.setCommentOwner("commentedUser");
+        comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
         comment.setParentCommentId("");
@@ -288,7 +288,7 @@ public class ApisApiServiceImplTestCase {
         Instant time = APIUtils.getCurrentUTCTime();
         Comment comment1 = new Comment();
         comment1.setUuid(UUID.randomUUID().toString());
-        comment1.setCommentOwner("commentedUser1");
+        comment1.setOwner("commentedUser1");
         comment1.setCommentText("this is a comment 1");
         comment1.setCategory("testCategory1");
         comment1.setParentCommentId("");
@@ -301,7 +301,7 @@ public class ApisApiServiceImplTestCase {
         time = APIUtils.getCurrentUTCTime();
         Comment comment2 = new Comment();
         comment2.setUuid(UUID.randomUUID().toString());
-        comment2.setCommentOwner("commentedUser2");
+        comment2.setOwner("commentedUser2");
         comment2.setCommentText("this is a comment 2");
         comment2.setCategory("testCategory2");
         comment2.setParentCommentId("");
@@ -358,7 +358,7 @@ public class ApisApiServiceImplTestCase {
         Instant time = APIUtils.getCurrentUTCTime();
         ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
-        comment.setCommentOwner("commentedUser");
+        comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
         comment.setParentCommentId("");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImplTestCase.java
@@ -240,6 +240,7 @@ public class ApisApiServiceImplTestCase {
         PowerMockito.when(RestApiUtil.getLoggedInUsername(request)).thenReturn(USER);
 
         Instant time = APIUtils.getCurrentUTCTime();
+        ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
         comment.setUuid(commentId);
         comment.setApiId(apiId);
@@ -252,6 +253,7 @@ public class ApisApiServiceImplTestCase {
         comment.setUpdatedUser("updatedUser");
         comment.setCreatedTime(time);
         comment.setUpdatedTime(time);
+        comment.setReplies(comments);
 
         Mockito.when(apiStore.getCommentByUUID(commentId, apiId)).thenReturn(comment);
 
@@ -354,6 +356,7 @@ public class ApisApiServiceImplTestCase {
         commentDTO.setLastUpdatedBy("updater");
 
         Instant time = APIUtils.getCurrentUTCTime();
+        ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
         comment.setCommentedUser("commentedUser");
         comment.setCommentText("this is a comment");
@@ -364,6 +367,7 @@ public class ApisApiServiceImplTestCase {
         comment.setUpdatedUser("updatedUser");
         comment.setCreatedTime(time);
         comment.setUpdatedTime(time);
+        comment.setReplies(comments);
 
         Mockito.doNothing().doThrow(new IllegalArgumentException()).when(apiStore)
                 .updateComment(comment, commentId, apiId, USER);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtilTestCase.java
@@ -58,7 +58,7 @@ public class CommentMappingUtilTestCase {
         ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
         comment.setUuid(commentUUID);
-        comment.setCommentedUser("commentedUser");
+        comment.setCommentOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testingCategory");
         comment.setParentCommentId("");
@@ -102,7 +102,7 @@ public class CommentMappingUtilTestCase {
         ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment1 = new Comment();
         comment1.setUuid(UUID.randomUUID().toString());
-        comment1.setCommentedUser("commentedUser1");
+        comment1.setCommentOwner("commentedUser1");
         comment1.setCommentText("this is a comment 1");
         comment1.setCategory("testingCategory1");
         comment1.setParentCommentId("");
@@ -116,7 +116,7 @@ public class CommentMappingUtilTestCase {
         time = APIUtils.getCurrentUTCTime();
         Comment comment2 = new Comment();
         comment2.setUuid(UUID.randomUUID().toString());
-        comment2.setCommentedUser("commentedUser2");
+        comment2.setCommentOwner("commentedUser2");
         comment2.setCommentText("this is a comment 2");
         comment2.setCategory("testingCategory1");
         comment2.setParentCommentId("");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtilTestCase.java
@@ -55,6 +55,7 @@ public class CommentMappingUtilTestCase {
         String commentUUID = UUID.randomUUID().toString();
         Instant time = APIUtils.getCurrentUTCTime();
 
+        ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
         comment.setUuid(commentUUID);
         comment.setCommentedUser("commentedUser");
@@ -66,6 +67,7 @@ public class CommentMappingUtilTestCase {
         comment.setUpdatedUser("updatedUser");
         comment.setCreatedTime(time);
         comment.setUpdatedTime(time);
+        comment.setReplies(comments);
 
         CommentDTO commentDTO = CommentMappingUtil.fromCommentToDTO(comment);
 
@@ -97,6 +99,7 @@ public class CommentMappingUtilTestCase {
     public void testFromCommentListToDTO() throws APIManagementException {
         Mockito.when(userNameMapper.getLoggedInUserIDFromPseudoName(Mockito.anyString())).thenReturn(Mockito.anyString());
         Instant time = APIUtils.getCurrentUTCTime();
+        ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment1 = new Comment();
         comment1.setUuid(UUID.randomUUID().toString());
         comment1.setCommentedUser("commentedUser1");
@@ -108,6 +111,7 @@ public class CommentMappingUtilTestCase {
         comment1.setUpdatedUser("updatedUser1");
         comment1.setCreatedTime(time);
         comment1.setUpdatedTime(time);
+        comment1.setReplies(comments);
 
         time = APIUtils.getCurrentUTCTime();
         Comment comment2 = new Comment();
@@ -121,6 +125,7 @@ public class CommentMappingUtilTestCase {
         comment2.setUpdatedUser("updatedUser2");
         comment2.setCreatedTime(time);
         comment2.setUpdatedTime(time);
+        comment2.setReplies(comments);
 
         List<Comment> commentList = new ArrayList<>();
         commentList.add(comment1);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtilTestCase.java
@@ -58,7 +58,7 @@ public class CommentMappingUtilTestCase {
         ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment = new Comment();
         comment.setUuid(commentUUID);
-        comment.setCommentOwner("commentedUser");
+        comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testingCategory");
         comment.setParentCommentId("");
@@ -102,7 +102,7 @@ public class CommentMappingUtilTestCase {
         ArrayList<Comment> comments = new ArrayList<Comment>();
         Comment comment1 = new Comment();
         comment1.setUuid(UUID.randomUUID().toString());
-        comment1.setCommentOwner("commentedUser1");
+        comment1.setOwner("commentedUser1");
         comment1.setCommentText("this is a comment 1");
         comment1.setCategory("testingCategory1");
         comment1.setParentCommentId("");
@@ -116,7 +116,7 @@ public class CommentMappingUtilTestCase {
         time = APIUtils.getCurrentUTCTime();
         Comment comment2 = new Comment();
         comment2.setUuid(UUID.randomUUID().toString());
-        comment2.setCommentOwner("commentedUser2");
+        comment2.setOwner("commentedUser2");
         comment2.setCommentText("this is a comment 2");
         comment2.setCategory("testingCategory1");
         comment2.setParentCommentId("");

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.wso2.carbon.apimgt</groupId>
     <artifactId>carbon-apimgt</artifactId>
     <packaging>pom</packaging>
-    <version>7.0.236-SNAPSHOT</version>
+    <version>7.0.236</version>
 
     <name>WSO2 Carbon - API Management Aggregator POM</name>
 


### PR DESCRIPTION
## Purpose
Earlier we had the ability only to retrieve the comments and replies as a single list. But it is a tedious task when displaying those in the UI. So, need a mechanism to retrieve the comments from the backend in a nested manner.

## Goals
- After getting the comments list from the database, organize the comment replies in a nested manner under the particular parent comment.

## Approach
Please refer the mail thread subjected as “[Dev] [APIM 3.0] Issue of retrieving nested API comments”.

## User stories
- As a Consumer, someone can retrieve nested comments in API Store.
- As a Publisher, someone can retrieve nested comments in API Publisher.

## Documentation
N/A - since this is a modification to the already implemented functionality. (Check https://github.com/wso2/carbon-apimgt/pull/5832 - the closed PR)

## Automation tests
 - Unit tests 
   Wrote and modified unit tests for API Store and API Publisher.
    - carbon-apimgt/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImplTestCase.java
    - carbon-apimgt/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImplTestCase.java
    - carbon-apimgt/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/store/mappings/CommentMappingUtilTestCase.java
    - carbon-apimgt/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/mappings/CommentMappingUtilTestCase.java

## Test environment
- jdk1.8.0_144
- Ubuntu 16.04 LTS
- h2, MySQL, MSSQL, Oracle, PostgreSQL
- Google Chrome Version 69.0.3497.100 (Official Build) (64-bit)
