### PR TITLE
Update commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1648,7 +1648,7 @@
         <!-- apache pdfbox version -->
         <pdfbox.version>1.8.16</pdfbox.version>
 
-        <event.processor.stub.version>2.1.29</event.processor.stub.version>
+        <event.processor.stub.version>2.1.30</event.processor.stub.version>
         <swagger.codegen.version>2.3.1.wso2v1</swagger.codegen.version>
         <swagger.inflector.version>1.0.16.wso2v1</swagger.inflector.version>
         <swagger.parser.version>1.0.32.wso2v1</swagger.parser.version>
@@ -1677,7 +1677,7 @@
         <reflection.version>0.9.11</reflection.version>
         <woodstox-core.version>5.2.1</woodstox-core.version>
         <apache.commons.version>2.6.2</apache.commons.version>
-        <apache.commons.lang3.version>3.8.1</apache.commons.lang3.version>
+        <apache.commons.lang3.version>3.9</apache.commons.lang3.version>
         <io.swagger.codegen.version>2.4.5</io.swagger.codegen.version>
 
         <maven.checkstyleplugin.version>2.17</maven.checkstyleplugin.version>


### PR DESCRIPTION
This PR updates commons-lang3 to the latest available version. 

event-processing also needs to be updated along with this to make it compatible.