### PR TITLE
Fix for Custom policies are not allowed to edit

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -4883,9 +4883,10 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     throw new APIManagementException("Invalid Execution Plan");
                 }
 
-                // checking if keytemplate already exist
-                if (apiMgtDAO.isKeyTemplatesExist(globalPolicy)) {
-                    throw new APIManagementException("Key Template Already Exist");
+                // checking if policy already exist
+                Policy policyIfExists = getGlobalPolicy(globalPolicy.getPolicyName());
+                if (policyIfExists != null) {
+                    throw new APIManagementException("Policy Name Already Exist");
                 }
 
                 String policyFile = PolicyConstants.POLICY_LEVEL_GLOBAL + "_" + globalPolicy.getPolicyName();
@@ -5156,10 +5157,6 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 // validating custom execution plan
                 if (!deploymentManager.validateExecutionPlan(policyString)) {
                     throw new APIManagementException("Invalid Execution Plan");
-                }
-                // checking if keytemplate already exist for another policy
-                if (apiMgtDAO.isKeyTemplatesExist(globalPolicy)) {
-                    throw new APIManagementException("Key Template Already Exist");
                 }
 
                 // getting key templates before updating database

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ThrottlingApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ThrottlingApiServiceImpl.java
@@ -686,10 +686,6 @@ public class ThrottlingApiServiceImpl extends ThrottlingApiService {
                     RestApiUtil.handleResourceAlreadyExistsError(
                             "Custom rule with name " + globalPolicy.getPolicyName() + " already exists", log);
                 }
-                if (apiProvider.isGlobalPolicyKeyTemplateExists(globalPolicy)) {
-                    RestApiUtil.handleResourceAlreadyExistsError(
-                            "Custom rule with key template " + globalPolicy.getKeyTemplate() + " already exists", log);
-                }
             } catch (PolicyNotFoundException ignore) {
             }
             //Add the policy

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/modules/policy/global-policy-edit.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/modules/policy/global-policy-edit.jag
@@ -24,10 +24,10 @@ var saveGlobalPolicy = function (action, policyName, description, siddhiQuery, k
         var errorMessage = i18n.localize("Error occurred while saving policy (Cause:")+ ex.message + ")";
         log.error(errorMessage);
 
-        if(errorMessage.indexOf("Invalid Execution Plan") > -1){
+        if (errorMessage.indexOf("Invalid Execution Plan") > -1) {
             errorMessage = i18n.localize("Siddhi Query deployment failed due to Siddhi syntax errors")
-        }else if(errorMessage.indexOf("Key Template Already Exis") > -1){
-            errorMessage = i18n.localize("Key Template Already Exists. Add a new Key Template");
+        } else if (errorMessage.indexOf("Policy Name Already Exist") > -1){
+            errorMessage = i18n.localize("Policy Name Already Exists. Add a new Policy Name");
         }
 
         return {

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/conf/locales/jaggery/locale_default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/conf/locales/jaggery/locale_default.json
@@ -141,7 +141,7 @@
     "JWT Token": "JWT Token",
     "KB": "KB",
     "Key Template": "Key Template",
-    "Key Template Already Exists. Add a new Key Template": "Key Template already exists. Add a new Key Template",
+    "Policy Name Already Exists. Add a new Policy Name": "Policy Name already exists. Add a new Policy Name",
     "Labels":"Labels",
     "Live Log Viewer": "Live Log Viewer",
     "Live log viewer": "Live log viewer",

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/conf/locales/jaggery/locale_en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/conf/locales/jaggery/locale_en.json
@@ -131,7 +131,7 @@
     "JWT Token": "JWT Token",
     "KB": "KB",
     "Key Template": "Key Template",
-    "Key Template Already Exists. Add a new Key Template": "Key Template already exists. Add a new Key Template",
+    "Policy Name Already Exists. Add a new Policy Name": "Policy Name already exists. Add a new Policy Name",
     "Live Log Viewer": "Live Log Viewer",
     "Live log viewer": "Live log viewer",
     "Log Analyzer": "Log Analyzer",

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/policy/global/edit/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/policy/global/edit/template.jag
@@ -45,7 +45,7 @@
                         <div class="form-group">
                             <label class="control-label col-sm-3"><%=i18n.localize("Name")%> <span class="requiredAstrix">*</span></label>
                             <div class="col-md-9">
-                                <input class="form-control" type="text" id="policyName" name="policyName" value="<%=nameFieldDisableStatus%>"/>
+                                <input class="form-control" type="text" id="policyName" name="policyName" <%=encode.forHtml(String(nameFieldDisableStatus))%>/>
                             </div>
                         </div>
                         <div class="form-group">


### PR DESCRIPTION
This PR introduces the following changes.

-  Remove Key Template exists check from add policy method in Impl layer, instead check if the policy is available.
-  Remove Key Template exists check from update policy method in Impl layer. Add the UI restriction for editing policy name.
-  Remove Key Template exist check from Add Global Policy REST API