### PR TITLE
Removing redundant libraries from war libs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/pom.xml
@@ -35,26 +35,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-service-description</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-jaxrs</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/webapp/META-INF/webapp-classloading.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/webapp/META-INF/webapp-classloading.xml
@@ -31,5 +31,5 @@
 	Tomcat environment is the default and every webapps gets it even if they didn't specify it.
 	e.g. If a webapps requires CXF, they will get both Tomcat and CXF.
      -->
-    <Environments>Carbon</Environments>
+    <Environments>CXF3, Carbon</Environments>
 </Classloading>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
@@ -47,22 +47,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-jaxrs</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
@@ -95,7 +90,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
+        <dependency>    
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
         </dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
@@ -50,11 +50,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <scope>provided</scope>
@@ -90,7 +85,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>    
+        <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
         </dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/webapp/META-INF/webapp-classloading.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/webapp/META-INF/webapp-classloading.xml
@@ -31,5 +31,5 @@
 	Tomcat environment is the default and every webapps gets it even if they didn't specify it.
 	e.g. If a webapps requires CXF, they will get both Tomcat and CXF.
      -->
-    <Environments>Carbon</Environments>
+    <Environments>CXF3, Carbon</Environments>
 </Classloading>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/webapp/WEB-INF/beans.xml
@@ -22,7 +22,7 @@
         </jaxrs:providers>
     </jaxrs:server>
     <bean id="RegistrationServiceBean" class="org.wso2.carbon.apimgt.rest.api.dcr.web.impl.RegistrationServiceImpl"/>
-    <bean id="jsonProvider" class="org.codehaus.jackson.jaxrs.JacksonJsonProvider"/>
+    <bean id="jsonProvider" class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
     <bean id="faultResponseWriter" class="org.wso2.carbon.apimgt.rest.api.dcr.web.FaultMessageBodyWriter"/>
     <bean id="AuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.auth.BasicAuthenticationInterceptor" />
     <bean id="ValidationInInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.validation.ValidationInInterceptor"/>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/pom.xml
@@ -35,26 +35,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-service-description</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-jaxrs</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/webapp/META-INF/webapp-classloading.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/webapp/META-INF/webapp-classloading.xml
@@ -30,5 +30,5 @@
 	Tomcat environment is the default and every webapps gets it even if they didn't specify it.
 	e.g. If a webapps requires CXF, they will get both Tomcat and CXF.
      -->
-    <Environments>Carbon</Environments>
+    <Environments>CXF3, Carbon</Environments>
 </Classloading>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/pom.xml
@@ -35,26 +35,17 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-service-description</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-jaxrs</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/webapp/META-INF/webapp-classloading.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/src/main/webapp/META-INF/webapp-classloading.xml
@@ -29,5 +29,5 @@
 	Tomcat environment is the default and every webapps gets it even if they didn't specify it.
 	e.g. If a webapps requires CXF, they will get both Tomcat and CXF.
      -->
-    <Environments>Carbon</Environments>
+    <Environments>CXF3, Carbon</Environments>
 </Classloading>


### PR DESCRIPTION
This PR is to remove packaging duplicate libraries in war files and enabling them to use jars from lib/runtimes/cxf3 directory.

This also fixes classpath issues.