### PR TITLE
 Supporting operations for Publisher REST API /apis

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromOpenAPISpec.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/APIDefinitionFromOpenAPISpec.java
@@ -377,35 +377,33 @@ public class APIDefinitionFromOpenAPISpec extends APIDefinition {
         JSONArray xWso2ScopesArray = new JSONArray();
         JSONObject xWso2ScopesObject;
 
-        JSONObject xScopesObject;//++++++++
+        JSONObject swaggerScopesObject;//++++++++
         JSONArray xScopesArray = new JSONArray();//+++++++
-        JSONObject scopesJsonObject = new JSONObject();//+++++
         JSONObject securityDefinitionJsonObject = new JSONObject() ;//+++++++
         JSONObject securityDefinitionAttr =new JSONObject();
 
         if (scopes != null) {
             for (Scope scope : scopes) {
                 xWso2ScopesObject = new JSONObject();
-                xScopesObject = new JSONObject();//++++++
-                xScopesObject.put(scope.getName(),scope.getDescription());//+++++
+                swaggerScopesObject = new JSONObject();//++++++
+                swaggerScopesObject.put(scope.getName(),scope.getDescription());//+++++
                 xWso2ScopesObject.put(APIConstants.SWAGGER_SCOPE_KEY, scope.getKey());
                 xWso2ScopesObject.put(APIConstants.SWAGGER_NAME, scope.getName());
                 xWso2ScopesObject.put(APIConstants.SWAGGER_ROLES, scope.getRoles());
                 xWso2ScopesObject.put(APIConstants.SWAGGER_DESCRIPTION, scope.getDescription());
 
                 xWso2ScopesArray.add(xWso2ScopesObject);
-                xScopesArray.add(xScopesObject);//+++++++++++++
+                xScopesArray.add(swaggerScopesObject);//+++++++++++++
             }
         }
 
-        scopesJsonObject.put("scopes",xScopesArray);//++++++++
-
-        securityDefinitionAttr.put("petstore_auth",scopesJsonObject);//++++
-        securityDefinitionAttr.put("type","oauth2");//++++
-        securityDefinitionAttr.put("authorizationUrl","test.com");//+++
-        securityDefinitionAttr.put("flow","implicit");//++++
-
-        //securityDefinitionJsonObject.put("petstore_auth",scopesJsonObject);//++++++
+        securityDefinitionJsonObject.put("type","oauth2");//++++
+        securityDefinitionJsonObject.put("tokenUrl","https://test.com");//+++
+        securityDefinitionJsonObject.put("flow","password");//++++
+        if (!xScopesArray.isEmpty()) {
+            securityDefinitionJsonObject.put("scopes", xScopesArray);//++++++++
+        }
+        securityDefinitionAttr.put("OAuth2Security",securityDefinitionJsonObject);//++++
 
         scopesObject.put(APIConstants.SWAGGER_X_WSO2_SCOPES, xWso2ScopesArray);
         securityDefinitionObject.put(APIConstants.SWAGGER_OBJECT_NAME_APIM, scopesObject);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsDTO.java
@@ -2,7 +2,6 @@ package org.wso2.carbon.apimgt.rest.api.publisher.v1.dto;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIEndpointDTO;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
@@ -21,22 +20,19 @@ public class APIOperationsDTO  {
   private String uritemplate = "/*";
   
   
-  private List<APIEndpointDTO> endpoint = new ArrayList<APIEndpointDTO>();
-  
-  
   private String httpVerb = "GET";
   
   
   private String id = null;
   
   
+  private String throttlingPolicy = null;
+  
+  
   private List<String> scopes = new ArrayList<String>();
   
   
   private String authType = "Any";
-  
-  
-  private String policy = null;
 
   
   /**
@@ -48,18 +44,6 @@ public class APIOperationsDTO  {
   }
   public void setUritemplate(String uritemplate) {
     this.uritemplate = uritemplate;
-  }
-
-  
-  /**
-   **/
-  @ApiModelProperty(value = "")
-  @JsonProperty("endpoint")
-  public List<APIEndpointDTO> getEndpoint() {
-    return endpoint;
-  }
-  public void setEndpoint(List<APIEndpointDTO> endpoint) {
-    this.endpoint = endpoint;
   }
 
   
@@ -90,6 +74,18 @@ public class APIOperationsDTO  {
   /**
    **/
   @ApiModelProperty(value = "")
+  @JsonProperty("throttlingPolicy")
+  public String getThrottlingPolicy() {
+    return throttlingPolicy;
+  }
+  public void setThrottlingPolicy(String throttlingPolicy) {
+    this.throttlingPolicy = throttlingPolicy;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
   @JsonProperty("scopes")
   public List<String> getScopes() {
     return scopes;
@@ -111,18 +107,6 @@ public class APIOperationsDTO  {
   }
 
   
-  /**
-   **/
-  @ApiModelProperty(value = "")
-  @JsonProperty("policy")
-  public String getPolicy() {
-    return policy;
-  }
-  public void setPolicy(String policy) {
-    this.policy = policy;
-  }
-
-  
 
   @Override
   public String toString()  {
@@ -130,12 +114,11 @@ public class APIOperationsDTO  {
     sb.append("class APIOperationsDTO {\n");
     
     sb.append("  uritemplate: ").append(uritemplate).append("\n");
-    sb.append("  endpoint: ").append(endpoint).append("\n");
     sb.append("  httpVerb: ").append(httpVerb).append("\n");
     sb.append("  id: ").append(id).append("\n");
+    sb.append("  throttlingPolicy: ").append(throttlingPolicy).append("\n");
     sb.append("  scopes: ").append(scopes).append("\n");
     sb.append("  authType: ").append(authType).append("\n");
-    sb.append("  policy: ").append(policy).append("\n");
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/APIMappingUtil.java
@@ -20,21 +20,45 @@ package org.wso2.carbon.apimgt.rest.api.publisher.v1.utils.mappings;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
-import org.wso2.carbon.apimgt.api.model.*;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIEndpoint;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.CORSConfiguration;
+import org.wso2.carbon.apimgt.api.model.Endpoint;
+import org.wso2.carbon.apimgt.api.model.EndpointSecurity;
+import org.wso2.carbon.apimgt.api.model.Label;
+import org.wso2.carbon.apimgt.api.model.LifeCycleEvent;
+import org.wso2.carbon.apimgt.api.model.Scope;
+import org.wso2.carbon.apimgt.api.model.Tier;
+import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIMRegistryServiceImpl;
 import org.wso2.carbon.apimgt.impl.definitions.APIDefinitionFromOpenAPISpec;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
-import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.*;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIBusinessInformationDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APICorsConfigurationDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIEndpointDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIEndpointSecurityDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIInfoDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIListDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIMaxTpsDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIOperationsDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.EndPointDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.EndPointEndpointSecurityDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.LabelDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.LifecycleHistoryDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.LifecycleHistoryItemDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.LifecycleStateAvailableTransitionsDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.LifecycleStateCheckItemsDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.LifecycleStateDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.PaginationDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ScopeDTO;
 import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.governance.custom.lifecycles.checklist.util.CheckListItem;
@@ -43,9 +67,14 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.wso2.carbon.apimgt.impl.utils.APIUtil.handleException;
 
@@ -54,9 +83,6 @@ public class APIMappingUtil {
     private static final Log log = LogFactory.getLog(APIMappingUtil.class);
 
     public static API fromDTOtoAPI(APIDTO dto, String provider) throws APIManagementException {
-
-//        APIDefinition apiDefinitionFromOpenAPISpec = new APIDefinitionFromOpenAPISpec();
-
         String providerEmailDomainReplaced = APIUtil.replaceEmailDomain(provider);
 
         // The provider name that is coming from the body is not honored for now.
@@ -497,8 +523,8 @@ public class APIMappingUtil {
 
         //Get Swagger definition which has URL templates, scopes and resource details
         String apiSwaggerDefinition = apiProvider.getOpenAPIDefinition(model.getId());
-
-        dto.setOperations(getOperationsFromSwaggerDef(apiSwaggerDefinition));
+        List<APIOperationsDTO> operationsDTOs = getOperationsFromSwaggerDef(model, apiSwaggerDefinition);
+        dto.setOperations(operationsDTOs);
 
         Set<String> apiTags = model.getTags();
         List<String> tagsToReturn = new ArrayList<>();
@@ -788,97 +814,69 @@ public class APIMappingUtil {
      * @return URI Templates
      * @throws APIManagementException
      */
-    public static Set<URITemplate> getURITemplates(API model, List<APIOperationsDTO> operations) throws APIManagementException {
+    public static Set<URITemplate> getURITemplates(API model, List<APIOperationsDTO> operations)
+            throws APIManagementException {
 
         boolean isHttpVerbDefined = false;
         Set<URITemplate> uriTemplates = new LinkedHashSet<>();
-        Set<Scope> scopesToAdd = new HashSet<>();
 
-        if (operations != null) {
-            for (APIOperationsDTO operation : operations) {
-                URITemplate template = new URITemplate();
+        if (operations == null || operations.isEmpty()) {
+            operations = getDefaultOperationsList();
+        }
 
-                String uriTempVal = operation.getUritemplate();
-                //if url template is a custom attribute "^x-" ignore.
-                if (uriTempVal.startsWith("x-") || uriTempVal.startsWith("X-")) {
-                    continue;
-                }
-                String httpVerb = operation.getHttpVerb();
-                List<String> scopeList = operation.getScopes();
-                if (scopeList != null) {
-                    for (String scopeKey : scopeList) {
-                        for (Scope definedScope : model.getScopes()) {
-                            if (definedScope.getKey().equalsIgnoreCase(scopeKey)) {
-                                Scope scope = new Scope();
-                                scope.setKey(scopeKey);
-                                scope.setName(definedScope.getName());
-                                scope.setDescription(definedScope.getDescription());
-                                scope.setRoles(definedScope.getRoles());
-                                template.setScopes(scope);
-                                template.setScope(scope);
+        for (APIOperationsDTO operation : operations) {
+            URITemplate template = new URITemplate();
 
-                            }
+            String uriTempVal = operation.getUritemplate();
+
+            String httpVerb = operation.getHttpVerb();
+            List<String> scopeList = operation.getScopes();
+            if (scopeList != null) {
+                for (String scopeKey : scopeList) {
+                    for (Scope definedScope : model.getScopes()) {
+                        if (definedScope.getKey().equalsIgnoreCase(scopeKey)) {
+                            Scope scope = new Scope();
+                            scope.setKey(scopeKey);
+                            scope.setName(definedScope.getName());
+                            scope.setDescription(definedScope.getDescription());
+                            scope.setRoles(definedScope.getRoles());
+                            template.setScopes(scope);
+                            template.setScope(scope);
                         }
                     }
                 }
-
-                if (APIConstants.SWAGGER_SUMMARY.equals(httpVerb.toLowerCase())
-                        || APIConstants.SWAGGER_DESCRIPTION.equals(httpVerb.toLowerCase())
-                        || APIConstants.SWAGGER_SERVERS.equals(httpVerb.toLowerCase())
-                        || APIConstants.PARAMETERS.equals(httpVerb.toLowerCase())
-                        || httpVerb.startsWith("x-")
-                        || httpVerb.startsWith("X-")) {
-                    // openapi 3.x allow 'summary', 'description' and extensions in PathItem Object.
-                    // which we are not interested at this point
-                    continue;
-                }
-                //Only continue for supported operations
-                else if (APIConstants.SUPPORTED_METHODS.contains(httpVerb.toLowerCase())) {
-                    isHttpVerbDefined = true;
-                    String authType = operation.getAuthType();
-                    if ("Application & Application User".equals(authType)) {
-                        authType = APIConstants.AUTH_APPLICATION_OR_USER_LEVEL_TOKEN;
-                    } else if ("Application User".equals(authType)) {
-                        authType = APIConstants.AUTH_APPLICATION_USER_LEVEL_TOKEN;
-                    } else if ("None".equals(authType)) {
-                        authType = APIConstants.AUTH_NO_AUTHENTICATION;
-                    } else if ("Application".equals(authType)) {
-                        authType = APIConstants.AUTH_APPLICATION_LEVEL_TOKEN;
-                    } else {
-                        authType = APIConstants.AUTH_APPLICATION_OR_USER_LEVEL_TOKEN;
-                    }
-                    template.setThrottlingTier(operation.getPolicy());
-                    template.setThrottlingTiers(operation.getPolicy());
-//                        template.setMediationScript((String) operation.get(APIConstants todo
-//                                .SWAGGER_X_MEDIATION_SCRIPT));
-//                        template.setMediationScripts(httpVerb.toUpperCase(), (String) operation.get( todo
-//                                APIConstants.SWAGGER_X_MEDIATION_SCRIPT));
-                    template.setUriTemplate(uriTempVal);
-                    template.setHTTPVerb(httpVerb.toUpperCase());
-                    template.setHttpVerbs(httpVerb.toUpperCase());
-                    template.setAuthType(authType);
-                    template.setAuthTypes(authType);
-//                    template.setScope(scope);moved to above
-//                    template.setScopes(scope);
-
-                    uriTemplates.add(template);
+            }
+            //Only continue for supported operations
+            if (APIConstants.SUPPORTED_METHODS.contains(httpVerb.toLowerCase())) {
+                isHttpVerbDefined = true;
+                String authType = operation.getAuthType();
+                if (RestApiConstants.ResourceAuthTypes.APPLICATION_OR_APPLICATION_USER.equals(authType)) {
+                    authType = APIConstants.AUTH_APPLICATION_OR_USER_LEVEL_TOKEN;
+                } else if (RestApiConstants.ResourceAuthTypes.APPLICATION_USER.equals(authType)) {
+                    authType = APIConstants.AUTH_APPLICATION_USER_LEVEL_TOKEN;
+                } else if (RestApiConstants.ResourceAuthTypes.NONE.equals(authType)) {
+                    authType = APIConstants.AUTH_NO_AUTHENTICATION;
+                } else if (RestApiConstants.ResourceAuthTypes.APPLICATION.equals(authType)) {
+                    authType = APIConstants.AUTH_APPLICATION_LEVEL_TOKEN;
                 } else {
-                    handleException("The HTTP method '" + httpVerb + "' provided for resource '" + uriTempVal
-                            + "' is invalid");
+                    authType = APIConstants.AUTH_APPLICATION_OR_USER_LEVEL_TOKEN;
                 }
-//                    JSONObject path = (JSONObject) paths.get(uriTempVal);todo
-                // Following code check is done to handle $ref objects supported by swagger spec
-                // See field types supported by "Path Item Object" in swagger spec.
-                   /* if (operation.("$ref")) {
-                        log.info("Reference " + uriTempVal + " path object was ignored when generating URL template " +
-                                "for api \"" + api.getId().getApiName() + '\"');
-                        continue;
-                    }*/
+                template.setThrottlingTier(operation.getThrottlingPolicy());
+                template.setThrottlingTiers(operation.getThrottlingPolicy());
+                template.setUriTemplate(uriTempVal);
+                template.setHTTPVerb(httpVerb.toUpperCase());
+                template.setHttpVerbs(httpVerb.toUpperCase());
+                template.setAuthType(authType);
+                template.setAuthTypes(authType);
+                uriTemplates.add(template);
+            } else {
+                handleException("The HTTP method '" + httpVerb + "' provided for resource '" + uriTempVal
+                        + "' is invalid");
+            }
 
-                if (!isHttpVerbDefined) {
-                    handleException("Resource '" + uriTempVal + "' has global parameters without " +
-                            "HTTP methods");
-                }
+            if (!isHttpVerbDefined) {
+                handleException("Resource '" + uriTempVal + "' has global parameters without " +
+                        "HTTP methods");
             }
         }
 
@@ -1002,13 +1000,77 @@ public class APIMappingUtil {
         return apiEndpointDTOList;
     }
 
-    private static List<APIOperationsDTO> getOperationsFromSwaggerDef(String swaggerDefinition) {
-//todo
+    /**
+     * Returns a set of operations from a given swagger definition
+     * 
+     * @param api API object
+     * @param swaggerDefinition Swagger definition 
+     * @return a set of operations from a given swagger definition
+     * @throws APIManagementException error while trying to retrieve URI templates of the given API
+     */
+    private static List<APIOperationsDTO> getOperationsFromSwaggerDef(API api, String swaggerDefinition)
+            throws APIManagementException {
+        APIDefinitionFromOpenAPISpec definitionFromOpenAPISpec = new APIDefinitionFromOpenAPISpec();
+        Set<URITemplate> uriTemplates = definitionFromOpenAPISpec.getURITemplates(api, swaggerDefinition);
+
         List<APIOperationsDTO> operationsDTOList = new ArrayList<>();
         if (!StringUtils.isEmpty(swaggerDefinition)) {
-
+            for (URITemplate uriTemplate : uriTemplates) {
+                APIOperationsDTO operationsDTO = getOperationFromURITemplate(uriTemplate);
+                operationsDTOList.add(operationsDTO);
+            }
         }
 
         return operationsDTOList;
+    }
+
+    /**
+     * Converts a URI template object to a REST API DTO
+     * 
+     * @param uriTemplate URI Template object
+     * @return REST API DTO representing URI template object
+     */
+    private static APIOperationsDTO getOperationFromURITemplate(URITemplate uriTemplate) {
+        APIOperationsDTO operationsDTO = new APIOperationsDTO();
+        operationsDTO.setId(""); //todo: Set ID properly
+        if (APIConstants.AUTH_APPLICATION_OR_USER_LEVEL_TOKEN.equals(uriTemplate.getAuthType())) {
+            operationsDTO.setAuthType(RestApiConstants.ResourceAuthTypes.APPLICATION_OR_APPLICATION_USER);
+        } else if (APIConstants.AUTH_APPLICATION_USER_LEVEL_TOKEN.equals(uriTemplate.getAuthType())) {
+            operationsDTO.setAuthType(RestApiConstants.ResourceAuthTypes.APPLICATION_USER);
+        } else if (APIConstants.AUTH_NO_AUTHENTICATION.equals(uriTemplate.getAuthType())) {
+            operationsDTO.setAuthType(RestApiConstants.ResourceAuthTypes.NONE);
+        } else if (APIConstants.AUTH_APPLICATION_LEVEL_TOKEN.equals(uriTemplate.getAuthType())) {
+            operationsDTO.setAuthType(RestApiConstants.ResourceAuthTypes.APPLICATION);
+        } else {
+            operationsDTO.setAuthType(RestApiConstants.ResourceAuthTypes.APPLICATION_OR_APPLICATION_USER);
+        }
+        operationsDTO.setAuthType(uriTemplate.getAuthType());
+        operationsDTO.setHttpVerb(uriTemplate.getHTTPVerb());
+        operationsDTO.setUritemplate(uriTemplate.getUriTemplate());
+        if (uriTemplate.getScope() != null) {
+            operationsDTO.setScopes(new ArrayList<String>() {{
+                add(uriTemplate.getScope().getName());
+            }});
+        }
+        operationsDTO.setThrottlingPolicy(uriTemplate.getThrottlingTier());
+        return operationsDTO;
+    }
+
+    /**
+     * Returns a default operations list with wildcard resources and http verbs
+     * 
+     * @return a default operations list
+     */
+    private static List<APIOperationsDTO> getDefaultOperationsList() {
+        List<APIOperationsDTO> operationsDTOs = new ArrayList<>();
+        for (String verb : RestApiConstants.SUPPORTED_METHODS) {
+            APIOperationsDTO operationsDTO = new APIOperationsDTO();
+            operationsDTO.setUritemplate("/*");
+            operationsDTO.setHttpVerb(verb);
+            operationsDTO.setThrottlingPolicy(APIConstants.UNLIMITED_TIER);
+            operationsDTO.setAuthType(APIConstants.AUTH_APPLICATION_OR_USER_LEVEL_TOKEN);
+            operationsDTOs.add(operationsDTO);
+        }
+        return operationsDTOs;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -5195,21 +5195,9 @@ definitions:
           authType:
             type: string
             default: "Any"
-          policy:
+          throttlingPolicy:
             type: string
             example: "Unlimited"
-          endpoint:
-            type: array
-            items:
-             properties:
-              key:
-               type: string
-               example: "01234567-0123-0123-0123-012345678901"
-              inline:
-               $ref: '#/definitions/EndPoint'
-              type:
-                type: string
-                example: "Production"
           scopes:
             type: array
             items:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
@@ -197,4 +197,13 @@ public final class RestApiConstants {
     public static final String SEQUENCE_CONTENT = "content";
     public static final String SEQUENCE_ARTIFACT_ID = "id";
     public static final String HTTP_METHOD = "method";
+    
+    public static final String[] SUPPORTED_METHODS = {"get", "put", "post", "delete", "patch"};
+
+    public static class ResourceAuthTypes {
+        public static final String APPLICATION_OR_APPLICATION_USER = "Application & Application User";
+        public static final String APPLICATION_USER = "Application User";
+        public static final String APPLICATION = "Application";
+        public static final String NONE = "None";
+    }
 }


### PR DESCRIPTION
## Purpose
1. Add APIs without operations will add an API with a default set of operations /* for GET, PUT, DELETE, POST, PATCH

2. Add APIs with operations will add the API with those operations and a generated minimal swagger definition.

sample `operations` field:
```
   "operations":    [
            {
         "uritemplate": "/order/{orderId}",
         "httpVerb": "GET",
         "id": "",
         "scopes": [],
         "authType": "Any",
         "throttlingPolicy": "Unlimited"
      },
            {
         "uritemplate": "/order/{orderId}",
         "httpVerb": "DELETE",
         "id": "",
         "scopes": [],
         "authType": "Any",
         "throttlingPolicy": "Unlimited"
      },
            {
         "uritemplate": "/order/{orderId}",
         "httpVerb": "PUT",
         "id": "",
         "scopes": [],
         "authType": "Any",
         "throttlingPolicy": "Unlimited"
      },
            {
         "uritemplate": "/menu",
         "httpVerb": "GET",
         "id": "",
         "scopes": [],
         "authType": "Any",
         "throttlingPolicy": "Unlimited"
      },
            {
         "uritemplate": "/order",
         "httpVerb": "POST",
         "id": "",
         "scopes": [],
         "authType": "Any",
         "throttlingPolicy": "Unlimited"
      }
   ]
```