### PR TITLE
Add initial implementation to retrieve settings in store and publisher

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
@@ -859,6 +859,6 @@ public interface APIConsumer extends APIManager {
      * @return set of settings.
      * @throws APIManagementException
      */
-    StoreSettings getStoreSettings() throws APIManagementException;
+    StoreSettings getStoreSettings(String username) throws APIManagementException;
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
@@ -852,4 +852,13 @@ public interface APIConsumer extends APIManager {
     Set<SubscribedAPI> getLightWeightSubscribedIdentifiers(Subscriber subscriber, APIIdentifier apiIdentifier, String groupingId) throws APIManagementException;
 
     Set<APIKey> getApplicationKeysOfApplication(int applicationId) throws APIManagementException;
+
+    /**
+     * Returns a set of settings associated with a API Store.
+     *
+     * @return set of settings.
+     * @throws APIManagementException
+     */
+    StoreSettings getStoreSettings() throws APIManagementException;
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -1089,4 +1089,13 @@ public interface APIProvider extends APIManager {
      */
     String getSequenceFileContent(APIIdentifier apiIdentifier, String type, String name) throws APIManagementException;
 
+    /**
+     * Returns a set of settings associated with a API Publisher.
+     *
+     * @return set of settings.
+     * @throws APIManagementException
+     */
+    PublisherSettings getPublisherSettings() throws APIManagementException;
+
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -1095,7 +1095,7 @@ public interface APIProvider extends APIManager {
      * @return set of settings.
      * @throws APIManagementException
      */
-    PublisherSettings getPublisherSettings() throws APIManagementException;
+    PublisherSettings getPublisherSettings(String username) throws APIManagementException;
 
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/PublisherSettings.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/PublisherSettings.java
@@ -1,0 +1,38 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.carbon.apimgt.api.model;
+
+/**
+ * This class represent the Settings
+ */
+public class PublisherSettings {
+
+    private String apiPublisherUrl;
+
+    public PublisherSettings() {
+    }
+
+    public String getApiPublisherUrl() {
+        return apiPublisherUrl;
+    }
+
+    public void setApiPublisherUrl(String apiPublisherUrl) {
+        this.apiPublisherUrl = apiPublisherUrl;
+    }
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/StoreSettings.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/StoreSettings.java
@@ -1,0 +1,47 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.carbon.apimgt.api.model;
+
+/**
+ * This class represent the Settings
+ */
+public class StoreSettings {
+
+    private String serverUrl;
+    private String apiStoreUrl;
+
+    public StoreSettings() {
+    }
+
+    public String getServerUrl() {
+        return serverUrl;
+    }
+
+    public void setServerUrl(String serverUrl) {
+        this.serverUrl = serverUrl;
+    }
+
+    public String getApiStoreUrl() {
+        return apiStoreUrl;
+    }
+
+    public void setApiStoreUrl(String apiStoreUrl) {
+        this.apiStoreUrl = apiStoreUrl;
+    }
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -605,6 +605,7 @@ public final class APIConstants {
     public static final String API_STORE_FORUM_ENABLED = API_STORE + "isStoreForumEnabled";
     public static final String MULTI_TENANT_USER_ADMIN_SERVICE = "MultiTenantUserAdminService";
     public static final String API_STORE_GROUP_EXTRACTOR_CLAIM_URI = API_STORE + "DefaultGroupExtractorClaimUri";
+    public static final String WSO2_ANONYMOUS_USER = "wso2.anonymous.user";
 
     public static final String API_PUBLISHER = "APIPublisher.";
     public static final String SHOW_API_PUBLISHER_URL_FROM_STORE = API_PUBLISHER + "DisplayURL";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -4682,7 +4682,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
     }
 
     @Override
-    public StoreSettings getStoreSettings() throws APIManagementException {
+    public StoreSettings getStoreSettings(String username) throws APIManagementException {
 
         APIManagerConfiguration config = ServiceReferenceHolder.getInstance()
                 .getAPIManagerConfigurationService().getAPIManagerConfiguration();
@@ -4690,8 +4690,15 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         String apiStoreUrl = config.getFirstProperty(APIConstants.API_STORE_URL);
 
         StoreSettings storeSettings = new StoreSettings();
-        storeSettings.setServerUrl(serverUrl);
-        storeSettings.setApiStoreUrl(apiStoreUrl);
+        // Retrieve store settings from anonymous user.
+        if (username.equalsIgnoreCase(APIConstants.WSO2_ANONYMOUS_USER)) {
+            storeSettings.setServerUrl(serverUrl);
+            storeSettings.setApiStoreUrl(apiStoreUrl);
+        } else {
+            // Retrieve store settings from logged in user.
+            storeSettings.setServerUrl(serverUrl);
+            storeSettings.setApiStoreUrl(apiStoreUrl);
+        }
         return storeSettings;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -36,27 +36,7 @@ import org.wso2.carbon.apimgt.api.APIMgtResourceNotFoundException;
 import org.wso2.carbon.apimgt.api.LoginPostExecutor;
 import org.wso2.carbon.apimgt.api.NewPostLoginExecutor;
 import org.wso2.carbon.apimgt.api.WorkflowResponse;
-import org.wso2.carbon.apimgt.api.model.API;
-import org.wso2.carbon.apimgt.api.model.APIIdentifier;
-import org.wso2.carbon.apimgt.api.model.APIKey;
-import org.wso2.carbon.apimgt.api.model.APIRating;
-import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
-import org.wso2.carbon.apimgt.api.model.AccessTokenRequest;
-import org.wso2.carbon.apimgt.api.model.Application;
-import org.wso2.carbon.apimgt.api.model.ApplicationConstants;
-import org.wso2.carbon.apimgt.api.model.ApplicationKeysDTO;
-import org.wso2.carbon.apimgt.api.model.Documentation;
-import org.wso2.carbon.apimgt.api.model.KeyManager;
-import org.wso2.carbon.apimgt.api.model.OAuthAppRequest;
-import org.wso2.carbon.apimgt.api.model.OAuthApplicationInfo;
-import org.wso2.carbon.apimgt.api.model.Scope;
-import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
-import org.wso2.carbon.apimgt.api.model.Subscriber;
-import org.wso2.carbon.apimgt.api.model.SubscriptionResponse;
-import org.wso2.carbon.apimgt.api.model.Tag;
-import org.wso2.carbon.apimgt.api.model.Tier;
-import org.wso2.carbon.apimgt.api.model.TierPermission;
-import org.wso2.carbon.apimgt.api.model.WSDLArchiveInfo;
+import org.wso2.carbon.apimgt.api.model.*;
 import org.wso2.carbon.apimgt.impl.caching.CacheInvalidator;
 import org.wso2.carbon.apimgt.impl.dto.ApplicationRegistrationWorkflowDTO;
 import org.wso2.carbon.apimgt.impl.dto.ApplicationWorkflowDTO;
@@ -4699,6 +4679,20 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
     public Set<APIKey> getApplicationKeysOfApplication(int applicationId) throws APIManagementException {
         Set<APIKey> apikeys = getApplicationKeys(applicationId);
         return apikeys;
+    }
+
+    @Override
+    public StoreSettings getStoreSettings() throws APIManagementException {
+
+        APIManagerConfiguration config = ServiceReferenceHolder.getInstance()
+                .getAPIManagerConfigurationService().getAPIManagerConfiguration();
+        String serverUrl = config.getFirstProperty(APIConstants.API_STORE_SERVER_URL);
+        String apiStoreUrl = config.getFirstProperty(APIConstants.API_STORE_URL);
+
+        StoreSettings storeSettings = new StoreSettings();
+        storeSettings.setServerUrl(serverUrl);
+        storeSettings.setApiStoreUrl(apiStoreUrl);
+        return storeSettings;
     }
 
     private void getZipFileFromFileList(String zipFile, Collection<File> fileList) throws APIManagementException {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -36,7 +36,28 @@ import org.wso2.carbon.apimgt.api.APIMgtResourceNotFoundException;
 import org.wso2.carbon.apimgt.api.LoginPostExecutor;
 import org.wso2.carbon.apimgt.api.NewPostLoginExecutor;
 import org.wso2.carbon.apimgt.api.WorkflowResponse;
-import org.wso2.carbon.apimgt.api.model.*;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.APIKey;
+import org.wso2.carbon.apimgt.api.model.APIRating;
+import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
+import org.wso2.carbon.apimgt.api.model.AccessTokenRequest;
+import org.wso2.carbon.apimgt.api.model.Application;
+import org.wso2.carbon.apimgt.api.model.ApplicationConstants;
+import org.wso2.carbon.apimgt.api.model.ApplicationKeysDTO;
+import org.wso2.carbon.apimgt.api.model.Documentation;
+import org.wso2.carbon.apimgt.api.model.KeyManager;
+import org.wso2.carbon.apimgt.api.model.OAuthAppRequest;
+import org.wso2.carbon.apimgt.api.model.OAuthApplicationInfo;
+import org.wso2.carbon.apimgt.api.model.Scope;
+import org.wso2.carbon.apimgt.api.model.StoreSettings;
+import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
+import org.wso2.carbon.apimgt.api.model.Subscriber;
+import org.wso2.carbon.apimgt.api.model.SubscriptionResponse;
+import org.wso2.carbon.apimgt.api.model.Tag;
+import org.wso2.carbon.apimgt.api.model.Tier;
+import org.wso2.carbon.apimgt.api.model.TierPermission;
+import org.wso2.carbon.apimgt.api.model.WSDLArchiveInfo;
 import org.wso2.carbon.apimgt.impl.caching.CacheInvalidator;
 import org.wso2.carbon.apimgt.impl.dto.ApplicationRegistrationWorkflowDTO;
 import org.wso2.carbon.apimgt.impl.dto.ApplicationWorkflowDTO;
@@ -4691,7 +4712,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
 
         StoreSettings storeSettings = new StoreSettings();
         // Retrieve store settings from anonymous user.
-        if (username.equalsIgnoreCase(APIConstants.WSO2_ANONYMOUS_USER)) {
+        if ((APIConstants.WSO2_ANONYMOUS_USER).equalsIgnoreCase(username)) {
             storeSettings.setServerUrl(serverUrl);
             storeSettings.setApiStoreUrl(apiStoreUrl);
         } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -48,23 +48,7 @@ import org.wso2.carbon.apimgt.api.dto.CertificateInformationDTO;
 import org.wso2.carbon.apimgt.api.dto.CertificateMetadataDTO;
 import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
 import org.wso2.carbon.apimgt.api.dto.UserApplicationAPIUsage;
-import org.wso2.carbon.apimgt.api.model.API;
-import org.wso2.carbon.apimgt.api.model.APIIdentifier;
-import org.wso2.carbon.apimgt.api.model.APIStateChangeResponse;
-import org.wso2.carbon.apimgt.api.model.APIStatus;
-import org.wso2.carbon.apimgt.api.model.APIStore;
-import org.wso2.carbon.apimgt.api.model.BlockConditionsDTO;
-import org.wso2.carbon.apimgt.api.model.CORSConfiguration;
-import org.wso2.carbon.apimgt.api.model.Documentation;
-import org.wso2.carbon.apimgt.api.model.DuplicateAPIException;
-import org.wso2.carbon.apimgt.api.model.LifeCycleEvent;
-import org.wso2.carbon.apimgt.api.model.Provider;
-import org.wso2.carbon.apimgt.api.model.ResourceFile;
-import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
-import org.wso2.carbon.apimgt.api.model.Subscriber;
-import org.wso2.carbon.apimgt.api.model.Tier;
-import org.wso2.carbon.apimgt.api.model.URITemplate;
-import org.wso2.carbon.apimgt.api.model.Usage;
+import org.wso2.carbon.apimgt.api.model.*;
 import org.wso2.carbon.apimgt.api.model.policy.APIPolicy;
 import org.wso2.carbon.apimgt.api.model.policy.ApplicationPolicy;
 import org.wso2.carbon.apimgt.api.model.policy.Condition;
@@ -92,7 +76,6 @@ import org.wso2.carbon.apimgt.impl.notification.NotifierConstants;
 import org.wso2.carbon.apimgt.impl.notification.exception.NotificationException;
 import org.wso2.carbon.apimgt.impl.publishers.WSO2APIPublisher;
 import org.wso2.carbon.apimgt.impl.soaptorest.WSDLSOAPOperationExtractor;
-import org.wso2.carbon.apimgt.api.model.WSDLArchiveInfo;
 import org.wso2.carbon.apimgt.impl.soaptorest.util.SOAPOperationBindingUtils;
 import org.wso2.carbon.apimgt.impl.template.APITemplateBuilder;
 import org.wso2.carbon.apimgt.impl.template.APITemplateBuilderImpl;
@@ -5846,6 +5829,18 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             throw new APIManagementException(e);
         }
         return sequenceText;
+    }
+
+    @Override
+    public PublisherSettings getPublisherSettings() throws APIManagementException {
+        APIManagerConfiguration config = ServiceReferenceHolder.getInstance()
+                .getAPIManagerConfigurationService().getAPIManagerConfiguration();
+        String apiStoreUrl = config.getFirstProperty(APIConstants.API_STORE_URL);
+
+        PublisherSettings publisherSettings = new PublisherSettings();
+        publisherSettings.setApiPublisherUrl(apiStoreUrl);
+        return publisherSettings;
+
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5832,15 +5832,20 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     }
 
     @Override
-    public PublisherSettings getPublisherSettings() throws APIManagementException {
+    public PublisherSettings getPublisherSettings(String username) throws APIManagementException {
         APIManagerConfiguration config = ServiceReferenceHolder.getInstance()
                 .getAPIManagerConfigurationService().getAPIManagerConfiguration();
         String apiStoreUrl = config.getFirstProperty(APIConstants.API_STORE_URL);
 
         PublisherSettings publisherSettings = new PublisherSettings();
-        publisherSettings.setApiPublisherUrl(apiStoreUrl);
+        // Retrieve publisher settings from anonymous user.
+        if (username.equalsIgnoreCase(APIConstants.WSO2_ANONYMOUS_USER)) {
+            publisherSettings.setApiPublisherUrl(apiStoreUrl);
+        } else {
+            // Retrieve publisher settings from logged in user.
+            publisherSettings.setApiPublisherUrl(apiStoreUrl);
+        }
         return publisherSettings;
-
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -48,7 +48,24 @@ import org.wso2.carbon.apimgt.api.dto.CertificateInformationDTO;
 import org.wso2.carbon.apimgt.api.dto.CertificateMetadataDTO;
 import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
 import org.wso2.carbon.apimgt.api.dto.UserApplicationAPIUsage;
-import org.wso2.carbon.apimgt.api.model.*;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.APIStateChangeResponse;
+import org.wso2.carbon.apimgt.api.model.APIStatus;
+import org.wso2.carbon.apimgt.api.model.APIStore;
+import org.wso2.carbon.apimgt.api.model.BlockConditionsDTO;
+import org.wso2.carbon.apimgt.api.model.CORSConfiguration;
+import org.wso2.carbon.apimgt.api.model.Documentation;
+import org.wso2.carbon.apimgt.api.model.DuplicateAPIException;
+import org.wso2.carbon.apimgt.api.model.LifeCycleEvent;
+import org.wso2.carbon.apimgt.api.model.Provider;
+import org.wso2.carbon.apimgt.api.model.ResourceFile;
+import org.wso2.carbon.apimgt.api.model.PublisherSettings;
+import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
+import org.wso2.carbon.apimgt.api.model.Subscriber;
+import org.wso2.carbon.apimgt.api.model.Tier;
+import org.wso2.carbon.apimgt.api.model.URITemplate;
+import org.wso2.carbon.apimgt.api.model.Usage;
 import org.wso2.carbon.apimgt.api.model.policy.APIPolicy;
 import org.wso2.carbon.apimgt.api.model.policy.ApplicationPolicy;
 import org.wso2.carbon.apimgt.api.model.policy.Condition;
@@ -5839,7 +5856,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
 
         PublisherSettings publisherSettings = new PublisherSettings();
         // Retrieve publisher settings from anonymous user.
-        if (username.equalsIgnoreCase(APIConstants.WSO2_ANONYMOUS_USER)) {
+        if ((APIConstants.WSO2_ANONYMOUS_USER).equalsIgnoreCase(username)) {
             publisherSettings.setApiPublisherUrl(apiStoreUrl);
         } else {
             // Retrieve publisher settings from logged in user.

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/SettingsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/SettingsApi.java
@@ -1,0 +1,44 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1;
+
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.*;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.SettingsApiService;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.factories.SettingsApiServiceFactory;
+
+import io.swagger.annotations.ApiParam;
+
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SettingsDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ErrorDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.*;
+
+@Path("/settings")
+@Consumes({ "application/json" })
+@Produces({ "application/json" })
+@io.swagger.annotations.Api(value = "/settings", description = "the settings API")
+public class SettingsApi  {
+
+   private final SettingsApiService delegate = SettingsApiServiceFactory.getSettingsApi();
+
+    @GET
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Retreive publisher settings", notes = "Retreive publisher settings\n", response = SettingsDTO.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "OK.\nSettings returned\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Not Found.\nRequested Settings does not exist.\n") })
+
+    public Response settingsGet()
+    {
+    return delegate.settingsGet();
+    }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/SettingsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/SettingsApiService.java
@@ -1,0 +1,19 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1;
+
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.*;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.*;
+
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SettingsDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ErrorDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+
+import javax.ws.rs.core.Response;
+
+public abstract class SettingsApiService {
+    public abstract Response settingsGet();
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/SettingsDTO.java
@@ -1,0 +1,43 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.dto;
+
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class SettingsDTO  {
+  
+  
+  
+  private String apiPublisherUrl = null;
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("apiPublisherUrl")
+  public String getApiPublisherUrl() {
+    return apiPublisherUrl;
+  }
+  public void setApiPublisherUrl(String apiPublisherUrl) {
+    this.apiPublisherUrl = apiPublisherUrl;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SettingsDTO {\n");
+    
+    sb.append("  apiPublisherUrl: ").append(apiPublisherUrl).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/factories/SettingsApiServiceFactory.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/factories/SettingsApiServiceFactory.java
@@ -1,0 +1,14 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.factories;
+
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.SettingsApiService;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.impl.SettingsApiServiceImpl;
+
+public class SettingsApiServiceFactory {
+
+   private final static SettingsApiService service = new SettingsApiServiceImpl();
+
+   public static SettingsApiService getSettingsApi()
+   {
+      return service;
+   }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SettingsApiServiceImpl.java
@@ -15,17 +15,24 @@
 * specific language governing permissions and limitations
 * under the License.
 */
-package org.wso2.carbon.apimgt.rest.api.store.v1.impl;
-
-
-import org.wso2.carbon.apimgt.api.APIConsumer;
-import org.wso2.carbon.apimgt.api.APIManagementException;
-import org.wso2.carbon.apimgt.api.model.StoreSettings;
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.impl;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.APIProvider;
+import org.wso2.carbon.apimgt.api.model.PublisherSettings;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.*;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.*;
 
-import org.wso2.carbon.apimgt.rest.api.store.v1.SettingsApiService;
+
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SettingsDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ErrorDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
 import javax.ws.rs.core.Response;
@@ -37,9 +44,9 @@ public class SettingsApiServiceImpl extends SettingsApiService {
     @Override
     public Response settingsGet(){
         try {
-            APIConsumer apiConsumer = RestApiUtil.getLoggedInUserConsumer();
-            StoreSettings storeSettings = apiConsumer.getStoreSettings();
-            return Response.ok().entity(storeSettings).build();
+            APIProvider apiProvider = RestApiUtil.getLoggedInUserProvider();
+            PublisherSettings publisherSettings = apiProvider.getPublisherSettings();
+            return Response.ok().entity(publisherSettings).build();
         } catch (APIManagementException e) {
             String errorMessage = "Error while retrieving Settings";
             RestApiUtil.handleInternalServerError(errorMessage, e, log);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SettingsApiServiceImpl.java
@@ -44,8 +44,9 @@ public class SettingsApiServiceImpl extends SettingsApiService {
     @Override
     public Response settingsGet(){
         try {
+            String username = RestApiUtil.getLoggedInUsername();
             APIProvider apiProvider = RestApiUtil.getLoggedInUserProvider();
-            PublisherSettings publisherSettings = apiProvider.getPublisherSettings();
+            PublisherSettings publisherSettings = apiProvider.getPublisherSettings(username);
             return Response.ok().entity(publisherSettings).build();
         } catch (APIManagementException e) {
             String errorMessage = "Error while retrieving Settings";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -3510,6 +3510,35 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+######################################################
+# The Publisher settings List
+######################################################
+  /settings:
+#-----------------------------------------------------
+# Retrieve Publisher settings
+#-----------------------------------------------------
+    get:
+      summary: Retreive publisher settings
+      security:
+        - OAuth2Security:
+          - apim:publisher_setting
+      x-scope: apim:publisher_setting
+      description: |
+        Retreive publisher settings
+      responses:
+        200:
+          description: |
+            OK.
+            Settings returned
+          schema:
+            $ref: '#/definitions/Settings'
+        404:
+          description: |
+            Not Found.
+            Requested Settings does not exist.
+          schema:
+            $ref: '#/definitions/Error'
+
 
 ######################################################
 # Parameters - required by some of the APIs above
@@ -4825,3 +4854,16 @@ definitions:
           This attribute declares whether an API should have a dedicated Gateway or not.
         type: boolean
         example: true
+
+#-----------------------------------------------------
+# The Settings resource
+#-----------------------------------------------------
+  Settings:
+    title: Settings
+    properties:
+      apiPublisherUrl:
+        type: string
+
+#-----------------------------------------------------
+# END-OF-FILE
+#-----------------------------------------------------

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
@@ -18,6 +18,7 @@
             <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.ImportApi"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.LabelsApi"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.PoliciesApi"/>
+            <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.SettingsApi"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.SubscriptionsApi"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.ThreatProtectionPoliciesApi"/>
             

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/SettingsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/SettingsApi.java
@@ -1,0 +1,44 @@
+package org.wso2.carbon.apimgt.rest.api.store.v1;
+
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.*;
+import org.wso2.carbon.apimgt.rest.api.store.v1.SettingsApiService;
+import org.wso2.carbon.apimgt.rest.api.store.v1.factories.SettingsApiServiceFactory;
+
+import io.swagger.annotations.ApiParam;
+
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SettingsDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ErrorDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.*;
+
+@Path("/settings")
+@Consumes({ "application/json" })
+@Produces({ "application/json" })
+@io.swagger.annotations.Api(value = "/settings", description = "the settings API")
+public class SettingsApi  {
+
+   private final SettingsApiService delegate = SettingsApiServiceFactory.getSettingsApi();
+
+    @GET
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Retreive store settings", notes = "Retreive store settings\n", response = SettingsDTO.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "OK.\nSettings returned\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Not Found.\nRequested Settings does not exist.\n") })
+
+    public Response settingsGet()
+    {
+    return delegate.settingsGet();
+    }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/SettingsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/SettingsApiService.java
@@ -1,0 +1,19 @@
+package org.wso2.carbon.apimgt.rest.api.store.v1;
+
+import org.wso2.carbon.apimgt.rest.api.store.v1.*;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.*;
+
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SettingsDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ErrorDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+
+import javax.ws.rs.core.Response;
+
+public abstract class SettingsApiService {
+    public abstract Response settingsGet();
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
@@ -1,0 +1,59 @@
+package org.wso2.carbon.apimgt.rest.api.store.v1.dto;
+
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class SettingsDTO  {
+  
+  
+  
+  private String serverUrl = null;
+  
+  
+  private String apiStoreUrl = null;
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("serverUrl")
+  public String getServerUrl() {
+    return serverUrl;
+  }
+  public void setServerUrl(String serverUrl) {
+    this.serverUrl = serverUrl;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("apiStoreUrl")
+  public String getApiStoreUrl() {
+    return apiStoreUrl;
+  }
+  public void setApiStoreUrl(String apiStoreUrl) {
+    this.apiStoreUrl = apiStoreUrl;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SettingsDTO {\n");
+    
+    sb.append("  serverUrl: ").append(serverUrl).append("\n");
+    sb.append("  apiStoreUrl: ").append(apiStoreUrl).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/factories/SettingsApiServiceFactory.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/factories/SettingsApiServiceFactory.java
@@ -1,0 +1,14 @@
+package org.wso2.carbon.apimgt.rest.api.store.v1.factories;
+
+import org.wso2.carbon.apimgt.rest.api.store.v1.SettingsApiService;
+import org.wso2.carbon.apimgt.rest.api.store.v1.impl.SettingsApiServiceImpl;
+
+public class SettingsApiServiceFactory {
+
+   private final static SettingsApiService service = new SettingsApiServiceImpl();
+
+   public static SettingsApiService getSettingsApi()
+   {
+      return service;
+   }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SettingsApiServiceImpl.java
@@ -37,8 +37,9 @@ public class SettingsApiServiceImpl extends SettingsApiService {
     @Override
     public Response settingsGet(){
         try {
+            String username = RestApiUtil.getLoggedInUsername();
             APIConsumer apiConsumer = RestApiUtil.getLoggedInUserConsumer();
-            StoreSettings storeSettings = apiConsumer.getStoreSettings();
+            StoreSettings storeSettings = apiConsumer.getStoreSettings(username);
             return Response.ok().entity(storeSettings).build();
         } catch (APIManagementException e) {
             String errorMessage = "Error while retrieving Settings";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SettingsApiServiceImpl.java
@@ -1,0 +1,32 @@
+package org.wso2.carbon.apimgt.rest.api.store.v1.impl;
+
+
+import org.wso2.carbon.apimgt.api.APIConsumer;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.StoreSettings;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.wso2.carbon.apimgt.rest.api.store.v1.SettingsApiService;
+import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
+
+import javax.ws.rs.core.Response;
+
+public class SettingsApiServiceImpl extends SettingsApiService {
+
+    private static final Log log = LogFactory.getLog(SettingsApiServiceImpl.class);
+
+    @Override
+    public Response settingsGet(){
+        try {
+            APIConsumer apiConsumer = RestApiUtil.getLoggedInUserConsumer();
+            StoreSettings storeSettings = apiConsumer.getStoreSettings();
+            return Response.ok().entity(storeSettings).build();
+        } catch (APIManagementException e) {
+            String errorMessage = "Error while retrieving Settings";
+            RestApiUtil.handleInternalServerError(errorMessage, e, log);
+        }
+        return null;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
@@ -2234,7 +2234,7 @@ paths:
             $ref: '#/definitions/Error'
 
 ######################################################
-# The "SDK Generation Languages" list resource APIs
+# The Store settings List
 ######################################################
   /settings:
 #-----------------------------------------------------

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
@@ -2232,6 +2232,36 @@ paths:
             Error while retrieving the list.
           schema:
             $ref: '#/definitions/Error'
+
+######################################################
+# The "SDK Generation Languages" list resource APIs
+######################################################
+  /settings:
+#-----------------------------------------------------
+# Retrieve store settings
+#-----------------------------------------------------
+    get:
+      summary: Retreive store settings
+      security:
+        - OAuth2Security:
+          - apim:store_setting
+      x-scope: apim:store_setting
+      description: |
+        Retreive store settings
+      responses:
+        200:
+          description: |
+            OK.
+            Settings returned
+          schema:
+            $ref: '#/definitions/Settings'
+        404:
+          description: |
+            Not Found.
+            Requested Settings does not exist.
+          schema:
+            $ref: '#/definitions/Error'
+
 ######################################################
 # Parameters - required by some of the APIs above
 ######################################################
@@ -3336,6 +3366,17 @@ definitions:
           This attribute declares whether an API should have a dedicated Gateway or not.
         type: boolean
         example: true
+
+#-----------------------------------------------------
+# The Settings resource
+#-----------------------------------------------------
+  Settings:
+    title: Settings
+    properties:
+      serverUrl:
+        type: string
+      apiStoreUrl:
+        type: string
        
 #-----------------------------------------------------
 # END-OF-FILE

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/webapp/WEB-INF/beans.xml
@@ -21,6 +21,7 @@
             <bean class="org.wso2.carbon.apimgt.rest.api.store.v1.PoliciesApi"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.store.v1.SdkGenApi"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.store.v1.SelfSignupApi"/>
+            <bean class="org.wso2.carbon.apimgt.rest.api.store.v1.SettingsApi"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.store.v1.SubscriptionsApi"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.store.v1.TagsApi"/>
             

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.json
@@ -1,9 +1,9 @@
 {
     "swagger": "2.0",
     "info": {
-        "version": "0.13.0",
+        "version": "v1.0",
         "title": "WSO2 API Manager - Publisher API",
-        "description": "This specifies a **RESTful API** for WSO2 **API Manager** - Publisher.\n\nPlease see [full swagger definition](https://raw.githubusercontent.com/wso2/carbon-apimgt/v6.1.66/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml) of the API which is written using [swagger 2.0](http://swagger.io/) specification.\n",
+        "description": "This specifies a **RESTful API** for WSO2 **API Manager** - Publisher.\n\nPlease see [full swagger definition](https://raw.githubusercontent.com/wso2/carbon-apimgt/v6.0.4/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/resources/publisher-api.yaml) of the API which is written using [swagger 2.0](http://swagger.io/) specification.\n",
         "contact": {
             "name": "WSO2",
             "url": "http://wso2.com/products/api-manager/",
@@ -15,87 +15,49 @@
         }
     },
     "schemes": [
-        "https"
+        "https",
+        "http"
     ],
     "host": "apis.wso2.com",
-    "basePath": "/api/am/publisher/v0.14",
+    "basePath": "/api/am/publisher/v1.0",
     "consumes": [
         "application/json"
     ],
     "produces": [
         "application/json"
     ],
-    "x-wso2-security": {
-        "apim": {
-            "x-wso2-scopes": [
-                {
-                    "description": "",
-                    "roles": "admin",
-                    "name": "apim:api_view",
-                    "key": "apim:api_view"
-                },
-                {
-                    "description": "",
-                    "roles": "admin",
-                    "name": "apim:api_create",
-                    "key": "apim:api_create"
-                },
-                {
-                    "description": "",
-                    "roles": "admin",
-                    "name": "apim:api_publish",
-                    "key": "apim:api_publish"
-                },
-                {
-                    "description": "",
-                    "roles": "admin",
-                    "name": "apim:tier_view",
-                    "key": "apim:tier_view"
-                },
-                {
-                    "description": "",
-                    "roles": "admin",
-                    "name": "apim:tier_manage",
-                    "key": "apim:tier_manage"
-                },
-                {
-                    "description": "",
-                    "roles": "admin",
-                    "name": "apim:subscription_view",
-                    "key": "apim:subscription_view"
-                },
-                {
-                    "description": "",
-                    "roles": "admin",
-                    "name": "apim:subscription_block",
-                    "key": "apim:subscription_block"
-                },
-                {
-                    "description": "",
-                    "roles": "admin",
-                    "name": "apim:mediation_policy_view",
-                    "key": "apim:mediation_policy_view"
-                },
-                {
-                    "description": "",
-                    "roles": "admin",
-                    "name": "apim:api_workflow",
-                    "key": "apim:api_workflow"
-                }
-            ]
+    "securityDefinitions": {
+        "OAuth2Security": {
+            "type": "oauth2",
+            "flow": "password",
+            "tokenUrl": "https://localhost:9443/token",
+            "scopes": {
+                "apim:api_view": "View API",
+                "apim:api_create": "Create API",
+                "apim:api_update": "Update API",
+                "apim:api_delete": "Delete API",
+                "apim:apidef_update": "Update API Definition",
+                "apim:api_publish": "Publish API",
+                "apim:subscription_view": "View Subscription",
+                "apim:subscription_block": "Block Subscription",
+                "apim:dedicated_gateway": "Update Dedicated Gateway",
+                "apim:external_services_discover": "Discover External Services"
+            }
         }
     },
+    "security": [
+        {
+            "OAuth2Security": [
+                "apim:api_view"
+            ]
+        }
+    ],
     "paths": {
         "/apis": {
             "get": {
-                "x-scope": "apim:api_view",
-                "produces": [
-                    "application/json",
-                    "application/gzip"
-                ],
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/publisher/v0.14/apis",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/apis\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"provider\": \"admin\",\n         \"version\": \"1.0.0\",\n         \"description\": \"This sample API provides Account Status Validation\",\n         \"name\": \"AccountVal\",\n         \"context\": \"/account\",\n         \"id\": \"2e81f147-c8a8-4f68-b4f0-69e0e7510b01\",\n         \"status\": \"PUBLISHED\"\n      },\n            {\n         \"provider\": \"admin\",\n         \"version\": \"1.0.0\",\n         \"description\": null,\n         \"name\": \"api1\",\n         \"context\": \"/api1\",\n         \"id\": \"3e22d2fb-277a-4e9e-8c7e-1c0f7f73960e\",\n         \"status\": \"PUBLISHED\"\n      }\n   ],\n   \"next\": \"\",\n   \"count\": 2\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9443/api/am/publisher/v1.0/apis",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/apis\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"provider\": \"admin\",\n         \"version\": \"1.0.0\",\n         \"description\": \"This sample API provides Account Status Validation\",\n         \"name\": \"AccountVal\",\n         \"context\": \"/account\",\n         \"id\": \"2e81f147-c8a8-4f68-b4f0-69e0e7510b01\",\n         \"lifeCycleStatus\": \"PUBLISHED\"\n      },\n            {\n         \"provider\": \"admin\",\n         \"version\": \"1.0.0\",\n         \"description\": null,\n         \"name\": \"api1\",\n         \"context\": \"/api1\",\n         \"id\": \"3e22d2fb-277a-4e9e-8c7e-1c0f7f73960e\",\n         \"lifeCycleStatus\": \"PUBLISHED\"\n      }\n   ],\n   \"next\": \"\",\n   \"count\": 2\n}",
                 "summary": "Retrieve/Search APIs\n",
                 "description": "This operation provides you a list of available APIs qualifying under a given search condition.\n\nEach retrieved API is represented with a minimal amount of attributes. If you want to get complete details of an API, you need to use **Get details of an API** operation.\n",
                 "parameters": [
@@ -108,24 +70,11 @@
                     {
                         "name": "query",
                         "in": "query",
-                        "description": "**Search condition**.\n\nYou can search in attributes by using an **\"<attribute>:\"** modifier.\n\nEg.\n\"provider:wso2\" will match an API if the provider of the API is exactly \"wso2\".\n\"status:PUBLISHED\" will match an API if the API is in PUBLISHED state.\n\"label:external\" will match an API if it contains a Microgateway label called \"external\".\n\nAdditionally you can use wildcards.\n\nEg.\n\"provider:wso2*\" will match an API if the provider of the API starts with \"wso2\".\n\nSupported attribute modifiers are [**version, context, status,\ndescription, subcontext, doc, provider, label**]\n\nIf no advanced attribute modifier has been specified,  the API names containing\nthe search term will be returned as a result.\n",
+                        "description": "**Search condition**.\n\nYou can search in attributes by using an **\"<attribute>:\"** modifier.\n\nEg.\n\"provider:wso2\" will match an API if the provider of the API is exactly \"wso2\".\n\nAdditionally you can use wildcards.\n\nEg.\n\"provider:wso2*\" will match an API if the provider of the API starts with \"wso2\".\n\nSupported attribute modifiers are [**version, context, lifeCycleStatus,\ndescription, subcontext, doc, provider**]\n\nIf no advanced attribute modifier has been specified, search will match the\ngiven query string against API Name.\n",
                         "type": "string"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/parameters/expand"
-                    },
-                    {
-                        "name": "tenantDomain",
-                        "in": "query",
-                        "description": "Tenant domain, whose APIs should be retrieved. If not specified, the logged in user's tenant domain will\nbe considered for this.\n",
-                        "required": false,
-                        "type": "string"
                     }
                 ],
                 "tags": [
@@ -159,11 +108,64 @@
                     }
                 }
             },
+            "head": {
+                "x-wso2-curl": "curl -I -k -X HEAD \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9090/api/am/publisher/v1.0/apis?query=name%3AapiName",
+                "x-wso2-request": "HEAD https://localhost:9090/api/am/publisher/v1.0/apis?query=name%3AapiName HTTP/1.1\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK Connection: keep-alive Content-Length: 0",
+                "summary": "Check given API attibute name is already exist\n",
+                "description": "Using this operation, you can check a given API context is already used. You need to provide the context name you want to check.\n",
+                "parameters": [
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "description": "**Search condition**.\n\nYou can search in attributes by using an **\"<attribute>:\"** modifier.\n\nEg.\n\"provider:wso2\" will match an API if the provider of the API is exactly \"wso2\".\n\nAdditionally you can use wildcards.\n\nEg.\n\"provider:wso2*\" will match an API if the provider of the API starts with \"wso2\".\n\nSupported attribute modifiers are [**version, context, lifeCycleStatus,\ndescription, subcontext, doc, provider**]\n\nIf no advanced attribute modifier has been specified, search will match the\ngiven query string against API Name.\n",
+                        "type": "string"
+                    },
+                    {
+                        "$ref": "#/parameters/If-None-Match"
+                    }
+                ],
+                "tags": [
+                    "API (Collection)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nRequested API attibute status is returned\n",
+                        "headers": {
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request.\nRequested API attribute does not meet requiremnts.\n"
+                    },
+                    "404": {
+                        "description": "Not Found.\nRequested API attribute does not exist.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "406": {
+                        "description": "Not Acceptable.\nThe requested media type is not supported\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
             "post": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json https://localhost:9443/api/am/publisher/v0.14/apis",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/apis\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"apiDefinition\": \"{\\\"paths\\\":{\\\"/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Created.\\\"}}}},\\\"/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"headers\\\":{},\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#/definitions/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http://www.apache.org/licenses/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http://www.pizzashack.com\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"status\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": false,\r\n   \"isDefaultVersion\": false,\r\n   \"type\": \"HTTP\",\r\n   \"transport\":    [\r\n      \"http\",\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\"],\r\n   \"tiers\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 5000,\r\n      \"production\": 1000\r\n   },\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [{\"name\":\"json_validator\",\"type\": \"in\"},{\"name\":\"log_out_message\",\"type\": \"out\"}],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
-                "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://localhost:9443/api/am/publisher/v0.14/apis/7a2298c4-c905-403f-8fac-38c73301631f\nContent-Type: application/json\n\n{\r\n   \"id\": \"7a2298c4-c905-403f-8fac-38c73301631f\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"apiDefinition\": \"{\\\"paths\\\":{\\\"/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Created.\\\"}}}},\\\"/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"headers\\\":{},\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#/definitions/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"integer\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http://www.apache.org/licenses/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http://www.pizzashack.com\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"type\": \"HTTP\",\r\n   \"transport\":    [\r\n      \"http\",\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\"],\r\n   \"tiers\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 5000,\r\n      \"production\": 1000\r\n   },\r\n   \"thumbnailUri\": null,\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [{\"name\":\"json_validator\",\"type\":\"in\",\"id\":\"142ece76-b208-4aab-b29a-f382045ed066\",\"shared\":false},{\"name\":\"log_out_message\",\"type\":\"out\",\"id\":\"b3527be8-95e6-41e0-8097-3276987b7d4b\",\"shared\":false}],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json https://127.0.0.1:9443/api/am/publisher/v1.0/apis",
+                "x-wso2-request": "POST https://127.0.0.1:9443/api/am/publisher/v1.0/apis\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"wsdlUri\": null,\r\n   \"lifeCycleStatus\": \"PUBLISHED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": false,\r\n   \"isDefaultVersion\": false,\r\n   \"transport\":    [\r\n      \"http\",\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\"],\r\n   \"policies\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 5000,\r\n      \"production\": 1000\r\n   },\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\r\n   \"visibleTenants\": [],\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1.0/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1.0/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+                "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://127.0.0.1:9443/api/am/publisher/v1.0/apis/7a2298c4-c905-403f-8fac-38c73301631f\nContent-Type: application/json\n\n{\r\n   \"id\": \"7a2298c4-c905-403f-8fac-38c73301631f\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"wsdlUri\": null,\r\n   \"lifeCycleStatus\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"transport\":    [\r\n      \"http\",\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\"],\r\n   \"policies\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 5000,\r\n      \"production\": 1000\r\n   },\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\r\n   \"visibleTenants\": [],\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1.0/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1.0/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
                 "summary": "Create a new API",
                 "description": "This operation can be used to create a new API specifying the details of the API in the payload. The new API will be in `CREATED` state.\n\nThere is a special capability for a user who has `APIM Admin` permission such that he can create APIs on behalf of other users. For that he can to specify `\"provider\" : \"some_other_user\"` in the payload so that the API's creator will be shown as `some_other_user` in the UI.\n",
                 "parameters": [
@@ -173,21 +175,18 @@
                         "description": "API object that needs to be added\n",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/APIDetailed"
+                            "$ref": "#/definitions/API"
                         }
-                    },
-                    {
-                        "$ref": "#/parameters/Content-Type"
                     }
                 ],
                 "tags": [
-                    "API (Individual)"
+                    "API (Collection)"
                 ],
                 "responses": {
                     "201": {
                         "description": "Created.\nSuccessful response with the newly created object as entity in the body.\nLocation header contains URL of newly created entity.\n",
                         "schema": {
-                            "$ref": "#/definitions/APIDetailed"
+                            "$ref": "#/definitions/API"
                         },
                         "headers": {
                             "Location": {
@@ -196,10 +195,6 @@
                             },
                             "Content-Type": {
                                 "description": "The content type of the body.\n",
-                                "type": "string"
-                            },
-                            "Authorization": {
-                                "description": "The brearer token.\n",
                                 "type": "string"
                             },
                             "ETag": {
@@ -225,18 +220,14 @@
         },
         "/apis/{apiId}": {
             "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/publisher/v0.14/apis/7a2298c4-c905-403f-8fac-38c73301631f",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/apis/7a2298c4-c905-403f-8fac-38c73301631f\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\r\n   \"id\": \"7a2298c4-c905-403f-8fac-38c73301631f\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"apiDefinition\": \"{\\\"paths\\\":{\\\"/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Created.\\\"}}}},\\\"/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"headers\\\":{},\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#/definitions/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http://www.apache.org/licenses/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http://www.pizzashack.com\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"status\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"type\": \"HTTP\",\r\n   \"transport\":    [\r\n      \"http\",\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\"],\r\n   \"tiers\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 5000,\r\n      \"production\": 1000\r\n   },\r\n   \"thumbnailUri\": null,\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9443/api/am/publisher/v1.0/apis/7a2298c4-c905-403f-8fac-38c73301631f",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/apis/7a2298c4-c905-403f-8fac-38c73301631f\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\r\n   \"id\": \"7a2298c4-c905-403f-8fac-38c73301631f\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"endpointId\": \"{\\\"paths\\\":{\\\"/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Created.\\\"}}}},\\\"/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"headers\\\":{},\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#/definitions/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"integer\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http://www.apache.org/licenses/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http://www.pizzashack.com\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"lifeCycleStatus\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"transport\":    [\r\n      \"http\",\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\"],\r\n   \"policies\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 5000,\r\n      \"production\": 1000\r\n   },\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\r\n   \"visibleTenants\": [],\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1.0/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1.0/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
                 "summary": "Get details of an API",
                 "description": "Using this operation, you can retrieve complete details of a single API. You need to provide the Id of the API to retrive it.\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/apiId"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
@@ -266,7 +257,7 @@
                             }
                         },
                         "schema": {
-                            "$ref": "#/definitions/APIDetailed"
+                            "$ref": "#/definitions/API"
                         }
                     },
                     "304": {
@@ -287,10 +278,16 @@
                 }
             },
             "put": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X PUT -d @data.json https://localhost:9443/api/am/publisher/v0.14/apis/7a2298c4-c905-403f-8fac-38c73301631f",
-                "x-wso2-request": "PUT https://localhost:9443/api/am/publisher/v0.14/apis/7a2298c4-c905-403f-8fac-38c73301631f\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\nContent-Type: application/json\n\n{\r\n   \"id\": \"7a2298c4-c905-403f-8fac-38c73301631f\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"apiDefinition\": \"{\\\"paths\\\":{\\\"/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Created.\\\"}}}},\\\"/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"headers\\\":{},\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#/definitions/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"integer\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http://www.apache.org/licenses/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http://www.pizzashack.com\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"status\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"type\": \"HTTP\",\r\n   \"transport\":    [\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\",\"chicken\"],\r\n   \"tiers\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 500,\r\n      \"production\": 100\r\n   },\r\n   \"thumbnailUri\": null,\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [{\"name\":\"json_validator\",\"type\": \"in\"},{\"name\":\"log_out_message\",\"type\": \"out\"}],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\r\n   \"id\": \"7a2298c4-c905-403f-8fac-38c73301631f\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"apiDefinition\": \"{\\\"paths\\\":{\\\"/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Created.\\\"}}}},\\\"/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"headers\\\":{},\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#/definitions/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http://www.apache.org/licenses/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http://www.pizzashack.com\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"status\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"type\": \"HTTP\",\r\n   \"transport\": [\"https\"],\r\n   \"tags\":    [\r\n      \"chicken\",\r\n      \"pizza\"\r\n   ],\r\n   \"tiers\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 500,\r\n      \"production\": 100\r\n   },\r\n   \"thumbnailUri\": null,\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [{\"name\":\"json_validator\",\"type\":\"in\",\"id\":\"142ece76-b208-4aab-b29a-f382045ed066\",\"shared\":false},{\"name\":\"log_out_message\",\"type\":\"out\",\"id\":\"b3527be8-95e6-41e0-8097-3276987b7d4b\",\"shared\":false}],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X PUT -d @data.json https://127.0.0.1:9443/api/am/publisher/v1.0/apis/7a2298c4-c905-403f-8fac-38c73301631f",
+                "x-wso2-request": "PUT https://127.0.0.1:9443/api/am/publisher/v1.0/apis/7a2298c4-c905-403f-8fac-38c73301631f\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\nContent-Type: application/json\n\n{\r\n   \"id\": \"7a2298c4-c905-403f-8fac-38c73301631f\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"endpointId\": \"{\\\"paths\\\":{\\\"/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Created.\\\"}}}},\\\"/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"headers\\\":{},\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#/definitions/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"integer\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http://www.apache.org/licenses/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http://www.pizzashack.com\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"lifeCycleStatus\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"transport\":    [\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\",\"chicken\"],\r\n   \"policies\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 500,\r\n      \"production\": 100\r\n   },\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\r\n   \"visibleTenants\": [],\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1.0/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1.0/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\r\n   \"id\": \"7a2298c4-c905-403f-8fac-38c73301631f\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"endpointId\": \"{\\\"paths\\\":{\\\"/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Created.\\\"}}}},\\\"/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"headers\\\":{},\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#/definitions/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"integer\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http://www.apache.org/licenses/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http://www.pizzashack.com\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"lifeCycleStatus\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"transport\": [\"https\"],\r\n   \"tags\":    [\r\n      \"chicken\",\r\n      \"pizza\"\r\n   ],\r\n   \"policies\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 500,\r\n      \"production\": 100\r\n   },\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\r\n   \"visibleTenants\": [],\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1.0/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1.0/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_update"
+                        ]
+                    }
+                ],
                 "summary": "Update an API",
                 "description": "This operation can be used to update an existing API.\nBut the properties `name`, `version`, `context`, `provider`, `state` will not be changed by this operation.\n",
                 "parameters": [
@@ -303,11 +300,8 @@
                         "description": "API object that needs to be added\n",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/APIDetailed"
+                            "$ref": "#/definitions/API"
                         }
-                    },
-                    {
-                        "$ref": "#/parameters/Content-Type"
                     },
                     {
                         "$ref": "#/parameters/If-Match"
@@ -323,7 +317,7 @@
                     "200": {
                         "description": "OK.\nSuccessful response with updated API object\n",
                         "schema": {
-                            "$ref": "#/definitions/APIDetailed"
+                            "$ref": "#/definitions/API"
                         },
                         "headers": {
                             "Location": {
@@ -371,10 +365,16 @@
                 }
             },
             "delete": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X DELETE https://localhost:9443/api/am/publisher/v0.14/apis/6fb74674-4ab8-4b52-9886-f9a376985060",
-                "x-wso2-request": "DELETE https://localhost:9443/api/am/publisher/v0.14/apis/6fb74674-4ab8-4b52-9886-f9a376985060\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X DELETE https://127.0.0.1:9443/api/am/publisher/v1.0/apis/6fb74674-4ab8-4b52-9886-f9a376985060",
+                "x-wso2-request": "DELETE https://127.0.0.1:9443/api/am/publisher/v1.0/apis/6fb74674-4ab8-4b52-9886-f9a376985060\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
                 "x-wso2-response": "HTTP/1.1 200 OK",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_delete"
+                        ]
+                    }
+                ],
                 "summary": "Delete an API",
                 "description": "This operation can be used to delete an existing API proving the Id of the API.\n",
                 "parameters": [
@@ -418,18 +418,14 @@
         },
         "/apis/{apiId}/swagger": {
             "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/swagger",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/swagger\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\nContent-Length: 329\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-tier\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"x-wso2-security\": {\"apim\": {\"x-wso2-scopes\": []}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/swagger",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/swagger\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\nContent-Length: 329\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-policy\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
                 "summary": "Get swagger definition",
                 "description": "This operation can be used to retrieve the swagger definition of an API.\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/apiId"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
@@ -443,6 +439,10 @@
                 ],
                 "responses": {
                     "200": {
+                        "schema": {
+                            "type": "string",
+                            "example": ""
+                        },
                         "description": "OK.\nRequested swagger document of the API is returned\n",
                         "headers": {
                             "Content-Type": {
@@ -480,10 +480,16 @@
                 "consumes": [
                     "multipart/form-data"
                 ],
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\" -F apiDefinition=\"{\\\"paths\\\":{\\\"\\/*\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{\\\"description\\\":\\\"OK\\\"}}}}},\\\"x-wso2-security\\\":{\\\"apim\\\":{\\\"x-wso2-scopes\\\":[]}},\\\"swagger\\\":\\\"2.0\\\",\\\"info\\\":{\\\"title\\\":\\\"PhoneVerification\\\",\\\"description\\\":\\\"Verify a phone number\\\",\\\"contact\\\":{\\\"email\\\":\\\"xx@ee.com\\\",\\\"name\\\":\\\"xx\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\" -X PUT \"https://localhost:9443/api/am/publisher/v0.14/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/swagger\"",
-                "x-wso2-request": "PUT https://localhost:9443/api/am/publisher/v0.14/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/swagger\nAuthorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\nContent-Length: 477\nContent-Type: multipart/form-data; boundary=------------------------4f51e636c0003d99\n\n--------------------------4f51e636c0003d99\nContent-Disposition: form-data; name=\"apiDefinition\"\n\n{\"paths\":{\"\\/*\":{\"get\":{\"x-auth-type\":\"Application\",\"x-throttling-tier\":\"Unlimited\",\"responses\":{\"200\":{\"description\":\"OK\"}}}}},\"x-wso2-security\":{\"apim\":{\"x-wso2-scopes\":[]}},\"swagger\":\"2.0\",\"info\":{\"title\":\"PhoneVerification\",\"description\":\"Verify a phone number\",\"contact\":{\"email\":\"xx@ee.com\",\"name\":\"xx\"},\"version\":\"1.0.0\"}}\n--------------------------4f51e636c0003d99--\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-tier\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"x-wso2-security\": {\"apim\": {\"x-wso2-scopes\": []}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\" -F endpointId=\"{\\\"paths\\\":{\\\"\\/*\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{\\\"description\\\":\\\"OK\\\"}}}}},\\\"swagger\\\":\\\"2.0\\\",\\\"info\\\":{\\\"title\\\":\\\"PhoneVerification\\\",\\\"description\\\":\\\"Verify a phone number\\\",\\\"contact\\\":{\\\"email\\\":\\\"xx@ee.com\\\",\\\"name\\\":\\\"xx\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\" -X PUT \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/swagger\"",
+                "x-wso2-request": "PUT https://127.0.0.1:9443/api/am/publisher/v1.0/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/swagger\nAuthorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\nContent-Length: 477\nContent-Type: multipart/form-data; boundary=------------------------4f51e636c0003d99\n\n--------------------------4f51e636c0003d99\nContent-Disposition: form-data; name=\"apiDefinition\"\n\n{\"paths\":{\"\\/*\":{\"get\":{\"x-auth-type\":\"Application\",\"x-throttling-policy\":\"Unlimited\",\"responses\":{\"200\":{\"description\":\"OK\"}}}}},\"swagger\":\"2.0\",\"info\":{\"title\":\"PhoneVerification\",\"description\":\"Verify a phone number\",\"contact\":{\"email\":\"xx@ee.com\",\"name\":\"xx\"},\"version\":\"1.0.0\"}}\n--------------------------4f51e636c0003d99--\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-policy\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:apidef_update"
+                        ]
+                    }
+                ],
                 "summary": "Update swagger definition",
                 "description": "This operation can be used to update the swagger definition of an existing API. Swagger definition to be updated is passed as a form data parameter `apiDefinition`.\n",
                 "parameters": [
@@ -492,13 +498,10 @@
                     },
                     {
                         "in": "formData",
-                        "name": "apiDefinition",
+                        "name": "endpointId",
                         "description": "Swagger definition of the API",
                         "type": "string",
                         "required": true
-                    },
-                    {
-                        "$ref": "#/parameters/Content-Type"
                     },
                     {
                         "$ref": "#/parameters/If-Match"
@@ -559,41 +562,26 @@
                 }
             }
         },
-        "/apis/{apiId}/resource-policies": {
+        "/apis/{apiId}/wsdl": {
             "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/resource-policies",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/resource-policies\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\r\n    \"list\": [\r\n        {\r\n            \"id\": \"1990b54c-6685-4058-a08c-8fd5353056a6\",\r\n            \"httpVerb\": \"get\",\r\n            \"resourcePath\": \"checkPhoneNumbers\",\r\n            \"content\": \"<header description=\\\"SOAPAction\\\" name=\\\"SOAPAction\\\" scope=\\\"transport\\\" value=\\\"http://ws.cdyne.com/PhoneVerify/query/CheckPhoneNumber\\\"/>\"\r\n        }\r\n    ],\r\n    \"count\": 1\r\n}",
-                "summary": "Get the resource policy (inflow/outflow) definitions",
-                "description": "This operation can be used to retrieve conversion policy resource definitions of an API.\n",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_view"
+                        ]
+                    }
+                ],
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9292/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/wsdl",
+                "x-wso2-request": "GET https://127.0.0.1:9292/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/wsdl\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\nContent-Length: 329\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-policy\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"x-wso2-security\": {\"apim\": {\"x-wso2-scopes\": []}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
+                "summary": "Get swagger definition",
+                "description": "This operation can be used to retrieve the swagger definition of an API.\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/apiId"
-                    },
-                    {
-                        "in": "query",
-                        "name": "resourcePath",
-                        "description": "Resource path of the resource policy definition",
-                        "type": "string",
-                        "required": false
-                    },
-                    {
-                        "in": "query",
-                        "name": "verb",
-                        "description": "HTTP verb of the resource path of the resource policy definition",
-                        "type": "string",
-                        "required": false
-                    },
-                    {
-                        "in": "query",
-                        "name": "sequenceType",
-                        "description": "sequence type of the resource policy resource definition",
-                        "type": "string",
-                        "required": true
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
@@ -607,10 +595,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK.\nList of resource policy definitions of the API is returned\n",
-                        "schema": {
-                            "$ref": "#/definitions/ResourcePolicyList"
-                        },
+                        "description": "OK.\nRequested WSDL document of the API is returned\n",
                         "headers": {
                             "Content-Type": {
                                 "description": "The content type of the body.\n",
@@ -628,79 +613,6 @@
                     },
                     "304": {
                         "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
-                    },
-                    "404": {
-                        "description": "Not Found.\nRequested API does not exist.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "406": {
-                        "description": "Not Acceptable.\nThe requested media type is not supported\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/apis/{apiId}/resource-policies/{resourceId}": {
-            "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/resource-policies/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/resource-policies/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\r\n            \"id\": \"6c735e1d-8041-4f1e-b246-d28edaa650b0\",\r\n            \"httpVerb\": \"post\",\r\n            \"resourcePath\": \"checkPhoneNumbers\",\r\n            \"content\": \"<header description=\\\"SOAPAction\\\" name=\\\"SOAPAction\\\" scope=\\\"transport\\\" value=\\\"http://ws.cdyne.com/PhoneVerify/query/CheckPhoneNumber\\\"/>\"\r\n}",
-                "summary": "Get the resource policy (inflow/outflow) definition for a given resource identifier.",
-                "description": "This operation can be used to retrieve conversion policy resource definitions of an API given the resource identifier.\n",
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/apiId"
-                    },
-                    {
-                        "$ref": "#/parameters/resourceId"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
-                    },
-                    {
-                        "$ref": "#/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/parameters/If-Modified-Since"
-                    }
-                ],
-                "tags": [
-                    "API (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\nRequested resource policy definition of the API is returned for the given resource identifier.\n",
-                        "schema": {
-                            "$ref": "#/definitions/ResourcePolicyInfo"
-                        },
-                        "headers": {
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            },
-                            "ETag": {
-                                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
-                                "type": "string"
-                            },
-                            "Last-Modified": {
-                                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "304": {
-                        "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
-                    },
-                    "400": {
-                        "description": "Bad Request.\nInvalid request or validation error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
                     },
                     "404": {
                         "description": "Not Found.\nRequested API does not exist.\n",
@@ -718,32 +630,30 @@
             },
             "put": {
                 "consumes": [
-                    "application/json"
+                    "multipart/form-ldata"
                 ],
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\" -F apiDefinition=\"{\\\"paths\\\":{\\\"\\/*\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{\\\"description\\\":\\\"OK\\\"}}}}},\\\"x-wso2-security\\\":{\\\"apim\\\":{\\\"x-wso2-scopes\\\":[]}},\\\"swagger\\\":\\\"2.0\\\",\\\"info\\\":{\\\"title\\\":\\\"PhoneVerification\\\",\\\"description\\\":\\\"Verify a phone number\\\",\\\"contact\\\":{\\\"email\\\":\\\"xx@ee.com\\\",\\\"name\\\":\\\"xx\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\" -X PUT \"https://localhost:9443/api/am/publisher/v0.14/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/resource-policies/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\"",
-                "x-wso2-request": "PUT https://localhost:9443/api/am/publisher/v0.14/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/resource-policies/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\nAuthorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\nContent-Length: 477\nContent-Type: application/json; boundary=------------------------4f51e636c0003d99\n\n--------------------------4f51e636c0003d99\n\n{ \"content\": \"<header description=\\\"SOAPAction\\\" name=\\\"SOAPAction\\\" scope=\\\"transport\\\" value=\\\"http://ws.cdyne.com/PhoneVerify/query/CheckPhoneNumber\\\"/>\"}\n--------------------------4f51e636c0003d99--\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\r\n            \"id\": \"6c735e1d-8041-4f1e-b246-d28edaa650b0\",\r\n            \"httpVerb\": \"post\",\r\n            \"resourcePath\": \"checkPhoneNumbers\",\r\n            \"content\": \"<header description=\\\"SOAPAction\\\" name=\\\"SOAPAction\\\" scope=\\\"transport\\\" value=\\\"http://ws.cdyne.com/PhoneVerify/query/CheckPhoneNumber\\\"/>\"\r\n}",
-                "summary": "Update the resource policy(inflow/outflow) definition for the given resource identifier",
-                "description": "This operation can be used to update the resource policy(inflow/outflow) definition for the given resource identifier of an existing API. resource policy definition to be updated is passed as a body parameter `content`.\n",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
+                "x-wso2-curl": "curl -k -H \"Authorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\" -F inlineContent=\"{\\\"paths\\\":{\\\"\\/*\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{\\\"description\\\":\\\"OK\\\"}}}}},\\\"x-wso2-security\\\":{\\\"apim\\\":{\\\"x-wso2-scopes\\\":[]}},\\\"swagger\\\":\\\"2.0\\\",\\\"info\\\":{\\\"title\\\":\\\"PhoneVerification\\\",\\\"description\\\":\\\"Verify a phone number\\\",\\\"contact\\\":{\\\"email\\\":\\\"xx@ee.com\\\",\\\"name\\\":\\\"xx\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\" -X PUT \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/wsdl\"",
+                "x-wso2-request": "PUT https://127.0.0.1:9443/api/am/publisher/v1.0/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/wsdl\nAuthorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\nContent-Length: 477\nContent-Type: multipart/form-data; boundary=------------------------4f51e636c0003d99\n\n--------------------------4f51e636c0003d99\nContent-Disposition: form-data; name=\"apiDefinition\"\n\n{\"paths\":{\"\\/*\":{\"get\":{\"x-auth-type\":\"Application\",\"x-throttling-policy\":\"Unlimited\",\"responses\":{\"200\":{\"description\":\"OK\"}}}}},\"x-wso2-security\":{\"apim\":{\"x-wso2-scopes\":[]}},\"swagger\":\"2.0\",\"info\":{\"title\":\"PhoneVerification\",\"description\":\"Verify a phone number\",\"contact\":{\"email\":\"xx@ee.com\",\"name\":\"xx\"},\"version\":\"1.0.0\"}}\n--------------------------4f51e636c0003d99--\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-policy\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"x-wso2-security\": {\"apim\": {\"x-wso2-scopes\": []}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
+                "summary": "Update WSDL definition",
+                "description": "This operation can be used to update the WSDL definition of an existing API. WSDL to be updated is passed as a form data parameter `inlineContent`.\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/apiId"
                     },
                     {
-                        "$ref": "#/parameters/resourceId"
-                    },
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "Content of the resource policy definition that needs to be updated",
-                        "schema": {
-                            "$ref": "#/definitions/ResourcePolicyInfo"
-                        },
+                        "in": "formData",
+                        "name": "file",
+                        "description": "WSDL file or archive to upload",
+                        "type": "file",
                         "required": true
-                    },
-                    {
-                        "$ref": "#/parameters/Content-Type"
                     },
                     {
                         "$ref": "#/parameters/If-Match"
@@ -757,10 +667,149 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK.\nSuccessful response with updated the resource policy definition\n",
+                        "description": "OK.\nSuccessful response with updated WSDL definition\n",
+                        "headers": {
+                            "Location": {
+                                "description": "The URL of the newly created resource.\n",
+                                "type": "string"
+                            },
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            },
+                            "ETag": {
+                                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            },
+                            "Last-Modified": {
+                                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request.\nInvalid request or validation error\n",
                         "schema": {
-                            "$ref": "#/definitions/ResourcePolicyInfo"
-                        },
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden.\nThe request must be conditional but no condition has been specified.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found.\nThe resource to be updated does not exist.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "412": {
+                        "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/apis/{apiId}/gateway-config": {
+            "get": {
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/swagger",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/swagger\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\nContent-Length: 329\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-policy\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
+                "summary": "Get gateway definition",
+                "description": "This operation can be used to retrieve the gateway configuration of an API.\n",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiId"
+                    },
+                    {
+                        "$ref": "#/parameters/If-None-Match"
+                    },
+                    {
+                        "$ref": "#/parameters/If-Modified-Since"
+                    }
+                ],
+                "tags": [
+                    "API (Individual)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nRequested gateway configuration of the API is returned\n",
+                        "headers": {
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            },
+                            "ETag": {
+                                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            },
+                            "Last-Modified": {
+                                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "304": {
+                        "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+                    },
+                    "404": {
+                        "description": "Not Found.\nRequested API does not exist.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "406": {
+                        "description": "Not Acceptable.\nThe requested media type is not supported\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "x-wso2-curl": "curl -k -H \"Authorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\" -F endpointId=\"{\\\"paths\\\":{\\\"\\/*\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{\\\"description\\\":\\\"OK\\\"}}}}},\\\"swagger\\\":\\\"2.0\\\",\\\"info\\\":{\\\"title\\\":\\\"PhoneVerification\\\",\\\"description\\\":\\\"Verify a phone number\\\",\\\"contact\\\":{\\\"email\\\":\\\"xx@ee.com\\\",\\\"name\\\":\\\"xx\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\" -X PUT \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/swagger\"",
+                "x-wso2-request": "PUT https://127.0.0.1:9443/api/am/publisher/v1.0/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/swagger\nAuthorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\nContent-Length: 477\nContent-Type: multipart/form-data; boundary=------------------------4f51e636c0003d99\n\n--------------------------4f51e636c0003d99\nContent-Disposition: form-data; name=\"apiDefinition\"\n\n{\"paths\":{\"\\/*\":{\"get\":{\"x-auth-type\":\"Application\",\"x-throttling-policy\":\"Unlimited\",\"responses\":{\"200\":{\"description\":\"OK\"}}}}},\"swagger\":\"2.0\",\"info\":{\"title\":\"PhoneVerification\",\"description\":\"Verify a phone number\",\"contact\":{\"email\":\"xx@ee.com\",\"name\":\"xx\"},\"version\":\"1.0.0\"}}\n--------------------------4f51e636c0003d99--\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-policy\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:apidef_update"
+                        ]
+                    }
+                ],
+                "summary": "Update gateway configuration",
+                "description": "This operation can be used to update the gateway configuration of an existing API. gateway configuration to be updated is passed as a form data parameter `gatewayConfig`.\n",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiId"
+                    },
+                    {
+                        "in": "formData",
+                        "name": "gatewayConfig",
+                        "description": "gateway configuration of the API",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "$ref": "#/parameters/If-Match"
+                    },
+                    {
+                        "$ref": "#/parameters/If-Unmodified-Since"
+                    }
+                ],
+                "tags": [
+                    "API (Individual)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nSuccessful response with updated gateway configuration\n",
                         "headers": {
                             "Location": {
                                 "description": "The URL of the newly created resource.\n",
@@ -809,18 +858,14 @@
         },
         "/apis/{apiId}/thumbnail": {
             "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer d34baf74-3f02-3929-814e-88b27f750ba9\" https://localhost:9443/api/am/publisher/v0.14/apis/29c9ec3d-f590-467e-83e6-96d43517080f/thumbnail > image.jpg",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/apis/29c9ec3d-f590-467e-83e6-96d43517080f/thumbnail\nAuthorization: Bearer d34baf74-3f02-3929-814e-88b27f750ba9\n",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer d34baf74-3f02-3929-814e-88b27f750ba9\" https://127.0.0.1:9443/api/am/publisher/v1.0/apis/29c9ec3d-f590-467e-83e6-96d43517080f/thumbnail > image.jpg",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/apis/29c9ec3d-f590-467e-83e6-96d43517080f/thumbnail\nAuthorization: Bearer d34baf74-3f02-3929-814e-88b27f750ba9\n",
                 "x-wso2-response": "HTTP/1.1 200 OK\r\nContent-Type: image/jpeg\r\n\r\n[image content]",
                 "summary": "Get thumbnail image",
                 "description": "This operation can be used to download a thumbnail image of an API.\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/apiId"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
@@ -871,10 +916,16 @@
                 "consumes": [
                     "multipart/form-data"
                 ],
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -X POST -H \"Authorization: Bearer d34baf74-3f02-3929-814e-88b27f750ba9\" https://localhost:9443/api/am/publisher/v0.14/apis/29c9ec3d-f590-467e-83e6-96d43517080f/thumbnail -F file=@image.jpg",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/thumbnail\nAuthorization: Bearer d34baf74-3f02-3929-814e-88b27f750ba9\nContent-Type: multipart/form-data; boundary=------------------------5e542e0e5b50e1e4\nContent-Length: 18333\n\n--------------------------5e542e0e5b50e1e4\nContent-Disposition: form-data; name=\"file\"; filename=\"image.jpg\"\nContent-Type: image/jpeg\n\n[image content]\n\n--------------------------5e542e0e5b50e1e4--\n",
-                "x-wso2-response": "HTTP/1.1 201 Created\r\nLocation: https://localhost:9443/api/am/publisher/v0.14/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/thumbnail\r\nContent-Type: application/json\r\n\r\n{\r\n   \"relativePath\": \"/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/thumbnail\",\r\n   \"mediaType\": \"image/jpeg\"\r\n}",
+                "x-wso2-curl": "curl -X POST -H \"Authorization: Bearer d34baf74-3f02-3929-814e-88b27f750ba9\" https://127.0.0.1:9443/api/am/publisher/v1.0/apis/29c9ec3d-f590-467e-83e6-96d43517080f/thumbnail -F file=@image.jpg",
+                "x-wso2-request": "POST https://127.0.0.1:9443/api/am/publisher/v1.0/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/thumbnail\nAuthorization: Bearer d34baf74-3f02-3929-814e-88b27f750ba9\nContent-Type: multipart/form-data; boundary=------------------------5e542e0e5b50e1e4\nContent-Length: 18333\n\n--------------------------5e542e0e5b50e1e4\nContent-Disposition: form-data; name=\"file\"; filename=\"image.jpg\"\nContent-Type: image/jpeg\n\n[image content]\n\n--------------------------5e542e0e5b50e1e4--\n",
+                "x-wso2-response": "HTTP/1.1 201 Created\r\nLocation: https://127.0.0.1:9443/api/am/publisher/v1.0/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/thumbnail\r\nContent-Type: application/json\r\n\r\n{\r\n   \"relativePath\": \"/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/thumbnail\",\r\n   \"mediaType\": \"image/jpeg\"\r\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_update"
+                        ]
+                    }
+                ],
                 "summary": "Upload a thumbnail image",
                 "description": "This operation can be used to upload a thumbnail image of an API. The thumbnail to be uploaded should be given as a form data parameter `file`.\n",
                 "parameters": [
@@ -887,9 +938,6 @@
                         "description": "Image to upload",
                         "type": "file",
                         "required": true
-                    },
-                    {
-                        "$ref": "#/parameters/Content-Type"
                     },
                     {
                         "$ref": "#/parameters/If-Match"
@@ -947,12 +995,131 @@
                 }
             }
         },
+        "/apis/{apiId}/threat-protection-policies": {
+            "post": {
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_update"
+                        ]
+                    }
+                ],
+                "summary": "Add a threat protection policy to an API",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiId"
+                    },
+                    {
+                        "name": "policyId",
+                        "in": "query",
+                        "description": "Threat protection policy id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "API (Individual)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Ok. Policy added succesfuly."
+                    },
+                    "404": {
+                        "description": "Specified API or Policy not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error while adding policy",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "get": {
+                "summary": "Get all threat protection policies associated with an API",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiId"
+                    }
+                ],
+                "tags": [
+                    "API (Individual)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Ok. List of policy ids is returned",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Specified API was not found.",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Error retrieving threat protection policies",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete a threat protection policy from an API",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiId"
+                    },
+                    {
+                        "name": "policyId",
+                        "in": "query",
+                        "description": "Threat protection policy id",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "API (Individual)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Ok. Policy deleted successfully."
+                    },
+                    "404": {
+                        "description": "Specified API or Policy not found",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Error while deleting the policy",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
         "/apis/copy-api": {
             "post": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X POST \"https://localhost:9443/api/am/publisher/v0.14/apis/copy-api?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&newVersion=2.0.0\"",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/apis/copy-api?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&newVersion=2.0.0\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://localhost:9443/api/am/publisher/v0.14/apis/25a84fc9-38c0-4578-95e8-29fb6b1c4771\nContent-Type: application/json\n\n{\r\n   \"id\": \"25a84fc9-38c0-4578-95e8-29fb6b1c4771\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"2.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"apiDefinition\": \"{\\\"paths\\\":{\\\"\\\\/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#\\\\/definitions\\\\/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"schema\\\":{\\\"$ref\\\":\\\"#\\\\/definitions\\\\/Order\\\"},\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"description\\\":\\\"Created.\\\"}}}},\\\"\\\\/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#\\\\/definitions\\\\/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"headers\\\":{},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application\\\\/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application\\\\/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http:\\\\/\\\\/www.apache.org\\\\/licenses\\\\/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http:\\\\/\\\\/www.pizzashack.com\\\"},\\\"version\\\":\\\"2.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"status\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"type\": \"HTTP\",\r\n   \"transport\": [\"https\"],\r\n   \"tags\":    [\r\n      \"chicken\",\r\n      \"pizza\"\r\n   ],\r\n   \"tiers\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 500,\r\n      \"production\": 100\r\n   },\r\n   \"thumbnailUri\": null,\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X POST \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/copy-api?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&newVersion=2.0.0\"",
+                "x-wso2-request": "POST https://127.0.0.1:9443/api/am/publisher/v1.0/apis/copy-api?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&newVersion=2.0.0\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://127.0.0.1:9443/api/am/publisher/v1.0/apis/25a84fc9-38c0-4578-95e8-29fb6b1c4771\nContent-Type: application/json\n\n{\r\n   \"id\": \"25a84fc9-38c0-4578-95e8-29fb6b1c4771\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"2.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"endpointId\": \"{\\\"paths\\\":{\\\"\\\\/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#\\\\/definitions\\\\/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"schema\\\":{\\\"$ref\\\":\\\"#\\\\/definitions\\\\/Order\\\"},\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"description\\\":\\\"Created.\\\"}}}},\\\"\\\\/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#\\\\/definitions\\\\/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"headers\\\":{},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application\\\\/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"integer\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application\\\\/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http:\\\\/\\\\/www.apache.org\\\\/licenses\\\\/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http:\\\\/\\\\/www.pizzashack.com\\\"},\\\"version\\\":\\\"2.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"lifeCycleStatus\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"transport\": [\"https\"],\r\n   \"tags\":    [\r\n      \"chicken\",\r\n      \"pizza\"\r\n   ],\r\n   \"policies\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 500,\r\n      \"production\": 100\r\n   },\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\r\n   \"visibleTenants\": [],\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1.0/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9443/am/sample/pizzashack/v1.0/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
                 "summary": "Create a new API version",
                 "description": "This operation can be used to create a new version of an existing API. The new version is specified as `newVersion` query parameter. New API will be in `CREATED` state.\n",
                 "parameters": [
@@ -986,30 +1153,33 @@
                             "$ref": "#/definitions/Error"
                         }
                     },
-                    "401": {
-                        "description": "Unauthenticated request.\n",
+                    "404": {
+                        "description": "Not Found.\nAPI to copy does not exist.\n",
                         "schema": {
                             "$ref": "#/definitions/Error"
                         }
-                    },
-                    "404": {
-                        "description": "Not Found.\nAPI to copy does not exist.\n"
                     }
                 }
             }
         },
         "/apis/change-lifecycle": {
             "post": {
-                "x-scope": "apim:api_publish",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X POST \"https://localhost:9443/api/am/publisher/v0.14/apis/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish\"",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/apis/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X POST \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish\"",
+                "x-wso2-request": "POST https://127.0.0.1:9443/api/am/publisher/v1.0/apis/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
                 "x-wso2-response": "HTTP/1.1 200 OK",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_publish"
+                        ]
+                    }
+                ],
                 "summary": "Change API Status",
-                "description": "This operation is used to change the lifecycle of an API. Eg: Publish an API which is in `CREATED` state. In order to change the lifecycle, we need to provide the lifecycle `action` as a query parameter.\n\nFor example, to Publish an API, `action` should be `Publish`. Note that the `Re-publish` action is available only after calling `Block`.\n\nSome actions supports providing additional paramters which should be provided as `lifecycleChecklist` parameter. Please see parameters table for more information.\n",
+                "description": "This operation is used to change the lifecycle of an API. Eg: Publish an API which is in `CREATED` state. In order to change the lifecycle, we need to provide the lifecycle `action` as a query parameter.\n\nFor example, to Publish an API, `action` should be `Publish`.\n\nSome actions supports providing additional paramters which should be provided as `lifecycleChecklist` parameter. Please see parameters table for more information.\n",
                 "parameters": [
                     {
                         "name": "action",
-                        "description": "The action to demote or promote the state of the API.\n\nSupported actions are [ **Publish, Deploy as a Prototype, Demote to Created, Demote to Prototyped, Block, Deprecate, Re-Publish, Retire **]\n",
+                        "description": "The action to demote or promote the state of the API.\n\nSupported actions are [ **Publish, Deploy as a Prototype, Demote to Created, Demote to Prototyped, Move to Maintenance, Deprecate, Re-Publish, Retire **]\n",
                         "in": "query",
                         "type": "string",
                         "required": true,
@@ -1018,7 +1188,7 @@
                             "Deploy as a Prototype",
                             "Demote to Created",
                             "Demote to Prototyped",
-                            "Block",
+                            "Move to Maintenance",
                             "Deprecate",
                             "Re-Publish",
                             "Retire"
@@ -1026,7 +1196,7 @@
                     },
                     {
                         "name": "lifecycleChecklist",
-                        "description": "\nSupported checklist items are as follows.\n1. **Deprecate Old Versions**: Setting this to true will deprecate older versions of a particular API when it is promoted to Published state from Created state.\n2. **Require Re-Subscription**: If you set this to true, users need to re subscribe to the API although they may have subscribed to an older version.\n\nYou can specify additional checklist items by using an **\"attribute:\"** modifier.\n\nEg: \"Deprecate Old Versions:true\" will deprecate older versions of a particular API when it is promoted to Published state from Created state. Multiple checklist items can be given in \"attribute1:true, attribute2:false\" format.\n\n**Sample CURL :**  curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X POST \"https://localhost:9443/api/am/publisher/v0.14/apis/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish&lifecycleChecklist=Deprecate Old Versions:true,Require Re-Subscription:true\"\n",
+                        "description": "\nYou can specify additional checklist items by using an **\"attribute:\"** modifier.\n\nEg: \"Deprecate Old Versions:true\" will deprecate older versions of a particular API when it is promoted to\nPublished state from Created state. Multiple checklist items can be given in \"attribute1:true, attribute2:false\"\nformat.\n\nSupported checklist items are as follows.\n1. **Deprecate Old Versions**: Setting this to true will deprecate older versions of a particular API when it is promoted to Published state from Created state.\n2. **Require Re-Subscription**: If you set this to true, users need to re subscribe to the API although they may have subscribed to an older version.\n",
                         "type": "string",
                         "in": "query"
                     },
@@ -1046,6 +1216,9 @@
                 "responses": {
                     "200": {
                         "description": "OK.\nLifecycle changed successfully.\n",
+                        "schema": {
+                            "$ref": "#/definitions/WorkflowResponse"
+                        },
                         "headers": {
                             "ETag": {
                                 "description": "Entity Tag of the changed API. Used by caches, or in conditional requests (Will be supported in future).\n",
@@ -1053,6 +1226,18 @@
                             },
                             "Last-Modified": {
                                 "description": "Date and time the API lifecycle has been modified the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "202": {
+                        "description": "Accepted.\nThe request has been accepted.\n",
+                        "schema": {
+                            "$ref": "#/definitions/WorkflowResponse"
+                        },
+                        "headers": {
+                            "Location": {
+                                "description": "Location of the newly created Application.\n",
                                 "type": "string"
                             }
                         }
@@ -1069,6 +1254,12 @@
                             "$ref": "#/definitions/Error"
                         }
                     },
+                    "409": {
+                        "description": "Conflict.\nPending workflow task exists.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
                     "412": {
                         "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
                         "schema": {
@@ -1078,14 +1269,347 @@
                 }
             }
         },
+        "/apis/{apiId}/lifecycle-history": {
+            "get": {
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer f8828f52-175a-4cb2-b246-02b1e6054f97\" http://127.0.0.1:9090/api/am/publisher/v1.0/apis/0527a55e-8dcf-4ce5-bddf-c77e8418be8a/lifecycle-history",
+                "x-wso2-request": "GET http://127.0.0.1:9090/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-history\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\n Content-Type: application/json \n Content-Encoding: gzip \n Transfer-Encoding: chunked \n\n [ { \"postState\" : \"Created\",\n    \"updatedTime\" : \"Feb 23, 2017 5:17:02 PM\",\n\"user\" : \"admin\"\n  },\n { \"postState\" : \"Published\",\n    \"previousState\" : \"Created\",\n    \"updatedTime\" : \"Feb 23, 2017 5:17:17 PM\",\n    \"user\" : \"admin\"\n }\n]",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_publish"
+                        ]
+                    }
+                ],
+                "summary": "Get Lifecycle state change history of the API.",
+                "description": "This operation can be used to retrieve Lifecycle state change history of the API.\n",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiId"
+                    },
+                    {
+                        "$ref": "#/parameters/If-None-Match"
+                    },
+                    {
+                        "$ref": "#/parameters/If-Modified-Since"
+                    }
+                ],
+                "tags": [
+                    "API (Individual)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nLifecycle state change history returned successfully.\n",
+                        "headers": {
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            },
+                            "ETag": {
+                                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            },
+                            "Last-Modified": {
+                                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "304": {
+                        "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+                    },
+                    "404": {
+                        "description": "Not Found.\nRequested API does not exist.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "412": {
+                        "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/apis/{apiId}/lifecycle": {
+            "get": {
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer f8828f52-175a-4cb2-b246-02b1e6054f97\" http://127.0.0.1:9090/api/am/publisher/v1.0/apis/0527a55e-8dcf-4ce5-bddf-c77e8418be8a/lifecycle",
+                "x-wso2-request": "GET http://127.0.0.1:9090/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\n Content-Type: application/json \n Content-Encoding: gzip \n Transfer-Encoding: chunked \n\n {  \n   \"lcName\":\"API_LIFECYCLE\",\n   \"state\":\"Published\",\n   \"lifecycleId\":\"2febf145f07e457c9643100b6ec60679\",\n   \"checkItemBeanList\":[  \n\n   ],\n   \"inputBeanList\":[  \n\n   ],\n   \"customCodeBeanList\":[  \n      {  \n         \"classObject\":{  \n\n         },\n         \"targetName\":\"Maintenance\"\n      },\n      {  \n         \"classObject\":{  \n\n         },\n         \"targetName\":\"Deprecated\"\n      },\n      {  \n         \"classObject\":{  \n\n         },\n         \"targetName\":\"Created\"\n      },\n      {  \n         \"classObject\":{  \n\n         },\n         \"targetName\":\"Prototyped\"\n      }\n   ],\n   \"availableTransitionBeanList\":[  \n      {  \n         \"event\":\"Move to Maintenance\",\n         \"targetState\":\"Maintenance\"\n      },\n      {  \n         \"event\":\"Deploy as a Prototype\",\n         \"targetState\":\"Prototyped\"\n      },\n      {  \n         \"event\":\"Demote to Created\",\n         \"targetState\":\"Created\"\n      },\n      {  \n         \"event\":\"Deprecate\",\n         \"targetState\":\"Deprecated\"\n      },\n      {  \n         \"event\":\"Publish\",\n         \"targetState\":\"Published\"\n      }\n   ],\n   \"permissionBeanList\":[  \n\n   ]\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_publish"
+                        ]
+                    }
+                ],
+                "summary": "Get Lifecycle state data of the API.",
+                "description": "This operation can be used to retrieve Lifecycle state data of the API.\n",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiId"
+                    },
+                    {
+                        "$ref": "#/parameters/If-None-Match"
+                    },
+                    {
+                        "$ref": "#/parameters/If-Modified-Since"
+                    }
+                ],
+                "tags": [
+                    "API (Individual)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nLifecycle state data returned successfully.\n",
+                        "headers": {
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            },
+                            "ETag": {
+                                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            },
+                            "Last-Modified": {
+                                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            }
+                        },
+                        "schema": {
+                            "$ref": "#/definitions/LifecycleState"
+                        }
+                    },
+                    "304": {
+                        "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+                    },
+                    "404": {
+                        "description": "Not Found.\nRequested API does not exist.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "412": {
+                        "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/apis/{apiId}/lifecycle/lifecycle-pending-task": {
+            "delete": {
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer f8828f52-175a-4cb2-b246-02b1e6054f97\" -X DELETE http://127.0.0.1:9090/api/am/publisher/v1.0/apis/0527a55e-8dcf-4ce5-bddf-c77e8418be8a/lifecycle/lifecycle-pending-task",
+                "x-wso2-request": "DELETE http://127.0.0.1:9090/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle/lifecycle-pending-task\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_publish"
+                        ]
+                    }
+                ],
+                "summary": "Delete pending lifecycle state change tasks.",
+                "description": "This operation can be used to remove pending lifecycle state change requests that are in pending state\n",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiId"
+                    }
+                ],
+                "tags": [
+                    "API (Individual)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nLifecycle state change pending task removed successfully.\n"
+                    },
+                    "404": {
+                        "description": "Not Found.\nRequested API does not exist.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "412": {
+                        "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/apis/import-definition": {
+            "post": {
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
+                "summary": "Import API Definition",
+                "description": "This operation can be used to create api from api definition.\n\nAPI definition can be either Swagger or a WSDL\n\nWSDL can be speficied as a single file or a ZIP archive with WSDLs and reference XSDs etc.\nWhen the type is WSDL, it is a **must** to specify additionalProperties with API's name, version, context and endpoints. See the example for additionalProperties.\n",
+                "parameters": [
+                    {
+                        "in": "formData",
+                        "name": "type",
+                        "description": "Definition type to upload",
+                        "type": "string",
+                        "required": false,
+                        "enum": [
+                            "SWAGGER",
+                            "WSDL"
+                        ],
+                        "default": "SWAGGER"
+                    },
+                    {
+                        "in": "formData",
+                        "name": "file",
+                        "description": "Definition to uploadas a file",
+                        "type": "file",
+                        "required": false
+                    },
+                    {
+                        "in": "formData",
+                        "name": "url",
+                        "description": "Definition url",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "in": "formData",
+                        "name": "additionalProperties",
+                        "description": "Additional attributes specified as a stringified JSON with API's schema",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "in": "formData",
+                        "name": "implementationType",
+                        "type": "string",
+                        "enum": [
+                            "soap",
+                            "httpBinding"
+                        ],
+                        "default": "SOAP",
+                        "description": "Currently this is only used when creating an API using a WSDL.\n\nIf 'SOAP' is specified, the API will be created with only one resource 'POST /' which is to be used for SOAP\noperations.\n\nIf 'HTTP_BINDING' is specified, the API will be created with resources using HTTP binding operations\nwhich are extracted from the WSDL.\n",
+                        "required": false
+                    },
+                    {
+                        "$ref": "#/parameters/If-Match"
+                    },
+                    {
+                        "$ref": "#/parameters/If-Unmodified-Since"
+                    }
+                ],
+                "tags": [
+                    "API (Collection)"
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created.\nSuccessful response with the newly created object as entity in the body.\nLocation header contains URL of newly created entity.\n",
+                        "schema": {
+                            "$ref": "#/definitions/API"
+                        },
+                        "headers": {
+                            "Location": {
+                                "description": "The URL of the newly created resource.\n",
+                                "type": "string"
+                            },
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            },
+                            "ETag": {
+                                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request.\nInvalid request or validation error.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type.\nThe entity of the request was in a not supported format.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/apis/validate-definition": {
+            "post": {
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
+                "summary": "Validate API definition and retrieve a summary",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "description": "This operation can be used to validate a swagger or WSDL definition and retrieve a summary.\n",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/definitionType"
+                    },
+                    {
+                        "$ref": "#/parameters/definitionFile"
+                    },
+                    {
+                        "$ref": "#/parameters/definitionUrl"
+                    }
+                ],
+                "tags": [
+                    "API (Collection)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nAPI definition validation information is returned\n",
+                        "schema": {
+                            "$ref": "#/definitions/APIDefinitionValidationResponse"
+                        },
+                        "headers": {
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request.\nInvalid request or validation error.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found.\nWorkflow for the given reference in not found.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
         "/apis/{apiId}/documents": {
             "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents\"",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents\"",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
                 "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"visibility\": \"API_LEVEL\",\n         \"sourceType\": \"INLINE\",\n         \"sourceUrl\": null,\n         \"otherTypeName\": null,\n         \"documentId\": \"0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\",\n         \"summary\": \"This is a sample documentation for v1.0.0\",\n         \"name\": \"PhoneVerification API Documentation\",\n         \"type\": \"HOWTO\"\n      },\n            {\n         \"visibility\": \"API_LEVEL\",\n         \"sourceType\": \"URL\",\n         \"sourceUrl\": \"http://wiki.cdyne.com/index.php/Phone_Verification\",\n         \"otherTypeName\": null,\n         \"documentId\": \"4145df31-04f1-440c-8d08-68952874622c\",\n         \"summary\": \"This is the URL for online documentation\",\n         \"name\": \"Online Documentation\",\n         \"type\": \"SAMPLES\"\n      }\n   ],\n   \"next\": \"\",\n   \"count\": 2\n}",
                 "summary": "Get a list of documents of an API",
-                "description": "This operation can be used to retrive a list of documents belonging to an API by providing the id of the API.\n",
+                "description": "This operation can be used to retrieve a list of documents belonging to an API by providing the id of the API.\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/apiId"
@@ -1095,9 +1619,6 @@
                     },
                     {
                         "$ref": "#/parameters/offset"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
@@ -1141,10 +1662,16 @@
                 }
             },
             "post": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json \"https://localhost:9443/api/am/publisher/v0.14/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents\"",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\nContent-Type: application/json\n\n{\n    \"visibility\": \"API_LEVEL\",\n    \"sourceType\": \"INLINE\",\n    \"sourceUrl\": null,\n    \"otherTypeName\": null,\n    \"summary\": \"This is a sample documentation\",\n    \"name\": \"Introduction to PhoneVerification API\",\n    \"type\": \"HOWTO\"\n}",
-                "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/ffd5790d-b7a9-4cb6-b76a-f8b83ecdd058\nContent-Type: application/json\n\n{\n   \"visibility\": \"API_LEVEL\",\n   \"sourceType\": \"INLINE\",\n   \"sourceUrl\": null,\n   \"otherTypeName\": null,\n   \"documentId\": \"ffd5790d-b7a9-4cb6-b76a-f8b83ecdd058\",\n   \"summary\": \"This is a sample documentation\",\n   \"name\": \"Introduction to PhoneVerification API\",\n   \"type\": \"HOWTO\"\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents\"",
+                "x-wso2-request": "POST https://127.0.0.1:9443/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\nContent-Type: application/json\n\n{\n    \"visibility\": \"API_LEVEL\",\n    \"sourceType\": \"INLINE\",\n    \"sourceUrl\": null,\n    \"otherTypeName\": null,\n    \"summary\": \"This is a sample documentation\",\n    \"name\": \"Introduction to PhoneVerification API\",\n    \"type\": \"HOWTO\"\n}",
+                "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/ffd5790d-b7a9-4cb6-b76a-f8b83ecdd058\nContent-Type: application/json\n\n{\n   \"visibility\": \"API_LEVEL\",\n   \"sourceType\": \"INLINE\",\n   \"sourceUrl\": null,\n   \"otherTypeName\": null,\n   \"documentId\": \"ffd5790d-b7a9-4cb6-b76a-f8b83ecdd058\",\n   \"summary\": \"This is a sample documentation\",\n   \"name\": \"Introduction to PhoneVerification API\",\n   \"type\": \"HOWTO\"\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
                 "summary": "Add a new document to an API",
                 "description": "This operation can be used to add a new documentation to an API. This operation only adds the metadata of a document. To add the actual content we need to use **Upload the content of an API document ** API once we obtain a document Id by this operation.\n",
                 "parameters": [
@@ -1161,7 +1688,10 @@
                         }
                     },
                     {
-                        "$ref": "#/parameters/Content-Type"
+                        "$ref": "#/parameters/If-Match"
+                    },
+                    {
+                        "$ref": "#/parameters/If-Unmodified-Since"
                     }
                 ],
                 "tags": [
@@ -1202,9 +1732,8 @@
         },
         "/apis/{apiId}/documents/{documentId}": {
             "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\"",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\"",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
                 "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"visibility\": \"API_LEVEL\",\n   \"sourceType\": \"INLINE\",\n   \"sourceUrl\": null,\n   \"otherTypeName\": null,\n   \"documentId\": \"0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\",\n   \"summary\": \"This is a sample documentation\",\n   \"name\": \"PhoneVerification API Documentation\",\n   \"type\": \"HOWTO\"\n}",
                 "summary": "Get a document of an API",
                 "description": "This operation can be used to retrieve a particular document's metadata associated with an API.\n",
@@ -1214,9 +1743,6 @@
                     },
                     {
                         "$ref": "#/parameters/documentId"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
@@ -1267,10 +1793,16 @@
                 }
             },
             "put": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\" -H \"Content-Type: application/json\" -X PUT -d data.json \"https://localhost:9443/api/am/publisher/v0.14/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\"",
-                "x-wso2-request": "PUT https://localhost:9443/api/am/publisher/v0.14/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\nAuthorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\nContent-Type: application/json\n\n{\n   \"visibility\": \"API_LEVEL\",\n   \"sourceType\": \"INLINE\",\n   \"sourceUrl\": null,\n   \"otherTypeName\": null,\n   \"documentId\": \"0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\",\n   \"summary\": \"This is a sample documentation for v1.0.0\",\n   \"name\": \"PhoneVerification API Documentation\",\n   \"type\": \"HOWTO\"\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\" -H \"Content-Type: application/json\" -X PUT -d data.json \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\"",
+                "x-wso2-request": "PUT https://127.0.0.1:9443/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\nAuthorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\nContent-Type: application/json\n\n{\n   \"visibility\": \"API_LEVEL\",\n   \"sourceType\": \"INLINE\",\n   \"sourceUrl\": null,\n   \"otherTypeName\": null,\n   \"documentId\": \"0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\",\n   \"summary\": \"This is a sample documentation for v1.0.0\",\n   \"name\": \"PhoneVerification API Documentation\",\n   \"type\": \"HOWTO\"\n}",
                 "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"visibility\": \"API_LEVEL\",\n   \"sourceType\": \"INLINE\",\n   \"sourceUrl\": null,\n   \"otherTypeName\": null,\n   \"documentId\": \"0bcb7f05-599d-4e1a-adce-5cb89bfe58d5\",\n   \"summary\": \"This is a sample documentation for v1.0.0\",\n   \"name\": \"PhoneVerification API Documentation\",\n   \"type\": \"HOWTO\"\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_update"
+                        ]
+                    }
+                ],
                 "summary": "Update a document of an API",
                 "description": "This operation can be used to update metadata of an API's document.\n",
                 "parameters": [
@@ -1288,9 +1820,6 @@
                         "schema": {
                             "$ref": "#/definitions/Document"
                         }
-                    },
-                    {
-                        "$ref": "#/parameters/Content-Type"
                     },
                     {
                         "$ref": "#/parameters/If-Match"
@@ -1348,10 +1877,16 @@
                 }
             },
             "delete": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X DELETE https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/ffd5790d-b7a9-4cb6-b76a-f8b83ecdd058",
-                "x-wso2-request": "DELETE https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/ffd5790d-b7a9-4cb6-b76a-f8b83ecdd058\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X DELETE https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/ffd5790d-b7a9-4cb6-b76a-f8b83ecdd058",
+                "x-wso2-request": "DELETE https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/ffd5790d-b7a9-4cb6-b76a-f8b83ecdd058\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
                 "x-wso2-response": "HTTP/1.1 200 OK",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_delete"
+                        ]
+                    }
+                ],
                 "summary": "Delete a document of an API",
                 "description": "This operation can be used to delete a document associated with an API.\n",
                 "parameters": [
@@ -1392,21 +1927,20 @@
         },
         "/apis/{apiId}/documents/{documentId}/content": {
             "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -k -H \"Authorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\" \"https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/daf732d3-bda2-46da-b381-2c39d901ea61/content\" > sample.pdf",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/daf732d3-bda2-46da-b381-2c39d901ea61/content\nAuthorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\n",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "x-wso2-curl": "curl -k -H \"Authorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\" \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/daf732d3-bda2-46da-b381-2c39d901ea61/content\" > sample.pdf",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/daf732d3-bda2-46da-b381-2c39d901ea61/content\nAuthorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\n",
                 "x-wso2-response": "HTTP/1.1 200 OK\nContent-Disposition: attachment; filename=\"sample.pdf\"\nContent-Type: application/octet-stream\nContent-Length: 7802\n\n%PDF-1.4\n%äüöß\n2 0 obj\n<</Length 3 0 R/Filter/FlateDecode>>\nstream\n..\n>>\nstartxref\n7279\n%%EOF",
                 "summary": "Get the content of an API document",
-                "description": "This operation can be used to retrive the content of an API's document.\n\nThe document can be of 3 types. In each cases responses are different.\n\n1. **Inline type**:\n   The content of the document will be retrieved in `text/plain` content type\n\n   _Sample cURL_ : `curl -k -H \"Authorization:Bearer 579f0af4-37be-35c7-81a4-f1f1e9ee7c51\" -F inlineContent=@\"docs.txt\" -X POST \"https://localhost:9443/api/am/publisher/v0.14/apis/995a4972-3178-4b17-a374-756e0e19127c/documents/43c2bcce-60e7-405f-bc36-e39c0c5e189e/content`\n2. **FILE type**:\n   The file will be downloaded with the related content type (eg. `application/pdf`)\n3. **URL type**:\n    The client will recieve the URL of the document as the Location header with the response with - `303 See Other`\n",
+                "description": "This operation can be used to retrive the content of an API's document.\n\nThe document can be of 3 types. In each cases responses are different.\n\n1. **Inline type**:\n   The content of the document will be retrieved in `text/plain` content type\n2. **FILE type**:\n   The file will be downloaded with the related content type (eg. `application/pdf`)\n3. **URL type**:\n    The client will recieve the URL of the document as the Location header with the response with - `303 See Other`\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/apiId"
                     },
                     {
                         "$ref": "#/parameters/documentId"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
@@ -1466,10 +2000,16 @@
                 "consumes": [
                     "multipart/form-data"
                 ],
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization:Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -F file=@\"sample.pdf\" -X POST \"https://localhost:9443/api/am/publisher/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/daf732d3-bda2-46da-b381-2c39d901ea61/content\"",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/documents/b3a79270-02bb-4e39-9ac1-90ce8f6c84af/content\nAuthorization:Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\nContent-Length: 8004\nContent-Type: multipart/form-data; boundary=------------------------7b9a53f1ffa452b9\n\n--------------------------7b9a53f1ffa452b9\nContent-Disposition: form-data; name=\"file\"; filename=\"sample.pdf\"\nContent-Type: application/octet-stream\n\n[file content]\n\n--------------------------7b9a53f1ffa452b9--\n",
-                "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://localhost:9443/api/am/publisher/v0.14/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/documents/b3a79270-02bb-4e39-9ac1-90ce8f6c84af/content\nContent-Type: application/json\n\n{\n    \"visibility\":\"API_LEVEL\",\n    \"sourceType\":\"FILE\",\n    \"sourceUrl\":null,\n    \"otherTypeName\":null,\n    \"documentId\":\"daf732d3-bda2-46da-b381-2c39d901ea61\",\n    \"summary\":\"This is a sample documentation pdf\",\n    \"name\":\"Introduction to PhoneVerification API PDF\",\n    \"type\":\"HOWTO\"\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization:Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -F file=@\"sample.pdf\" -X POST \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/daf732d3-bda2-46da-b381-2c39d901ea61/content\"",
+                "x-wso2-request": "POST https://127.0.0.1:9443/api/am/publisher/v1.0/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/documents/b3a79270-02bb-4e39-9ac1-90ce8f6c84af/content\nAuthorization:Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\nContent-Length: 8004\nContent-Type: multipart/form-data; boundary=------------------------7b9a53f1ffa452b9\n\n--------------------------7b9a53f1ffa452b9\nContent-Disposition: form-data; name=\"file\"; filename=\"sample.pdf\"\nContent-Type: application/octet-stream\n\n[file content]\n\n--------------------------7b9a53f1ffa452b9--\n",
+                "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://127.0.0.1:9443/api/am/publisher/v1.0/apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/documents/b3a79270-02bb-4e39-9ac1-90ce8f6c84af/content\nContent-Type: application/json\n\n{\n    \"visibility\":\"API_LEVEL\",\n    \"sourceType\":\"FILE\",\n    \"sourceUrl\":null,\n    \"otherTypeName\":null,\n    \"documentId\":\"daf732d3-bda2-46da-b381-2c39d901ea61\",\n    \"summary\":\"This is a sample documentation pdf\",\n    \"name\":\"Introduction to PhoneVerification API PDF\",\n    \"type\":\"HOWTO\"\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
                 "summary": "Upload the content of an API document",
                 "description": "Thid operation can be used to upload a file or add inline content to an API document.\n\n**IMPORTANT:**\n* Either **file** or **inlineContent** form data parameters should be specified at one time.\n* Document's source type should be **FILE** in order to upload a file to the document using **file** parameter.\n* Document's source type should be **INLINE** in order to add inline content to the document using **inlineContent** parameter.\n",
                 "parameters": [
@@ -1492,9 +2032,6 @@
                         "description": "Inline content of the document",
                         "type": "string",
                         "required": false
-                    },
-                    {
-                        "$ref": "#/parameters/Content-Type"
                     },
                     {
                         "$ref": "#/parameters/If-Match"
@@ -1552,49 +2089,33 @@
                 }
             }
         },
-        "/apis/{apiId}/policies/mediation": {
+        "/apis/{apiId}/scopes": {
             "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer fb2a0784-f60c-3276-8fde-5b0f70e61ecc\" https://localhost:9443/api/am/publisher/v0.14/apis/40082986-6488-4b86-801a-b0b069d4588c/policies/mediation",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/apis/40082986-6488-4b86-801a-b0b069d4588c/policies/mediation\r\nAuthorization: Bearer fb2a0784-f60c-3276-8fde-5b0f70e61ecc",
-                "x-wso2-response": "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\r\n   \"count\": 1,\r\n   \"next\": null,\r\n   \"previous\": null,\r\n   \"list\": [   {\r\n      \"name\": \"add_custom_header_fault\",\r\n      \"id\": \"6460d7e6-4272-4e3a-9879-437228d83123\",\r\n      \"type\": \"fault\"\r\n   }]\r\n}",
-                "summary": "Get all mediation policies of an API\n",
-                "description": "This operation provides you a list of available mediation policies of an API.\n",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/scopes\"",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/scopes\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json",
+                "summary": "Get a list of scopes of an API",
+                "description": "This operation can be used to retrieve a list of scopes belonging to an API by providing the id of the API.\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/apiId"
-                    },
-                    {
-                        "$ref": "#/parameters/limit"
-                    },
-                    {
-                        "$ref": "#/parameters/offset"
-                    },
-                    {
-                        "name": "query",
-                        "in": "query",
-                        "description": "-Not supported yet-",
-                        "type": "string"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
                     }
                 ],
                 "tags": [
-                    "Mediation Policy (Collection)"
+                    "Scope (Collection)"
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK.\nList of qualifying APIs is returned.\n",
+                        "description": "OK.\nScope list is returned.\n",
                         "schema": {
-                            "$ref": "#/definitions/mediationList"
+                            "$ref": "#/definitions/ScopeList"
                         },
                         "headers": {
                             "Content-Type": {
-                                "description": "The content type of the body.",
+                                "description": "The content type of the body.\n",
                                 "type": "string"
                             },
                             "ETag": {
@@ -1606,6 +2127,12 @@
                     "304": {
                         "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
                     },
+                    "404": {
+                        "description": "Not Found.\nRequested API does not exist.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
                     "406": {
                         "description": "Not Acceptable.\nThe requested media type is not supported\n",
                         "schema": {
@@ -1615,27 +2142,30 @@
                 }
             },
             "post": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer 6cea3696-0151-3282-bf79-a0c4db6f308a\" -H \"Content-Type: application/json\" -X POST -d @data.json \"https://localhost:9443/api/am/publisher/v0.14/apis/40082986-6488-4b86-801a-b0b069d4588c/policies/mediation\"",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/apis/40082986-6488-4b86-801a-b0b069d4588c/policies/mediation\r\nContent-Type: application/json\r\nAuthorization: Bearer 6cea3696-0151-3282-bf79-a0c4db6f308a\r\n\r\n{\r\n   \"name\": \"add_custom_header_fault\",\r\n   \"type\": \"fault\",\r\n   \"config\": \"<sequence xmlns=\\\"http://ws.apache.org/ns/synapse\\\" name=\\\"add_custom_header_fault\\\">\\n    <property name=\\\"CustomHeader\\\" scope=\\\"transport\\\" value=\\\"example\\\"/>\\n<\\/sequence>\\n\"\r\n}",
-                "x-wso2-response": "HTTP/1.1 201 Created\r\nLocation: https://localhost:9443/api/am/publisher/v0.14/registry/resource/_system/governance/apimgt/applicationdata/provider/admin/hello/1.0.0/fault/add_custom_header_fault.xml\r\nContent-Type: application/json\r\n\r\n{  \r\n   \"id\":\"624b9f7d-bfaf-484b-94cc-e84491f5d725\",\r\n   \"name\":\"add_custom_header_fault\",\r\n   \"type\":\"fault\",\r\n   \"config\":\"<sequence xmlns=\\\"http://ws.apache.org/ns/synapse\\\" name=\\\"add_custom_header_fault\\\">\\n    <property name=\\\"CustomHeader\\\" scope=\\\"transport\\\" value=\\\"example\\\"/>\\n</sequence>\\n\"\r\n}",
-                "summary": "Add an API specific mediation policy",
-                "description": "This operation can be used to add an API specifc mediation policy.\n",
-                "parameters": [
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/scopes\"",
+                "x-wso2-request": "POST https://127.0.0.1:9443/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/scopes\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\nContent-Type: application/json",
+                "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/scopes/ffd5790d-b7a9-4cb6-b76a-f8b83ecdd058\nContent-Type: application/json",
+                "security": [
                     {
-                        "in": "body",
-                        "name": "body",
-                        "description": "mediation policy to upload",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/Mediation"
-                        }
-                    },
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
+                "summary": "Add a new scope to an API",
+                "description": "This operation can be used to add a new scope to an API.\n",
+                "parameters": [
                     {
                         "$ref": "#/parameters/apiId"
                     },
                     {
-                        "$ref": "#/parameters/Content-Type"
+                        "in": "body",
+                        "name": "body",
+                        "description": "Scope object that needs to be added\n",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Scope"
+                        }
                     },
                     {
                         "$ref": "#/parameters/If-Match"
@@ -1645,17 +2175,151 @@
                     }
                 ],
                 "tags": [
-                    "Mediation Policy (Collection)"
+                    "Scope (Collection)"
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK.\nmediation policy uploaded\n",
+                    "201": {
+                        "description": "Created.\nSuccessful response with the newly created Scope object as entity in the body.\nLocation header contains URL of newly added scope.\n",
                         "schema": {
-                            "$ref": "#/definitions/Mediation"
+                            "$ref": "#/definitions/Scope"
                         },
                         "headers": {
                             "Location": {
-                                "description": "The URL of the uploaded thumbnail image of the API.\n",
+                                "description": "Location to the newly created Scope.\n",
+                                "type": "string"
+                            },
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            },
+                            "ETag": {
+                                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request.\nInvalid request or validation error\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported media type.\nThe entity of the request was in a not supported format.\n"
+                    }
+                }
+            }
+        },
+        "/apis/{apiId}/scopes/{name}": {
+            "get": {
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/scopes/read\"",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/scopes/read\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n",
+                "summary": "Get a scope of an API",
+                "description": "This operation can be used to retrieve a particular scope's metadata associated with an API.\n",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiId"
+                    },
+                    {
+                        "$ref": "#/parameters/scopeName"
+                    },
+                    {
+                        "$ref": "#/parameters/If-None-Match"
+                    },
+                    {
+                        "$ref": "#/parameters/If-Modified-Since"
+                    }
+                ],
+                "tags": [
+                    "Scope (Individual)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nScope returned.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Scope"
+                        },
+                        "headers": {
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            },
+                            "ETag": {
+                                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            },
+                            "Last-Modified": {
+                                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "304": {
+                        "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+                    },
+                    "404": {
+                        "description": "Not Found.\nRequested Scope does not exist.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "406": {
+                        "description": "Not Acceptable.\nThe requested media type is not supported\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "x-wso2-curl": "curl -k -H \"Authorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\" -H \"Content-Type: application/json\" -X PUT -d data.json \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/scopes/read\"",
+                "x-wso2-request": "PUT https://127.0.0.1:9443/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/scopes/read\nAuthorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\nContent-Type: application/json\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_update"
+                        ]
+                    }
+                ],
+                "summary": "Update a Scope of an API",
+                "description": "This operation can be used to update scope of an API\n",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiId"
+                    },
+                    {
+                        "$ref": "#/parameters/scopeName"
+                    },
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "Scope object that needs to be added\n",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Scope"
+                        }
+                    },
+                    {
+                        "$ref": "#/parameters/If-Match"
+                    },
+                    {
+                        "$ref": "#/parameters/If-Unmodified-Since"
+                    }
+                ],
+                "tags": [
+                    "Scope (Individual)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nScope updated\n",
+                        "schema": {
+                            "$ref": "#/definitions/Scope"
+                        },
+                        "headers": {
+                            "Location": {
+                                "description": "The URL of the updated scope.\n",
                                 "type": "string"
                             },
                             "Content-Type": {
@@ -1691,25 +2355,66 @@
                         }
                     }
                 }
-            }
-        },
-        "/apis/{apiId}/policies/mediation/{mediationPolicyId}": {
-            "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer 5aa0acc0-0ce3-3a0b-8cc8-db5ef696ee23\" https://localhost:9443/api/am/publisher/v0.14/apis/40082986-6488-4b86-801a-b0b069d4588c/policies/mediation/624b9f7d-bfaf-484b-94cc-e84491f5d725",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/apis/40082986-6488-4b86-801a-b0b069d4588c/policies/mediation/624b9f7d-bfaf-484b-94cc-e84491f5d725\r\nAuthorization: Bearer 5aa0acc0-0ce3-3a0b-8cc8-db5ef696ee23",
-                "x-wso2-response": "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\r\n   \"id\": \"624b9f7d-bfaf-484b-94cc-e84491f5d725\",\r\n   \"name\": \"add_custom_header_fault\",\r\n   \"type\": \"fault\",\r\n   \"config\": \"<sequence xmlns=\\\"http://ws.apache.org/ns/synapse\\\" name=\\\"add_custom_header_fault\\\">\\n    <property name=\\\"CustomHeader\\\" scope=\\\"transport\\\" value=\\\"example\\\"/>\\n<\\/sequence>\\n\"\r\n}",
-                "summary": "Get an API specific mediation policy",
-                "description": "This operation can be used to retrieve a particular API specific mediation policy.\n",
+            },
+            "delete": {
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X DELETE https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/scopes/ffd5790d-b7a9-4cb6-b76a-f8b83ecdd058",
+                "x-wso2-request": "DELETE https://127.0.0.1:9443/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/scopes/ffd5790d-b7a9-4cb6-b76a-f8b83ecdd058\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_delete"
+                        ]
+                    }
+                ],
+                "summary": "Delete a scope of an API",
+                "description": "This operation can be used to delete a scope associated with an API.\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/apiId"
                     },
                     {
-                        "$ref": "#/parameters/mediationPolicyId"
+                        "$ref": "#/parameters/scopeName"
                     },
                     {
-                        "$ref": "#/parameters/Accept"
+                        "$ref": "#/parameters/If-Match"
+                    },
+                    {
+                        "$ref": "#/parameters/If-Unmodified-Since"
+                    }
+                ],
+                "tags": [
+                    "Scope (Individual)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nResource successfully deleted.\n"
+                    },
+                    "404": {
+                        "description": "Not Found.\nResource to be deleted does not exist.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "412": {
+                        "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/apis/{apiId}/dedicated-gateway": {
+            "get": {
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9292/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/dedicatedGateway",
+                "x-wso2-request": "GET https://127.0.0.1:9292/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/dedicatedGateway\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n\"isEnabled\":true\n}",
+                "summary": "Get enability of dedicatedGateway",
+                "description": "This operation can be used to retrieve whether the dedicated gateway is enabled in a certain API.\n",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/apiId"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
@@ -1719,13 +2424,13 @@
                     }
                 ],
                 "tags": [
-                    "Mediation Policy (Individual)"
+                    "DedicatedGateway (Individual)"
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK.\nMediation policy returned.\n",
+                        "description": "OK.\nisEnabled of dedicated Gateway returned\n",
                         "schema": {
-                            "$ref": "#/definitions/Mediation"
+                            "$ref": "#/definitions/DedicatedGateway"
                         },
                         "headers": {
                             "Content-Type": {
@@ -1746,61 +2451,13 @@
                         "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
                     },
                     "404": {
-                        "description": "Not Found.\nRequested Document does not exist.\n",
+                        "description": "Not Found.\nRequested Dedicated Gateway does not exist.\n",
                         "schema": {
                             "$ref": "#/definitions/Error"
                         }
                     },
                     "406": {
-                        "description": "Not Acceptable.\nThe requested media type is not supported\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer fb2a0784-f60c-3276-8fde-5b0f70e61ecc\" -X DELETE https://localhost:9443/api/am/publisher/v0.14/apis/40082986-6488-4b86-801a-b0b069d4588c/policies/mediation/60f5146d-1774-405d-86b3-9b040ac266d5",
-                "x-wso2-request": "DELETE https://localhost:9443/api/am/publisher/v0.14/apis/40082986-6488-4b86-801a-b0b069d4588c/policies/mediation/60f5146d-1774-405d-86b3-9b040ac266d5\r\nAuthorization: Bearer fb2a0784-f60c-3276-8fde-5b0f70e61ecc",
-                "x-wso2-response": "HTTP/1.1 200 OK",
-                "summary": "Delete an API specific mediation policy",
-                "description": "This operation can be used to delete an existing API specific mediation policy providing the Id of the API and the Id of the mediation policy.\n",
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/apiId"
-                    },
-                    {
-                        "$ref": "#/parameters/mediationPolicyId"
-                    },
-                    {
-                        "$ref": "#/parameters/If-Match"
-                    },
-                    {
-                        "$ref": "#/parameters/If-Unmodified-Since"
-                    }
-                ],
-                "tags": [
-                    "Mediation Policy (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\nResource successfully deleted.\n"
-                    },
-                    "403": {
-                        "description": "Forbidden.\nThe request must be conditional but no condition has been specified.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found.\nResource to be deleted does not exist.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "412": {
-                        "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+                        "description": "Not Acceptable.\nThe requested media type is not supported.\n",
                         "schema": {
                             "$ref": "#/definitions/Error"
                         }
@@ -1808,30 +2465,31 @@
                 }
             },
             "put": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer 9e41fae2-3ada-3dd1-8f12-2077202f4285\" -H \"Content-Type: application/json\" -X PUT -d @data.json https://localhost:9443/api/am/publisher/v0.14/apis/40082986-6488-4b86-801a-b0b069d4588c/policies/mediation/820fdcf7-7258-42b5-809e-674b893644d1",
-                "x-wso2-request": "PUT https://localhost:9443/api/am/publisher/v0.14/apis/40082986-6488-4b86-801a-b0b069d4588c/policies/mediation/820fdcf7-7258-42b5-809e-674b893644d1\r\nContent-Type: application/json\r\nAuthorization: Bearer 9e41fae2-3ada-3dd1-8f12-2077202f4285\r\n\r\n{\r\n   \"name\": \"add_custom_header_fault\",\r\n   \"type\": \"fault\",\r\n   \"config\": \"<sequence xmlns=\\\"http://ws.apache.org/ns/synapse\\\" name=\\\"add_custom_header_fault\\\">\\n    <property name=\\\"CustomHeader\\\" scope=\\\"transport\\\" value=\\\"example\\\"/>\\n<\\/sequence>\\n\"\r\n}",
-                "x-wso2-response": "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\r\n   \"id\": \"a7365481-5b3f-463c-a646-a498895ac210\",\r\n   \"name\": \"add_custom_header_fault\",\r\n   \"type\": \"fault\",\r\n   \"config\": \"<sequence xmlns=\\\"http://ws.apache.org/ns/synapse\\\" name=\\\"add_custom_header_fault\\\">\\n    <property name=\\\"CustomHeader\\\" scope=\\\"transport\\\" value=\\\"example\\\"/>\\n<\\/sequence>\\n\"\r\n}",
-                "summary": "Update an API specific mediation policy",
-                "description": "This operation can be used to update an existing mediation policy of an API.\n",
+                "x-wso2-curl": "curl -k -H \"Authorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\" -H \"Content-Type: application/json\" -X PUT -d data.json \"https://127.0.0.1:9292/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/dedicatedGateway",
+                "x-wso2-request": "PUT https://127.0.0.1:9292/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/dedicatedGateway\nAuthorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\nContent-Type: application/json\n\n{\n   \"isEnabled\": \"true\"\n}",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"enabled\": \"true\"\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:dedicated_gateway"
+                        ]
+                    }
+                ],
+                "x-scopes": "apim:dedicated_gateway",
+                "summary": "Update enabling of dedicated Gateway of API",
+                "description": "This operation can be used to update metadata of an API's dedicatedGateway.\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/apiId"
                     },
                     {
-                        "$ref": "#/parameters/mediationPolicyId"
-                    },
-                    {
                         "in": "body",
                         "name": "body",
-                        "description": "Mediation policy object that needs to be updated\n",
+                        "description": "dedicated Gateway object that needs to be added\n",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/Mediation"
+                            "$ref": "#/definitions/DedicatedGateway"
                         }
-                    },
-                    {
-                        "$ref": "#/parameters/Content-Type"
                     },
                     {
                         "$ref": "#/parameters/If-Match"
@@ -1841,25 +2499,21 @@
                     }
                 ],
                 "tags": [
-                    "Mediation Policy (Individual)"
+                    "DedicatedGateway (Individual)"
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK.\nSuccessful response with updated API object\n",
+                        "description": "OK.\nDedicated Gateway of API updated\n",
                         "schema": {
-                            "$ref": "#/definitions/Mediation"
+                            "$ref": "#/definitions/DedicatedGateway"
                         },
                         "headers": {
-                            "Location": {
-                                "description": "The URL of the newly created resource.\n",
-                                "type": "string"
-                            },
                             "Content-Type": {
                                 "description": "The content type of the body.\n",
                                 "type": "string"
                             },
                             "ETag": {
-                                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
                                 "type": "string"
                             },
                             "Last-Modified": {
@@ -1869,13 +2523,7 @@
                         }
                     },
                     "400": {
-                        "description": "Bad Request.\nInvalid request or validation error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden.\nThe request must be conditional but no condition has been specified.\n",
+                        "description": "Bad Request.\nInvalid request or validation error.\n",
                         "schema": {
                             "$ref": "#/definitions/Error"
                         }
@@ -1895,54 +2543,46 @@
                 }
             }
         },
-        "/apis/{apiId}/wsdl": {
+        "/export/apis": {
             "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/publisher/v0.14/apis/7f82f6b0-2667-441e-af23-c0fc44cf3a17/wsdl\"",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/apis/7f82f6b0-2667-441e-af23-c0fc44cf3a17/wsdl\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\r\n   \"name\": \"admin--hello1.0.0.wsdl\",\r\n   \"wsdlDefinition\": \"<definitions xmlns=\\\"http://schemas.xmlsoap.org/wsdl/\\\" xmlns:xsd=\\\"http://www.w3.org/2001/XMLSchema\\\" xmlns:soap=\\\"http://schemas.xmlsoap.org/wsdl/soap/\\\" xmlns:tns=\\\"http://www.examples.com/wsdl/HelloService.wsdl\\\" name=\\\"HelloService\\\" targetNamespace=\\\"http://www.examples.com/wsdl/HelloService.wsdl\\\">\\n  <message name=\\\"SayHelloResponse\\\">\\n    <part name=\\\"greeting\\\" type=\\\"xsd:string\\\">\\n    <\\/part>\\n  <\\/message>\\n  <message name=\\\"SayHelloRequest\\\">\\n    <part name=\\\"firstName\\\" type=\\\"xsd:string\\\">\\n    <\\/part>\\n  <\\/message>\\n  <portType name=\\\"Hello_PortType\\\">\\n    <operation name=\\\"sayHello\\\">\\n      <input message=\\\"tns:SayHelloRequest\\\">\\n    <\\/input>\\n      <output message=\\\"tns:SayHelloResponse\\\">\\n    <\\/output>\\n    <\\/operation>\\n  <\\/portType>\\n  <binding name=\\\"Hello_Binding\\\" type=\\\"tns:Hello_PortType\\\">\\n    <soap:binding style=\\\"rpc\\\" transport=\\\"http://schemas.xmlsoap.org/soap/http\\\"/>\\n    <operation name=\\\"sayHello\\\">\\n      <soap:operation soapAction=\\\"sayHello\\\"/>\\n      <input>\\n        <soap:body use=\\\"encoded\\\" encodingStyle=\\\"http://schemas.xmlsoap.org/soap/encoding/\\\" namespace=\\\"urn:examples:helloservice\\\"/>\\n      <\\/input>\\n      <output>\\n        <soap:body use=\\\"encoded\\\" encodingStyle=\\\"http://schemas.xmlsoap.org/soap/encoding/\\\" namespace=\\\"urn:examples:helloservice\\\"/>\\n      <\\/output>\\n    <\\/operation>\\n  <\\/binding>\\n  <service name=\\\"Hello_Service\\\">\\n<documentation>WSDL File for HelloService<\\/documentation>\\n    <port name=\\\"Hello_Port\\\" binding=\\\"tns:Hello_Binding\\\">\\n      <soap:address location=\\\"http://localhost:8280/hellp/1.0.0\\\"/>\\n    <\\/port>\\n  <\\/service>\\n<\\/definitions>\"\r\n}",
-                "summary": "Get the WSDL of an API",
-                "description": "This operation can be used to retrieve the WSDL definition of an API.\n",
+                "produces": [
+                    "application/zip"
+                ],
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9292/api/am/publisher/v1.0/export/apis?query=xxx > exported-apis.zip",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/export/apis?query=xxx\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\n Connection: keep-alive\n  Content-Disposition: attachment; filename=\"exported-apis.zip\"\n  Content-Type: application/zip",
+                "summary": "Export information related to an API.",
+                "description": "This operation can be used to export information related to a particular API.\n",
                 "parameters": [
                     {
-                        "$ref": "#/parameters/apiId"
+                        "name": "query",
+                        "in": "query",
+                        "description": "API search query\n",
+                        "required": true,
+                        "type": "string"
                     },
                     {
-                        "$ref": "#/parameters/Accept"
+                        "$ref": "#/parameters/limit"
                     },
                     {
-                        "$ref": "#/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/parameters/If-Modified-Since"
+                        "$ref": "#/parameters/offset"
                     }
                 ],
                 "tags": [
-                    "Wsdl (Individual)"
+                    "Export Configuration"
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK.\nRequested WSDL DTO object belongs to the API\n",
-                        "schema": {
-                            "$ref": "#/definitions/Wsdl"
-                        },
+                        "description": "OK.\nExport Configuration returned.\n",
                         "headers": {
                             "Content-Type": {
                                 "description": "The content type of the body.\n",
                                 "type": "string"
-                            },
-                            "ETag": {
-                                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
-                                "type": "string"
-                            },
-                            "Last-Modified": {
-                                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
-                                "type": "string"
                             }
+                        },
+                        "schema": {
+                            "type": "file"
                         }
-                    },
-                    "304": {
-                        "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
                     },
                     "404": {
                         "description": "Not Found.\nRequested API does not exist.\n",
@@ -1955,60 +2595,61 @@
                         "schema": {
                             "$ref": "#/definitions/Error"
                         }
+                    },
+                    "412": {
+                        "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
                     }
                 }
-            },
-            "post": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\" -H \"Content-Type: application/json\" -X POST -d @data.json \"https://localhost:9443/api/am/publisher/v0.14/apis/af3f96da-9ccf-463f-8cee-13ec8530a9cd/wsdl\"",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/apis/af3f96da-9ccf-463f-8cee-13ec8530a9cd/wsdl\r\nContent-Type: application/json\r\nAuthorization: Bearer 7d237cab-7011-3f81-b384-24d03e750873\r\n\r\n{\r\n   \"name\": \"admin--PizzaShackAPI1.0.0.wsdl\",\r\n   \"wsdlDefinition\": \"<definitions xmlns=\\\"http://schemas.xmlsoap.org/wsdl/\\\" xmlns:xsd=\\\"http://www.w3.org/2001/XMLSchema\\\" xmlns:soap=\\\"http://schemas.xmlsoap.org/wsdl/soap/\\\" xmlns:tns=\\\"http://www.examples.com/wsdl/HelloService.wsdl\\\" name=\\\"HelloService\\\" targetNamespace=\\\"http://www.examples.com/wsdl/HelloService.wsdl\\\">\\n  <message name=\\\"SayHelloResponse\\\">\\n    <part name=\\\"greeting\\\" type=\\\"xsd:string\\\">\\n    <\\/part>\\n  <\\/message>\\n  <message name=\\\"SayHelloRequest\\\">\\n    <part name=\\\"firstName\\\" type=\\\"xsd:string\\\">\\n    <\\/part>\\n  <\\/message>\\n  <portType name=\\\"Hello_PortType\\\">\\n    <operation name=\\\"sayHello\\\">\\n      <input message=\\\"tns:SayHelloRequest\\\">\\n    <\\/input>\\n      <output message=\\\"tns:SayHelloResponse\\\">\\n    <\\/output>\\n    <\\/operation>\\n  <\\/portType>\\n  <binding name=\\\"Hello_Binding\\\" type=\\\"tns:Hello_PortType\\\">\\n    <soap:binding style=\\\"rpc\\\" transport=\\\"http://schemas.xmlsoap.org/soap/http\\\"/>\\n    <operation name=\\\"sayHello\\\">\\n      <soap:operation soapAction=\\\"sayHello\\\"/>\\n      <input>\\n        <soap:body use=\\\"encoded\\\" encodingStyle=\\\"http://schemas.xmlsoap.org/soap/encoding/\\\" namespace=\\\"urn:examples:helloservice\\\"/>\\n      <\\/input>\\n      <output>\\n        <soap:body use=\\\"encoded\\\" encodingStyle=\\\"http://schemas.xmlsoap.org/soap/encoding/\\\" namespace=\\\"urn:examples:helloservice\\\"/>\\n      <\\/output>\\n    <\\/operation>\\n  <\\/binding>\\n  <service name=\\\"Hello_Service\\\">\\n<documentation>WSDL File for HelloService<\\/documentation>\\n    <port name=\\\"Hello_Port\\\" binding=\\\"tns:Hello_Binding\\\">\\n      <soap:address location=\\\"http://localhost:8280/hellp/1.0.0\\\"/>\\n    <\\/port>\\n  <\\/service>\\n<\\/definitions>\"\r\n}",
-                "x-wso2-response": "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\r\n   \"name\": \"admin--PizzaShackAPI1.0.0.wsdl\",\r\n   \"wsdlDefinition\": \"<definitions xmlns=\\\"http://schemas.xmlsoap.org/wsdl/\\\" xmlns:xsd=\\\"http://www.w3.org/2001/XMLSchema\\\" xmlns:soap=\\\"http://schemas.xmlsoap.org/wsdl/soap/\\\" xmlns:tns=\\\"http://www.examples.com/wsdl/HelloService.wsdl\\\" name=\\\"HelloService\\\" targetNamespace=\\\"http://www.examples.com/wsdl/HelloService.wsdl\\\">\\n  <message name=\\\"SayHelloResponse\\\">\\n    <part name=\\\"greeting\\\" type=\\\"xsd:string\\\">\\n    <\\/part>\\n  <\\/message>\\n  <message name=\\\"SayHelloRequest\\\">\\n    <part name=\\\"firstName\\\" type=\\\"xsd:string\\\">\\n    <\\/part>\\n  <\\/message>\\n  <portType name=\\\"Hello_PortType\\\">\\n    <operation name=\\\"sayHello\\\">\\n      <input message=\\\"tns:SayHelloRequest\\\">\\n    <\\/input>\\n      <output message=\\\"tns:SayHelloResponse\\\">\\n    <\\/output>\\n    <\\/operation>\\n  <\\/portType>\\n  <binding name=\\\"Hello_Binding\\\" type=\\\"tns:Hello_PortType\\\">\\n    <soap:binding style=\\\"rpc\\\" transport=\\\"http://schemas.xmlsoap.org/soap/http\\\"/>\\n    <operation name=\\\"sayHello\\\">\\n      <soap:operation soapAction=\\\"sayHello\\\"/>\\n      <input>\\n        <soap:body use=\\\"encoded\\\" encodingStyle=\\\"http://schemas.xmlsoap.org/soap/encoding/\\\" namespace=\\\"urn:examples:helloservice\\\"/>\\n      <\\/input>\\n      <output>\\n        <soap:body use=\\\"encoded\\\" encodingStyle=\\\"http://schemas.xmlsoap.org/soap/encoding/\\\" namespace=\\\"urn:examples:helloservice\\\"/>\\n      <\\/output>\\n    <\\/operation>\\n  <\\/binding>\\n  <service name=\\\"Hello_Service\\\">\\n<documentation>WSDL File for HelloService<\\/documentation>\\n    <port name=\\\"Hello_Port\\\" binding=\\\"tns:Hello_Binding\\\">\\n      <soap:address location=\\\"http://localhost:8280/hellp/1.0.0\\\"/>\\n    <\\/port>\\n  <\\/service>\\n<\\/definitions>\"\r\n}",
-                "summary": "Add a WSDL to an API",
-                "description": "This operation can be used to add a WSDL definition to an existing API.\n",
+            }
+        },
+        "/import/apis": {
+            "put": {
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "x-wso2-curl": "curl -k -F \"file=@exported.zip\" -X PUT -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9292/api/am/publisher/v1.0/import/apis",
+                "x-wso2-request": "PUT https://127.0.0.1:9292/api/am/publisher/v1.0/import/apis\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\"count\":2,\"list\":[{\"id\":\"4df90edc-f76b-4b19-bf57-7d161fa04467\",\"name\":\"testApi2\",\"context\":\"/test2\",\"version\":\"2.0.3\",\"provider\":\"admin\",\"lifeCycleStatus\":\"Created\",\"workflowStatus\":\"APPROVED\"},{\"id\":\"4066bc9e-1d87-4296-bcca-f6e38d3da6d0\",\"name\":\"testApi\",\"context\":\"/testApi\",\"version\":\"1.0.0\",\"provider\":\"admin\",\"lifeCycleStatus\":\"Created\",\"workflowStatus\":\"APPROVED\"}]}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_update"
+                        ]
+                    }
+                ],
+                "summary": "Imports API(s).",
+                "description": "This operation can be used to import one or more existing APIs.\n",
                 "parameters": [
                     {
-                        "$ref": "#/parameters/apiId"
-                    },
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "JSON payload including WSDL definition that needs to be added\n",
+                        "name": "file",
+                        "in": "formData",
+                        "description": "Zip archive consisting on exported api configuration\n",
                         "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/Wsdl"
-                        }
+                        "type": "file"
                     },
                     {
-                        "$ref": "#/parameters/Content-Type"
-                    },
-                    {
-                        "$ref": "#/parameters/If-Match"
-                    },
-                    {
-                        "$ref": "#/parameters/If-Unmodified-Since"
+                        "name": "provider",
+                        "in": "query",
+                        "description": "If defined, updates the existing provider of each API with the specified provider.\nThis is to cater scenarios where the current API provider does not exist in the environment\nthat the API is imported to.\n",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "tags": [
-                    "Wsdl (Individual)"
+                    "Import Configuration"
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK.\nSuccessful response with updated wsdl definition\n",
+                        "description": "OK.\nSuccessful response with the updated object as entity in the body.\n",
+                        "schema": {
+                            "$ref": "#/definitions/APIList"
+                        },
                         "headers": {
-                            "Location": {
-                                "description": "The URL of the newly created resource.\n",
-                                "type": "string"
-                            },
                             "Content-Type": {
                                 "description": "The content type of the body.\n",
-                                "type": "string"
-                            },
-                            "ETag": {
-                                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
-                                "type": "string"
-                            },
-                            "Last-Modified": {
-                                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
                                 "type": "string"
                             }
                         }
@@ -2019,14 +2660,76 @@
                             "$ref": "#/definitions/Error"
                         }
                     },
-                    "403": {
-                        "description": "Forbidden.\nThe request must be conditional but no condition has been specified.\n",
+                    "406": {
+                        "description": "Not Acceptable.\nThe requested media type is not supported\n",
                         "schema": {
                             "$ref": "#/definitions/Error"
                         }
                     },
-                    "404": {
-                        "description": "Not Found.\nThe resource to be updated does not exist.\n",
+                    "412": {
+                        "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "x-wso2-curl": "curl -k -F \"file=@exported.zip\" -X POST -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9292/api/am/publisher/v1.0/import/apis",
+                "x-wso2-request": "POST https://127.0.0.1:9292/api/am/publisher/v1.0/import/apis\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\"count\":2,\"list\":[{\"id\":\"4df90edc-f76b-4b19-bf57-7d161fa04467\",\"name\":\"testApi2\",\"context\":\"/test2\",\"version\":\"2.0.3\",\"provider\":\"admin\",\"lifeCycleStatus\":\"Created\",\"workflowStatus\":\"APPROVED\"},{\"id\":\"4066bc9e-1d87-4296-bcca-f6e38d3da6d0\",\"name\":\"testApi\",\"context\":\"/testApi\",\"version\":\"1.0.0\",\"provider\":\"admin\",\"lifeCycleStatus\":\"Created\",\"workflowStatus\":\"APPROVED\"}]}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
+                "summary": "Imports API(s).",
+                "description": "This operation can be used to import one or more existing APIs.\n",
+                "parameters": [
+                    {
+                        "name": "file",
+                        "in": "formData",
+                        "description": "Zip archive consisting on exported api configuration\n",
+                        "required": true,
+                        "type": "file"
+                    },
+                    {
+                        "name": "provider",
+                        "in": "query",
+                        "description": "If defined, updates the existing provider of each API with the specified provider.\nThis is to cater scenarios where the current API provider does not exist in the environment\nthat the API is imported to.\n",
+                        "required": false,
+                        "type": "string"
+                    }
+                ],
+                "tags": [
+                    "Import Configuration"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nSuccessful response with the updated object as entity in the body.\n",
+                        "schema": {
+                            "$ref": "#/definitions/APIList"
+                        },
+                        "headers": {
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request.\nInvalid request or validation error\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "406": {
+                        "description": "Not Acceptable.\nThe requested media type is not supported\n",
                         "schema": {
                             "$ref": "#/definitions/Error"
                         }
@@ -2040,78 +2743,20 @@
                 }
             }
         },
-        "/applications/{applicationId}": {
-            "get": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/publisher/v0.14/applications/896658a0-b4ee-4535-bbfa-806c894a4015",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/applications/896658a0-b4ee-4535-bbfa-806c894a4015\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"groupId\": \"\",\n   \"subscriber\": \"admin\",\n   \"throttlingTier\": \"Unlimited\",\n   \"applicationId\": \"896658a0-b4ee-4535-bbfa-806c894a4015\",\n   \"description\": null,\n   \"name\": \"DefaultApplication\"\n}",
-                "summary": "Get details of an application",
-                "description": "This operation can be used to retrieve details of an individual application specifying the application id in the URI.\n",
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/applicationId"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
-                    },
-                    {
-                        "$ref": "#/parameters/If-None-Match"
-                    },
-                    {
-                        "$ref": "#/parameters/If-Modified-Since"
-                    }
-                ],
-                "tags": [
-                    "Application (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\nApplication returned.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Application"
-                        },
-                        "headers": {
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            },
-                            "ETag": {
-                                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
-                                "type": "string"
-                            },
-                            "Last-Modified": {
-                                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "304": {
-                        "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
-                    },
-                    "404": {
-                        "description": "Not Found.\nRequested application does not exist.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "406": {
-                        "description": "Not Acceptable.\nThe requested media type is not supported\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            }
-        },
         "/subscriptions": {
             "get": {
-                "x-scope": "apim:subscription_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/publisher/v0.14/subscriptions?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b\"",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/subscriptions?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n \n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"subscriptionId\": \"64eca60b-2e55-4c38-8603-e9e6bad7d809\",\n         \"tier\": \"Gold\",\n         \"apiIdentifier\": \"admin-PhoneVerification-1.0.0\",\n         \"applicationId\": \"896658a0-b4ee-4535-bbfa-806c894a4015\",\n         \"status\": \"UNBLOCKED\"\n      },\n            {\n         \"subscriptionId\": \"7ac22c34-8745-4cfe-91e0-262c50b2f2e3\",\n         \"tier\": \"Gold\",\n         \"apiIdentifier\": \"admin-PhoneVerification-1.0.0\",\n         \"applicationId\": \"367a2361-8db5-4140-8133-c6c8dc7fa0c4\",\n         \"status\": \"UNBLOCKED\"\n      }\n   ],\n   \"next\": \"\",\n   \"count\": 2\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://127.0.0.1:9443/api/am/publisher/v1.0/subscriptions?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b\"",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/subscriptions?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n \n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"subscriptionId\": \"64eca60b-2e55-4c38-8603-e9e6bad7d809\",\n         \"policy\": \"Gold\",\n         \"apiIdentifier\": \"admin-PhoneVerification-1.0.0\",\n         \"applicationId\": \"896658a0-b4ee-4535-bbfa-806c894a4015\",\n         \"lifeCycleStatus\": \"UNBLOCKED\"\n      },\n            {\n         \"subscriptionId\": \"7ac22c34-8745-4cfe-91e0-262c50b2f2e3\",\n         \"policy\": \"Gold\",\n         \"apiIdentifier\": \"admin-PhoneVerification-1.0.0\",\n         \"applicationId\": \"367a2361-8db5-4140-8133-c6c8dc7fa0c4\",\n         \"lifeCycleStatus\": \"UNBLOCKED\"\n      }\n   ],\n   \"next\": \"\",\n   \"count\": 2\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:subscription_view"
+                        ]
+                    }
+                ],
                 "summary": "Get all Subscriptions",
-                "description": "This operation can be used to retrieve a list of subscriptions of the user associated with the provided access token. This operation is capable of\n\n1. Retrieving all subscriptions for the user's APIs.\n`GET https://localhost:9443/api/am/publisher/v0.14/subscriptions`\n\n2. Retrieving subscriptions for a specific API.\n`GET https://localhost:9443/api/am/publisher/v0.14/subscriptions?apiId=c43a325c-260b-4302-81cb-768eafaa3aed`\n",
+                "description": "This operation can be used to retrieve a list of subscriptions of the user associated with the provided access token. This operation is capable of\n\n1. Retrieving all subscriptions for the user's APIs.\n`GET https://127.0.0.1:9443/api/am/publisher/v1.0/subscriptions`\n\n2. Retrieving subscriptions for a specific API.\n`GET https://127.0.0.1:9443/api/am/publisher/v1.0/subscriptions?apiId=c43a325c-260b-4302-81cb-768eafaa3aed`\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/apiId-Q"
@@ -2121,9 +2766,6 @@
                     },
                     {
                         "$ref": "#/parameters/offset"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
@@ -2163,18 +2805,21 @@
         },
         "/subscriptions/{subscriptionId}": {
             "get": {
-                "x-scope": "apim:subscription_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/publisher/v0.14/subscriptions/64eca60b-2e55-4c38-8603-e9e6bad7d809",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/subscriptions/64eca60b-2e55-4c38-8603-e9e6bad7d809\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"subscriptionId\": \"64eca60b-2e55-4c38-8603-e9e6bad7d809\",\n   \"tier\": \"Gold\",\n   \"apiIdentifier\": \"admin-PhoneVerification-1.0.0\",\n   \"applicationId\": \"896658a0-b4ee-4535-bbfa-806c894a4015\",\n   \"status\": \"UNBLOCKED\"\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9443/api/am/publisher/v1.0/subscriptions/64eca60b-2e55-4c38-8603-e9e6bad7d809",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/subscriptions/64eca60b-2e55-4c38-8603-e9e6bad7d809\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"subscriptionId\": \"64eca60b-2e55-4c38-8603-e9e6bad7d809\",\n   \"policy\": \"Gold\",\n   \"apiIdentifier\": \"admin-PhoneVerification-1.0.0\",\n   \"applicationId\": \"896658a0-b4ee-4535-bbfa-806c894a4015\",\n   \"lifeCycleStatus\": \"UNBLOCKED\"\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:subscription_view"
+                        ]
+                    }
+                ],
                 "summary": "Get details of a subscription",
                 "description": "This operation can be used to get details of a single subscription.\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/subscriptionId"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
@@ -2190,7 +2835,7 @@
                     "200": {
                         "description": "OK.\nSubscription returned\n",
                         "schema": {
-                            "$ref": "#/definitions/ExtendedSubscription"
+                            "$ref": "#/definitions/Subscription"
                         },
                         "headers": {
                             "Content-Type": {
@@ -2221,10 +2866,16 @@
         },
         "/subscriptions/block-subscription": {
             "post": {
-                "x-scope": "apim:subscription_block",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X POST \"https://localhost:9443/api/am/publisher/v0.14/subscriptions/block-subscription?subscriptionId=64eca60b-2e55-4c38-8603-e9e6bad7d809&blockState=PROD_ONLY_BLOCKED\"",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/subscriptions/block-subscription?subscriptionId=64eca60b-2e55-4c38-8603-e9e6bad7d809&blockState=PROD_ONLY_BLOCKED\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n \n{\n   \"subscriptionId\": \"64eca60b-2e55-4c38-8603-e9e6bad7d809\",\n   \"tier\": \"Gold\",\n   \"apiIdentifier\": \"admin-PhoneVerification-1.0.0\",\n   \"applicationId\": \"896658a0-b4ee-4535-bbfa-806c894a4015\",\n   \"status\": \"PROD_ONLY_BLOCKED\"\n}",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X POST \"https://127.0.0.1:9443/api/am/publisher/v1.0/subscriptions/block-subscription?subscriptionId=64eca60b-2e55-4c38-8603-e9e6bad7d809&blockState=PROD_ONLY_BLOCKED\"",
+                "x-wso2-request": "POST https://127.0.0.1:9443/api/am/publisher/v1.0/subscriptions/block-subscription?subscriptionId=64eca60b-2e55-4c38-8603-e9e6bad7d809&blockState=PROD_ONLY_BLOCKED\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n \n{\n   \"subscriptionId\": \"64eca60b-2e55-4c38-8603-e9e6bad7d809\",\n   \"policy\": \"Gold\",\n   \"apiIdentifier\": \"admin-PhoneVerification-1.0.0\",\n   \"applicationId\": \"896658a0-b4ee-4535-bbfa-806c894a4015\",\n   \"lifeCycleStatus\": \"PROD_ONLY_BLOCKED\"\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:subscription_block"
+                        ]
+                    }
+                ],
                 "summary": "Block a subscription",
                 "description": "This operation can be used to block a subscription. Along with the request, `blockState` must be specified as a query parameter.\n\n1. `BLOCKED` : Subscription is completely blocked for both Production and Sandbox environments.\n2. `PROD_ONLY_BLOCKED` : Subscription is blocked for Production environment only.\n",
                 "parameters": [
@@ -2289,10 +2940,16 @@
         },
         "/subscriptions/unblock-subscription": {
             "post": {
-                "x-scope": "apim:subscription_block",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X POST \"https://localhost:9443/api/am/publisher/v0.14/subscriptions/unblock-subscription?subscriptionId=64eca60b-2e55-4c38-8603-e9e6bad7d809\"",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/subscriptions/unblock-subscription?subscriptionId=64eca60b-2e55-4c38-8603-e9e6bad7d809\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8`\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"subscriptionId\": \"64eca60b-2e55-4c38-8603-e9e6bad7d809\",\n   \"tier\": \"Gold\",\n   \"apiIdentifier\": \"admin-PhoneVerification-1.0.0\",\n   \"applicationId\": \"896658a0-b4ee-4535-bbfa-806c894a4015\",\n   \"status\": \"UNBLOCKED\"\n} ",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X POST \"https://127.0.0.1:9443/api/am/publisher/v1.0/subscriptions/unblock-subscription?subscriptionId=64eca60b-2e55-4c38-8603-e9e6bad7d809\"",
+                "x-wso2-request": "POST https://127.0.0.1:9443/api/am/publisher/v1.0/subscriptions/unblock-subscription?subscriptionId=64eca60b-2e55-4c38-8603-e9e6bad7d809\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8`\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"subscriptionId\": \"64eca60b-2e55-4c38-8603-e9e6bad7d809\",\n   \"policy\": \"Gold\",\n   \"apiIdentifier\": \"admin-PhoneVerification-1.0.0\",\n   \"applicationId\": \"896658a0-b4ee-4535-bbfa-806c894a4015\",\n   \"lifeCycleStatus\": \"UNBLOCKED\"\n} ",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:subscription_block"
+                        ]
+                    }
+                ],
                 "summary": "Unblock a Subscription",
                 "parameters": [
                     {
@@ -2344,14 +3001,20 @@
                 }
             }
         },
-        "/tiers/{tierLevel}": {
+        "/policies/{tierLevel}": {
             "get": {
-                "x-scope": "apim:tier_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/publisher/v0.14/tiers/api",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/tiers/api\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9443/api/am/publisher/v1.0/policies/api",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/policies/api\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
                 "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"unitTime\": 60000,\n         \"tierPlan\": \"FREE\",\n         \"tierLevel\": \"api\",\n         \"stopOnQuotaReach\": true,\n         \"requestCount\": 1,\n         \"description\": \"Allows 1 request(s) per minute.\",\n         \"name\": \"Bronze\",\n         \"attributes\": {}\n      },\n            {\n         \"unitTime\": 60000,\n         \"tierPlan\": \"FREE\",\n         \"tierLevel\": \"api\",\n         \"stopOnQuotaReach\": true,\n         \"requestCount\": 20,\n         \"description\": \"Allows 20 request(s) per minute.\",\n         \"name\": \"Gold\",\n         \"attributes\": {}\n      },\n            {\n         \"unitTime\": 60000,\n         \"tierPlan\": \"FREE\",\n         \"tierLevel\": \"api\",\n         \"stopOnQuotaReach\": true,\n         \"requestCount\": 5,\n         \"description\": \"Allows 5 request(s) per minute.\",\n         \"name\": \"Silver\",\n         \"attributes\": {}\n      },\n            {\n         \"unitTime\": 0,\n         \"tierPlan\": null,\n         \"tierLevel\": \"api\",\n         \"stopOnQuotaReach\": true,\n         \"requestCount\": 0,\n         \"description\": \"Allows unlimited requests\",\n         \"name\": \"Unlimited\",\n         \"attributes\": {}\n      }\n   ],\n   \"next\": \"\",\n   \"count\": 4\n}",
-                "summary": "Get all tiers",
-                "description": "This operation can be used to list the available tiers for a given tier level. Tier level should be specified as a path parameter and should be one of `api`, `application` and `resource`.\n",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_update"
+                        ]
+                    }
+                ],
+                "summary": "Get all policies",
+                "description": "This operation can be used to list the available policies for a given policy level. Tier level should be specified as a path parameter and should be one of `api`, `application` and `resource`.\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/limit"
@@ -2363,9 +3026,6 @@
                         "$ref": "#/parameters/tierLevel"
                     },
                     {
-                        "$ref": "#/parameters/Accept"
-                    },
-                    {
                         "$ref": "#/parameters/If-None-Match"
                     }
                 ],
@@ -2374,7 +3034,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK.\nList of tiers returned.\n",
+                        "description": "OK.\nList of policies returned.\n",
                         "schema": {
                             "$ref": "#/definitions/TierList"
                         },
@@ -2399,84 +3059,28 @@
                         }
                     }
                 }
-            },
-            "post": {
-                "x-scope": "apim:tier_manage",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json \"https://localhost:9443/api/am/publisher/v0.14/tiers/api\"",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/tiers/api\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\nContent-Type: application/json\n\n{\n    \"unitTime\": 60000,\n    \"tierPlan\": \"FREE\",\n    \"tierLevel\": \"api\",\n    \"stopOnQuotaReach\": true,\n    \"requestCount\": 5,\n    \"description\": \"Allows 5 request(s) per minute.\",\n    \"name\": \"Low\",\n    \"attributes\": {\n            \"a\":10,\n            \"b\":30\n        }\n}",
-                "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://localhost:9443/api/am/publisher/v0.14/tiers/Low\nContent-Type: application/json\n\n{\n   \"unitTime\": 60000,\n   \"tierPlan\": \"FREE\",\n   \"tierLevel\": \"api\",\n   \"stopOnQuotaReach\": true,\n   \"requestCount\": 5,\n   \"description\": \"Allows 5 request(s) per minute.\",\n   \"name\": \"Low\",\n   \"attributes\":    {\n      \"b\": \"30\",\n      \"a\": \"10\"\n   }\n}",
-                "summary": "Create a Tier",
-                "description": "This operation can be used to create a new throttling tier. The only supported tier level is `api` tiers.\n`POST https://localhost:9443/api/am/publisher/v0.14/tiers/api`\n\n**IMPORTANT:**\n* This is only effective when Advanced Throttling is disabled in the Server. If enabled, we need to use Admin REST API for throttling tiers modification related operations.\n",
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "Tier object that should to be added\n",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/Tier"
-                        }
-                    },
-                    {
-                        "$ref": "#/parameters/tierLevel-A"
-                    },
-                    {
-                        "$ref": "#/parameters/Content-Type"
-                    }
-                ],
-                "tags": [
-                    "Throttling Tier (Collection)"
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created.\nSuccessful response with the newly created object as entity in the body.\nLocation header contains URL of newly created entity.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Tier"
-                        },
-                        "headers": {
-                            "Location": {
-                                "description": "Location of the newly created tier.\n",
-                                "type": "string"
-                            },
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            },
-                            "ETag": {
-                                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional request'\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nInvalid request or validation error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "415": {
-                        "description": "Unsupported media type.\nThe entity of the request was in a not supported format.\n"
-                    }
-                }
             }
         },
-        "/tiers/{tierLevel}/{tierName}": {
+        "/policies/{tierLevel}/{tierName}": {
             "get": {
-                "x-scope": "apim:tier_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/publisher/v0.14/tiers/api/Bronze",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/tiers/api/Bronze\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9443/api/am/publisher/v1.0/policies/api/Bronze",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/policies/api/Bronze\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
                 "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"unitTime\": 60000,\n   \"tierPlan\": \"FREE\",\n   \"tierLevel\": \"api\",\n   \"stopOnQuotaReach\": true,\n   \"requestCount\": 1,\n   \"description\": \"Allows 1 request(s) per minute.\",\n   \"name\": \"Bronze\",\n   \"attributes\": {}\n}",
-                "summary": "Get details of a tier",
-                "description": "This operation can be used to retrieve details of a single tier by specifying the tier level and tier name.\nNote that the scope of the API is mandatory while retreiving the access token with the following cURL command : `curl -k -d \\\"grant_type=password&username=username&password=password&scope=apim:tier_view\\\" -H \\\"Authorization: Basic <token>\\\" https://localhost:8243/token`.\nYou will receive the access token as the response, for example `\"access_token\":\"8644c013-7ff1-3217-b150-d7b92cae6be7\"`.\n",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_update"
+                        ]
+                    }
+                ],
+                "summary": "Get details of a policy",
+                "description": "This operation can be used to retrieve details of a single policy by specifying the policy level and policy name.\n",
                 "parameters": [
                     {
                         "$ref": "#/parameters/tierName"
                     },
                     {
                         "$ref": "#/parameters/tierLevel"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
                     },
                     {
                         "$ref": "#/parameters/If-None-Match"
@@ -2525,32 +3129,194 @@
                         }
                     }
                 }
-            },
-            "put": {
-                "x-scope": "apim:tier_manage",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X PUT -d @data.json \"https://localhost:9443/api/am/publisher/v0.14/tiers/api/Low\"",
-                "x-wso2-request": "PUT https://localhost:9443/api/am/publisher/v0.14/tiers/api/Low\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\nContent-Type: application/json\n\n{\n   \"unitTime\": 60000,\n   \"tierPlan\": \"FREE\",\n   \"tierLevel\": \"api\",\n   \"stopOnQuotaReach\": true,\n   \"requestCount\": 10,\n   \"description\": \"Allows 10 request(s) per minute.\",\n   \"name\": \"Low\",\n   \"attributes\":    {\n      \"a\": \"30\",\n      \"b\": \"10\",\n      \"c\": \"20\"\n   }\n}\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"unitTime\": 60000,\n   \"tierPlan\": \"FREE\",\n   \"tierLevel\": \"api\",\n   \"stopOnQuotaReach\": true,\n   \"requestCount\": 10,\n   \"description\": \"Allows 10 request(s) per minute.\",\n   \"name\": \"Low\",\n   \"attributes\":    {\n      \"b\": \"10\",\n      \"c\": \"20\",\n      \"a\": \"30\"\n   }\n}",
-                "summary": "Update a Tier",
-                "description": "This operation can be used to update an existing tier. The only supported tier level is `api` tiers.\n`PUT https://localhost:9443/api/am/publisher/v0.14/tiers/api/Low`\n\n**IMPORTANT:**\n* This is only effective when Advanced Throttling is disabled in the Server. If enabled, we need to use Admin REST API for throttling tiers modification related operations.\n",
+            }
+        },
+        "/endpoints": {
+            "get": {
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://127.0.0.1:9443/api/am/publisher/v1.0/endpoints\"",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/endpoints\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n  \"list\": [\n    {\n      \"id\": \"01234567-0123-0123-0123-012345678901\",\n      \"name\": \"Endpoint 1\",\n      \"endpointConfig\": {\n        \"serviceUrl\": \"http://192.168.56.1:8281\",\n        \"timeout\": 1000\n      },\n      \"endpointSecurity\": {\n        \"enabled\": false\n      },\n      \"maxTps\": 1000,\n      \"type\": \"http\"\n    }\n  ],\n  \"count\": 1\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_view"
+                        ]
+                    }
+                ],
+                "summary": "Get all endpoints",
+                "description": "This operation can be used to retrieve the list of endpoints available.\n",
                 "parameters": [
                     {
-                        "$ref": "#/parameters/tierName"
+                        "$ref": "#/parameters/If-None-Match"
                     },
+                    {
+                        "$ref": "#/parameters/If-Modified-Since"
+                    }
+                ],
+                "tags": [
+                    "Endpoint (Collection)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nEndpoint list is returned.\n",
+                        "schema": {
+                            "$ref": "#/definitions/EndPointList"
+                        },
+                        "headers": {
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            },
+                            "ETag": {
+                                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "304": {
+                        "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+                    },
+                    "404": {
+                        "description": "Not Found.\nRequested API does not exist.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json \"https://127.0.0.1:9443/api/am/publisher/v1.0/endpoints\"",
+                "x-wso2-request": "",
+                "x-wso2-response": "",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
+                "summary": "Add a new endpoint",
+                "description": "This operation can be used to add a new endpoint.\n",
+                "parameters": [
                     {
                         "in": "body",
                         "name": "body",
-                        "description": "Tier object that needs to be modified\n",
+                        "description": "EndPoint object that needs to be added\n",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/Tier"
+                            "$ref": "#/definitions/EndPoint"
                         }
                     },
                     {
-                        "$ref": "#/parameters/tierLevel-A"
+                        "$ref": "#/parameters/If-None-Match"
                     },
                     {
-                        "$ref": "#/parameters/Content-Type"
+                        "$ref": "#/parameters/If-Modified-Since"
+                    }
+                ],
+                "tags": [
+                    "Endpoint (Collection)"
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created.\nSuccessful response with the newly created Document object as entity in the body.\nLocation header contains URL of newly added document.\n",
+                        "schema": {
+                            "$ref": "#/definitions/EndPoint"
+                        },
+                        "headers": {
+                            "Location": {
+                                "description": "Location to the newly created Document.\n",
+                                "type": "string"
+                            },
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            },
+                            "ETag": {
+                                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request.\nInvalid request or validation error\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported media type.\nThe entity of the request was in a not supported format.\n"
+                    }
+                }
+            },
+            "head": {
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
+                "summary": "Check given Endpoint is already exist\n",
+                "description": "Using this operation, you can check a given Endpoint name is already used. You need to provide the name you want to check.\n",
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "type": "string"
+                    },
+                    {
+                        "$ref": "#/parameters/If-None-Match"
+                    }
+                ],
+                "tags": [
+                    "Endpoint (Collection)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nRequested Endpoint attibute status is returned\n",
+                        "headers": {
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request.\nRequested Endpoint attribute does not meet requiremnts.\n"
+                    },
+                    "404": {
+                        "description": "Not Found.\nRequested Endpoint does not exist.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "406": {
+                        "description": "Not Acceptable.\nThe requested media type is not supported\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/endpoints/{endpointId}": {
+            "get": {
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://127.0.0.1:9443/api/am/publisher/v1.0/endpoints/1234-123-2111-345\"",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/endpoints/1234-123-2111-345\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"list\": [   {\n      \"showInApiConsole\": true,\n      \"serverUrl\": \"https://192.168.56.1:9444//services/\",\n      \"endpoints\":       {\n         \"http\": \"http://192.168.56.1:8281\",\n         \"https\": \"https://192.168.56.1:8244\"\n      },\n      \"name\": \"Production and Sandbox\",\n      \"type\": \"hybrid\"\n   }],\n   \"count\": 1\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
+                "summary": "Get specific endpoints",
+                "description": "This operation can be used to retrieve endpoint specific details.\n",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/endpointId"
                     },
                     {
                         "$ref": "#/parameters/If-Match"
@@ -2560,13 +3326,77 @@
                     }
                 ],
                 "tags": [
-                    "Throttling Tier (Individual)"
+                    "Endpoint (individual)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nEndpoint details returned.\n",
+                        "schema": {
+                            "$ref": "#/definitions/EndPoint"
+                        },
+                        "headers": {
+                            "Content-Type": {
+                                "description": "The content type of the body.\n",
+                                "type": "string"
+                            },
+                            "ETag": {
+                                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "304": {
+                        "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+                    },
+                    "404": {
+                        "description": "Not Found.\nRequested API does not exist.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "x-wso2-curl": "",
+                "x-wso2-request": "",
+                "x-wso2-response": "",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
+                "summary": "Update a Tier",
+                "description": "This operation can be used to update an existing endpoint.\n`PUT https://127.0.0.1:9443/api/am/publisher/v1.0/endpoints/api/Low`\n",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/endpointId"
+                    },
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "Tier object that needs to be modified\n",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/EndPoint"
+                        }
+                    },
+                    {
+                        "$ref": "#/parameters/If-Match"
+                    },
+                    {
+                        "$ref": "#/parameters/If-Unmodified-Since"
+                    }
+                ],
+                "tags": [
+                    "Endpoint (individual)"
                 ],
                 "responses": {
                     "200": {
                         "description": "OK.\nSubscription updated.\n",
                         "schema": {
-                            "$ref": "#/definitions/Tier"
+                            "$ref": "#/definitions/EndPoint"
                         },
                         "headers": {
                             "Location": {
@@ -2608,18 +3438,21 @@
                 }
             },
             "delete": {
-                "x-scope": "apim:tier_manage",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X DELETE \"https://localhost:9443/api/am/publisher/v0.14/tiers/api/Low\"",
-                "x-wso2-request": "DELETE https://localhost:9443/api/am/publisher/v0.14/tiers/api/Low\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X DELETE https://127.0.0.1:9443/api/am/publisher/v1.0/endpoints/6fb74674-4ab8-4b52-9886-f9a376985060",
+                "x-wso2-request": "DELETE https://127.0.0.1:9443/api/am/publisher/v1.0/endpoints/6fb74674-4ab8-4b52-9886-f9a376985060\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
                 "x-wso2-response": "HTTP/1.1 200 OK",
-                "summary": "Delete a Tier",
-                "description": "This operation can be used to delete an existing tier. The only supported tier level is `api` tiers.\n`DELETE https://localhost:9443/api/am/publisher/v0.14/tiers/api/Low`\n\n**IMPORTANT:**\n* This is only effective when Advanced Throttling is disabled in the Server. If enabled, we need to use Admin REST API for throttling tiers modification related operations.\n",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_create"
+                        ]
+                    }
+                ],
+                "summary": "Delete an endpoint",
+                "description": "This operation can be used to delete an existing Endpoint proving the Id of the Endpoint.\n",
                 "parameters": [
                     {
-                        "$ref": "#/parameters/tierName"
-                    },
-                    {
-                        "$ref": "#/parameters/tierLevel-A"
+                        "$ref": "#/parameters/endpointId"
                     },
                     {
                         "$ref": "#/parameters/If-Match"
@@ -2629,11 +3462,17 @@
                     }
                 ],
                 "tags": [
-                    "Throttling Tier (Individual)"
+                    "Endpoint (individual)"
                 ],
                 "responses": {
                     "200": {
                         "description": "OK.\nResource successfully deleted.\n"
+                    },
+                    "403": {
+                        "description": "Forbidden.\nThe request must be conditional but no condition has been specified.\n",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
                     },
                     "404": {
                         "description": "Not Found.\nResource to be deleted does not exist.\n",
@@ -2650,106 +3489,38 @@
                 }
             }
         },
-        "/tiers/update-permission": {
-            "post": {
-                "x-scope": "apim:tier_manage",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json \"https://localhost:9443/api/am/publisher/v0.14/tiers/update-permission?tierName=Bronze&tierLevel=api\"",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/tiers/update-permission?tierName=Bronze&tierLevel=api\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\nContent-Type: application/json\n\n{\n    \"permissionType\":\"deny\",\n    \"roles\": [\"Internal/everyone\",\"admin\"]\n}",
-                "x-wso2-response": "HTTP/1.1 200 OK",
-                "summary": "Update tier permission",
-                "description": "This operation can be used to update tier permissions which controls access for the particular tier based on the subscribers' roles.\n",
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/tierName-Q"
-                    },
-                    {
-                        "$ref": "#/parameters/tierLevel-Q"
-                    },
-                    {
-                        "$ref": "#/parameters/If-Match"
-                    },
-                    {
-                        "$ref": "#/parameters/If-Unmodified-Since"
-                    },
-                    {
-                        "in": "body",
-                        "name": "permissions",
-                        "schema": {
-                            "$ref": "#/definitions/TierPermission"
-                        }
-                    }
-                ],
-                "tags": [
-                    "Throttling Tier (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\nSuccessfully updated tier permissions\n",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Tier"
-                            }
-                        },
-                        "headers": {
-                            "ETag": {
-                                "description": "Entity Tag of the modified tier.\n Used by caches, or in conditional requests (Will be supported in future).\n",
-                                "type": "string"
-                            },
-                            "Last-Modified": {
-                                "description": "Date and time the tier has been modified.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nInvalid request or validation error.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden.\nThe request must be conditional but no condition has been specified.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found.\nRequested tier does not exist.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "412": {
-                        "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/environments": {
+        "/labels": {
             "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/publisher/v0.14/environments\"",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/environments\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"list\": [   {\n      \"showInApiConsole\": true,\n      \"serverUrl\": \"https://localhost:9443/services/\",\n      \"endpoints\":       {\n         \"http\": \"http://localhost:8280\",\n         \"https\": \"https://localhost:8243\"\n      },\n      \"name\": \"Production and Sandbox\",\n      \"type\": \"hybrid\"\n   }],\n   \"count\": 1\n}",
-                "summary": "Get all gateway environments",
-                "description": "This operation can be used to retrieve the list of gateway environments available.\n",
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://127.0.0.1:9443/api/am/publisher/v1.0/labels\"",
+                "x-wso2-request": "GET https://127.0.0.1:9443/api/am/publisher/v1.0/labels\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:api_publish"
+                        ]
+                    }
+                ],
+                "summary": "Get all labels",
+                "description": "This operation can be used to retrieve the list of labels available.\n",
                 "parameters": [
                     {
-                        "$ref": "#/parameters/apiId-Q"
+                        "$ref": "#/parameters/If-None-Match"
+                    },
+                    {
+                        "$ref": "#/parameters/If-Modified-Since"
+                    },
+                    {
+                        "$ref": "#/parameters/labelType-Q"
                     }
                 ],
                 "tags": [
-                    "Environment (Collection)"
+                    "Label (Collection)"
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK.\nEnvironment list is returned.\n",
+                        "description": "OK.\nLabel list is returned.\n",
                         "schema": {
-                            "$ref": "#/definitions/EnvironmentList"
+                            "$ref": "#/definitions/LabelList"
                         },
                         "headers": {
                             "Content-Type": {
@@ -2774,50 +3545,85 @@
                 }
             }
         },
-        "/policies/mediation": {
+        "/threat-protection-policies": {
             "get": {
-                "x-scope": "apim:mediation_policy_view",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/publisher/v0.14/policies/mediation",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/policies/mediation\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\r\n   \"count\": 10,\r\n   \"next\": null,\r\n   \"previous\": null,\r\n   \"list\":    [\r\n            {\r\n         \"name\": \"debug_json_fault\",\r\n         \"id\": \"563de8f3-dd1d-4ec7-afc2-d158c663ed34\",\r\n         \"type\": \"fault\"\r\n      },\r\n            {\r\n         \"name\": \"json_fault\",\r\n         \"id\": \"f9c36f4d-a2b6-41e7-b311-d358a47916be\",\r\n         \"type\": \"fault\"\r\n      },\r\n            {\r\n         \"name\": \"json_to_xml_in_message\",\r\n         \"id\": \"3921225b-7918-4b95-a851-22c4e4e3e911\",\r\n         \"type\": \"in\"\r\n      },\r\n            {\r\n         \"name\": \"debug_in_flow\",\r\n         \"id\": \"2bc15f93-4455-4763-89b8-83600fb9d731\",\r\n         \"type\": \"in\"\r\n      },\r\n            {\r\n         \"name\": \"log_in_message\",\r\n         \"id\": \"4d287cca-76ab-44ca-b22e-919fc27c50e3\",\r\n         \"type\": \"in\"\r\n      },\r\n            {\r\n         \"name\": \"preserve_accept_header\",\r\n         \"id\": \"3776b215-b3bc-40b6-bdcb-06efa7de64be\",\r\n         \"type\": \"in\"\r\n      },\r\n            {\r\n         \"name\": \"xml_to_json_in_message\",\r\n         \"id\": \"50ac2002-769e-4f90-8549-6d0248dff7d2\",\r\n         \"type\": \"in\"\r\n      },\r\n            {\r\n         \"name\": \"xml_to_json_out_message\",\r\n         \"id\": \"2af75853-ed75-4d25-81aa-0ebbeca691ea\",\r\n         \"type\": \"out\"\r\n      },\r\n            {\r\n         \"name\": \"json_to_xml_out_message\",\r\n         \"id\": \"d9fa3ffc-f6b6-4171-ab97-eb44196cb66e\",\r\n         \"type\": \"out\"\r\n      },\r\n            {\r\n         \"name\": \"debug_out_flow\",\r\n         \"id\": \"260b7701-4071-46bd-9b66-900ac6fffed6\",\r\n         \"type\": \"out\"\r\n      },\r\n            {\r\n         \"name\": \"apply_accept_header\",\r\n         \"id\": \"15c17c2f-33e3-4c37-a262-04dfa49983a4\",\r\n         \"type\": \"out\"\r\n      },\r\n            {\r\n         \"name\": \"log_out_message\",\r\n         \"id\": \"d37dca41-c048-492a-82cf-9a2292c6fff0\",\r\n         \"type\": \"out\"\r\n      }\r\n   ]\r\n}",
-                "summary": "Get all global level mediation policies\n",
-                "description": "This operation provides you a list of available all global level mediation policies.\n",
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/limit"
-                    },
-                    {
-                        "$ref": "#/parameters/offset"
-                    },
-                    {
-                        "name": "query",
-                        "in": "query",
-                        "description": "-Not supported yet-",
-                        "type": "string"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
-                    },
-                    {
-                        "$ref": "#/parameters/If-None-Match"
-                    }
-                ],
+                "summary": "Get All Threat Protection Policies",
+                "description": "This can be used to get all defined threat protection policies",
                 "tags": [
-                    "Mediation Policy (Collection)"
+                    "Threat Protection Policies"
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK.\nList of mediation policies is returned.\n",
+                        "description": "Ok. List of policies is returned",
                         "schema": {
-                            "$ref": "#/definitions/mediationList"
+                            "$ref": "#/definitions/ThreatProtectionPolicyList"
+                        }
+                    }
+                }
+            }
+        },
+        "/threat-protection-policies/{policyId}": {
+            "get": {
+                "summary": "Get a threat protection policy",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/threatProtectionPolicyId"
+                    }
+                ],
+                "tags": [
+                    "Threat Protection Policy"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Ok. Policy is returned",
+                        "schema": {
+                            "$ref": "#/definitions/ThreatProtectionPolicy"
+                        }
+                    },
+                    "404": {
+                        "description": "No policy found for given policy ID"
+                    }
+                }
+            }
+        },
+        "/external-resources/services": {
+            "get": {
+                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://127.0.0.1:9292/api/am/publisher/v1.0/external-resources/services\"",
+                "x-wso2-request": "GET https://127.0.0.1:9292/api/am/publisher/v1.0/external-resources/services\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n  \"list\": [\n    {\n      \"id\": \"ds-0\",\n      \"name\": \"service-1\",\n      \"endpointConfig\": {\n        \"serviceUrl\": \"http://192.168.56.1:8281\",\n        \"serviceType\": \"NodePort\",\n        \"namespace\": \"default\"\n      },\n      \"endpointSecurity\": {\n        \"enabled\": false\n      },\n      \"maxTps\": 1000,\n      \"type\": \"http\"\n    }\n  ],\n  \"count\": 1\n}",
+                "security": [
+                    {
+                        "OAuth2Security": [
+                            "apim:external_services_discover"
+                        ]
+                    }
+                ],
+                "summary": "Get all service endpoints after service discovery",
+                "description": "This operation can be used to retrieve the list of service endpoints available in the cluster after a process of service discovery.\n",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/If-None-Match"
+                    },
+                    {
+                        "$ref": "#/parameters/If-Modified-Since"
+                    }
+                ],
+                "tags": [
+                    "External Resources (Collection)"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK.\nService Endpoint list is returned with other details.\n",
+                        "schema": {
+                            "$ref": "#/definitions/EndPointList"
                         },
                         "headers": {
                             "Content-Type": {
-                                "description": "The content type of the body.",
+                                "description": "The content type of the body.\n",
                                 "type": "string"
                             },
                             "ETag": {
-                                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
                                 "type": "string"
                             }
                         }
@@ -2825,61 +3631,8 @@
                     "304": {
                         "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
                     },
-                    "406": {
-                        "description": "Not Acceptable.\nThe requested media type is not supported\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/workflows/update-workflow-status": {
-            "post": {
-                "x-scope": "apim:api_workflow",
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json \"https://localhost:9443/api/am/publisher/v0.14/workflows/update-workflow-status?workflowReferenceId=56e3a170-a7a7-45f8-b051-7e43a58a67e1\"",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/workflows/update-workflow-status?workflowReferenceId=56e3a170-a7a7-45f8-b051-7e43a58a67e1\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\nContent-Type: application/json\n\n{\n   \"status\" : \"APPROVED\",\n   \"attributes\" : {\n      \"apiCurrentState\": \"Created\",\n      \"apiLCAction\": \"Publish\",\n      \"apiName\":\"APIname\",\n      \"apiVersion\" : \"1.0.0\",\n      \"apiProvider\" : \"admin\",\n      \"invoker\": \"admin\"\n   }\n}",
-                "x-wso2-response": "HTTP/1.1 200 OK",
-                "summary": "Update workflow status",
-                "description": "This operation can be used to approve or reject a workflow task.\n",
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/workflowReferenceId-Q"
-                    },
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "Workflow event that need to be updated\n",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/Workflow"
-                        }
-                    }
-                ],
-                "tags": [
-                    "Workflows (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\nWorkflow request information is returned.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Workflow"
-                        },
-                        "headers": {
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nInvalid request or validation error.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
                     "404": {
-                        "description": "Not Found.\nWorkflow for the given reference in not found.\n",
+                        "description": "Not Found.\nRequested API does not exist.\n",
                         "schema": {
                             "$ref": "#/definitions/Error"
                         }
@@ -2887,786 +3640,27 @@
                 }
             }
         },
-        "/clientCertificates": {
+        "/settings": {
             "get": {
-                "x-scope": "apim:api_view",
-                "produces": [
-                    "application/json"
-                ],
-                "x-wso2-curl": "curl -X GET https://localhost:9443/api/am/publisher/v0.14/clientCertificates -H 'authorization: Bearer f80b8c34-01bc-3ac2-99b6-4873e45c861c'",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/clientCertificates  -H 'authorization: Bearer f80b8c34-01bc-3ac2-99b6-4873e45c861c'",
-                "x-wso2-response": "HTTP/1.1 200 OK {\"count\":1,\"next\":\"\",\"previous\":\"\",\"certificates\":[{\"alias\":\"newtest1\", \"apiId\":\"admin-mesting12da1-1.0.0\",\"tier\":\"Bronze\"}],\"pagination\":{\"total\":1, \"offset\":0,\"limit\":25}}",
-                "summary": "Retrieve/ Search uploaded Client Certificates.",
-                "description": "This operation can be used to retrieve and search the uploaded client certificates.\n",
-                "tags": [
-                    "ClientCertificates (Collection)"
-                ],
-                "parameters": [
+                "summary": "Retreive publisher settings",
+                "security": [
                     {
-                        "$ref": "#/parameters/limit"
-                    },
-                    {
-                        "$ref": "#/parameters/offset"
-                    },
-                    {
-                        "in": "query",
-                        "name": "alias",
-                        "required": false,
-                        "type": "string",
-                        "description": "Alias for the client certificate"
-                    },
-                    {
-                        "in": "query",
-                        "name": "apiId",
-                        "required": false,
-                        "type": "string",
-                        "description": "UUID of the API"
+                        "OAuth2Security": [
+                            "apim:publisher_setting"
+                        ]
                     }
                 ],
+                "x-scope": "apim:publisher_setting",
+                "description": "Retreive publisher settings\n",
                 "responses": {
                     "200": {
-                        "description": "OK. Successful response with the list of matching certificate information in the body.\n",
+                        "description": "OK.\nSettings returned\n",
                         "schema": {
-                            "$ref": "#/definitions/ClientCertificates"
-                        },
-                        "headers": {
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nFailure due to not providing alias or server is not configured to support mutual SSL authentication.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "x-scope": "apim:api_create",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "x-wso2-curl": "curl -X POST https://localhost:9443/api/am/publisher/v0.14/clientCertificates -H 'authorization: Bearer f2f562bd-f6d9-3fad-b48d-72ab5702c98a' -H 'content-type: multipart/form-data' -F certificate=@test.crt -F alias=alias -F apiId=fea749dd-d548-4a8b-b308-34903b39a34b -F tier=Gold",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/clientCertificates -H 'authorization: Bearer f2f562bd-f6d9-3fad-b48d-72ab5702c98a' -H 'content-type: multipart/form-data' -F certificate=@test.crt -F alias=alias -F apiId=fea749dd-d548-4a8b-b308-34903b39a34b -F tier=Gold",
-                "x-wso2-response": "HTTP/1.1 201 Created Location: https://localhost:9443/api/am/publisher/v0.14/clientCertificates?alias=newtest1 Date: Tue, 09 Oct 2018 16:18:10 GMT Content-Type: application/json Transfer-Encoding: chunked Server: WSO2 Carbon Server {\"alias\":\"alias\",\"apiId\":\"fea749dd-d548-4a8b-b308-34903b39a34b\",\"tier\":\"Gold\"}",
-                "summary": "Upload a new certificate.",
-                "description": "This operation can be used to upload a new certificate for an endpoint.\n",
-                "parameters": [
-                    {
-                        "in": "formData",
-                        "name": "certificate",
-                        "description": "The certificate that needs to be uploaded.",
-                        "required": true,
-                        "type": "file"
-                    },
-                    {
-                        "in": "formData",
-                        "name": "alias",
-                        "description": "Alias for the certificate",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "formData",
-                        "name": "apiId",
-                        "description": "apiId to which the certificate should be applied.",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "formData",
-                        "name": "tier",
-                        "description": "apiId to which the certificate should be applied.",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "tags": [
-                    "ClientCertificates (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\nThe Certificate added successfully.\n",
-                        "headers": {
-                            "Location": {
-                                "description": "The URL of the newly created resource.\n",
-                                "type": "string"
-                            },
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        },
-                        "schema": {
-                            "$ref": "#/definitions/ClientCertMetadata"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nFailures due to existing alias or expired certificate.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error\nFailed to add the Certificate due to an Internal Server Error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/clientCertificates/{alias}": {
-            "put": {
-                "x-scope": "apim:api_create",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "x-wso2-curl": "curl -X PUT https://localhost:9443/api/am/publisher/v0.14/clientCertificates/newtest1 -H 'authorization: Bearer f80b8c34-01bc-3ac2-99b6-4873e45c861c' -F tier=Bronze",
-                "x-wso2-request": "PUT https://localhost:9443/api/am/publisher/v0.14/clientCertificates/newtest1 -H 'authorization: Bearer f80b8c34-01bc-3ac2-99b6-4873e45c861c' -F tier=Bronze",
-                "x-wso2-response": "HTTP/1.1 200 OK\r\n {\r\n\"alias\":\"newtest1\",\r\n\"apiId\":\"fea749dd-d548-4a8b-b308-34903b39a34b\",\r\n \"tier\":\"Gold\"\r\n}\r\n",
-                "summary": "Update a certificate.",
-                "description": "This operation can be used to update an uploaded certificate.\n",
-                "parameters": [
-                    {
-                        "in": "formData",
-                        "name": "certificate",
-                        "description": "The certificate that needs to be uploaded.",
-                        "required": false,
-                        "type": "file"
-                    },
-                    {
-                        "in": "path",
-                        "name": "alias",
-                        "description": "Alias for the certificate",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "formData",
-                        "name": "tier",
-                        "description": "The tier of the certificate",
-                        "required": false,
-                        "type": "string"
-                    }
-                ],
-                "tags": [
-                    "ClientCertificates (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\nThe Certificate updated successfully.\n",
-                        "schema": {
-                            "$ref": "#/definitions/ClientCertMetadata"
-                        },
-                        "headers": {
-                            "Location": {
-                                "description": "The URL of the newly created resource.\n",
-                                "type": "string"
-                            },
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nFailure due to not providing alias.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
+                            "$ref": "#/definitions/Settings"
                         }
                     },
                     "404": {
-                        "description": "Not Found.\nUpdating certificate failed. Alias not found or server is not configured to support mutual SSL\nauthentication.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -X DELETE https://localhost:9443/api/am/publisher/v0.14/clientCertificates/newtest1 -H 'authorization: Bearer f80b8c34-01bc-3ac2-99b6-4873e45c861c' ",
-                "x-wso2-request": "DELETE https://localhost:9443/api/am/publisher/v0.14/clientCertificates/newtest1 -H 'authorization: Bearer f80b8c34-01bc-3ac2-99b6-4873e45c861c'",
-                "x-wso2-response": "HTTP/1.1 200 OK",
-                "summary": "Delete a certificate.",
-                "description": "This operation can be used to delete an uploaded certificate.\n",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "alias",
-                        "description": "The alias of the certificate that should be deleted.\n",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "tags": [
-                    "ClientCertificates (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\nThe Certificate deleted successfully.\n",
-                        "headers": {
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nAlias not found or server is not configured to support mutual SSL authentication.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found. |\nFailed to delete the certificate. Certificate could not found for\nthe given alias\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            },
-            "get": {
-                "x-scope": "apim:api_view",
-                "produces": [
-                    "application/json"
-                ],
-                "x-wso2-curl": "curl -X GET https://localhost:9443/api/am/publisher/v0.14/clientCertificates/newtest1 -H 'authorization: Bearer f80b8c34-01bc-3ac2-99b6-4873e45c861c'",
-                "x-wso2-request": "GET https://apis.wso2.com/api/am/publisher/v0.14/clientCertificates/newtest1 Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8",
-                "x-wso2-response": "HTTP/1.1 200 OK Date: Tue, 09 Oct 2018 16:25:43 GMT Content-Type: application/json Transfer-Encoding: chunked Server: WSO2 Carbon Server {\"status\":\"Active\",\"validity\":{\"from\":\"Fri Sep 14 15:46:22 IST 2018\",\"to\":\"Sat Sep 14 15:46:22 IST 2019\"},\"version\":\"3\",\"subject\":\"EMAILADDRESS=wso2@wso2.com, CN=WSO2, OU=test, O=WSO2, L=colombo, ST=Some-State, C=CA\"}",
-                "summary": "Get the certificate information.",
-                "description": "This operation can be used to get the information about a certificate.\n",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "alias",
-                        "type": "string",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "ClientCertificates (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\n",
-                        "schema": {
-                            "$ref": "#/definitions/CertificateInfo"
-                        },
-                        "headers": {
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nAlias not found or server is not configured to support mutual SSL authentication.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found.\nAlias not found\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/clientCertificates/{alias}/content": {
-            "get": {
-                "x-scope": "apim:api_view",
-                "x-wso2-curl": "curl -X GET https://localhost:9443/api/am/publisher/v0.14/clientCertificates/newtest1/content -H 'authorization: Bearer f80b8c34-01bc-3ac2-99b6-4873e45c861c'",
-                "x-wso2-request": "GET https://apis.wso2.com/api/am/publisher/v0.14/certificates/wso2carbon/content Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8",
-                "x-wso2-response": "HTTP/1.1 200 OK Content-Disposition: attachment; filename=\"newtest1.crt\" Date: Tue, 09 Oct 2018 16:21:25 GMT Content-Type: application/octet-stream Content-Length: 997 Server: WSO2 Carbon Server",
-                "summary": "Download a certificate.",
-                "description": "This operation can be used to download a certificate which matches the given alias.\n",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "alias",
-                        "type": "string",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "ClientCertificates (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\n",
-                        "headers": {
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nAlias not provided or server is not configured to support mutual SSL authentication.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found. Certificate for the Alias not found.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/certificates": {
-            "get": {
-                "x-scope": "apim:api_create",
-                "produces": [
-                    "application/json"
-                ],
-                "x-wso2-curl": "curl -X GET -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" \"https://localhost:9443/api/am/publisher/v0.14/certificates\"",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.14/certificates?alias=wso2carbon&endpoint=https://www.abc.com",
-                "x-wso2-response": "HTTP/1.1 200 OK \n\n{\n  \"count\":1,\n  \"next\":\"\",\n  \"previous\":\"\",\n\"certificates\":[\n   {\n    \"alias\":\"wso2carbon\",\n    \"endpoint\":\"https://www.abc.com\"\n   }\n],\n  \"pagination\":{\n    \"total\":1,\n          \"offset\":0,\n          \"limit\":25\n   } \n}",
-                "summary": "Retrieve/Search uploaded certificates.",
-                "description": "This operation can be used to retrieve and search the uploaded certificates.\n",
-                "tags": [
-                    "Certificates (Collection)"
-                ],
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/limit"
-                    },
-                    {
-                        "$ref": "#/parameters/offset"
-                    },
-                    {
-                        "in": "query",
-                        "name": "alias",
-                        "required": false,
-                        "type": "string",
-                        "description": "Alias for the certificate"
-                    },
-                    {
-                        "in": "query",
-                        "name": "endpoint",
-                        "required": false,
-                        "type": "string",
-                        "description": "Endpoint of which the certificate is uploaded"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK. Successful response with the list of matching certificate information in the body.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Certificates"
-                        },
-                        "headers": {
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nInvalid request or validation error.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "x-scope": "apim:api_create",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "x-wso2-curl": "curl -X POST -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: multipart/form-data\"  -F \"certificate=@/home/user/wso2carbon.cert\" -F \"alias=wso2carbon\" -F \"endpoint=https://www.abc.com\" \"https://localhost:9443/api/am/publisher/v0.14/certificates/certificate\"",
-                "x-wso2-request": "POST https://localhost:9443/api/am/publisher/v0.14/certificates/certificate \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -F \"certificate=/home/user/wso2carbon.cert\" -F \"alias=wso2carbon\" -F \"endpoint=https://www.abc.com\"",
-                "x-wso2-response": "HTTP/1.1 201 Created Location: https://localhost:9443/api/am/publisher/v0.14/clientCertificates?alias=newtest1 Date: Fri, 05 Oct 2018 09:50:48 GMT Content-Type: application/json Transfer-Encoding: chunked Server: WSO2 Carbon Server {\"alias\": \"newtest1\",\"apiId\": \"4624bdfb-6acd-465a-8454-bac9c4c94d88\",\"tier\": \"Gold\"}",
-                "summary": "Upload a new Certificate.",
-                "description": "This operation can be used to upload a new certificate for an endpoint.\n",
-                "parameters": [
-                    {
-                        "in": "formData",
-                        "name": "certificate",
-                        "description": "The certificate that needs to be uploaded.",
-                        "required": true,
-                        "type": "file"
-                    },
-                    {
-                        "in": "formData",
-                        "name": "alias",
-                        "description": "Alias for the certificate",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "formData",
-                        "name": "endpoint",
-                        "description": "Endpoint to which the certificate should be applied.",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "tags": [
-                    "Certificates (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\nThe Certificate added successfully.\n",
-                        "headers": {
-                            "Location": {
-                                "description": "The URL of the newly created resource.\n",
-                                "type": "string"
-                            },
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        },
-                        "schema": {
-                            "$ref": "#/definitions/CertMetadata"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nInvalid request or validation error.\n* Failures due to existing alias or expired certificate.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error\n* Failed to add the Certificate due to an Internal Server Error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/certificates/{alias}": {
-            "put": {
-                "x-scope": "apim:api_create",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "x-wso2-curl": "curl -X PUT -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type:multipart/form-data\" -F \"certificate=@/home/user/wso2carbon.cert\" \"https://localhost:9443/api/am/publisher/v0.14/certificates/wso2carbon\"",
-                "x-wso2-request": "PUT https://localhost:9443/api/am/publisher/v0.14/certificates/wso2carbon Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8 -F  \"certificate=@/home/user/wso2carbon.cert\"",
-                "x-wso2-response": "HTTP/1.1 200 OK\r\n {\"alias\":wso2carbon,\"endpoint\":\"https://www.abc.com\"}",
-                "summary": "Update a certificate.",
-                "description": "This operation can be used to update an uploaded certificate.\n",
-                "parameters": [
-                    {
-                        "in": "formData",
-                        "name": "certificate",
-                        "description": "The certificate that needs to be uploaded.",
-                        "required": true,
-                        "type": "file"
-                    },
-                    {
-                        "in": "path",
-                        "name": "alias",
-                        "description": "Alias for the certificate",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "tags": [
-                    "Certificates (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\nThe Certificate updated successfully.\n",
-                        "schema": {
-                            "$ref": "#/definitions/CertMetadata"
-                        },
-                        "headers": {
-                            "Location": {
-                                "description": "The URL of the newly created resource.\n",
-                                "type": "string"
-                            },
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nInvalid request or validation error.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found.\nUpdating certificate failed. Alias not found\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -X DELETE -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/publisher/v0.14/certificates/wso2carbon\"",
-                "x-wso2-request": "DELETE https://localhost:9443/api/am/publisher/v0.14/certificates/wso2carbon Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8",
-                "x-wso2-response": "HTTP/1.1 200 OK",
-                "summary": "Delete a certificate.",
-                "description": "This operation can be used to delete an uploaded certificate.\n",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "alias",
-                        "description": "The alias of the certificate that should be deleted.\n",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "tags": [
-                    "Certificates (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\nThe Certificate deleted successfully.\n",
-                        "headers": {
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\n\nInvalid request or validation error.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found. |\nFailed to delete the certificate. Certificate could not found for\nthe given alias\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            },
-            "get": {
-                "x-scope": "apim:api_create",
-                "produces": [
-                    "application/json"
-                ],
-                "x-wso2-curl": "curl -X GET \"https://apis.wso2.com/api/am/publisher/v0.14/certificates/wso2carbon\" -H  \"accept: application/json\"",
-                "x-wso2-request": "GET https://apis.wso2.com/api/am/publisher/v0.14/certificates/wso2carbon Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8",
-                "x-wso2-response": "HTTP/1.1 200 OK \nContent-Type: application/json\r\n {\n  \"status\":\"Active\",\n  \"validity\":{\n    \"from\":\"Fri May 04 19:01:01 IST 2018\",\n    \"to\":\"Thu Aug 02 19:01:01 IST 2018\"\n  }\n,  \"version\":\"3\",\n  \"subject\":\"CN=wso2.com, OU=wso2, O=wso2, L=Colombo, ST=Western, C=LK\"\n}",
-                "summary": "Get the certificate information.",
-                "description": "This operation can be used to get the information about a certificate.\n",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "alias",
-                        "type": "string",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "Certificates (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\n",
-                        "schema": {
-                            "$ref": "#/definitions/CertificateInfo"
-                        },
-                        "headers": {
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nInvalid request or validation error.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found.\nAlias not found\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/certificates/{alias}/content": {
-            "get": {
-                "x-scope": "apim:api_create",
-                "x-wso2-curl": "curl -X GET \"https://apis.wso2.com/api/am/publisher/v0.14/certificates/wso2carbon/content\" -H \"accept: application/json\"",
-                "x-wso2-request": "GET https://apis.wso2.com/api/am/publisher/v0.14/certificates/wso2carbon/content Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8",
-                "x-wso2-response": "HTTP/1.1 200 OK\r\n [content of the certificate]",
-                "summary": "Download a certificate.",
-                "description": "This operation can be used to download a certificate which matches the given alias.\n",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "alias",
-                        "type": "string",
-                        "required": true
-                    }
-                ],
-                "tags": [
-                    "Certificates (Individual)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\n",
-                        "headers": {
-                            "Content-Type": {
-                                "description": "The content type of the body.\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request.\nInvalid request or validation error.\n*\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found. Certificate for the Alias not found.\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error\n",
-                        "schema": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    }
-                }
-            }
-        },
-        "/search": {
-            "get": {
-                "x-scope": "apim:api_view",
-                "produces": [
-                    "application/json"
-                ],
-                "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/publisher/v0.13/search=query?sample",
-                "x-wso2-request": "GET https://localhost:9443/api/am/publisher/v0.13/search\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-                "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"provider\": \"admin\",\n         \"version\": \"1.0.0\",\n         \"description\": \"This sample API provides Account Status Validation\",\n         \"name\": \"AccountVal\",\n         \"context\": \"/account\",\n         \"id\": \"2e81f147-c8a8-4f68-b4f0-69e0e7510b01\",\n         \"status\": \"PUBLISHED\"\n      },\n            {\n         \"provider\": \"admin\",\n         \"version\": \"1.0.0\",\n         \"description\": null,\n         \"name\": \"api1\",\n         \"context\": \"/api1\",\n         \"id\": \"3e22d2fb-277a-4e9e-8c7e-1c0f7f73960e\",\n         \"status\": \"PUBLISHED\"\n      }\n   ],\n   \"next\": \"\",\n   \"count\": 2\n}",
-                "summary": "Retrieve/Search APIs and API Documents by content\n",
-                "description": "This operation provides you a list of available APIs and API Documents qualifying the given keyword match.\n",
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/limit"
-                    },
-                    {
-                        "$ref": "#/parameters/offset"
-                    },
-                    {
-                        "name": "query",
-                        "in": "query",
-                        "description": "**Search**.\n\nYou can search by proving a keyword.\n",
-                        "type": "string"
-                    },
-                    {
-                        "$ref": "#/parameters/Accept"
-                    },
-                    {
-                        "$ref": "#/parameters/If-None-Match"
-                    }
-                ],
-                "tags": [
-                    "API (Collection)"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK.\nList of qualifying APIs and API documents is returned.\n",
-                        "schema": {
-                            "$ref": "#/definitions/SearchResultList"
-                        },
-                        "headers": {
-                            "Content-Type": {
-                                "description": "The content type of the body.",
-                                "type": "string"
-                            },
-                            "ETag": {
-                                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "304": {
-                        "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
-                    },
-                    "406": {
-                        "description": "Not Acceptable.\nThe requested media type is not supported\n",
+                        "description": "Not Found.\nRequested Settings does not exist.\n",
                         "schema": {
                             "$ref": "#/definitions/Error"
                         }
@@ -3679,18 +3673,44 @@
         "apiId": {
             "name": "apiId",
             "in": "path",
-            "description": "**API ID** consisting of the **UUID** of the API. Using the **UUID** in the API call is recommended.\nThe combination of the provider of the API, name of the API and the version is also accepted as a valid API ID.\nShould be formatted as **provider-name-version**.\n",
+            "description": "**API ID** consisting of the **UUID** of the API.\nThe combination of the provider of the API, name of the API and the version is also accepted as a valid API ID.\nShould be formatted as **provider-name-version**.\n",
             "required": true,
-            "type": "string",
-            "x-encoded": true
+            "type": "string"
+        },
+        "endpointId": {
+            "name": "endpointId",
+            "in": "path",
+            "description": "**Endpoint ID** consisting of the **UUID** of the Endpoint**.\n",
+            "required": true,
+            "type": "string"
         },
         "apiId-Q": {
             "name": "apiId",
             "in": "query",
-            "description": "**API ID** consisting of the **UUID** of the API. Using the **UUID** in the API call is recommended.\nThe combination of the provider of the API, name of the API and the version is also accepted as a valid API I.\nShould be formatted as **provider-name-version**.\n",
+            "description": "**API ID** consisting of the **UUID** of the API.\nThe combination of the provider of the API, name of the API and the version is also accepted as a valid API I.\nShould be formatted as **provider-name-version**.\n",
             "required": true,
-            "type": "string",
-            "x-encoded": true
+            "type": "string"
+        },
+        "labelType-Q": {
+            "name": "labelType",
+            "in": "query",
+            "description": "**API ID** consisting of the **UUID** of the API.\nThe combination of the provider of the API, name of the API and the version is also accepted as a valid API I.\nShould be formatted as **provider-name-version**.\n",
+            "required": false,
+            "type": "string"
+        },
+        "name": {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the API\n",
+            "required": true,
+            "type": "string"
+        },
+        "version": {
+            "name": "version",
+            "in": "path",
+            "description": "Version of the API\n",
+            "required": true,
+            "type": "string"
         },
         "documentId": {
             "name": "documentId",
@@ -3713,20 +3733,6 @@
             "required": true,
             "type": "string"
         },
-        "mediationPolicyId": {
-            "name": "mediationPolicyId",
-            "in": "path",
-            "description": "Mediation policy Id\n",
-            "required": true,
-            "type": "string"
-        },
-        "resourceId": {
-            "name": "resourceId",
-            "in": "path",
-            "description": "registry resource Id\n",
-            "required": true,
-            "type": "string"
-        },
         "subscriptionId-Q": {
             "name": "subscriptionId",
             "in": "query",
@@ -3744,14 +3750,14 @@
         "tierName-Q": {
             "name": "tierName",
             "in": "query",
-            "description": "Name of the tier\n",
+            "description": "Name of the policy\n",
             "required": true,
             "type": "string"
         },
         "tierLevel": {
             "name": "tierLevel",
             "in": "path",
-            "description": "List API or Application or Resource type tiers.\n",
+            "description": "List API or Application or Resource type policies.\n",
             "type": "string",
             "enum": [
                 "api",
@@ -3760,20 +3766,10 @@
             ],
             "required": true
         },
-        "tierLevel-A": {
-            "name": "tierLevel",
-            "in": "path",
-            "description": "List API or Application or Resource type tiers.\n",
-            "type": "string",
-            "enum": [
-                "api"
-            ],
-            "required": true
-        },
         "tierLevel-Q": {
             "name": "tierLevel",
             "in": "query",
-            "description": "List API or Application or Resource type tiers.\n",
+            "description": "List API or Application or Resource type policies.\n",
             "type": "string",
             "enum": [
                 "api",
@@ -3796,64 +3792,78 @@
             "default": 0,
             "type": "integer"
         },
-        "Accept": {
-            "name": "Accept",
-            "in": "header",
-            "description": "Media types acceptable for the response. Default is application/json.\n",
-            "default": "application/json",
-            "type": "string"
-        },
-        "Content-Type": {
-            "name": "Content-Type",
-            "in": "header",
-            "description": "Media type of the entity in the body. Default is application/json.\n",
-            "default": "application/json",
-            "required": true,
-            "type": "string"
-        },
-        "Authorization": {
-            "name": "Authorization",
-            "in": "header",
-            "description": "Holds the bearer token for apis that require authentication.\n",
-            "required": true,
-            "type": "string"
-        },
         "If-None-Match": {
             "name": "If-None-Match",
             "in": "header",
-            "description": "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resource (Will be supported in future).\n",
+            "description": "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resourec.\n",
             "type": "string"
         },
         "If-Modified-Since": {
             "name": "If-Modified-Since",
             "in": "header",
-            "description": "Validator for conditional requests; based on Last Modified header of the\nformerly retrieved variant of the resource (Will be supported in future).\n",
+            "description": "Validator for conditional requests; based on Last Modified header of the\nformerly retrieved variant of the resource.\n",
             "type": "string"
         },
         "If-Match": {
             "name": "If-Match",
             "in": "header",
-            "description": "Validator for conditional requests; based on ETag (Will be supported in future).\n",
+            "description": "Validator for conditional requests; based on ETag.\n",
             "type": "string"
         },
         "If-Unmodified-Since": {
             "name": "If-Unmodified-Since",
             "in": "header",
-            "description": "Validator for conditional requests; based on Last Modified header (Will be supported in future).\n",
+            "description": "Validator for conditional requests; based on Last Modified header.\n",
             "type": "string"
         },
-        "workflowReferenceId-Q": {
-            "name": "workflowReferenceId",
-            "in": "query",
-            "description": "Workflow reference id\n",
+        "definitionType": {
+            "in": "formData",
+            "name": "type",
+            "description": "Definition type to upload",
+            "type": "string",
+            "required": true,
+            "enum": [
+                "SWAGGER",
+                "WSDL"
+            ],
+            "default": "SWAGGER"
+        },
+        "definitionFile": {
+            "in": "formData",
+            "name": "file",
+            "description": "Definition to upload as a file",
+            "type": "file",
+            "required": false
+        },
+        "scopeName": {
+            "name": "name",
+            "in": "path",
+            "description": "Scope name\n",
             "required": true,
             "type": "string"
         },
-        "expand": {
-            "name": "expand",
-            "in": "query",
-            "description": "Defines whether the returned response should contain full details of API\n",
-            "type": "boolean"
+        "definitionUrl": {
+            "in": "formData",
+            "name": "url",
+            "description": "Definition url",
+            "type": "string",
+            "required": false
+        },
+        "threatProtectionPolicyId": {
+            "name": "policyId",
+            "in": "path",
+            "description": "The UUID of a Policy\n",
+            "required": true,
+            "type": "string"
+        },
+        "threatProtectionPolicy": {
+            "name": "threatProtectionPolicy",
+            "in": "body",
+            "description": "Threat protection policy request parameter\n",
+            "required": true,
+            "schema": {
+                "$ref": "#/definitions/ThreatProtectionPolicy"
+            }
         }
     },
     "definitions": {
@@ -3880,22 +3890,6 @@
                     "items": {
                         "$ref": "#/definitions/APIInfo"
                     }
-                },
-                "pagination": {
-                    "properties": {
-                        "offset": {
-                            "type": "integer",
-                            "example": 12
-                        },
-                        "limit": {
-                            "type": "integer",
-                            "example": 25
-                        },
-                        "total": {
-                            "type": "integer",
-                            "example": 1290
-                        }
-                    }
                 }
             }
         },
@@ -3904,27 +3898,22 @@
             "properties": {
                 "id": {
                     "type": "string",
-                    "description": "UUID of the api registry artifact\n",
                     "example": "01234567-0123-0123-0123-012345678901"
                 },
                 "name": {
                     "type": "string",
-                    "description": "Name of the API",
                     "example": "CalculatorAPI"
                 },
                 "description": {
                     "type": "string",
-                    "description": "A brief description about the API",
                     "example": "A calculator API that supports basic operations"
                 },
                 "context": {
                     "type": "string",
-                    "description": "A string that represents the context of the user's request",
                     "example": "CalculatorAPI"
                 },
                 "version": {
                     "type": "string",
-                    "description": "The version of the API",
                     "example": "1.0.0"
                 },
                 "provider": {
@@ -3932,230 +3921,345 @@
                     "type": "string",
                     "example": "admin"
                 },
-                "status": {
+                "lifeCycleStatus": {
                     "type": "string",
-                    "description": "This describes in which status of the lifecycle the API is",
                     "example": "CREATED"
                 },
-                "thumbnailUri": {
+                "workflowStatus": {
                     "type": "string",
-                    "example": "/apis/01234567-0123-0123-0123-012345678901/thumbnail"
+                    "example": "APPROVED"
+                },
+                "securityScheme": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
-        "APIDetailed": {
+        "API": {
             "title": "API object",
             "required": [
                 "name",
                 "context",
                 "version",
-                "tiers",
+                "policies",
                 "isDefaultVersion",
                 "transport",
-                "endpointConfig",
-                "visibility",
-                "type",
-                "apiDefinition"
+                "visibility"
             ],
-            "allOf": [
-                {
-                    "$ref": "#/definitions/APIInfo"
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "UUID of the api registry artifact\n",
+                    "example": "01234567-0123-0123-0123-012345678901"
                 },
-                {
+                "name": {
+                    "type": "string",
+                    "example": "CalculatorAPI"
+                },
+                "description": {
+                    "type": "string",
+                    "example": "A calculator API that supports basic operations"
+                },
+                "context": {
+                    "type": "string",
+                    "example": "CalculatorAPI"
+                },
+                "version": {
+                    "type": "string",
+                    "example": "1.0.0"
+                },
+                "provider": {
+                    "description": "If the provider value is not given user invoking the api will be used as the provider.\n",
+                    "type": "string",
+                    "example": "admin"
+                },
+                "wsdlUri": {
+                    "description": "WSDL URL if the API is based on a WSDL endpoint\n",
+                    "type": "string",
+                    "example": "http://www.webservicex.com/globalweather.asmx?wsdl"
+                },
+                "lifeCycleStatus": {
+                    "type": "string",
+                    "example": "CREATED"
+                },
+                "workflowStatus": {
+                    "type": "string",
+                    "example": "APPROVED"
+                },
+                "createdTime": {
+                    "type": "string",
+                    "example": "2017-02-20T13:57:16.229Z"
+                },
+                "apiPolicy": {
+                    "type": "string",
+                    "example": "UNLIMITED"
+                },
+                "lastUpdatedTime": {
+                    "type": "string",
+                    "example": "2017-02-20T13:57:16.229Z"
+                },
+                "responseCaching": {
+                    "type": "string",
+                    "example": "Disabled"
+                },
+                "cacheTimeout": {
+                    "type": "integer",
+                    "example": 300
+                },
+                "destinationStatsEnabled": {
+                    "type": "string",
+                    "example": "Disabled"
+                },
+                "isDefaultVersion": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "transport": {
+                    "description": "Supported transports for the API (http and/or https).\n",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "http",
+                        "https"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "substract",
+                        "add"
+                    ]
+                },
+                "hasOwnGateway": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "labels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "public",
+                        "private"
+                    ]
+                },
+                "policies": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "Unlimited"
+                    ]
+                },
+                "visibility": {
+                    "type": "string",
+                    "enum": [
+                        "PUBLIC",
+                        "PRIVATE",
+                        "RESTRICTED"
+                    ],
+                    "example": "PUBLIC"
+                },
+                "visibleRoles": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": []
+                },
+                "permission": {
+                    "type": "string",
+                    "example": "[{\"groupId\" : 1000, \"permission\" : [\"READ\",\"UPDATE\"]},{\"groupId\" : 1001, \"permission\" : [\"READ\",\"UPDATE\"]}]"
+                },
+                "userPermissionsForApi": {
+                    "type": "array",
+                    "description": "LoggedIn user permissions for the API\n",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "READ",
+                        "UPDATE"
+                    ]
+                },
+                "visibleTenants": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": []
+                },
+                "gatewayEnvironments": {
+                    "description": "Comma separated list of gateway environments.\n",
+                    "type": "string",
+                    "example": "Production and Sandbox"
+                },
+                "sequences": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Sequence"
+                    },
+                    "example": []
+                },
+                "businessInformation": {
                     "properties": {
-                        "apiDefinition": {
-                            "description": "Swagger definition of the API which contains details about URI templates and scopes\n",
+                        "businessOwner": {
                             "type": "string",
-                            "example": "{\"paths\":{\"/substract\":{\"get\":{\"x-auth-type\":\"Application & Application User\",\"x-throttling-tier\":\"Unlimited\",\"parameters\":[{\"name\":\"x\",\"required\":true,\"type\":\"string\",\"in\":\"query\"},{\"name\":\"y\",\"required\":true,\"type\":\"string\",\"in\":\"query\"}],\"responses\":{\"200\":{}}}},\"/add\":{\"get\":{\"x-auth-type\":\"Application & Application User\",\"x-throttling-tier\":\"Unlimited\",\"parameters\":[{\"name\":\"x\",\"required\":true,\"type\":\"string\",\"in\":\"query\"},{\"name\":\"y\",\"required\":true,\"type\":\"string\",\"in\":\"query\"}],\"responses\":{\"200\":{}}}}},\"swagger\":\"2.0\",\"info\":{\"title\":\"CalculatorAPI\",\"version\":\"1.0.0\"}}"
+                            "example": "businessowner"
                         },
-                        "wsdlUri": {
-                            "description": "WSDL URL if the API is based on a WSDL endpoint\n",
+                        "businessOwnerEmail": {
                             "type": "string",
-                            "example": "http://www.webservicex.com/globalweather.asmx?wsdl"
+                            "example": "businessowner@wso2.com"
                         },
-                        "responseCaching": {
+                        "technicalOwner": {
                             "type": "string",
-                            "example": "Disabled"
+                            "example": "technicalowner"
                         },
-                        "cacheTimeout": {
-                            "type": "integer",
-                            "example": 300
-                        },
-                        "destinationStatsEnabled": {
+                        "technicalOwnerEmail": {
                             "type": "string",
-                            "example": "Disabled"
-                        },
-                        "isDefaultVersion": {
+                            "example": "technicalowner@wso2.com"
+                        }
+                    }
+                },
+                "corsConfiguration": {
+                    "description": "CORS configuration for the API\n",
+                    "properties": {
+                        "corsConfigurationEnabled": {
                             "type": "boolean",
-                            "example": false
+                            "default": false
                         },
-                        "type": {
-                            "type": "string",
-                            "description": "The api creation type to be used. Accepted values are HTTP, WS, SOAPTOREST",
-                            "enum": [
-                                "HTTP",
-                                "WS",
-                                "SOAPTOREST"
-                            ],
-                            "example": "HTTP",
-                            "default": "HTTP"
-                        },
-                        "transport": {
-                            "description": "Supported transports for the API (http and/or https).\n",
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            },
-                            "example": [
-                                "http",
-                                "https"
-                            ]
-                        },
-                        "tags": {
-                            "type": "array",
-                            "description": "Search keywords related to the API",
-                            "items": {
-                                "type": "string"
-                            },
-                            "example": [
-                                "substract",
-                                "add"
-                            ]
-                        },
-                        "tiers": {
-                            "type": "array",
-                            "description": "The subscription tiers selected for the particular API",
-                            "items": {
-                                "type": "string"
-                            },
-                            "example": [
-                                "Unlimited"
-                            ]
-                        },
-                        "apiLevelPolicy": {
-                            "description": "The policy selected for the particular API",
-                            "type": "string",
-                            "example": [
-                                "http",
-                                "https"
-                            ]
-                        },
-                        "authorizationHeader": {
-                            "type": "string",
-                            "description": "Name of the Authorization header used for invoking the API. If it is not set, Authorization header name specified\nin tenant or system level will be used.\n"
-                        },
-                        "apiSecurity": {
-                            "type": "string",
-                            "description": "Type of API security, the current API secured with. It can be either OAuth2 or mutual SSL or both. If\nit is not set OAuth2 will be set as the security for the current API.\n"
-                        },
-                        "maxTps": {
-                            "$ref": "#/definitions/APIMaxTps"
-                        },
-                        "visibility": {
-                            "type": "string",
-                            "description": "The visibility level of the API. Accepts one of the following. PUBLIC, PRIVATE, RESTRICTED OR CONTROLLED.",
-                            "enum": [
-                                "PUBLIC",
-                                "PRIVATE",
-                                "RESTRICTED",
-                                "CONTROLLED"
-                            ],
-                            "example": "PUBLIC"
-                        },
-                        "visibleRoles": {
-                            "type": "array",
-                            "description": "The user roles that are able to access the API",
-                            "items": {
-                                "type": "string"
-                            },
-                            "example": []
-                        },
-                        "visibleTenants": {
+                        "accessControlAllowOrigins": {
                             "type": "array",
                             "items": {
                                 "type": "string"
                             }
                         },
-                        "endpointConfig": {
-                            "type": "string",
-                            "example": "{\"production_endpoints\":{\"url\":\"https://localhost:9443/am/sample/pizzashack/v1/api/\",\"config\":{\"suspendErrorCode\":\"101000\",\"suspendDuration\":\"2000\",\"suspendMaxDuration\":\"3\",\"factor\":\"2\",\"retryErroCode\":\"101000\",\"retryTimeOut\":\"4\",\"retryDelay\":\"1000\",\"actionSelect\":\"fault\",\"actionDuration\":\"3000\"}},\"sandbox_endpoints\":{\"url\":\"https://localhost:9443/am/sample/pizzashack/v1/api/\",\"config\":null},\"endpoint_type\":\"http\"}"
+                        "accessControlAllowCredentials": {
+                            "type": "boolean",
+                            "default": false
                         },
-                        "endpointSecurity": {
-                            "$ref": "#/definitions/APIEndpointSecurity"
-                        },
-                        "gatewayEnvironments": {
-                            "description": "Comma separated list of gateway environments.\n",
-                            "type": "string",
-                            "example": "Production and Sandbox"
-                        },
-                        "labels": {
-                            "description": "Labels of micro-gateway environments attached to the API.\n",
+                        "accessControlAllowHeaders": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/Label"
+                                "type": "string"
                             }
                         },
-                        "sequences": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Sequence"
-                            },
-                            "example": "\"sequences\": [ {\"name\": \"json_to_xml_in_message\",\"config\": null,\"type\": \"in\"}, {\"name\": \"xml_to_json_out_message\",\"config\": null,\"type\": \"out\"}, {\"name\": \"json_fault\",\"config\": null,\"type\": \"fault\"} ],"
-                        },
-                        "subscriptionAvailability": {
-                            "type": "string",
-                            "description": "The subscription availability. Accepts one of the following. current_tenant, all_tenants or specific_tenants.",
-                            "enum": [
-                                "current_tenant",
-                                "all_tenants",
-                                "specific_tenants"
-                            ],
-                            "example": "current_tenant"
-                        },
-                        "subscriptionAvailableTenants": {
+                        "accessControlAllowMethods": {
                             "type": "array",
                             "items": {
                                 "type": "string"
+                            }
+                        }
+                    }
+                },
+                "endpoint": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "example": "01234567-0123-0123-0123-012345678901"
                             },
-                            "example": [
-                                "tenant1",
-                                "tenant2"
-                            ]
-                        },
-                        "additionalProperties": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
+                            "inline": {
+                                "$ref": "#/definitions/EndPoint"
                             },
-                            "description": "Map of custom properties of API"
-                        },
-                        "accessControl": {
-                            "type": "string",
-                            "description": "Is the API is restricted to certain set of publishers or creators or is it visible to all the\npublishers and creators. If the accessControl restriction is none, this API can be modified by all the\npublishers and creators, if not it can only be viewable/modifiable by certain set of publishers and creators,\n based on the restriction.\n",
-                            "enum": [
-                                "NONE",
-                                "RESTRICTED"
-                            ]
-                        },
-                        "accessControlRoles": {
+                            "type": {
+                                "type": "string",
+                                "example": "Production"
+                            }
+                        }
+                    }
+                },
+                "securityScheme": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "example": "postapiresource"
+                            },
+                            "uritemplate": {
+                                "type": "string",
+                                "default": "/*"
+                            },
+                            "httpVerb": {
+                                "type": "string",
+                                "default": "GET"
+                            },
+                            "authType": {
+                                "type": "string",
+                                "default": "Any"
+                            },
+                            "policy": {
+                                "type": "string",
+                                "example": "Unlimited"
+                            },
+                            "endpoint": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "key": {
+                                            "type": "string",
+                                            "example": "01234567-0123-0123-0123-012345678901"
+                                        },
+                                        "inline": {
+                                            "$ref": "#/definitions/EndPoint"
+                                        },
+                                        "type": {
+                                            "type": "string",
+                                            "example": "Production"
+                                        }
+                                    }
+                                }
+                            },
+                            "scopes": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "threatProtectionPolicies": {
+                    "properties": {
+                        "list": {
                             "type": "array",
-                            "description": "The user roles that are able to view/modify as API publisher or creator.",
                             "items": {
-                                "type": "string"
-                            },
-                            "example": [
-                                "admin"
-                            ]
-                        },
-                        "businessInformation": {
-                            "$ref": "#/definitions/APIBusinessInformation"
-                        },
-                        "corsConfiguration": {
-                            "$ref": "#/definitions/APICorsConfiguration"
+                                "properties": {
+                                    "policyId": {
+                                        "type": "string"
+                                    },
+                                    "priority": {
+                                        "type": "integer"
+                                    }
+                                }
+                            }
                         }
                     }
                 }
-            ]
+            }
         },
         "Application": {
             "title": "Application",
@@ -4183,10 +4287,6 @@
                 "description": {
                     "type": "string",
                     "example": "Sample calculator application"
-                },
-                "groupId": {
-                    "type": "string",
-                    "example": ""
                 }
             }
         },
@@ -4254,7 +4354,6 @@
                     "type": "string",
                     "enum": [
                         "INLINE",
-                        "MARKDOWN",
                         "URL",
                         "FILE"
                     ],
@@ -4264,9 +4363,21 @@
                     "type": "string",
                     "example": ""
                 },
+                "fileName": {
+                    "type": "string",
+                    "example": ""
+                },
+                "inlineContent": {
+                    "type": "string",
+                    "example": "This is doc content. This can have many lines."
+                },
                 "otherTypeName": {
                     "type": "string",
                     "example": ""
+                },
+                "permission": {
+                    "type": "string",
+                    "example": "[{\"groupId\" : 1000, \"permission\" : [\"READ\",\"UPDATE\"]},{\"groupId\" : 1001, \"permission\" : [\"READ\",\"UPDATE\"]}]"
                 },
                 "visibility": {
                     "type": "string",
@@ -4276,104 +4387,19 @@
                         "API_LEVEL"
                     ],
                     "example": "API_LEVEL"
-                }
-            }
-        },
-        "mediationList": {
-            "title": "Mediation List",
-            "properties": {
-                "count": {
-                    "type": "integer",
-                    "description": "Number of mediation sequences returned.\n",
-                    "example": 1
                 },
-                "next": {
+                "createdTime": {
                     "type": "string",
-                    "description": "Link to the next subset of sequences qualified.\nEmpty if no more sequences are to be returned.\n",
-                    "example": ""
+                    "example": "2017-02-20T13:57:16.229Z"
                 },
-                "previous": {
-                    "type": "string",
-                    "description": "Link to the previous subset of sequences qualified.\nEmpty if current subset is the first subset returned.\n",
-                    "example": ""
+                "createdBy": {
+                    "type": "string"
                 },
-                "list": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/MediationInfo"
-                    }
-                }
-            }
-        },
-        "MediationInfo": {
-            "title": "MediationInfo",
-            "required": [
-                "name",
-                "type",
-                "id"
-            ],
-            "properties": {
-                "name": {
+                "lastUpdatedTime": {
                     "type": "string",
-                    "example": "json_fault.xml"
+                    "example": "2017-02-20T13:57:16.229Z"
                 },
-                "id": {
-                    "type": "string",
-                    "example": "01234567-0123-0123-0123-012345678901"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "in",
-                        "out",
-                        "fault"
-                    ],
-                    "example": "in"
-                }
-            }
-        },
-        "Mediation": {
-            "title": "Mediation",
-            "required": [
-                "name",
-                "type",
-                "config"
-            ],
-            "properties": {
-                "id": {
-                    "type": "string",
-                    "example": "01234567-0123-0123-0123-012345678901"
-                },
-                "name": {
-                    "type": "string",
-                    "example": "json_fault.xml"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "in",
-                        "out",
-                        "fault"
-                    ],
-                    "example": "in"
-                },
-                "config": {
-                    "type": "string",
-                    "example": "<sequence xmlns=\"http://ws.apache.org/ns/synapse\" name=\"log_in_message\"> <log level=\"full\"> <property name=\"IN_MESSAGE\" value=\"IN_MESSAGE_21133232\"/> </log> </sequence>"
-                }
-            }
-        },
-        "Wsdl": {
-            "title": "Wsdl",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "example": "admin--calculatorAPI2.0.wsdl"
-                },
-                "wsdlDefinition": {
+                "lastUpdatedBy": {
                     "type": "string"
                 }
             }
@@ -4389,12 +4415,12 @@
                 "next": {
                     "type": "string",
                     "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n",
-                    "example": "/tiers/api?limit=1&offset=2"
+                    "example": "/policies/api?limit=1&offset=2"
                 },
                 "previous": {
                     "type": "string",
                     "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n",
-                    "example": "/tiers/api?limit=1&offset=0"
+                    "example": "/policies/api?limit=1&offset=0"
                 },
                 "list": {
                     "type": "array",
@@ -4432,7 +4458,7 @@
                     "example": "api"
                 },
                 "attributes": {
-                    "description": "Custom attributes added to the tier policy\n",
+                    "description": "Custom attributes added to the policy policy\n",
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
@@ -4455,7 +4481,7 @@
                     "example": "min"
                 },
                 "tierPlan": {
-                    "description": "This attribute declares whether this tier is available under commercial or free\n",
+                    "description": "This attribute declares whether this policy is available under commercial or free\n",
                     "type": "string",
                     "enum": [
                         "FREE",
@@ -4470,32 +4496,6 @@
                 }
             }
         },
-        "TierPermission": {
-            "title": "tierPermission",
-            "required": [
-                "permissionType",
-                "roles"
-            ],
-            "properties": {
-                "permissionType": {
-                    "type": "string",
-                    "enum": [
-                        "allow",
-                        "deny"
-                    ],
-                    "example": "deny"
-                },
-                "roles": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "Internal/everyone"
-                    ]
-                }
-            }
-        },
         "SubscriptionList": {
             "title": "Subscription List",
             "properties": {
@@ -4507,12 +4507,12 @@
                 "next": {
                     "type": "string",
                     "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n",
-                    "example": "/subscriptions?limit=1&offset=2&apiId=01234567-0123-0123-0123-012345678901&groupId="
+                    "example": "/subscriptions?limit=1&offset=2&apiId=01234567-0123-0123-0123-012345678901"
                 },
                 "previous": {
                     "type": "string",
                     "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n",
-                    "example": "/subscriptions?limit=1&offset=0&apiId=01234567-0123-0123-0123-012345678901&groupId="
+                    "example": "/subscriptions?limit=1&offset=0&apiId=01234567-0123-0123-0123-012345678901"
                 },
                 "list": {
                     "type": "array",
@@ -4525,58 +4525,36 @@
         "Subscription": {
             "title": "Subscription",
             "required": [
-                "applicationId",
-                "apiIdentifier",
-                "tier"
+                "subscriptionId",
+                "applicationInfo",
+                "policy",
+                "subscriptionStatus"
             ],
             "properties": {
                 "subscriptionId": {
                     "type": "string",
                     "example": "01234567-0123-0123-0123-012345678901"
                 },
-                "applicationId": {
-                    "type": "string",
-                    "example": "01234567-0123-0123-0123-012345678901"
+                "applicationInfo": {
+                    "$ref": "#/definitions/Application"
                 },
-                "apiIdentifier": {
-                    "type": "string",
-                    "example": "01234567-0123-0123-0123-012345678901"
-                },
-                "tier": {
+                "policy": {
                     "type": "string",
                     "example": "Unlimited"
                 },
-                "status": {
+                "subscriptionStatus": {
                     "type": "string",
                     "enum": [
                         "BLOCKED",
                         "PROD_ONLY_BLOCKED",
-                        "UNBLOCKED",
+                        "SANDBOX_ONLY_BLOCKED",
+                        "ACTIVE",
                         "ON_HOLD",
                         "REJECTED"
                     ],
-                    "example": "UNBLOCKED"
+                    "example": "BLOCKED"
                 }
             }
-        },
-        "ExtendedSubscription": {
-            "title": "Subscription with Ext. Workflow Reference",
-            "required": [
-                "workflowId"
-            ],
-            "allOf": [
-                {
-                    "$ref": "#/definitions/Subscription"
-                },
-                {
-                    "properties": {
-                        "workflowId": {
-                            "type": "string",
-                            "example": "01234567-0123-0123-0123-012345678901"
-                        }
-                    }
-                }
-            ]
         },
         "Sequence": {
             "title": "Sequence",
@@ -4588,38 +4566,18 @@
                     "type": "string",
                     "example": "log_in_message"
                 },
+                "config": {
+                    "type": "string",
+                    "example": ""
+                },
                 "type": {
                     "type": "string",
                     "example": "in"
-                },
-                "id": {
-                    "type": "string",
-                    "example": "69ea3fa6-55c6-472e-896d-e449dd34a824"
-                },
-                "shared": {
-                    "type": "boolean",
-                    "example": true
-                }
-            }
-        },
-        "Label": {
-            "title": "Label",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "example": "Development"
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Explanation about the micro gateway."
                 }
             }
         },
         "Error": {
-            "title": "Error object returned with 4XX HTTP status",
+            "title": "Error object returned with 4XX HTTP lifeCycleStatus",
             "required": [
                 "code",
                 "message"
@@ -4666,68 +4624,6 @@
                 }
             }
         },
-        "Environment": {
-            "title": "Environment",
-            "required": [
-                "name",
-                "type",
-                "serverUrl",
-                "endpoints",
-                "showInApiConsole"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "example": "Production and Sandbox"
-                },
-                "type": {
-                    "type": "string",
-                    "example": "hybrid"
-                },
-                "serverUrl": {
-                    "type": "string",
-                    "example": "https://localhost:9443/services/"
-                },
-                "showInApiConsole": {
-                    "type": "boolean",
-                    "example": true
-                },
-                "endpoints": {
-                    "$ref": "#/definitions/EnvironmentEndpoints"
-                }
-            }
-        },
-        "EnvironmentList": {
-            "title": "Environment List",
-            "properties": {
-                "count": {
-                    "type": "integer",
-                    "description": "Number of Environments returned.\n",
-                    "example": 1
-                },
-                "list": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Environment"
-                    }
-                }
-            }
-        },
-        "EnvironmentEndpoints": {
-            "title": "Environment Endpoints",
-            "properties": {
-                "http": {
-                    "type": "string",
-                    "description": "HTTP environment URL",
-                    "example": "http://localhost:8280"
-                },
-                "https": {
-                    "type": "string",
-                    "description": "HTTPS environment URL",
-                    "example": "https://localhost:8243"
-                }
-            }
-        },
         "FileInfo": {
             "title": "File Information including meta data",
             "properties": {
@@ -4743,477 +4639,471 @@
                 }
             }
         },
-        "Workflow": {
-            "title": "workflow",
-            "required": [
-                "status"
-            ],
-            "properties": {
-                "status": {
-                    "description": "This attribute declares whether this workflow task is approved or rejected.\n",
-                    "type": "string",
-                    "enum": [
-                        "APPROVED",
-                        "REJECTED"
-                    ],
-                    "example": "APPROVED"
-                },
-                "attributes": {
-                    "description": "Custom attributes to complete the workflow task\n",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "example": {}
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Approve workflow request."
-                }
-            }
-        },
-        "APIMaxTps": {
-            "properties": {
-                "production": {
-                    "type": "integer",
-                    "format": "int64",
-                    "example": 1000
-                },
-                "sandbox": {
-                    "type": "integer",
-                    "format": "int64",
-                    "example": 1000
-                }
-            }
-        },
-        "APIEndpointSecurity": {
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "example": "basic",
-                    "description": "Accepts one of the following, basic or digest.",
-                    "enum": [
-                        "basic",
-                        "digest"
-                    ]
-                },
-                "username": {
-                    "type": "string",
-                    "example": "admin"
-                },
-                "password": {
-                    "type": "string",
-                    "example": "password"
-                }
-            }
-        },
-        "APIBusinessInformation": {
-            "properties": {
-                "businessOwner": {
-                    "type": "string",
-                    "example": "businessowner"
-                },
-                "businessOwnerEmail": {
-                    "type": "string",
-                    "example": "businessowner@wso2.com"
-                },
-                "technicalOwner": {
-                    "type": "string",
-                    "example": "technicalowner"
-                },
-                "technicalOwnerEmail": {
-                    "type": "string",
-                    "example": "technicalowner@wso2.com"
-                }
-            }
-        },
-        "APICorsConfiguration": {
-            "description": "CORS configuration for the API\n",
-            "properties": {
-                "corsConfigurationEnabled": {
-                    "type": "boolean",
-                    "default": false
-                },
-                "accessControlAllowOrigins": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "accessControlAllowCredentials": {
-                    "type": "boolean",
-                    "default": false
-                },
-                "accessControlAllowHeaders": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "accessControlAllowMethods": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "Certificates": {
-            "title": "Certificates",
-            "description": "Representation of a list of certificates",
-            "properties": {
-                "count": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "next": {
-                    "type": "string",
-                    "example": "/certificates?limit=1&offset=2"
-                },
-                "previous": {
-                    "type": "string",
-                    "example": "/certificates?limit=1&offset=0"
-                },
-                "certificates": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/CertMetadata"
-                    }
-                },
-                "pagination": {
-                    "properties": {
-                        "offset": {
-                            "type": "integer",
-                            "example": 12
-                        },
-                        "limit": {
-                            "type": "integer",
-                            "example": 25
-                        },
-                        "total": {
-                            "type": "integer",
-                            "example": 1290
-                        }
-                    }
-                }
-            }
-        },
-        "CertMetadata": {
-            "title": "Certificate",
-            "description": "Representation of the details of a certificate",
-            "properties": {
-                "alias": {
-                    "type": "string",
-                    "example": "wso2carbon"
-                },
-                "endpoint": {
-                    "type": "string",
-                    "example": "www.abc.com"
-                }
-            }
-        },
-        "CertificateInfo": {
-            "title": "Certificate information",
-            "properties": {
-                "status": {
-                    "type": "string",
-                    "example": "Active"
-                },
-                "validity": {
-                    "$ref": "#/definitions/CertificateValidity"
-                },
-                "version": {
-                    "type": "string",
-                    "example": "V3"
-                },
-                "subject": {
-                    "type": "string",
-                    "example": "CN=wso2.com, OU=wso2, O=wso2, L=Colombo, ST=Western, C=LK"
-                }
-            }
-        },
-        "CertificateValidity": {
-            "title": "Certificate Valid period",
-            "properties": {
-                "from": {
-                    "type": "string",
-                    "example": "12-12-2017"
-                },
-                "to": {
-                    "type": "string",
-                    "example": "01-01-2019"
-                }
-            }
-        },
-        "ClientCertificates": {
-            "title": "Client Certificates",
-            "description": "Representation of a list of client certificates",
-            "properties": {
-                "count": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "next": {
-                    "type": "string",
-                    "example": "/certificates?limit=1&offset=2"
-                },
-                "previous": {
-                    "type": "string",
-                    "example": "/certificates?limit=1&offset=0"
-                },
-                "certificates": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ClientCertMetadata"
-                    }
-                },
-                "pagination": {
-                    "properties": {
-                        "offset": {
-                            "type": "integer",
-                            "example": 12
-                        },
-                        "limit": {
-                            "type": "integer",
-                            "example": 25
-                        },
-                        "total": {
-                            "type": "integer",
-                            "example": 1290
-                        }
-                    }
-                }
-            }
-        },
-        "ClientCertMetadata": {
-            "title": "Client certificate meta data",
-            "description": "Meta data of certificate",
-            "properties": {
-                "alias": {
-                    "type": "string",
-                    "example": "wso2carbon"
-                },
-                "apiId": {
-                    "type": "string",
-                    "example": "64eca60b-2e55-4c38-8603-e9e6bad7d809"
-                },
-                "tier": {
-                    "type": "string",
-                    "example": "Gold"
-                }
-            }
-        },
-        "SearchResultList": {
-            "title": "Unified Search Result List",
-            "properties": {
-                "count": {
-                    "type": "integer",
-                    "description": "Number of results returned.\n",
-                    "example": 1
-                },
-                "next": {
-                    "type": "string",
-                    "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n",
-                    "example": "/apis?limit=1&offset=2&query="
-                },
-                "previous": {
-                    "type": "string",
-                    "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n",
-                    "example": "/apis?limit=1&offset=0&query="
-                },
-                "list": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/SearchResult"
-                    }
-                },
-                "pagination": {
-                    "properties": {
-                        "offset": {
-                            "type": "integer",
-                            "example": 12
-                        },
-                        "limit": {
-                            "type": "integer",
-                            "example": 25
-                        },
-                        "total": {
-                            "type": "integer",
-                            "example": 1290
-                        }
-                    }
-                }
-            }
-        },
-        "SearchResult": {
-            "title": "Search Result",
+        "EndPoint": {
+            "title": "Endpoints",
             "properties": {
                 "id": {
                     "type": "string",
+                    "description": "UUID of the Endpoint entry\n",
                     "example": "01234567-0123-0123-0123-012345678901"
                 },
                 "name": {
                     "type": "string",
-                    "example": "TestAPI"
+                    "description": "name of the Endpoint entry\n",
+                    "example": "Endpoint 1"
+                },
+                "endpointConfig": {
+                    "type": "string",
+                    "description": "Endpoint Configuration",
+                    "example": "{url: http://localhost:8280, timeout: 1000}"
+                },
+                "endpointSecurity": {
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "example": false
+                        },
+                        "type": {
+                            "type": "string",
+                            "example": "basic"
+                        },
+                        "username": {
+                            "type": "string",
+                            "example": "basic"
+                        },
+                        "password": {
+                            "type": "string",
+                            "example": "basic"
+                        }
+                    }
+                },
+                "maxTps": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "Endpoint max tps",
+                    "example": 1000
                 },
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "DOC",
-                        "API"
-                    ],
-                    "example": "API"
+                    "example": "http"
                 }
             }
         },
-        "APISearchResult": {
-            "title": "API Result",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/SearchResult"
+        "EndPointList": {
+            "title": "EndPoint List",
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "description": "Number of EndPoints returned.\n",
+                    "example": 1
                 },
-                {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/EndPoint"
+                    }
+                }
+            }
+        },
+        "Scope": {
+            "title": "Scope",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "name of Scope\n",
+                    "example": "apim:api_view"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "description of Scope\n",
+                    "example": "This Scope can used to view Apis"
+                },
+                "bindings": {
                     "properties": {
-                        "description": {
+                        "type": {
                             "type": "string",
-                            "description": "A brief description about the API",
-                            "example": "A calculator API that supports basic operations"
+                            "description": "Type of binding role / permission\n"
                         },
-                        "context": {
-                            "type": "string",
-                            "description": "A string that represents the context of the user's request",
-                            "example": "CalculatorAPI"
-                        },
+                        "values": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "ScopeList": {
+            "title": "Scope List",
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "description": "Number of Scopes returned.\n",
+                    "example": 1
+                },
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "example": "apim:api_view"
+                            },
+                            "description": {
+                                "type": "string",
+                                "example": "Scope for Api view"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "Label": {
+            "title": "Label",
+            "required": [
+                "labelId",
+                "name",
+                "type",
+                "access_urls"
+            ],
+            "properties": {
+                "labelId": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "access_urls": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "LabelList": {
+            "title": "Label List",
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "description": "Number of Labels returned.\n"
+                },
+                "next": {
+                    "type": "string",
+                    "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n"
+                },
+                "previous": {
+                    "type": "string",
+                    "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n"
+                },
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Label"
+                    }
+                }
+            }
+        },
+        "LifecycleState": {
+            "title": "Lifecycle State",
+            "properties": {
+                "lcName": {
+                    "type": "string",
+                    "example": "API Lifecycle"
+                },
+                "state": {
+                    "type": "string",
+                    "example": "Created"
+                },
+                "lifecyelId": {
+                    "type": "string",
+                    "example": "01234567-0123-0123-0123-012345678901"
+                },
+                "checkItemBeanList": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "permissionBeans": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "roles": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "forTarget": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "name": {
+                                "type": "string",
+                                "example": "Deprecate old versions after publish the API"
+                            },
+                            "validationBeans": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "classObject": {
+                                            "type": "object"
+                                        },
+                                        "targetName": {
+                                            "type": "string",
+                                            "example": "Published"
+                                        },
+                                        "customMessage": {
+                                            "type": "string",
+                                            "example": "Validation successful"
+                                        }
+                                    }
+                                }
+                            },
+                            "targets": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "value": {
+                                "type": "boolean",
+                                "example": false
+                            }
+                        }
+                    }
+                },
+                "inputBeanList": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "example": "Gateways to be published"
+                            },
+                            "isRequired": {
+                                "type": "boolean",
+                                "example": true
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "placeHolder": {
+                                "type": "string"
+                            },
+                            "tooltip": {
+                                "type": "string"
+                            },
+                            "regex": {
+                                "type": "string"
+                            },
+                            "values": {
+                                "type": "string"
+                            },
+                            "forTarget": {
+                                "type": "string",
+                                "example": "Created"
+                            }
+                        }
+                    }
+                },
+                "customCodeBeanList": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "classObject": {
+                                "type": "object"
+                            },
+                            "targetName": {
+                                "type": "string",
+                                "example": "Published"
+                            },
+                            "customMessage": {
+                                "type": "string",
+                                "example": "Validation successful"
+                            }
+                        }
+                    }
+                },
+                "availableTransitionBeanList": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "event": {
+                                "type": "string",
+                                "example": "Promote"
+                            },
+                            "targetState": {
+                                "type": "string",
+                                "example": "Created"
+                            }
+                        }
+                    }
+                },
+                "permissionBeanList": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "roles": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "forTarget": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "WorkflowResponse": {
+            "title": "workflow Response",
+            "required": [
+                "workflowStatus"
+            ],
+            "properties": {
+                "workflowStatus": {
+                    "description": "This attribute declares whether this workflow task is approved or rejected.\n",
+                    "type": "string",
+                    "enum": [
+                        "CREATED",
+                        "APPROVED",
+                        "REJECTED",
+                        "REGISTERED"
+                    ],
+                    "example": "APPROVED"
+                },
+                "jsonPayload": {
+                    "description": "Attributes that returned after the workflow execution\n",
+                    "type": "string"
+                }
+            }
+        },
+        "APIDefinitionValidationResponse": {
+            "title": "API definition validation Response",
+            "required": [
+                "isValid"
+            ],
+            "properties": {
+                "isValid": {
+                    "description": "This attribute declares whether this definition is valid or not.\n",
+                    "type": "boolean",
+                    "example": true
+                },
+                "definitionType": {
+                    "description": "This attribute declares whether this definition is a swagger or WSDL\n",
+                    "type": "string",
+                    "enum": [
+                        "SWAGGER",
+                        "WSDL"
+                    ],
+                    "example": "WSDL"
+                },
+                "wsdlInfo": {
+                    "description": "Summary of the WSDL including the basic information",
+                    "properties": {
                         "version": {
+                            "description": "WSDL version\n",
                             "type": "string",
-                            "description": "The version of the API",
-                            "example": "1.0.0"
+                            "example": "1.1"
                         },
-                        "provider": {
-                            "description": "If the provider value is not given, the user invoking the API will be used as the provider.\n",
-                            "type": "string",
-                            "example": "admin"
+                        "endpoints": {
+                            "description": "A list of endpoints the service exposes\n",
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Name of the endpoint",
+                                        "example": "StockQuoteSoap"
+                                    },
+                                    "location": {
+                                        "type": "string",
+                                        "description": "Endpoint URL",
+                                        "example": "http://www.webservicex.net/stockquote.asmx"
+                                    }
+                                }
+                            }
                         },
-                        "status": {
-                            "type": "string",
-                            "description": "This describes in which status of the lifecycle the API is",
-                            "example": "CREATED"
-                        },
-                        "thumbnailUri": {
-                            "type": "string",
-                            "example": "/apis/01234567-0123-0123-0123-012345678901/thumbnail"
+                        "bindingInfo": {
+                            "description": "WSDL binding related information\n",
+                            "properties": {
+                                "hasHttpBinding": {
+                                    "description": "Indicates whether the WSDL contains HTTP Bindings",
+                                    "type": "boolean"
+                                },
+                                "hasSoapBinding": {
+                                    "description": "Indicates whether the WSDL contains SOAP Bindings",
+                                    "type": "boolean"
+                                }
+                            }
                         }
                     }
                 }
-            ]
+            }
         },
-        "DocumentSearchResult": {
-            "title": "Document Result",
-            "allOf": [
-                {
-                    "$ref": "#/definitions/SearchResult"
-                },
-                {
-                    "properties": {
-                        "docType": {
-                            "type": "string",
-                            "enum": [
-                                "HOWTO",
-                                "SAMPLES",
-                                "PUBLIC_FORUM",
-                                "SUPPORT_FORUM",
-                                "API_MESSAGE_FORMAT",
-                                "SWAGGER_DOC",
-                                "OTHER"
-                            ],
-                            "example": "HOWTO"
-                        },
-                        "summary": {
-                            "type": "string",
-                            "example": "Summary of Calculator Documentation"
-                        },
-                        "sourceType": {
-                            "type": "string",
-                            "enum": [
-                                "INLINE",
-                                "URL",
-                                "FILE"
-                            ],
-                            "example": "INLINE"
-                        },
-                        "sourceUrl": {
-                            "type": "string",
-                            "example": ""
-                        },
-                        "otherTypeName": {
-                            "type": "string",
-                            "example": ""
-                        },
-                        "visibility": {
-                            "type": "string",
-                            "enum": [
-                                "OWNER_ONLY",
-                                "PRIVATE",
-                                "API_LEVEL"
-                            ],
-                            "example": "API_LEVEL"
-                        },
-                        "apiName": {
-                            "type": "string",
-                            "description": "The name of the associated API",
-                            "example": "TestAPI"
-                        },
-                        "apiVersion": {
-                            "type": "string",
-                            "description": "The version of the associated API",
-                            "example": "1.0.0"
-                        },
-                        "apiProvider": {
-                            "type": "string",
-                            "example": "admin"
-                        }
-                    }
-                }
-            ]
-        },
-        "ResourcePolicyList": {
-            "title": "Resource policy List",
+        "ThreatProtectionPolicyList": {
+            "title": "Threat Protection Policy List",
             "properties": {
                 "list": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/ResourcePolicyInfo"
+                        "$ref": "#/definitions/ThreatProtectionPolicy"
                     }
-                },
-                "count": {
-                    "type": "integer",
-                    "description": "Number of policy resources returned.\n",
-                    "example": 1
                 }
             }
         },
-        "ResourcePolicyInfo": {
-            "title": "Resource policy Info object with conversion policy resource details.",
+        "ThreatProtectionPolicy": {
+            "title": "Threat Protection Policy Schema",
+            "required": [
+                "name",
+                "type",
+                "policy"
+            ],
             "properties": {
-                "id": {
+                "uuid": {
                     "type": "string",
-                    "description": "UUID of the resource policy registry artifact\n",
-                    "example": "01234567-0123-0123-0123-012345678901"
+                    "description": "Policy ID"
                 },
-                "httpVerb": {
+                "name": {
                     "type": "string",
-                    "description": "HTTP verb used for the resource path",
-                    "example": "get"
+                    "description": "Name of the policy"
                 },
-                "resourcePath": {
+                "type": {
                     "type": "string",
-                    "description": "A string that represents the resource path of the api for the related resource policy",
-                    "example": "CalculatorAPI"
+                    "description": "Type of the policy"
                 },
-                "content": {
+                "policy": {
                     "type": "string",
-                    "description": "The resource policy content",
-                    "example": "<header description=\"SOAPAction\" name=\"SOAPAction\" scope=\"transport\" value=\"http://ws.cdyne.com/PhoneVerify/query/CheckPhoneNumber\"/>"
+                    "description": "policy as a json string"
+                }
+            }
+        },
+        "DedicatedGateway": {
+            "title": "Dedicated Gateway for the API",
+            "required": [
+                "isEnabled"
+            ],
+            "properties": {
+                "isEnabled": {
+                    "description": "This attribute declares whether an API should have a dedicated Gateway or not.\n",
+                    "type": "boolean",
+                    "example": true
+                }
+            }
+        },
+        "Settings": {
+            "title": "Settings",
+            "properties": {
+                "apiPublisherUrl": {
+                    "type": "string"
                 }
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/store-api.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/store-api.json
@@ -1,9 +1,9 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "0.14.0",
+    "version": "v1.0",
     "title": "WSO2 API Manager - Store",
-    "description": "This specifies a **RESTful API** for WSO2 **API Manager** - Store.\n\nPlease see [full swagger definition](https://raw.githubusercontent.com/wso2/carbon-apimgt/v6.1.66/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/resources/store-api.yaml) of the API which is written using [swagger 2.0](http://swagger.io/) specification.\n",
+    "description": "This document specifies a **RESTful API** for WSO2 **API Manager** - Store.\n\nIt is written with [swagger 2](http://swagger.io/).\n",
     "contact": {
       "name": "WSO2",
       "url": "http://wso2.com/products/api-manager/",
@@ -15,10 +15,11 @@
     }
   },
   "schemes": [
-    "https"
+    "https",
+    "http"
   ],
   "host": "apis.wso2.com",
-  "basePath": "/api/am/store/v0.14",
+  "basePath": "/api/am/store/v1.0",
   "consumes": [
     "application/json"
   ],
@@ -30,22 +31,35 @@
       "x-wso2-scopes": [
         {
           "description": "",
-          "roles": "Internal/subscriber",
+          "roles": "Internal/username",
           "name": "apim:subscribe",
           "key": "apim:subscribe"
         }
       ]
     }
   },
+  "securityDefinitions": {
+    "OAuth2Security": {
+      "type": "oauth2",
+      "flow": "password",
+      "tokenUrl": "https://localhost:9443/token",
+      "scopes": {
+        "apim:subscribe": "Subscribe API",
+        "apim:self-signup": "Self Sign-up",
+        "apim:dedicated_gateway": "Updating dedicated Gateway"
+      }
+    }
+  },
   "paths": {
     "/apis": {
       "get": {
-        "x-wso2-curl": "curl https://localhost:9443/api/am/store/v0.14/apis",
-        "x-wso2-curl-tenant": "curl -k -H \"X-WSO2-Tenant:test.com\" https://localhost:9443/api/am/store/v0.14/apis",
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/apis\n",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"provider\": \"admin\",\n         \"version\": \"1.0.0\",\n         \"description\": \"This API provide Account Status Validation.\",\n         \"status\": \"PUBLISHED\",\n         \"name\": \"AccountVal\",\n         \"context\": \"/account/1.0.0\",\n         \"id\": \"2e81f147-c8a8-4f68-b4f0-69e0e7510b01\"\n      },\n            {\n         \"provider\": \"admin\",\n         \"version\": \"1.0.0\",\n         \"description\": null,\n         \"status\": \"PUBLISHED\",\n         \"name\": \"api1\",\n         \"context\": \"/api1/1.0.0\",\n         \"id\": \"3e22d2fb-277a-4e9e-8c7e-1c0f7f73960e\"\n      },\n            {\n         \"provider\": \"admin\",\n         \"version\": \"2.0.0\",\n         \"description\": \"Verify a phone number\",\n         \"status\": \"PUBLISHED\",\n         \"name\": \"PhoneVerification\",\n         \"context\": \"/phoneverify/2.0.0\",\n         \"id\": \"c43a325c-260b-4302-81cb-768eafaa3aed\"\n      }\n   ],\n   \"count\": 3,\n   \"next\": \"\"\n}",
+        "security": [
+          {
+            "OAuth2Security": null
+          }
+        ],
         "summary": "Retrieve/Search APIs\n",
-        "description": "This operation provides you a list of available APIs qualifying under a given search condition.\n\nEach retrieved API is represented with a minimal amount of attributes. If you want to get complete details of an API, you need to use **Get details of an API** operation.\n\nThis operation supports retriving APIs of other tenants. The required tenant domain need to be specified as a header `X-WSO2-Tenant`. If not specified super tenant's APIs will be retrieved. If you used an Authorization header, the user's tenant associated with the access token will be used.\n\n**NOTE:**\n* By default, this operation retrieves Published APIs. In order to retrieve Prototyped APIs, you need to use **query** parameter and specify **status:PROTOTYPED**.\n* This operation does not require an Authorization header by default. But if it is provided, it will be validated and checked for permissions of the user, hence you may be able to see APIs which are restricted for special permissions/roles.\n",
+        "description": "Get a list of available APIs qualifying under a given search condition.\n",
         "parameters": [
           {
             "$ref": "#/parameters/limit"
@@ -54,23 +68,21 @@
             "$ref": "#/parameters/offset"
           },
           {
-            "$ref": "#/parameters/requestedTenant"
+            "$ref": "#/parameters/labels"
           },
           {
             "name": "query",
             "in": "query",
-            "description": "**Search condition**.\n\nYou can search in attributes by using an **\"<attribute>:\"** modifier.\n\nEg.\n\"provider:wso2\" will match an API if the provider of the API is exactly \"wso2\".\n\nAdditionally you can use wildcards.\n\nEg.\n\"provider:wso2*\" will match an API if the provider of the API starts with \"wso2\".\n\nSupported attribute modifiers are [**version, context, status,\ndescription, subcontext, doc, provider, tag**]\n\nIf no advanced attribute modifier has been specified, search will match the\ngiven query string against API Name.\n",
+            "description": "**Search condition**.\n\nYou can search in attributes by using an **\"attribute:\"** modifier.\n\nEg.\n\"provider:wso2\" will match an API if the provider of the API is exactly \"wso2\".\n\nAdditionally you can use wildcards.\n\nEg.\n\"provider:wso2*\" will match an API if the provider of the API starts with \"wso2\".\n\nSupported attribute modifiers are [**version, context, lifeCycleStatus,\ndescription, subcontext, doc, provider, tag **]\n\nIf no advanced attribute modifier has been specified, search will match the\ngiven query string against API Name.\n",
             "type": "string"
-          },
-          {
-            "$ref": "#/parameters/Accept"
           },
           {
             "$ref": "#/parameters/If-None-Match"
           }
         ],
         "tags": [
-          "API (Collection)"
+          "API (Collection)",
+          "Retrieve"
         ],
         "responses": {
           "200": {
@@ -79,18 +91,14 @@
               "$ref": "#/definitions/APIList"
             },
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.",
-                "type": "string"
-              },
               "ETag": {
-                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests.\n",
                 "type": "string"
               }
             }
           },
           "304": {
-            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource.\n"
           },
           "406": {
             "description": "Not Acceptable.\nThe requested media type is not supported\n",
@@ -103,46 +111,38 @@
     },
     "/apis/{apiId}": {
       "get": {
-        "x-wso2-curl": "curl https://localhost:9443/api/am/store/v0.14/apis/c43a325c-260b-4302-81cb-768eafaa3aed",
-        "x-wso2-curl-tenant": "curl -k -H \"X-WSO2-Tenant:test.com\" https://localhost:9443/api/am/store/v0.14/apis/c43a325c-260b-4302-81cb-768eafaa3aed",
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/apis/c43a325c-260b-4302-81cb-768eafaa3aed\n",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\r\n   \"thumbnailUrl\": null,\r\n   \"tiers\": [\"Unlimited\"],\r\n   \"businessInformation\":    {\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"businessOwner\": \"Jane Roe\",\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\"\r\n   },\r\n   \"apiDefinition\": \"{\\\"paths\\\":{\\\"/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"},\\\"Content-Type\\\":{\\\"description\\\":\\\"The content type of the body.\\\",\\\"type\\\":\\\"string\\\"}},\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Created. Successful response with the newly created object as entity in the body. Location header contains URL of newly created entity.\\\"}}}},\\\"/order/{orderId}\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Get details of an Order\\\",\\\"parameters\\\":[{\\\"description\\\":\\\"Order Id\\\",\\\"name\\\":\\\"orderId\\\",\\\"format\\\":\\\"string\\\",\\\"type\\\":\\\"string\\\",\\\"required\\\":true,\\\"in\\\":\\\"path\\\"}],\\\"responses\\\":{\\\"200\\\":{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"headers\\\":{},\\\"description\\\":\\\"OK Requested Order will be returned\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http://www.apache.org/licenses/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http://www.pizzashack.com\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"endpointURLs\": [   {\r\n      \"environmentName\": \"Production and Sandbox\",\r\n      \"environmentType\": \"hybrid\",\r\n      \"environmentURLs\":       {\r\n         \"http\": \"http://localhost:8280//pizzashack/1.0.0\",\r\n         \"https\": \"https://localhost:8243//pizzashack/1.0.0\"\r\n      }\r\n   }],\r\n   \"transport\":    [\r\n      \"http\",\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\"],\r\n   \"version\": \"1.0.0\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"provider\": \"admin\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"context\": \"/pizzashack/1.0.0\",\r\n   \"id\": \"8848faaa-7fd1-478a-baa2-48a4ebb92c98\",\r\n   \"status\": \"PUBLISHED\"\r\n}  ",
-        "summary": "Get details of an API\n",
-        "description": "Using this operation, you can retrieve complete details of a single API. You need to provide the Id of the API to retrive it.\n\n`X-WSO2-Tenant` header can be used to retrive an API of a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.\n\n**NOTE:**\n* This operation does not require an Authorization header by default. But if it is provided, it will be validated and checked for permissions of the user, hence you may be able to see APIs which are restricted for special permissions/roles. \\n\n",
+        "summary": "Get details of an API",
+        "security": [
+          {
+            "OAuth2Security": null
+          }
+        ],
+        "description": "Get details of an API\n",
         "parameters": [
           {
             "$ref": "#/parameters/apiId"
-          },
-          {
-            "$ref": "#/parameters/Accept"
           },
           {
             "$ref": "#/parameters/If-None-Match"
           },
           {
             "$ref": "#/parameters/If-Modified-Since"
-          },
-          {
-            "$ref": "#/parameters/requestedTenant"
           }
         ],
         "tags": [
-          "API (Individual)"
+          "API (Individual)",
+          "Retrieve"
         ],
         "responses": {
           "200": {
             "description": "OK.\nRequested API is returned\n",
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
                 "description": "Entity Tag of the response resource. Used by caches, or in conditional requests.\n",
                 "type": "string"
               },
               "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests.\n",
                 "type": "string"
               }
             },
@@ -170,46 +170,38 @@
     },
     "/apis/{apiId}/swagger": {
       "get": {
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/apis/c43a325c-260b-4302-81cb-768eafaa3aed/swagger\n",
-        "x-wso2-curl": "curl https://localhost:9443/api/am/store/v0.14/apis/c43a325c-260b-4302-81cb-768eafaa3aed/swagger",
-        "x-wso2-curl-tenant": "curl -k -H \"X-WSO2-Tenant:test.com\" https://localhost:9443/api/am/store/v0.14/apis/c43a325c-260b-4302-81cb-768eafaa3aed/swagger",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-tier\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"x-wso2-security\": {\"apim\": {\"x-wso2-scopes\": []}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"2.0.0\"\n   }\n}\n",
-        "summary": "Get swagger definition\n",
-        "description": "You can use this operation to retrieve the swagger definition of an API.\n\n `X-WSO2-Tenant` header can be used to retrive the swagger definition an API of a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.\n\n**NOTE:**\n* This operation does not require an Authorization header by default. But in order to see a restricted API's swagger definition, you need to provide Authorization header.\n",
+        "summary": "Get API swagger definition",
+        "security": [
+          {
+            "OAuth2Security": null
+          }
+        ],
+        "description": "Get the swagger of an API\n",
         "parameters": [
           {
             "$ref": "#/parameters/apiId"
-          },
-          {
-            "$ref": "#/parameters/Accept"
           },
           {
             "$ref": "#/parameters/If-None-Match"
           },
           {
             "$ref": "#/parameters/If-Modified-Since"
-          },
-          {
-            "$ref": "#/parameters/requestedTenant"
           }
         ],
         "tags": [
-          "API (Individual)"
+          "API (Individual)",
+          "Retrieve"
         ],
         "responses": {
           "200": {
             "description": "OK.\nRequested swagger document of the API is returned\n",
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
                 "description": "Entity Tag of the response resource. Used by caches, or in conditional requests.\n",
                 "type": "string"
               },
               "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests.\n",
                 "type": "string"
               }
             }
@@ -232,23 +224,38 @@
         }
       }
     },
-    "/apis/generate-sdk/": {
-      "post": {
+    "/apis/{apiId}/sdks/{language}": {
+      "get": {
+        "produces": [
+          "application/zip"
+        ],
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
         "x-scope": "apim:subscribe",
-        "x-wso2-request": "POST https://localhost:9443/api/am/store/v0.14/apis/generate-sdk?apiId=e93fb282-b456-48fc-8981-003fb89086ae&language=java\nAuthorization: Bearer 2e29904b-f3b0-366e-ba13-b469abedd88e\n",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer 2e29904b-f3b0-366e-ba13-b469abedd88e\" -X POST 'https://localhost:9443/api/am/store/v0.14/apis/generate-sdk?apiId=5721d128-76d0-4cb9-b300-2bd9578beddb&language=java' > PizzaAPI_Java_SDK.zip",
-        "x-wso2-response": "HTTP/1.1 200 OK \nContent-Disposition: attachment; filename=\"PizzaShackAPI_1.0.0_java.zip\"\nContent-Type: application/zip\n\n[zip content]",
-        "summary": "Generate SDK for an API\n",
-        "description": "This operation can be used to generate SDK for an API by providing the id of the API along with the preferred language.\n",
+        "x-wso2-curl": "curl -X GET -k -H \"Authorization:Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9292/api/am/store/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/sdks/java > Swagger Petstore_java_1.0.0.zip",
+        "x-wso2-request": "GET https://localhost:9292/api/am/store/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/sdks/java\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-disposition : attachment; filename=\"Swagger Petstore_java_1.0.0.zip\"\nContent-type : application/zip",
+        "summary": "Generate a SDK for an API\n",
+        "description": "This operation can be used to generate SDKs (System Development Kits), for the APIs available in the API Store, for a requested development language.\n",
         "parameters": [
           {
-            "$ref": "#/parameters/apiId-Q"
+            "in": "path",
+            "name": "apiId",
+            "type": "string",
+            "required": true,
+            "description": "ID of the specific API for which the SDK is required.\n"
           },
           {
-            "$ref": "#/parameters/language"
-          },
-          {
-            "$ref": "#/parameters/requestedTenant"
+            "in": "path",
+            "name": "language",
+            "type": "string",
+            "required": true,
+            "description": "Programming language of the SDK that is required.\n"
           }
         ],
         "tags": [
@@ -256,28 +263,22 @@
         ],
         "responses": {
           "200": {
-            "description": "OK.\nSDK generated successfully.\n",
-            "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              }
-            }
+            "description": "OK.\nSDK generated successfully.\n"
           },
           "400": {
-            "description": "Bad request.\nSDK language is not supported.\n",
+            "description": "Bad Request.\nRequested SDK Language is not supported.\n",
             "schema": {
               "$ref": "#/definitions/Error"
             }
           },
           "404": {
-            "description": "Not Found.\nRequested API does not exist.\n",
+            "description": "Not found.\nRequested API does not exist.\n",
             "schema": {
               "$ref": "#/definitions/Error"
             }
           },
-          "406": {
-            "description": "Not Acceptable.\nThe requested media type is not supported\n",
+          "500": {
+            "description": "Internal Server Error.\nError while generating SDK.\n",
             "schema": {
               "$ref": "#/definitions/Error"
             }
@@ -285,50 +286,48 @@
         }
       }
     },
-    "/apis/{apiId}/documents": {
+    "/apis/{apiId}/wsdl": {
       "get": {
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/apis/c43a325c-260b-4302-81cb-768eafaa3aed/documents\n",
-        "x-wso2-curl": "curl https://localhost:9443/api/am/store/v0.14/apis/c43a325c-260b-4302-81cb-768eafaa3aed/documents",
-        "x-wso2-curl-tenant": "curl -k -H \"X-WSO2-Tenant:test.com\" https://localhost:9443/api/am/store/v0.14/apis/c43a325c-260b-4302-81cb-768eafaa3aed/documents",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"sourceType\": \"INLINE\",\n         \"sourceUrl\": null,\n         \"otherTypeName\": null,\n         \"documentId\": \"850a4f34-db2c-4d23-9d85-3f95fbfb082c\",\n         \"summary\": \"This is a sample documentation for v1.0.0\",\n         \"name\": \"PhoneVerification API Documentation\",\n         \"type\": \"HOWTO\"\n      },\n            {\n         \"sourceType\": \"URL\",\n         \"sourceUrl\": \"http://wiki.cdyne.com/index.php/Phone_Verification\",\n         \"otherTypeName\": null,\n         \"documentId\": \"98e18be8-5861-43c7-ba26-8cbbccd3a76f\",\n         \"summary\": \"This is the URL for online documentation\",\n         \"name\": \"Online Documentation\",\n         \"type\": \"SAMPLES\"\n      },\n            {\n         \"sourceType\": \"FILE\",\n         \"sourceUrl\": null,\n         \"otherTypeName\": null,\n         \"documentId\": \"b66451ff-c6c2-4f6a-b91d-3821dc119b04\",\n         \"summary\": \"This is a sample documentation pdf\",\n         \"name\": \"Introduction to PhoneVerification API PDF\",\n         \"type\": \"HOWTO\"\n      }\n   ],\n   \"count\": 3,\n   \"next\": \"\"\n}",
-        "summary": "Get a list of documents of an API\n",
-        "description": "This operation can be used to retrive a list of documents belonging to an API by providing the id of the API.\n\n`X-WSO2-Tenant` header can be used to retrive documents of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.\n\n**NOTE:**\n* This operation does not require an Authorization header by default. But in order to see a restricted API's documents, you need to provide Authorization header.\n",
+        "security": [
+          {
+            "OAuth2Security": null
+          }
+        ],
+        "produces": [
+          "application/octet-stream"
+        ],
+        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9292/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/wsdl",
+        "x-wso2-request": "GET https://127.0.0.1:9292/api/am/publisher/v1.0/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/wsdl\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\nContent-Length: 329\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-policy\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"x-wso2-security\": {\"apim\": {\"x-wso2-scopes\": []}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
+        "summary": "Get API WSDL definition",
+        "description": "This operation can be used to retrieve the swagger definition of an API.\n",
         "parameters": [
           {
             "$ref": "#/parameters/apiId"
           },
           {
-            "$ref": "#/parameters/limit"
-          },
-          {
-            "$ref": "#/parameters/offset"
-          },
-          {
-            "$ref": "#/parameters/requestedTenant"
-          },
-          {
-            "$ref": "#/parameters/Accept"
+            "$ref": "#/parameters/label-Q"
           },
           {
             "$ref": "#/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Modified-Since"
           }
         ],
         "tags": [
-          "Document (Collection)"
+          "API (Individual)"
         ],
         "responses": {
           "200": {
-            "description": "OK.\nDocument list is returned.\n",
-            "schema": {
-              "$ref": "#/definitions/DocumentList"
-            },
+            "description": "OK.\nRequested WSDL document of the API is returned\n",
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
                 "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              },
+              "Last-Modified": {
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
                 "type": "string"
               }
             }
@@ -351,26 +350,80 @@
         }
       }
     },
+    "/apis/{apiId}/documents": {
+      "get": {
+        "summary": "Get a list of API documents",
+        "security": [
+          {
+            "OAuth2Security": null
+          }
+        ],
+        "description": "Get a list of documents belonging to an API.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "$ref": "#/parameters/limit"
+          },
+          {
+            "$ref": "#/parameters/offset"
+          },
+          {
+            "$ref": "#/parameters/If-None-Match"
+          }
+        ],
+        "tags": [
+          "Document (Collection)",
+          "API (Individual)",
+          "Retrieve"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nDocument list is returned.\n",
+            "schema": {
+              "$ref": "#/definitions/DocumentList"
+            },
+            "headers": {
+              "ETag": {
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests.\n",
+                "type": "string"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource.\n"
+          },
+          "404": {
+            "description": "Not Found.\nRequested API does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "406": {
+            "description": "Not Acceptable.\nThe requested media type is not supported\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/apis/{apiId}/documents/{documentId}": {
       "get": {
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/apis/c43a325c-260b-4302-81cb-768eafaa3aed/documents/850a4f34-db2c-4d23-9d85-3f95fbfb082c\n",
-        "x-wso2-curl": "curl \"https://localhost:9443/api/am/store/v0.14/apis/c43a325c-260b-4302-81cb-768eafaa3aed/documents/850a4f34-db2c-4d23-9d85-3f95fbfb082c\"",
-        "x-wso2-curl-tenant": "curl -k -H \"X-WSO2-Tenant:test.com\" https://localhost:9443/api/am/store/v0.14/apis/c43a325c-260b-4302-81cb-768eafaa3aed/documents/850a4f34-db2c-4d23-9d85-3f95fbfb082c",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"sourceType\": \"INLINE\",\n   \"sourceUrl\": null,\n   \"otherTypeName\": null,\n   \"documentId\": \"850a4f34-db2c-4d23-9d85-3f95fbfb082c\",\n   \"summary\": \"This is a sample documentation for v1.0.0\",\n   \"name\": \"PhoneVerification API Documentation\",\n   \"type\": \"HOWTO\"\n}",
-        "summary": "Get a document of an API\n",
-        "description": "This operation can be used to retrieve a particular document's metadata associated with an API.\n\n`X-WSO2-Tenant` header can be used to retrive a document of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.\n\n**NOTE:**\n* This operation does not require an Authorization header by default. But in order to see a restricted API's document, you need to provide Authorization header.\n",
+        "summary": "Get a document of an API",
+        "security": [
+          {
+            "OAuth2Security": null
+          }
+        ],
+        "description": "Get a particular document associated with an API.\n",
         "parameters": [
           {
             "$ref": "#/parameters/apiId"
           },
           {
             "$ref": "#/parameters/documentId"
-          },
-          {
-            "$ref": "#/parameters/requestedTenant"
-          },
-          {
-            "$ref": "#/parameters/Accept"
           },
           {
             "$ref": "#/parameters/If-None-Match"
@@ -380,7 +433,9 @@
           }
         ],
         "tags": [
-          "Document (Individual)"
+          "Document (Individual)",
+          "API (Individual)",
+          "Retrieve"
         ],
         "responses": {
           "200": {
@@ -389,16 +444,12 @@
               "$ref": "#/definitions/Document"
             },
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
                 "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests.\n",
                 "type": "string"
               },
               "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional reuquests.\n",
                 "type": "string"
               }
             }
@@ -423,24 +474,19 @@
     },
     "/apis/{apiId}/documents/{documentId}/content": {
       "get": {
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5/content\n",
-        "x-wso2-curl": "curl \"https://localhost:9443/api/am/store/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5/content\" > sample.pdf",
-        "x-wso2-curl-tenant": "curl -k -H \"X-WSO2-Tenant:test.com\" \"https://localhost:9443/api/am/store/v0.14/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5/content\" > sample.pdf",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Disposition: attachment; filename=\"sample.pdf\"\nContent-Type: application/octet-stream\nContent-Length: 7802\n\n%PDF-1.4\n%äüöß\n2 0 obj\n<</Length 3 0 R/Filter/FlateDecode>>\nstream\n..\n>>\nstartxref\n7279\n%%EOF",
-        "summary": "Get the content of an API document\n",
-        "description": "This operation can be used to retrive the content of an API's document.\n\nThe document can be of 3 types. In each cases responses are different.\n\n1. **Inline type**:\n   The content of the document will be retrieved in `text/plain` content type\n2. **FILE type**:\n   The file will be downloaded with the related content type (eg. `application/pdf`)\n3. **URL type**:\n    The client will recieve the URL of the document as the Location header with the response with - `303 See Other`\n\n`X-WSO2-Tenant` header can be used to retrive the content of a document of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.\n\n**NOTE:**\n* This operation does not require an Authorization header by default. But in order to see a restricted API's document content, you need to provide Authorization header.\n",
+        "summary": "Get the content of an API document",
+        "security": [
+          {
+            "OAuth2Security": null
+          }
+        ],
+        "description": "Downloads a FILE type document/get the inline content or source url of a certain document.\n",
         "parameters": [
           {
             "$ref": "#/parameters/apiId"
           },
           {
             "$ref": "#/parameters/documentId"
-          },
-          {
-            "$ref": "#/parameters/requestedTenant"
-          },
-          {
-            "$ref": "#/parameters/Accept"
           },
           {
             "$ref": "#/parameters/If-None-Match"
@@ -450,22 +496,20 @@
           }
         ],
         "tags": [
-          "Document (Individual)"
+          "Document (Individual)",
+          "API (Individual)",
+          "Retrieve"
         ],
         "responses": {
           "200": {
             "description": "OK.\nFile or inline content returned.\n",
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
                 "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests.\n",
                 "type": "string"
               },
               "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional reuquests.\n",
                 "type": "string"
               }
             }
@@ -497,57 +541,40 @@
         }
       }
     },
-    "/apis/{apiId}/thumbnail": {
+    "/apis/{apiId}/ratings": {
       "get": {
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/apis/e93fb282-b456-48fc-8981-003fb89086ae/thumbnail\n",
-        "x-wso2-curl": "curl https://localhost:9443/api/am/store/v0.14/apis/e93fb282-b456-48fc-8981-003fb89086ae/thumbnail > image.jpg",
-        "x-wso2-curl-tenant": "curl -k -H \"X-WSO2-Tenant:test.com\" https://localhost:9443/api/am/store/v0.14/apis/e93fb282-b456-48fc-8981-003fb89086ae/thumbnail > image.jpg",
-        "x-wso2-response": "HTTP/1.1 200 OK\r\nContent-Type: image/jpeg\r\n\r\n[image content]",
-        "summary": "Get thumbnail image",
-        "description": "This operation can be used to download a thumbnail image of an API.\n\n`X-WSO2-Tenant` header can be used to retrive a thumbnail of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.\n\n**NOTE:**\n* This operation does not require an Authorization header by default. But in order to see a restricted API's thumbnail, you need to provide Authorization header.\n",
+        "summary": "Get API ratings",
+        "security": [
+          {
+            "OAuth2Security": null
+          }
+        ],
+        "description": "Get the rating of an API.\n",
         "parameters": [
           {
             "$ref": "#/parameters/apiId"
           },
           {
-            "$ref": "#/parameters/requestedTenant"
+            "$ref": "#/parameters/limit"
           },
           {
-            "$ref": "#/parameters/Accept"
-          },
-          {
-            "$ref": "#/parameters/If-None-Match"
-          },
-          {
-            "$ref": "#/parameters/If-Modified-Since"
+            "$ref": "#/parameters/offset"
           }
         ],
         "tags": [
-          "API (Individual)"
+          "Rating (Collection)",
+          "API (Individual)",
+          "Retrieve"
         ],
         "responses": {
           "200": {
-            "description": "OK.\nThumbnail image returned\n",
-            "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
-              "ETag": {
-                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests.\n",
-                "type": "string"
-              },
-              "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
-                "type": "string"
-              }
+            "description": "OK.\nRating returned.\n",
+            "schema": {
+              "$ref": "#/definitions/RatingList"
             }
           },
-          "304": {
-            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource.\n"
-          },
           "404": {
-            "description": "Not Found.\nRequested Document does not exist.\n",
+            "description": "Not Found.\nRequested rating does not exist.\n",
             "schema": {
               "$ref": "#/definitions/Error"
             }
@@ -561,18 +588,1183 @@
         }
       }
     },
-    "/applications": {
+    "/apis/{apiId}/ratings/{ratingId}": {
       "get": {
-        "x-scope": "apim:subscribe",
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/applications\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/store/v0.14/applications\"",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"groupId\": \"\",\n         \"subscriber\": \"admin\",\n         \"throttlingTier\": \"Unlimited\",\n         \"applicationId\": \"367a2361-8db5-4140-8133-c6c8dc7fa0c4\",\n         \"description\": \"\",\n         \"status\": \"APPROVED\",\n         \"name\": \"app1\"\n      },\n            {\n         \"groupId\": \"\",\n         \"subscriber\": \"admin\",\n         \"throttlingTier\": \"Unlimited\",\n         \"applicationId\": \"896658a0-b4ee-4535-bbfa-806c894a4015\",\n         \"description\": null,\n         \"status\": \"APPROVED\",\n         \"name\": \"DefaultApplication\"\n      }\n   ],\n   \"count\": 2,\n   \"next\": \"\"\n}",
-        "summary": "Retrieve/Search applications\n",
-        "description": "This operation can be used to retrieve list of applications that is belonged to the user associated with the provided access token.\n",
+        "summary": "Get a single API rating",
+        "security": [
+          {
+            "OAuth2Security": null
+          }
+        ],
+        "description": "Get a specific rating of an API.\n",
         "parameters": [
           {
-            "$ref": "#/parameters/groupId"
+            "$ref": "#/parameters/apiId"
           },
+          {
+            "$ref": "#/parameters/ratingId"
+          },
+          {
+            "$ref": "#/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Modified-Since"
+          }
+        ],
+        "tags": [
+          "Rating (Individual)",
+          "API (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nRating returned.\n",
+            "schema": {
+              "$ref": "#/definitions/Rating"
+            },
+            "headers": {
+              "ETag": {
+                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests.\n",
+                "type": "string"
+              },
+              "Last-Modified": {
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests.\n",
+                "type": "string"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource.\n"
+          },
+          "404": {
+            "description": "Not Found.\nRequested rating does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "406": {
+            "description": "Not Acceptable.\nThe requested media type is not supported\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/user-rating": {
+      "put": {
+        "summary": "Add or update logged in user's rating for an API",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "description": "Adds or updates a rating\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Rating object that should to be added\n",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Rating"
+            }
+          }
+        ],
+        "tags": [
+          "Rating (Individual)",
+          "API (Individual)",
+          "Create"
+        ],
+        "responses": {
+          "201": {
+            "description": "Created.\nSuccessful response with the newly created object as entity in the body.\nLocation header contains URL of newly created entity.\n",
+            "schema": {
+              "$ref": "#/definitions/Rating"
+            },
+            "headers": {
+              "Location": {
+                "description": "Location to the newly created Rating.\n",
+                "type": "string"
+              },
+              "ETag": {
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional request.\n",
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "415": {
+            "description": "Unsupported media type.\nThe entity of the request was in a not supported format.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/comments": {
+      "get": {
+        "summary": "Retrieve API comments",
+        "security": [
+          {
+            "OAuth2Security": null
+          }
+        ],
+        "description": "Get a list of Comments that are already added to APIs\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "$ref": "#/parameters/limit"
+          },
+          {
+            "$ref": "#/parameters/offset"
+          }
+        ],
+        "tags": [
+          "Comment (Collection)",
+          "Retrieve"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nComments list is returned.\n",
+            "schema": {
+              "$ref": "#/definitions/CommentList"
+            }
+          },
+          "406": {
+            "description": "Not Acceptable. The requested media type is not supported\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add an API comment",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Comment object that should to be added\n",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Comment"
+            }
+          }
+        ],
+        "tags": [
+          "Comment (Individual)",
+          "API (Individual)",
+          "Create"
+        ],
+        "responses": {
+          "201": {
+            "description": "Created.\nSuccessful response with the newly created object as entity in the body.\nLocation header contains URL of newly created entity.\n",
+            "schema": {
+              "$ref": "#/definitions/Comment"
+            },
+            "headers": {
+              "Location": {
+                "description": "Location to the newly created Comment.\n",
+                "type": "string"
+              },
+              "ETag": {
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional request.\n",
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "415": {
+            "description": "Unsupported media type.\nThe entity of the request was in a not supported format.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/comments/{commentId}": {
+      "get": {
+        "summary": "Get details of an API comment",
+        "security": [
+          {
+            "OAuth2Security": null
+          }
+        ],
+        "description": "Get the individual comment given by a username for a certain API.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/commentId"
+          },
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "$ref": "#/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Modified-Since"
+          }
+        ],
+        "tags": [
+          "Comment (Individual)",
+          "API (Individual)",
+          "Retrieve"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nComment returned.\n",
+            "schema": {
+              "$ref": "#/definitions/Comment"
+            },
+            "headers": {
+              "ETag": {
+                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests.\n",
+                "type": "string"
+              },
+              "Last-Modified": {
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests.\n",
+                "type": "string"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource.\n"
+          },
+          "404": {
+            "description": "Not Found.\nRequested comment does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "406": {
+            "description": "Not Acceptable.\nThe requested media type is not supported\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an API comment",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "description": "Remove a Comment\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/commentId"
+          },
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "$ref": "#/parameters/If-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Unmodified-Since"
+          }
+        ],
+        "tags": [
+          "Comment (Individual)",
+          "API (Individual)",
+          "Delete"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nResource successfully deleted.\n"
+          },
+          "404": {
+            "description": "Not Found.\nResource to be deleted does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update an API comment",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "description": "Update a certain Comment\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/commentId"
+          },
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Comment object that needs to be updated\n",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Comment"
+            }
+          },
+          {
+            "$ref": "#/parameters/If-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Unmodified-Since"
+          }
+        ],
+        "tags": [
+          "Comment (Individual)",
+          "API (Individual)",
+          "Update"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nComment updated.\n",
+            "schema": {
+              "$ref": "#/definitions/Comment"
+            },
+            "headers": {
+              "Location": {
+                "description": "The URL of the newly created resource.\n",
+                "type": "string"
+              },
+              "ETag": {
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional request.\n",
+                "type": "string"
+              },
+              "Last-Modified": {
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional reuquests.\n",
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nThe resource to be updated does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "412": {
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/composite-apis": {
+      "get": {
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9090/api/am/store/v1/composite-apis",
+        "x-wso2-request": "GET https://127.0.0.1:9090/api/am/store/v1/composite-apis\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"provider\": \"admin\",\n         \"version\": \"1.0.0\",\n         \"description\": \"This sample API provides Account Status Validation\",\n         \"name\": \"AccountVal\",\n         \"context\": \"/account\",\n         \"id\": \"2e81f147-c8a8-4f68-b4f0-69e0e7510b01\",\n         \"lifeCycleStatus\": \"PUBLISHED\"\n      },\n            {\n         \"provider\": \"admin\",\n         \"version\": \"1.0.0\",\n         \"description\": null,\n         \"name\": \"api1\",\n         \"context\": \"/api1\",\n         \"id\": \"3e22d2fb-277a-4e9e-8c7e-1c0f7f73960e\",\n         \"lifeCycleStatus\": \"PUBLISHED\"\n      }\n   ],\n   \"next\": \"\",\n   \"count\": 2\n}",
+        "summary": "Retrieve/Search Composite APIs\n",
+        "description": "This operation provides you a list of available Composite APIs qualifying under a given search condition.\n\nEach retrieved Composite API is represented with a minimal amount of attributes. If you want to get complete details of a Composite API, you need to use **Get details of a Composite API** operation.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/limit"
+          },
+          {
+            "$ref": "#/parameters/offset"
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "**Search condition**.\n\nYou can search in attributes by using an **\"<attribute>:\"** modifier.\n\nEg.\n\"provider:wso2\" will match a Composite API if the provider of the Composite API is exactly \"wso2\".\n\nAdditionally you can use wildcards.\n\nEg.\n\"provider:wso2*\" will match a Composite API if the provider of the Composite API starts with \"wso2\".\n\nSupported attribute modifiers are [**version, context, lifeCycleStatus,\ndescription, subcontext, doc, provider**]\n\nIf no advanced attribute modifier has been specified, search will match the\ngiven query string against Composite API Name.\n",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/If-None-Match"
+          }
+        ],
+        "tags": [
+          "Composite API (Collection)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nList of qualifying Composite APIs is returned.\n",
+            "schema": {
+              "$ref": "#/definitions/CompositeAPIList"
+            },
+            "headers": {
+              "ETag": {
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+          },
+          "406": {
+            "description": "Not Acceptable.\nThe requested media type is not supported\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json https://127.0.0.1:9090/api/am/store/v1/composite-apis",
+        "x-wso2-request": "POST https://127.0.0.1:9090/api/am/store/v1/composite-apis\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"wsdlUri\": null,\r\n   \"lifeCycleStatus\": \"PUBLISHED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": false,\r\n   \"isDefaultVersion\": false,\r\n   \"transport\":    [\r\n      \"http\",\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\"],\r\n   \"policies\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 5000,\r\n      \"production\": 1000\r\n   },\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\r\n   \"visibleTenants\": [],\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9090/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9090/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+        "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://127.0.0.1:9090/api/am/publisher/v1/apis/7a2298c4-c905-403f-8fac-38c73301631f\nContent-Type: application/json\n\n{\r\n   \"id\": \"7a2298c4-c905-403f-8fac-38c73301631f\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"wsdlUri\": null,\r\n   \"lifeCycleStatus\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"transport\":    [\r\n      \"http\",\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\"],\r\n   \"policies\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 5000,\r\n      \"production\": 1000\r\n   },\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\r\n   \"visibleTenants\": [],\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9090/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9090/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+        "summary": "Create a new API",
+        "description": "This operation can be used to create a new API specifying the details of the API in the payload. The new API will be in `CREATED` state.\n\nThere is a special capability for a user who has `APIM Admin` permission such that he can create APIs on behalf of other users. For that he can to specify `\"provider\" : \"some_other_user\"` in the payload so that the API's creator will be shown as `some_other_user` in the UI.\n",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "API object that needs to be added\n",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CompositeAPI"
+            }
+          }
+        ],
+        "tags": [
+          "Composite API (Collection)"
+        ],
+        "responses": {
+          "201": {
+            "description": "Created.\nSuccessful response with the newly created object as entity in the body.\nLocation header contains URL of newly created entity.\n",
+            "schema": {
+              "$ref": "#/definitions/CompositeAPI"
+            },
+            "headers": {
+              "Location": {
+                "description": "The URL of the newly created resource.\n",
+                "type": "string"
+              },
+              "ETag": {
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "415": {
+            "description": "Unsupported Media Type.\nThe entity of the request was in a not supported format.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/composite-apis/{apiId}": {
+      "get": {
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9090/api/am/store/v1/composite-apis/7a2298c4-c905-403f-8fac-38c73301631f",
+        "x-wso2-request": "GET https://127.0.0.1:9090/api/am/store/v1/composite-apis/7a2298c4-c905-403f-8fac-38c73301631f\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\r\n   \"id\": \"7a2298c4-c905-403f-8fac-38c73301631f\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"endpointId\": \"{\\\"paths\\\":{\\\"/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Created.\\\"}}}},\\\"/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"headers\\\":{},\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#/definitions/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"integer\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http://www.apache.org/licenses/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http://www.pizzashack.com\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"lifeCycleStatus\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"transport\":    [\r\n      \"http\",\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\"],\r\n   \"policies\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 5000,\r\n      \"production\": 1000\r\n   },\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\r\n   \"visibleTenants\": [],\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9090/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9090/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+        "summary": "Get details of a Composite API",
+        "description": "Using this operation, you can retrieve complete details of a single Composite API. You need to provide the Id of the Composite API to retrive it.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "$ref": "#/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Modified-Since"
+          }
+        ],
+        "tags": [
+          "Composite API (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nRequested Compoiste API is returned\n",
+            "headers": {
+              "ETag": {
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              },
+              "Last-Modified": {
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/CompositeAPI"
+            }
+          },
+          "304": {
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+          },
+          "404": {
+            "description": "Not Found.\nRequested API does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "406": {
+            "description": "Not Acceptable.\nThe requested media type is not supported\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X PUT -d @data.json https://127.0.0.1:9090/api/am/store/v1/composite-apis/7a2298c4-c905-403f-8fac-38c73301631f",
+        "x-wso2-request": "PUT https://127.0.0.1:9090/api/am/store/v1/composite-apis/7a2298c4-c905-403f-8fac-38c73301631f\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\nContent-Type: application/json\n\n{\r\n   \"id\": \"7a2298c4-c905-403f-8fac-38c73301631f\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"endpointId\": \"{\\\"paths\\\":{\\\"/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Created.\\\"}}}},\\\"/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"headers\\\":{},\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#/definitions/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"integer\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http://www.apache.org/licenses/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http://www.pizzashack.com\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"lifeCycleStatus\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"transport\":    [\r\n      \"https\"\r\n   ],\r\n   \"tags\": [\"pizza\",\"chicken\"],\r\n   \"policies\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 500,\r\n      \"production\": 100\r\n   },\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\r\n   \"visibleTenants\": [],\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9090/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9090/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\r\n   \"id\": \"7a2298c4-c905-403f-8fac-38c73301631f\",\r\n   \"name\": \"PizzaShackAPI\",\r\n   \"description\": \"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\r\\n\",\r\n   \"context\": \"/pizzashack\",\r\n   \"version\": \"1.0.0\",\r\n   \"provider\": \"admin\",\r\n   \"endpointId\": \"{\\\"paths\\\":{\\\"/order\\\":{\\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Create a new Order\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Order object that needs to be added\\\",\\\"name\\\":\\\"body\\\",\\\"required\\\":true,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"201\\\":{\\\"headers\\\":{\\\"Location\\\":{\\\"description\\\":\\\"The URL of the newly created resource.\\\",\\\"type\\\":\\\"string\\\"}},\\\"schema\\\":{\\\"$ref\\\":\\\"#/definitions/Order\\\"},\\\"description\\\":\\\"Created.\\\"}}}},\\\"/menu\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"description\\\":\\\"Return a list of available menu items\\\",\\\"parameters\\\":[],\\\"responses\\\":{\\\"200\\\":{\\\"headers\\\":{},\\\"schema\\\":{\\\"title\\\":\\\"Menu\\\",\\\"properties\\\":{\\\"list\\\":{\\\"items\\\":{\\\"$ref\\\":\\\"#/definitions/MenuItem\\\"},\\\"type\\\":\\\"array\\\"}},\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"OK.\\\"}}}}},\\\"schemes\\\":[\\\"https\\\"],\\\"produces\\\":[\\\"application/json\\\"],\\\"swagger\\\":\\\"2.0\\\",\\\"definitions\\\":{\\\"MenuItem\\\":{\\\"title\\\":\\\"Pizza menu Item\\\",\\\"properties\\\":{\\\"price\\\":{\\\"type\\\":\\\"string\\\"},\\\"description\\\":{\\\"type\\\":\\\"string\\\"},\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"image\\\":{\\\"type\\\":\\\"string\\\"}},\\\"required\\\":[\\\"name\\\"]},\\\"Order\\\":{\\\"title\\\":\\\"Pizza Order\\\",\\\"properties\\\":{\\\"customerName\\\":{\\\"type\\\":\\\"string\\\"},\\\"delivered\\\":{\\\"type\\\":\\\"boolean\\\"},\\\"address\\\":{\\\"type\\\":\\\"string\\\"},\\\"pizzaType\\\":{\\\"type\\\":\\\"string\\\"},\\\"creditCardNumber\\\":{\\\"type\\\":\\\"string\\\"},\\\"quantity\\\":{\\\"type\\\":\\\"number\\\"},\\\"orderId\\\":{\\\"type\\\":\\\"integer\\\"}},\\\"required\\\":[\\\"orderId\\\"]}},\\\"consumes\\\":[\\\"application/json\\\"],\\\"info\\\":{\\\"title\\\":\\\"PizzaShackAPI\\\",\\\"description\\\":\\\"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\\\n\\\",\\\"license\\\":{\\\"name\\\":\\\"Apache 2.0\\\",\\\"url\\\":\\\"http://www.apache.org/licenses/LICENSE-2.0.html\\\"},\\\"contact\\\":{\\\"email\\\":\\\"architecture@pizzashack.com\\\",\\\"name\\\":\\\"John Doe\\\",\\\"url\\\":\\\"http://www.pizzashack.com\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\",\r\n   \"wsdlUri\": null,\r\n   \"lifeCycleStatus\": \"CREATED\",\r\n   \"responseCaching\": \"Disabled\",\r\n   \"cacheTimeout\": 300,\r\n   \"destinationStatsEnabled\": null,\r\n   \"isDefaultVersion\": false,\r\n   \"transport\": [\"https\"],\r\n   \"tags\":    [\r\n      \"chicken\",\r\n      \"pizza\"\r\n   ],\r\n   \"policies\": [\"Unlimited\"],\r\n   \"maxTps\":    {\r\n      \"sandbox\": 500,\r\n      \"production\": 100\r\n   },\r\n   \"visibility\": \"PUBLIC\",\r\n   \"visibleRoles\": [],\r\n   \"visibleTenants\": [],\r\n   \"endpointConfig\": \"{\\\"production_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9090/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"sandbox_endpoints\\\":{\\\"url\\\":\\\"https://localhost:9090/am/sample/pizzashack/v1/api/\\\",\\\"config\\\":null},\\\"endpoint_type\\\":\\\"http\\\"}\",\r\n   \"endpointSecurity\":    {\r\n      \"username\": \"user\",\r\n      \"type\": \"basic\",\r\n      \"password\": \"pass\"\r\n   },\r\n   \"gatewayEnvironments\": \"Production and Sandbox\",\r\n   \"sequences\": [],\r\n   \"subscriptionAvailability\": null,\r\n   \"subscriptionAvailableTenants\": [],\r\n   \"businessInformation\":    {\r\n      \"businessOwnerEmail\": \"marketing@pizzashack.com\",\r\n      \"technicalOwnerEmail\": \"architecture@pizzashack.com\",\r\n      \"technicalOwner\": \"John Doe\",\r\n      \"businessOwner\": \"Jane Roe\"\r\n   },\r\n   \"corsConfiguration\":    {\r\n      \"accessControlAllowOrigins\": [\"*\"],\r\n      \"accessControlAllowHeaders\":       [\r\n         \"authorization\",\r\n         \"Access-Control-Allow-Origin\",\r\n         \"Content-Type\",\r\n         \"SOAPAction\"\r\n      ],\r\n      \"accessControlAllowMethods\":       [\r\n         \"GET\",\r\n         \"PUT\",\r\n         \"POST\",\r\n         \"DELETE\",\r\n         \"PATCH\",\r\n         \"OPTIONS\"\r\n      ],\r\n      \"accessControlAllowCredentials\": false,\r\n      \"corsConfigurationEnabled\": false\r\n   }\r\n}",
+        "summary": "Update a Composite API",
+        "description": "This operation can be used to update an existing Composite API.\nBut the properties `name`, `version`, `context`, `provider`, `state` will not be changed by this operation.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "API object that needs to be added\n",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CompositeAPI"
+            }
+          },
+          {
+            "$ref": "#/parameters/If-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Unmodified-Since"
+          }
+        ],
+        "tags": [
+          "Composite API (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nSuccessful response with updated Composite API object\n",
+            "schema": {
+              "$ref": "#/definitions/CompositeAPI"
+            },
+            "headers": {
+              "Location": {
+                "description": "The URL of the newly created resource.\n",
+                "type": "string"
+              },
+              "ETag": {
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              },
+              "Last-Modified": {
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden.\nThe request must be conditional but no condition has been specified.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nThe resource to be updated does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "412": {
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X DELETE https://127.0.0.1:9090/api/am/store/v1/composite-apis/6fb74674-4ab8-4b52-9886-f9a376985060",
+        "x-wso2-request": "DELETE https://127.0.0.1:9090/api/am/store/v1/composite-apis/6fb74674-4ab8-4b52-9886-f9a376985060\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK",
+        "summary": "Delete a Composite API",
+        "description": "This operation can be used to delete an existing Composite API proving the Id of the Composite API.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "$ref": "#/parameters/If-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Unmodified-Since"
+          }
+        ],
+        "tags": [
+          "Composite API (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nResource successfully deleted.\n"
+          },
+          "403": {
+            "description": "Forbidden.\nThe request must be conditional but no condition has been specified.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nResource to be deleted does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "412": {
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/composite-apis/{apiId}/dedicated-gateway": {
+      "get": {
+        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9090/api/am/store/v1/composite-apis/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/dedicated-gateway",
+        "x-wso2-request": "GET https://127.0.0.1:9292/api/am/store/v1/composite-apis/96077508-fd01-4fae-bc64-5de0e2baf43c/dedicated-gateway\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n\"isEnabled\":true\n}",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "summary": "Get details of dedicated-gateway",
+        "description": "This operation can be used to retrieve whether the dedicated gateway is enabled in a certain Composite API.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "$ref": "#/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Modified-Since"
+          }
+        ],
+        "tags": [
+          "DedicatedGateway (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nisEnabled of dedicated Gateway returned\n",
+            "schema": {
+              "$ref": "#/definitions/DedicatedGateway"
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "The content type of the body.\n",
+                "type": "string"
+              },
+              "ETag": {
+                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              },
+              "Last-Modified": {
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+          },
+          "404": {
+            "description": "Not Found.\nRequested Dedicated Gateway does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "406": {
+            "description": "Not Acceptable.\nThe requested media type is not supported.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "x-wso2-curl": "curl -k -H \"Authorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\" -H \"Content-Type: application/json\" -X PUT -d data.json \"https://127.0.0.1:9443/api/am/publisher/v1.0/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/dedicated-gateway",
+        "x-wso2-request": "PUT https://127.0.0.1:9292/api/am/store/v1/composite-apis/96077508-fd01-4fae-bc64-5de0e2baf43c/dedicated-gateway\nAuthorization:Bearer b0982cd2aacd463ff5f63cd5ebe58f4a\nContent-Type: application/json\n\n{\n   \"isEnabled\": \"true\"\n}",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"enabled\": \"true\"\n}",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:dedicated_gateway"
+            ]
+          }
+        ],
+        "x-scope": "apim:dedicated_gateway",
+        "summary": "Update enabling of dedicated Gateway of Composite API",
+        "description": "This operation can be used to update metadata of an API's dedicated-gateway.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "dedicated Gateway object that needs to be added\n",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DedicatedGateway"
+            }
+          },
+          {
+            "$ref": "#/parameters/If-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Unmodified-Since"
+          }
+        ],
+        "tags": [
+          "dedicated-gateway (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nDedicated Gateway of Composite API updated\n",
+            "schema": {
+              "$ref": "#/definitions/DedicatedGateway"
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "The content type of the body.\n",
+                "type": "string"
+              },
+              "ETag": {
+                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              },
+              "Last-Modified": {
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nThe resource to be updated does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "412": {
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/composite-apis/{apiId}/swagger": {
+      "get": {
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9090/api/am/store/v1/composite-apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/swagger",
+        "x-wso2-request": "GET https://127.0.0.1:9090/api/am/store/v1/composite-apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/swagger\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\nContent-Length: 329\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-policy\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"x-wso2-security\": {\"apim\": {\"x-wso2-scopes\": []}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
+        "summary": "Get swagger definition",
+        "description": "This operation can be used to retrieve the swagger definition of a Composite API.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "$ref": "#/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Modified-Since"
+          }
+        ],
+        "tags": [
+          "Composite API (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nRequested swagger document of the Composite API is returned\n",
+            "headers": {
+              "ETag": {
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              },
+              "Last-Modified": {
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+          },
+          "404": {
+            "description": "Not Found.\nRequested API does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "406": {
+            "description": "Not Acceptable.\nThe requested media type is not supported\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "x-wso2-curl": "curl -k -H \"Authorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\" -F endpointId=\"{\\\"paths\\\":{\\\"\\/*\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{\\\"description\\\":\\\"OK\\\"}}}}},\\\"x-wso2-security\\\":{\\\"apim\\\":{\\\"x-wso2-scopes\\\":[]}},\\\"swagger\\\":\\\"2.0\\\",\\\"info\\\":{\\\"title\\\":\\\"PhoneVerification\\\",\\\"description\\\":\\\"Verify a phone number\\\",\\\"contact\\\":{\\\"email\\\":\\\"xx@ee.com\\\",\\\"name\\\":\\\"xx\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\" -X PUT \"https://127.0.0.1:9090/api/am/store/v1/composite-apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/swagger\"",
+        "x-wso2-request": "PUT https://127.0.0.1:9090/api/am/store/v1/composite-apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/swagger\nAuthorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\nContent-Length: 477\nContent-Type: multipart/form-data; boundary=------------------------4f51e636c0003d99\n\n--------------------------4f51e636c0003d99\nContent-Disposition: form-data; name=\"apiDefinition\"\n\n{\"paths\":{\"\\/*\":{\"get\":{\"x-auth-type\":\"Application\",\"x-throttling-policy\":\"Unlimited\",\"responses\":{\"200\":{\"description\":\"OK\"}}}}},\"x-wso2-security\":{\"apim\":{\"x-wso2-scopes\":[]}},\"swagger\":\"2.0\",\"info\":{\"title\":\"PhoneVerification\",\"description\":\"Verify a phone number\",\"contact\":{\"email\":\"xx@ee.com\",\"name\":\"xx\"},\"version\":\"1.0.0\"}}\n--------------------------4f51e636c0003d99--\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-policy\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"x-wso2-security\": {\"apim\": {\"x-wso2-scopes\": []}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
+        "summary": "Update swagger definition",
+        "description": "This operation can be used to update the swagger definition of an existing Composite API. Swagger definition to be updated is passed as a form data parameter `apiDefinition`.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "in": "formData",
+            "name": "apiDefinition",
+            "description": "Swagger definition of the Composite API",
+            "type": "string",
+            "required": true
+          },
+          {
+            "$ref": "#/parameters/If-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Unmodified-Since"
+          }
+        ],
+        "tags": [
+          "Composite API (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nSuccessful response with updated Swagger definition\n",
+            "headers": {
+              "Location": {
+                "description": "The URL of the newly created resource.\n",
+                "type": "string"
+              },
+              "ETag": {
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              },
+              "Last-Modified": {
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden.\nThe request must be conditional but no condition has been specified.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nThe resource to be updated does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "412": {
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/composite-apis/{apiId}/implementation": {
+      "get": {
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://127.0.0.1:9090/api/am/store/v1/composite-apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/implementation",
+        "x-wso2-request": "GET https://127.0.0.1:9090/api/am/store/v1/composite-apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/implementation\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\nContent-Length: 329\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-policy\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"x-wso2-security\": {\"apim\": {\"x-wso2-scopes\": []}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
+        "summary": "Get Composite API implementation",
+        "description": "This operation can be used to retrieve the Ballerina implementation of a Composite API.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "$ref": "#/parameters/If-None-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Modified-Since"
+          }
+        ],
+        "tags": [
+          "Composite API (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nRequested Ballerina implementation of the Composite API is returned\n",
+            "headers": {
+              "ETag": {
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              },
+              "Last-Modified": {
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+          },
+          "404": {
+            "description": "Not Found.\nRequested API does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "406": {
+            "description": "Not Acceptable.\nThe requested media type is not supported\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "x-wso2-curl": "curl -k -H \"Authorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\" -F endpointId=\"{\\\"paths\\\":{\\\"\\/*\\\":{\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application\\\",\\\"x-throttling-policy\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{\\\"description\\\":\\\"OK\\\"}}}}},\\\"x-wso2-security\\\":{\\\"apim\\\":{\\\"x-wso2-scopes\\\":[]}},\\\"swagger\\\":\\\"2.0\\\",\\\"info\\\":{\\\"title\\\":\\\"PhoneVerification\\\",\\\"description\\\":\\\"Verify a phone number\\\",\\\"contact\\\":{\\\"email\\\":\\\"xx@ee.com\\\",\\\"name\\\":\\\"xx\\\"},\\\"version\\\":\\\"1.0.0\\\"}}\" -X PUT \"https://127.0.0.1:9090/api/am/store/v1/composite-apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/implementation\"",
+        "x-wso2-request": "PUT https://127.0.0.1:9090/api/am/store/v1/composite-apis/8848faaa-7fd1-478a-baa2-48a4ebb92c98/implementation\nAuthorization:Bearer 5311eca3-8ac8-354e-ab36-7e2fdd6a4013\nContent-Length: 477\nContent-Type: multipart/form-data; boundary=------------------------4f51e636c0003d99\n\n--------------------------4f51e636c0003d99\nContent-Disposition: form-data; name=\"apiImplementation\"\n\n{\"paths\":{\"\\/*\":{\"get\":{\"x-auth-type\":\"Application\",\"x-throttling-policy\":\"Unlimited\",\"responses\":{\"200\":{\"description\":\"OK\"}}}}},\"x-wso2-security\":{\"apim\":{\"x-wso2-scopes\":[]}},\"swagger\":\"2.0\",\"info\":{\"title\":\"PhoneVerification\",\"description\":\"Verify a phone number\",\"contact\":{\"email\":\"xx@ee.com\",\"name\":\"xx\"},\"version\":\"1.0.0\"}}\n--------------------------4f51e636c0003d99--\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"paths\": {\"/*\": {\"get\":    {\n      \"x-auth-type\": \"Application\",\n      \"x-throttling-policy\": \"Unlimited\",\n      \"responses\": {\"200\": {\"description\": \"OK\"}}\n   }}},\n   \"x-wso2-security\": {\"apim\": {\"x-wso2-scopes\": []}},\n   \"swagger\": \"2.0\",\n   \"info\":    {\n      \"title\": \"PhoneVerification\",\n      \"description\": \"Verify a phone number\",\n      \"contact\":       {\n         \"email\": \"xx@ee.com\",\n         \"name\": \"xx\"\n      },\n      \"version\": \"1.0.0\"\n   }\n}",
+        "summary": "Update Composite API implementation",
+        "description": "This operation can be used to update the Ballerina implementation of a Composite API. Ballerina implementation to be updated is passed as a form data parameter `apiImplementation`.\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiId"
+          },
+          {
+            "in": "formData",
+            "name": "apiImplementation",
+            "description": "Ballerina implementation of the Composite API",
+            "type": "file",
+            "required": true
+          },
+          {
+            "$ref": "#/parameters/If-Match"
+          },
+          {
+            "$ref": "#/parameters/If-Unmodified-Since"
+          }
+        ],
+        "tags": [
+          "Composite API (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nSuccessful response with updated Ballerina implementation\n",
+            "schema": {
+              "$ref": "#/definitions/FileInfo"
+            },
+            "headers": {
+              "Location": {
+                "description": "The URL of the newly created resource.\n",
+                "type": "string"
+              },
+              "ETag": {
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              },
+              "Last-Modified": {
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden.\nThe request must be conditional but no condition has been specified.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nThe resource to be updated does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "412": {
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/applications": {
+      "get": {
+        "summary": "Get all applications",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "description": "Get a list of applications\n",
+        "parameters": [
           {
             "name": "query",
             "in": "query",
@@ -584,9 +1776,6 @@
           },
           {
             "$ref": "#/parameters/offset"
-          },
-          {
-            "$ref": "#/parameters/Accept"
           },
           {
             "$ref": "#/parameters/If-None-Match"
@@ -602,18 +1791,14 @@
               "$ref": "#/definitions/ApplicationList"
             },
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
-                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests.\n",
                 "type": "string"
               }
             }
           },
           "304": {
-            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource.\n"
           },
           "400": {
             "description": "Bad Request.\nInvalid request or validation error.\n",
@@ -630,12 +1815,16 @@
         }
       },
       "post": {
+        "summary": "Create a new application",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
         "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json \"https://localhost:9443/api/am/store/v0.14/applications\"",
-        "x-wso2-request": "POST https://localhost:9443/api/am/store/v0.14/applications\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\n    \"throttlingTier\": \"Unlimited\",\n    \"description\": \"sample app description\",\n    \"name\": \"sampleapp\",\n    \"callbackUrl\": \"http://my.server.com/callback\"\n \"groupId\": \"org1\"\n}",
-        "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://localhost:9443/api/am/store/v0.14/applications/c30f3a6e-ffa4-4ae7-afce-224d1f820524\nContent-Type: application/json\n\n{\n   \"groupId\": null,\n   \"callbackUrl\": \"http://my.server.com/callback\",\n   \"subscriber\": \"admin\",\n   \"throttlingTier\": \"Unlimited\",\n   \"applicationId\": \"c30f3a6e-ffa4-4ae7-afce-224d1f820524\",\n   \"description\": \"sample app description\",\n   \"status\": \"APPROVED\",\n   \"name\": \"sampleapp\",\n   \"keys\": []\n}",
-        "summary": "Create a new application\n",
-        "description": "This operation can be used to create a new application specifying the details of the application in the payload.\n",
+        "description": "Create a new application.\n",
         "parameters": [
           {
             "in": "body",
@@ -645,13 +1834,11 @@
             "schema": {
               "$ref": "#/definitions/Application"
             }
-          },
-          {
-            "$ref": "#/parameters/Content-Type"
           }
         ],
         "tags": [
-          "Application (Individual)"
+          "Application (Individual)",
+          "Create"
         ],
         "responses": {
           "201": {
@@ -664,12 +1851,20 @@
                 "description": "Location of the newly created Application.\n",
                 "type": "string"
               },
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
-                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional request\n",
+                "type": "string"
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted.\nThe request has been accepted.\n",
+            "schema": {
+              "$ref": "#/definitions/WorkflowResponse"
+            },
+            "headers": {
+              "Location": {
+                "description": "Location of the newly created Application.\n",
                 "type": "string"
               }
             }
@@ -697,18 +1892,19 @@
     },
     "/applications/{applicationId}": {
       "get": {
+        "summary": "Get details of an application",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
         "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/store/v0.14/applications/896658a0-b4ee-4535-bbfa-806c894a4015\"",
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/applications/896658a0-b4ee-4535-bbfa-806c894a4015\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"groupId\": \"\",\n   \"callbackUrl\": null,\n   \"subscriber\": \"admin\",\n   \"throttlingTier\": \"Unlimited\",\n   \"applicationId\": \"896658a0-b4ee-4535-bbfa-806c894a4015\",\n   \"description\": null,\n   \"status\": \"APPROVED\",\n   \"name\": \"DefaultApplication\",\n   \"keys\": [   {\n      \"consumerKey\": \"AVoREWiB16kY_GTIzscl40GYYZQa\",\n      \"consumerSecret\": \"KXQxmS8W3xDvvJH4AfR6xrhKIeIa\",\n      \"keyState\": \"COMPLETED\",\n      \"keyType\": \"PRODUCTION\",\n      \"supportedGrantTypes\": null,\n      \"token\":       {\n         \"validityTime\": 3600,\n         \"accessToken\": \"3887da6d111f0429c6dff47a46e87209\",\n         \"tokenScopes\":          [\n            \"am_application_scope\",\n            \"default\"\n         ]\n      }\n   }]\n}",
-        "summary": "Get details of an application\n",
-        "description": "This operation can be used to retrieve details of an individual application specifying the application id in the URI.\n",
+        "description": "Get application details\n",
         "parameters": [
           {
             "$ref": "#/parameters/applicationId"
-          },
-          {
-            "$ref": "#/parameters/Accept"
           },
           {
             "$ref": "#/parameters/If-None-Match"
@@ -718,7 +1914,8 @@
           }
         ],
         "tags": [
-          "Application (Individual)"
+          "Application (Individual)",
+          "Retrieve"
         ],
         "responses": {
           "200": {
@@ -727,16 +1924,12 @@
               "$ref": "#/definitions/Application"
             },
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
                 "description": "Entity Tag of the response resource. Used by caches, or in conditional requests.\n",
                 "type": "string"
               },
               "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional reuquests.\n",
                 "type": "string"
               }
             }
@@ -759,12 +1952,16 @@
         }
       },
       "put": {
+        "summary": "Update an application",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
         "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X PUT -d @data.json \"https://localhost:9443/api/am/store/v0.14/applications/c30f3a6e-ffa4-4ae7-afce-224d1f820524\"",
-        "x-wso2-request": "PUT https://localhost:9443/api/am/store/v0.14/applications/c30f3a6e-ffa4-4ae7-afce-224d1f820524\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\n   \"callbackUrl\": \"\",\n   \"throttlingTier\": \"Bronze\",\n   \"description\": \"sample app description updated\",\n   \"name\": \"sampleapp\",\n    \"groupId\": \"org1\"\n}",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"groupId\": null,\n   \"callbackUrl\": \"\",\n   \"subscriber\": \"admin\",\n   \"throttlingTier\": \"Bronze\",\n   \"applicationId\": \"c30f3a6e-ffa4-4ae7-afce-224d1f820524\",\n   \"description\": \"sample app description updated\",\n   \"status\": \"APPROVED\",\n   \"name\": \"sampleapp\",\n   \"keys\": []\n}",
-        "summary": "Update an application\n",
-        "description": "This operation can be used to update an application. Upon succesfull you will retrieve the updated application as the response.\n",
+        "description": "Update application details\n",
         "parameters": [
           {
             "$ref": "#/parameters/applicationId"
@@ -779,9 +1976,6 @@
             }
           },
           {
-            "$ref": "#/parameters/Content-Type"
-          },
-          {
             "$ref": "#/parameters/If-Match"
           },
           {
@@ -789,7 +1983,8 @@
           }
         ],
         "tags": [
-          "Application (Individual)"
+          "Application (Individual)",
+          "Update"
         ],
         "responses": {
           "200": {
@@ -802,16 +1997,12 @@
                 "description": "The URL of the newly created resource.\n",
                 "type": "string"
               },
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
-                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests.\n",
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional request.\n",
                 "type": "string"
               },
               "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional reuquests.\n",
                 "type": "string"
               }
             }
@@ -837,12 +2028,16 @@
         }
       },
       "delete": {
+        "summary": "Delete an application",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
         "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X DELETE \"https://localhost:9443/api/am/store/v0.14/applications/367a2361-8db5-4140-8133-c6c8dc7fa0c4\"",
-        "x-wso2-request": "DELETE https://localhost:9443/api/am/store/v0.14/applications/367a2361-8db5-4140-8133-c6c8dc7fa0c4\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-        "x-wso2-response": "HTTP/1.1 200 OK",
-        "summary": "Remove an application\n",
-        "description": "This operation can be used to remove an application specifying its id.\n",
+        "description": "Delete an application\n",
         "parameters": [
           {
             "$ref": "#/parameters/applicationId"
@@ -855,11 +2050,24 @@
           }
         ],
         "tags": [
-          "Application (Individual)"
+          "Application (Individual)",
+          "Delete"
         ],
         "responses": {
           "200": {
             "description": "OK.\nResource successfully deleted.\n"
+          },
+          "202": {
+            "description": "Accepted.\nThe request has been accepted.\n",
+            "schema": {
+              "$ref": "#/definitions/WorkflowResponse"
+            },
+            "headers": {
+              "Location": {
+                "description": "Location of the existing Application.\n",
+                "type": "string"
+              }
+            }
           },
           "404": {
             "description": "Not Found.\nResource to be deleted does not exist.\n",
@@ -876,92 +2084,41 @@
         }
       }
     },
-    "/applications/{applicationId}/keys/{keyType}": {
-      "get": {
+    "/applications/{applicationId}/generate-keys": {
+      "post": {
+        "summary": "Generate application keys",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
         "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/store/v0.14/applications/896658a0-b4ee-4535-bbfa-806c894a4015/keys/PRODUCTION\"",
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/applications/896658a0-b4ee-4535-bbfa-806c894a4015/keys/PRODUCTION\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n {\n      \"consumerKey\": \"QwEtRHd4NJkcFuRUfAT5af8XEEoa\",\n      \"consumerSecret\": \"7Fairfeu321ENjOR9w2xgJl3i70a\",\n       \"supportedGrantTypes\": [\n        \"refresh_token\",\n        \"urn:ietf:params:oauth:grant-type:saml2-bearer\",\n        \"password\",\n        \"client_credentials\",\n        \"iwa:ntlm\"\n      ],\n      \"callbackUrl\": \"http://sample/com/callback\",\n      \"keyState\": \"COMPLETED\",\n      \"keyType\": \"SANDBOX\"}\n",
-        "summary": "Get key details of a given type\n",
-        "description": "This operation can be used to retrieve key details of an individual application specifying the key type in the URI.\n",
+        "description": "Generate keys (Consumer key/secret) for application\n",
         "parameters": [
           {
             "$ref": "#/parameters/applicationId"
-          },
-          {
-            "$ref": "#/parameters/keyType"
-          },
-          {
-            "$ref": "#/parameters/groupId"
-          },
-          {
-            "$ref": "#/parameters/Accept"
-          }
-        ],
-        "tags": [
-          "Application (Individual)",
-          "Application Keys"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK.\nApplication key details returned.\n",
-            "schema": {
-              "$ref": "#/definitions/ApplicationKey"
-            },
-            "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found.\nRequested application does not exist.\n",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "406": {
-            "description": "Not Acceptable.\nThe requested media type is not supported\n",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      },
-      "put": {
-        "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X PUT -d @data.json \"https://localhost:9443/api/am/store/v0.14/applications/c30f3a6e-ffa4-4ae7-afce-224d1f820524/keys/SANDBOX\"",
-        "x-wso2-request": "PUT https://localhost:9443/api/am/store/v0.14/applications/896658a0-b4ee-4535-bbfa-806c894a4015/keys/SANDBOX\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n{\n   \"supportedGrantTypes\": [\n     \"refresh_token\",\n     \"urn:ietf:params:oauth:grant-type:saml2-bearer\",\n     \"password\",\n     \"client_credentials\",\n     \"iwa:ntlm\"\n   ],\n   \"callbackUrl\": \"http://sample/com/callback\"\n }\n",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n {\n      \"consumerKey\": \"QwEtRHd4NJkcFuRUfAT5af8XEEoa\",\n      \"consumerSecret\": \"7Fairfeu321ENjOR9w2xgJl3i70a\",\n       \"supportedGrantTypes\": [\n        \"refresh_token\",\n        \"urn:ietf:params:oauth:grant-type:saml2-bearer\",\n        \"password\",\n        \"client_credentials\",\n        \"iwa:ntlm\"\n      ],\n      \"callbackUrl\": \"http://sample/com/callback\",\n      \"keyState\": \"COMPLETED\",\n      \"keyType\": \"PRODUCTION\"}\n",
-        "summary": "Update grant types and callback url of an application\n",
-        "description": "This operation can be used to update grant types and callback url of an application. (Consumer Key and Consumer Secret are ignored) Upon succesfull you will retrieve the updated key details as the response.\n",
-        "parameters": [
-          {
-            "$ref": "#/parameters/applicationId"
-          },
-          {
-            "$ref": "#/parameters/keyType"
           },
           {
             "in": "body",
             "name": "body",
-            "description": "Grant types/Callback URL update request object\n",
+            "description": "Application key generation request object\n",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/ApplicationKey"
+              "$ref": "#/definitions/ApplicationKeyGenerateRequest"
             }
           }
         ],
         "tags": [
-          "Application (Individual)",
-          "Application Keys"
+          "Application Key (Individual)",
+          "Application (Individual)"
         ],
         "responses": {
           "200": {
-            "description": "Ok.\nGrant types or/and callback url is/are updated.\n",
+            "description": "OK.\nKeys are generated.\n",
             "schema": {
-              "$ref": "#/definitions/ApplicationKey"
+              "$ref": "#/definitions/ApplicationKeys"
             }
           },
           "400": {
@@ -985,29 +2142,248 @@
         }
       }
     },
-    "/applications/generate-keys": {
+    "/applications/{applicationId}/map-keys": {
       "post": {
+        "summary": "Map application keys",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
         "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json  \"https://localhost:9443/api/am/store/v0.14/applications/generate-keys?applicationId=c30f3a6e-ffa4-4ae7-afce-224d1f820524\"",
-        "x-wso2-request": "POST https://localhost:9443/api/am/store/v0.14/applications/generate-keys?applicationId=c30f3a6e-ffa4-4ae7-afce-224d1f820524\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\n  \"validityTime\": \"3600\",\n  \"keyType\": \"PRODUCTION\",\n  \"accessAllowDomains\": [ \"ALL\" ],\n  \"scopes\": [ \"am_application_scope\", \"default\" ],\n  \"supportedGrantTypes\": [ \"urn:ietf:params:oauth:grant-type:saml2-bearer\", \"iwa:ntlm\", \"refresh_token\", \"client_credentials\", \"password\" ]\n}",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"consumerSecret\": \"8V7DDKtKGtuG_9GDjaOJ5sijdX0a\",\n   \"consumerKey\": \"LOFL8He72MSGVil4SS_bsh9O8MQa\",\n   \"keyState\": \"APPROVED\",\n   \"keyType\": \"PRODUCTION\",\n   \"supportedGrantTypes\":    [\n      \"urn:ietf:params:oauth:grant-type:saml2-bearer\",\n      \"iwa:ntlm\",\n      \"refresh_token\",\n      \"client_credentials\",\n      \"password\"\n   ],\n   \"token\":    {\n      \"validityTime\": 3600,\n      \"accessToken\": \"fd2cdc4906fbc162e033d57f85a71c21\",\n      \"tokenScopes\":       [\n         \"am_application_scope\",\n         \"default\"\n      ]\n   }\n}",
-        "summary": "Generate keys for application\n",
-        "description": "This operation can be used to generate client ID and client secret for an application\n\n**NOTE**\n\n* This operation does not require the client ID and the client secret by default.\n* When using credentials from a third party key manager, you can generate access tokens by providing only the client ID or both the client ID and the client secret.\n",
+        "description": "Map keys (Consumer key/secret) to an application\n",
         "parameters": [
           {
-            "$ref": "#/parameters/applicationId-Q"
+            "$ref": "#/parameters/applicationId"
           },
           {
             "in": "body",
             "name": "body",
-            "description": "Application object the keys of which are to be generated\n",
+            "description": "Application key mapping request object\n",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/ApplicationKeyGenerateRequest"
+              "$ref": "#/definitions/ApplicationKeyMappingRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Application Key (Individual)",
+          "Application (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nKeys are mapped.\n",
+            "schema": {
+              "$ref": "#/definitions/ApplicationKeys"
             }
           },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nThe resource to be updated does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "412": {
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/applications/{applicationId}/keys": {
+      "get": {
+        "summary": "Retrieve all application keys",
+        "security": [
           {
-            "$ref": "#/parameters/Content-Type"
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "description": "Retrieve keys (Consumer key/secret) of application\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/applicationId"
+          }
+        ],
+        "tags": [
+          "Application Key (Collection)",
+          "Application (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nKeys are returned.\n",
+            "schema": {
+              "$ref": "#/definitions/ApplicationKeysList"
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nThe resource does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "412": {
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/applications/{applicationId}/keys/{keyType}": {
+      "get": {
+        "summary": "Retrieve application keys for a provided type",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "description": "Retrieve keys (Consumer key/secret) of application by a given type\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/applicationId"
+          },
+          {
+            "$ref": "#/parameters/keyType"
+          }
+        ],
+        "tags": [
+          "Application Key (Collection)",
+          "Application (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nKeys of given type are returned.\n",
+            "schema": {
+              "$ref": "#/definitions/ApplicationKeys"
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nThe resource does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "412": {
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update an application key",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "description": "Update grant types and callback url (Consumer Key and Consumer Secret are ignored)\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/applicationId"
+          },
+          {
+            "$ref": "#/parameters/keyType"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Grant types/Callback URL update request object\n",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationKeys"
+            }
+          }
+        ],
+        "tags": [
+          "Application Key (Individual)",
+          "Application (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok.\nGrant types or/and callback url is/are updated.\n",
+            "schema": {
+              "$ref": "#/definitions/ApplicationKeys"
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nThe resource to be updated does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "412": {
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/applications/{applicationId}/generate-token": {
+      "post": {
+        "summary": "Generate application token",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "description": "Generate an access token for application by client_credentials grant type\n",
+        "parameters": [
+          {
+            "$ref": "#/parameters/applicationId"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Application token generation request object\n",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationTokenGenerateRequest"
+            }
           },
           {
             "$ref": "#/parameters/If-Match"
@@ -1017,27 +2393,14 @@
           }
         ],
         "tags": [
+          "Application Token (Individual)",
           "Application (Individual)"
         ],
         "responses": {
           "200": {
-            "description": "OK.\nKeys are generated.\n",
+            "description": "OK.\nToken is generated.\n",
             "schema": {
-              "$ref": "#/definitions/ApplicationKey"
-            },
-            "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
-              "ETag": {
-                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
-                "type": "string"
-              },
-              "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).‚\n",
-                "type": "string"
-              }
+              "$ref": "#/definitions/ApplicationToken"
             }
           },
           "400": {
@@ -1053,7 +2416,7 @@
             }
           },
           "412": {
-            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met (Will be supported in future).\n",
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
             "schema": {
               "$ref": "#/definitions/Error"
             }
@@ -1061,167 +2424,31 @@
         }
       }
     },
-    "/applications/scopes/{applicationId}": {
+    "/export/applications": {
       "get": {
-        "deprecated": true,
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
         "x-scope": "apim:subscribe",
-        "x-wso2-request": "GET https://127.0.0.1:9443/api/am/store/v0.14/applications/scopes/896658a0-b4ee-4535-bbfa-806c894a4015\nAuthorization: Beareraa0ddec1ac656744234477f20fafcb0d",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer aa0ddec1ac656744234477f20fafcb0d\" \"https://127.0.0.1:9443/api/am/store/v0.14/applications/scopes/896658a0-b4ee-4535-bbfa-806c894a4015\"",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n{\n   \"list\": [   {\n      \"key\":\"api_scope\",\n      \"name\":\"API Scope\",\n      \"roles\":null,\n      \"description\":\"\"\n   }]\n}",
-        "summary": "Get scopes associated with a particular application based on subscribed APIs\n",
-        "description": "Get scopes associated with a particular application based on subscribed APIs\n",
+        "produces": [
+          "application/zip"
+        ],
+        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9292/api/am/store/v1.0/export/applications?appId=xxx > exported-application.zip",
+        "x-wso2-request": "GET https://127.0.0.1:9292/api/am/store/v1.0/export/applications?appId=xxx\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\n Connection: keep-alive\n  Content-Disposition: attachment; filename=\"exported-applications.zip\"\n  Content-Type: application/zip",
+        "summary": "Export details related to an Application.",
+        "description": "This operation can be used to export details related to a perticular application.\n",
         "parameters": [
           {
-            "$ref": "#/parameters/applicationId"
-          },
-          {
-            "$ref": "#/parameters/filterByUserRoles"
-          },
-          {
-            "$ref": "#/parameters/If-None-Match"
-          },
-          {
-            "$ref": "#/parameters/If-Modified-Since"
-          }
-        ],
-        "tags": [
-          "Application (Individual)"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK.\nScope returned.\n",
-            "schema": {
-              "$ref": "#/definitions/ScopeList"
-            },
-            "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
-              "ETag": {
-                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests.\n",
-                "type": "string"
-              },
-              "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional reuquests.\n",
-                "type": "string"
-              }
-            }
-          },
-          "304": {
-            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource.\n"
-          },
-          "401": {
-            "description": "Un authorized.\nThe user is not authorized to view the application .\n",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "404": {
-            "description": "Not Found.\nRequested application does not exist.\n",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "406": {
-            "description": "Not Acceptable.\nThe requested media type is not supported\n",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
-    "/applications/{applicationId}/scopes": {
-      "get": {
-        "x-scope": "apim:subscribe",
-        "x-wso2-request": "GET https://127.0.0.1:9443/api/am/store/v0.14/applications/896658a0-b4ee-4535-bbfa-806c894a4015/scopes\nAuthorization: Beareraa0ddec1ac656744234477f20fafcb0d",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer aa0ddec1ac656744234477f20fafcb0d\" \"https://127.0.0.1:9443/api/am/store/v0.14/applications/896658a0-b4ee-4535-bbfa-806c894a4015/scopes\"",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n{\n   \"list\": [   {\n      \"key\":\"api_scope\",\n      \"name\":\"API Scope\",\n      \"roles\":null,\n      \"description\":\"\"\n   }]\n}",
-        "summary": "Get scopes associated with a particular application based on subscribed APIs\n",
-        "description": "Get scopes associated with a particular application based on subscribed APIs\n",
-        "parameters": [
-          {
-            "$ref": "#/parameters/applicationId"
-          },
-          {
-            "$ref": "#/parameters/filterByUserRoles"
-          },
-          {
-            "$ref": "#/parameters/If-None-Match"
-          },
-          {
-            "$ref": "#/parameters/If-Modified-Since"
-          }
-        ],
-        "tags": [
-          "Application (Individual)"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK.\nScope returned.\n",
-            "schema": {
-              "$ref": "#/definitions/ScopeList"
-            },
-            "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
-              "ETag": {
-                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests.\n",
-                "type": "string"
-              },
-              "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional reuquests.\n",
-                "type": "string"
-              }
-            }
-          },
-          "304": {
-            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource.\n"
-          },
-          "401": {
-            "description": "Un authorized.\nThe user is not authorized to view the application .\n",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "404": {
-            "description": "Not Found.\nRequested application does not exist.\n",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "406": {
-            "description": "Not Acceptable.\nThe requested media type is not supported\n",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
-    "/applications/regenerate-consumersecret": {
-      "post": {
-        "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST -d @data.json  \"https://localhost:9443/api/am/store/v0.14/applications/regenerate-consumersecret\"",
-        "x-wso2-request": "POST https://localhost:9443/api/am/store/v0.14/applications/regenerate-consumersecret\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\n  \"consumerKey\": \"AVoREWiB16kY_GTIzscl40GYYZQa\"\n}",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"consumerSecret\": \"8V7DDKtKGtuG_9GDjaOJ5sijdX0a\",\n   \"consumerKey\": \"LOFL8He72MSGVil4SS_bsh9O8MQa\"\n}",
-        "summary": "Re generate consumer secret for an application\n",
-        "description": "This operation can be used to re generate consumer secret for an application\n",
-        "parameters": [
-          {
-            "in": "body",
-            "name": "body",
-            "description": "The consumer key associated with the application\n",
+            "name": "appId",
+            "in": "query",
+            "description": "Application Search Query\n",
             "required": true,
-            "schema": {
-              "$ref": "#/definitions/ApplicationKeyReGenerateRequest"
-            }
-          },
-          {
-            "$ref": "#/parameters/Content-Type"
+            "type": "string"
           }
         ],
         "tags": [
@@ -1229,21 +2456,76 @@
         ],
         "responses": {
           "200": {
-            "description": "OK.\nKeys are re generated.\n",
-            "schema": {
-              "$ref": "#/definitions/ApplicationKeyReGenerateResponse"
-            },
+            "description": "OK.\nExport Configuration returned.\n",
             "headers": {
               "Content-Type": {
                 "description": "The content type of the body.\n",
                 "type": "string"
-              },
-              "ETag": {
-                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
-                "type": "string"
-              },
-              "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).‚\n",
+              }
+            },
+            "schema": {
+              "type": "file"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nRequested Application does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "406": {
+            "description": "Not Acceptable.\nThe requested media type is not supported\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "412": {
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/import/applications": {
+      "put": {
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "x-wso2-curl": "curl -k -F \"file=@exported.zip\" -X PUT -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9292/api/am/store/v1.0/import/applications",
+        "x-wso2-request": "PUT https://127.0.0.1:9292/api/am/store/v1.0/import/applications\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type:application/json\n\n{\"applicationUUID\":\"645b8e32-3643-48e5-ab42-aed853a8cd77\",\"workflowResponse\":{\"workflowStatus\":\"APPROVED\"}}",
+        "summary": "Imports an Updates an Application.",
+        "description": "This operation can be used to import an existing Application.\n",
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "description": "Zip archive consisting on exported application configuration\n",
+            "required": true,
+            "type": "file"
+          }
+        ],
+        "tags": [
+          "Application (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nSuccessful response with the updated object as entity in the body.\n",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "The content type of the body.\n",
                 "type": "string"
               }
             }
@@ -1254,14 +2536,75 @@
               "$ref": "#/definitions/Error"
             }
           },
-          "404": {
-            "description": "Not Found.\nThe resource to be updated does not exist.\n",
+          "406": {
+            "description": "Not Acceptable.\nThe requested media type is not supported\n",
             "schema": {
               "$ref": "#/definitions/Error"
             }
           },
           "412": {
-            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met (Will be supported in future).\n",
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "x-wso2-curl": "curl -k -F \"file=@exported.zip\" -X POST -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9292/api/am/store/v1.0/import/applications",
+        "x-wso2-request": "POST https://127.0.0.1:9292/api/am/store/v1.0/import/applications\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\"name\":\"sampleApp2\",\"uuid\":\"5e3ac21a-cc14-4404-95f1-659900c165c4\",\"description\":\"sample app 2\",\"policy\":{\"uuid\":\"5b74ec82-264e-4104-91ef-fdd41b981798\",\"policyName\":\"50PerMin\",\"isDeployed\":false},\"status\":\"APPROVED\",\"createdUser\":\"admin\",\"createdTime\":{\"date\":{\"year\":2017,\"month\":11,\"day\":8},\"time\":{\"hour\":4,\"minute\":10,\"second\":4,\"nano\":434000000}}}",
+        "summary": "Imports an Application.",
+        "description": "This operation can be used to import an existing Application.\n",
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "description": "Zip archive consisting on exported application configuration\n",
+            "required": true,
+            "type": "file"
+          }
+        ],
+        "tags": [
+          "Application (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nSuccessful response with the updated object as entity in the body.\n",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            },
+            "headers": {
+              "Content-Type": {
+                "description": "The content type of the body.\n",
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "406": {
+            "description": "Not Acceptable.\nThe requested media type is not supported\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "412": {
+            "description": "Precondition Failed.\nThe request has not been performed because one of the preconditions is not met.\n",
             "schema": {
               "$ref": "#/definitions/Error"
             }
@@ -1271,12 +2614,16 @@
     },
     "/subscriptions": {
       "get": {
+        "summary": "Get all subscriptions",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
         "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/store/v0.14/subscriptions?apiId=c43a325c-260b-4302-81cb-768eafaa3aed\"",
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/subscriptions?apiId=c43a325c-260b-4302-81cb-768eafaa3aed\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"tier\": \"Bronze\",\n         \"subscriptionId\": \"03b8ef2b-5ae5-41f5-968e-52fa7fbd5d33\",\n         \"apiIdentifier\": \"admin-PhoneVerification-2.0.0\",\n         \"applicationId\": \"896658a0-b4ee-4535-bbfa-806c894a4015\",\n         \"status\": \"UNBLOCKED\"\n      },\n            {\n         \"tier\": \"Bronze\",\n         \"subscriptionId\": \"5ed42650-9f5e-4dd4-94f3-3f09f1b17354\",\n         \"apiIdentifier\": \"admin-PhoneVerification-2.0.0\",\n         \"applicationId\": \"846118a5-3b25-4c22-a983-2d0278936f09\",\n         \"status\": \"UNBLOCKED\"\n      }\n   ],\n   \"count\": 2,\n   \"next\": \"\"\n}",
-        "summary": "Get all subscriptions\n",
-        "description": "This operation can be used to retrieve a list of subscriptions of the user associated with the provided access token. This operation is capable of\n\n1. Retrieving applications which are subscibed to a specific API.\n`GET https://localhost:9443/api/am/store/v0.14/subscriptions?apiId=c43a325c-260b-4302-81cb-768eafaa3aed`\n\n2. Retrieving APIs which are subscribed by a specific application.\n`GET https://localhost:9443/api/am/store/v0.14/subscriptions?applicationId=c43a325c-260b-4302-81cb-768eafaa3aed`\n\n**IMPORTANT:**\n* It is mandatory to provide either **apiId** or **applicationId**.\n",
+        "description": "Get subscription list.\nThe API Identifier or Application Identifier\nthe subscriptions of which are to be returned are passed as parameters.\n",
         "parameters": [
           {
             "$ref": "#/parameters/apiId-Q"
@@ -1285,7 +2632,7 @@
             "$ref": "#/parameters/applicationId-Q"
           },
           {
-            "$ref": "#/parameters/groupId"
+            "$ref": "#/parameters/apiType"
           },
           {
             "$ref": "#/parameters/offset"
@@ -1294,14 +2641,12 @@
             "$ref": "#/parameters/limit"
           },
           {
-            "$ref": "#/parameters/Accept"
-          },
-          {
             "$ref": "#/parameters/If-None-Match"
           }
         ],
         "tags": [
-          "Subscription (Collection)"
+          "Subscription (Collection)",
+          "Retrieve"
         ],
         "responses": {
           "200": {
@@ -1310,18 +2655,14 @@
               "$ref": "#/definitions/SubscriptionList"
             },
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
-                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests.\n",
                 "type": "string"
               }
             }
           },
           "304": {
-            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource.\n"
           },
           "406": {
             "description": "Not Acceptable. The requested media type is not supported\n",
@@ -1332,12 +2673,16 @@
         }
       },
       "post": {
+        "summary": "Add a new subscription",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
         "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST  -d @data.json \"https://localhost:9443/api/am/store/v0.14/subscriptions\"",
-        "x-wso2-request": "POST https://localhost:9443/api/am/store/v0.14/subscriptions\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\n    \"tier\": \"Gold\",\n    \"apiIdentifier\": \"c43a325c-260b-4302-81cb-768eafaa3aed\",\n    \"applicationId\": \"c30f3a6e-ffa4-4ae7-afce-224d1f820524\"\n}",
-        "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://localhost:9443/api/am/store/v0.14/subscriptions/5b65808c-cdf2-43e1-a695-de63e3ad0ae9\nContent-Type: application/json\n\n{\n   \"tier\": \"Gold\",\n   \"subscriptionId\": \"5b65808c-cdf2-43e1-a695-de63e3ad0ae9\",\n   \"apiIdentifier\": \"admin-PhoneVerification-2.0.0\",\n   \"applicationId\": \"c30f3a6e-ffa4-4ae7-afce-224d1f820524\",\n   \"status\": \"UNBLOCKED\"\n}",
-        "summary": "Add a new subscription\n",
-        "description": "This operation can be used to add a new subscription providing the id of the API and the application.\n",
+        "description": "Add a new subscription\n",
         "parameters": [
           {
             "in": "body",
@@ -1347,13 +2692,11 @@
             "schema": {
               "$ref": "#/definitions/Subscription"
             }
-          },
-          {
-            "$ref": "#/parameters/Content-Type"
           }
         ],
         "tags": [
-          "Subscription (Individual)"
+          "Subscription (Individual)",
+          "Create"
         ],
         "responses": {
           "201": {
@@ -1366,72 +2709,20 @@
                 "description": "Location to the newly created subscription.\n",
                 "type": "string"
               },
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
-                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional request.\n",
                 "type": "string"
               }
             }
           },
-          "400": {
-            "description": "Bad Request.\nInvalid request or validation error.\n",
+          "202": {
+            "description": "Accepted.\nThe request has been accepted.\n",
             "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "415": {
-            "description": "Unsupported media type.\nThe entity of the request was in a not supported format.\n"
-          }
-        }
-      }
-    },
-    "/subscriptions/multiple": {
-      "post": {
-        "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -H \"Content-Type: application/json\" -X POST  -d @data.json \"https://localhost:9443/api/am/store/v0.14/subscriptions/multiple\"",
-        "x-wso2-request": "POST https://localhost:9443/api/am/store/v0.14/subscriptions/multiple\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n\n{\n    \"tier\": \"Gold\",\n    \"apiIdentifier\": \"c43a325c-260b-4302-81cb-768eafaa3aed\",\n    \"applicationId\": \"c30f3a6e-ffa4-4ae7-afce-224d1f820524\"\n}",
-        "x-wso2-response": "HTTP/1.1 201 Created\nLocation: https://localhost:9443/api/am/store/v0.14/subscriptions/5b65808c-cdf2-43e1-a695-de63e3ad0ae9\nContent-Type: application/json\n\n{\n   \"tier\": \"Gold\",\n   \"subscriptionId\": \"5b65808c-cdf2-43e1-a695-de63e3ad0ae9\",\n   \"apiIdentifier\": \"admin-PhoneVerification-2.0.0\",\n   \"applicationId\": \"c30f3a6e-ffa4-4ae7-afce-224d1f820524\",\n   \"status\": \"UNBLOCKED\"\n}",
-        "summary": "Add new subscriptions\n",
-        "description": "This operation can be used to add a new subscriptions providing the ids of the APIs and the applications.\n",
-        "parameters": [
-          {
-            "in": "body",
-            "name": "body",
-            "description": "Subscription objects that should to be added\n",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Subscription"
-              }
-            }
-          },
-          {
-            "$ref": "#/parameters/Content-Type"
-          }
-        ],
-        "tags": [
-          "Subscription (Multitple)"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK.\nSuccessful response with the newly created objects as entity in the body.\n",
-            "schema": {
-              "$ref": "#/definitions/Subscription",
-              "items": {
-                "type": "array"
-              }
+              "$ref": "#/definitions/WorkflowResponse"
             },
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
-              "ETag": {
-                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+              "Location": {
+                "description": "Location of the newly created subscription.\n",
                 "type": "string"
               }
             }
@@ -1450,18 +2741,19 @@
     },
     "/subscriptions/{subscriptionId}": {
       "get": {
+        "summary": "Get details of a subscription",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
         "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" \"https://localhost:9443/api/am/store/v0.14/subscriptions/5b65808c-cdf2-43e1-a695-de63e3ad0ae9\"",
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/subscriptions/5b65808c-cdf2-43e1-a695-de63e3ad0ae9\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"tier\": \"Gold\",\n   \"subscriptionId\": \"5b65808c-cdf2-43e1-a695-de63e3ad0ae9\",\n   \"apiIdentifier\": \"admin-PhoneVerification-2.0.0\",\n   \"applicationId\": \"c30f3a6e-ffa4-4ae7-afce-224d1f820524\",\n   \"status\": \"UNBLOCKED\"\n}",
-        "summary": "Get details of a subscription\n",
-        "description": "This operation can be used to get details of a single subscription.\n",
+        "description": "Get subscription details\n",
         "parameters": [
           {
             "$ref": "#/parameters/subscriptionId"
-          },
-          {
-            "$ref": "#/parameters/Accept"
           },
           {
             "$ref": "#/parameters/If-None-Match"
@@ -1471,7 +2763,8 @@
           }
         ],
         "tags": [
-          "Subscription (Individual)"
+          "Subscription (Individual)",
+          "Retrieve"
         ],
         "responses": {
           "200": {
@@ -1480,16 +2773,12 @@
               "$ref": "#/definitions/Subscription"
             },
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.",
-                "type": "string"
-              },
               "ETag": {
-                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests.\n",
+                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests.",
                 "type": "string"
               },
               "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Date and time the resource has been modifed the last time. Used by caches, or in conditional reuquests.",
                 "type": "string"
               }
             }
@@ -1506,12 +2795,16 @@
         }
       },
       "delete": {
+        "summary": "Remove a subscription",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
         "x-scope": "apim:subscribe",
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X DELETE \"https://localhost:9443/api/am/store/v0.14/subscriptions/5b65808c-cdf2-43e1-a695-de63e3ad0ae9\"",
-        "x-wso2-request": "DELETE https://localhost:9443/api/am/store/v0.14/subscriptions/5b65808c-cdf2-43e1-a695-de63e3ad0ae9\n",
-        "x-wso2-response": "HTTP/1.1 200 OK",
-        "summary": "Remove a subscription\n",
-        "description": "This operation can be used to remove a subscription.\n",
+        "description": "Remove subscription\n",
         "parameters": [
           {
             "$ref": "#/parameters/subscriptionId"
@@ -1524,11 +2817,24 @@
           }
         ],
         "tags": [
-          "Subscription (Individual)"
+          "Subscription (Individual)",
+          "Delete"
         ],
         "responses": {
           "200": {
             "description": "OK.\nResource successfully deleted.\n"
+          },
+          "202": {
+            "description": "Accepted.\nThe request has been accepted.\n",
+            "schema": {
+              "$ref": "#/definitions/WorkflowResponse"
+            },
+            "headers": {
+              "Location": {
+                "description": "Location of the existing subscription.\n",
+                "type": "string"
+              }
+            }
           },
           "404": {
             "description": "Not Found.\nResource to be deleted does not exist.\n",
@@ -1545,14 +2851,15 @@
         }
       }
     },
-    "/tiers/{tierLevel}": {
+    "/policies/{tierLevel}": {
       "get": {
-        "x-wso2-curl": "curl \"https://localhost:9443/api/am/store/v0.14/tiers/api\"",
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/tiers/api\n",
-        "x-wso2-curl-tenant": "curl -k -H \"X-WSO2-Tenant:test.com\" https://localhost:9443/api/am/store/v0.14/tiers/api",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"unitTime\": 60000,\n         \"tierPlan\": \"FREE\",\n         \"stopOnQuotaReach\": true,\n         \"tierLevel\": \"api\",\n         \"requestCount\": 1,\n         \"description\": \"Allows 1 request(s) per minute.\",\n         \"name\": \"Bronze\",\n         \"attributes\": {}\n      },\n            {\n         \"unitTime\": 60000,\n         \"tierPlan\": \"FREE\",\n         \"stopOnQuotaReach\": true,\n         \"tierLevel\": \"api\",\n         \"requestCount\": 20,\n         \"description\": \"Allows 20 request(s) per minute.\",\n         \"name\": \"Gold\",\n         \"attributes\": {}\n      },\n            {\n         \"unitTime\": 60000,\n         \"tierPlan\": \"FREE\",\n         \"stopOnQuotaReach\": true,\n         \"tierLevel\": \"api\",\n         \"requestCount\": 5,\n         \"description\": \"Allows 5 request(s) per minute.\",\n         \"name\": \"Silver\",\n         \"attributes\": {}\n      },\n            {\n         \"unitTime\": 0,\n         \"tierPlan\": null,\n         \"stopOnQuotaReach\": true,\n         \"tierLevel\": \"api\",\n         \"requestCount\": 0,\n         \"description\": \"Allows unlimited requests\",\n         \"name\": \"Unlimited\",\n         \"attributes\": {}\n      }\n   ],\n   \"count\": 4,\n   \"next\": \"\"\n}",
-        "summary": "Get available tiers\n",
-        "description": "This operation can be used to retrieve all the tiers available for the provided tier level. Tier level should be specified as a path parameter and should be one of `api` and `application`.\n\n`X-WSO2-Tenant` header can be used to retrive tiers that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.\n\n**NOTE**:\n* API tiers are the ones that is available during subscription of an application to an API. Hence they are also called subscription tiers and are same as the subscription policies in Admin REST API.\n",
+        "summary": "Get all available policies",
+        "security": [
+          {
+            "OAuth2Security": null
+          }
+        ],
+        "description": "Get available policies\n",
         "parameters": [
           {
             "$ref": "#/parameters/limit"
@@ -1564,21 +2871,16 @@
             "$ref": "#/parameters/tierLevel"
           },
           {
-            "$ref": "#/parameters/requestedTenant"
-          },
-          {
-            "$ref": "#/parameters/Accept"
-          },
-          {
             "$ref": "#/parameters/If-None-Match"
           }
         ],
         "tags": [
-          "Throttling Tier (Collection)"
+          "Tier (Collection)",
+          "Retrieve"
         ],
         "responses": {
           "200": {
-            "description": "OK.\nList of tiers returned.\n",
+            "description": "OK.\nList of policies returned.\n",
             "schema": {
               "type": "array",
               "items": {
@@ -1586,18 +2888,14 @@
               }
             },
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.",
-                "type": "string"
-              },
               "ETag": {
-                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests.\n",
                 "type": "string"
               }
             }
           },
           "304": {
-            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource.\n"
           },
           "406": {
             "description": "Not Acceptable.\nThe requested media type is not supported\n",
@@ -1608,26 +2906,16 @@
         }
       }
     },
-    "/tiers/{tierLevel}/{tierName}": {
+    "/policies/{tierLevel}/{tierName}": {
       "get": {
-        "x-wso2-curl": "curl \"https://localhost:9443/api/am/store/v0.14/tiers/api/Bronze\"",
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/tiers/api/Bronze\n",
-        "x-wso2-curl-tenant": "curl -k -H \"X-WSO2-Tenant:test.com\" https://localhost:9443/api/am/store/v0.14/tiers/api/Bronze",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"unitTime\": 60000,\n   \"tierPlan\": \"FREE\",\n   \"stopOnQuotaReach\": true,\n   \"tierLevel\": \"api\",\n   \"requestCount\": 1,\n   \"description\": \"Allows 1 request(s) per minute.\",\n   \"name\": \"Bronze\",\n   \"attributes\": {}\n}",
-        "summary": "Get details of a tier\n",
-        "description": "This operation can be used to retrieve details of a single tier by specifying the tier level and tier name.\n\n`X-WSO2-Tenant` header can be used to retrive tiers that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.\n",
+        "summary": "Get a single policy details",
+        "description": "Get policy details\n",
         "parameters": [
           {
             "$ref": "#/parameters/tierName"
           },
           {
             "$ref": "#/parameters/tierLevel"
-          },
-          {
-            "$ref": "#/parameters/requestedTenant"
-          },
-          {
-            "$ref": "#/parameters/Accept"
           },
           {
             "$ref": "#/parameters/If-None-Match"
@@ -1637,7 +2925,8 @@
           }
         ],
         "tags": [
-          "Throttling Tier (Individual)"
+          "Tier (Individual)",
+          "Retrieve"
         ],
         "responses": {
           "200": {
@@ -1646,22 +2935,18 @@
               "$ref": "#/definitions/Tier"
             },
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
-                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests.\n",
                 "type": "string"
               },
               "Last-Modified": {
-                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Date and time the resource has been modifed the last time.\nUsed by caches, or in conditional reuquests.\n",
                 "type": "string"
               }
             }
           },
           "304": {
-            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource.\n"
           },
           "404": {
             "description": "Not Found.\nRequested Tier does not exist.\n",
@@ -1680,12 +2965,8 @@
     },
     "/tags": {
       "get": {
-        "x-wso2-curl": "curl \"https://localhost:9443/api/am/store/v0.14/tags\"",
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.14/tags\n",
-        "x-wso2-curl-tenant": "curl -k -H \"X-WSO2-Tenant:test.com\" https://localhost:9443/api/am/store/v0.14/tags",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"weight\": 1,\n         \"name\": \"mobile\"\n      },\n            {\n         \"weight\": 1,\n         \"name\": \"multimedia\"\n      },\n            {\n         \"weight\": 1,\n         \"name\": \"phone\"\n      }\n   ],\n   \"count\": 3,\n   \"next\": \"\"\n}",
-        "summary": "Get all tags\n",
-        "description": "This operation can be used to retrieve a list of tags that are already added to APIs.\n\n`X-WSO2-Tenant` header can be used to retrive tags that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.\n\n**NOTE:**\n* This operation does not require an Authorization header by default. But in order to see a restricted API's tags, you need to provide Authorization header.\n",
+        "summary": "Get all tags",
+        "description": "Get a list of tags that are already added to APIs\n",
         "parameters": [
           {
             "$ref": "#/parameters/limit"
@@ -1694,17 +2975,12 @@
             "$ref": "#/parameters/offset"
           },
           {
-            "$ref": "#/parameters/requestedTenant"
-          },
-          {
-            "$ref": "#/parameters/Accept"
-          },
-          {
             "$ref": "#/parameters/If-None-Match"
           }
         ],
         "tags": [
-          "Tag (Collection)"
+          "Tag (Collection)",
+          "Retrieve"
         ],
         "responses": {
           "200": {
@@ -1713,18 +2989,14 @@
               "$ref": "#/definitions/TagList"
             },
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.\n",
-                "type": "string"
-              },
               "ETag": {
-                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests.\n",
                 "type": "string"
               }
             }
           },
           "304": {
-            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
+            "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource.\n"
           },
           "404": {
             "description": "Not Found. Requested API does not exist.\n",
@@ -1741,55 +3013,36 @@
         }
       }
     },
-    "/search": {
+    "/labels": {
       "get": {
-        "produces": [
-          "application/json"
-        ],
-        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/store/v0.13/search?query=sample",
-        "x-wso2-request": "GET https://localhost:9443/api/am/store/v0.13/search\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
-        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type: application/json\n\n{\n   \"previous\": \"\",\n   \"list\":    [\n            {\n         \"provider\": \"admin\",\n         \"version\": \"1.0.0\",\n         \"description\": \"This sample API provides Account Status Validation\",\n         \"name\": \"AccountVal\",\n         \"context\": \"/account\",\n         \"id\": \"2e81f147-c8a8-4f68-b4f0-69e0e7510b01\",\n         \"status\": \"PUBLISHED\"\n      },\n            {\n         \"provider\": \"admin\",\n         \"version\": \"1.0.0\",\n         \"description\": null,\n         \"name\": \"api1\",\n         \"context\": \"/api1\",\n         \"id\": \"3e22d2fb-277a-4e9e-8c7e-1c0f7f73960e\",\n         \"status\": \"PUBLISHED\"\n      }\n   ],\n   \"next\": \"\",\n   \"count\": 2\n}",
-        "summary": "Retrieve/Search APIs and API Documents by content\n",
-        "description": "This operation provides you a list of available APIs and API Documents qualifying the given keyword match.\n",
+        "summary": "Get label information based on the label name",
+        "description": "This operation can be used to retrieve the information of the labels\n",
         "parameters": [
           {
-            "$ref": "#/parameters/limit"
-          },
-          {
-            "$ref": "#/parameters/offset"
-          },
-          {
-            "$ref": "#/parameters/requestedTenant"
-          },
-          {
-            "name": "query",
+            "name": "labelType",
+            "description": "type of the label.\n",
             "in": "query",
-            "description": "**Search**.\n\nYou can search by using providing the search term in the query parameters.\n",
             "type": "string"
           },
           {
-            "$ref": "#/parameters/Accept"
+            "$ref": "#/parameters/If-None-Match"
           },
           {
-            "$ref": "#/parameters/If-None-Match"
+            "$ref": "#/parameters/If-Modified-Since"
           }
         ],
         "tags": [
-          "API (Collection)"
+          "Label (Collection)"
         ],
         "responses": {
           "200": {
-            "description": "OK.\nList of qualifying APIs and docs is returned.\n",
+            "description": "OK.\nLabel list is returned.\n",
             "schema": {
-              "$ref": "#/definitions/SearchResultList"
+              "$ref": "#/definitions/LabelList"
             },
             "headers": {
-              "Content-Type": {
-                "description": "The content type of the body.",
-                "type": "string"
-              },
               "ETag": {
-                "description": "Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).\n",
+                "description": "Entity Tag of the response resource.\nUsed by caches, or in conditional requests (Will be supported in future).\n",
                 "type": "string"
               }
             }
@@ -1797,8 +3050,124 @@
           "304": {
             "description": "Not Modified.\nEmpty body because the client has already the latest version of the requested resource (Will be supported in future).\n"
           },
-          "406": {
-            "description": "Not Acceptable.\nThe requested media type is not supported\n",
+          "404": {
+            "description": "Not Found.\nRequested API does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/self-signup": {
+      "post": {
+        "summary": "Register a new user",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:self-signup"
+            ]
+          }
+        ],
+        "x-scope": "apim:self-signup",
+        "description": "User self signup API\n",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "User object to represent the new user\n",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "tags": [
+          "Sign Up"
+        ],
+        "responses": {
+          "201": {
+            "description": "Created.\nSuccessful response with the newly created object as entity in the body.\nLocation header contains URL of newly created entity.\n",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "202": {
+            "description": "Accepted.\nThe request has been accepted.\n",
+            "schema": {
+              "$ref": "#/definitions/WorkflowResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request.\nInvalid request or validation error.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/sdk-gen/languages": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:subscribe"
+            ]
+          }
+        ],
+        "x-scope": "apim:subscribe",
+        "x-wso2-curl": "curl -X GET -k -H \"Authorization:Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9292/api/am/store/v1.0/sdk-gen/languages",
+        "x-wso2-request": "GET https://localhost:9292/api/am/store/v1.0/sdk-gen/languages\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nContent-Type : application/json",
+        "summary": "Get a list of supported SDK languages\n",
+        "description": "This operation will provide a list of programming languages that are supported by the swagger codegen library for generating System Development Kits (SDKs) for APIs available in the API Manager Store\n",
+        "tags": [
+          "SDK Languages"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nList of supported languages for generating SDKs.\n"
+          },
+          "404": {
+            "description": "Not Found.\nThe list of languages is not found.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error.\nError while retrieving the list.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/settings": {
+      "get": {
+        "summary": "Retreive store settings",
+        "security": [
+          {
+            "OAuth2Security": [
+              "apim:store_setting"
+            ]
+          }
+        ],
+        "x-scope": "apim:store_setting",
+        "description": "Retreive store settings\n",
+        "responses": {
+          "200": {
+            "description": "OK.\nSettings returned\n",
+            "schema": {
+              "$ref": "#/definitions/Settings"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nRequested Settings does not exist.\n",
             "schema": {
               "$ref": "#/definitions/Error"
             }
@@ -1808,75 +3177,88 @@
     }
   },
   "parameters": {
-    "requestedTenant": {
-      "name": "X-WSO2-Tenant",
-      "in": "header",
-      "description": "For cross-tenant invocations, this is used to specify the tenant domain, where the resource need to be\n  retirieved from.\n",
-      "required": false,
-      "type": "string"
-    },
     "apiId": {
       "name": "apiId",
       "in": "path",
-      "description": "**API ID** consisting of the **UUID** of the API. Using the **UUID** in the API call is recommended.\nThe combination of the provider of the API, name of the API and the version is also accepted as a valid API ID.\nShould be formatted as **provider-name-version**.\n",
+      "description": "**API ID** consisting of the **UUID** of the API.\nThe combination of the provider of the API, name of the API and the version is also accepted as a valid API ID.\nShould be formatted as **provider-name-version**.\n",
       "required": true,
-      "type": "string",
-      "x-encoded": true
+      "type": "string"
     },
     "apiId-Q": {
       "name": "apiId",
       "in": "query",
-      "description": "**API ID** consisting of the **UUID** of the API. Using the **UUID** in the API call is recommended.\nThe combination of the provider of the API, name of the API and the version is also accepted as a valid API I.\nShould be formatted as **provider-name-version**.\n",
-      "required": true,
-      "type": "string",
-      "x-encoded": true
-    },
-    "language": {
-      "name": "language",
-      "in": "query",
-      "description": "Programming language to generate SDK.\n",
+      "description": "**API ID** consisting of the **UUID** of the API.\nThe combination of the provider of the API, name of the API and the version is also accepted as a valid API I.\nShould be formatted as **provider-name-version**.\n",
       "required": true,
       "type": "string"
     },
     "documentId": {
       "name": "documentId",
       "in": "path",
-      "description": "Document Identifier\n",
+      "description": "**Document Identifier**\n",
       "required": true,
       "type": "string"
     },
     "applicationId": {
       "name": "applicationId",
       "in": "path",
-      "description": "Application Identifier consisting of the UUID of the Application.\n",
+      "description": "**Application Identifier** consisting of the UUID of the Application.\n",
       "required": true,
       "type": "string"
-    },
-    "filterByUserRoles": {
-      "name": "filterByUserRoles",
-      "in": "query",
-      "description": "Filter user by roles.\n",
-      "required": false,
-      "type": "boolean"
     },
     "applicationId-Q": {
       "name": "applicationId",
       "in": "query",
-      "description": "Application Identifier consisting of the UUID of the Application.\n",
+      "description": "**Application Identifier** consisting of the UUID of the Application.\n",
       "required": true,
       "type": "string"
     },
-    "groupId": {
-      "name": "groupId",
+    "keyType": {
+      "name": "keyType",
+      "in": "path",
+      "description": "**Application Key Type** standing for the type of the keys (i.e. Production or Sandbox).\n",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "PRODUCTION",
+        "SANDBOX"
+      ]
+    },
+    "apiType": {
+      "name": "apiType",
       "in": "query",
-      "description": "Application Group Id\n",
+      "description": "**API Type** filters information pertaining to a specific type of API\n",
       "required": false,
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "STANDARD",
+        "COMPOSITE"
+      ]
     },
     "subscriptionId": {
       "name": "subscriptionId",
       "in": "path",
       "description": "Subscription Id\n",
+      "required": true,
+      "type": "string"
+    },
+    "commentId": {
+      "name": "commentId",
+      "in": "path",
+      "description": "Comment Id\n",
+      "required": true,
+      "type": "string"
+    },
+    "ratingId": {
+      "name": "ratingId",
+      "in": "path",
+      "description": "Rating Id\n",
+      "required": true,
+      "type": "string"
+    },
+    "subscriberName": {
+      "name": "subscriberName",
+      "in": "path",
+      "description": "subscriber Name\n",
       "required": true,
       "type": "string"
     },
@@ -1890,7 +3272,7 @@
     "tierLevel": {
       "name": "tierLevel",
       "in": "path",
-      "description": "List API or Application type tiers.\n",
+      "description": "List API or Application type policies.\n",
       "type": "string",
       "enum": [
         "api",
@@ -1912,42 +3294,16 @@
       "default": 0,
       "type": "integer"
     },
-    "keyType": {
-      "name": "keyType",
-      "in": "path",
-      "description": "**Application Key Type** standing for the type of the keys (i.e. Production or Sandbox).\n",
-      "required": true,
-      "type": "string",
-      "enum": [
-        "PRODUCTION",
-        "SANDBOX"
-      ]
-    },
-    "Accept": {
-      "name": "Accept",
-      "in": "header",
-      "description": "Media types acceptable for the response. Default is application/json.\n",
-      "default": "application/json",
-      "type": "string"
-    },
-    "Content-Type": {
-      "name": "Content-Type",
-      "in": "header",
-      "description": "Media type of the entity in the body. Default is application/json.\n",
-      "default": "application/json",
-      "required": true,
-      "type": "string"
-    },
     "If-None-Match": {
       "name": "If-None-Match",
       "in": "header",
-      "description": "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resource.\n",
+      "description": "Validator for conditional requests; based on the ETag of the formerly retrieved\nvariant of the resourec.\n",
       "type": "string"
     },
     "If-Modified-Since": {
       "name": "If-Modified-Since",
       "in": "header",
-      "description": "Validator for conditional requests; based on Last Modified header of the\nformerly retrieved variant of the resource (Will be supported in future).\n",
+      "description": "Validator for conditional requests; based on Last Modified header of the\nformerly retrieved variant of the resource.\n",
       "type": "string"
     },
     "If-Match": {
@@ -1959,7 +3315,28 @@
     "If-Unmodified-Since": {
       "name": "If-Unmodified-Since",
       "in": "header",
-      "description": "Validator for conditional requests; based on Last Modified header (Will be supported in future).\n",
+      "description": "Validator for conditional requests; based on Last Modified header.\n",
+      "type": "string"
+    },
+    "label-Q": {
+      "name": "label",
+      "in": "query",
+      "description": "Gateway Label\n",
+      "required": false,
+      "type": "string"
+    },
+    "label": {
+      "name": "label",
+      "in": "query",
+      "description": "store label\n",
+      "required": true,
+      "type": "string"
+    },
+    "labels": {
+      "name": "labels",
+      "in": "query",
+      "description": "Comma seperated store labels\n",
+      "required": false,
       "type": "string"
     }
   },
@@ -1969,304 +3346,263 @@
       "properties": {
         "count": {
           "type": "integer",
-          "description": "Number of APIs returned.\n",
-          "example": 1
+          "description": "Number of APIs returned.\n"
         },
         "next": {
           "type": "string",
-          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n",
-          "example": "/apis?limit=1&offset=2&query="
+          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n"
         },
         "previous": {
           "type": "string",
-          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n",
-          "example": "/apis?limit=1&offset=0&query="
+          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n"
         },
         "list": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/APIInfo"
           }
-        },
-        "pagination": {
-          "properties": {
-            "offset": {
-              "type": "integer",
-              "example": 12
-            },
-            "limit": {
-              "type": "integer",
-              "example": 25
-            },
-            "total": {
-              "type": "integer",
-              "example": 1290
-            }
-          }
         }
       }
     },
-    "APIInfo": {
-      "title": "API Info object with basic API details.",
+    "CompositeAPIList": {
+      "title": "Composite API List",
       "properties": {
-        "id": {
-          "type": "string",
-          "example": "01234567-0123-0123-0123-012345678901"
+        "count": {
+          "type": "integer",
+          "description": "Number of Composite APIs returned.\n"
         },
-        "name": {
+        "next": {
           "type": "string",
-          "example": "CalculatorAPI"
+          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n"
         },
-        "description": {
+        "previous": {
           "type": "string",
-          "example": "A calculator API that supports basic operations"
+          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n"
         },
-        "context": {
-          "type": "string",
-          "example": "CalculatorAPI"
-        },
-        "version": {
-          "type": "string",
-          "example": "1.0.0"
-        },
-        "provider": {
-          "description": "If the provider value is not given, the user invoking the API will be used as the provider.\n",
-          "type": "string",
-          "example": "admin"
-        },
-        "status": {
-          "type": "string",
-          "example": "PUBLISHED"
-        },
-        "thumbnailUri": {
-          "type": "string",
-          "example": "/apis/01234567-0123-0123-0123-012345678901/thumbnail"
-        },
-        "scopes": {
+        "list": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScopeInfo"
+            "$ref": "#/definitions/CompositeAPIInfo"
           }
         }
       }
     },
-    "API": {
-      "title": "API object",
+    "BaseAPIInfo": {
+      "discriminator": "type",
+      "title": "Base API info object with basic API details",
       "required": [
         "name",
         "context",
         "version",
         "provider",
-        "status",
-        "apiDefinition"
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "context": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "hasOwnGateway": {
+          "type": "boolean"
+        },
+        "provider": {
+          "description": "If the provider value is not given, the user invoking the API will be used as the provider.\n",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "APIInfo",
+            "CompositeAPIInfo"
+          ]
+        }
+      }
+    },
+    "APIInfo": {
+      "title": "Standard API Info object with basic API details.",
+      "required": [
+        "lifeCycleStatus"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseAPIInfo"
+        },
+        {
+          "properties": {
+            "lifeCycleStatus": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "CompositeAPIInfo": {
+      "title": "Composite API Info object with basic API details.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseAPIInfo"
+        },
+        {
+          "properties": {
+            "applicationId": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "BaseAPI": {
+      "discriminator": "type",
+      "title": "Base API object",
+      "required": [
+        "name",
+        "context",
+        "version",
+        "provider",
+        "type"
       ],
       "properties": {
         "id": {
           "type": "string",
-          "description": "UUID of the api registry artifact\n",
-          "example": "01234567-0123-0123-0123-012345678901"
+          "description": "UUID of the api registry artifact\n"
         },
         "name": {
-          "type": "string",
-          "description": "Name of the API",
-          "example": "CalculatorAPI"
+          "type": "string"
         },
         "description": {
-          "type": "string",
-          "description": "A brief description about the API",
-          "example": "A calculator API that supports basic operations"
+          "type": "string"
         },
         "context": {
-          "type": "string",
-          "description": "A string that represents thecontext of the user's request",
-          "example": "CalculatorAPI"
+          "type": "string"
         },
         "version": {
-          "type": "string",
-          "description": "The version of the API",
-          "example": "1.0.0"
+          "type": "string"
         },
         "provider": {
           "description": "If the provider value is not given user invoking the api will be used as the provider.\n",
-          "type": "string",
-          "example": "admin"
+          "type": "string"
         },
         "apiDefinition": {
           "description": "Swagger definition of the API which contains details about URI templates and scopes\n",
-          "type": "string",
-          "example": "{\"paths\":{\"\\/substract\":{\"get\":{\"x-auth-type\":\"Application & Application User\",\"x-throttling-tier\":\"Unlimited\",\"parameters\":[{\"name\":\"x\",\"required\":true,\"type\":\"string\",\"in\":\"query\"},{\"name\":\"y\",\"required\":true,\"type\":\"string\",\"in\":\"query\"}],\"responses\":{\"200\":{}}}},\"\\/add\":{\"get\":{\"x-auth-type\":\"Application & Application User\",\"x-throttling-tier\":\"Unlimited\",\"parameters\":[{\"name\":\"x\",\"required\":true,\"type\":\"string\",\"in\":\"query\"},{\"name\":\"y\",\"required\":true,\"type\":\"string\",\"in\":\"query\"}],\"responses\":{\"200\":{}}}}},\"swagger\":\"2.0\",\"info\":{\"title\":\"CalculatorAPI\",\"version\":\"1.0.0\"}}"
-        },
-        "wsdlUri": {
-          "description": "WSDL URL if the API is based on a WSDL endpoint\n",
-          "type": "string",
-          "example": "http://www.webservicex.com/globalweather.asmx?wsdl"
-        },
-        "status": {
-          "type": "string",
-          "description": "This describes in which status of the lifecycle the API is.",
-          "example": "PUBLISHED"
-        },
-        "isDefaultVersion": {
-          "type": "boolean",
-          "example": false
+          "type": "string"
         },
         "transport": {
           "type": "array",
           "items": {
             "description": "Supported transports for the API (http and/or https).\n",
             "type": "string"
-          },
-          "example": [
-            "http",
-            "https"
-          ]
-        },
-        "authorizationHeader": {
-          "type": "string",
-          "description": "Name of the Authorization header used for invoking the API. If it is not set, Authorization header name specified\nin tenant or system level will be used.\n"
-        },
-        "apiSecurity": {
-          "type": "string",
-          "description": "Supported API security for the API ( mutualssl and/or oauth2)\n"
-        },
-        "tags": {
-          "type": "array",
-          "description": "Search keywords related to the API",
-          "items": {
-            "type": "string"
-          },
-          "example": [
-            "substract",
-            "add"
-          ]
-        },
-        "tiers": {
-          "type": "array",
-          "description": "The subscription tiers selected for the particular API",
-          "items": {
-            "type": "string"
-          },
-          "example": [
-            "Unlimited"
-          ]
-        },
-        "thumbnailUrl": {
-          "type": "string",
-          "example": ""
-        },
-        "additionalProperties": {
-          "description": "Custom(user defined) properties of API\n",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "example": {}
-        },
-        "endpointURLs": {
-          "type": "array",
-          "items": {
-            "properties": {
-              "environmentName": {
-                "type": "string",
-                "example": "Production and Sandbox"
-              },
-              "environmentType": {
-                "type": "string",
-                "example": "hybrid"
-              },
-              "environmentURLs": {
-                "properties": {
-                  "http": {
-                    "type": "string",
-                    "description": "HTTP environment URL",
-                    "example": "http://localhost:8280/phoneverify/1.0.0"
-                  },
-                  "https": {
-                    "type": "string",
-                    "description": "HTTPS environment URL",
-                    "example": "https://localhost:8243/phoneverify/1.0.0"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "businessInformation": {
-          "properties": {
-            "businessOwner": {
-              "type": "string",
-              "example": "businessowner"
-            },
-            "businessOwnerEmail": {
-              "type": "string",
-              "example": "businessowner@wso2.com"
-            },
-            "technicalOwner": {
-              "type": "string",
-              "example": "technicalowner"
-            },
-            "technicalOwnerEmail": {
-              "type": "string",
-              "example": "technicalowner@wso2.com"
-            }
           }
         },
         "labels": {
-          "description": "Labels of micro-gateway environments attached to the API.\n",
           "type": "array",
-          "items": {
-            "$ref": "#/definitions/Label"
-          }
-        },
-        "environmentList": {
-          "type": "array",
-          "description": "The environment list configured with non empty endpoint URLs for the particular API.",
           "items": {
             "type": "string"
-          },
-          "example": [
-            "PRODUCTION",
-            "SANDBOX"
+          }
+        },
+        "hasOwnGateway": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "API",
+            "CompositeAPI"
           ]
         }
       }
     },
-    "Label": {
-      "title": "Label",
+    "API": {
+      "title": "Standard API object",
       "required": [
-        "name"
+        "lifeCycleStatus"
       ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "example": "Public"
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseAPI"
         },
-        "accessUrls": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "example": "http://localhost:9443/"
+        {
+          "properties": {
+            "lifeCycleStatus": {
+              "type": "string"
+            },
+            "isDefaultVersion": {
+              "type": "boolean"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "policies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "wsdlUri": {
+              "type": "string"
+            },
+            "businessInformation": {
+              "properties": {
+                "businessOwner": {
+                  "type": "string"
+                },
+                "businessOwnerEmail": {
+                  "type": "string"
+                },
+                "technicalOwner": {
+                  "type": "string"
+                },
+                "technicalOwnerEmail": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
-      }
+      ]
+    },
+    "CompositeAPI": {
+      "title": "Composite API object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseAPI"
+        },
+        {
+          "properties": {
+            "applicationId": {
+              "type": "string"
+            }
+          }
+        }
+      ]
     },
     "ApplicationList": {
       "title": "Application List",
       "properties": {
         "count": {
           "type": "integer",
-          "description": "Number of applications returned.\n",
-          "example": 1
+          "description": "Number of applications returned.\n"
         },
         "next": {
           "type": "string",
-          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n",
-          "example": "/applications?limit=1&offset=2&groupId="
+          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n"
         },
         "previous": {
           "type": "string",
-          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n",
-          "example": "/applications?limit=1&offset=0&groupId="
+          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n"
         },
         "list": {
           "type": "array",
@@ -2284,59 +3620,36 @@
       ],
       "properties": {
         "applicationId": {
-          "type": "string",
-          "example": "01234567-0123-0123-0123-012345678901"
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "example": "CalculatorApp"
+          "type": "string"
         },
         "subscriber": {
           "description": "If subscriber is not given user invoking the API will be taken as the subscriber.\n",
-          "type": "string",
-          "example": "admin"
+          "type": "string"
         },
         "throttlingTier": {
-          "type": "string",
-          "example": "Unlimited"
+          "type": "string"
         },
-        "callbackUrl": {
+        "permission": {
           "type": "string",
-          "example": ""
+          "example": "[{\"groupId\" : 1000, \"permission\" : [\"READ\",\"UPDATE\"]},{\"groupId\" : 1001, \"permission\" : [\"READ\",\"UPDATE\"]}]"
         },
         "description": {
-          "type": "string",
-          "example": "Sample calculator application"
+          "type": "string"
         },
-        "tokenType": {
-          "type": "string",
-          "enum": [
-            "OAUTH",
-            "JWT"
-          ],
-          "description": "Type of the access token generated for this application.\n\n**OAUTH:** A UUID based access token which is issued by default.\n**JWT:** A self-contained, signed JWT based access token. **Note:** This can be only used in Microgateway environments.\n",
-          "default": "OAUTH",
-          "example": "OAUTH"
+        "lifeCycleStatus": {
+          "type": "string"
         },
-        "status": {
-          "type": "string",
-          "example": "APPROVED",
-          "default": ""
-        },
-        "groupId": {
-          "type": "string",
-          "example": ""
+        "token": {
+          "$ref": "#/definitions/ApplicationToken"
         },
         "keys": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ApplicationKey"
-          },
-          "example": []
-        },
-        "attributes": {
-          "type": "object",
-          "example": "External Reference ID, Billing Tier"
+            "$ref": "#/definitions/ApplicationKeys"
+          }
         }
       }
     },
@@ -2344,36 +3657,22 @@
       "title": "Application info object with basic application details",
       "properties": {
         "applicationId": {
-          "type": "string",
-          "example": "01234567-0123-0123-0123-012345678901"
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "example": "CalculatorApp"
+          "type": "string"
         },
         "subscriber": {
-          "type": "string",
-          "example": "admin"
+          "type": "string"
         },
         "throttlingTier": {
-          "type": "string",
-          "example": "Unlimited"
+          "type": "string"
         },
         "description": {
-          "type": "string",
-          "example": "Sample calculator application"
+          "type": "string"
         },
-        "status": {
-          "type": "string",
-          "example": "APPROVED"
-        },
-        "groupId": {
-          "type": "string",
-          "example": ""
-        },
-        "attributes": {
-          "type": "object",
-          "example": "External Reference ID, Billing Tier"
+        "lifeCycleStatus": {
+          "type": "string"
         }
       }
     },
@@ -2382,18 +3681,15 @@
       "properties": {
         "count": {
           "type": "integer",
-          "description": "Number of Documents returned.\n",
-          "example": 1
+          "description": "Number of Documents returned.\n"
         },
         "next": {
           "type": "string",
-          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n",
-          "example": "/apis/01234567-0123-0123-0123-012345678901/documents?limit=1&offset=2"
+          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n"
         },
         "previous": {
           "type": "string",
-          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n",
-          "example": "/apis/01234567-0123-0123-0123-012345678901/documents?limit=1&offset=0"
+          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n"
         },
         "list": {
           "type": "array",
@@ -2412,12 +3708,10 @@
       ],
       "properties": {
         "documentId": {
-          "type": "string",
-          "example": "01234567-0123-0123-0123-012345678901"
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "example": "CalculatorDoc"
+          "type": "string"
         },
         "type": {
           "type": "string",
@@ -2429,30 +3723,27 @@
             "API_MESSAGE_FORMAT",
             "SWAGGER_DOC",
             "OTHER"
-          ],
-          "example": "HOWTO"
+          ]
         },
         "summary": {
-          "type": "string",
-          "example": "Summary of Calculator Documentation"
+          "type": "string"
         },
         "sourceType": {
           "type": "string",
           "enum": [
             "INLINE",
-            "MARKDOWN",
             "URL",
             "FILE"
-          ],
-          "example": "INLINE"
+          ]
         },
         "sourceUrl": {
-          "type": "string",
-          "example": ""
+          "type": "string"
+        },
+        "inlineContent": {
+          "type": "string"
         },
         "otherTypeName": {
-          "type": "string",
-          "example": ""
+          "type": "string"
         }
       }
     },
@@ -2461,18 +3752,15 @@
       "properties": {
         "count": {
           "type": "integer",
-          "description": "Number of Tiers returned.\n",
-          "example": 1
+          "description": "Number of Tiers returned.\n"
         },
         "next": {
           "type": "string",
-          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n",
-          "example": "/tiers/api?limit=1&offset=2"
+          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n"
         },
         "previous": {
           "type": "string",
-          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n",
-          "example": "/tiers/api?limit=1&offset=0"
+          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n"
         },
         "list": {
           "type": "array",
@@ -2493,56 +3781,61 @@
       ],
       "properties": {
         "name": {
-          "type": "string",
-          "example": "Platinum"
+          "type": "string"
         },
         "description": {
-          "type": "string",
-          "example": "Allows 50 request(s) per minute."
+          "type": "string"
         },
         "tierLevel": {
           "type": "string",
           "enum": [
             "api",
-            "application"
-          ],
-          "example": "api"
+            "application",
+            "subscription"
+          ]
         },
         "attributes": {
-          "description": "Custom attributes added to the tier policy\n",
+          "description": "Custom attributes added to the policy policy\n",
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          },
-          "example": {}
+          }
         },
         "requestCount": {
           "description": "Maximum number of requests which can be sent within a provided unit time\n",
           "type": "integer",
-          "format": "int64",
-          "example": 50
+          "format": "int64"
         },
         "unitTime": {
           "type": "integer",
-          "format": "int64",
-          "example": 60000
+          "format": "int64"
         },
         "tierPlan": {
-          "description": "This attribute declares whether this tier is available under commercial or free\n",
+          "description": "This attribute declares whether this policy is available under commercial or free\n",
           "type": "string",
           "enum": [
             "FREE",
             "COMMERCIAL"
-          ],
-          "example": "FREE"
+          ]
         },
         "stopOnQuotaReach": {
           "description": "If this attribute is set to false, you are capabale of sending requests\neven if the request count exceeded within a unit time\n",
-          "type": "boolean",
-          "example": true
+          "type": "boolean"
+        }
+      }
+    },
+    "FileInfo": {
+      "title": "File Information including meta data",
+      "properties": {
+        "relativePath": {
+          "type": "string",
+          "description": "relative location of the file (excluding the base context and host of the Publisher API)",
+          "example": "apis/01234567-0123-0123-0123-012345678901/thumbnail"
         },
-        "TierPermissions": {
-          "$ref": "#/definitions/TierPermissionInfo"
+        "mediaType": {
+          "type": "string",
+          "description": "media-type of the file",
+          "example": "image/jpeg"
         }
       }
     },
@@ -2551,18 +3844,15 @@
       "properties": {
         "count": {
           "type": "integer",
-          "description": "Number of Subscriptions returned.\n",
-          "example": 1
+          "description": "Number of Subscriptions returned.\n"
         },
         "next": {
           "type": "string",
-          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n",
-          "example": "/subscriptions?limit=1&offset=2&apiId=01234567-0123-0123-0123-012345678901&groupId="
+          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n"
         },
         "previous": {
           "type": "string",
-          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n",
-          "example": "/subscriptions?limit=1&offset=0&apiId=01234567-0123-0123-0123-012345678901&groupId="
+          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n"
         },
         "list": {
           "type": "array",
@@ -2577,38 +3867,38 @@
       "required": [
         "applicationId",
         "apiIdentifier",
-        "tier"
+        "policy",
+        "apiName",
+        "apiVersion"
       ],
       "properties": {
         "subscriptionId": {
-          "type": "string",
-          "description": "The UUID of the subscription",
-          "example": "faae5fcc-cbae-40c4-bf43-89931630d313"
+          "type": "string"
         },
         "applicationId": {
-          "type": "string",
-          "description": "The UUID of the application",
-          "example": "b3ade481-30b0-4b38-9a67-498a40873a6d"
+          "type": "string"
         },
         "apiIdentifier": {
-          "type": "string",
-          "description": "The unique identifier of the API.",
-          "example": "admin-PizzaShackAPI-1.0.0"
+          "type": "string"
         },
-        "tier": {
-          "type": "string",
-          "example": "Unlimited"
+        "apiName": {
+          "type": "string"
         },
-        "status": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "policy": {
+          "type": "string"
+        },
+        "lifeCycleStatus": {
           "type": "string",
           "enum": [
             "BLOCKED",
             "PROD_ONLY_BLOCKED",
-            "UNBLOCKED",
+            "ACTIVE",
             "ON_HOLD",
             "REJECTED"
-          ],
-          "example": "UNBLOCKED"
+          ]
         }
       }
     },
@@ -2620,12 +3910,10 @@
       ],
       "properties": {
         "name": {
-          "type": "string",
-          "example": "tag1"
+          "type": "string"
         },
         "weight": {
-          "type": "integer",
-          "example": 5
+          "type": "integer"
         }
       }
     },
@@ -2634,18 +3922,15 @@
       "properties": {
         "count": {
           "type": "integer",
-          "description": "Number of Tags returned.\n",
-          "example": 1
+          "description": "Number of Tags returned.\n"
         },
         "next": {
           "type": "string",
-          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n",
-          "example": "/tags?limit=1&offset=2"
+          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n"
         },
         "previous": {
           "type": "string",
-          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n",
-          "example": "/tags?limit=1&offset=0"
+          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n"
         },
         "list": {
           "type": "array",
@@ -2655,8 +3940,124 @@
         }
       }
     },
+    "Rating": {
+      "title": "Rating",
+      "required": [
+        "ratingId",
+        "apiId",
+        "username",
+        "rating"
+      ],
+      "properties": {
+        "ratingId": {
+          "type": "string"
+        },
+        "apiId": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string",
+          "description": "If username is not given user invoking the API will be taken as the username.\n"
+        },
+        "rating": {
+          "type": "integer"
+        }
+      }
+    },
+    "RatingList": {
+      "title": "Rating List",
+      "properties": {
+        "avgRating": {
+          "type": "string",
+          "description": "Average Rating of the API\n"
+        },
+        "userRating": {
+          "type": "string",
+          "description": "Rating given by the user\n"
+        },
+        "count": {
+          "type": "integer",
+          "description": "Number of Subscriber Ratings returned.\n"
+        },
+        "next": {
+          "type": "string",
+          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n"
+        },
+        "previous": {
+          "type": "string",
+          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n"
+        },
+        "list": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Rating"
+          }
+        }
+      }
+    },
+    "Comment": {
+      "title": "Comment",
+      "required": [
+        "commentId",
+        "apiId",
+        "username",
+        "commentText"
+      ],
+      "properties": {
+        "commentId": {
+          "type": "string"
+        },
+        "apiId": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string",
+          "description": "If username is not given user invoking the API will be taken as the username.\n"
+        },
+        "commentText": {
+          "type": "string"
+        },
+        "createdTime": {
+          "type": "string",
+          "example": "2017-02-20T13:57:16.229Z"
+        },
+        "createdBy": {
+          "type": "string"
+        },
+        "lastUpdatedTime": {
+          "type": "string",
+          "example": "2017-02-20T13:57:16.229Z"
+        },
+        "lastUpdatedBy": {
+          "type": "string"
+        }
+      }
+    },
+    "CommentList": {
+      "title": "Comments List",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "description": "Number of Comments returned.\n"
+        },
+        "next": {
+          "type": "string",
+          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n"
+        },
+        "previous": {
+          "type": "string",
+          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n"
+        },
+        "list": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
+        }
+      }
+    },
     "Error": {
-      "title": "Error object returned with 4XX HTTP status",
+      "title": "Error object returned with 4XX HTTP lifeCycleStatus",
       "required": [
         "code",
         "message"
@@ -2688,7 +4089,7 @@
       }
     },
     "ErrorListItem": {
-      "title": "Description of Individual errors that may have occurred during a request.",
+      "title": "Description of individual errors that may have occurred during a request.",
       "required": [
         "code",
         "message"
@@ -2699,101 +4100,72 @@
         },
         "message": {
           "type": "string",
-          "description": "Description about Individual errors occurred\n"
+          "description": "Description about individual errors occurred\n"
         }
       }
     },
-    "Token": {
-      "title": "Token details for invoking APIs",
+    "ApplicationToken": {
+      "title": "Application token details to invoke APIs",
       "properties": {
         "accessToken": {
           "type": "string",
-          "description": "Access token",
-          "example": "01234567890123456789012345678901"
+          "description": "Access token"
         },
         "tokenScopes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Valid scopes for the access token",
-          "example": [
-            "default"
-          ]
+          "type": "string",
+          "description": "Valid scopes for the access token"
         },
         "validityTime": {
           "type": "integer",
           "format": "int64",
-          "description": "Maximum validity time for the access token",
-          "example": 3600
+          "description": "Maximum validity time for the access token"
         }
       }
     },
-    "ApplicationKey": {
+    "ApplicationKeys": {
       "title": "Application key details",
       "properties": {
         "consumerKey": {
           "type": "string",
-          "description": "The consumer key associated with the application and identifying the client",
-          "example": "vYDoc9s7IgAFdkSyNDaswBX7ejoa"
+          "description": "Consumer key of the application"
         },
         "consumerSecret": {
           "type": "string",
-          "description": "The client secret that is used to authenticate the client with the authentication server",
-          "example": "TIDlOFkpzB7WjufO3OJUhy1fsvAa"
+          "description": "Consumer secret of the application"
         },
         "supportedGrantTypes": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The grant types that are supported by the application",
-          "example": [
-            "client_credentials",
-            "password"
-          ]
+          "description": "Supported grant types for the application"
         },
         "callbackUrl": {
           "type": "string",
-          "description": "Callback URL",
-          "example": "http://sample.com/callback/url"
-        },
-        "keyState": {
-          "type": "string",
-          "description": "Describes the state of the key generation.",
-          "example": "APPROVED"
+          "description": "Callback URL"
         },
         "keyType": {
-          "description": "Describes to which endpoint the key belongs",
+          "description": "Key type",
           "type": "string",
           "enum": [
             "PRODUCTION",
             "SANDBOX"
-          ],
-          "example": "PRODUCTION"
-        },
-        "groupId": {
-          "type": "string",
-          "description": "Application group id (if any).",
-          "example": 2
-        },
-        "token": {
-          "$ref": "#/definitions/Token"
+          ]
         }
       }
     },
-    "ApplicationKeyReGenerateResponse": {
-      "title": "Application key details after re generating consumer secret",
+    "ApplicationKeysList": {
+      "title": "Application Keys List",
       "properties": {
-        "consumerKey": {
-          "type": "string",
-          "description": "The consumer key associated with the application, used to indetify the client",
-          "example": "vYDoc9s7IgAFdkSyNDaswBX7ejoa"
+        "count": {
+          "type": "integer",
+          "description": "Number of applications keys returned.\n"
         },
-        "consumerSecret": {
-          "type": "string",
-          "description": "The client secret that is used to authenticate the client with the authentication server",
-          "example": "TIDlOFkpzB7WjufO3OJUhy1fsvAa"
+        "list": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationKeys"
+          }
         }
       }
     },
@@ -2801,8 +4173,7 @@
       "title": "Application key generation request object",
       "required": [
         "keyType",
-        "validityTime",
-        "accessAllowDomains"
+        "grantTypesToBeSupported"
       ],
       "properties": {
         "keyType": {
@@ -2810,329 +4181,192 @@
           "enum": [
             "PRODUCTION",
             "SANDBOX"
-          ],
-          "example": "PRODUCTION"
+          ]
         },
-        "validityTime": {
-          "type": "string",
-          "example": 3600
-        },
-        "supportedGrantTypes": {
+        "grantTypesToBeSupported": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The grant types that are supported by the application",
-          "example": [
-            "client_credentials",
-            "password"
-          ]
+          "description": "Grant types that should be supported by the application"
         },
         "callbackUrl": {
           "type": "string",
-          "description": "Callback URL",
-          "example": ""
-        },
-        "accessAllowDomains": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Allowed domains for the access token",
-          "example": [
-            "ALL"
-          ]
-        },
-        "scopes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Allowed scopes for the access token",
-          "example": [
-            "am_application_scope",
-            "default"
-          ]
-        },
-        "clientId": {
-          "type": "string",
-          "description": "Client ID for generating access token.",
-          "example": ""
-        },
-        "clientSecret": {
-          "type": "string",
-          "description": "Client secret for generating access token. This is given together with the client Id.",
-          "example": ""
+          "description": "Callback URL"
         }
       }
     },
-    "ApplicationKeyReGenerateRequest": {
-      "title": "Application key re generation request object",
+    "ApplicationKeyMappingRequest": {
+      "title": "Application key provision request object",
       "required": [
-        "consumerKey"
+        "consumerKey",
+        "consumerSecret"
       ],
       "properties": {
         "consumerKey": {
           "type": "string",
-          "description": "The consumer key associated with the application, used to identify the client",
-          "example": "vYDoc9s7IgAFdkSyNDaswBX7ejoa"
-        }
-      }
-    },
-    "ScopeInfo": {
-      "title": "API Scope info object with scope details",
-      "properties": {
-        "key": {
-          "type": "string",
-          "example": "admin_scope"
+          "description": "Consumer key of the application"
         },
-        "name": {
+        "consumerSecret": {
           "type": "string",
-          "example": "admin scope"
+          "description": "Consumer secret of the application"
         },
-        "roles": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Allowed roles for the scope",
-          "example": [
-            "manager",
-            "developer"
-          ]
-        }
-      }
-    },
-    "TierPermissionInfo": {
-      "title": "Tier Permission info object with tier permission details",
-      "properties": {
-        "type": {
+        "keyType": {
           "type": "string",
           "enum": [
-            "allow",
-            "deny"
+            "PRODUCTION",
+            "SANDBOX"
           ]
+        }
+      }
+    },
+    "ApplicationTokenGenerateRequest": {
+      "title": "Application access token generation request object",
+      "required": [
+        "consumerKey",
+        "consumerSecret"
+      ],
+      "properties": {
+        "consumerKey": {
+          "type": "string",
+          "description": "Consumer key of the application"
         },
-        "roles": {
+        "consumerSecret": {
+          "type": "string",
+          "description": "Consumer secret of the application"
+        },
+        "validityPeriod": {
+          "type": "integer",
+          "description": "Token validity period"
+        },
+        "scopes": {
+          "type": "string",
+          "description": "Allowed scopes (space seperated) for the access token"
+        },
+        "revokeToken": {
+          "type": "string",
+          "description": "Token to be revoked, if any."
+        }
+      }
+    },
+    "Label": {
+      "title": "Label",
+      "required": [
+        "labelId",
+        "name",
+        "access_urls"
+      ],
+      "properties": {
+        "labelId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "access_urls": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "roles for this permission",
-          "example": [
-            "manager",
-            "developer"
-          ]
-        }
-      }
-    },
-    "ApplicationScope": {
-      "title": "Scope of the APIs",
-      "properties": {
-        "key": {
-          "type": "string",
-          "description": "Key of scope",
-          "example": "apim:fileread"
-        },
-        "name": {
-          "type": "string",
-          "description": "Name of the scope",
-          "example": "apim file read"
-        },
-        "roles": {
-          "type": "string",
-          "description": "Roles scope is bounded to",
-          "example": "admin, role1"
-        },
-        "description": {
-          "type": "string",
-          "description": "Description of the scope"
-        }
-      }
-    },
-    "ScopeList": {
-      "title": "Scope list",
-      "properties": {
-        "list": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ApplicationScope"
           }
         }
       }
     },
-    "SearchResultList": {
-      "title": "Search Result List",
+    "LabelList": {
+      "title": "Label List",
       "properties": {
         "count": {
           "type": "integer",
-          "description": "Number of results returned.\n",
-          "example": 1
+          "description": "Number of Labels returned.\n"
         },
         "next": {
           "type": "string",
-          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n",
-          "example": "/apis?limit=1&offset=2&search="
+          "description": "Link to the next subset of resources qualified.\nEmpty if no more resources are to be returned.\n"
         },
         "previous": {
           "type": "string",
-          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n",
-          "example": "/apis?limit=1&offset=0&search="
+          "description": "Link to the previous subset of resources qualified.\nEmpty if current subset is the first subset returned.\n"
         },
         "list": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/SearchResult"
-          }
-        },
-        "pagination": {
-          "properties": {
-            "offset": {
-              "type": "integer",
-              "example": 12
-            },
-            "limit": {
-              "type": "integer",
-              "example": 25
-            },
-            "total": {
-              "type": "integer",
-              "example": 1290
-            }
+            "$ref": "#/definitions/Label"
           }
         }
       }
     },
-    "SearchResult": {
-      "title": "Search Result",
+    "WorkflowResponse": {
+      "title": "workflow Response",
+      "required": [
+        "workflowStatus"
+      ],
       "properties": {
-        "id": {
-          "type": "string",
-          "example": "01234567-0123-0123-0123-012345678901"
-        },
-        "name": {
-          "type": "string",
-          "example": "TestAPI"
-        },
-        "type": {
+        "workflowStatus": {
+          "description": "This attribute declares whether this workflow task is approved or rejected.\n",
           "type": "string",
           "enum": [
-            "DOC",
-            "API"
+            "CREATED",
+            "APPROVED",
+            "REJECTED",
+            "REGISTERED"
           ],
-          "example": "API"
+          "example": "APPROVED"
+        },
+        "jsonPayload": {
+          "description": "Attributes that returned after the workflow execution\n",
+          "type": "string"
         }
       }
     },
-    "APISearchResult": {
-      "title": "API Result",
-      "allOf": [
-        {
-          "$ref": "#/definitions/SearchResult"
+    "User": {
+      "title": "User",
+      "required": [
+        "username",
+        "password",
+        "firstName",
+        "lastName",
+        "email"
+      ],
+      "properties": {
+        "username": {
+          "type": "string"
         },
-        {
-          "properties": {
-            "description": {
-              "type": "string",
-              "description": "A brief description about the API",
-              "example": "A calculator API that supports basic operations"
-            },
-            "context": {
-              "type": "string",
-              "description": "A string that represents the context of the user's request",
-              "example": "CalculatorAPI"
-            },
-            "version": {
-              "type": "string",
-              "description": "The version of the API",
-              "example": "1.0.0"
-            },
-            "provider": {
-              "description": "If the provider value is not given, the user invoking the API will be used as the provider.\n",
-              "type": "string",
-              "example": "admin"
-            },
-            "status": {
-              "type": "string",
-              "description": "This describes in which status of the lifecycle the API is",
-              "example": "CREATED"
-            },
-            "thumbnailUri": {
-              "type": "string",
-              "example": "/apis/01234567-0123-0123-0123-012345678901/thumbnail"
-            }
-          }
+        "password": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
         }
-      ]
+      }
     },
-    "DocumentSearchResult": {
-      "title": "Document Result",
-      "allOf": [
-        {
-          "$ref": "#/definitions/SearchResult"
-        },
-        {
-          "properties": {
-            "docType": {
-              "type": "string",
-              "enum": [
-                "HOWTO",
-                "SAMPLES",
-                "PUBLIC_FORUM",
-                "SUPPORT_FORUM",
-                "API_MESSAGE_FORMAT",
-                "SWAGGER_DOC",
-                "OTHER"
-              ],
-              "example": "HOWTO"
-            },
-            "summary": {
-              "type": "string",
-              "example": "Summary of Calculator Documentation"
-            },
-            "sourceType": {
-              "type": "string",
-              "enum": [
-                "INLINE",
-                "URL",
-                "FILE"
-              ],
-              "example": "INLINE"
-            },
-            "sourceUrl": {
-              "type": "string",
-              "example": ""
-            },
-            "otherTypeName": {
-              "type": "string",
-              "example": ""
-            },
-            "visibility": {
-              "type": "string",
-              "enum": [
-                "OWNER_ONLY",
-                "PRIVATE",
-                "API_LEVEL"
-              ],
-              "example": "API_LEVEL"
-            },
-            "apiName": {
-              "type": "string",
-              "description": "The name of the associated API",
-              "example": "TestAPI"
-            },
-            "apiVersion": {
-              "type": "string",
-              "description": "The version of the associated API",
-              "example": "1.0.0"
-            },
-            "apiProvider": {
-              "type": "string",
-              "example": "admin"
-            }
-          }
+    "DedicatedGateway": {
+      "title": "Dedicated Gateway for the Composite API",
+      "required": [
+        "isEnabled"
+      ],
+      "properties": {
+        "isEnabled": {
+          "description": "This attribute declares whether an API should have a dedicated Gateway or not.\n",
+          "type": "boolean",
+          "example": true
         }
-      ]
+      }
+    },
+    "Settings": {
+      "title": "Settings",
+      "properties": {
+        "serverUrl": {
+          "type": "string"
+        },
+        "apiStoreUrl": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
@@ -452,6 +452,10 @@
                 <URI>/api/am/store/{version}/search</URI>
                 <HTTPMethods>GET</HTTPMethods>
             </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/settings</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </WhiteListedURI>
         </WhiteListedURIs>
         <ETagSkipList>
             <ETagSkipURI>


### PR DESCRIPTION
## Purpose

Add store and publisher settings retrieve capability

**Supports below:**
Sample curl for listing store settings for anonymous user:
curl -k "https://localhost:9443/api/am/store/v1/settings"

Sample curl for listing store settings for logged in user:
curl -k -H "Authorization: Bearer b1903101-b50c-3591-847d-18670cd48eb7" "https://localhost:9443/api/am/store/v1/settings"

Sample curl for listing publisher settings for anonymous user:
curl -k "https://localhost:9443/api/am/publisher/v1/settings"

Sample curl for listing store settings for logged in user:
curl -k -H "Authorization: Bearer b1903101-b50c-3591-847d-18670cd48eb7" "https://localhost:9443/api/am/publisher/v1/settings"
