### PR TITLE
Fixes product-apim#4429

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/test/resources/carbon-home/repository/conf/api-manager.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/test/resources/carbon-home/repository/conf/api-manager.xml
@@ -218,7 +218,7 @@
         <ThriftClientConnectionTimeOut>10000</ThriftClientConnectionTimeOut>
         <!--ThriftClientPort>10397</ThriftClientPort-->
 
-        <EnableThriftServer>true</EnableThriftServer>
+        <EnableThriftServer>false</EnableThriftServer>
         <ThriftServerHost>localhost</ThriftServerHost>
         <!--ThriftServerPort>10397</ThriftServerPort-->
 

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.common/src/test/resources/carbon-home/repository/conf/api-manager.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.common/src/test/resources/carbon-home/repository/conf/api-manager.xml
@@ -236,7 +236,7 @@
         <ThriftClientConnectionTimeOut>10000</ThriftClientConnectionTimeOut>
         <!--ThriftClientPort>10397</ThriftClientPort-->
 
-        <EnableThriftServer>true</EnableThriftServer>
+        <EnableThriftServer>false</EnableThriftServer>
         <ThriftServerHost>localhost</ThriftServerHost>
         <!--ThriftServerPort>10397</ThriftServerPort-->
 

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.rest.api/src/test/resources/carbon-home/api-manager.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.rest.api/src/test/resources/carbon-home/api-manager.xml
@@ -218,7 +218,7 @@
         <ThriftClientConnectionTimeOut>10000</ThriftClientConnectionTimeOut>
         <!--ThriftClientPort>10397</ThriftClientPort-->
 
-        <EnableThriftServer>true</EnableThriftServer>
+        <EnableThriftServer>false</EnableThriftServer>
         <ThriftServerHost>localhost</ThriftServerHost>
         <!--ThriftServerPort>10397</ThriftServerPort-->
 

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.tenant.initializer/src/test/resources/carbon-home/repository.conf/api-manager.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.tenant.initializer/src/test/resources/carbon-home/repository.conf/api-manager.xml
@@ -218,7 +218,7 @@
         <ThriftClientConnectionTimeOut>10000</ThriftClientConnectionTimeOut>
         <!--ThriftClientPort>10397</ThriftClientPort-->
 
-        <EnableThriftServer>true</EnableThriftServer>
+        <EnableThriftServer>false</EnableThriftServer>
         <ThriftServerHost>localhost</ThriftServerHost>
         <!--ThriftServerPort>10397</ThriftServerPort-->
 

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.usage.publisher/src/test/resources/carbon-home/amConfig.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.usage.publisher/src/test/resources/carbon-home/amConfig.xml
@@ -27,12 +27,12 @@
         <Password>admin</Password>
         <EnableJWTCache>false</EnableJWTCache>
         <EnableKeyMgtValidationInfoCache>false</EnableKeyMgtValidationInfoCache>
-        <KeyValidatorClientType>ThriftClient</KeyValidatorClientType>
+        <KeyValidatorClientType>WSClient</KeyValidatorClientType>
         <ThriftClientPort>10397</ThriftClientPort>
         <ThriftClientConnectionTimeOut>10000</ThriftClientConnectionTimeOut>
         <ThriftServerPort>10397</ThriftServerPort>
         <!--ThriftServerHost>localhost</ThriftServerHost-->
-        <EnableThriftServer>true</EnableThriftServer>
+        <EnableThriftServer>false</EnableThriftServer>
         <ApplicationTokenScope>am_application_scope</ApplicationTokenScope>
         <KeyValidationHandlerClassName>org.wso2.carbon.apimgt.keymgt.handlers.DefaultKeyValidationHandler</KeyValidationHandlerClassName>
         <TokenEndPointName>/oauth2/token</TokenEndPointName>

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/amConfig.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/amConfig.xml
@@ -42,12 +42,12 @@
         <Password>admin</Password>
         <EnableJWTCache>false</EnableJWTCache>
         <EnableKeyMgtValidationInfoCache>false</EnableKeyMgtValidationInfoCache>
