### PR TITLE
Add refresh token grant to DCR and creating a userinfo call to get token user info.

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/configs/config.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/configs/config.jag
@@ -17,7 +17,7 @@
             "callbackUrl": callbackUrl,
             "clientName": "publisher",
             "owner": "admin",
-            "grantType": "authorization_code",
+            "grantType": "authorization_code refresh_token",
             "saasApp": true
         };
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/login/introspect.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/login/introspect.jag
@@ -1,33 +1,44 @@
 <%
 
     var log = new Log("Jaggery service for token introspection");
+
+    var userInfoEndpoint = "https://localhost:8243/userinfo";
     var introspectEndpoint = "https://localhost:9443/oauth2/introspect"
     var tokenP1 = request.getCookie("WSO2_AM_TOKEN_1_Default").value;
     var tokenP2 = request.getCookie("AM_ACC_TOKEN_DEFAULT_P2").value;
+    var token = tokenP1 + tokenP2;
+    var userData = {};
+    var user_result = get(userInfoEndpoint, userData , {
+        "Authorization": "Bearer "+token
+    });
+    log.info(user_result);
 
-    var data = {token: tokenP1 + tokenP2 }
+    var data = {token: token }
     log.info(data);
-    var result = post(introspectEndpoint, data , {
+    var introspect_result = post(introspectEndpoint, data , {
         "Authorization": "Basic YWRtaW46YWRtaW4=", // TODO: get super admin username password from configs and do encoding ~tmkb
         "Content-Type": "application/x-www-form-urlencoded"
     });
 
-    log.info(result);
+    log.info(introspect_result);
     response.contentType = "application/json";
 
-    if (result.data.active) {
-        print(result.data);
+    var scopes = "apim:api_view apim:api_create apim:api_publish apim:tier_view apim:tier_manage apim:subscription_view apim:subscription_block apim:mediation_policy_view apim:api_workflow openid"; // TODO: fetch from introspect request
+
+    if (introspect_result.data.active) {
+        print(introspect_result.data);
     } else {
         log.warn("Something went wrong while introspecting the token " + tokenP1 + tokenP2 );
 
         // TODO: remove mock once the introspect API issue get resolved ~tmkb
         var mock = {
             "exp": 1464161608,
-            "username": "dummy_admin@carbon.super",
+            "username": JSON.parse(user_result.data).sub,
             "active": true,
             "token_type": "Bearer",
             "client_id": "rgfKVdnMQnJSSr_pKFTxj3apiwYa",
-            "iat": 1464158008
+            "iat": 1464158008,
+            "scope": scopes
           };
           print(mock);
     }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/login/token_callback.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/login/token_callback.jag
@@ -31,14 +31,14 @@
     var access_token_token_part_1 = access_token.substring(0, token_length/2);
     var access_token_token_part_2 = access_token.substring(token_length/2, token_length);
 
-    // var refresh_token = String(token_response.refresh_token);
-    // token_length = token_response.refresh_token.length;
-    // var refresh_token_token_part_1 = refresh_token.substring(0, token_length/2);
-    // var refresh_token_token_part_2 = refresh_token.substring(token_length/2, token_length);
+    var refresh_token = String(token_response.refresh_token);
+    token_length = token_response.refresh_token.length;
+    var refresh_token_token_part_1 = refresh_token.substring(0, token_length/2);
+    var refresh_token_token_part_2 = refresh_token.substring(token_length/2, token_length);
 
     var response_data = {
         AM_ACC_TOKEN_DEFAULT_P1: String(access_token_token_part_1),
-        // AM_REF_TOKEN_DEFAULT_P1: String(refresh_token_token_part_1),
+        AM_REF_TOKEN_DEFAULT_P1: String(refresh_token_token_part_1),
         id_token: String(token_response.id_token),
         scope: String(token_response.scope),
         expires_in: String(token_response.expires_in)
@@ -53,8 +53,8 @@
     cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/api/am/publisher/", "HttpOnly": true, "secure": true, "maxAge": -1};
     response.addCookie(cookie);
 
-    // cookie = {'name': 'AM_REF_TOKEN_DEFAULT_P2', 'value': refresh_token_token_part_2, 'path': "/publisher-new/", "HttpOnly": true, "secure": true, "maxAge": -1};
-    // response.addCookie(cookie);
+    cookie = {'name': 'AM_REF_TOKEN_DEFAULT_P2', 'value': refresh_token_token_part_2, 'path': "/publisher-new/", "HttpOnly": true, "secure": true, "maxAge": -1};
+    response.addCookie(cookie);
 
     cookie = {'name': 'WSO2_AM_TOKEN_1_Default', 'value': access_token_token_part_1, 'path': "/publisher-new/", "secure": true, "maxAge": -1}; // TODO: set maxage accordingly to toke expire time ~tmkb
     response.addCookie(cookie);


### PR DESCRIPTION
## Related Issues
#6237 
#6236 

## Purpose

Add refresh token grant to DCR and creating a userinfo call to get token user info.

## Goals

- Enable the creation of refresh token.
- Get the token user info from the userinfo endpoint.
- Add scopes to the request.
