### PR TITLE
implementation for DELETE /apis REST API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -28,11 +28,14 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.KeyManager;
 import org.wso2.carbon.apimgt.api.model.Label;
+import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
 import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.api.model.policy.APIPolicy;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.GZIPUtils;
+import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
 import org.wso2.carbon.apimgt.impl.soaptorest.SequenceGenerator;
 import org.wso2.carbon.apimgt.impl.soaptorest.util.SOAPOperationBindingUtils;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
@@ -337,10 +340,45 @@ public class ApisApiServiceImpl extends ApisApiService {
         return null;
     }
 
+    /**
+     * Delete API
+     *
+     * @param apiId   API Id
+     * @param ifMatch If-Match header value
+     * @return Status of API Deletion
+     */
     @Override
     public Response apisApiIdDelete(String apiId, String ifMatch) {
-        // do some magic!
-        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+
+        try {
+            String username = RestApiUtil.getLoggedInUsername();
+            String tenantDomain = RestApiUtil.getLoggedInUserTenantDomain();
+            APIProvider apiProvider = RestApiUtil.getProvider(username);
+            APIIdentifier apiIdentifier = APIMappingUtil.getAPIIdentifierFromApiIdOrUUID(apiId, tenantDomain);
+
+            //check if the API has subscriptions
+            List<SubscribedAPI> apiUsages = apiProvider.getAPIUsageByAPIId(apiIdentifier);
+            if (apiUsages != null && apiUsages.size() > 0) {
+                RestApiUtil.handleConflict("Cannot remove the API " + apiId + " as active subscriptions exist", log);
+            }
+
+            //deletes the API
+            apiProvider.deleteAPI(apiIdentifier);
+            KeyManager keyManager = KeyManagerHolder.getKeyManagerInstance();
+            keyManager.deleteRegisteredResourceByAPIId(apiId);
+            return Response.ok().build();
+        } catch (APIManagementException e) {
+            //Auth failure occurs when cross tenant accessing APIs. Sends 404, since we don't need to expose the existence of the resource
+            if (RestApiUtil.isDueToResourceNotFound(e) || RestApiUtil.isDueToAuthorizationFailure(e)) {
+                RestApiUtil.handleResourceNotFoundError(RestApiConstants.RESOURCE_API, apiId, e, log);
+            } else if (isAuthorizationFailure(e)) {
+                RestApiUtil.handleAuthorizationFailure("Authorization failure while deleting API : " + apiId, e, log);
+            } else {
+                String errorMessage = "Error while deleting API : " + apiId;
+                RestApiUtil.handleInternalServerError(errorMessage, e, log);
+            }
+        }
+        return null;
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/APIMappingUtil.java
@@ -39,6 +39,8 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -673,6 +675,67 @@ public class APIMappingUtil {
         }
     }
 
+    /**
+     * Returns the APIIdentifier given the uuid or the id in {provider}-{api}-{version} format
+     *
+     * @param apiId                 uuid or the id in {provider}-{api}-{version} format
+     * @param requestedTenantDomain tenant domain of the API
+     * @return APIIdentifier which represents the given id
+     * @throws APIManagementException
+     */
+    public static APIIdentifier getAPIIdentifierFromApiIdOrUUID(String apiId, String requestedTenantDomain)
+            throws APIManagementException {
+
+        return getAPIInfoFromApiIdOrUUID(apiId, requestedTenantDomain).getId();
+    }
+
+    /**
+     * Returns an API with minimal info given the uuid or the id in {provider}-{api}-{version} format
+     *
+     * @param apiId                 uuid or the id in {provider}-{api}-{version} format
+     * @param requestedTenantDomain tenant domain of the API
+     * @return API which represents the given id
+     * @throws APIManagementException
+     */
+    public static API getAPIInfoFromApiIdOrUUID(String apiId, String requestedTenantDomain)
+            throws APIManagementException {
+
+        API api;
+        APIProvider apiProvider = RestApiUtil.getLoggedInUserProvider();
+        if (RestApiUtil.isUUID(apiId)) {
+            api = apiProvider.getLightweightAPIByUUID(apiId, requestedTenantDomain);
+        } else {
+            APIIdentifier apiIdentifier;
+            try {
+                apiIdentifier = getAPIIdentifierFromApiId(apiId);
+            } catch (UnsupportedEncodingException e) {
+                throw new APIManagementException("Couldn't decode value", e);
+            }
+
+            //Checks whether the logged in user's tenant and the API's tenant is equal
+            RestApiUtil.validateUserTenantWithAPIIdentifier(apiIdentifier);
+
+            api = apiProvider.getLightweightAPI(apiIdentifier);
+        }
+        return api;
+    }
+
+    public static APIIdentifier getAPIIdentifierFromApiId(String apiId) throws UnsupportedEncodingException {
+        //if apiId contains -AT-, that need to be replaced before splitting
+        apiId = APIUtil.replaceEmailDomainBack(apiId);
+        String[] apiIdDetails = apiId.split(RestApiConstants.API_ID_DELIMITER);
+
+        if (apiIdDetails.length < 3) {
+            RestApiUtil.handleBadRequest("Provided API identifier '" + apiId + "' is invalid", log);
+        }
+
+        // apiId format: provider-apiName-version
+        String providerName = URLDecoder.decode(apiIdDetails[0], "UTF-8");
+        String apiName = URLDecoder.decode(apiIdDetails[1], "UTF-8");
+        String version = URLDecoder.decode(apiIdDetails[2], "UTF-8");
+        String providerNameEmailReplaced = APIUtil.replaceEmailDomain(providerName);
+        return new APIIdentifier(providerNameEmailReplaced, apiName, version);
+    }
 
     /**
      * This method returns URI templates according to the given list of operations


### PR DESCRIPTION
## Purpose
provide the implementation for DELETE api in Publisher REST API.

With this REST api we have introduced a new scope apim:api_delete so that the access token has to be taken with this scope.

Sample request:'
curl -k -H "Authorization: Bearer 6b1fd4d0-eb22-31b4-a804-25a74de296fd" -H "Content-Type: application/json" -X DELETE  https://localhost:9443/api/am/publisher/v1.0/apis/e08b8f07-9c42-4541-9079-230ab1e7860e

