### PR TITLE
Change 'iat' claim to seconds from milliseconds.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/APIMJWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/APIMJWTGenerator.java
@@ -159,9 +159,9 @@ public class APIMJWTGenerator extends JWTGenerator {
     public Map<String, Object> populateStandardClaims(JwtTokenInfoDTO jwtTokenInfoDTO) throws APIManagementException {
 
         //generating expiring timestamp
-        long currentTime = System.currentTimeMillis();
+        long currentTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
         // jwtTokenInfoDTO.getExpirationTime() gives the token validity time given when the token is generated.
-        long expireIn = TimeUnit.MILLISECONDS.toSeconds(currentTime) + jwtTokenInfoDTO.getExpirationTime();
+        long expireIn = currentTime + jwtTokenInfoDTO.getExpirationTime();
 
         String endUserName = jwtTokenInfoDTO.getEndUserName();
 


### PR DESCRIPTION
Signed-off-by: nimanthag <nimanthag@wso2.com>

## Purpose
> The 'exp' claim is in seconds and the 'iat' claim is in milliseconds. Ideally the 'iat' claim needs to be in seconds as well to be consistance : Resolves https://github.com/wso2/carbon-apimgt/issues/5788

## Goals
> Change 'iat' stamping time to seconds from millisecond.

## Approach
> Convert 'iat' claim stamping time to seconds from millisecond.


## User stories
>N/A

## Release note
> AbstractJWTGenerator class generate 'iat' claim in seconds (before milliseconds)
## Documentation
> N/A because in [https://docs.wso2.com/display/AM220/JWT+Grant](url) 'iat' type is not specified.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
>N/A
## Security checks
>N/A
## Samples
>N/A

## Related PRs
>N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A