### PR TITLE
Enable scope validation to publisher

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/App.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/App.jsx
@@ -89,13 +89,35 @@ class Publisher extends React.Component {
         this.loadLocale(locale);
         const user = AuthManager.getUser();
         if (user) {
-            this.setState({ user, userResolved: true });
+            const hasViewScope = user.scopes.includes('apim:api_view');
+            if (hasViewScope) {
+                this.setState({ user, userResolved: true });
+            } else {
+                console.log('No relevant scopes found, redirecting to login page');
+                this.setState({ userResolved: true });
+            }
         } else {
             // If no user data available , Get the user info from existing token information
             // This could happen when OAuth code authentication took place and could send
             // user information via redirection
             const userPromise = AuthManager.getUserFromToken();
-            if (userPromise) userPromise.then(loggedUser => this.setState({ user: loggedUser, userResolved: true }));
+            userPromise.then((loggedUser) => {
+                if (loggedUser != null) {
+                    const hasViewScope = loggedUser.scopes.includes('apim:api_view');
+                    if (hasViewScope) {
+                        this.setState({ user: loggedUser, userResolved: true });
+                    } else {
+                        console.log('No relevant scopes found, redirecting to login page');
+                        this.setState({ userResolved: true });
+                    }
+                } else {
+                    console.log('User returned with null, redirect to login page');
+                    this.setState({ userResolved: true });
+                }
+            }).catch((error) => {
+                console.log('Error: ' + error + ',redirecting to login page');
+                this.setState({ userResolved: true });
+            });
         }
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/data/AuthManager.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/data/AuthManager.js
@@ -111,7 +111,7 @@ class AuthManager {
     static getUserFromToken() {
         const partialToken = Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1);
         if (!partialToken) {
-            return new Promise(resolve => resolve(null));
+            return new Promise((resolve, reject) => reject(new Error('No partial token found')));
         }
         const promisedResponse = fetch('/publisher-new/services/auth/introspect', { credentials: 'same-origin' });
         return promisedResponse
@@ -376,8 +376,7 @@ class AuthManager {
 
 // TODO: derive this from swagger definitions ~tmkb
 AuthManager.CONST = {
-    USER_SCOPES:
-        'apim:api_view apim:api_create apim:api_publish apim:tier_view apim:tier_manage ' +
+    USER_SCOPES: 'apim:api_view apim:api_create apim:api_publish apim:tier_view apim:tier_manage ' +
         'apim:subscription_view apim:subscription_block apim:subscribe apim:external_services_discover',
 };
 export default AuthManager;


### PR DESCRIPTION
## Issue
product-apim: https://github.com/wso2/product-apim/issues/4706

## Purpose

- Need to validate user scopes while authenticating users to access resources in publisher.

## Goals

- Check for "apim:api_view" scope when logging in the user.

## Approach
First, check for user to exist in local storage, if the user is present check the user for scopes. If the user doesn't exist in the local storage, then get the user from access token by introspection.Then check for the valid scopes.

## User stories
Users should be validated for relevant scopes before accessing resources.