### PR TITLE
OIDC logout for publisher

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/jaggery.conf
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/jaggery.conf
@@ -18,8 +18,8 @@
             "path": "/site/public/pages/index.html"
         },
         {
-            "url": "/logout/*",
-            "path": "/site/public/pages/index.html"
+            "url": "/services/logout",
+            "path": "/services/logout/logout.jag"
         },
         {
             "url": "/endpoints/*",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/configs/config.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/configs/config.jag
@@ -36,6 +36,8 @@
     }
     var authRequestParams = "?response_type=code&client_id=" + clientId + "&scope=" + scopes + "&redirect_uri=" + callbackUrl;
     log.debug("Redirecting to = " + authorizeEndpoint + authRequestParams);
+    var cookie = {'name': 'CLIENT_ID', 'value': clientId, 'path': "/publisher-new/", "HttpOnly": false, "secure": true, "maxAge": -1};
+    response.addCookie(cookie);
     response.sendRedirect(authorizeEndpoint + authRequestParams);
 
 %>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/login/token_callback.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/login/token_callback.jag
@@ -1,64 +1,118 @@
 <%
     var log = new Log("Token Request Function");
+    var state = request.getParameter("state","UTF-8");
+    log.debug("state: " + state);
+    if ( state !== null ) {
+        var SystemApplicationDTO = Packages.org.wso2.carbon.apimgt.impl.dao.SystemApplicationDAO;
+        var systemApplicationDAO = new SystemApplicationDTO();
+        var systemApplicationDTO = systemApplicationDAO.getClientCredentialsForApplication("admin_publisher");
 
-    var tokenRequestData = {
-        "grant_type": "authorization_code",
-        "code": request.getParameter("code","UTF-8"),
-        "redirect_uri": "https://localhost:9443/publisher-new/services/auth/callback",
-    };
+        var clientId = systemApplicationDTO.getConsumerKey();
+        var clientSecret = systemApplicationDTO.getConsumerSecret();
+        var Base64 = org.apache.axiom.om.util.Base64;
+        var String = Packages.java.lang.String;
+        var base64encoded = Base64.encode ( new String (clientId + ":" + clientSecret).getBytes());
+        var tokenRevokeEndpoint = "https://localhost:9443/oauth2/revoke";
 
-    var SystemApplicationDTO = Packages.org.wso2.carbon.apimgt.impl.dao.SystemApplicationDAO;
-    var systemApplicationDAO = new SystemApplicationDTO();
-    var systemApplicationDTO = systemApplicationDAO.getClientCredentialsForApplication("admin_publisher");
+        var tokenP1 = request.getCookie("WSO2_AM_TOKEN_1_Default").value;
+        var tokenP2 = request.getCookie("AM_ACC_TOKEN_DEFAULT_P2").value;
+        var token = tokenP1 + tokenP2;
+        var tokenRevokeRequestData = {
+            "token": token
+        };
+        var result = post(tokenRevokeEndpoint, tokenRevokeRequestData,{"Authorization": "Basic " + base64encoded});
+        log.debug("revoke token response:"+response);
 
-    var clientId = systemApplicationDTO.getConsumerKey();
-    var clientSecret = systemApplicationDTO.getConsumerSecret();
-    var Base64 = org.apache.axiom.om.util.Base64;
-    var String = Packages.java.lang.String;
-    var Integer = Packages.java.lang.Integer;
-    var base64encoded = Base64.encode ( new String (clientId + ":" + clientSecret).getBytes());
-    var tokenEndpoint = "https://localhost:8243/token";
-    var result = post(tokenEndpoint, tokenRequestData,{"Authorization": "Basic " + base64encoded});
+        var cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': '', 'path': "/publisher-new/", "HttpOnly": true, "secure": true, "maxAge": 2};
+        response.addCookie(cookie);
 
-    log.debug("Token response: " + result.data);
-    response.contentType = "application/json";
-    var token_response = JSON.parse(result.data);
+        cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': '', 'path': "/api/am/publisher/", "HttpOnly": true, "secure": true, "maxAge": 2};
+        response.addCookie(cookie);
 
-    var token_length = token_response.access_token.length;
-    var access_token = String(token_response.access_token);
+        cookie = {'name': 'AM_REF_TOKEN_DEFAULT_P2', 'value': '', 'path': "/publisher-new/", "HttpOnly": true, "secure": true, "maxAge": 2};
+        response.addCookie(cookie);
 
+        cookie = {'name': 'WSO2_AM_TOKEN_1_Default', 'value': '', 'path': "/publisher-new/", "secure": true, "maxAge": 2}; 
+        response.addCookie(cookie);
 
-    var access_token_token_part_1 = access_token.substring(0, token_length/2);
-    var access_token_token_part_2 = access_token.substring(token_length/2, token_length);
+        cookie = {'name': 'AM_ID_TOKEN_DEFAULT_P2', 'value':'', 'path': "/publisher-new/services/logout", "secure": true, "maxAge": 2}; 
+        response.addCookie(cookie);
 
-    var refresh_token = String(token_response.refresh_token);
-    token_length = token_response.refresh_token.length;
-    var refresh_token_token_part_1 = refresh_token.substring(0, token_length/2);
-    var refresh_token_token_part_2 = refresh_token.substring(token_length/2, token_length);
+        cookie = {'name': 'AM_ID_TOKEN_DEFAULT_P1', 'value':'', 'path': "/publisher-new/services/logout", "secure": true, "maxAge": 2}; 
+        response.addCookie(cookie);
 
-    var response_data = {
-        AM_ACC_TOKEN_DEFAULT_P1: String(access_token_token_part_1),
-        AM_REF_TOKEN_DEFAULT_P1: String(refresh_token_token_part_1),
-        id_token: String(token_response.id_token),
-        scope: String(token_response.scope),
-        expires_in: String(token_response.expires_in)
-    } // TODO: not in use ~tmkb
+        log.debug("redirecting to login");
+        response.sendRedirect("/publisher-new/login");
+    } else {
+        var tokenRequestData = {
+            "grant_type": "authorization_code",
+            "code": request.getParameter("code","UTF-8"),
+            "redirect_uri": "https://localhost:9443/publisher-new/services/auth/callback",
+        };
 
-    // Setting access token part 1 as secured HTTP only cookie, Can't restrict the path to /api/am/publisher
-    // because partial HTTP only cookie is required for get the user information from access token,
-    // hence setting the HTTP only access token path to /publisher-new/
-    var cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/publisher-new/", "HttpOnly": true, "secure": true, "maxAge": Integer(token_response.expires_in)};
-    response.addCookie(cookie);
+        var SystemApplicationDTO = Packages.org.wso2.carbon.apimgt.impl.dao.SystemApplicationDAO;
+        var systemApplicationDAO = new SystemApplicationDTO();
+        var systemApplicationDTO = systemApplicationDAO.getClientCredentialsForApplication("admin_publisher");
 
-    cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/api/am/publisher/", "HttpOnly": true, "secure": true, "maxAge": Integer(token_response.expires_in)};
-    response.addCookie(cookie);
+        var clientId = systemApplicationDTO.getConsumerKey();
+        var clientSecret = systemApplicationDTO.getConsumerSecret();
+        var Base64 = org.apache.axiom.om.util.Base64;
+        var String = Packages.java.lang.String;
+        var Integer = Packages.java.lang.Integer;
+        var base64encoded = Base64.encode ( new String (clientId + ":" + clientSecret).getBytes());
+        var tokenEndpoint = "https://localhost:8243/token";
+        var result = post(tokenEndpoint, tokenRequestData,{"Authorization": "Basic " + base64encoded});
 
-    cookie = {'name': 'AM_REF_TOKEN_DEFAULT_P2', 'value': refresh_token_token_part_2, 'path': "/publisher-new/", "HttpOnly": true, "secure": true, "maxAge": -1};
-    response.addCookie(cookie);
+        log.debug("Token response: " + result.data);
+        response.contentType = "application/json";
+        var token_response = JSON.parse(result.data);
 
-    cookie = {'name': 'WSO2_AM_TOKEN_1_Default', 'value': access_token_token_part_1, 'path': "/publisher-new/", "secure": true, "maxAge": Integer(token_response.expires_in)}; 
-    response.addCookie(cookie);
+        var token_length = token_response.access_token.length;
+        var access_token = String(token_response.access_token);
 
-    response.sendRedirect("/publisher-new/apis");
+        var id_token_length = token_response.id_token.length;
+        var id_token = String(token_response.id_token);
 
+        var id_token_part_1 = id_token.substring(0,id_token_length/2);
+        var id_token_part_2 = id_token.substring(id_token_length/2,id_token_length);
+
+        var access_token_token_part_1 = access_token.substring(0, token_length/2);
+        var access_token_token_part_2 = access_token.substring(token_length/2, token_length);
+
+        var refresh_token = String(token_response.refresh_token);
+        token_length = token_response.refresh_token.length;
+        var refresh_token_token_part_1 = refresh_token.substring(0, token_length/2);
+        var refresh_token_token_part_2 = refresh_token.substring(token_length/2, token_length);
+
+        var response_data = {
+            AM_ACC_TOKEN_DEFAULT_P1: String(access_token_token_part_1),
+            AM_REF_TOKEN_DEFAULT_P1: String(refresh_token_token_part_1),
+            id_token: String(token_response.id_token),
+            scope: String(token_response.scope),
+            expires_in: String(token_response.expires_in)
+        } // TODO: not in use ~tmkb
+
+        // Setting access token part 1 as secured HTTP only cookie, Can't restrict the path to /api/am/publisher
+        // because partial HTTP only cookie is required for get the user information from access token,
+        // hence setting the HTTP only access token path to /publisher-new/
+        var cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/publisher-new/", "HttpOnly": true, "secure": true, "maxAge": Integer(token_response.expires_in)};
+        response.addCookie(cookie);
+
+        cookie = {'name': 'AM_ACC_TOKEN_DEFAULT_P2', 'value': access_token_token_part_2, 'path': "/api/am/publisher/", "HttpOnly": true, "secure": true, "maxAge": Integer(token_response.expires_in)};
+        response.addCookie(cookie);
+
+        cookie = {'name': 'AM_REF_TOKEN_DEFAULT_P2', 'value': refresh_token_token_part_2, 'path': "/publisher-new/", "HttpOnly": true, "secure": true, "maxAge": -1};
+        response.addCookie(cookie);
+
+        cookie = {'name': 'WSO2_AM_TOKEN_1_Default', 'value': access_token_token_part_1, 'path': "/publisher-new/", "secure": true, "maxAge": Integer(token_response.expires_in)}; 
+        response.addCookie(cookie);
+
+        cookie = {'name': 'AM_ID_TOKEN_DEFAULT_P2', 'value':id_token_part_2, 'path': "/publisher-new/services/logout", "secure": true, "maxAge": Integer(token_response.expires_in)}; 
+        response.addCookie(cookie);
+
+        cookie = {'name': 'AM_ID_TOKEN_DEFAULT_P1', 'value':id_token_part_1, 'path': "/publisher-new/services/logout", "secure": true, "maxAge": Integer(token_response.expires_in)}; 
+        response.addCookie(cookie);
+
+        response.sendRedirect("/publisher-new/apis");
+    }
 %>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/logout/logout.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/logout/logout.jag
