### PR TITLE
Fixed the 'visible to Roles' in an API configuration issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
@@ -33,6 +33,7 @@ import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
@@ -921,8 +921,8 @@ public class APIProviderHostObject extends ScriptableObject {
         if (visibility != null && visibility.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
             visibleRoles = (String) apiData.get("visibleRoles", apiData);
             StringBuilder roleBuilder = new StringBuilder();
-            for (String n : visibleRoles.split(",")) {
-                roleBuilder.append(n.trim()).append(",");
+            for (String role : visibleRoles.split(",")) {
+                roleBuilder.append(role.trim()).append(",");
             }
             roleBuilder.deleteCharAt(roleBuilder.length() - 1);
             visibleRoles = roleBuilder.toString();
@@ -1247,8 +1247,8 @@ public class APIProviderHostObject extends ScriptableObject {
         if (visibility != null && visibility.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
             visibleRoles = (String) apiData.get("visibleRoles", apiData);
             StringBuilder roleBuilder = new StringBuilder();
-            for (String n : visibleRoles.split(",")) {
-                roleBuilder.append(n.trim()).append(",");
+            for (String role : visibleRoles.split(",")) {
+                roleBuilder.append(role.trim()).append(",");
             }
             roleBuilder.deleteCharAt(roleBuilder.length() - 1);
             visibleRoles = roleBuilder.toString();
@@ -1831,8 +1831,8 @@ public class APIProviderHostObject extends ScriptableObject {
         if (visibility != null && visibility.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
             visibleRoles = (String) apiData.get("visibleRoles", apiData);
             StringBuilder roleBuilder = new StringBuilder();
-            for (String n : visibleRoles.split(",")) {
-                roleBuilder.append(n.trim()).append(",");
+            for (String role : visibleRoles.split(",")) {
+                roleBuilder.append(role.trim()).append(",");
             }
             roleBuilder.deleteCharAt(roleBuilder.length() - 1);
             visibleRoles = roleBuilder.toString();

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
@@ -920,6 +920,7 @@ public class APIProviderHostObject extends ScriptableObject {
 
         if (visibility != null && visibility.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
             visibleRoles = (String) apiData.get("visibleRoles", apiData);
+            visibleRoles =  visibleRoles.replaceAll("\\s+","");
         }
 
         String publisherAccessControl = (String) apiData.get(APIConstants.ACCESS_CONTROL_PARAMETER, apiData);
@@ -1239,7 +1240,8 @@ public class APIProviderHostObject extends ScriptableObject {
         }
 
         if (visibility != null && visibility.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
-            visibleRoles = (String) apiData.get("visibleRoles", apiData);
+            visibleRoles = ((String) apiData.get("visibleRoles", apiData));
+            visibleRoles = visibleRoles.replaceAll("\\s+","");
         }
 
         if (publisherAccessControl != null && publisherAccessControl.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
@@ -33,7 +33,6 @@ import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.ObjectUtils;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -136,6 +135,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.cache.Caching;
 import javax.xml.namespace.QName;
 
@@ -920,12 +920,8 @@ public class APIProviderHostObject extends ScriptableObject {
 
         if (visibility != null && visibility.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
             visibleRoles = (String) apiData.get("visibleRoles", apiData);
-            StringBuilder roleBuilder = new StringBuilder();
-            for (String role : visibleRoles.split(",")) {
-                roleBuilder.append(role.trim()).append(",");
-            }
-            roleBuilder.deleteCharAt(roleBuilder.length() - 1);
-            visibleRoles = roleBuilder.toString();
+            visibleRoles = Arrays.stream(visibleRoles.split(",")).map(String::trim).collect(Collectors.
+                    joining(","));
         }
 
         String publisherAccessControl = (String) apiData.get(APIConstants.ACCESS_CONTROL_PARAMETER, apiData);
@@ -1246,12 +1242,8 @@ public class APIProviderHostObject extends ScriptableObject {
 
         if (visibility != null && visibility.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
             visibleRoles = (String) apiData.get("visibleRoles", apiData);
-            StringBuilder roleBuilder = new StringBuilder();
-            for (String role : visibleRoles.split(",")) {
-                roleBuilder.append(role.trim()).append(",");
-            }
-            roleBuilder.deleteCharAt(roleBuilder.length() - 1);
-            visibleRoles = roleBuilder.toString();
+            visibleRoles = Arrays.stream(visibleRoles.split(",")).map(String::trim).collect(Collectors.
+                    joining(","));
         }
 
         if (publisherAccessControl != null && publisherAccessControl.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
@@ -1830,12 +1822,8 @@ public class APIProviderHostObject extends ScriptableObject {
         String publisherAccessControlRoles = "";
         if (visibility != null && visibility.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
             visibleRoles = (String) apiData.get("visibleRoles", apiData);
-            StringBuilder roleBuilder = new StringBuilder();
-            for (String role : visibleRoles.split(",")) {
-                roleBuilder.append(role.trim()).append(",");
-            }
-            roleBuilder.deleteCharAt(roleBuilder.length() - 1);
-            visibleRoles = roleBuilder.toString();
+            visibleRoles = Arrays.stream(visibleRoles.split(",")).map(String::trim).collect(Collectors.
+                    joining(","));
         }
         if (publisherAccessControl != null && publisherAccessControl.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
             publisherAccessControlRoles = (String) apiData.get(APIConstants.ACCESS_CONTROL_ROLES_PARAMETER, apiData);

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
@@ -920,7 +920,12 @@ public class APIProviderHostObject extends ScriptableObject {
 
         if (visibility != null && visibility.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
             visibleRoles = (String) apiData.get("visibleRoles", apiData);
-            visibleRoles =  visibleRoles.replaceAll("\\s+","");
+            StringBuilder roleBuilder = new StringBuilder();
+            for (String n : visibleRoles.split(",")) {
+                roleBuilder.append(n.trim()).append(",");
+            }
+            roleBuilder.deleteCharAt(roleBuilder.length() - 1);
+            visibleRoles = roleBuilder.toString();
         }
 
         String publisherAccessControl = (String) apiData.get(APIConstants.ACCESS_CONTROL_PARAMETER, apiData);
@@ -1216,6 +1221,7 @@ public class APIProviderHostObject extends ScriptableObject {
         String thumbUrl = (String) apiData.get("thumbUrl", apiData);
         String environments = (String) apiData.get("environments", apiData);
         String visibleRoles = "";
+        String visibleRolesArray[] ;
         String publisherAccessControl = (String) apiData.get(APIConstants.ACCESS_CONTROL_PARAMETER, apiData);
         String publisherAccessControlRoles = "";
         String additionalProperties = (String) apiData.get("additionalProperties", apiData);
@@ -1240,8 +1246,13 @@ public class APIProviderHostObject extends ScriptableObject {
         }
 
         if (visibility != null && visibility.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
-            visibleRoles = ((String) apiData.get("visibleRoles", apiData));
-            visibleRoles = visibleRoles.replaceAll("\\s+","");
+            visibleRoles = (String) apiData.get("visibleRoles", apiData);
+            StringBuilder roleBuilder = new StringBuilder();
+            for (String n : visibleRoles.split(",")) {
+                roleBuilder.append(n.trim()).append(",");
+            }
+            roleBuilder.deleteCharAt(roleBuilder.length() - 1);
+            visibleRoles = roleBuilder.toString();
         }
 
         if (publisherAccessControl != null && publisherAccessControl.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
@@ -1820,6 +1831,12 @@ public class APIProviderHostObject extends ScriptableObject {
         String publisherAccessControlRoles = "";
         if (visibility != null && visibility.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
             visibleRoles = (String) apiData.get("visibleRoles", apiData);
+            StringBuilder roleBuilder = new StringBuilder();
+            for (String n : visibleRoles.split(",")) {
+                roleBuilder.append(n.trim()).append(",");
+            }
+            roleBuilder.deleteCharAt(roleBuilder.length() - 1);
+            visibleRoles = roleBuilder.toString();
         }
         if (publisherAccessControl != null && publisherAccessControl.equals(APIConstants.API_RESTRICTED_VISIBILITY)) {
             publisherAccessControlRoles = (String) apiData.get(APIConstants.ACCESS_CONTROL_ROLES_PARAMETER, apiData);

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
@@ -1221,7 +1221,6 @@ public class APIProviderHostObject extends ScriptableObject {
         String thumbUrl = (String) apiData.get("thumbUrl", apiData);
         String environments = (String) apiData.get("environments", apiData);
         String visibleRoles = "";
-        String visibleRolesArray[] ;
         String publisherAccessControl = (String) apiData.get(APIConstants.ACCESS_CONTROL_PARAMETER, apiData);
         String publisherAccessControlRoles = "";
         String additionalProperties = (String) apiData.get("additionalProperties", apiData);


### PR DESCRIPTION
## Purpose
This fixes for the issue in the field of 'Visible to Roles' in an API configuration, is not acceptable for multiple roles with space after the comma separation.

## Goals
The access control logic should work for multiple roles even when there is a space after the comma.  (Eg: health-subscriber, education-subscriber)

https://github.com/wso2/product-apim/issues/3980