### PR TITLE
Provides GraphQL support over Publisher REST API [Do not merge]

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
@@ -663,6 +663,22 @@ public interface APIManager {
     void updateWsdl(String resourcePath, String wsdlDefinition) throws APIManagementException;
 
     /**
+     * Returns the graphql schema content in registry specified by the schema name
+     *
+     * @param apiId api identifier of the API
+     * @return schema content matching name if exist else null
+     */
+    String getGraphqlSchema(APIIdentifier apiId) throws APIManagementException;
+
+    /**
+     * Create a graphql schema in the path specified.
+     *
+     * @param resourcePath   Registry path of the resource
+     * @param schemaDefinition schema content
+     */
+    void uploadGraphqlSchema(String resourcePath, String schemaDefinition) throws APIManagementException;
+
+    /**
      * Returns the corresponding application given the subscriberId and application name
      *
      * @param subscriberId subscriberId of the Application

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -162,9 +162,12 @@ public final class APIConstants {
 
     // registry location for wsdl files
     public static final String API_WSDL_RESOURCE_LOCATION = API_APPLICATION_DATA_LOCATION + "/wsdls/";
+    public static final String API_GRAPHQL_SCHEMA_RESOURCE_LOCATION = API_APPLICATION_DATA_LOCATION + "/wsdls/";
     public static final String API_WSDL_RESOURCE = API_APPLICATION_DATA_LOCATION+"/wsdls";
     public static final String WSDL_FILE_EXTENSION = ".wsdl";
+    public static final String GRAPHQL_SCHEMA_FILE_EXTENSION = ".wsdl";
     public static final String WSDL_PROVIDER_SEPERATOR = "--";
+    public static final String GRAPHQL_SCHEMA_PROVIDER_SEPERATOR = "--";
     public static final String API_WSDL_ARCHIVE_LOCATION = "archives/";
     public static final String API_WSDL_EXTRACTED_DIRECTORY = "extracted";
     public static final String WSDL_ARCHIVES_TEMP_FOLDER = "WSDL-archives";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -162,10 +162,10 @@ public final class APIConstants {
 
     // registry location for wsdl files
     public static final String API_WSDL_RESOURCE_LOCATION = API_APPLICATION_DATA_LOCATION + "/wsdls/";
-    public static final String API_GRAPHQL_SCHEMA_RESOURCE_LOCATION = API_APPLICATION_DATA_LOCATION + "/wsdls/";
+    public static final String API_GRAPHQL_SCHEMA_RESOURCE_LOCATION = API_APPLICATION_DATA_LOCATION + "/graphql/";
     public static final String API_WSDL_RESOURCE = API_APPLICATION_DATA_LOCATION+"/wsdls";
     public static final String WSDL_FILE_EXTENSION = ".wsdl";
-    public static final String GRAPHQL_SCHEMA_FILE_EXTENSION = ".wsdl";
+    public static final String GRAPHQL_SCHEMA_FILE_EXTENSION = ".graphql";
     public static final String WSDL_PROVIDER_SEPERATOR = "--";
     public static final String GRAPHQL_SCHEMA_PROVIDER_SEPERATOR = "--";
     public static final String API_WSDL_ARCHIVE_LOCATION = "archives/";
@@ -175,7 +175,7 @@ public final class APIConstants {
     public static final String WSDL_FILE = "wsdlFile";
     public static final String UPDATED_WSDL_ZIP = "updated.zip";
     public static final String FILE_URI_PREFIX = "file://";
-    
+
     public static final String API_DOC_RESOURCE_NAME = "api-doc.json";
 
     public static final String API_DOC_1_2_RESOURCE_NAME = "/api-doc";
@@ -343,7 +343,7 @@ public final class APIConstants {
     public static final String IDENTITY_OAUTH2_FIELD_TIME_CREATED = "TIME_CREATED";
     public static final String IDENTITY_OAUTH2_FIELD_VALIDITY_PERIOD = "VALIDITY_PERIOD";
     public static final String IDENTITY_OAUTH2_FIELD_USER_DOMAIN = "USER_DOMAIN";
-    
+
     public static final String DOT = ".";
     public static final String EXP = "exp";
     public static final String JWT = "JWT";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -1035,6 +1035,57 @@ public abstract class AbstractAPIManager implements APIManager {
     }
 
     /**
+     * Returns the wsdl content in registry specified by the wsdl name
+     *
+     * @param apiId Api Identifier
+     * @return wsdl content matching name if exist else null
+     */
+    @Override
+    public String getGraphqlSchema(APIIdentifier apiId) throws APIManagementException {
+        String schemaDoc = null;
+        String schemaName = apiId.getProviderName() + "--" + apiId.getApiName() +
+                apiId.getVersion() + ".graphql";
+        String schemaResourePath = APIConstants.API_GRAPHQL_SCHEMA_RESOURCE_LOCATION + schemaName;
+        try {
+            if (registry.resourceExists(schemaResourePath)) {
+                Resource schemaResource = registry.get(schemaResourePath);
+                schemaDoc = IOUtils.toString(schemaResource.getContentStream(),
+                        RegistryConstants.DEFAULT_CHARSET_ENCODING);
+            }
+        } catch (RegistryException e) {
+            String msg = "Error while getting schema file from the registry ";
+            log.error(msg, e);
+            throw new APIManagementException(msg, e);
+        } catch (IOException e) {
+            String error = "Error occurred while getting the content of schema " + schemaName;
+            log.error(error);
+            throw new APIManagementException(error, e);
+        }
+        return schemaDoc;
+    }
+
+    /**
+     * Create a graphql schema in the path specified.
+     *
+     * @param resourcePath   Registry path of the resource
+     * @param schemaDefinition wsdl content
+     */
+    @Override
+    public void uploadGraphqlSchema(String resourcePath, String schemaDefinition)
+            throws APIManagementException {
+        try {
+            Resource resource = registry.newResource();
+            resource.setContent(schemaDefinition);
+            resource.setMediaType(String.valueOf(ContentType.TEXT_PLAIN));
+            registry.put(resourcePath, resource);
+        } catch (RegistryException e) {
+            String msg = "Error while uploading schema to from the registry ";
+            log.error(msg, e);
+            throw new APIManagementException(msg, e);
+        }
+    }
+
+    /**
      * Returns the swagger 2.0 definition of the given API
      *
      * @param apiId id of the APIIdentifier

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/UserAwareAPIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/UserAwareAPIProvider.java
@@ -95,6 +95,12 @@ public class UserAwareAPIProvider extends APIProviderImpl {
     }
 
     @Override
+    public String getGraphqlSchema(APIIdentifier apiId) throws APIManagementException {
+        checkAccessControlPermission(apiId);
+        return super.getGraphqlSchema(apiId);
+    }
+
+    @Override
     public boolean updateAPIStatus(APIIdentifier identifier, String status, boolean publishToGateway,
             boolean deprecateOldVersions, boolean makeKeysForwardCompatible)
             throws APIManagementException, FaultGatewaysException {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/UserAwareAPIProviderTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/UserAwareAPIProviderTest.java
@@ -289,6 +289,16 @@ public class UserAwareAPIProviderTest {
     }
 
     /**
+     * This method checks the behaviour of getGraphqlSchema method when there is no schema for the relevant API.
+     *
+     * @throws APIManagementException API Management Exception.
+     */
+    @Test
+    public void testGetGraphqlSchema() throws APIManagementException {
+        Assert.assertNull("Non-existing schema file was retrieved successfully",
+                userAwareAPIProvider.getGraphqlSchema(apiIdentifier));
+    }
+    /**
      * This methos checks the getLifecycleEvents method of a non-existing API.
      *
      * @throws APIManagementException API Management Exception.

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApi.java
@@ -11,6 +11,7 @@ import org.wso2.carbon.apimgt.rest.api.publisher.dto.DocumentDTO;
 import java.io.File;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.DocumentListDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.APIDetailedDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.dto.GraphQLSchemaDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.MediationListDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.MediationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.FileInfoDTO;
@@ -227,6 +228,51 @@ public class ApisApi  {
     @ApiParam(value = "Validator for conditional requests; based on Last Modified header of the\nformerly retrieved variant of the resource (Will be supported in future).\n"  )@HeaderParam("If-Modified-Since") String ifModifiedSince)
     {
     return delegate.apisApiIdGet(apiId,accept,ifNoneMatch,ifModifiedSince);
+    }
+    @GET
+    @Path("/{apiId}/graphqlSchema")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Get the Schema of a GraphQL API", notes = "This operation can be used to retrieve the Schema definition of a GraphQL API.\n", response = GraphQLSchemaDTO.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "OK.\nRequested GraphQL Schema DTO object belongs to the API\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 304, message = "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Not Found.\nRequested API does not exist.\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 406, message = "Not Acceptable.\nThe requested media type is not supported\n") })
+
+    public Response apisApiIdGraphqlSchemaGet(@ApiParam(value = "**API ID** consisting of the **UUID** of the API. Using the **UUID** in the API call is recommended.\nThe combination of the provider of the API, name of the API and the version is also accepted as a valid API ID.\nShould be formatted as **provider-name-version**.\n",required=true ) @PathParam("apiId") @Encoded String apiId,
+    @ApiParam(value = "Media types acceptable for the response. Default is application/json.\n"  , defaultValue="application/json")@HeaderParam("Accept") String accept,
+    @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resource (Will be supported in future).\n"  )@HeaderParam("If-None-Match") String ifNoneMatch,
+    @ApiParam(value = "Validator for conditional requests; based on Last Modified header of the\nformerly retrieved variant of the resource (Will be supported in future).\n"  )@HeaderParam("If-Modified-Since") String ifModifiedSince)
+    {
+    return delegate.apisApiIdGraphqlSchemaGet(apiId,accept,ifNoneMatch,ifModifiedSince);
+    }
+    @POST
+    @Path("/{apiId}/graphqlSchema")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Add a Schema to a GraphQL API", notes = "This operation can be used to add a GraphQL Schema definition to an existing GraphQL API.\n", response = void.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "OK.\nSuccessful response with updated schema definition\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Bad Request.\nInvalid request or validation error\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 403, message = "Forbidden.\nThe request must be conditional but no condition has been specified.\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Not Found.\nThe resource to be updated does not exist.\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 412, message = "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n") })
+
+    public Response apisApiIdGraphqlSchemaPost(@ApiParam(value = "**API ID** consisting of the **UUID** of the API. Using the **UUID** in the API call is recommended.\nThe combination of the provider of the API, name of the API and the version is also accepted as a valid API ID.\nShould be formatted as **provider-name-version**.\n",required=true ) @PathParam("apiId") @Encoded String apiId,
+    @ApiParam(value = "JSON payload including Schema definition that needs to be added\n" ,required=true ) GraphQLSchemaDTO body,
+    @ApiParam(value = "Media type of the entity in the body. Default is application/json.\n" ,required=true , defaultValue="application/json")@HeaderParam("Content-Type") String contentType,
+    @ApiParam(value = "Validator for conditional requests; based on ETag (Will be supported in future).\n"  )@HeaderParam("If-Match") String ifMatch,
+    @ApiParam(value = "Validator for conditional requests; based on Last Modified header (Will be supported in future).\n"  )@HeaderParam("If-Unmodified-Since") String ifUnmodifiedSince)
+    {
+    return delegate.apisApiIdGraphqlSchemaPost(apiId,body,contentType,ifMatch,ifUnmodifiedSince);
     }
     @GET
     @Path("/{apiId}/policies/mediation")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/ApisApiService.java
@@ -8,6 +8,7 @@ import org.wso2.carbon.apimgt.rest.api.publisher.dto.DocumentDTO;
 import java.io.File;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.DocumentListDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.APIDetailedDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.dto.GraphQLSchemaDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.MediationListDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.MediationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.dto.FileInfoDTO;
@@ -31,6 +32,8 @@ public abstract class ApisApiService {
     public abstract Response apisApiIdDocumentsGet(String apiId,Integer limit,Integer offset,String accept,String ifNoneMatch);
     public abstract Response apisApiIdDocumentsPost(String apiId,DocumentDTO body,String contentType);
     public abstract Response apisApiIdGet(String apiId,String accept,String ifNoneMatch,String ifModifiedSince);
+    public abstract Response apisApiIdGraphqlSchemaGet(String apiId,String accept,String ifNoneMatch,String ifModifiedSince);
+    public abstract Response apisApiIdGraphqlSchemaPost(String apiId,GraphQLSchemaDTO body,String contentType,String ifMatch,String ifUnmodifiedSince);
     public abstract Response apisApiIdPoliciesMediationGet(String apiId,Integer limit,Integer offset,String query,String accept,String ifNoneMatch);
     public abstract Response apisApiIdPoliciesMediationMediationPolicyIdDelete(String apiId,String mediationPolicyId,String ifMatch,String ifUnmodifiedSince);
     public abstract Response apisApiIdPoliciesMediationMediationPolicyIdGet(String apiId,String mediationPolicyId,String accept,String ifNoneMatch,String ifModifiedSince);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APIDetailedDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/APIDetailedDTO.java
@@ -44,7 +44,7 @@ public class APIDetailedDTO extends APIInfoDTO {
   private Boolean isDefaultVersion = null;
   
   public enum TypeEnum {
-     HTTP,  WS,  SOAPTOREST, 
+     HTTP,  WS,  SOAPTOREST,  GRAPHQL, 
   };
   
   private TypeEnum type = TypeEnum.HTTP;
@@ -200,9 +200,9 @@ public class APIDetailedDTO extends APIInfoDTO {
 
   
   /**
-   * The api creation type to be used. Accepted values are HTTP, WS, SOAPTOREST
+   * The api creation type to be used. Accepted values are HTTP, WS, SOAPTOREST, GRAPHQL
    **/
-  @ApiModelProperty(value = "The api creation type to be used. Accepted values are HTTP, WS, SOAPTOREST")
+  @ApiModelProperty(value = "The api creation type to be used. Accepted values are HTTP, WS, SOAPTOREST, GRAPHQL")
   @JsonProperty("type")
   public TypeEnum getType() {
     return type;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/GraphQLSchemaDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/dto/GraphQLSchemaDTO.java
@@ -1,0 +1,59 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.dto;
+
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class GraphQLSchemaDTO  {
+  
+  
+  @NotNull
+  private String name = null;
+  
+  
+  private String schemaDefinition = null;
+
+  
+  /**
+   **/
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("schemaDefinition")
+  public String getSchemaDefinition() {
+    return schemaDefinition;
+  }
+  public void setSchemaDefinition(String schemaDefinition) {
+    this.schemaDefinition = schemaDefinition;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class GraphQLSchemaDTO {\n");
+    
+    sb.append("  name: ").append(name).append("\n");
+    sb.append("  schemaDefinition: ").append(schemaDefinition).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml
@@ -1774,6 +1774,142 @@ paths:
 
 
   ######################################################
+  # The GraphQL Schema Resource
+  ######################################################
+  /apis/{apiId}/graphqlSchema:
+
+    #-----------------------------------------------------
+    # Retrieve the details about a certain GraphQL schema
+    #-----------------------------------------------------
+    get:
+      x-scope: apim:api_view
+      x-wso2-curl: "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/publisher/v0.14/apis/7f82f6b0-2667-441e-af23-c0fc44cf3a17/graphqlSchema\""
+      x-wso2-request: |
+        GET https://localhost:9443/api/am/publisher/v0.14/apis/7f82f6b0-2667-441e-af23-c0fc44cf3a17/graphqlSchema
+        Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8
+      x-wso2-response: "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n{\r\n   \"name\": \"admin--hello1.0.0.graphql\",\r\n   \"schemaDefinition\": \"schema {\r\n  \r\n  # The query root of HackerNews GraphQL interface.\r\n  query: Query\r\n\r\n  # The root query for implementing GraphQL mutations.\r\n  mutation: Mutation\r\n}\r\n\r\ntype Link {\r\n\r\n  # ID of the link\r\n  id: ID!\r\n\r\n  # URL of the link\r\n  url: String!\r\n\r\n  # Description of the link\r\n  description: String\r\n}\r\n\r\ninput LinkFilter {\r\n\r\n  # Value to be checked whether it contains in the description\r\n  description_contains: String\r\n\r\n  # Value to be checked whether it contains in the URL\r\n  url_contains: String\r\n}\r\n\r\ntype Query {\r\n\r\n  # Fetches all the links\r\n  #\r\n  # Arguments\r\n  # filter: To filter the links according a specific criteria\r\n  # skip: Skip to a specific index in the list (default value is 0)\r\n  # first: Index of the link first to display (default value is 0)\r\n  allLinks(filter: LinkFilter, skip: Int = 0, first: Int = 0): [Link]\r\n}\r\n\r\ntype Mutation {\r\n\r\n  # Creates a new link\r\n  #\r\n  # Arguments\r\n  # url: URL of the link\r\n  # description: Description about the link\r\n  createLink(url: String!, description: String!): Link\r\n}\r\n\"\r\n}"
+      summary: Get the Schema of a GraphQL API
+      description: |
+        This operation can be used to retrieve the Schema definition of a GraphQL API.
+      parameters:
+        - $ref: '#/parameters/apiId'
+        - $ref: '#/parameters/Accept'
+        - $ref: '#/parameters/If-None-Match'
+        - $ref: '#/parameters/If-Modified-Since'
+      tags:
+        - GraphQL Schema (Individual)
+      responses:
+        200:
+          description: |
+            OK.
+            Requested GraphQL Schema DTO object belongs to the API
+          schema:
+            $ref: '#/definitions/GraphQLSchema'
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              type: string
+            ETag:
+              description: |
+                Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).
+              type: string
+            Last-Modified:
+              description: |
+                Date and time the resource has been modifed the last time.
+                Used by caches, or in conditional requests (Will be supported in future).
+              type: string
+
+        304:
+          description: |
+            Not Modified.
+            Empty body because the client has already the latest version of the requested resource (Will be supported in future).
+        404:
+          description: |
+            Not Found.
+            Requested API does not exist.
+          schema:
+            $ref: '#/definitions/Error'
+        406:
+          description: |
+            Not Acceptable.
+            The requested media type is not supported
+          schema:
+            $ref: '#/definitions/Error'
+    #-----------------------------------------------------
+    # Add a GraphQL schema to the registry
+    #-----------------------------------------------------
+    post:
+      x-scope: apim:api_create
+      x-wso2-curl: "curl -k -H \"Authorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\" -H \"Content-Type: application/json\" -X POST -d @data.json \"https://localhost:9443/api/am/publisher/v0.14/apis/af3f96da-9ccf-463f-8cee-13ec8530a9cd/graphqlSchema\""
+      x-wso2-request: "POST https://localhost:9443/api/am/publisher/v0.14/apis/af3f96da-9ccf-463f-8cee-13ec8530a9cd/graphqlSchema\r\nContent-Type: text/plain\r\nAuthorization: Bearer 7d237cab-7011-3f81-b384-24d03e750873\r\n\r\n{\r\n   \"name\": \"admin--HackerNewsAPI1.0.0.graphql\",\r\n   \"schemaDefinition\": \"schema {\r\n  \r\n  # The query root of HackerNews GraphQL interface.\r\n  query: Query\r\n\r\n  # The root query for implementing GraphQL mutations.\r\n  mutation: Mutation\r\n}\r\n\r\ntype Link {\r\n\r\n  # ID of the link\r\n  id: ID!\r\n\r\n  # URL of the link\r\n  url: String!\r\n\r\n  # Description of the link\r\n  description: String\r\n}\r\n\r\ninput LinkFilter {\r\n\r\n  # Value to be checked whether it contains in the description\r\n  description_contains: String\r\n\r\n  # Value to be checked whether it contains in the URL\r\n  url_contains: String\r\n}\r\n\r\ntype Query {\r\n\r\n  # Fetches all the links\r\n  #\r\n  # Arguments\r\n  # filter: To filter the links according a specific criteria\r\n  # skip: Skip to a specific index in the list (default value is 0)\r\n  # first: Index of the link first to display (default value is 0)\r\n  allLinks(filter: LinkFilter, skip: Int = 0, first: Int = 0): [Link]\r\n}\r\n\r\ntype Mutation {\r\n\r\n  # Creates a new link\r\n  #\r\n  # Arguments\r\n  # url: URL of the link\r\n  # description: Description about the link\r\n  createLink(url: String!, description: String!): Link\r\n}\r\n\"\r\n}"
+      x-wso2-response: "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n{\r\n   \"name\": \"admin--HackerNewsAPI1.0.0.graphql\",\r\n   \"schemaDefinition\": \"schema {\r\n  \r\n  # The query root of HackerNews GraphQL interface.\r\n  query: Query\r\n\r\n  # The root query for implementing GraphQL mutations.\r\n  mutation: Mutation\r\n}\r\n\r\ntype Link {\r\n\r\n  # ID of the link\r\n  id: ID!\r\n\r\n  # URL of the link\r\n  url: String!\r\n\r\n  # Description of the link\r\n  description: String\r\n}\r\n\r\ninput LinkFilter {\r\n\r\n  # Value to be checked whether it contains in the description\r\n  description_contains: String\r\n\r\n  # Value to be checked whether it contains in the URL\r\n  url_contains: String\r\n}\r\n\r\ntype Query {\r\n\r\n  # Fetches all the links\r\n  #\r\n  # Arguments\r\n  # filter: To filter the links according a specific criteria\r\n  # skip: Skip to a specific index in the list (default value is 0)\r\n  # first: Index of the link first to display (default value is 0)\r\n  allLinks(filter: LinkFilter, skip: Int = 0, first: Int = 0): [Link]\r\n}\r\n\r\ntype Mutation {\r\n\r\n  # Creates a new link\r\n  #\r\n  # Arguments\r\n  # url: URL of the link\r\n  # description: Description about the link\r\n  createLink(url: String!, description: String!): Link\r\n}\r\n\"\r\n}"
+      summary: Add a Schema to a GraphQL API
+      description: |
+        This operation can be used to add a GraphQL Schema definition to an existing GraphQL API.
+      parameters:
+        - $ref: '#/parameters/apiId'
+        - in: body
+          name: body
+          description: |
+            JSON payload including Schema definition that needs to be added
+          required: true
+          schema:
+            $ref: '#/definitions/GraphQLSchema'
+        - $ref: '#/parameters/Content-Type'
+        - $ref: '#/parameters/If-Match'
+        - $ref: '#/parameters/If-Unmodified-Since'
+      tags:
+        - GraphQL Schema (Individual)
+      responses:
+        200:
+          description: |
+            OK.
+            Successful response with updated schema definition
+          headers:
+            Location:
+              description: |
+                The URL of the newly created resource.
+              type: string
+            Content-Type:
+              description: |
+                The content type of the body.
+              type: string
+            ETag:
+              description: |
+                Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).
+              type: string
+            Last-Modified:
+              description: |
+                Date and time the resource has been modifed the last time.
+                Used by caches, or in conditional requests (Will be supported in future).
+              type: string
+        400:
+          description: |
+            Bad Request.
+            Invalid request or validation error
+          schema:
+            $ref: '#/definitions/Error'
+        403:
+          description: |
+            Forbidden.
+            The request must be conditional but no condition has been specified.
+          schema:
+            $ref: '#/definitions/Error'
+        404:
+          description: |
+            Not Found.
+            The resource to be updated does not exist.
+          schema:
+            $ref: '#/definitions/Error'
+        412:
+          description: |
+            Precondition Failed.
+            The request has not been performed because one of the preconditions is not met.
+          schema:
+            $ref: '#/definitions/Error'
+
+  ######################################################
   # The "Individual Application" resource APIs
   ######################################################
   '/applications/{applicationId}':
@@ -3702,11 +3838,12 @@ definitions:
             example: false
           type:
             type: string
-            description: The api creation type to be used. Accepted values are HTTP, WS, SOAPTOREST
+            description: The api creation type to be used. Accepted values are HTTP, WS, SOAPTOREST, GRAPHQL
             enum:
               - HTTP
               - WS
               - SOAPTOREST
+              - GRAPHQL
             example: HTTP
             default: HTTP
           transport:
@@ -4031,6 +4168,20 @@ definitions:
         type: string
         example: admin--calculatorAPI2.0.wsdl
       wsdlDefinition:
+        type: string
+
+  #-----------------------------------------------------
+  # The GraphQL Schema resource
+  #-----------------------------------------------------
+  GraphQLSchema:
+    title: GraphQL Schema
+    required:
+      - name
+    properties:
+      name:
+        type: string
+        example: admin--HackerNewsAPI2.0.graphql
+      schemaDefinition:
         type: string
 
 


### PR DESCRIPTION
## Purpose
We can create a GraphQL API by simply using our Publisher REST API, but we cannot do it since we need to have GRAPHQL as a type in our publisher definition. After that change is done we can proceed and create a GraphQL API. 
A GraphQL API mainly defined based on a schema file which consists of all the required definitions of queries and mutations which can be used to invoke the particular GraphQL API. So there is a need to handle this schema file through Publisher REST API. 

## Goals
- Provides functionality to create a GraphQL API through Publisher REST API
- Provides the functionality to add a GraphQL schema for a particular API using our Publisher REST API
- Provides the functionality to retrieve a GraphQL schema of a particular API using our Publisher REST API

## Approach
GraphQL is developed by Facebook which is an alternative to REST. It is a query language for APIs where a particular user can specify exactly what data is needed from an API. We know that we can use a Swagger Definition (Open API Specification) to design a REST API. But in GraphQL, we can use Schema Definition Language (SDL) to write the **Schema** for a GraphQL API. Invoking a GraphQL API simply means fetching data using GraphQL queries and writing data using GraphQL mutations. 

We can simply create and publish a GraphQL API using the Publisher REST API which we have in WSO2 API Manager. You just need to change the **type** of the API as **GRAPHQL**  instead of HTTP/WS/SOAPTOREST and change the **apiDefinition** as follows (following is the required defintion for a GraphQL API).
<code>
"{\"swagger\": \"2.0\",\"info\": {\"title\": \"\",\"version\": \"\"},\"paths\": {\"\/\": {\"get\": {\"responses\": {\"200\": {\"description\": \"\"}},\"parameters\": [{\"name\": \"query\",\"in\": \"query\",\"required\": true,\"type\": \"string\",\"description\": \" Query to be passed to the GraphQL API\"}],\"produces\": [\"application\/json\"],\"consumes\": [\"application\/json\"],\"summary\": \"GET method to be used in GraphQL API\"},\"post\": {\"parameters\": [{\"name\": \"Payload\",\"description\": \"Query or Mutation to be passed to the GraphQL API\",\"required\": false,\"in\": \"body\",\"schema\": {\"type\": \"object\",\"properties\": {\"payload\": {\"type\": \"string\"}}}}],\"responses\": {\"200\": {\"description\": \"\"}},\"summary\": \"POST method to be used in GraphQL API\",\"produces\": [\"application\/json\"],\"consumes\": [\"application\/json\"]}}}}"
</code>

In we have given support from WSO2 APIM in order to create and publish a GraphQL API in order to invoke it over https/http.
Please refer the mail thread subjected as "[Architecture] GraphQL support for WSO2 APIM" and the Git issue in https://github.com/wso2/product-apim/issues/3184 for more information. 

## User stories
- Using Publisher APIs in WSO2 someone can 
  - Create a GraphQL API
  - Upload a Schema definition for an existing GraphQL API 
  - Retrieve a Schema definition of an existing GraphQL API 

## Documentation
Documentation changes are required.

## Automation tests
 - Unit tests 
   Added few tests in
   - components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AbstractAPIManagerTestCase.java
   -  components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/UserAwareAPIProviderTest.java

## Test environment
- jdk1.8.0_144
- Ubuntu 16.04 LTS