### PR TITLE
Fix for the 'Adding microgateway environments to Store console'

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/api-doc/ajax/get.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/api-doc/ajax/get.jag
@@ -150,7 +150,7 @@ var log = new Log();
                     var accessURLs = labels[i].accessURLs.split(",");
                     var accessURL = "";
                     for(var j = 0 ; j < accessURLs.length ; j++){
-                        if(accessURLs[j].indexOf("https://") > 0){
+                        if (accessURLs[j].trim().indexOf("https://") == 0) {
                             urlArr[count] = accessURLs[j];
                             break;
                         }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/wso2/templates/api/swagger/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/themes/wso2/templates/api/swagger/template.jag
@@ -427,7 +427,7 @@ function checkOnKeyPress(e) {
                     var gatewayLabels = api.labels;
                     for (var i = 0; i < gatewayLabels.length; i++) {
                         var label = gatewayLabels[i];
-                        if(label.labelName && label.accessURLs.indexOf("https://") > 0) {
+                        if (label.labelName && label.accessURLs.trim().indexOf("https://") == 0) {
                             %>
                               <option value="<%=encode.forHtmlAttribute(label.labelName)%>" class="microgw-label" data-attr="microGW"><%=encode.forHtmlAttribute(label.labelName)%></option>
                             <%


### PR DESCRIPTION
## Purpose
This PR contains a fix for the ''Adding microgateway environments to Store console drop-down list''.

As per the current implementation's expectations, after adding a label from Admin portal, those environments (label names) should be listed in the "API Gateways" drop-down list in the Store-API Console. But it's not available in the current product when URL is given with spaces. Hence have done the trimming.

Related Git issue is: [carbon apimgt-6083](https://github.com/wso2/carbon-apimgt/issues/6083)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
[carbon-apimgt/pull/1405](https://github.com/wso2-support/carbon-apimgt/pull/1405)
