### PR TITLE
Fix for #5629

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/APIProviderHostObject.java
@@ -1131,10 +1131,6 @@ public class APIProviderHostObject extends ScriptableObject {
         name = (name != null ? name.trim() : null);
         version = (version != null ? version.trim() : null);
         APIIdentifier apiId = new APIIdentifier(provider, name, version);
-        APIProvider apiProvider = getAPIProvider(thisObj);
-        if (apiProvider.getAPI(apiId) == null) {
-            return null;
-        }
 
         boolean isTenantFlowStarted = false;
         String apiJSON = null;
@@ -1144,6 +1140,10 @@ public class APIProviderHostObject extends ScriptableObject {
                 isTenantFlowStarted = true;
                 PrivilegedCarbonContext.startTenantFlow();
                 PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+            }
+            APIProvider apiProvider = getAPIProvider(thisObj);
+            if (apiProvider.getAPI(apiId) == null) {
+                return null;
             }
             RegistryService registryService = ServiceReferenceHolder.getInstance().getRegistryService();
             int tenantId;


### PR DESCRIPTION
## Purpose
Resolves #5629 

## Goals
Resources of the apis created in the tenant space are retrieved from the tenant cache instead of the super tenant cache.

## Approach
In the method **getOpenAPIDefinitionResource** of **APIProviderHostObject.java**, a code block was not properly enclosed in the tenant flow. And this PR fix that.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
java version "1.8.0_201"
Ubuntu 18.04 LTS
Chrome Version 72.0.3626.109
