### PR TITLE
Remove x-roles property in resources of swagger

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthCredentialValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthCredentialValidator.java
@@ -53,6 +53,8 @@ import java.net.URL;
 import java.rmi.RemoteException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -204,7 +206,25 @@ public class BasicAuthCredentialValidator {
                 String resourceRoles = null;
                 Map<String, Object> vendorExtensions = getVendorExtensions(synCtx, swagger);
                 if (vendorExtensions != null) {
-                    resourceRoles = (String) vendorExtensions.get(APIConstants.SWAGGER_X_ROLES);
+                    String resourceScope = (String) vendorExtensions.get(APIConstants.SWAGGER_X_SCOPE);
+                    if (StringUtils.isNotBlank(resourceScope)) {
+                        LinkedHashMap swaggerWSO2Security = (LinkedHashMap) swagger.getVendorExtensions()
+                                .get(APIConstants.SWAGGER_X_WSO2_SECURITY);
+                        if (swaggerWSO2Security != null) {
+                            LinkedHashMap swaggerObjectAPIM = (LinkedHashMap) swaggerWSO2Security
+                                    .get(APIConstants.SWAGGER_OBJECT_NAME_APIM);
+                            if (swaggerObjectAPIM != null) {
+                                ArrayList<LinkedHashMap> scopes = (ArrayList<LinkedHashMap>) swaggerObjectAPIM
+                                        .get(APIConstants.SWAGGER_X_WSO2_SCOPES);
+                                for (LinkedHashMap scope : scopes) {
+                                    if (resourceScope.equals(scope.get(APIConstants.SWAGGER_SCOPE_KEY))) {
+                                        resourceRoles = (String) scope.get(APIConstants.SWAGGER_ROLES);
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
                 if (StringUtils.isNotBlank(resourceRoles)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1099,7 +1099,6 @@ public final class APIConstants {
     public static final String CUSTOM_ERROR_MESSAGE = "ERROR_MESSAGE";
     //Swagger v2.0 constants
     public static final String SWAGGER_X_SCOPE = "x-scope";
-    public static final String SWAGGER_X_ROLES = "x-roles";
     public static final String SWAGGER_X_AUTH_TYPE = "x-auth-type";
     public static final String SWAGGER_X_THROTTLING_TIER = "x-throttling-tier";
     public static final String SWAGGER_X_MEDIATION_SCRIPT = "x-mediation-script";

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/item-design/js/api-design.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/themes/wso2/templates/item-design/js/api-design.js
@@ -383,21 +383,6 @@ APIDesigner.prototype.update_elements = function(resource, newValue){
     if ($(this).attr('data-attr-type') == "comma_seperated") {
         newValue = $.map(newValue.split(","), $.trim);
     }
-
-    var roles_updated = false;
-    if (API_DESIGNER.api_doc['x-wso2-security'] != null) {
-        for (var i = 0; i < API_DESIGNER.api_doc['x-wso2-security'].apim['x-wso2-scopes'].length; i++) {
-            if (API_DESIGNER.api_doc['x-wso2-security'].apim['x-wso2-scopes'][i].key === newValue) {
-                obj["x-roles"] = API_DESIGNER.api_doc['x-wso2-security'].apim['x-wso2-scopes'][i].roles;
-                roles_updated = true;
-                break;
-            }
-        }
-    }
-    if (!roles_updated) {
-        obj["x-roles"] = "";
-    }
-
     API_DESIGNER.openAPIDefinition.update_element(this, obj, newValue);
     API_DESIGNER.load_swagger_editor_content();
 };


### PR DESCRIPTION
"x-roles" property added for each API resource is unwanted since each resource contains the scope bound (with the property "x-scopes") and scope-role mapping is available in "x-wso2-security" property.