### PR TITLE
Fix swagger local entry implemenation to support multi-tenant scenario

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/APILocalEntryAdmin.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/APILocalEntryAdmin.java
@@ -34,45 +34,49 @@ public class APILocalEntryAdmin extends org.wso2.carbon.core.AbstractAdmin {
      * Add Local Entry to the gateway.
      *
      * @param content
+     * @param tenantDomain Tenant Domain
      * @return Status of the operation
      * @throws AxisFault
      */
-    public boolean addLocalEntry(String content) throws AxisFault {
-        LocalEntryClient localEntryClient = getLocalEntryAdminClient();
+    public boolean addLocalEntry(String content, String tenantDomain) throws AxisFault {
+        LocalEntryClient localEntryClient = getLocalEntryAdminClient(tenantDomain);
         return localEntryClient.addLocalEntry(content);
     }
 
     /**
      * Get the Local entry client.
      *
+     * @param tenantDomain Tenant Domain
      * @return LocalEntryClient
      * @throws AxisFault
      */
-    protected LocalEntryClient getLocalEntryAdminClient() throws AxisFault {
-        return new LocalEntryClient();
+    protected LocalEntryClient getLocalEntryAdminClient(String tenantDomain) throws AxisFault {
+        return new LocalEntryClient(tenantDomain);
     }
 
     /**
      * Get the Local entry for given API.
      *
-     * @param key key of the existing local entry.
+     * @param key          key of the existing local entry.
+     * @param tenantDomain Tenant Domain
      * @return LocalEntry
      * @throws AxisFault
      */
-    public Object getEntry(String key) throws AxisFault {
-        LocalEntryClient localEntryAdminClient = getLocalEntryAdminClient();
+    public Object getEntry(String key, String tenantDomain) throws AxisFault {
+        LocalEntryClient localEntryAdminClient = getLocalEntryAdminClient(tenantDomain);
         return localEntryAdminClient.getEntry(key);
     }
 
     /**
      * Delete the local entry.
      *
-     * @param key Key of the local entry to be deleted.
+     * @param key          Key of the local entry to be deleted.
+     * @param tenantDomain Tenant Domain
      * @return Status of the operation
      * @throws AxisFault
      */
-    public Boolean deleteLocalEntry(String key) throws AxisFault {
-        LocalEntryClient localEntryAdminClient = getLocalEntryAdminClient();
+    public Boolean deleteLocalEntry(String key, String tenantDomain) throws AxisFault {
+        LocalEntryClient localEntryAdminClient = getLocalEntryAdminClient(tenantDomain);
         return localEntryAdminClient.deleteEntry(key);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -220,7 +220,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             Environment environment = environments.get(environmentName);
             api.getEnvironments();
             try {
-                localEntryAdminClient = new LocalEntryAdminClient(environment);
+                localEntryAdminClient = new LocalEntryAdminClient(environment, tenantDomain);
                 localEntryAdminClient.deleteEntry(api.getUUID());
                 localEntryAdminClient.addLocalEntry("<localEntry key=\"" + api.getUUID() + "\">" +
                         jsonText.replaceAll("&(?!amp;)", "&amp;").
@@ -244,7 +244,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         for (String environmentName : api.getEnvironments()) {
             Environment environment = environments.get(environmentName);
             try {
-                localEntryAdminClient = new LocalEntryAdminClient(environment);
+                localEntryAdminClient = new LocalEntryAdminClient(environment, tenantDomain);
                 localEntryAdminClient.deleteEntry(api.getUUID());
             } catch (AxisFault e) {
                 log.error("Error occurred while Deleting the local entry ", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/LocalEntryAdminClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/LocalEntryAdminClient.java
@@ -25,7 +25,6 @@ import org.apache.axis2.client.Stub;
 import org.apache.axis2.context.ServiceContext;
 import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.axis2.util.URL;
-import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.impl.dto.Environment;
 import org.wso2.carbon.apimgt.localentry.stub.APILocalEntryAdminStub;
 import org.wso2.carbon.authenticator.stub.AuthenticationAdminStub;
@@ -42,8 +41,10 @@ import java.rmi.RemoteException;
  */
 public class LocalEntryAdminClient {
     private APILocalEntryAdminStub localEntryAdminServiceStub;
+    private String tenantDomain;
 
-    public LocalEntryAdminClient(Environment environment) throws AxisFault {
+    public LocalEntryAdminClient(Environment environment, String tenantDomain) throws AxisFault {
+        this.tenantDomain = tenantDomain;
         localEntryAdminServiceStub = new APILocalEntryAdminStub(null,
                 environment.getServerURL() + "APILocalEntryAdmin");
         setup(localEntryAdminServiceStub, environment);
@@ -98,7 +99,7 @@ public class LocalEntryAdminClient {
      */
     public void addLocalEntry(String content) throws AxisFault {
         try {
-            localEntryAdminServiceStub.addLocalEntry(content);
+            localEntryAdminServiceStub.addLocalEntry(content, tenantDomain);
         } catch (RemoteException e) {
             throw new AxisFault("Error occurred while adding the Local Entry: ", e.getMessage(), e);
         }
@@ -113,8 +114,8 @@ public class LocalEntryAdminClient {
      */
     public Boolean getEntry(String key) throws AxisFault {
         try {
-            Object object = localEntryAdminServiceStub.getEntry(key);
-            return object != null;
+            Object localEntryObject = localEntryAdminServiceStub.getEntry(key, tenantDomain);
+            return localEntryObject != null;
         } catch (RemoteException e) {
             throw new AxisFault("Error occurred while getting the Local Entry: ", e.getMessage(), e);
         }
@@ -129,7 +130,7 @@ public class LocalEntryAdminClient {
      */
     public boolean deleteEntry(String key) throws AxisFault {
         try {
-            return localEntryAdminServiceStub.deleteLocalEntry(key);
+            return localEntryAdminServiceStub.deleteLocalEntry(key, tenantDomain);
         } catch (RemoteException e) {
             throw new AxisFault("Error occurred while deleting the Local Entry: ", e.getMessage(), e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -1498,7 +1498,7 @@
 
         <carbon.commons.version>4.6.65</carbon.commons.version>
         <carbon.registry.version>4.6.46</carbon.registry.version>
-        <carbon.mediation.version>4.6.149</carbon.mediation.version>
+        <carbon.mediation.version>4.6.151</carbon.mediation.version>
 
         <!-- Carbon Identity versions -->
         <carbon.identity.version>5.12.368</carbon.identity.version>

--- a/service-stubs/apimgt/org.wso2.carbon.apimgt.localentry.stub/src/main/resources/APILocalEntryAdmin.wsdl
+++ b/service-stubs/apimgt/org.wso2.carbon.apimgt.localentry.stub/src/main/resources/APILocalEntryAdmin.wsdl
@@ -6,6 +6,7 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="key" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="tenantDomain" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -20,6 +21,7 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="content" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="tenantDomain" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -34,6 +36,7 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="key" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="tenantDomain" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>


### PR DESCRIPTION
## Purpose
> Adding swagger as a local entry to the API Gateway based on the tenant domain.

Related to [https://github.com/wso2/carbon-apimgt/pull/6128](https://github.com/wso2/carbon-apimgt/pull/6128)