### PR TITLE
Adding cross tenant APIs/Apps export support to REST API for 3.0 migration

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIAdmin.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIAdmin.java
@@ -59,5 +59,5 @@ public interface APIAdmin  {
      */
     Label updateLabel(Label label) throws APIManagementException;
 
-    Application[] getAllApplicationsOfTenant(String appTenantDomain) throws APIManagementException;
+    Application[] getAllApplicationsOfTenantForMigration(String appTenantDomain) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIAdmin.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIAdmin.java
@@ -17,6 +17,7 @@
 */
 package org.wso2.carbon.apimgt.api;
 
+import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.Label;
 
 import java.util.List;
@@ -57,4 +58,6 @@ public interface APIAdmin  {
      * @throws APIManagementException if failed to update label
      */
     Label updateLabel(Label label) throws APIManagementException;
+
+    Application[] getAllApplicationsOfTenant(String appTenantDomain) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.impl;
 
 import org.wso2.carbon.apimgt.api.APIAdmin;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.Label;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 
@@ -71,5 +72,10 @@ public class APIAdminImpl implements APIAdmin {
      */
     public Label updateLabel(Label label) throws APIManagementException{
         return apiMgtDAO.updateLabel(label);
+    }
+
+    @Override
+    public Application[] getAllApplicationsOfTenant(String appTenantDomain) throws APIManagementException{
+        return apiMgtDAO.getLightWeightApplicationsOfTenant(appTenantDomain);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -75,7 +75,7 @@ public class APIAdminImpl implements APIAdmin {
     }
 
     @Override
-    public Application[] getAllApplicationsOfTenant(String appTenantDomain) throws APIManagementException{
-        return apiMgtDAO.getLightWeightApplicationsOfTenant(appTenantDomain);
+    public Application[] getAllApplicationsOfTenantForMigration(String appTenantDomain) throws APIManagementException{
+        return apiMgtDAO.getAllApplicationsOfTenantForMigration(appTenantDomain);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1465,4 +1465,5 @@ public final class APIConstants {
     public static final String JAVA_IO_TMPDIR = "java.io.tmpdir";
     public static final String JSON_FILENAME_EXTENSION = ".json";
     public static final String JSON_GZIP_FILENAME_EXTENSION = ".json.gz";
+    public static final String MIGRATION_MODE = "migrationMode";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -3240,6 +3240,17 @@ class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         Application application = apiMgtDAO.getApplicationById(id);
         String userId = application.getSubscriber().getName();
         checkAppAttributes(application, userId);
+        if (Boolean.getBoolean(APIConstants.MIGRATION_MODE)) {
+            Application applicationWithKeys = apiMgtDAO.getApplicationById(id);
+            if (applicationWithKeys != null) {
+                Set<APIKey> keys = getApplicationKeys(applicationWithKeys.getId());
+
+                for (APIKey key : keys) {
+                    applicationWithKeys.addKey(key);
+                }
+            }
+            return applicationWithKeys;
+        }
         return apiMgtDAO.getApplicationById(id);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -4115,6 +4115,86 @@ public class ApiMgtDAO {
         return applications;
     }
 
+    public Application[] getLightWeightApplicationsOfTenant(String appTenantDomain) throws
+            APIManagementException {
+
+        Connection connection;
+        PreparedStatement prepStmt = null;
+        ResultSet rs;
+        Application[] applications = null;
+        String sqlQuery = SQLConstants.GET_APPLICATIONS_PREFIX;
+        Subscriber subscriber;
+
+        String whereClause = "AND SUB.TENANT_ID=?";
+        sqlQuery += whereClause ;
+        try {
+            connection = APIMgtDBUtil.getConnection();
+            String blockingFilerSql = null;
+            if (connection.getMetaData().getDriverName().contains("MS SQL") ||
+                    connection.getMetaData().getDriverName().contains("Microsoft")) {
+                sqlQuery = sqlQuery.replaceAll("NAME", "cast(NAME as varchar(100)) collate " +
+                        "SQL_Latin1_General_CP1_CI_AS as NAME");
+                blockingFilerSql = " select distinct x.*,bl.ENABLED from ( " + sqlQuery + " )x left join " +
+                        "AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.VALUE = (x.USER_ID + ':') + x" +
+                        ".name)";
+            } else {
+                blockingFilerSql = " select distinct x.*,bl.ENABLED from ( " + sqlQuery
+                        + " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.VALUE = "
+                        + "concat(concat(x.USER_ID,':'),x.name))";
+            }
+
+            int appTenantId = APIUtil.getTenantIdFromTenantDomain(appTenantDomain);
+            prepStmt = connection.prepareStatement(blockingFilerSql);
+            prepStmt.setInt(1, appTenantId);
+            rs = prepStmt.executeQuery();
+
+            ArrayList<Application> applicationsList = new ArrayList<Application>();
+            Application application;
+            Map<String,String> applicationAttributes;
+            int applicationId = 0;
+            while (rs.next()) {
+                subscriber = new Subscriber(rs.getString("USER_ID"));
+                subscriber.setId(rs.getInt("SUBSCRIBER_ID"));
+                application = new Application(rs.getString("NAME"), subscriber);
+
+                applicationId = rs.getInt("APPLICATION_ID");
+                application.setId(applicationId);
+                application.setTier(rs.getString("APPLICATION_TIER"));
+                application.setCallbackUrl(rs.getString("CALLBACK_URL"));
+                application.setDescription(rs.getString("DESCRIPTION"));
+                application.setStatus(rs.getString("APPLICATION_STATUS"));
+                application.setGroupId(rs.getString("GROUP_ID"));
+                application.setUUID(rs.getString("UUID"));
+                application.setIsBlackListed(rs.getBoolean("ENABLED"));
+                application.setOwner(rs.getString("CREATED_BY"));
+                application.setTokenType(rs.getString("TOKEN_TYPE"));
+                applicationAttributes = getApplicationAttributes(connection, applicationId);
+                application.setApplicationAttributes(applicationAttributes);
+                if (multiGroupAppSharingEnabled) {
+                    setGroupIdInApplication(application);
+                }
+                applicationsList.add(application);
+            }
+            Collections.sort(applicationsList, new Comparator<Application>() {
+                public int compare(Application o1, Application o2) {
+                    return o1.getName().compareToIgnoreCase(o2.getName());
+                }
+            });
+            applications = applicationsList.toArray(new Application[applicationsList.size()]);
+        } catch (SQLException e) {
+            handleException("Error when reading the application information from" + " the persistence store.", e);
+        } finally {
+            if (prepStmt != null) {
+                try {
+                    prepStmt.close();
+                } catch (SQLException e) {
+                    log.warn("Database error. Could not close Statement. Continuing with others." + e.getMessage(), e);
+                }
+            }
+        }
+        return applications;
+    }
+
     /**
      * Returns all the consumerkeys of application which are subscribed for the given api
      *

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -4137,10 +4137,6 @@ public class ApiMgtDAO {
             ArrayList<Application> applicationsList = new ArrayList<Application>();
             Application application;
             while (rs.next()) {
-                /*subscriber = new Subscriber(rs.getString("USER_ID"));
-                subscriber.setId(rs.getInt("SUBSCRIBER_ID"));
-                application = new Application(rs.getString("NAME"), subscriber);
-                */
                 application = new Application(Integer.parseInt(rs.getString("APPLICATION_ID")));
                 application.setName(rs.getString("NAME"));
                 application.setOwner(rs.getString("CREATED_BY"));

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -4144,7 +4144,7 @@ public class ApiMgtDAO {
             }
             applications = applicationsList.toArray(new Application[applicationsList.size()]);
         } catch (SQLException e) {
-            handleException("Error when reading the application information from" + " the persistence store.", e);
+            handleException("Error when reading the application information from the persistence store.", e);
         } finally {
             if (prepStmt != null) {
                 try {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -1312,6 +1312,18 @@ public class SQLConstants {
             " WHERE " +
             "   SUB.SUBSCRIBER_ID = APP.SUBSCRIBER_ID ";
 
+    public static final String GET_SIMPLE_APPLICATIONS =
+            " SELECT " +
+            "   APPLICATION_ID, " +
+            "   NAME," +
+            "   USER_ID, " +
+            "   APP.CREATED_BY " +
+            " FROM" +
+            "   AM_APPLICATION APP, "+
+            "   AM_SUBSCRIBER SUB  "+
+            " WHERE " +
+            "   SUB.SUBSCRIBER_ID = APP.SUBSCRIBER_ID ";
+
     public static final String GET_APPLICATIONS_BY_OWNER =
             "SELECT " +
             "   UUID, " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -1319,8 +1319,8 @@ public class SQLConstants {
             "   USER_ID, " +
             "   APP.CREATED_BY " +
             " FROM" +
-            "   AM_APPLICATION APP, "+
-            "   AM_SUBSCRIBER SUB  "+
+            "   AM_APPLICATION APP, " +
+            "   AM_SUBSCRIBER SUB  " +
             " WHERE " +
             "   SUB.SUBSCRIBER_ID = APP.SUBSCRIBER_ID ";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ApplicationsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ApplicationsApi.java
@@ -63,9 +63,10 @@ public class ApplicationsApi  {
     @ApiParam(value = "Maximum size of resource array to return.\n", defaultValue="25") @QueryParam("limit") Integer limit,
     @ApiParam(value = "Starting point within the complete list of items qualified.\n", defaultValue="0") @QueryParam("offset") Integer offset,
     @ApiParam(value = "Media types acceptable for the response. Default is application/json.\n"  , defaultValue="application/json")@HeaderParam("Accept") String accept,
-    @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resource (Will be supported in future).\n"  )@HeaderParam("If-None-Match") String ifNoneMatch)
+    @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resource (Will be supported in future).\n"  )@HeaderParam("If-None-Match") String ifNoneMatch,
+    @ApiParam(value = "Whether to get the applications of all the users of all tenants\n") @QueryParam("tenantDomain")  String tenantDomain)
     {
-    return delegate.applicationsGet(user,limit,offset,accept,ifNoneMatch);
+    return delegate.applicationsGet(user,limit,offset,accept,ifNoneMatch,tenantDomain);
     }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ApplicationsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ApplicationsApiService.java
@@ -15,6 +15,7 @@ import javax.ws.rs.core.Response;
 
 public abstract class ApplicationsApiService {
     public abstract Response applicationsApplicationIdChangeOwnerPost(String owner,String applicationId);
-    public abstract Response applicationsGet(String user,Integer limit,Integer offset,String accept,String ifNoneMatch,String tenantDomain);
+    public abstract Response applicationsGet(String user,Integer limit,Integer offset,String accept,String ifNoneMatch,
+                                             String tenantDomain);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ApplicationsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ApplicationsApiService.java
@@ -15,6 +15,6 @@ import javax.ws.rs.core.Response;
 
 public abstract class ApplicationsApiService {
     public abstract Response applicationsApplicationIdChangeOwnerPost(String owner,String applicationId);
-    public abstract Response applicationsGet(String user,Integer limit,Integer offset,String accept,String ifNoneMatch);
+    public abstract Response applicationsGet(String user,Integer limit,Integer offset,String accept,String ifNoneMatch,String tenantDomain);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImpl.java
@@ -74,9 +74,14 @@ public class ExportApiServiceImpl extends ExportApiService {
                 String errorMsg = "No application found with name " + appName + " owned by " + appOwner;
                 log.error(errorMsg);
                 return Response.status(Response.Status.NOT_FOUND).entity(errorMsg).build();
-            } else {
+            } else if( Boolean.getBoolean(RestApiConstants.MIGRATION_MODE)) {
                 String appTenant = MultitenantUtils.getTenantDomain(applicationDetails.getSubscriber().getName());
                 RestApiUtil.handleMigrationSpecificPermissionViolations(appTenant, username);
+            } else if (!MultitenantUtils.getTenantDomain(applicationDetails.getSubscriber().getName()).equals
+                    (MultitenantUtils.getTenantDomain(username))) {  // normal non-migration flow
+                String errorMsg = "Cross Tenant Exports are not allowed";
+                log.error(errorMsg);
+                return Response.status(Response.Status.FORBIDDEN).entity(errorMsg).build();
             }
             exportedFilePath = importExportManager.exportApplication(applicationDetails,
                     DEFAULT_APPLICATION_EXPORT_DIR);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImpl.java
@@ -67,7 +67,6 @@ public class ExportApiServiceImpl extends ExportApiService {
             consumer = RestApiUtil.getConsumer(username);
             FileBasedApplicationImportExportManager importExportManager = new FileBasedApplicationImportExportManager
                     (consumer, pathToExportDir);
-            String appTenant = MultitenantUtils.getTenantDomain(applicationDetails.getSubscriber().getName());
             if (importExportManager.isOwnerAvailable(appOwner)) {
                 applicationDetails = importExportManager.getApplicationDetails(appName, appOwner);
             }
@@ -76,6 +75,7 @@ public class ExportApiServiceImpl extends ExportApiService {
                 log.error(errorMsg);
                 return Response.status(Response.Status.NOT_FOUND).entity(errorMsg).build();
             } else {
+                String appTenant = MultitenantUtils.getTenantDomain(applicationDetails.getSubscriber().getName());
                 RestApiUtil.handleMigrationSpecificPermissionViolations(appTenant, username);
             }
             exportedFilePath = importExportManager.exportApplication(applicationDetails,

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImpl.java
@@ -74,7 +74,7 @@ public class ExportApiServiceImpl extends ExportApiService {
                 String errorMsg = "No application found with name " + appName + " owned by " + appOwner;
                 log.error(errorMsg);
                 return Response.status(Response.Status.NOT_FOUND).entity(errorMsg).build();
-            } else if( Boolean.getBoolean(RestApiConstants.MIGRATION_MODE)) {
+            } else if (Boolean.getBoolean(RestApiConstants.MIGRATION_MODE)) { // migration flow
                 String appTenant = MultitenantUtils.getTenantDomain(applicationDetails.getSubscriber().getName());
                 RestApiUtil.handleMigrationSpecificPermissionViolations(appTenant, username);
             } else if (!MultitenantUtils.getTenantDomain(applicationDetails.getSubscriber().getName()).equals

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/ApplicationImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/ApplicationImportExportManager.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.APIKey;
 import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
 import org.wso2.carbon.apimgt.api.model.Subscriber;
@@ -62,12 +63,7 @@ public class ApplicationImportExportManager {
         Application application;
         int appId = APIUtil.getApplicationId(appName, username);
         String groupId = apiConsumer.getGroupId(appId);
-
-        if (Boolean.getBoolean(RestApiConstants.MIGRATION_MODE)) {
-            application = apiConsumer.getApplicationsByName(username, appName, groupId);
-        } else {
-            application = apiConsumer.getApplicationById(appId);
-        }
+        application = apiConsumer.getApplicationById(appId);
         if (application != null) {
             application.setGroupId(groupId);
             application.setOwner(application.getSubscriber().getName());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/ApplicationImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/ApplicationImportExportManager.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.apimgt.api.model.Subscriber;
 import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -62,7 +63,12 @@ public class ApplicationImportExportManager {
         Application application;
         int appId = APIUtil.getApplicationId(appName, username);
         String groupId = apiConsumer.getGroupId(appId);
-        application = apiConsumer.getApplicationById(appId);
+
+        if (Boolean.getBoolean(RestApiConstants.MIGRATION_ENABLED)) {
+            application = apiConsumer.getApplicationsByName(username, appName, groupId);
+        } else {
+            application = apiConsumer.getApplicationById(appId);
+        }
         if (application != null) {
             application.setGroupId(groupId);
             application.setOwner(application.getSubscriber().getName());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/ApplicationImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/ApplicationImportExportManager.java
@@ -26,7 +26,6 @@ import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
-import org.wso2.carbon.apimgt.api.model.APIStatus;
 import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
 import org.wso2.carbon.apimgt.api.model.Subscriber;
@@ -64,7 +63,7 @@ public class ApplicationImportExportManager {
         int appId = APIUtil.getApplicationId(appName, username);
         String groupId = apiConsumer.getGroupId(appId);
 
-        if (Boolean.getBoolean(RestApiConstants.MIGRATION_ENABLED)) {
+        if (Boolean.getBoolean(RestApiConstants.MIGRATION_MODE)) {
             application = apiConsumer.getApplicationsByName(username, appName, groupId);
         } else {
             application = apiConsumer.getApplicationById(appId);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/resources/admin-api.yaml
@@ -1777,6 +1777,15 @@ paths:
         - $ref: '#/parameters/offset'
         - $ref: '#/parameters/Accept'
         - $ref: '#/parameters/If-None-Match'
+        - name: tenantDomain
+          in: query
+          description: |
+               Tenant domain of the applications to get. This has to be specified only if require to get applications of
+               another tenant other than the requester's tenant. So, if not specified, the default will be set as the
+               requester's tenant domain. This cross tenant Application access is allowed only for super tenant admin
+               users only at a migration process.
+          required: false
+          type: string
       tags:
         - Application (Collection)
       responses:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/test/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/test/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImplTestCase.java
@@ -32,12 +32,13 @@ import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.Subscriber;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.admin.ExportApiService;
-import org.wso2.carbon.apimgt.rest.api.util.exception.ForbiddenException;
+import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
 import javax.ws.rs.core.Response;
 
-import static org.powermock.api.mockito.PowerMockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({RestApiUtil.class, APIUtil.class})
@@ -70,11 +71,11 @@ public class ExportApiServiceImplTestCase {
 
     /**
      * This method tests the functionality of ExportApplicationsGet, for a cross tenant application
-     * export attempt
+     * export attempt when the migrationMode is not enabled
      *
      * @throws Exception Exception.
      */
-    @Test (expected = ForbiddenException.class)
+    @Test
     public void testExportApplicationsGetCrossTenantError() throws Exception {
         PowerMockito.mockStatic(RestApiUtil.class);
         PowerMockito.when(RestApiUtil.getLoggedInUsername()).thenReturn(USER);
@@ -85,10 +86,32 @@ public class ExportApiServiceImplTestCase {
         Mockito.when(apiConsumer.getSubscriber("admin@hr.lk")).thenReturn(subscriber);
         Mockito.when(APIUtil.getApplicationId("sampleApp", "admin@hr.lk")).thenReturn(1);
         Mockito.when(apiConsumer.getApplicationById(1)).thenReturn(testApp);
+        Response response = exportApiService.exportApplicationsGet("sampleApp", "admin@hr.lk");
+        Assert.assertEquals(response.getStatus(), 403);
+    }
 
-        PowerMockito.doThrow(new ForbiddenException()).when(RestApiUtil.class);
-        RestApiUtil.handleMigrationSpecificPermissionViolations("hr.lk","admin");//this do define the mocking method
-        exportApiService.exportApplicationsGet("sampleApp", "admin@hr.lk");
+    /**
+     * This method tests the functionality of ExportApplicationsGet, for a cross tenant application export attempt when
+     * the migrationMode is enabled
+     *
+     * @throws Exception Exception.
+     */
+    @Test
+    public void testExportApplicationsGetCrossTenantAtMigrationMode() throws Exception {
+        PowerMockito.mockStatic(RestApiUtil.class);
+        PowerMockito.when(RestApiUtil.getLoggedInUsername()).thenReturn(USER);
+        PowerMockito.when(RestApiUtil.getConsumer(USER)).thenReturn(apiConsumer);
+        System.setProperty(RestApiConstants.MIGRATION_MODE, "true");
+        PowerMockito.mockStatic(APIUtil.class);
+        Application testApp = new Application("sampleApp", new Subscriber("admin@hr.lk"));
+        Subscriber subscriber = new Subscriber("admin@hr.lk");
+        when(apiConsumer.getSubscriber("admin@hr.lk")).thenReturn(subscriber);
+        when(APIUtil.getApplicationId("sampleApp", "admin@hr.lk")).thenReturn(1);
+        when(apiConsumer.getApplicationById(1)).thenReturn(testApp);
+        doNothing().when(RestApiUtil.class, "handleMigrationSpecificPermissionViolations", "hr.lk", "admin");
+        Response response = exportApiService.exportApplicationsGet("sampleApp", "admin@hr.lk");
+        Assert.assertEquals(response.getStatus(), 200);
+        System.clearProperty(RestApiConstants.MIGRATION_MODE);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/test/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/test/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImplTestCase.java
@@ -32,9 +32,12 @@ import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.Subscriber;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.admin.ExportApiService;
+import org.wso2.carbon.apimgt.rest.api.util.exception.ForbiddenException;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
 import javax.ws.rs.core.Response;
+
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({RestApiUtil.class, APIUtil.class})
@@ -71,7 +74,7 @@ public class ExportApiServiceImplTestCase {
      *
      * @throws Exception Exception.
      */
-    @Test
+    @Test (expected = ForbiddenException.class)
     public void testExportApplicationsGetCrossTenantError() throws Exception {
         PowerMockito.mockStatic(RestApiUtil.class);
         PowerMockito.when(RestApiUtil.getLoggedInUsername()).thenReturn(USER);
@@ -82,8 +85,10 @@ public class ExportApiServiceImplTestCase {
         Mockito.when(apiConsumer.getSubscriber("admin@hr.lk")).thenReturn(subscriber);
         Mockito.when(APIUtil.getApplicationId("sampleApp", "admin@hr.lk")).thenReturn(1);
         Mockito.when(apiConsumer.getApplicationById(1)).thenReturn(testApp);
-        Response response = exportApiService.exportApplicationsGet("sampleApp", "admin@hr.lk");
-        Assert.assertEquals(response.getStatus(), 403);
+
+        PowerMockito.doThrow(new ForbiddenException()).when(RestApiUtil.class);
+        RestApiUtil.handleMigrationSpecificPermissionViolations("hr.lk","admin");//this do define the mocking method
+        exportApiService.exportApplicationsGet("sampleApp", "admin@hr.lk");
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApi.java
@@ -555,9 +555,10 @@ public class ApisApi  {
     @ApiParam(value = "**Search condition**.\n\nYou can search in attributes by using an **\"<attribute>:\"** modifier.\n\nEg.\n\"provider:wso2\" will match an API if the provider of the API is exactly \"wso2\".\n\"status:PUBLISHED\" will match an API if the API is in PUBLISHED state.\n\"label:external\" will match an API if it contains a Microgateway label called \"external\".\n\nAdditionally you can use wildcards.\n\nEg.\n\"provider:wso2*\" will match an API if the provider of the API starts with \"wso2\".\n\nSupported attribute modifiers are [**version, context, status,\ndescription, subcontext, doc, provider, label**]\n\nIf no advanced attribute modifier has been specified,  the API names containing\nthe search term will be returned as a result.\n") @QueryParam("query")  String query,
     @ApiParam(value = "Media types acceptable for the response. Default is application/json.\n"  , defaultValue="application/json")@HeaderParam("Accept") String accept,
     @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resource (Will be supported in future).\n"  )@HeaderParam("If-None-Match") String ifNoneMatch,
-    @ApiParam(value = "Defines whether the returned response should contain full details of API\n") @QueryParam("expand")  Boolean expand)
+    @ApiParam(value = "Whether the returned response should contain full details of API\n") @QueryParam("expand")  Boolean expand,
+    @ApiParam(value = "Tenant domain, whose APIs should be retrieved. If not specified, the logged in user's tenant domain will\nbe considered for this.\n") @QueryParam("tenantDomain")  String tenantDomain)
     {
-    return delegate.apisGet(limit,offset,query,accept,ifNoneMatch,expand);
+    return delegate.apisGet(limit,offset,query,accept,ifNoneMatch,expand,tenantDomain);
     }
     @POST
     

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApiService.java
@@ -45,7 +45,7 @@ public abstract class ApisApiService {
     public abstract Response apisApiIdWsdlPost(String apiId,WsdlDTO body,String contentType,String ifMatch,String ifUnmodifiedSince);
     public abstract Response apisChangeLifecyclePost(String action,String apiId,String lifecycleChecklist,String ifMatch,String ifUnmodifiedSince);
     public abstract Response apisCopyApiPost(String newVersion,String apiId);
-    public abstract Response apisGet(Integer limit,Integer offset,String query,String accept,String ifNoneMatch,Boolean expand);
+    public abstract Response apisGet(Integer limit,Integer offset,String query,String accept,String ifNoneMatch,Boolean expand,String tenantDomain);
     public abstract Response apisPost(APIDetailedDTO body,String contentType);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
@@ -111,10 +111,12 @@ public class ApisApiServiceImpl extends ApisApiService {
      * @param query       search condition
      * @param accept      Accept header value
      * @param ifNoneMatch If-None-Match header value
+     * @param tenantDomain tenant domain of APIs to be returned
      * @return matched APIs for the given search condition
      */
     @Override
-    public Response apisGet(Integer limit, Integer offset, String query, String accept, String ifNoneMatch, Boolean expand) {
+    public Response apisGet(Integer limit, Integer offset, String query, String accept, String ifNoneMatch, Boolean expand,
+                            String tenantDomain) {
         List<API> allMatchedApis = new ArrayList<>();
         APIListDTO apiListDTO;
 
@@ -131,7 +133,11 @@ public class ApisApiServiceImpl extends ApisApiService {
             //We should send null as the provider, Otherwise searchAPIs will return all APIs of the provider
             // instead of looking at type and query
             String username = RestApiUtil.getLoggedInUsername();
-            String tenantDomain = MultitenantUtils.getTenantDomain(APIUtil.replaceEmailDomainBack(username));
+
+            if (tenantDomain == null) {
+                tenantDomain = MultitenantUtils.getTenantDomain(APIUtil.replaceEmailDomainBack(username));
+            }
+            RestApiUtil.handleMigrationSpecificPermissionViolations(tenantDomain, username);
             Map<String, Object> result = apiProvider.searchPaginatedAPIs(newSearchQuery, tenantDomain,
                                         offset, limit, false);
             Set<API> apis = (Set<API>) result.get("apis");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml
@@ -149,6 +149,13 @@ paths:
       - $ref : "#/parameters/Accept"
       - $ref : "#/parameters/If-None-Match"
       - $ref : "#/parameters/expand"
+      - name: tenantDomain
+        in: query
+        description: |
+             Tenant domain, whose APIs should be retrieved. If not specified, the logged in user's tenant domain will
+             be considered for this.
+        required: false
+        type: string
       tags:
       - API (Collection)
       responses:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
@@ -163,8 +163,8 @@ public final class RestApiConstants {
     public static final String PUT = "PUT";
     public static final String DELETE = "DELETE";
 
-    //System property 'migrationEnabled' set at server startup
-    public static final String MIGRATION_ENABLED = "migrationEnabled";
+    //System property set at server startup
+    public static final String MIGRATION_MODE = "migrationMode";
 
     public static final String CERTS_BASE_PATH = "/certificates";
     public static final String CLIENT_CERTS_BASE_PATH = "/clientCertificates";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
@@ -163,6 +163,9 @@ public final class RestApiConstants {
     public static final String PUT = "PUT";
     public static final String DELETE = "DELETE";
 
+    //System property 'migrationEnabled' set at server startup
+    public static final String MIGRATION_ENABLED = "migrationEnabled";
+
     public static final String CERTS_BASE_PATH = "/certificates";
     public static final String CLIENT_CERTS_BASE_PATH = "/clientCertificates";
     public static final String CERTS_GET_PAGINATED_URL =

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
@@ -86,7 +86,6 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.validation.ConstraintViolation;
-import javax.ws.rs.core.Response;
 
 public class RestApiUtil {
 
@@ -1297,7 +1296,7 @@ public class RestApiUtil {
     /**
      * Handle if any cross tenant access permission violations detected. Cross tenant resources (apis/apps) can be
      * retrieved only by super tenant admin user, only while a migration process(2.6.0 to 3.0.0). APIM server has to be
-     * started with the system property 'migrationEnabled=true' if a migration related exports are to be done.
+     * started with the system property 'migrationMode=true' if a migration related exports are to be done.
      *
      * @param targetTenantDomain Tenant domain of which resources are requested
      * @param username           Resource requester/logged in user name
@@ -1309,7 +1308,7 @@ public class RestApiUtil {
         if (!isCrossTenantAccess) {
             return;
         }
-        boolean migrationEnabled = Boolean.getBoolean(RestApiConstants.MIGRATION_ENABLED);
+        boolean migrationMode = Boolean.getBoolean(RestApiConstants.MIGRATION_MODE);
         String superAdminRole = null;
         try {
             superAdminRole = ServiceReferenceHolder.getInstance().getRealmService().
@@ -1336,12 +1335,12 @@ public class RestApiUtil {
         }
 
         boolean isSuperTenantAdmin = isSuperTenantUser && isSuperAdminRoleNameExist;
-        boolean hasMigrationSpecificPermissions = migrationEnabled && isSuperTenantAdmin;
+        boolean hasMigrationSpecificPermissions = migrationMode && isSuperTenantAdmin;
 
         if (!hasMigrationSpecificPermissions) {
             String errorMsg = "Cross Tenant resource access is not allowed for this request. User " + username +
                     " is not allowed to access resources in " + targetTenantDomain + ".Both the facts; setting " +
-                    "'migrationEnabled=true' system property set at APIM Server startup and the requester being a super " +
+                    "'migrationMode=true' system property set at APIM Server startup and the requester being a super " +
                     "tenant admin, should be satisfied for this to be allowed";
             ErrorDTO errorDTO = getErrorDTO(RestApiConstants.STATUS_FORBIDDEN_MESSAGE_DEFAULT, 403l, errorMsg);
             throw new ForbiddenException(errorDTO);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
@@ -1308,7 +1308,8 @@ public class RestApiUtil {
      * @param username           Logged in user name
      * @throws ForbiddenException
      */
-    public static void handleMigrationSpecificPermissionViolations(String targetTenantDomain, String username) throws ForbiddenException {
+    public static void handleMigrationSpecificPermissionViolations(String targetTenantDomain, String username) throws
+            ForbiddenException {
         boolean isCrossTenantAccess = !targetTenantDomain.equals(MultitenantUtils.getTenantDomain(username));
         if (!isCrossTenantAccess) {
             return;
@@ -1324,14 +1325,16 @@ public class RestApiUtil {
         //check whether logged in user is a super tenant user
         String superTenantDomain = null;
         try {
-            superTenantDomain = ServiceReferenceHolder.getInstance().getRealmService().getTenantManager().getSuperTenantDomain();
+            superTenantDomain = ServiceReferenceHolder.getInstance().getRealmService().getTenantManager().
+                    getSuperTenantDomain();
         } catch (UserStoreException e) {
             RestApiUtil.handleInternalServerError("Error in getting the super tenant domain", e, log);
         }
         boolean isSuperTenantUser = RestApiUtil.getLoggedInUserTenantDomain().equals(superTenantDomain);
         if (!isSuperTenantUser) {
             String errorMsg = "Cross Tenant resource access is not allowed for this request. User " + username +
-                    " is not allowed to access resources in " + targetTenantDomain + " as the requester is not a super tenant user";
+                    " is not allowed to access resources in " + targetTenantDomain + " as the requester is not a super " +
+                    "tenant user";
             log.error(errorMsg);
             ErrorDTO errorDTO = getErrorDTO(RestApiConstants.STATUS_FORBIDDEN_MESSAGE_DEFAULT, 403l, errorMsg);
             throw new ForbiddenException(errorDTO);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/admin-api.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/admin-api.json
@@ -1810,6 +1810,13 @@
           },
           {
             "$ref": "#/parameters/If-None-Match"
+          },
+          {
+            "name": "tenantDomain",
+            "in": "query",
+            "description": "Tenant domain of the applications to get. This has to be specified only if require to get applications of\nanother tenant other than the requester's tenant. So, if not specified, the default will be set as the\nrequester's tenant domain. This cross tenant Application access is allowed only for super tenant admin\nusers only at a migration process.\n",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [
@@ -2037,8 +2044,10 @@
     },
     "/labels": {
       "get": {
-        "x-scope": "apim:label_view",
-        "x-wso2-response": "HTTP/1.1 200 OK",
+        "x-scope": "apim:label_read",
+        "x-wso2-request": "GET https://localhost:9443/api/am/admin/v0.13/labels\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/admin/v0.13/labels\"",
+        "x-wso2-response": "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\r\n  \"count\": 1,\r\n  \"list\": [\r\n  {\r\n  \"id\":\"d7cf8523-9180-4255-84fa-6cb171c1f779\",\r\n  \"name\":\"internal\",\r\n  \"description\":\"label used for internal purpose\",\r\n  \"accessUrls\":[\r\n    \"https://localhost:9095\"\r\n         ]\r\n       }\r\n   ]\r\n}",
         "summary": "Get all registered Labels",
         "description": "Get all registered Labels\n",
         "tags": [
@@ -2055,7 +2064,9 @@
       },
       "post": {
         "x-scope": "apim:label_manage",
-        "x-wso2-response": "HTTP/1.1 200 OK",
+        "x-wso2-curl": "curl -k -X POST -H \"Authorization: Bearer 0d63e133-7ad6-3aeb-9ca9-9299e0708122\" -H \"Content-Type: application/json\" https://apis.wso2.com/api/am/admin/v0.13/labels -d @data.json",
+        "x-wso2-request": "POST https://localhost:9443/api/am/admin/v0.13/labels\r\nAuthorization: Bearer 0d63e133-7ad6-3aeb-9ca9-9299e0708122\r\nContent-Type: application/json\r\n\r\n   {\r\n       \"name\":\"internal\",\r\n  \"description\":\"label used for internal purpose\",\r\n  \"accessUrls\":[\r\n    \"https://localhost:9095\"\r\n         ]\r\n     }",
+        "x-wso2-response": "HTTP/1.1 201 Created\r\nContent-Type: application/json\r\n\r\n{\r\n  \"id\":\"d7cf8523-9180-4255-84fa-6cb171c1f779\",\r\n  \"name\":\"internal\",\r\n  \"description\":\"label used for internal purpose\",\r\n  \"accessUrls\":[\r\n    \"https://localhost:9095\"\r\n         ]\r\n       }\r\n   ]\r\n}",
         "summary": "Add a Label",
         "description": "Add a new gateway Label\n",
         "parameters": [

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.json
@@ -119,6 +119,13 @@
                     },
                     {
                         "$ref": "#/parameters/expand"
+                    },
+                    {
+                        "name": "tenantDomain",
+                        "in": "query",
+                        "description": "Tenant domain, whose APIs should be retrieved. If not specified, the logged in user's tenant domain will be considered for this.\n",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "tags": [


### PR DESCRIPTION
## Purpose
Adding cross tenant API/Application export support to the REST apis for APIM 2.x to 3.0.0 migration

## Approach
This PR do the below changes which are required for APIM 2.6.0 to 3.0.0 migration

1) Get list of Applications For Applications export

- Change Admin REST API - /applications GET to  get list of apps for the given tenant/cross tenants too. 
- Validate special permissions to allow only the super tenant admin users, only when the server is started with migrationMode=true property, to get cross tenant application list

2) For exporting Applications 
- Change Admin REST API - /export/applications GET to export Apps of the given tenant/cross tenants too
- Validate special permissions to allow only the super tenant admin users, only when the server is started with migrationMode=true property, for cross tenant apps export

3) Get list of APIs to export 
- Change Publisher REST API - /apis GET to get a list of APIs of the given tenant/cross tenants too
- Validate special permissions to allow only the super tenant admin users, only when the server is started with migrationMode=true property, to cross tenant APIs list