### PR TITLE
Fix throttling policies/rate limit not working across tenants issue.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -514,8 +514,15 @@ public class ApiMgtDAO {
             ps = conn.prepareStatement(sql);
             ps.setString(1, context);
             ps.setString(2, consumerKey);
-            if (!defaultVersionInvoked) {
-                ps.setString(3, version);
+            if (!isAdvancedThrottleEnabled) {
+                if (!defaultVersionInvoked) {
+                    ps.setString(3, version);
+                }
+            } else {
+                ps.setInt(3, apiOwnerTenantId);
+                if (!defaultVersionInvoked) {
+                    ps.setString(4, version);
+                }
             }
             rs = ps.executeQuery();
             if (rs.next()) {
@@ -11713,8 +11720,15 @@ public class ApiMgtDAO {
             ps = conn.prepareStatement(sql);
             ps.setString(1, context);
             ps.setString(2, consumerKey);
-            if (!defaultVersionInvoked) {
-                ps.setString(3, version);
+            if (!isAdvancedThrottleEnabled) {
+                if (!defaultVersionInvoked) {
+                    ps.setString(3, version);
+                }
+            } else {
+                ps.setInt(3, apiOwnerTenantId);
+                if (!defaultVersionInvoked) {
+                    ps.setString(4, version);
+                }
             }
 
             rs = ps.executeQuery();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -350,7 +350,7 @@ public class SQLConstants {
                     "   AND API.API_ID = SUB.API_ID" +
                     "   AND AKM.APPLICATION_ID=APP.APPLICATION_ID" +
                     "   AND APS.NAME = SUB.TIER_ID" +
-                    "   AND SUBS.TENANT_ID = APS.TENANT_ID";
+                    "   AND APS.TENANT_ID = ? ";
 
     public static final String ADVANCED_VALIDATE_SUBSCRIPTION_KEY_VERSION_SQL =
             " SELECT " +
@@ -379,13 +379,14 @@ public class SQLConstants {
                     " WHERE " +
                     "   API.CONTEXT = ? " +
                     "   AND AKM.CONSUMER_KEY = ? " +
+                    "   AND APS.TENANT_ID = ? " +
                     "   AND API.API_VERSION = ? " +
                     "   AND SUB.APPLICATION_ID = APP.APPLICATION_ID" +
                     "   AND APP.SUBSCRIBER_ID = SUBS.SUBSCRIBER_ID" +
                     "   AND API.API_ID = SUB.API_ID" +
                     "   AND AKM.APPLICATION_ID=APP.APPLICATION_ID" +
-                    "   AND APS.NAME = SUB.TIER_ID" +
-                    "   AND SUBS.TENANT_ID = APS.TENANT_ID";
+                    "   AND APS.NAME = SUB.TIER_ID" ;
+
 
     public static final String UPDATE_TOKEN_PREFIX = "UPDATE ";
 


### PR DESCRIPTION
Signed-off-by: nimanthag <nimanthag@wso2.com>

## Purpose
> Resolves https://github.com/wso2/product-apim/issues/3491

## Goals
> The underlying query does not return any data from the subscription policy table. As a result, API returns an error 900908 (forbidden). In the query, There is an equality check for policy subscriber tenant id and subscriber tenant id which fail in this scenario. The goal is to correct that sql.
## Approach
> check equality for policy subscription tenant id with apiOwner tenant id instead of subscriber tenant id.

## User stories
> If one tenant publishes an API and another tenant subscribe it with a tier that is not present in its own policies, every call to the API returns an error (forbidden). If a tier is created in the subscriber tenant with the same name, the API call works fine.
Also, the rate limit applied is the one in the subscriber tier, not the one defined by the publisher.

## Release note
> N/A 

## Automation tests
 - **Integration tests**
   > 

- Create a tenant A
- Create a new subscription throttling policy, e.g. "Tier 1" - 2 msg per minute
- Publish an API available to all tenants, with "Tier 1" enabled
- Create a tenant B
- Subscribe to it using "Tier 1"
- Try to call the API - Response recieve as expected . Tested the rate as well(2 msg per minute).
-  Create a new subscription throttling policy using tenant B e.g. "Tier 1" - 1 msg per minute.
-  Redo the above using teanant B.
-  Try to call the API - Response recieve as expected . Tested the rate as well(1 msg per minute).

