### PR TITLE
Fix frontend freeze error when secure API deploy as a prototype.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIClientGenerationManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIClientGenerationManager.java
@@ -127,7 +127,7 @@ public class APIClientGenerationManager {
             }
             Registry requiredRegistry = null;
             try {
-                requiredRegistry = getGovernanceUserRegistry(apiProvider, tenantId);
+                requiredRegistry = getGovernanceUserRegistry(MultitenantUtils.getTenantAwareUsername(apiProvider), tenantId);
             } catch (RegistryException e) {
                 handleSDKGenException("Error occurred when retrieving the tenant registry for tenant : " +
                         requestedTenant + " tenant ID : " + tenantId, e);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/blocks/item-design/ajax/add.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/blocks/item-design/ajax/add.jag
@@ -471,8 +471,19 @@ if(jagg.isCSRFTokenValid())
              }
              apiData.endpointUTPassword = decodedPassword.toString();
             } else {
-             apiData.endpointUTPassword = session.get(request.getParameter("name", "UTF-8") + "-" +
-                                                                request.getParameter("version") + "-epPassword");
+                var encryptedPasswordFromSession = session.get(request.getParameter("name", "UTF-8") + "-" +
+                                                                              request.getParameter("version") + "-epPassword");
+                if (encryptedPasswordFromSession) {
+
+                    var byteArray = CryptoUtil.getDefaultCryptoUtil().base64DecodeAndDecrypt(encryptedPasswordFromSession);
+                    var decodedPassword = "";
+                    for(var index = 0; index < byteArray.length; index += 1) {
+                        decodedPassword += String.fromCharCode(byteArray[index]);
+                    }
+                    apiData.endpointUTPassword = decodedPassword.toString();
+                } else {
+                    apiData.endpointUTPassword = encryptedPasswordFromSession;
+                }
             }
             apiData.endpoint_config= request.getParameter("endpoint_config","UTF-8");
             apiData.destinationStats= request.getParameter("destinationStats","UTF-8");


### PR DESCRIPTION
Signed-off-by: nimanthag <nimanthag@wso2.com>

## Purpose
> Resolves https://github.com/wso2/product-apim/issues/4090

## Goals
> Fix frontend freeze error when secure API deploy as a prototype in APIM.

## Approach
> when the API is demoted from published state to the prototyped state the apiBackendPassword is set as null. Whereas it should be set to "*****". This is due to the element stored in the password field not being submitted via the form when the "Deploy as Prototype" button is clicked. Due to this reason, in this case, it does not hit the code block and goes into the else block causing the error to arise. Added an additional check to else block.
## Automation tests
 - Integration tests
   > Manual. Developer testing record.
<img width="1680" alt="screen shot 2018-12-13 at 6 05 52 pm" src="https://user-images.githubusercontent.com/42195796/49958327-76b6ba80-ff30-11e8-9077-bd6ba5563847.png">

