### PR TITLE
Adding Token Merge Interceptor

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
@@ -33,6 +33,7 @@
     </jaxrs:server>
 
     <bean id="PreAuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.PreAuthenticationInterceptor" />
+    <bean id="TokenMergeInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.auth.TokenMergeInterceptor" />
 
     <!-- For Basic Authentication scheme please comment the AuthenticationInterceptor which contains "OAuthAuthenticationInterceptor"
             and uncomment the AuthenticationInterceptor which contains "BasicAuthenticationInterceptor"-->
@@ -42,6 +43,7 @@
     <bean id="ValidationInInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.validation.ValidationInInterceptor"/>
     <cxf:bus>
         <cxf:inInterceptors>
+            <ref bean="TokenMergeInterceptor"/>
             <ref bean="PreAuthenticationInterceptor"/>
             <ref bean="AuthenticationInterceptor"/>
             <ref bean="ValidationInInterceptor"/>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
@@ -112,6 +112,8 @@ public final class RestApiConstants {
     public static final String REST_API_PROVIDER = "admin";
     public static final String REST_API_WEB_APP_AUTHENTICATOR_IMPL_CLASS_NAME = "org.wso2.carbon.apimgt.rest.api.util.impl.WebAppAuthenticatorImpl";
     public static final String AUTH_HEADER_NAME = "Authorization";
+    public static final String COOKIE_NAME = "cookie";
+    public static final String AUTH_COOKIE_NAME = "WSO2_AM_TOKEN_DEFAULT";
 
     public static final int PAGINATION_LIMIT_DEFAULT = 25;
     public static final int PAGINATION_OFFSET_DEFAULT = 0;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/interceptors/auth/TokenMergeInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/interceptors/auth/TokenMergeInterceptor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.rest.api.util.interceptors.auth;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
+
+import java.util.ArrayList;
+import java.util.TreeMap;
+
+public class TokenMergeInterceptor extends AbstractPhaseInterceptor {
+
+    private static final Log logger = LogFactory.getLog(TokenMergeInterceptor.class);
+
+    public TokenMergeInterceptor() {
+        //We will use PRE_INVOKE phase as we need to process message before hit actual service
+        super(Phase.PRE_INVOKE);
+    }
+
+    public void handleMessage(Message message) throws Fault {
+        //If Authorization headers are present anonymous URI check will be skipped
+
+        ArrayList authHeaders = (ArrayList) ((TreeMap) (message.get(Message.PROTOCOL_HEADERS)))
+                .get(RestApiConstants.AUTH_HEADER_NAME);
+
+        ArrayList tokenCookie = (ArrayList) ((TreeMap) (message.get(Message.PROTOCOL_HEADERS)))
+                .get(RestApiConstants.COOKIE_NAME);
+
+        TreeMap headers = (TreeMap) message.get(Message.PROTOCOL_HEADERS);
+        if (authHeaders != null && tokenCookie != null) {
+            String headerTokenString = authHeaders.get(0).toString();
+            String cookieTokenString = tokenCookie.get(0).toString();
+            int startingIndexOfToken =
+                    cookieTokenString.lastIndexOf(RestApiConstants.AUTH_COOKIE_NAME) + RestApiConstants.AUTH_COOKIE_NAME
+                            .length() + 1;
+            String tokenStringPartTwo = cookieTokenString.substring(startingIndexOfToken);
+            String accessToken = headerTokenString + tokenStringPartTwo;
+            ArrayList AuthorizationHeader = new ArrayList<>();
+            AuthorizationHeader.add(0, accessToken);
+            headers.put(RestApiConstants.AUTH_HEADER_NAME, AuthorizationHeader);
+            message.put(Message.PROTOCOL_HEADERS, headers);
+        } else {
+            return;
+        }
+    }
+}


### PR DESCRIPTION
## Purpose

- Implementing Token merge interceptor in which two parts of the divided token coming in the header and in cookie, will be merged and sent as a single token as the "Authorization" token.