### PR TITLE
Add labeling feature to cloud hybrid gateway

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/dto/LabelDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/dto/LabelDTO.java
@@ -33,6 +33,8 @@ public class LabelDTO  {
     @NotNull
     private String name = null;
 
+    private String description = null;
+
     private List<String> accessUrls = new ArrayList<String>();
 
     private String lastUpdatedTime = null;
@@ -75,6 +77,17 @@ public class LabelDTO  {
     /**
      **/
     @ApiModelProperty(value = "")
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     **/
+    @ApiModelProperty(value = "")
     @JsonProperty("accessUrls")
     public List<String> getAccessUrls() {
         return accessUrls;
@@ -88,6 +101,7 @@ public class LabelDTO  {
         StringBuilder sb = new StringBuilder();
         sb.append("class LabelDTO {\n");
         sb.append("  name: ").append(name).append("\n");
+        sb.append("  description:  ").append(description).append("\n");
         sb.append("  accessUrls: ").append(accessUrls).append("\n");
         sb.append("}\n");
         return sb.toString();

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/util/APISynchronizationConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/util/APISynchronizationConstants.java
@@ -38,4 +38,11 @@ public class APISynchronizationConstants {
     public static final String API_DEFAULT_VERSION = "v0.14";
     public static final String URL_PATH_SEPARATOR = "/";
     public static final String CLOUD_API = "cloud";
+    public static final String QUESTION_MARK = "?";
+    public static final String OFFSET_PREFIX = "offset=";
+    public static final String API_SEARCH_LABEL_QUERY_PREFIX = "query=label:";
+    public static final String AMPERSAND = "&";
+    public static final String PAGINATION_LIMIT_PREFIX = "limit=";
+    public static final String PAGINATION_LIMIT = "500";
+    public static final String CHARSET_UTF8 = "UTF-8";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.common/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/common/util/OnPremiseGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.common/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/common/util/OnPremiseGatewayConstants.java
@@ -29,6 +29,7 @@ public class OnPremiseGatewayConstants {
     public static final String API_PUBLISHER_URL_PROPERTY_KEY = "api.publisher.url";
     public static final String DEFAULT_API_PUBLISHER_URL = "https://localhost:9443";
     public static final String API_ADMIN_URL_PROPERTY_KEY = "api.admin.url";
+    public static final String GATEWAY_LABEL_PROPERTY_KEY = "api.hybrid.gateway.label";
     public static final int DEFAULT_PORT = 9443;
     public static final int DEFAULT_GATEWAY_PORT = 8243;
     public static final String UPDATED_API_INFO_RETRIEVAL_DURATION = "updated.api.info.retrieval.duration";

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.configurator/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/configurator/ConfigConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.configurator/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/configurator/ConfigConstants.java
@@ -28,6 +28,8 @@ public class ConfigConstants {
     public static final String CONF_DIR = "conf";
     public static final String CLOUD_CONFIG_DIR = "wso2-cloud";
     public static final String RESOURCES_DIR = "resources";
+    public static final String UPDATES_DIR = "updates";
+    public static final String WUM_DIR = "wum";
 
     public static final String EMAIL = "email";
     public static final String TENANT_DOMAIN = "tenant.domain";
@@ -36,6 +38,7 @@ public class ConfigConstants {
     public static final String HOST_NAME = "hostname";
     public static final String MAC_ADDRESS = "macAddress";
     public static final String PORT = "port";
+    public static final String LAST_WUM_UPDATE = "lastWumUpdate";
 
     public static final String CONFIGURE_LOCK_FILE_NAME = "configure.lck";
     public static final String CONFIG_TOOL_CONFIG_FILE_NAME = "gateway-config-tool.properties";
@@ -43,6 +46,9 @@ public class ConfigConstants {
     public static final String GATEWAY_CARBON_FILE_NAME = "carbon.xml";
 
     public static final String API_KEY_VALIDATION_CLIENT_TYPE = "api.key.validator.client.type";
+    public static final String HYBRID_GATEWAY_LABEL_PROPERTY = "api.hybrid.gateway.label";
+    public static final String HYBRID_GATEWAY_ENV_METADATA = "api.hybrid.meta.env.";
+    public static final String HYBRID_GATEWAY_CUSTOM_METADATA = "api.hybrid.meta.custom.";
 
     public static final String PUBLIC_CLOUD_SETUP = "public.cloud.setup";
     public static final String STRATOS_PUBLIC_CLOUD_SETUP = "stratos.public.cloud.setup";

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.configurator/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/configurator/dto/MicroGatewayInitializationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.configurator/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/configurator/dto/MicroGatewayInitializationDTO.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.carbon.apimgt.hybrid.gateway.configurator.dto;
 
+import java.util.Map;
+
 /**
  *  DTO to store micro gateway details
  */
@@ -26,6 +28,10 @@ public class MicroGatewayInitializationDTO {
     private String macAddress = null;
     private String port = null;
     private String hostName = null;
+    private String gwUrl = null;
+    private String label = null;
+    private Map<String, String> envMetadataMap = null;
+    private Map<String, String> customMetadataMap = null;
 
     /**
      * Retrieve tenant domain
@@ -99,4 +105,58 @@ public class MicroGatewayInitializationDTO {
         this.hostName = hostName;
     }
 
+    /**
+     * Get the label configured for this micro GW instance. Can be null if no label
+     * is configured.
+     *
+     * @return label
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Set the label configured for this GW.
+     *
+     * @param label configured label
+     */
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    /**
+     * Get system environment specific metadata
+     *
+     * @return envMetadataMap environment metadata
+     */
+    public Map<String, String> getEnvMetadataMap() {
+        return envMetadataMap;
+    }
+
+    /**
+     * Set the system environment specific metadata
+     *
+     * @param envMetadataMap environment metadata
+     */
+    public void setEnvMetadataMap(Map<String, String> envMetadataMap) {
+        this.envMetadataMap = envMetadataMap;
+    }
+
+    /**
+     * Get the custom configured metadata (which are not related to system environments)
+     *
+     * @return customMetadataMap custom metadata
+     */
+    public Map<String, String> getCustomMetadataMap() {
+        return customMetadataMap;
+    }
+
+    /**
+     * Set the custom configured metadata (which are not related to system environments)
+     *
+     * @param customMetadataMap custom metadata
+     */
+    public void setCustomMetadataMap(Map<String, String> customMetadataMap) {
+        this.customMetadataMap = customMetadataMap;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.configurator/src/test/java/org/wso2/carbon/apimgt/hybrid/gateway/configurator/ConfiguratorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.configurator/src/test/java/org/wso2/carbon/apimgt/hybrid/gateway/configurator/ConfiguratorTest.java
@@ -86,7 +86,7 @@ public class ConfiguratorTest {
         String carbonFilePath = carbonConfigDirPath + File.separator + ConfigConstants.GATEWAY_CARBON_FILE_NAME;
         int port = Configurator.getGatewayPort(carbonFilePath);
         deviceDetails.put(ConfigConstants.PORT, Integer.toString(port));
-        String payload = Configurator.getInitializationPayload(deviceDetails, args);
+        String payload = Configurator.getInitializationPayload(gatewayProperties, deviceDetails, args);
         String authHeader = Configurator.createAuthHeader(args);
         //Set initialization endpoint
         String initApiUrl = gatewayProperties.getProperty(ConfigConstants.INITIALIZATION_API_URL);


### PR DESCRIPTION
## Purpose
This PR consists of the changes related to 'adding labeling feature to WSO2 Cloud Hybrid Gateway'.
(Please refer this mail thread: "Adding Labeling feature to WSO2 Hybrid Gateway" for detailed explanation.)

Followings are the sub tasks implemented:

- Read environment and custom properties configured in on-premise-gateway-properties and send those values (to the Cloud REST API /initialize endpoint) during initialization
- Send label related data during initialization
- Synchronize APIs during server startup for a configured "label". If no label is configured, all the APIs will be synchronized.
- Synchronize APIs periodically. (If a "label" is configured, only the APIs that are published under that label will be synchronized periodically. If not all the APIs will be synchronized)
- Handle API pagination

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
Related to the PR [wso2-support/carbon-apimgt : 1395](https://github.com/wso2-support/carbon-apimgt/pull/1359)
