### PR TITLE
fix issue in schema validator

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/JsonSchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/JsonSchemaValidator.java
@@ -106,7 +106,7 @@ public class JsonSchemaValidator extends AbstractMediator {
             }
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("JSON Schema Validator : " + APIMgtGatewayConstants.REQUEST_TYPE_FAIL_MSG);
+                log.debug("JSON Schema Validator: " + APIMgtGatewayConstants.REQUEST_TYPE_FAIL_MSG);
             }
         }
         GatewayUtils.setOriginalInputStream(inputStreams, axis2MC);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/JsonSchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/JsonSchemaValidator.java
@@ -105,8 +105,9 @@ public class JsonSchemaValidator extends AbstractMediator {
                 AnalyzerHolder.returnObject(apimThreatAnalyzer);
             }
         } else {
-            GatewayUtils.handleThreat(messageContext, APIMgtGatewayConstants.HTTP_SC_CODE,
-                    APIMgtGatewayConstants.REQUEST_TYPE_FAIL_MSG);
+            if (log.isDebugEnabled()) {
+                log.debug("JSON Schema Validator : " + APIMgtGatewayConstants.REQUEST_TYPE_FAIL_MSG);
+            }
         }
         GatewayUtils.setOriginalInputStream(inputStreams, axis2MC);
         if (validRequest) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/XMLSchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/XMLSchemaValidator.java
@@ -126,8 +126,9 @@ public class XMLSchemaValidator extends AbstractMediator {
             //return analyzer to the pool
             AnalyzerHolder.returnObject(apimThreatAnalyzer);
         } else {
-            GatewayUtils.handleThreat(messageContext, APIMgtGatewayConstants.HTTP_SC_CODE,
-                    APIMgtGatewayConstants.REQUEST_TYPE_FAIL_MSG);
+            if (log.isDebugEnabled()) {
+                log.debug("XML Schema Validator : " + APIMgtGatewayConstants.REQUEST_TYPE_FAIL_MSG);
+            }
         }
         GatewayUtils.setOriginalInputStream(inputStreams, axis2MC);
         if (validRequest) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/XMLSchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/XMLSchemaValidator.java
@@ -127,7 +127,7 @@ public class XMLSchemaValidator extends AbstractMediator {
             AnalyzerHolder.returnObject(apimThreatAnalyzer);
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("XML Schema Validator : " + APIMgtGatewayConstants.REQUEST_TYPE_FAIL_MSG);
+                log.debug("XML Schema Validator: " + APIMgtGatewayConstants.REQUEST_TYPE_FAIL_MSG);
             }
         }
         GatewayUtils.setOriginalInputStream(inputStreams, axis2MC);


### PR DESCRIPTION
When a user tries to invoke GET requests, He/She is getting an error message that says the resource method is not compatible with the validator. But It confuses the user and also it should be handled internally without prompting an error.