### PR TITLE
Modifies tests for comments feature

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/SampleTestObjectCreator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/SampleTestObjectCreator.java
@@ -1129,7 +1129,7 @@ public class SampleTestObjectCreator {
         comment.setApiId(apiId);
         comment.setCommentText("this is a sample comment");
         comment.setCategory("sample category");
-        comment.setParentCommentId(UUID.randomUUID().toString());
+        comment.setParentCommentId(null);
         comment.setEntryPoint(entryPoint);
         comment.setOwner("admin");
         comment.setUpdatedUser("admin");
@@ -1145,7 +1145,7 @@ public class SampleTestObjectCreator {
         comment.setApiId(apiId);
         comment.setCommentText("this is a sample comment - alternative");
         comment.setCategory("sample alt category");
-        comment.setParentCommentId(UUID.randomUUID().toString());
+        comment.setParentCommentId(null);
         comment.setEntryPoint(entryPoint);
         comment.setOwner("admin");
         comment.setUpdatedUser("admin");

--- a/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImplIT.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImplIT.java
@@ -1644,16 +1644,17 @@ public class ApiDAOImplIT extends DAOIntegrationTestBase {
         apiDAO.addAPI(api);
         Comment comment1 = SampleTestObjectCreator.createDefaultComment(api.getId(), ENTRY_POINT);
         Comment comment2 = SampleTestObjectCreator.createAlternativeComment(api.getId(), ENTRY_POINT);
+        Comment commentReply = SampleTestObjectCreator.createCommentReply(api.getId(), ENTRY_POINT, comment1.getUuid());
         apiDAO.addComment(comment1, api.getId());
         apiDAO.addComment(comment2, api.getId());
+        apiDAO.addComment(commentReply, api.getId());
 
         List<Comment> commentsFromDB = apiDAO.getCommentsForApi(api.getId());
         Assert.assertEquals(commentsFromDB.size(), 2);
         Assert.assertTrue(
-                commentsFromDB.get(0).getCommentText().equals(comment1.getCommentText()) || commentsFromDB.get(0)
-                        .getCommentText().equals(comment2.getCommentText()));
-        Assert.assertTrue(
-                commentsFromDB.get(1).getCommentText().equals(comment1.getCommentText()) || commentsFromDB.get(1)
+                commentsFromDB.get(0).getCommentText().equals(comment1.getCommentText()));
+        Assert.assertEquals(commentsFromDB.get(0).getReplies().size(), 1);
+        Assert.assertTrue(commentsFromDB.get(1)
                         .getCommentText().equals(comment2.getCommentText()));
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImplTestCase.java
@@ -2227,7 +2227,7 @@ public class ApisApiServiceImplTestCase {
         commentDTO.setCommentId(commentId);
         commentDTO.setCommentText("comment text");
         commentDTO.setCategory("testCategory");
-        commentDTO.setParentCommentId("");
+        commentDTO.setParentCommentId(null);
         commentDTO.setEntryPoint("APIPublisher");
         commentDTO.setCreatedBy("creater");
         commentDTO.setLastUpdatedBy("updater");
@@ -2239,7 +2239,7 @@ public class ApisApiServiceImplTestCase {
         comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
-        comment.setParentCommentId("");
+        comment.setParentCommentId(null);
         comment.setEntryPoint("APIPublisher");
         comment.setCreatedUser("createdUser");
         comment.setUpdatedUser("updatedUser");
@@ -2297,7 +2297,7 @@ public class ApisApiServiceImplTestCase {
         comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
-        comment.setParentCommentId("");
+        comment.setParentCommentId(null);
         comment.setEntryPoint("APIPublisher");
         comment.setCreatedUser("createdUser");
         comment.setUpdatedUser("updatedUser");
@@ -2342,7 +2342,7 @@ public class ApisApiServiceImplTestCase {
         comment1.setOwner("commentedUser1");
         comment1.setCommentText("this is a comment 1");
         comment1.setCategory("testCategory1");
-        comment1.setParentCommentId("");
+        comment1.setParentCommentId(null);
         comment1.setEntryPoint("APIPublisher");
         comment1.setCreatedUser("createdUser1");
         comment1.setUpdatedUser("updatedUser1");
@@ -2355,7 +2355,7 @@ public class ApisApiServiceImplTestCase {
         comment2.setOwner("commentedUser2");
         comment2.setCommentText("this is a comment 2");
         comment2.setCategory("testCategory2");
-        comment2.setParentCommentId("");
+        comment2.setParentCommentId(null);
         comment2.setEntryPoint("APIPublisher");
         comment2.setCreatedUser("createdUser2");
         comment2.setUpdatedUser("updatedUser2");
@@ -2402,7 +2402,7 @@ public class ApisApiServiceImplTestCase {
         commentDTO.setApiId(apiId);
         commentDTO.setCommentText("comment text");
         commentDTO.setCategory("testCategory");
-        commentDTO.setParentCommentId("");
+        commentDTO.setParentCommentId(null);
         commentDTO.setEntryPoint("APIPublisher");
         commentDTO.setCreatedBy("creater");
         commentDTO.setLastUpdatedBy("updater");
@@ -2413,7 +2413,7 @@ public class ApisApiServiceImplTestCase {
         comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
-        comment.setParentCommentId("");
+        comment.setParentCommentId(null);
         comment.setEntryPoint("APIPublisher");
         comment.setCreatedUser("createdUser");
         comment.setUpdatedUser("updatedUser");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImplTestCase.java
@@ -179,7 +179,7 @@ public class ApisApiServiceImplTestCase {
         commentDTO.setCommentId(commentId);
         commentDTO.setCommentText("comment text");
         commentDTO.setCategory("testCategory");
-        commentDTO.setParentCommentId("");
+        commentDTO.setParentCommentId(null);
         commentDTO.setEntryPoint("APIStore");
         commentDTO.setCreatedBy("creater");
         commentDTO.setLastUpdatedBy("updater");
@@ -191,7 +191,7 @@ public class ApisApiServiceImplTestCase {
         comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
-        comment.setParentCommentId("");
+        comment.setParentCommentId(null);
         comment.setEntryPoint("APIStore");
         comment.setCreatedUser("createdUser");
         comment.setUpdatedUser("updatedUser");
@@ -247,7 +247,7 @@ public class ApisApiServiceImplTestCase {
         comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
-        comment.setParentCommentId("");
+        comment.setParentCommentId(null);
         comment.setEntryPoint("APIStore");
         comment.setCreatedUser("createdUser");
         comment.setUpdatedUser("updatedUser");
@@ -291,7 +291,7 @@ public class ApisApiServiceImplTestCase {
         comment1.setOwner("commentedUser1");
         comment1.setCommentText("this is a comment 1");
         comment1.setCategory("testCategory1");
-        comment1.setParentCommentId("");
+        comment1.setParentCommentId(null);
         comment1.setEntryPoint("APIStore");
         comment1.setCreatedUser("createdUser1");
         comment1.setUpdatedUser("updatedUser1");
@@ -304,7 +304,7 @@ public class ApisApiServiceImplTestCase {
         comment2.setOwner("commentedUser2");
         comment2.setCommentText("this is a comment 2");
         comment2.setCategory("testCategory2");
-        comment2.setParentCommentId("");
+        comment2.setParentCommentId(null);
         comment2.setEntryPoint("APIStore");
         comment2.setCreatedUser("createdUser2");
         comment2.setUpdatedUser("updatedUser2");
@@ -350,7 +350,7 @@ public class ApisApiServiceImplTestCase {
         commentDTO.setApiId(apiId);
         commentDTO.setCommentText("comment text");
         commentDTO.setCategory("testCategory");
-        commentDTO.setParentCommentId("");
+        commentDTO.setParentCommentId(null);
         commentDTO.setEntryPoint("APIStore");
         commentDTO.setCreatedBy("creater");
         commentDTO.setLastUpdatedBy("updater");
@@ -361,7 +361,7 @@ public class ApisApiServiceImplTestCase {
         comment.setOwner("commentedUser");
         comment.setCommentText("this is a comment");
         comment.setCategory("testCategory");
-        comment.setParentCommentId("");
+        comment.setParentCommentId(null);
         comment.setEntryPoint("APIStore");
         comment.setCreatedUser("createdUser");
         comment.setUpdatedUser("updatedUser");


### PR DESCRIPTION
## Purpose
Modifies the unit tests and DAO  integration tests related to comments feature.

## Goals
To test whether correctly functions when parentCommentId is null.

## Approach
Please refer the mail threads subjected as “[Dev] [APIM 3.0] API Comments” and “[Architecture] Project 240: Communication channel between API Providers and API Consumers”.

## Documentation
N/A - since this is a modification to the already implemented functionality.

## Automation tests
  - Unit tests 
Modified some test cases to inlcude "null" as the parentCommentId.
     -  carbon-apimgt/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/test/java/org/wso2/carbon/apimgt/rest/api/store/impl/ApisApiServiceImplTestCase.java
      - carbon-apimgt/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImplTestCase.java
 - Integration tests
Modified DAO Integration tests.
      - carbon-apimgt/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/dao/impl/ApiDAOImplIT.java
       - carbon-apimgt/components/apimgt/org.wso2.carbon.apimgt.core/src/test/java/org/wso2/carbon/apimgt/core/SampleTestObjectCreator.java

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/5843

## Test environment
 - jdk1.8.0_144
 - Ubuntu 16.04 LTS
 - h2, MySQL, MSSQL, Oracle, PostgreSQL
 