### PR TITLE
Fix rest api doc generation

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
@@ -45,6 +45,21 @@
             <artifactId>axis2</artifactId>
         </dependency>
     </dependencies>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <reportSets>
+                    <reportSet>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
     <build>
         <plugins>
             <plugin>

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
@@ -45,6 +45,21 @@
             <artifactId>axis2</artifactId>
         </dependency>
     </dependencies>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <reportSets>
+                    <reportSet>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
## Purpose
Maven site tries to generate unwanted reports since the correct configuration to skip these reports are not provided.
Fixes wso2/product-apim#4555