### PR TITLE
Fixed Regex Threat Protector performance issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -223,6 +223,10 @@
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.re2j</groupId>
+            <artifactId>re2j</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -351,6 +355,7 @@
                             org.wso2.carbon.context,
                             org.wso2.carbon.mediation.*; version="${carbon.mediation.imp.pkg.version}",
                             org.wso2.carbon.apimgt.tracing.*; version="${carbon.apimgt.imp.pkg.version}",
+                            org.wso2.orbit.re2j.*; version="1.2.wso2v1",
                             *;resolution:=optional
                         </Import-Package>
                     </instructions>

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -70,6 +70,8 @@ public class APIMgtGatewayConstants {
     public static final String ENABLED_CHECK_HEADERS  = "enabledCheckHeaders";
     public static final String REST_URL_POSTFIX = "REST_URL_POSTFIX";
     public static final String TRANSPORT_HEADERS = "TRANSPORT_HEADERS";
+    public static final String REGEX_THREAT_PROTECTOR_ENABLED_TENANTS = "regexThreatProtectorEnabledTenants";
+    public static final String PAYLOAD_SIZE_LIMIT_FOR_REGEX_TREAT_PROTECTOR = "payloadSizeLimitForRegexThreatProtector";
 
     /**
      * Constants for handling threat protection exceptions.

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/RegularExpressionProtector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/RegularExpressionProtector.java
@@ -18,23 +18,30 @@
 
 package org.wso2.carbon.apimgt.gateway.mediators;
 
+import com.google.re2j.Pattern;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.soap.SOAPBody;
 import org.apache.axiom.soap.SOAPEnvelope;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpHeaders;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractMediator;
+import org.apache.synapse.rest.RESTUtils;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.threatprotection.utils.ThreatProtectorConstants;
 import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 /**
  * This mediator would protect the backend resources from the threat vulnerabilities by matching the
@@ -60,17 +67,31 @@ public class RegularExpressionProtector extends AbstractMediator {
         if (logger.isDebugEnabled()) {
             logger.debug("RegularExpressionProtector mediator is activated...");
         }
-        Object messageProperty = messageContext.getProperty(APIMgtGatewayConstants.REGEX_PATTERN);
-        if (messageProperty != null) {
-            pattern = Pattern.compile(messageProperty.toString(), Pattern.CASE_INSENSITIVE);
-        } else {
-            GatewayUtils.handleThreat(messageContext, APIMgtGatewayConstants.HTTP_SC_CODE,
-                    "Threat detection key words are missing");
+        if (!isTenantAllowed(messageContext)) {
+            return true;
         }
-        messageProperty = messageContext.getProperty(APIMgtGatewayConstants.ENABLED_CHECK_BODY);
+        Object messageProperty = messageContext.getProperty(APIMgtGatewayConstants.ENABLED_CHECK_BODY);
+
         if (messageProperty != null) {
             enabledCheckBody = Boolean.valueOf(messageProperty.toString());
         }
+        if (isContentAware()) {
+            if (isPayloadSizeExceeded(messageContext)) {
+                return true;
+            }
+        }
+
+        messageProperty = messageContext.getProperty(APIMgtGatewayConstants.REGEX_PATTERN);
+        if (messageProperty != null) {
+            if (pattern == null) {
+                pattern = Pattern.compile(messageProperty.toString(), Pattern.CASE_INSENSITIVE);
+            }
+        } else {
+            GatewayUtils.handleThreat(messageContext, APIMgtGatewayConstants.HTTP_SC_CODE,
+                    "Threat detection key words are missing");
+            return true;
+        }
+
         messageProperty = messageContext.getProperty(APIMgtGatewayConstants.ENABLED_CHECK_PATHPARAM);
         if (messageProperty != null) {
             enabledCheckPathParam = Boolean.valueOf(messageProperty.toString());
@@ -83,10 +104,84 @@ public class RegularExpressionProtector extends AbstractMediator {
         if (messageProperty != null) {
             threatType = String.valueOf(messageProperty);
         }
-        checkRequestBody(messageContext);
-        checkRequestHeaders(messageContext);
-        checkRequestPath(messageContext);
+        if (isRequestBodyVulnerable(messageContext) || isRequestHeadersVulnerable(messageContext) ||
+                isRequestPathVulnerable(messageContext)) {
+            return true;
+        }
         return true;
+    }
+
+    /**
+     * Using Regex Threat Protector mediator will be restricted to the tenants defined by the system property
+     * 'regexThreatProtectorEnabledTenants' as a list of comma separated values and super tenant. If this system
+     * property is not defined, then this restriction will not be applied at all. If invoked API is existing within a
+     * tenant, which was defined in this list, this method returns true. If this system property is not defined, this
+     * check won't be done and so will return true, hence all the tenants will be allowed to use this mediator
+     *
+     * @param messageContext contains the message properties of the relevant API request which was
+     *                       enabled the regexValidator message mediation in flow.
+     * @return true if the tenant is allowed to use this Mediator
+     */
+    private boolean isTenantAllowed(MessageContext messageContext) {
+        String allowedTenants = System.getProperty(APIMgtGatewayConstants.REGEX_THREAT_PROTECTOR_ENABLED_TENANTS);
+        if (allowedTenants == null) {
+            return true;
+        }
+        List<String> allowedTenantsList = Arrays.asList(allowedTenants.split(","));
+        String tenantDomain = MultitenantUtils.getTenantDomainFromRequestURL(RESTUtils.getFullRequestPath
+                (messageContext));
+        if (StringUtils.isEmpty(tenantDomain)) {
+            tenantDomain = org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+        if (!allowedTenantsList.contains(tenantDomain) &&
+                !tenantDomain.equals(org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            GatewayUtils.handleThreat(messageContext, APIMgtGatewayConstants.HTTP_SC_CODE,
+                    "This tenant is not allowed to use Regular Expression Threat Protector mediator");
+            return false;
+        } else {
+            return true;
+        }
+    }
+    /**
+     * This method returns true if the request payload size exceeds the system property
+     * 'payloadSizeLimitForRegexThreatProtector' value (in KB) defined. If this system property is not defined, this
+     * check won't be done.
+     *
+     * @param messageContext contains the message properties of the relevant API request which was
+     *                       enabled the regexValidator message mediation in flow.
+     * @return true if the payload size has exceeded the defined value in system property
+     */
+    private boolean isPayloadSizeExceeded(MessageContext messageContext) {
+        // payloadSizeLimit is in KB
+        Integer payloadSizeLimit = Integer.getInteger(APIMgtGatewayConstants.PAYLOAD_SIZE_LIMIT_FOR_REGEX_TREAT_PROTECTOR);
+        if (payloadSizeLimit == null) {
+            return false;
+        }
+        long requestPayloadSize = 0;
+        org.apache.axis2.context.MessageContext axis2MC = ((Axis2MessageContext) messageContext)
+                .getAxis2MessageContext();
+        Map headers = (Map) axis2MC.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
+        String contentLength = (String) headers.get(HttpHeaders.CONTENT_LENGTH);
+        if (contentLength != null) {
+            requestPayloadSize = Integer.parseInt(contentLength);
+        } else {  //When chunking is enabled
+            SOAPEnvelope env = messageContext.getEnvelope();
+            if (env != null) {
+                SOAPBody soapbody = env.getBody();
+                if (soapbody != null) {
+                    byte[] size = soapbody.toString().getBytes(Charset.defaultCharset());
+                    requestPayloadSize = size.length;
+                }
+            }
+        }
+        if (requestPayloadSize > payloadSizeLimit * 1024) {
+            GatewayUtils.handleThreat(messageContext, APIMgtGatewayConstants.HTTP_SC_CODE, "Exceeded Request Payload " +
+                    "size limit allowed to be used with the enabledCheckBody option of Regular Expression Threat " +
+                    "Protector mediator");
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -95,7 +190,7 @@ public class RegularExpressionProtector extends AbstractMediator {
      * @param messageContext contains the message properties of the relevant API request which was
      *                       enabled the regexValidator message mediation in flow.
      */
-    private void checkRequestBody(MessageContext messageContext) {
+    private boolean isRequestBodyVulnerable(MessageContext messageContext) {
         SOAPEnvelope soapEnvelope;
         SOAPBody soapBody;
         OMElement omElement;
@@ -104,15 +199,15 @@ public class RegularExpressionProtector extends AbstractMediator {
         if (enabledCheckBody) {
             soapEnvelope = axis2MC.getEnvelope();
             if (soapEnvelope == null) {
-                return;
+                return false;
             }
             soapBody = soapEnvelope.getBody();
             if (soapBody == null) {
-                return;
+                return false;
             }
             omElement = soapBody.getFirstElement();
             if (omElement == null) {
-                return;
+                return false;
             }
             String payload = omElement.toString();
             if (pattern != null && payload != null && pattern.matcher(payload).find()) {
@@ -122,16 +217,20 @@ public class RegularExpressionProtector extends AbstractMediator {
                 }
                 GatewayUtils.handleThreat(messageContext, APIMgtGatewayConstants.HTTP_SC_CODE,
                         threatType + " " + APIMgtGatewayConstants.PAYLOAD_THREAT_MSG);
+                return true;
             }
         }
+        return false;
     }
 
     /**
-     * This method checks whether the request header contains matching vulnerable keywords.
-     * * @param messageContext contains the message properties of the relevant API request which was
-     * enabled the regexValidator message mediation in flow.
+     * This method checks whether the request path contains matching vulnerable keywords.
+     *
+     * @param messageContext contains the message properties of the relevant API request which was
+     *                       enabled the regexValidator message mediation in flow.
+     * @return true if request path contains matching vulnerable keywords.
      */
-    private void checkRequestPath(MessageContext messageContext) {
+    private boolean isRequestPathVulnerable(MessageContext messageContext) {
         org.apache.axis2.context.MessageContext axis2MC = ((Axis2MessageContext)
                 messageContext).getAxis2MessageContext();
         String parameter = null;
@@ -144,6 +243,7 @@ public class RegularExpressionProtector extends AbstractMediator {
                 logger.error(message, e);
                 GatewayUtils.handleThreat(messageContext, ThreatProtectorConstants.HTTP_SC_CODE,
                         message + e.getMessage());
+                return true;
             }
             if (pattern != null && parameter != null && pattern.matcher(parameter).find()) {
                 if (logger.isDebugEnabled()) {
@@ -152,8 +252,10 @@ public class RegularExpressionProtector extends AbstractMediator {
                 }
                 GatewayUtils.handleThreat(messageContext, APIMgtGatewayConstants.HTTP_SC_CODE,
                         threatType + " " + APIMgtGatewayConstants.QPARAM_THREAT_MSG);
+                return true;
             }
         }
+        return false;
     }
 
     /**
@@ -161,8 +263,9 @@ public class RegularExpressionProtector extends AbstractMediator {
      *
      * @param messageContext contains the message properties of the relevant API request which was
      *                       enabled the regexValidator message mediation in flow.
+     * @return true if request Headers contain matching vulnerable keywords
      */
-    private void checkRequestHeaders(MessageContext messageContext) {
+    private boolean isRequestHeadersVulnerable(MessageContext messageContext) {
         org.apache.axis2.context.MessageContext axis2MC = ((Axis2MessageContext)
                 messageContext).getAxis2MessageContext();
         if (enabledCheckHeaders) {
@@ -174,8 +277,10 @@ public class RegularExpressionProtector extends AbstractMediator {
                 }
                 GatewayUtils.handleThreat(messageContext, APIMgtGatewayConstants.HTTP_SC_CODE,
                         threatType + " " + APIMgtGatewayConstants.HTTP_HEADER_THREAT_MSG);
+                return true;
             }
         }
+        return false;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/RegularExpressionProtector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/RegularExpressionProtector.java
@@ -134,7 +134,7 @@ public class RegularExpressionProtector extends AbstractMediator {
             tenantDomain = org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
         }
         if (!allowedTenantsList.contains(tenantDomain) &&
-                !tenantDomain.equals(org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+                !(org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME).equals(tenantDomain)) {
             GatewayUtils.handleThreat(messageContext, APIMgtGatewayConstants.HTTP_SC_CODE,
                     "This tenant is not allowed to use Regular Expression Threat Protector mediator");
             return false;

--- a/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
@@ -197,7 +197,7 @@
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>org.json.wso2:json:${orbit.version.json}</bundleDef>
                                 <bundleDef>org.apache.commons:commons-pool2:${apache.commons.version}</bundleDef>
-                                <bundleDef>org.wso2.orbit.re2j:re2j:${re2j.version}</bundleDef>
+                                <bundleDef>org.wso2.orbit.re2j:re2j:"1.2.wso2v1"</bundleDef>
                             </bundles>
                             <importBundles>
                                 <importBundleDef>org.wso2.carbon.mediation:org.wso2.carbon.mediation.security.stub:${carbon.mediation.version}</importBundleDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
@@ -111,6 +111,10 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.re2j</groupId>
+            <artifactId>re2j</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -193,11 +197,13 @@
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>org.json.wso2:json:${orbit.version.json}</bundleDef>
                                 <bundleDef>org.apache.commons:commons-pool2:${apache.commons.version}</bundleDef>
+                                <bundleDef>org.wso2.orbit.re2j:re2j</bundleDef>
                             </bundles>
                             <importBundles>
                                 <importBundleDef>org.wso2.carbon.mediation:org.wso2.carbon.mediation.security.stub:${carbon.mediation.version}</importBundleDef>
                                 <importBundleDef>org.wso2.carbon.commons:org.wso2.carbon.ganalytics.publisher:${carbon.commons.version}</importBundleDef>
                                 <importBundleDef>org.wso2.carbon.mediation:org.wso2.carbon.mediation.security.stub:${carbon.mediation.version}</importBundleDef>
+                                <importBundleDef>org.wso2.orbit.re2j:re2j:${re2j.version}</importBundleDef>
                             </importBundles>
                             <importFeatures>
                                 <importFeatureDef>org.apache.synapse.wso2:${carbon.mediation.version}</importFeatureDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
@@ -197,7 +197,7 @@
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>org.json.wso2:json:${orbit.version.json}</bundleDef>
                                 <bundleDef>org.apache.commons:commons-pool2:${apache.commons.version}</bundleDef>
-                                <bundleDef>org.wso2.orbit.re2j:re2j</bundleDef>
+                                <bundleDef>org.wso2.orbit.re2j:re2j:${re2j.version}</bundleDef>
                             </bundles>
                             <importBundles>
                                 <importBundleDef>org.wso2.carbon.mediation:org.wso2.carbon.mediation.security.stub:${carbon.mediation.version}</importBundleDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
@@ -197,7 +197,7 @@
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>org.json.wso2:json:${orbit.version.json}</bundleDef>
                                 <bundleDef>org.apache.commons:commons-pool2:${apache.commons.version}</bundleDef>
-                                <bundleDef>org.wso2.orbit.re2j:re2j:"1.2.wso2v1"</bundleDef>
+                                <bundleDef>org.wso2.orbit.re2j:re2j:${re2j.version}</bundleDef>
                             </bundles>
                             <importBundles>
                                 <importBundleDef>org.wso2.carbon.mediation:org.wso2.carbon.mediation.security.stub:${carbon.mediation.version}</importBundleDef>

--- a/pom.xml
+++ b/pom.xml
@@ -1449,6 +1449,11 @@
                 <scope>compile</scope>
             </dependency>
             <dependency>
+                <groupId>org.wso2.orbit.re2j</groupId>
+                <artifactId>re2j</artifactId>
+                <version>${re2j.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.aspectj</groupId>
                 <artifactId>aspectjrt</artifactId>
                 <version>${aspectj.version}</version>
@@ -1648,6 +1653,7 @@
         <httpcore.version>4.3.3.wso2v1</httpcore.version>
         <slf4j.wso2.version>1.5.10.wso2v1</slf4j.wso2.version>
         <ballerina.lang.version>0.970.0</ballerina.lang.version>
+        <re2j.version>1.2.wso2v1</re2j.version>
         <maven-site-plugin.version>3.3</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>2.7</maven-project-info-reports-plugin.version>
         <swagger-codegen-maven-plugin.version>2.3.1</swagger-codegen-maven-plugin.version>


### PR DESCRIPTION
Purpose
These fixes improve the performance of the regex threat protector

Approach

* Adding optional system property (-DregexThreatProtectorEnabledTenants) to define tenants who are allowed to use the regex threat protector mediator.

* Add an optional global system property (i.e. -DregexThreatProtectorPayloadSizeLimit) to drop the request flow, if the payload size is exceeding the provided size.

* Using rej2 third-party library instead of java.util.regex library for regex operations to improve regex operations.

* Skipping checking the regex pattern in next sections, if found in first sections. (checked sections are a requested body, headers, path)

https://github.com/wso2/product-apim/issues/4031