### PR TITLE
Fix for 'Usernames are sometimes case sensitive but other times the aren't'

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/application/application-remove/ajax/application-remove.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/application/application-remove/ajax/application-remove.jag
@@ -72,13 +72,6 @@ include("/jagg/jagg.jag");
         var consumer = jagg.module("manager").getAPIConsumerObj();
         var application = consumer.getApplicationById(applicationId);
         var subscriber = application.getSubscriber().getName();
-        if (!subscriber.equalsIgnoreCase(username)) {
-            print({
-                error: true,
-                message: "Only application owner can delete the application"
-            });
-            return;
-        }
         result = consumer.removeApplication(application, username);
         session.remove("selectedApp");
         if (result) {

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/application/application-update/ajax/application-update.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/application/application-update/ajax/application-update.jag
@@ -106,13 +106,6 @@ include("/jagg/jagg.jag");
         var consumer = jagg.module("manager").getAPIConsumerObj();
         var application = consumer.getApplicationById(applicationId);
         var subscriber = application.getSubscriber().getName();
-        if (subscriber != username) {
-           print({
-               error: true,
-               message: "Only application owner can update the application"
-           });
-           return;
-        }
 
         if (null == request.getParameter("callbackUrlNew")) {
            callbackUrlNew = "";


### PR DESCRIPTION
## Purpose
This PR will fix the issue of https://github.com/wso2/product-apim/issues/4614

## Approach
* The 'CompareCaseInsensitively' parameter in the <APIM_HOME>/repository/conf/api-manager.xml is evaluated in the 'APIConsumerImpl.java'.
* So there is no need of this validation.
* Application updating issue will fix by removing the extra form-data.