### PR TITLE
Fix getSubscriptionByApplication when group sharing is enabled

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/subscription/subscription-list/ajax/subscription-list.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/blocks/subscription/subscription-list/ajax/subscription-list.jag
@@ -200,6 +200,9 @@ include("/jagg/jagg.jag");
         var groupId = session.get("groupId");
         if (jagg.isMultiGroupEnabled()) {
             groupId = request.getParameter("groupId");
+            if (!groupId) {
+                groupId = "";
+            }
         }
 
         result = mod.getAPISubscriptionsForApplication(username, appname, groupId);


### PR DESCRIPTION
## Purpose
This PR fixes the issue [1] where Jaggery API [2] does not work when application group sharing is enabled.

[1] wso2/product-apim#4754
[2] https://docs.wso2.com/display/AM260/Store+APIs#StoreAPIs-ListSubscriptionsbyApplication