### PR TITLE
Add threatFault.xml to existing tenant space

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/TenantServiceCreator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/TenantServiceCreator.java
@@ -112,6 +112,17 @@ public class TenantServiceCreator extends AbstractAxis2ConfigurationContextObser
             if (!authFailureHandlerSequenceNameFile.exists()) {
                 createTenantSynapseConfigHierarchy(synapseConfigDir, tenantDomain);
             }
+
+            String threatFaultConfigLocation = synapseConfigsDir.getAbsolutePath() + File.separator +
+                    manger.getTracker().getCurrentConfigurationName() + File.separator +
+                    MultiXMLConfigurationBuilder.SEQUENCES_DIR + File.separator + threatFaultSequenceName + ".xml";
+            File threatFaultXml = new File(threatFaultConfigLocation);
+            if (!threatFaultXml.exists()) {
+                FileUtils.copyFile(new File(synapseConfigRootPath + threatFaultSequenceName + ".xml"),
+                        new File(synapseConfigDir.getAbsolutePath() + File.separator +
+                                MultiXMLConfigurationBuilder.SEQUENCES_DIR + File.separator +
+                                threatFaultSequenceName + ".xml"));
+            }
         } catch (RemoteException e) {
             log.error("Failed to create Tenant's synapse sequences.", e);
         } catch (Exception e) {


### PR DESCRIPTION
The issue -[1], _threat_fault.xml file is not getting copied into tenant space is fixed in #5854. But, this file is not getting added into the already created tenant space. This PR contains changes to check whether the file exists in tenant space and add if it is not there during tenant loading.

[1] https://github.com/wso2/product-apim/issues/3927