### PR TITLE
 Navigate to API console after token generation from Wizard

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
@@ -431,7 +431,7 @@ Applications )
                                         </Grid>
                                     </AppBar>
                                     <div className={classes.plainContent}>
-                                        <Wizard onClickFunction={(a,b)=>this.handleClickToggle(a,b)} updateSubscriptionData={updateSubscriptionData}/>
+                                        <Wizard apiId={api.id} onClickFunction={(a,b)=>this.handleClickToggle(a,b)} updateSubscriptionData={updateSubscriptionData}/>
                                     </div>
                                 </Dialog>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Wizard.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Wizard.jsx
@@ -312,7 +312,7 @@ class Wizard extends React.Component {
 
     /**
      *
-     *
+     * Set state.redirect to true to redirect to the API console page
      * @memberof Wizard
      */
     handleRedirectTest = () => {

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Wizard.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Wizard.jsx
@@ -84,6 +84,7 @@ class Wizard extends React.Component {
         super(props);
         this.getStepContent = this.getStepContent.bind(this);
         this.handleNext = this.handleNext.bind(this);
+        this.handleRedirectTest = this.handleRedirectTest.bind(this);
     }
 
     state = {
@@ -315,7 +316,7 @@ class Wizard extends React.Component {
      * Set state.redirect to true to redirect to the API console page
      * @memberof Wizard
      */
-    handleRedirectTest = () => {
+    handleRedirectTest() {
         this.setState({ redirect: true });
 
     };

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Wizard.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Wizard.jsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 import React from 'react';
+import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
@@ -90,6 +91,7 @@ class Wizard extends React.Component {
         activeStep: 0,
         appId: null,
         tab: 0,
+        redirect: false,
     };
 
     /**
@@ -311,10 +313,24 @@ class Wizard extends React.Component {
     /**
      *
      *
+     * @memberof Wizard
+     */
+    handleRedirectTest = () => {
+        this.setState({ redirect: true });
+
+    };
+
+    /**
+     *
+     *
      * @returns
      * @memberof Wizard
      */
     render() {
+        if (this.state.redirect) {
+            return <Redirect push to={'/apis/' + this.props.apiId + '/test'} />;
+        }
+
         const { classes } = this.props;
         const steps = getSteps();
         const { activeStep } = this.state;
@@ -349,7 +365,9 @@ class Wizard extends React.Component {
                                             <Button disabled={activeStep === 0} onClick={this.handleBack} className={classes.button} variant='outlined'>
                                                 Back
                                             </Button>
-
+                                            <Button disabled={activeStep < steps.length - 1} onClick={this.handleRedirectTest} className={classes.button} variant='outlined'>
+                                                Test
+                                            </Button>
                                             <Button variant='contained' color='primary' onClick={() => this.handleNext()} className={classes.button}>
                                                 {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
                                             </Button>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/index.jsx
@@ -272,8 +272,10 @@ class Details extends React.Component {
      * @memberof Details
      */
     updateActiveLink() {
+        const { active } = this.state;
         const currentLink = this.props.location.pathname.match(/[^\/]+(?=\/$|$)/g);
-        if (currentLink && currentLink.length > 0 && this.state.active !== currentLink[0]) {
+
+        if (currentLink && currentLink.length > 0 && active !== currentLink[0]) {
             this.setState({ active: currentLink[0] });
         }
     }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/index.jsx
@@ -262,11 +262,20 @@ class Details extends React.Component {
      * @memberof Details
      */
     componentDidMount() {
+        this.updateActiveLink();
+        this.updateSubscriptionData();
+    }
+
+    /**
+     *
+     * Selects the active link for the side panel based on the URL
+     * @memberof Details
+     */
+    updateActiveLink() {
         const currentLink = this.props.location.pathname.match(/[^\/]+(?=\/$|$)/g);
-        if (currentLink && currentLink.length > 0) {
+        if (currentLink && currentLink.length > 0 && this.state.active !== currentLink[0]) {
             this.setState({ active: currentLink[0] });
         }
-        this.updateSubscriptionData();
     }
 
     /**
@@ -276,8 +285,10 @@ class Details extends React.Component {
      * @memberof Details
      */
     render() {
+        this.updateActiveLink();
+
         const { classes, theme } = this.props;
-        const { api } = this.state;
+        const { active } = this.state;
         const redirect_url = '/apis/' + this.props.match.params.api_uuid + '/overview';
         const leftMenuIconMainSize = theme.custom.leftMenuIconMainSize;
         const globalStyle = 'body{ font-family: ' + theme.typography.fontFamily + '}';
@@ -291,12 +302,12 @@ class Details extends React.Component {
                             <Typography className={classes.leftLInkMainText}>ALL APIs</Typography>
                         </div>
                     </Link>
-                    <LeftMenuItem text='overview' handleMenuSelect={this.handleMenuSelect} active={this.state.active} />
-                    <LeftMenuItem text='credentials' handleMenuSelect={this.handleMenuSelect} active={this.state.active} />
-                    <LeftMenuItem text='comments' handleMenuSelect={this.handleMenuSelect} active={this.state.active} />
-                    <LeftMenuItem text='test' handleMenuSelect={this.handleMenuSelect} active={this.state.active} />
-                    <LeftMenuItem text='docs' handleMenuSelect={this.handleMenuSelect} active={this.state.active} />
-                    <LeftMenuItem text='sdk' handleMenuSelect={this.handleMenuSelect} active={this.state.active} />
+                    <LeftMenuItem text='overview' handleMenuSelect={this.handleMenuSelect} active={active} />
+                    <LeftMenuItem text='credentials' handleMenuSelect={this.handleMenuSelect} active={active} />
+                    <LeftMenuItem text='comments' handleMenuSelect={this.handleMenuSelect} active={active} />
+                    <LeftMenuItem text='test' handleMenuSelect={this.handleMenuSelect} active={active} />
+                    <LeftMenuItem text='docs' handleMenuSelect={this.handleMenuSelect} active={active} />
+                    <LeftMenuItem text='sdk' handleMenuSelect={this.handleMenuSelect} active={active} />
                 </div>
                 <div className={classes.content}>
                     <InfoBar api_uuid={this.props.match.params.api_uuid} innerRef={node => (this.infoBar = node)} />


### PR DESCRIPTION
## Purpose
When subscribing to API from a new app using the wizard, provide an option to navigate to the API console page once token is generated.