@@ -1,0 +1,13 @@
+<%
+    var log = new Log("Logout Request Function");
+    var idTokenP1 = request.getCookie("AM_ID_TOKEN_DEFAULT_P1").value;
+    var idTokenP2 = request.getCookie("AM_ID_TOKEN_DEFAULT_P2").value;
+    var idToken = idTokenP1 + idTokenP2;
+    // var idToken = session.get('idToken');
+    var postLogoutRedirectURI = "https://localhost:9443/publisher-new/services/auth/callback";
+    var logoutState = "state_1";
+    var url = 'https://localhost:9443/oidc/logout?id_token_hint=' + idToken
+        + '&post_logout_redirect_uri=' + postLogoutRedirectURI + '&state=' + logoutState;
+    log.debug("Redirecting to = " + url);
+    response.sendRedirect(url);
+%>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Base/Header/avatar/Avatar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Base/Header/avatar/Avatar.jsx
@@ -15,7 +15,7 @@ import AccountCircle from '@material-ui/icons/AccountCircle';
 import NightMode from '@material-ui/icons/Brightness2';
 import { withStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
-import qs from 'qs';
+// import qs from 'qs';
 import PropTypes from 'prop-types';
 
 const styles = theme => ({
@@ -68,6 +68,15 @@ class Avatar extends Component {
     }
 
     /**
+     * Do OIDC logout redirection
+     * @param {React.SyntheticEvent} e Click event of the submit button
+     */
+    doOIDCLogout = (e) => {
+        e.preventDefault();
+        window.location = '/publisher-new/services/logout';
+    }
+
+    /**
      *
      * @inheritdoc
      * @returns {React.Component} @inheritdoc
@@ -75,10 +84,10 @@ class Avatar extends Component {
      */
     render() {
         const { classes, user } = this.props;
-        const { pathname } = window.location;
-        const params = qs.stringify({
-            referrer: pathname.split('/').reduce((acc, cv, ci) => (ci <= 1 ? '' : acc + '/' + cv)),
-        });
+        // const { pathname } = window.location;
+        // const params = qs.stringify({
+        //     referrer: pathname.split('/').reduce((acc, cv, ci) => (ci <= 1 ? '' : acc + '/' + cv)),
+        // });
         const { openMenu, profileIcon } = this.state;
         return (
             <React.Fragment>
@@ -99,8 +108,8 @@ class Avatar extends Component {
                                     <MenuList>
                                         <MenuItem onClick={this.toggleMenu}>Profile</MenuItem>
                                         <MenuItem onClick={this.toggleMenu}>My account</MenuItem>
-                                        <Link to={{ pathname: '/logout', search: params }}>
-                                            <MenuItem onClick={this.toggleMenu}>Logout</MenuItem>
+                                        <Link to={{ pathname: '/services/logout' }}>
+                                            <MenuItem onClick={this.doOIDCLogout}>Logout</MenuItem>
                                         </Link>
 
                                         <Divider />

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Login/SelectLogin.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Login/SelectLogin.jsx
@@ -32,22 +32,41 @@ import './login.css';
  * @extends {Component}
  */
 class SelectLogin extends Component {
+    /**
+     * Creates an instance of SelectLogin.
+     * @param {any} props @inheritDoc
+     * @memberof SelectLogin
+     */
     constructor(props) {
         super(props);
         this.doBasicLogin = this.doBasicLogin.bind(this);
         this.doIDPLogin = this.doIDPLogin.bind(this);
     }
 
+    /**
+     * Do Basic Authentication redirection
+     * @param {React.SyntheticEvent} e Click event of the submit button
+     */
     doBasicLogin = (e) => {
         e.preventDefault();
         window.location = '/publisher-new/login/basic';
     }
 
+    /**
+     * Do IDP Authentication redirection
+     * @param {React.SyntheticEvent} e Click event of the submit button
+     */
     doIDPLogin = (e) => {
         e.preventDefault();
         window.location = '/publisher-new/services/configs';
     }
 
+    /**
+     *
+     *
+     * @returns {React.Component} Render SelectLogin component
+     * @memberof SelectLogin
+     */
     render() {
         return (
             <div className='login-flex-container'>


### PR DESCRIPTION
## Issue
Product-apim: https://github.com/wso2/product-apim/issues/4799 

## Purpose
Users should be able to logged out of the application. 

## Goals
User session in the browser should be destroyed.
User session in the IDP server should be destroyed.
User should be redirected to login page once logged out.

## Approach
POST request to the oidc/logout endpoint will destory the IDP user logged in session. In this request id_token and redirection url will be provided. This id_token is generated when the user access token request to the /token endpoint happens and will be stored in the session. Once this POST request successfully completed, it will be redirected to provided auth/callback endpoint ,and in here, the user browser cookies will be removed and user will be redirected to the login page.

## User stories
User should be able to successfully logged out of the application.