### PR TITLE
Fix Wrong word: "Proper Value" in API Store Additional Property Table

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/conf/locales/jaggery/locale_default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/conf/locales/jaggery/locale_default.json
@@ -358,7 +358,7 @@
     "Return to public store": "Return to the public Store",
     "API Properties": "API Properties",
     "Property Name": "Property Name",
-    "Property Value": "Proper Value",
+    "Property Value": "Property Value",
     "By API Properties [Syntax - {property name}:{property value}]" : "By API Properties [Syntax - {property name}:{property value}]",
     "Groups" : "Groups",
     "Type a group and enter" : "Type a group and enter",


### PR DESCRIPTION
Signed-off-by: nimanthag <nimanthag@wso2.com>

## Purpose
> Resolves https://github.com/wso2/product-apim/issues/4055

## Goals
> Correct the spelling mistake
## Approach
> Change locale json file

## Manual tests
 - Checked the correct word present in the front end.
