### PR TITLE
Adding /swagger.yaml resource for publisher api v1

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/SwaggerYamlApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/SwaggerYamlApi.java
@@ -1,0 +1,69 @@
+/*
+ *
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.rest.api.publisher.v1;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
+
+import java.io.IOException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+@Path("/swagger.yaml")
+@Consumes({ "text/yaml" })
+@Produces({ "text/yaml" })
+@io.swagger.annotations.Api(value = "/swagger.yaml", description = "the swagger.yaml API")
+public class SwaggerYamlApi {
+
+    private static final Log log = LogFactory.getLog(SwaggerYamlApi.class);
+
+    /**
+     * Retrieves swagger definition of Publisher REST API and returns
+     * 
+     * @return swagger definition of Publisher REST API in yaml format
+     */
+    @GET
+    @Consumes({ "text/yaml" })
+    @Produces({ "text/yaml" })
+    @io.swagger.annotations.ApiOperation(value = "Get Swagger Definition", notes = "Get Swagger Definition of Publisher REST API.", response = Void.class)
+    @io.swagger.annotations.ApiResponses(value = {
+            @io.swagger.annotations.ApiResponse(code = 200, message = "OK.\nSwagger Definition is returned."),
+
+            @io.swagger.annotations.ApiResponse(code = 304, message = "Not Modified.\nEmpty body because the client has already the latest version of the requested resource."),
+
+            @io.swagger.annotations.ApiResponse(code = 406, message = "Not Acceptable.\nThe requested media type is not supported") })
+
+    public Response swaggerYamlGet() {
+        try {
+            String definition = IOUtils
+                    .toString(this.getClass().getResourceAsStream("/publisher-api.yaml"), "UTF-8");
+            return Response.ok().entity(definition).build();
+        } catch (IOException e) {
+            String errorMessage = "Error while retrieving the swagger definition of the Publisher API";
+            RestApiUtil.handleInternalServerError(errorMessage, e, log);
+        }
+        return null;
+    }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
@@ -24,6 +24,7 @@
             <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.SearchApi"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.SubscriptionsApi"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.ThreatProtectionPoliciesApi"/>
+            <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.SwaggerYamlApi"/>
             
         </jaxrs:serviceBeans>
         <jaxrs:providers>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
@@ -409,6 +409,18 @@
                 <HTTPMethods>GET,HEAD</HTTPMethods>
             </WhiteListedURI>
             <WhiteListedURI>
+                <URI>/api/am/publisher/{version}/swagger.yaml</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/swagger.yaml</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/admin/{version}/swagger.yaml</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
                 <URI>/api/am/store/{version}/apis</URI>
                 <HTTPMethods>GET,HEAD</HTTPMethods>
             </WhiteListedURI>


### PR DESCRIPTION
## Purpose
Supports below to retrieve the swagger definition of a publisher API v1 in yaml format. 
`GET https://localhost:9443/api/am/publisher/v1/swagger.yaml`
