### PR TITLE
update analytics-commons version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1458,7 +1458,7 @@
         <carbon.apimgt.imp.pkg.version>[6.0.0, 7.0.0)</carbon.apimgt.imp.pkg.version>
 
         <analytics.shared.version>1.0.4</analytics.shared.version>
-        <carbon.analytics.common.version>5.1.55</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.1.56</carbon.analytics.common.version>
         <!-- Carbon kernel version -->
         <carbon.kernel.version>4.4.38</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>


### PR DESCRIPTION
This version bumping is to ensure that apim distribution will not end up with redundant jsonpath jars.