### PR TITLE
avoid NullPointerExceptions

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -732,11 +732,15 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     private void validateApiInfo(API api) throws APIManagementException {
         String apiName = api.getId().getApiName();
         String apiVersion = api.getId().getVersion();
-        if (containsIllegals(apiName)) {
+        if (apiName == null) {
+            handleException("API Name is required.");
+        } else if (containsIllegals(apiName)) {
             handleException("API Name contains one or more illegal characters  " +
                     "( " + APIConstants.REGEX_ILLEGAL_CHARACTERS_FOR_API_METADATA + " )");
         }
-        if (containsIllegals(apiVersion)) {
+        if (apiVersion == null) {
+            handleException("API Version is required.");
+        } else if (containsIllegals(apiVersion)) {
             handleException("API Version contains one or more illegal characters  " +
                     "( " + APIConstants.REGEX_ILLEGAL_CHARACTERS_FOR_API_METADATA + " )");
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
@@ -218,7 +218,9 @@ public class ApisApiServiceImpl extends ApisApiService {
                     RestApiUtil.handleBadRequest(errorMessage, log);
                 }
             }
-            if (body.getContext().endsWith("/")) {
+            if (body.getContext() == null) {
+                RestApiUtil.handleBadRequest("Parameter: \"context\" cannot be null", log);
+            } else if (StringUtils.endsWith(body.getContext(), "/")) {
                 RestApiUtil.handleBadRequest("Context cannot end with '/' character", log);
             }
             if (apiProvider.isApiNameWithDifferentCaseExist(body.getName())) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/utils/mappings/APIMappingUtil.java
@@ -428,7 +428,9 @@ public class APIMappingUtil {
         if (dto.getStatus() != null) {
             model.setStatus((dto.getStatus() != null) ? dto.getStatus().toUpperCase() : null);
         }
-        model.setAsDefaultVersion(dto.getIsDefaultVersion());
+        if (dto.getIsDefaultVersion() != null) {
+            model.setAsDefaultVersion(dto.getIsDefaultVersion());
+        }
         model.setResponseCache(dto.getResponseCaching());
         if (dto.getCacheTimeout() != null) {
             model.setCacheTimeout(dto.getCacheTimeout());
@@ -487,7 +489,9 @@ public class APIMappingUtil {
 
         String transports = StringUtils.join(dto.getTransport(), ',');
         model.setTransports(transports);
-        model.setVisibility(mapVisibilityFromDTOtoAPI(dto.getVisibility()));
+        if (dto.getVisibility() != null) {
+            model.setVisibility(mapVisibilityFromDTOtoAPI(dto.getVisibility()));
+        }
         if (dto.getVisibleRoles() != null) {
             String visibleRoles = StringUtils.join(dto.getVisibleRoles(), ',');
             model.setVisibleRoles(visibleRoles);


### PR DESCRIPTION
## Purpose
While using the API of API Manager 2.6.0, I got several NPEs as no proper validation was present.  

## Goals
Added null checks and additional exception messages.
