### PR TITLE
Fix error when loading apis that has not no subscriptions

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/subscription/subscription-list/ajax/subscription-list.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/subscription/subscription-list/ajax/subscription-list.jag
@@ -334,16 +334,18 @@ include("/jagg/jagg.jag");
 
           var applicationId = request.getParameter("applicationId");
           mod = jagg.module("subscription");
-          result = mod.getApplicationKeysOfApplication(applicationId);
-          if (result.error) {
-              obj = {
-                  error:result.error,
-                  message:result.message
-              };
-          } else {
-              obj = {
-                  error:false,
-                  apikeys:result.apikeys
+          if (applicationId != null) {
+              result = mod.getApplicationKeysOfApplication(applicationId);
+              if (result.error) {
+                  obj = {
+                      error:result.error,
+                      message:result.message
+                  };
+              } else {
+                  obj = {
+                      error:false,
+                      apikeys:result.apikeys
+                  }
               }
           }
           print(obj);


### PR DESCRIPTION
## Purpose
This PR fixes the NPE when navigating to api-info page of an api that does not have subscriptions.

## Approach
Before calling getApplicationKeysForAppId it is checked whether the appId is not null.