### PR TITLE
Remove redundant authorization button

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package-lock.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package-lock.json
@@ -12763,6 +12763,16 @@
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
             "dev": true
         },
+        "source-map-loader": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
+            "integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
+            "dev": true,
+            "requires": {
+                "async": "2.6.2",
+                "loader-utils": "1.2.3"
+            }
+        },
         "source-map-resolve": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
@@ -13180,10 +13190,10 @@
                 "utfstring": "2.0.0"
             }
         },
-        "swagger-ui-react": {
+        "swagger-ui": {
             "version": "3.22.2",
-            "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-3.22.2.tgz",
-            "integrity": "sha512-TgGpkPJdt5epVYUQbpwsVxDxBKXnCUSbNqqIMH0x7fbDuv3zvm0BH9aGM4RiCSimKZfQKJYZ5IOZyaSF019NDw==",
+            "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-3.22.2.tgz",
+            "integrity": "sha512-kwKuQ6wwxnj95REpg7polhg2/EIZ5h19mit8z8XnSnuB+P2dDYcZGcan1Fd+oLrJxLwMcGhNiN87DDn+R35xBg==",
             "requires": {
                 "@braintree/sanitize-url": "2.1.0",
                 "@kyleshockey/js-yaml": "1.0.1",
@@ -13201,7 +13211,9 @@
                 "lodash": "4.17.11",
                 "memoizee": "0.4.14",
                 "prop-types": "15.7.2",
+                "react": "15.6.2",
                 "react-debounce-input": "3.2.0",
+                "react-dom": "15.6.2",
                 "react-immutable-proptypes": "2.1.0",
                 "react-immutable-pure-component": "1.2.3",
                 "react-inspector": "2.3.1",
@@ -13242,6 +13254,29 @@
                     "integrity": "sha512-PipOsAKamRw7+CXtKiieehyjUeDVPJ5J7b2kdJYerEf6TSUQoD2ijpVyZ88KQm5YXziff4h762bz3+vzf56khg==",
                     "requires": {
                         "deep-equal": "1.0.1"
+                    }
+                },
+                "react": {
+                    "version": "15.6.2",
+                    "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+                    "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+                    "requires": {
+                        "create-react-class": "15.6.3",
+                        "fbjs": "0.8.17",
+                        "loose-envify": "1.4.0",
+                        "object-assign": "4.1.1",
+                        "prop-types": "15.7.2"
+                    }
+                },
+                "react-dom": {
+                    "version": "15.6.2",
+                    "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
+                    "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+                    "requires": {
+                        "fbjs": "0.8.17",
+                        "loose-envify": "1.4.0",
+                        "object-assign": "4.1.1",
+                        "prop-types": "15.7.2"
                     }
                 },
                 "swagger-client": {

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package.json
@@ -46,7 +46,7 @@
         "react-router-dom": "^4.4.0-alpha.1",
         "react-tap-event-plugin": "^2.0.1",
         "swagger-client": "3.4.8",
-        "swagger-ui-react": "^3.22.2"
+        "swagger-ui": "^3.22.2"
     },
     "devDependencies": {
         "babel-core": "^6.24.1",
@@ -76,9 +76,10 @@
         "mock-local-storage": "^1.0.5",
         "react-test-renderer": "^16.7.0",
         "sinon": "^7.2.2",
+        "source-map-loader": "^0.2.4",
         "style-loader": "^0.18.1",
         "webpack": "v4.28.4",
-        "webpack-cli": "^3.3.2",
-        "webpack-bundle-analyzer": "^3.2.0"
+        "webpack-bundle-analyzer": "^3.2.0",
+        "webpack-cli": "^3.3.2"
     }
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -20,7 +20,6 @@ import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
-import 'swagger-ui-react/swagger-ui.css';
 import TextField from '@material-ui/core/TextField';
 import { withStyles } from '@material-ui/core/styles';
 import IconButton from '@material-ui/core/IconButton';

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/ApiConsole/PatchedSwaggerUIReact.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/ApiConsole/PatchedSwaggerUIReact.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import swaggerUIConstructor, { presets } from 'swagger-ui';
+
+/**
+ *
+ *
+ * @export
+ * @class SwaggerUI
+ * @extends {React.Component}
+ */
+export default class SwaggerUI extends React.Component {
+    constructor(props) {
+        super(props);
+        this.SwaggerUIComponent = null;
+        this.system = null;
+    }
+
+    /**
+     *
+     *
+     * @memberof SwaggerUI
+     */
+    componentDidMount() {
+        const ui = swaggerUIConstructor({
+            spec: this.props.spec,
+            url: this.props.url,
+            defaultModelsExpandDepth: this.props.defaultModelsExpandDepth,
+            presets: [presets.apis, ...this.props.presets],
+            requestInterceptor: this.requestInterceptor,
+            responseInterceptor: this.responseInterceptor,
+            onComplete: this.onComplete,
+            docExpansion: this.props.docExpansion,
+        });
+
+        this.system = ui;
+        this.SwaggerUIComponent = ui.getComponent('App', 'root');
+
+        this.forceUpdate();
+    }
+
+    /**
+     *
+     *
+     * @param {*} prevProps
+     * @memberof SwaggerUI
+     */
+    componentDidUpdate(prevProps) {
+        if (this.props.url !== prevProps.url) {
+            // flush current content
+            this.system.specActions.updateSpec('');
+
+            if (this.props.url) {
+                // update the internal URL
+                this.system.specActions.updateUrl(this.props.url);
+                // trigger remote definition fetch
+                this.system.specActions.download(this.props.url);
+            }
+        }
+
+        if (this.props.spec !== prevProps.spec && this.props.spec) {
+            if (typeof this.props.spec === 'object') {
+                this.system.specActions.updateSpec(JSON.stringify(this.props.spec));
+            } else {
+                this.system.specActions.updateSpec(this.props.spec);
+            }
+        }
+    }
+
+    requestInterceptor = (req) => {
+        if (typeof this.props.requestInterceptor === 'function') {
+            return this.props.requestInterceptor(req);
+        }
+        return req;
+    };
+
+    responseInterceptor = (res) => {
+        if (typeof this.props.responseInterceptor === 'function') {
+            return this.props.responseInterceptor(res);
+        }
+        return res;
+    };
+
+    onComplete = () => {
+        if (typeof this.props.onComplete === 'function') {
+            return this.props.onComplete(this.system);
+        }
+    };
+
+    render() {
+        return this.SwaggerUIComponent ? <this.SwaggerUIComponent /> : null;
+    }
+}
+SwaggerUI.defaultProps = {
+    docExpansion: 'list',
+    defaultModelsExpandDepth: 1,
+    presets: [],
+};
+
+SwaggerUI.propTypes = {
+    spec: PropTypes.oneOf([PropTypes.string, PropTypes.object]),
+    url: PropTypes.string,
+    defaultModelsExpandDepth: PropTypes.number,
+    requestInterceptor: PropTypes.func,
+    responseInterceptor: PropTypes.func,
+    onComplete: PropTypes.func,
+    docExpansion: PropTypes.oneOf(['list', 'full', 'none']),
+    presets: PropTypes.arrayOf(PropTypes.func),
+};

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/ApiConsole/SwaggerUI.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/ApiConsole/SwaggerUI.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import SwaggerUILib from 'swagger-ui-react';
+import 'swagger-ui/dist/swagger-ui.css';
+import SwaggerUILib from './PatchedSwaggerUIReact';
 
 const disableAuthorizeAndInfoPlugin = function () {
     return {
@@ -12,7 +13,6 @@ const disableAuthorizeAndInfoPlugin = function () {
 };
 /**
  *
- *
  * @class SwaggerUI
  * @extends {Component}
  */
@@ -22,11 +22,15 @@ const SwaggerUI = (props) => {
     const componentProps = {
         spec,
         validatorUrl: null,
+        docExpansion: 'list',
+        defaultModelsExpandDepth: 0,
         requestInterceptor: (req) => {
             req.headers.Authorization = 'Bearer ' + accessTokenProvider();
             return req;
         },
+
         presets: [disableAuthorizeAndInfoPlugin],
+        plugins: null,
     };
     return <SwaggerUILib {...componentProps} />;
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/webpack.config.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/webpack.config.js
@@ -42,6 +42,11 @@ const config = {
     module: {
         rules: [
             {
+                test: /\.js$/,
+                use: ['source-map-loader'],
+                enforce: 'pre',
+            },
+            {
                 test: /\.(js|jsx)$/,
                 exclude: /node_modules/,
                 use: [


### PR DESCRIPTION
Hopefully, if https://github.com/swagger-api/swagger-ui/pull/5386 get merged or could find a workaround. We can remove the `PatchedSwaggerUIReact.jsx` file and use the `swagger-ui-react` library directly.

Related issues: 
https://github.com/wso2/product-apim/issues/4958