### PR TITLE
Make BACKEND_REQUEST_END_TIME available when analytics is disabled

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
@@ -53,14 +53,13 @@ public class APIMgtLatencyStatsHandler extends AbstractHandler {
         org.apache.axis2.context.MessageContext axis2MC = ((Axis2MessageContext) messageContext)
                 .getAxis2MessageContext();
         org.apache.axis2.context.MessageContext.setCurrentMessageContext(axis2MC);
-        if (APIUtil.isAnalyticsEnabled()) {
-            if (messageContext.getProperty(APIMgtGatewayConstants.BACKEND_REQUEST_END_TIME) == null) {
-
+        if (messageContext.getProperty(APIMgtGatewayConstants.BACKEND_REQUEST_END_TIME) == null) {
+            messageContext.setProperty(APIMgtGatewayConstants.BACKEND_REQUEST_END_TIME, System.currentTimeMillis());
+            if (APIUtil.isAnalyticsEnabled()) {
                 long executionStartTime = Long.parseLong((String) messageContext.getProperty(APIMgtGatewayConstants
                         .BACKEND_REQUEST_START_TIME));
                 messageContext.setProperty(APIMgtGatewayConstants.BACKEND_LATENCY, System.currentTimeMillis() -
                         executionStartTime);
-                messageContext.setProperty(APIMgtGatewayConstants.BACKEND_REQUEST_END_TIME, System.currentTimeMillis());
             }
         }
         return true;


### PR DESCRIPTION
## Purpose
This PR changes accessibility to obtain BACKEND_REQUEST_END_TIME without enabling analytics. Fixes https://github.com/wso2/product-apim/issues/4188