### PR TITLE
Fix invalid token cache initialization issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidator.java
@@ -78,6 +78,8 @@ public class APIKeyValidator {
 
     private static boolean gatewayTokenCacheInit = false;
 
+    private static boolean gatewayInvalidTokenCacheInit = false;
+
     private static boolean resourceCacheInit = false;
 
     protected Log log = LogFactory.getLog(getClass());
@@ -153,8 +155,8 @@ public class APIKeyValidator {
         String apimGWCacheExpiry = getApiManagerConfiguration().
                 getFirstProperty(APIConstants.TOKEN_CACHE_EXPIRY);
 
-        if (!gatewayTokenCacheInit) {
-            gatewayTokenCacheInit = true;
+        if (!gatewayInvalidTokenCacheInit) {
+            gatewayInvalidTokenCacheInit = true;
             if (apimGWCacheExpiry != null) {
                 return getCache(APIConstants.API_MANAGER_CACHE_MANAGER, APIConstants.GATEWAY_INVALID_TOKEN_CACHE_NAME,
                         Long.parseLong(apimGWCacheExpiry), Long.parseLong(apimGWCacheExpiry));


### PR DESCRIPTION
## Purpose
> This will enable the valid token cache and invalid token cache to get initialized independently from each other.