### PR TITLE
Add API-provider tenant domain validation for adding APIs through publisher REST-API.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
@@ -285,6 +285,20 @@ public class ApisApiServiceImpl extends ApisApiService {
                                 provider + ") overridden with current user (" + username + ")");
                     }
                     provider = username;
+                } else {
+                    if (!MultitenantUtils.getTenantDomain(username).equals(MultitenantUtils
+                            .getTenantDomain(provider))) {
+                        String errorMessage = "Error while adding new API : " + body.getProvider() + "-" +
+                                body.getName() + "-" + body.getVersion() + ". The tenant " +
+                                "domain '" + MultitenantUtils.getTenantDomain(provider) + "' of provider '" + provider
+                                + "' is not compatible with admin's('" + username + "') tenant domain '" +
+                                MultitenantUtils.getTenantDomain(username) + "'";
+                        RestApiUtil.handleBadRequest(errorMessage, log);
+                    } else {
+                        //When tenant domain contains upper case characters, this will convert those to lowercase
+                        provider = MultitenantUtils.getTenantAwareUsername(provider) + "@" +
+                                MultitenantUtils.getTenantDomain(provider);
+                    }
                 }
             } else {
                 //Set username in case provider is null or empty


### PR DESCRIPTION
## Purpose
When adding API through the publisher REST-APIs, tenant admin can set API-provider.
In that process, if the tenant admin set a wrong tenant domain or username without the tenant domain, the API manager could not handle the scenario.

## Goals
Set API-provider tenant domain validation for adding APIs through publisher REST-API.

## Approach
* Check the provider-tenant domain and validate it.
* If the tenant domain contains uppercase letters, convert it to lowercase characters.
