### PR TITLE
Resolving policy tiers not getting listed on the drop down issue

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/LifeCycle/Policies.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/LifeCycle/Policies.jsx
@@ -118,13 +118,13 @@ class Policies extends Component {
                     >
                         {policies.map(policy => (
                             <MenuItem
-                                key={policy.policyName}
-                                value={policy.policyName}
+                                key={policy.name}
+                                value={policy.name}
                                 style={{
-                                    fontWeight: policies.indexOf(policy.policyName) !== -1 ? '500' : '400',
+                                    fontWeight: policies.indexOf(policy.name) !== -1 ? '500' : '400',
                                 }}
                             >
-                                {policy.displayName}
+                                {policy.name}
                             </MenuItem>
                         ))}
                     </Select>


### PR DESCRIPTION
## Purpose
Product-apim: https://github.com/wso2/product-apim/issues/4709

## Purpose
Resolving policy tiers not getting listed on the drop down issue

## Goals
Need to display policy tiers when creating a new REST API in publisher.

## Approach
Changing the incorrect array name reference in the policies array.

## User stories
Users need to be able to view all the policies when creating a REST API in publisher.