### PR TITLE
Fix Travis configs 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: java
-sudo: false
+sudo: true
+# Can't update to xenial distribution (ubuntu 16.04) bause of the Java JDK restriction (Not supporting )
+dist: trusty
 
 # Using -q Quiet output which only show errors, to overcome TravisCI log limit issue
-script: mvn clean install -q -B -V | grep -v DEBUG; exit "${PIPESTATUS[0]}";
+script: mvn clean install -Dmaven.test.skip -q -B -V | grep -v DEBUG; exit "${PIPESTATUS[0]}";
 
 cache:
   directories:
   - $HOME/.m2_1
+  - $HOME/.m2
+  - features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/node_modules
+  - features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/node_modules


### PR DESCRIPTION
## Purpose
Change Travis configs to prevent exceeding execution time cap in Travis free tier.

Note that, I have skip running the test, for the time being, to complete the build within the 50 minutes limit. Until we figure out a way to run the build with tests within 50 min limit.

- Travis default JDK is: `Leiningen 2.9.1 on Java 11.0.2 OpenJDK 64-Bit Server VM`
- Had to change the JDK version. (Since JDK 8 is EOL they don't [use it by default](https://docs.travis-ci.com/user/languages/java/))

With this, we could at least make sure that, Changes will not break the build. Otherwise, there is no use of Travis at all. We just ignore its build failures and merge the PRs?

WDYT?