### PR TITLE
Enable scope validation to store login

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/Errors/ScopeNotFound.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/Errors/ScopeNotFound.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, {Component} from 'react'
+
+const ScopeNotFound = (props) => {
+    return (
+        <div>
+            <div className="message message-danger">
+                <h4><i className="icon fw fw-error"/>Un-authorized Access</h4>
+                <p>
+                    Sorry, the page you are looking for <span style={{color: 'green'}}> {props.location.pathname} </span>
+                    is not allowed under logged in user role scopes. Please login with different user with relevant permission to access this resource.
+                </p>
+            </div>
+
+        </div>
+    );
+};
+
+export default ScopeNotFound

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/Errors/index.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/Errors/index.js
@@ -18,5 +18,6 @@
 
 import PageNotFound from './PageNotfound'
 import ResourceNotFound from './ResourceNotFound'
+import ScopeNotFound from './ScopeNotFound'
 
-export {PageNotFound, ResourceNotFound}
+export { PageNotFound, ResourceNotFound, ScopeNotFound }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/data/AuthManager.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/data/AuthManager.js
@@ -132,7 +132,7 @@ class AuthManager {
     static getUserFromToken() {
         const partialToken = Utils.getCookie(User.CONST.WSO2_AM_TOKEN_1);
         if (!partialToken) {
-            return new Promise(resolve => resolve(null));
+            return new Promise((resolve, reject) => reject(new Error('No partial token found')));
         }
         const promisedResponse = fetch('/store-new/services/auth/introspect', { credentials: 'same-origin' });
         return promisedResponse
@@ -142,6 +142,7 @@ class AuthManager {
                 if (data.active) {
                     const currentEnv = Utils.getCurrentEnvironment();
                     user = new User(currentEnv.label, data.username);
+                    user.scopes = data.scope.split(' ');
                     AuthManager.setUser(user, currentEnv.label);
                 } else {
                     console.warn('User with ' + partialToken + ' is not active!');


### PR DESCRIPTION
## Issues
Product-apim: https://github.com/wso2/product-apim/issues/4710

## Purpose
Need to validate user scopes while authenticating users to access resources in publisher.

## Goals

- Check for "apim:subscribe" scope when logging in the user.
- Display an error message when directed to an unauthorized resource.

## Approach
First, check for user to exist in local storage, if the user is present check the user for scopes. If the user doesn't exist in the local storage, then get the user from access token by introspection.Then check for the valid scopes.
Then, the user with valid scopes can access relevant resources. Users can be logged in with default scopes(Anonymous user) but will be restricted access to protected resources.

## User stories

- Users should be validated for relevant scopes before accessing resources.
- Users should be given an error message as to why they can not access the resource.
