### PR TITLE
fix for https://github.com/wso2/product-apim/issues/4302

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/SAMLGroupIDExtractorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/SAMLGroupIDExtractorImpl.java
@@ -66,7 +66,12 @@ public class SAMLGroupIDExtractorImpl implements NewPostLoginExecutor {
         String username = "";
         String organization = "";
         try {
-            String claim = "http://wso2.org/claims/organization";
+            APIManagerConfiguration config = ServiceReferenceHolder.getInstance().
+                    getAPIManagerConfigurationService().getAPIManagerConfiguration();
+            String claim = config.getFirstProperty(APIConstants.API_STORE_GROUP_EXTRACTOR_CLAIM_URI);
+            if (StringUtils.isBlank(claim)) {
+                claim = "http://wso2.org/claims/organization";
+            }
             samlResponseStream = getByteArrayInputStream(loginResponse);
             DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
             builderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
@@ -242,7 +247,12 @@ public class SAMLGroupIDExtractorImpl implements NewPostLoginExecutor {
         String[] groupIdArray = null;
 
         try {
-            String claim = "http://wso2.org/claims/organization";
+            APIManagerConfiguration config = ServiceReferenceHolder.getInstance().
+                    getAPIManagerConfigurationService().getAPIManagerConfiguration();
+            String claim = config.getFirstProperty(APIConstants.API_STORE_GROUP_EXTRACTOR_CLAIM_URI);
+            if (StringUtils.isBlank(claim)) {
+                claim = "http://wso2.org/claims/organization";
+            }
             samlResponseStream = getByteArrayInputStream(loginResponse);
             DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
             builderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/SAMLGroupIDExtractorImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/SAMLGroupIDExtractorImplTest.java
@@ -120,9 +120,15 @@ public class SAMLGroupIDExtractorImplTest {
         UserRealm userRealm = Mockito.mock(UserRealm.class);
         TenantManager tenantManager = Mockito.mock(TenantManager.class);
         UserStoreManager userStoreManager = Mockito.mock(UserStoreManager.class);
+        APIManagerConfigurationService apiManagerConfigService = Mockito.mock(APIManagerConfigurationService.class);
+        APIManagerConfiguration apiManagerConfig = Mockito.mock(APIManagerConfiguration.class);
         Mockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
         Mockito.when(serviceReferenceHolder.getRealmService()).thenReturn(realmService);
         Mockito.when(realmService.getTenantManager()).thenReturn(tenantManager);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService()).thenReturn(apiManagerConfigService);
+        Mockito.when(apiManagerConfigService.getAPIManagerConfiguration()).thenReturn(apiManagerConfig);
+        Mockito.when(apiManagerConfig.getFirstProperty(APIConstants.API_STORE_GROUP_EXTRACTOR_CLAIM_URI)).
+                thenReturn("http://wso2.org/claims/organization");
 
         Mockito.when(tenantManager.getTenantId("carbon.super")).thenReturn(1234);
         Mockito.when(realmService.getTenantUserRealm(1234)).thenReturn(userRealm);
@@ -148,7 +154,8 @@ public class SAMLGroupIDExtractorImplTest {
         Mockito.when(documentBuilder.parse(samlGroupIDExtractor.getByteArrayInputStream("test"))).
                 thenReturn(document);
         Mockito.when(document.getDocumentElement()).thenReturn(element);
-
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
         PowerMockito.mockStatic(Configuration.class);
         Response response = Mockito.mock(Response.class);
         List<Assertion> assertion = new ArrayList();
@@ -164,6 +171,13 @@ public class SAMLGroupIDExtractorImplTest {
         Mockito.when(subject.getNameID()).thenReturn(nameID);
         Mockito.when(nameID.getValue()).thenReturn("user");
         System.setProperty(APIConstants.READ_ORGANIZATION_FROM_SAML_ASSERTION, "true");
+        APIManagerConfigurationService apiManagerConfigService = Mockito.mock(APIManagerConfigurationService.class);
+        Mockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService()).thenReturn(apiManagerConfigService);
+        APIManagerConfiguration apiManagerConfig = Mockito.mock(APIManagerConfiguration.class);
+        Mockito.when(apiManagerConfigService.getAPIManagerConfiguration()).thenReturn(apiManagerConfig);
+        Mockito.when(apiManagerConfig.getFirstProperty(APIConstants.API_STORE_GROUP_EXTRACTOR_CLAIM_URI)).
+                thenReturn("http://wso2.org/claims/organization");
 
         System.setProperty("carbon.home", "");
         PrivilegedCarbonContext carbonContext;


### PR DESCRIPTION
## Purpose
> This PR provides the fox for https://github.com/wso2/product-apim/issues/4302

## Goals
> Need to be able to use any claim as the gruopId in multi group application sharing.

## Approach
> use configuration to read claim attribute.


## Automation tests
 - Unit tests 
   > org.wso2.carbon.apimgt.impl.SAMLGroupIDExtractorImplTest