### PR TITLE
Add Support for Product Subscription Tiers

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/AuthenticationContext.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/AuthenticationContext.java
@@ -43,6 +43,8 @@ public class AuthenticationContext {
     private String subscriberTenantDomain;
     private String spikeArrestUnit;
     private boolean stopOnQuotaReach;
+    private String productName;
+    private String productProvider;
 
     public List<String> getThrottlingDataList() {
         return throttlingDataList;
@@ -189,5 +191,21 @@ public class AuthenticationContext {
 
     public void setStopOnQuotaReach(boolean stopOnQuotaReach) {
         this.stopOnQuotaReach = stopOnQuotaReach;
+    }
+
+    public void setProductName(String productName) {
+        this.productName = productName;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public void setProductProvider(String productProvider) {
+        this.productProvider = productProvider;
+    }
+
+    public String getProductProvider() {
+        return productProvider;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/APIKeyValidatorClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/APIKeyValidatorClient.java
@@ -181,6 +181,8 @@ public class APIKeyValidatorClient {
         dto.setSpikeArrestUnit(generatedDto.getSpikeArrestUnit());
         dto.setSubscriberTenantDomain(generatedDto.getSubscriberTenantDomain());
         dto.setStopOnQuotaReach(generatedDto.getStopOnQuotaReach());
+        dto.setProductName(generatedDto.getProductName());
+        dto.setProductProvider(generatedDto.getProductProvider());
         return dto;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
@@ -273,6 +273,10 @@ public class OAuthAuthenticator implements Authenticator {
             authContext.setStopOnQuotaReach(info.isStopOnQuotaReach());
             authContext.setIsContentAware(info.isContentAware());
             APISecurityUtils.setAuthenticationContext(synCtx, authContext, securityContextHeader);
+            if (info.getProductName() != null && info.getProductProvider() != null) {
+                authContext.setProductName(info.getProductName());
+                authContext.setProductProvider(info.getProductProvider());
+            }
 
             /* Synapse properties required for BAM Mediator*/
             //String tenantDomain = MultitenantUtils.getTenantDomain(info.getApiPublisher());

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/APIThrottleConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/APIThrottleConstants.java
@@ -63,4 +63,6 @@ public class APIThrottleConstants {
             "xmlns:throttle=\"http://www.wso2.org/products/wso2commons/throttle\">\n" +
             "    <throttle:MediatorThrottleAssertion>\n";
     public static final String WS_THROTTLE_POLICY_BOTTOM = "</throttle:MediatorThrottleAssertion>\n" +"</wsp:Policy>";
+    public static final String SUBSCRIPTION_TYPE = "subscriptionType";
+    public static final String APPLICATION_NAME = "applicationName";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleHandler.java
@@ -154,7 +154,9 @@ public class ThrottleHandler extends AbstractHandler implements ManagedLifecycle
         //Throttle Keys
         //applicationLevelThrottleKey key is combination of {applicationId}:{authorizedUser}
         String applicationLevelThrottleKey;
-        //subscriptionLevelThrottleKey key is combination of {applicationId}:{apiContext}:{apiVersion}
+        //subscriptionLevelThrottleKey key for an api subscription is combination of {applicationId}:{apiContext}:{apiVersion}
+        //subscriptionLevelThrottleKey key for an api subscription is combination of {applicationId}:{productName}:{productProvider}
+        //Todo: add product version to key when versioning is supported
         String subscriptionLevelThrottleKey;
         // The key is combination of {apiContext}/ {apiVersion}{resourceUri}:{httpMethod} if policy is user level then authorized user will append at end
         String resourceLevelThrottleKey;
@@ -357,8 +359,13 @@ public class ThrottleHandler extends AbstractHandler implements ManagedLifecycle
                     //if resource level not throttled then move to subscription level
                     if (!isResourceLevelThrottled) {
                         //Subscription Level Throttling
-                        subscriptionLevelThrottleKey = authContext.getApplicationId() + ":" + apiContext + ":"
-                                                       + apiVersion;
+                        if (authContext.getProductName() != null && authContext.getProductProvider() != null) {
+                            subscriptionLevelThrottleKey =
+                                    authContext.getApplicationId() + ":" + authContext.getProductName() + ":"
+                                            + authContext.getProductProvider();
+                        } else {
+                            subscriptionLevelThrottleKey = authContext.getApplicationId() + ":" + apiContext + ":" + apiVersion;
+                        }
                         isSubscriptionLevelThrottled = getThrottleDataHolder().
                                 isThrottled(subscriptionLevelThrottleKey);
                         if (!isSubscriptionLevelThrottled && authContext.getSpikeArrestLimit() > 0) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/throttling/publisher/DataProcessAndPublishingAgent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/throttling/publisher/DataProcessAndPublishingAgent.java
@@ -211,6 +211,16 @@ public class DataProcessAndPublishingAgent implements Runnable {
                 }
             }
             jsonObMap.put(APIThrottleConstants.MESSAGE_SIZE, messageSizeInBytes);
+            if (!StringUtils.isEmpty(authenticationContext.getApplicationName())) {
+                jsonObMap.put(APIThrottleConstants.APPLICATION_NAME, authenticationContext.getApplicationName());
+            }
+            if (!StringUtils.isEmpty(authenticationContext.getProductName()) && !StringUtils
+                    .isEmpty(authenticationContext.getProductProvider())) {
+                jsonObMap.put(APIThrottleConstants.SUBSCRIPTION_TYPE, "APIProduct");
+            } else {
+                jsonObMap.put(APIThrottleConstants.SUBSCRIPTION_TYPE, "API");
+            }
+
         }
 
         Object[] objects = new Object[]{messageContext.getMessageID(),


### PR DESCRIPTION
## Purpose
This PR adds support for product subscription tiers. 

## Approach
* During api request authhentication the request is identified as api/product. New productName and productProvider fields are introduced to authentication context to pass along product related details to throttle handler.
* subscriptionLevelThrottleKey key for an api subscription is combination of {applicationId}:{apiContext}:{apiVersion}
* subscriptionLevelThrottleKey key for an api subscription is combination of {applicationId}:{productName}:{productProvider}
        
