### PR TITLE
Set axis2 context to subscriberservice stub

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/SubscriberKeyMgtClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/SubscriberKeyMgtClient.java
@@ -21,10 +21,6 @@ package org.wso2.carbon.apimgt.keymgt.client;
 import org.apache.axis2.client.Options;
 import org.apache.axis2.client.ServiceClient;
 import org.apache.axis2.context.ConfigurationContext;
-<<<<<<< HEAD
-import org.apache.axis2.context.ConfigurationContextFactory;
-=======
->>>>>>> f1360a9... Adding activate method to keymgt client component
 import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/SubscriberKeyMgtClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/SubscriberKeyMgtClient.java
@@ -42,13 +42,12 @@ public class SubscriberKeyMgtClient {
     private APIKeyMgtSubscriberServiceStub subscriberServiceStub;
     private volatile String cookie;
 
-    public      SubscriberKeyMgtClient(String backendServerURL, String username, String password)
-            throws Exception {
+    public SubscriberKeyMgtClient(String backendServerURL, String username, String password) throws Exception {
         try {
-            ConfigurationContext ctx = ConfigurationContextFactory.createConfigurationContextFromFileSystem
-                    (getClientRepoLocation(), getAxis2ClientXmlLocation());
-            subscriberServiceStub = new APIKeyMgtSubscriberServiceStub(
-                    ctx, backendServerURL + "APIKeyMgtSubscriberService");
+            ConfigurationContext ctx = ConfigurationContextFactory
+                    .createConfigurationContextFromFileSystem(getClientRepoLocation(), getAxis2ClientXmlLocation());
+            subscriberServiceStub = new APIKeyMgtSubscriberServiceStub(ctx,
+                    backendServerURL + "APIKeyMgtSubscriberService");
             ServiceClient client = subscriberServiceStub._getServiceClient();
             Options options = client.getOptions();
             options.setManageSession(true);

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/SubscriberKeyMgtClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/SubscriberKeyMgtClient.java
@@ -59,17 +59,6 @@ public class SubscriberKeyMgtClient {
         }
     }
 
-    protected String getAxis2ClientXmlLocation() {
-        String axis2ClientXml = ServerConfiguration.getInstance().getFirstProperty("Axis2Config" +
-                ".clientAxis2XmlLocation");
-        return axis2ClientXml;
-    }
-    protected String getClientRepoLocation() {
-        String axis2ClientXml = ServerConfiguration.getInstance().getFirstProperty("Axis2Config" +
-                ".ClientRepositoryLocation");
-        return axis2ClientXml;
-    }
-
     public OAuthApplicationInfo createOAuthApplicationbyApplicationInfo(OAuthApplicationInfo oauthAppInfo) throws Exception {
         //setCookie(subscriberServiceStub);
         OAuthApplicationInfo oAuthApplicationInfo = subscriberServiceStub.createOAuthApplicationByApplicationInfo(oauthAppInfo);

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/SubscriberKeyMgtClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/SubscriberKeyMgtClient.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.apimgt.keymgt.client;
 
 import org.apache.axis2.client.Options;
 import org.apache.axis2.client.ServiceClient;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.ConfigurationContextFactory;
 import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -28,6 +30,7 @@ import org.wso2.carbon.apimgt.keymgt.stub.subscriber.APIKeyMgtSubscriberServiceA
 import org.wso2.carbon.apimgt.keymgt.stub.subscriber.APIKeyMgtSubscriberServiceAPIManagementException;
 import org.wso2.carbon.apimgt.keymgt.stub.subscriber.APIKeyMgtSubscriberServiceIdentityException;
 import org.wso2.carbon.apimgt.keymgt.stub.subscriber.APIKeyMgtSubscriberServiceStub;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.utils.CarbonUtils;
 
 import java.rmi.RemoteException;
@@ -39,11 +42,13 @@ public class SubscriberKeyMgtClient {
     private APIKeyMgtSubscriberServiceStub subscriberServiceStub;
     private volatile String cookie;
 
-    public SubscriberKeyMgtClient(String backendServerURL, String username, String password)
+    public      SubscriberKeyMgtClient(String backendServerURL, String username, String password)
             throws Exception {
         try {
+            ConfigurationContext ctx = ConfigurationContextFactory.createConfigurationContextFromFileSystem
+                    (getClientRepoLocation(), getAxis2ClientXmlLocation());
             subscriberServiceStub = new APIKeyMgtSubscriberServiceStub(
-                    null, backendServerURL + "APIKeyMgtSubscriberService");
+                    ctx, backendServerURL + "APIKeyMgtSubscriberService");
             ServiceClient client = subscriberServiceStub._getServiceClient();
             Options options = client.getOptions();
             options.setManageSession(true);
@@ -54,6 +59,17 @@ public class SubscriberKeyMgtClient {
             log.error(errorMsg, e);
             throw e;
         }
+    }
+
+    protected String getAxis2ClientXmlLocation() {
+        String axis2ClientXml = ServerConfiguration.getInstance().getFirstProperty("Axis2Config" +
+                ".clientAxis2XmlLocation");
+        return axis2ClientXml;
+    }
+    protected String getClientRepoLocation() {
+        String axis2ClientXml = ServerConfiguration.getInstance().getFirstProperty("Axis2Config" +
+                ".ClientRepositoryLocation");
+        return axis2ClientXml;
     }
 
     public OAuthApplicationInfo createOAuthApplicationbyApplicationInfo(OAuthApplicationInfo oauthAppInfo) throws Exception {

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/SubscriberKeyMgtClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/SubscriberKeyMgtClient.java
@@ -21,11 +21,15 @@ package org.wso2.carbon.apimgt.keymgt.client;
 import org.apache.axis2.client.Options;
 import org.apache.axis2.client.ServiceClient;
 import org.apache.axis2.context.ConfigurationContext;
+<<<<<<< HEAD
 import org.apache.axis2.context.ConfigurationContextFactory;
+=======
+>>>>>>> f1360a9... Adding activate method to keymgt client component
 import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.model.xsd.OAuthApplicationInfo;
+import org.wso2.carbon.apimgt.keymgt.client.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.keymgt.stub.subscriber.APIKeyMgtSubscriberServiceAPIKeyMgtException;
 import org.wso2.carbon.apimgt.keymgt.stub.subscriber.APIKeyMgtSubscriberServiceAPIManagementException;
 import org.wso2.carbon.apimgt.keymgt.stub.subscriber.APIKeyMgtSubscriberServiceIdentityException;
@@ -44,8 +48,7 @@ public class SubscriberKeyMgtClient {
 
     public SubscriberKeyMgtClient(String backendServerURL, String username, String password) throws Exception {
         try {
-            ConfigurationContext ctx = ConfigurationContextFactory
-                    .createConfigurationContextFromFileSystem(getClientRepoLocation(), getAxis2ClientXmlLocation());
+            ConfigurationContext ctx = ServiceReferenceHolder.getInstance().getAxis2ConfigurationContext();
             subscriberServiceStub = new APIKeyMgtSubscriberServiceStub(ctx,
                     backendServerURL + "APIKeyMgtSubscriberService");
             ServiceClient client = subscriberServiceStub._getServiceClient();

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/internal/APIMKeyMgtClientComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/internal/APIMKeyMgtClientComponent.java
@@ -1,0 +1,54 @@
+/*
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.wso2.carbon.apimgt.keymgt.client.internal;
+
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.ConfigurationContextFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.wso2.carbon.base.ServerConfiguration;
+
+/**
+ * @scr.component name="api.keymgt.client.component" immediate="true"
+ */
+public class APIMKeyMgtClientComponent {
+
+    private static final Log log = LogFactory.getLog(APIMKeyMgtClientComponent.class);
+
+    protected void activate(ComponentContext context) {
+        try {
+            ConfigurationContext ctx = ConfigurationContextFactory.createConfigurationContextFromFileSystem
+                    (getClientRepoLocation(), getAxis2ClientXmlLocation());
+            ServiceReferenceHolder.getInstance().setAxis2ConfigurationContext(ctx);
+        } catch (AxisFault axisFault) {
+            log.error("Failed to initialize APIMKeyMgtClientComponent", axisFault);
+        }
+    }
+
+    private String getAxis2ClientXmlLocation() {
+        String axis2ClientXml = ServerConfiguration.getInstance().getFirstProperty("Axis2Config" +
+                ".clientAxis2XmlLocation");
+        return axis2ClientXml;
+    }
+    private String getClientRepoLocation() {
+        String axis2ClientXml = ServerConfiguration.getInstance().getFirstProperty("Axis2Config" +
+                ".ClientRepositoryLocation");
+        return axis2ClientXml;
+    }
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/internal/ServiceReferenceHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/src/main/java/org/wso2/carbon/apimgt/keymgt/client/internal/ServiceReferenceHolder.java
@@ -1,0 +1,40 @@
+/*
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.wso2.carbon.apimgt.keymgt.client.internal;
+
+import org.apache.axis2.context.ConfigurationContext;
+
+public class ServiceReferenceHolder {
+
+    private static ServiceReferenceHolder instance = new ServiceReferenceHolder();
+    private ConfigurationContext axis2ConfigurationContext;
+
+
+    public void setAxis2ConfigurationContext(ConfigurationContext axis2ConfigurationContext) {
+        this.axis2ConfigurationContext = axis2ConfigurationContext;
+    }
+
+    public ConfigurationContext getAxis2ConfigurationContext() {
+        return axis2ConfigurationContext;
+    }
+
+    private ServiceReferenceHolder() {
+    }
+
+    public static ServiceReferenceHolder getInstance() {
+        return instance;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/pom.xml
@@ -225,7 +225,7 @@
 							!org.wso2.carbon.apimgt.keymgt.stub.subscriber,
 							!org.wso2.carbon.apimgt.keymgt.stub.types.axis2,
 							!org.wso2.carbon.apimgt.keymgt.stub.types.carbon,
-							!org.wso2.carbon.apimgt.keymgt.stub.useradmin
+							!org.wso2.carbon.apimgt.keymgt.stub.useradmin,
 							!org.wso2.carbon.apimgt.keymgt.client,
 							org.wso2.carbon.apimgt.keymgt.*
 						</Export-Package>


### PR DESCRIPTION
Without this fix, subscriber service calls were intermittently diverting to the synapse layer. 