### PR TITLE
Fix the issue of not showing all the scopes in Store UI 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
@@ -792,7 +792,18 @@ public interface APIConsumer extends APIManager {
 	 */
 	Set<Scope> getScopesBySubscribedAPIs(List<APIIdentifier> identifiers) throws APIManagementException;
 
-	/**
+    /**
+     * Returns a set of scopes associated with an application subscription.
+     *
+     * @param username    subscriber of the application
+     * @param applicationId applicationId of the application
+     * @return set of scopes.
+     * @throws APIManagementException
+     */
+    JSONArray getScopesForApplicationSubscription(String username, int applicationId)
+            throws APIManagementException;
+
+    /**
 	 * Returns the scopes of an access token as a string
 	 *
 	 * @param accessToken access token you want to receive scopes for

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -2583,7 +2583,6 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             JSONObject scopeObj = new JSONObject();
             scopeObj.put("scopeKey", scope.getKey());
             scopeObj.put("scopeName", scope.getName());
-
             scopeArray.add(scopeObj);
         }
         return scopeArray;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -2570,6 +2570,25 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         return subscribedAPIs;
     }
 
+    public JSONArray getScopesForApplicationSubscription(String username, int applicationId)
+            throws APIManagementException {
+        Set<Scope> scopeSet = new LinkedHashSet<Scope>();
+        JSONObject scopeList = new JSONObject();
+        JSONArray scopeArray = new JSONArray();
+
+        Subscriber subscriber = new Subscriber(username);
+        scopeSet = apiMgtDAO.getScopesForApplicationSubscription(subscriber, applicationId);
+
+        for (Scope scope : scopeSet) {
+            JSONObject scopeObj = new JSONObject();
+            scopeObj.put("scopeKey", scope.getKey());
+            scopeObj.put("scopeName", scope.getName());
+
+            scopeArray.add(scopeObj);
+        }
+        return scopeArray;
+    }
+
     /*
      *@see super.getSubscribedAPIsByApplicationId
      *

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -110,6 +110,22 @@ public class SQLConstants {
             "   AND API.API_ID = SP.API_ID" +
             "   AND SP.SUBS_CREATE_STATE = '" +APIConstants.SubscriptionCreatedStatus.SUBSCRIBE + "'";
 
+    public static final String GET_SUBSCRIBED_API_IDs_BY_APP_ID_SQL =
+            " SELECT " +
+                    "   API.API_ID " +
+                    " FROM " +
+                    "   AM_SUBSCRIBER SUB," +
+                    "   AM_APPLICATION APP, " +
+                    "   AM_SUBSCRIPTION SUBS, " +
+                    "   AM_API API " +
+                    " WHERE " +
+                    "   SUB.TENANT_ID = ? " +
+                    "   AND SUB.SUBSCRIBER_ID=APP.SUBSCRIBER_ID " +
+                    "   AND APP.APPLICATION_ID=SUBS.APPLICATION_ID " +
+                    "   AND API.API_ID=SUBS.API_ID" +
+                    "   AND APP.APPLICATION_ID= ? " +
+                    "   AND SUBS.SUBS_CREATE_STATE = '" + APIConstants.SubscriptionCreatedStatus.SUBSCRIBE + "'";
+
     public static final String GET_SUBSCRIBED_APIS_OF_USER_BY_APP_SQL =
             " SELECT " +
                     "   API.API_PROVIDER AS API_PROVIDER," +

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/modules/subscription/list.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/modules/subscription/list.jag
@@ -68,6 +68,28 @@ var getAllSubscriptionsOfApplicationById = function (username, selectedAppId, st
     }
 };
 
+var getAllScopesOfApplicationSubscription = function (username, selectedAppId)  {
+    var result,
+    log = new Log(),
+    store = jagg.module("manager"). getAPIConsumerObj();
+    try {
+	    result = store.getScopesForApplicationSubscription(username , selectedAppId);
+        if (log.isDebugEnabled()) {
+            log.debug("getAllScopesOfApplicationSubscription : " + stringify(result));
+        }
+        return {
+            error:false,
+            result:result
+        };
+    } catch (e) {
+        log.error(e);
+        return {
+            error:true,
+            result:e
+        };
+    }
+};
+
 var getAPISubscriptions = function (api, username) {
     var subscriptions,
             log = new Log(),

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/modules/subscription/module.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/modules/subscription/module.jag
@@ -17,6 +17,10 @@ jagg.module("subscription", {
         return jagg.require(jagg.getModulesDir() + "subscription/list.jag").getAllSubscriptions.apply(this, arguments);
     },
 
+    getAllScopesOfApplicationSubscription:function () {
+        return jagg.require(jagg.getModulesDir() + "subscription/list.jag").getAllScopesOfApplicationSubscription.apply(this, arguments);
+    },
+
     getAllSubscriptionsOfApplication:function () {
         return jagg.require(jagg.getModulesDir() + "subscription/list.jag").getAllSubscriptionsOfApplication.apply(this, arguments);
     },

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/application/application-view/block.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/application/application-view/block.jag
@@ -7,8 +7,10 @@ jagg.block("application/application-view", {
     getOutputs:function (inputs) {
         user = jagg.getUser();
         var application = null;
+        var applicationId = null;
         var oauthapp = null;
         var scopes = [];
+        var scopeList = [];
         var grant_types = [];
         if (user) {
             username = user.username;
@@ -18,8 +20,14 @@ jagg.block("application/application-view", {
             mod = jagg.module("application");
             result = mod.getApplicationById(username, applicationId + '', groupId);
             application = result.application;
+            applicationId = application.id;
 
             var result2 = jagg.module("subscription").getAllSubscriptionsOfApplicationById(username, applicationId, 0, 10);
+            var scopesResult = jagg.module("subscription").getAllScopesOfApplicationSubscription(username, applicationId);
+
+            for (i = 0; i < scopesResult.result.size(); i++) {
+                scopeList.push({"scopeKey": scopesResult.result.get(i).get("scopeKey"), "scopeName": scopesResult.result.get(i).get("scopeName")});
+            }
 
             var log = new Log();
 
@@ -29,7 +37,7 @@ jagg.block("application/application-view", {
                 for(i=0;i < result2.applications.length;i++){
                     if(result2.applications[i].name == applicationName){
                         oauthapp = result2.applications[i];
-                        scopes = oauthapp.scopes;
+                        scopes = scopeList;
                     }
                 }
             }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/application/application-view/block.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/application/application-view/block.jag
@@ -7,7 +7,6 @@ jagg.block("application/application-view", {
     getOutputs:function (inputs) {
         user = jagg.getUser();
         var application = null;
-        var applicationId = null;
         var oauthapp = null;
         var scopes = [];
         var scopeList = [];
@@ -20,7 +19,6 @@ jagg.block("application/application-view", {
             mod = jagg.module("application");
             result = mod.getApplicationById(username, applicationId + '', groupId);
             application = result.application;
-            applicationId = application.id;
 
             var result2 = jagg.module("subscription").getAllSubscriptionsOfApplicationById(username, applicationId, 0, 10);
             var scopesResult = jagg.module("subscription").getAllScopesOfApplicationSubscription(username, applicationId);


### PR DESCRIPTION
## Purpose
The number of scopes can be shown in the drop-down list of APIM Store is limited to 10.if we have more scopes than 10, then scopes which exceed 10 are disappeared from the drop-down list.

refer: https://github.com/wso2/product-apim/issues/4723

## Goals
Extract all the scopes of subscribed application from the DB

## Approach
Introduced new method to extract only all the scopes related to an application from the DB level.

