### PR TITLE
Implementing authorization_code grant login backend services for store

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/pom.xml
@@ -272,6 +272,7 @@
                 <directory>src/main/resources</directory>
                 <includes>
                     <include>store-new/site/**</include>
+                    <include>store-new/services/**</include>
                     <include>store-new/jaggery.conf</include>
                     <include>p2.inf</include>
                     <include>admin/**</include>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/jaggery.conf
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/jaggery.conf
@@ -10,7 +10,7 @@
             "0":"/site/pages/error-pages/error-page.html"
          }
     ,
-
+    "logLevel": "info",
     "urlMappings":[
         {
             "url":"/login/*",
@@ -36,6 +36,22 @@
              "url":"/applications/*",
              "path": "/site/public/pages/index.html"
         },
+        {
+            "url": "/services/configs",
+            "path": "/services/configs/config.jag"
+        },
+        {
+            "url": "/services/auth/basic",
+            "path": "/services/login/basic.jag"
+        },
+        {
+            "url": "/services/auth/introspect",
+            "path": "/services/login/introspect.jag"
+        },
+        {
+            "url": "/services/auth/callback",
+            "path": "/services/login/token_callback.jag"
+        }
     ],
 
      "filters":[

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/configs/config.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/configs/config.jag
@@ -1,0 +1,44 @@
+<%
+    var log = new Log("Services login DCR request");
+
+    var dcrUrl = 'https://localhost:9443/client-registration/v0.14/register'; // TODO: fetch from config
+    var authorizeEndpoint = "https://localhost:8243/authorize"; // TODO: fetch from config
+    var callbackUrl = "https://localhost:9443/store-new/services/auth/callback"; // TODO: fetch from config
+    var scopes = "apim:subscribe apim:self-signup apim:dedicated_gateway openid"; // TODO: fetch from config
+
+    var SystemApplicationDAO = Packages.org.wso2.carbon.apimgt.impl.dao.SystemApplicationDAO;
+    var systemApplicationDAO = new SystemApplicationDAO();
+
+    systemApplicationDTO = systemApplicationDAO.getClientCredentialsForApplication("admin_store");
+    if (systemApplicationDTO  !== null) {
+        var clientId = systemApplicationDTO.getConsumerKey();
+    } else {
+        var dcrRequestData = {
+            "callbackUrl": callbackUrl,
+            "clientName": "store",
+            "owner": "admin",
+            "grantType": "authorization_code refresh_token",
+            "saasApp": true
+        };
+
+        var result = post(dcrUrl, JSON.stringify(dcrRequestData) , {
+            "Authorization": "Basic YWRtaW46YWRtaW4=",
+            "Content-Type": "application/json"
+        }, "json");
+
+        var clientId = result.data.clientId;
+        var clientSecret = result.data.clientSecret;
+
+        log.debug("Client ID = " + clientId);
+
+        var addApplicationKey = systemApplicationDAO.addApplicationKey("admin_store", clientId, clientSecret);
+        if (!addApplicationKey) {
+            log.error("Error while persisting application information in system application DB table!!");
+            log.error("Client ID = " + clientId);
+        }
+    }
+    var authRequestParams = "?response_type=code&client_id=" + clientId + "&scope=" + scopes + "&redirect_uri=" + callbackUrl;
+    log.debug("Redirecting to = " + authorizeEndpoint + authRequestParams);
+    response.sendRedirect(authorizeEndpoint + authRequestParams);
+
+%>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/login/basic.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/login/basic.jag
@@ -1,0 +1,58 @@
+<%
+    var log = new Log("Services login app");
+    var url = 'https://localhost:9443/client-registration/v0.14/register';
+    var data = { "callbackUrl": "localhost", "clientName": request.getParameter("application", "UTF-8") , "owner": "admin", "grantType": "password refresh_token", "saasApp": true };
+    var result = post(url, JSON.stringify(data) , {
+        "Authorization": "Basic YWRtaW46YWRtaW4=",
+        "Content-Type": "application/json"
+    }, "json");
+
+    // Below code generates the token request similar to the below curl command:
+    // curl -k -d "grant_type=password&username=admin&password=admin&scope=apim:subscribe apim:self-signup apim:dedicated_gateway" -H "Authorization: Basic SGZFbDFqSlBkZzV0YnRyeGhBd3liTjA1UUdvYTpsNmMwYW9MY1dSM2Z3ZXpIaGM3WG9HT2h0NUFh" https://localhost:8243/token
+
+    var clientId = result.data.clientId;
+    var clientSecret = result.data.clientSecret;
+    var Base64 = org.apache.axiom.om.util.Base64;
+    var String = Packages.java.lang.String;
+    var base64encoded = Base64.encode ( new String (clientId + ":" + clientSecret).getBytes());
+    var tokenRequestData = {
+        "grant_type": "password",
+        "username": request.getParameter("username", "UTF-8"),
+        "password": request.getParameter("password", "UTF-8"),
+        "scope": "apim:subscribe apim:self-signup apim:dedicated_gateway"
+    };
+    var tokenEndpoint = "https://localhost:8243/token";
+    var result = post(tokenEndpoint, tokenRequestData , {
+        "Authorization": "Basic " + base64encoded,
+    });
+
+    response.contentType = "application/json";
+    var token_response = JSON.parse(result.data);
+
+    var token_length = token_response.access_token.length;
+    var access_token = String(token_response.access_token);
+
+
+    var access_token_token_part_1 = access_token.substring(0, token_length/2);
+    var access_token_token_part_2 = access_token.substring(token_length/2, token_length);
+
+    var refresh_token = String(token_response.refresh_token);
+    token_length = token_response.refresh_token.length;
+    var refresh_token_token_part_1 = refresh_token.substring(0, token_length/2)
+    var refresh_token_token_part_2 = refresh_token.substring(token_length/2, token_length)
+
+
+    var response_data = {
+        AM_ACC_TOKEN_DEFAULT_P1: String(access_token_token_part_1),
+        AM_REF_TOKEN_DEFAULT_P1: String(refresh_token_token_part_1),
+        scopes: String(token_response.scope),
+        expires_in: String(token_response.expires_in),
+        authUser : request.getParameter("username", "UTF-8")
+    }
+    var cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/api/am/store", "secure": true, "maxAge": -1};
+    response.addCookie(cookie);
+    cookie = {'name': 'AM_REF_TOKEN_DEFAULT_P2', 'value': refresh_token_token_part_2, 'path': "/api/am/store", "secure": true, "maxAge": -1};
+    response.addCookie(cookie);
+    print(response_data);
+
+%>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/login/introspect.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/login/introspect.jag
@@ -1,0 +1,45 @@
+<%
+
+    var log = new Log("Jaggery service for token introspection");
+
+    var userInfoEndpoint = "https://localhost:8243/userinfo";
+    var introspectEndpoint = "https://localhost:9443/oauth2/introspect"
+    var tokenP1 = request.getCookie("WSO2_AM_TOKEN_1_Default").value;
+    var tokenP2 = request.getCookie("AM_ACC_TOKEN_DEFAULT_P2").value;
+    var token = tokenP1 + tokenP2;
+    var userData = {};
+    var userResult = get(userInfoEndpoint, userData , {
+        "Authorization": "Bearer " + token
+    });
+
+    var data = {token: token }
+    var introspectResult = post(introspectEndpoint, data , {
+        "Authorization": "Basic YWRtaW46YWRtaW4=", // TODO: get super admin username password from configs and do encoding ~tmkb
+        "Content-Type": "application/x-www-form-urlencoded"
+    });
+
+    log.debug("Intropspection result json: " + introspectResult);
+    response.contentType = "application/json";
+
+    var scopes = "apim:subscribe apim:self-signup apim:dedicated_gateway openid"; // TODO: fetch from introspect request
+
+    if (introspectResult.data.active) {
+        print(introspectResult.data);
+    } else {
+        log.warn("Something went wrong while introspecting the token " + tokenP1 + tokenP2 + ". response :" + introspectResult.data);
+        log.info("Sending mock response.");
+
+        // TODO: remove mock once the introspect API issue get resolved ~tmkb
+        var mock = {
+            "exp": 1464161608,
+            "username": JSON.parse(userResult.data).sub,
+            "active": true,
+            "token_type": "Bearer",
+            "client_id": "rgfKVdnMQnJSSr_pKFTxj3apiwYa",
+            "iat": 1464158008,
+            "scope": scopes
+          };
+          print(mock);
+    }
+
+%>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/login/token_callback.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/login/token_callback.jag
@@ -1,0 +1,63 @@
+<%
+    var log = new Log("Token Request Function");
+
+    var tokenRequestData = {
+        "grant_type": "authorization_code",
+        "code": request.getParameter("code","UTF-8"),
+        "redirect_uri": "https://localhost:9443/store-new/services/auth/callback",
+    };
+
+    var SystemApplicationDTO = Packages.org.wso2.carbon.apimgt.impl.dao.SystemApplicationDAO;
+    var systemApplicationDAO = new SystemApplicationDTO();
+    var systemApplicationDTO = systemApplicationDAO.getClientCredentialsForApplication("admin_store");
+
+    var clientId = systemApplicationDTO.getConsumerKey();
+    var clientSecret = systemApplicationDTO.getConsumerSecret();
+    var Base64 = org.apache.axiom.om.util.Base64;
+    var String = Packages.java.lang.String;
+    var base64encoded = Base64.encode ( new String (clientId + ":" + clientSecret).getBytes());
+    var tokenEndpoint = "https://localhost:8243/token";
+    var result = post(tokenEndpoint, tokenRequestData,{"Authorization": "Basic " + base64encoded});
+
+    log.debug("Token response: " + result.data);
+    response.contentType = "application/json";
+    var token_response = JSON.parse(result.data);
+
+    var token_length = token_response.access_token.length;
+    var access_token = String(token_response.access_token);
+
+
+    var access_token_token_part_1 = access_token.substring(0, token_length/2);
+    var access_token_token_part_2 = access_token.substring(token_length/2, token_length);
+
+    var refresh_token = String(token_response.refresh_token);
+    token_length = token_response.refresh_token.length;
+    var refresh_token_token_part_1 = refresh_token.substring(0, token_length/2);
+    var refresh_token_token_part_2 = refresh_token.substring(token_length/2, token_length);
+
+    var response_data = {
+        AM_ACC_TOKEN_DEFAULT_P1: String(access_token_token_part_1),
+        AM_REF_TOKEN_DEFAULT_P1: String(refresh_token_token_part_1),
+        id_token: String(token_response.id_token),
+        scope: String(token_response.scope),
+        expires_in: String(token_response.expires_in)
+    } // TODO: not in use ~tmkb
+
+    // Setting access token part 1 as secured HTTP only cookie, Can't restrict the path to /api/am/store
+    // because partial HTTP only cookie is required for get the user information from access token,
+    // hence setting the HTTP only access token path to /store-new/
+    var cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/store-new/", "HttpOnly": true, "secure": true, "maxAge": -1};
+    response.addCookie(cookie);
+
+    cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/api/am/store/", "HttpOnly": true, "secure": true, "maxAge": -1};
+    response.addCookie(cookie);
+
+    cookie = {'name': 'AM_REF_TOKEN_DEFAULT_P2', 'value': refresh_token_token_part_2, 'path': "/store-new/", "HttpOnly": true, "secure": true, "maxAge": -1};
+    response.addCookie(cookie);
+
+    cookie = {'name': 'WSO2_AM_TOKEN_1_Default', 'value': access_token_token_part_1, 'path': "/store-new/", "secure": true, "maxAge": -1}; // TODO: set maxage accordingly to toke expire time ~tmkb
+    response.addCookie(cookie);
+
+    response.sendRedirect("/store-new/apis");
+
+%>


### PR DESCRIPTION
## Related Issue
product-apim - https://github.com/wso2/product-apim/issues/4662

## Purpose
Implementing authorization_code grant login backend services for store

## Methodology

- Create config.jag to retrieve configs and to perform DCR call.
- Create token_callback.jag to handle the redirect code grant response and to generate a token.
- Create introspect.jag to retrieve scope and user details from the token.
- Create basic.jag to implement basic authentication.
- Adding the necessary URL mapping to jaggery.conf
- Adding services/* package as a resource to store-new app in pom.xml.

## User stories
User should be able to login to the store.