### PR TITLE
Fix UI improvement when selecting endpoint types

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/item-implement/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/item-implement/template.jag
@@ -199,12 +199,12 @@
 								                            <label class="control-label col-xs-12 col-sm-3 col-md-3 col-lg-3">
 								                            </label>
 							                                <div class="col-xs-12 col-sm-9 col-md-9 col-lg-9">
-																<label class="checkbox">
-																  <input type="checkbox" id="load_balance" name="load_balance" {{#if load_balance }}checked="checked"{{/if}}>
+																<label class="radio">
+																  <input type="radio" id="load_balance" name="load_balance" {{#if load_balance }}checked="checked"{{/if}}>
 																  <span class="helper">Load Balanced</span>
 																</label>
-							                                    <label class="checkbox">
-																  <input type="checkbox" id="failover" name="failover" {{#if failover }}checked="checked"{{/if}} {{#if failOver }}checked="checked"{{/if}}>
+							                                    <label class="radio">
+																  <input type="radio" id="failover" name="failover" {{#if failover }}checked="checked"{{/if}} {{#if failOver }}checked="checked"{{/if}}>
 																  <span class="helper"><%=i18n.localize("Failover")%></span>
 																</label>
 							                                </div>


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-apim/issues/4005

## Goals
> Currently we have checkboxes to select the endpoint type: either Load balanced or failover. AFAIK, we do not need to select both configurations. But it is able to select both endpoint types while endpoint configurations displayed below belongs to Load balanced type.

## Approach
> Introduce radio button instead of a checkbox.