-        <KeyValidatorClientType>ThriftClient</KeyValidatorClientType>
+        <KeyValidatorClientType>WSClient</KeyValidatorClientType>
         <ThriftClientPort>10397</ThriftClientPort>
         <ThriftClientConnectionTimeOut>10000</ThriftClientConnectionTimeOut>
         <ThriftServerPort>10397</ThriftServerPort>
         <!--ThriftServerHost>localhost</ThriftServerHost-->
-        <EnableThriftServer>true</EnableThriftServer>
+        <EnableThriftServer>false</EnableThriftServer>
         <ApplicationTokenScope>am_application_scope</ApplicationTokenScope>
         <KeyValidationHandlerClassName>org.wso2.carbon.apimgt.keymgt.handlers.DefaultKeyValidationHandler</KeyValidationHandlerClassName>
         <TokenEndPointName>/oauth2/token</TokenEndPointName>

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/resources/amConfig.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/resources/amConfig.xml
@@ -42,12 +42,12 @@
         <Password>admin</Password>
         <EnableJWTCache>false</EnableJWTCache>
         <EnableKeyMgtValidationInfoCache>false</EnableKeyMgtValidationInfoCache>
-        <KeyValidatorClientType>ThriftClient</KeyValidatorClientType>
+        <KeyValidatorClientType>WSClient</KeyValidatorClientType>
         <ThriftClientPort>10397</ThriftClientPort>
         <ThriftClientConnectionTimeOut>10000</ThriftClientConnectionTimeOut>
         <ThriftServerPort>10397</ThriftServerPort>
         <!--ThriftServerHost>localhost</ThriftServerHost-->
-        <EnableThriftServer>true</EnableThriftServer>
+        <EnableThriftServer>false</EnableThriftServer>
         <ApplicationTokenScope>am_application_scope</ApplicationTokenScope>
         <KeyValidationHandlerClassName>org.wso2.carbon.apimgt.keymgt.handlers.DefaultKeyValidationHandler</KeyValidationHandlerClassName>
         <TokenEndPointName>/oauth2/token</TokenEndPointName>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
@@ -230,11 +230,11 @@
              -If you need to start two API Manager instances in the same machine, you need to give different ports to "ThriftServerPort" value in two nodes.
              -ThriftServerHost - Allows to configure a hostname for the thrift server. It uses the carbon hostname by default.
 	         -The Gateway uses this parameter to connect to the key validation thrift service. -->
-        <KeyValidatorClientType>ThriftClient</KeyValidatorClientType>
+        <KeyValidatorClientType>WSClient</KeyValidatorClientType>
         <ThriftClientConnectionTimeOut>10000</ThriftClientConnectionTimeOut>
         <!--ThriftClientPort>10397</ThriftClientPort-->
 
-        <EnableThriftServer>true</EnableThriftServer>
+        <EnableThriftServer>false</EnableThriftServer>
         <ThriftServerHost>localhost</ThriftServerHost>
         <!--ThriftServerPort>10397</ThriftServerPort-->
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/life-cycles/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/life-cycles/template.jag
@@ -216,7 +216,7 @@ var publishedInExternalStores=<%=publishedInExternalStores%>;
                 </div>
                <%} else if (lcData.nextStates[i].toLowerCase().indexOf("publish") > -1) {%>
                <div class="btn-group" role="group">
-                    <input type="button" id="actionButton<%=String(i)%>" <%if(api.availableTiers == null || api.availableTiers == ""){%>disabled<%}%> class="btn btn-primary" onclick="updateStatus('<%=lcData.nextStates[i]%>')"  value="<%=i18n.localize(next, next)%>"/>
+                    <input type="button" id="actionButton<%=String(i)%>" <%if((api.availableTiers == null || api.availableTiers == "") && api.apisecurity_oauth2 == "checked" ){%>disabled<%}%> class="btn btn-primary" onclick="updateStatus('<%=lcData.nextStates[i]%>')"  value="<%=i18n.localize(next, next)%>"/>
                 </div>
                <%} else {%>
                <div class="btn-group" role="group">


### PR DESCRIPTION
- fixes wso2/product-apim#4429 

(for non-oauth APIs there will be no **subscription** tier. The existing logic was disabling the LC publish button based on tier availability. This fix does that check only for oauth APIs.)

- Changes default key validation client to WSClient from Thrift (separate PR will be sent to remove thrift dependencies and configs related to this)
