### PR TITLE
Adding token expiry time to the cookies

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/configs/config.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/configs/config.jag
@@ -1,6 +1,5 @@
 <%
     var log = new Log("Services login DCR request");
-    log.info("Hit the service");
     var dcrUrl = 'https://localhost:9443/client-registration/v0.14/register'; // TODO: fetch from config
     var authorizeEndpoint = "https://localhost:8243/authorize"; // TODO: fetch from config
     var callbackUrl = "https://localhost:9443/publisher-new/services/auth/callback"; // TODO: fetch from config
@@ -28,7 +27,6 @@
         var clientId = result.data.clientId;
         var clientSecret = result.data.clientSecret;
 
-        log.info("Client ID = " + clientId);
 
         var addApplicationKey = systemApplicationDAO.addApplicationKey("admin_publisher", clientId, clientSecret);
         if (!addApplicationKey) {
@@ -37,7 +35,7 @@
         }
     }
     var authRequestParams = "?response_type=code&client_id=" + clientId + "&scope=" + scopes + "&redirect_uri=" + callbackUrl;
-    log.info("Redirecting to = " + authorizeEndpoint + authRequestParams);
+    log.debug("Redirecting to = " + authorizeEndpoint + authRequestParams);
     response.sendRedirect(authorizeEndpoint + authRequestParams);
 
 %>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/login/token_callback.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/login/token_callback.jag
@@ -15,12 +15,12 @@
     var clientSecret = systemApplicationDTO.getConsumerSecret();
     var Base64 = org.apache.axiom.om.util.Base64;
     var String = Packages.java.lang.String;
+    var Integer = Packages.java.lang.Integer;
     var base64encoded = Base64.encode ( new String (clientId + ":" + clientSecret).getBytes());
-    log.info(base64encoded);
     var tokenEndpoint = "https://localhost:8243/token";
     var result = post(tokenEndpoint, tokenRequestData,{"Authorization": "Basic " + base64encoded});
 
-    log.info(result.data);
+    log.debug("Token response: " + result.data);
     response.contentType = "application/json";
     var token_response = JSON.parse(result.data);
 
@@ -47,16 +47,16 @@
     // Setting access token part 1 as secured HTTP only cookie, Can't restrict the path to /api/am/publisher
     // because partial HTTP only cookie is required for get the user information from access token,
     // hence setting the HTTP only access token path to /publisher-new/
-    var cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/publisher-new/", "HttpOnly": true, "secure": true, "maxAge": -1};
+    var cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/publisher-new/", "HttpOnly": true, "secure": true, "maxAge": Integer(token_response.expires_in)};
     response.addCookie(cookie);
 
-    cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/api/am/publisher/", "HttpOnly": true, "secure": true, "maxAge": -1};
+    cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/api/am/publisher/", "HttpOnly": true, "secure": true, "maxAge": Integer(token_response.expires_in)};
     response.addCookie(cookie);
 
     cookie = {'name': 'AM_REF_TOKEN_DEFAULT_P2', 'value': refresh_token_token_part_2, 'path': "/publisher-new/", "HttpOnly": true, "secure": true, "maxAge": -1};
     response.addCookie(cookie);
 
-    cookie = {'name': 'WSO2_AM_TOKEN_1_Default', 'value': access_token_token_part_1, 'path': "/publisher-new/", "secure": true, "maxAge": -1}; // TODO: set maxage accordingly to toke expire time ~tmkb
+    cookie = {'name': 'WSO2_AM_TOKEN_1_Default', 'value': access_token_token_part_1, 'path': "/publisher-new/", "secure": true, "maxAge": Integer(token_response.expires_in)}; 
     response.addCookie(cookie);
 
     response.sendRedirect("/publisher-new/apis");

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/login/token_callback.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/login/token_callback.jag
@@ -15,6 +15,7 @@
     var clientSecret = systemApplicationDTO.getConsumerSecret();
     var Base64 = org.apache.axiom.om.util.Base64;
     var String = Packages.java.lang.String;
+    var Integer = Packages.java.lang.Integer;
     var base64encoded = Base64.encode ( new String (clientId + ":" + clientSecret).getBytes());
     var tokenEndpoint = "https://localhost:8243/token";
     var result = post(tokenEndpoint, tokenRequestData,{"Authorization": "Basic " + base64encoded});
@@ -46,16 +47,16 @@
     // Setting access token part 1 as secured HTTP only cookie, Can't restrict the path to /api/am/store
     // because partial HTTP only cookie is required for get the user information from access token,
     // hence setting the HTTP only access token path to /store-new/
-    var cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/store-new/", "HttpOnly": true, "secure": true, "maxAge": -1};
+    var cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/store-new/", "HttpOnly": true, "secure": true, "maxAge": Integer(token_response.expires_in)};
     response.addCookie(cookie);
 
-    cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/api/am/store/", "HttpOnly": true, "secure": true, "maxAge": -1};
+    cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/api/am/store/", "HttpOnly": true, "secure": true, "maxAge": Integer(token_response.expires_in)};
     response.addCookie(cookie);
 
     cookie = {'name': 'AM_REF_TOKEN_DEFAULT_P2', 'value': refresh_token_token_part_2, 'path': "/store-new/", "HttpOnly": true, "secure": true, "maxAge": -1};
     response.addCookie(cookie);
 
-    cookie = {'name': 'WSO2_AM_TOKEN_1_Default', 'value': access_token_token_part_1, 'path': "/store-new/", "secure": true, "maxAge": -1}; // TODO: set maxage accordingly to toke expire time ~tmkb
+    cookie = {'name': 'WSO2_AM_TOKEN_1_Default', 'value': access_token_token_part_1, 'path': "/store-new/", "secure": true, "maxAge": Integer(token_response.expires_in)}; 
     response.addCookie(cookie);
 
     response.sendRedirect("/store-new/apis");


### PR DESCRIPTION
## Issue
Product-apim: https://github.com/wso2/product-apim/issues/4756

## Purpose

- Need to add expiry time taken from token response, when setting the cookies.
- Remove unnecessary log.info() methods

## Goals
Cookies should be expired according to the given specific expiry time.