### PR TITLE
 Fix authorize endpoint url

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/configs/config.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/configs/config.jag
@@ -13,7 +13,7 @@ var settingsAPIUrl = serverUrl + SETTINGS_REST_API_URL_SUFFIX;
 var settingsResponse = get(settingsAPIUrl, {}, "json");
 
 var dcrUrl = MGT_TRANSPORT + HOST + ":" + serverPort + DCR_URL_SUFFIX;
-var authorizeEndpoint = MGT_TRANSPORT + HOST + ":" + serverPort + AUTHORIZE_ENDPOINT_SUFFIX;
+var authorizeEndpoint = serverUrl + AUTHORIZE_ENDPOINT_SUFFIX;
 var callbackUrl = serverUrl + site.context + CALLBACK_URL_SUFFIX;
 var scopes = settingsResponse.data.scopes.join(" ");
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/configs/config.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/configs/config.jag
@@ -12,7 +12,7 @@
     var settingsResponse = get(settingsAPIUrl, {}, "json");
 
     var dcrUrl = MGT_TRANSPORT + HOST + ":" + serverPort + DCR_URL_SUFFIX;
-    var authorizeEndpoint = MGT_TRANSPORT + HOST + ":" + serverPort + AUTHORIZE_ENDPOINT_SUFFIX;
+    var authorizeEndpoint = serverUrl + AUTHORIZE_ENDPOINT_SUFFIX;
     var callbackUrl = serverUrl + site.context + CALLBACK_URL_SUFFIX;
     var scopes = settingsResponse.data.scopes.join(" ");
 


### PR DESCRIPTION
Authorize endpoint url is composed from the host and the port retrieved from the carbon.xml