### PR TITLE
Fixing regression issues caused by version bumps

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/.eslintrc.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/.eslintrc.js
@@ -21,8 +21,8 @@ module.exports = {
         ecmaVersion: 6,
         ecmaFeatures: {
             jsx: true,
-            modules: true,
-        },
+            modules: true
+        }
     },
     env: {
         browser: true,
@@ -31,7 +31,7 @@ module.exports = {
         jest: true,
         node: true
     },
-    extends: ['airbnb','plugin:jest/recommended'],
+    extends: ['airbnb', 'plugin:jest/recommended'],
     rules: {
         'max-len': ['error', { code: 120, tabWidth: 4 }],
         'require-jsdoc': [
@@ -40,15 +40,15 @@ module.exports = {
                 require: {
                     FunctionDeclaration: true,
                     MethodDefinition: true,
-                    ClassDeclaration: true,
-                },
-            },
+                    ClassDeclaration: true
+                }
+            }
         ],
         'valid-jsdoc': [
             'warn',
             {
-                requireReturn: false,
-            },
+                requireReturn: false
+            }
         ],
         indent: ['error', 4, { SwitchCase: 1 }],
         'import/no-extraneous-dependencies': [
@@ -56,8 +56,8 @@ module.exports = {
             {
                 devDependencies: false,
                 optionalDependencies: false,
-                peerDependencies: false,
-            },
+                peerDependencies: false
+            }
         ],
         'import/no-unresolved': ['off'],
         'import/extensions': ['off'],
@@ -66,8 +66,8 @@ module.exports = {
         'no-underscore-dangle': [
             'error',
             {
-                allowAfterThis: true,
-            },
+                allowAfterThis: true
+            }
         ],
         'no-restricted-syntax': ['off'],
         'no-plusplus': ['off'],
@@ -84,7 +84,7 @@ module.exports = {
         'no-mixed-operators': ['error'],
         'jsx-quotes': ['error', 'prefer-single'],
         'no-else-return': 'off',
-        'no-unused-vars': ['error'],
+        'no-unused-vars': ['error']
     },
-    plugins: ['react','jest'],
+    plugins: ['react', 'jest']
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/package-lock.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/package-lock.json
@@ -1801,6 +1801,82 @@
             "integrity": "sha512-ayw3qQ9KNn2K5q6ggrLclh+rdZsSLwYIUz3uAer1NzaCpalJLR4g32G845ylgq7Xy2AunMHnNfD3FC3s0rUcsA==",
             "dev": true
         },
+        "@stoplight/graphite": {
+            "version": "8.2.5",
+            "resolved": "https://registry.npmjs.org/@stoplight/graphite/-/graphite-8.2.5.tgz",
+            "integrity": "sha512-ksuN4YsUyfTLjJGPZR/a6Ddx3BbR9yk9snUKIdWNMA0qOTvoyo2JK+zCF2NRWRNYnIiCPWc5mIsLT7NUXZnxyg==",
+            "dev": true,
+            "requires": {
+                "@stoplight/json": "^2.2.2",
+                "@stoplight/json-ref-resolver": "^2",
+                "@stoplight/lifecycle": "^2",
+                "@stoplight/markdown": "^2.2.3",
+                "@stoplight/spectral": "^3.1",
+                "@stoplight/types": "^9.0.2",
+                "@stoplight/yaml": "^2.5.1",
+                "@types/urijs": "~1.19.1",
+                "axios": "~0.19",
+                "diff-match-patch": "~1.0.4",
+                "eol": "~0.9.1",
+                "fast-json-patch": "~2.1.0",
+                "immer": "^3.1.3",
+                "jiff": "~0.7.3",
+                "lodash": "^4.17.11",
+                "micromatch": "~4.0.2",
+                "neo-async": "~2.6.1",
+                "openapi3-ts": "~1.3.0",
+                "treeify": "~1.1.0",
+                "urijs": "~1.19.1",
+                "uuid": "~3.3.2",
+                "vscode-uri": "~2.0.2"
+            }
+        },
+        "@stoplight/json": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-2.2.2.tgz",
+            "integrity": "sha512-QJK2Sz4HHvqix5uKQn4TgrZoH1OFwZ3y+D4wxxqNnf2G540xkleQ6dp/DSsosBqJQnGXNHUe6woSsI0q/9xrVw==",
+            "dev": true,
+            "requires": {
+                "@stoplight/fast-safe-stringify": "2.1.2",
+                "@stoplight/types": "9.0.2",
+                "jsonc-parser": "2.1.0",
+                "lodash": "4.x.x"
+            },
+            "dependencies": {
+                "@stoplight/types": {
+                    "version": "9.0.2",
+                    "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-9.0.2.tgz",
+                    "integrity": "sha512-fMVOgl0TSWA9VvsdGyTA26qp2AQ/g4jgSHm3BeFbGIBRGaVKU8JoUNV/tH+a7uxuPIzXzcE1BQa9fENOCKF2BQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@stoplight/json-ref-resolver": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-2.0.2.tgz",
+            "integrity": "sha512-vqi8R4RmnYqgEPGrISlgAPFDWPqoZb3i39l4qhhFGT7YIPprgxqtBrRhCcPOrG808720jomjz/R18+nS0EjBPw==",
+            "dev": true,
+            "requires": {
+                "@stoplight/json": "2.x.x",
+                "@types/urijs": "1.x.x",
+                "dependency-graph": "0.8.x",
+                "fast-memoize": "2.x.x",
+                "immer": "3.x.x",
+                "lodash": "4.x.x",
+                "urijs": "1.x.x",
+                "vscode-uri": "2.x.x"
+            }
+        },
+        "@stoplight/lifecycle": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@stoplight/lifecycle/-/lifecycle-2.0.1.tgz",
+            "integrity": "sha512-PDgDPgvoeWvzoWOK3wWXSCNG4ncn86IiCpn14XWMzRFV0yGEhpAtWPfsiWB/CdR7N8rp8MhzQY+/gKRSyJn5kQ==",
+            "dev": true,
+            "requires": {
+                "strict-event-emitter-types": "^2.0.0",
+                "wolfy87-eventemitter": "5.2.6"
+            }
+        },
         "@stoplight/markdown": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@stoplight/markdown/-/markdown-2.3.0.tgz",
@@ -1877,390 +1953,33 @@
             }
         },
         "@stoplight/prism-core": {
-            "version": "3.0.0-pre.2",
-            "resolved": "https://registry.npmjs.org/@stoplight/prism-core/-/prism-core-3.0.0-pre.2.tgz",
-            "integrity": "sha512-1UqmRGKZy4qhsz32TVvYiqufxCjE9n1U7YctQfI802KDyQbasp+wX8cQH6MI+dPa/S51chKmRyxEEwvZOw+s1w==",
+            "version": "3.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@stoplight/prism-core/-/prism-core-3.0.0-beta.3.tgz",
+            "integrity": "sha512-YnKY7aDo3rIINzncuDOxkA/Do6PJ4Q3dKGKR7vuEXKDSDIm5bds70xMnerBSqWbCIUaSb3bIDgG9Rc3O5fpW9w==",
             "dev": true,
             "requires": {
-                "@stoplight/graphite": "5.2.0",
-                "axios": "0.x.x",
-                "lodash": "4.x.x",
-                "mobx": "5.x.x",
-                "tslib": "1.9.x"
+                "@stoplight/graphite": "^8.2.5",
+                "axios": "^0.18.0",
+                "lodash": "^4.0.0",
+                "mobx": "^5.10.1",
+                "pino": "^5.12.6",
+                "tslib": "^1.10.0"
             },
             "dependencies": {
-                "@stoplight/graphite": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/@stoplight/graphite/-/graphite-5.2.0.tgz",
-                    "integrity": "sha512-0u6mlIzsZuqidV17Go5Hmt7zdNn40x7DJB826E2TE9/uydj59F+qnpPEErWp8IfAmBzzWs0MiG/jJhOCJClthQ==",
+                "axios": {
+                    "version": "0.18.1",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+                    "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
                     "dev": true,
                     "requires": {
-                        "@stoplight/json": "1.x.x",
-                        "@stoplight/json-ref-resolver": "1.x.x",
-                        "@stoplight/lifecycle": "1.x.x",
-                        "@stoplight/markdown": "2.x.x",
-                        "@stoplight/spectral": "2.0.6",
-                        "@stoplight/types": "4.1.0",
-                        "@stoplight/yaml": "2.x.x",
-                        "@types/swagger-schema-official": "2.0.x",
-                        "@types/urijs": "1.15.x",
-                        "axios": "0.18.x",
-                        "diff-match-patch": "1.0.x",
-                        "fast-json-patch": "2.0.x",
-                        "immer": "2.x.x",
-                        "jiff": "0.7.x",
-                        "lodash": "4.x.x",
-                        "micromatch": "3.1.x",
-                        "neo-async": "2.6.x",
-                        "openapi3-ts": "1.2.x",
-                        "strict-event-emitter-types": "2.0.x",
-                        "swagger-schema-official": "2.0.0-bab6bed",
-                        "treeify": "1.1.x",
-                        "urijs": "1.19.x",
-                        "uuid": "3.3.x",
-                        "wolfy87-eventemitter": "5.2.x"
-                    },
-                    "dependencies": {
-                        "axios": {
-                            "version": "0.18.1",
-                            "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-                            "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
-                            "dev": true,
-                            "requires": {
-                                "follow-redirects": "1.5.10",
-                                "is-buffer": "^2.0.2"
-                            }
-                        }
+                        "follow-redirects": "1.5.10",
+                        "is-buffer": "^2.0.2"
                     }
-                },
-                "@stoplight/json": {
-                    "version": "1.9.0",
-                    "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-1.9.0.tgz",
-                    "integrity": "sha512-5DwyrS+B2lGKVeDyNBaq1iTL2ovXaNVgh98r/jwO3z4A2d/xLffmPwnjgUByga+UBUbFMCFXdM3nj134V3Mt+w==",
-                    "dev": true,
-                    "requires": {
-                        "@stoplight/fast-safe-stringify": "2.1.2",
-                        "@stoplight/types": "4.0.x",
-                        "jsonc-parser": "2.1.0",
-                        "lodash": "4.x.x"
-                    },
-                    "dependencies": {
-                        "@stoplight/types": {
-                            "version": "4.0.0",
-                            "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-4.0.0.tgz",
-                            "integrity": "sha512-xh7STKNeE7j4Z6w8vkw+QxSCaxhF5+c2mY7UBqT6BMiom/Ep/EdYmYq3dmvYfXqwbkiTMR6qbYymwqnoJo8Z6w==",
-                            "dev": true
-                        }
-                    }
-                },
-                "@stoplight/json-ref-resolver": {
-                    "version": "1.5.3",
-                    "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-1.5.3.tgz",
-                    "integrity": "sha512-gyw1lRc90mheXD3DPvaG/dUQbGJ8JkAkZTaHvSB5WYTTabFzA86Ovo0x4GfLdUYeDJEMozLjRRS8X9IhX6opmA==",
-                    "dev": true,
-                    "requires": {
-                        "@stoplight/json": "^2.1",
-                        "@types/urijs": "^1.19",
-                        "dependency-graph": "^0.8",
-                        "fast-memoize": "^2.4",
-                        "immer": "^3.0",
-                        "lodash": "^4.17.5",
-                        "urijs": "^1.19"
-                    },
-                    "dependencies": {
-                        "@stoplight/json": {
-                            "version": "2.2.2",
-                            "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-2.2.2.tgz",
-                            "integrity": "sha512-QJK2Sz4HHvqix5uKQn4TgrZoH1OFwZ3y+D4wxxqNnf2G540xkleQ6dp/DSsosBqJQnGXNHUe6woSsI0q/9xrVw==",
-                            "dev": true,
-                            "requires": {
-                                "@stoplight/fast-safe-stringify": "2.1.2",
-                                "@stoplight/types": "9.0.2",
-                                "jsonc-parser": "2.1.0",
-                                "lodash": "4.x.x"
-                            }
-                        },
-                        "@stoplight/types": {
-                            "version": "9.0.2",
-                            "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-9.0.2.tgz",
-                            "integrity": "sha512-fMVOgl0TSWA9VvsdGyTA26qp2AQ/g4jgSHm3BeFbGIBRGaVKU8JoUNV/tH+a7uxuPIzXzcE1BQa9fENOCKF2BQ==",
-                            "dev": true
-                        },
-                        "@types/urijs": {
-                            "version": "1.19.2",
-                            "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.2.tgz",
-                            "integrity": "sha512-8Q7e4XLsVuqWkvl5Q9osdxi4R2nciXOu2sNWaroAY1rL58PEiSFU23q/elrAAUQdsHMaHk4kwsiOZh1rZ+7APA==",
-                            "dev": true
-                        },
-                        "immer": {
-                            "version": "3.1.3",
-                            "resolved": "https://registry.npmjs.org/immer/-/immer-3.1.3.tgz",
-                            "integrity": "sha512-HG5SXTXTTVy9lGNwS075cNhQoV375jHsIJO3UtMjuUWJOuwlMr0u42FlsKTJcppt5AzsFAsmj9r4kHvsSHh3hQ==",
-                            "dev": true
-                        }
-                    }
-                },
-                "@stoplight/lifecycle": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/@stoplight/lifecycle/-/lifecycle-1.1.0.tgz",
-                    "integrity": "sha512-D4dfckTnidplimqD4rvL7xJt6g1U1ZYDSBAR+5DhKfDgt1gWrzI0W8EwH5pml/wm8n/W7Y0sUWVcUuw25OCg8A==",
-                    "dev": true,
-                    "requires": {
-                        "strict-event-emitter-types": "^2.0.0",
-                        "wolfy87-eventemitter": "5.2.6"
-                    }
-                },
-                "@stoplight/spectral": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-2.0.6.tgz",
-                    "integrity": "sha512-TglLS+JXiMpZ5OexZHxtvvJCpGBrrHBaSLXoZUS9EH0pdJ88ZTM//qAYaMjhbyPtpuck4Vvq8CN4Wn9osvZT3g==",
-                    "dev": true,
-                    "requires": {
-                        "@oclif/command": "^1.0",
-                        "@oclif/config": "^1.12.11",
-                        "@oclif/plugin-help": "^2.0",
-                        "@stoplight/json": "1.x.x",
-                        "@stoplight/json-ref-resolver": "1.x.x",
-                        "@stoplight/types": "4.1.x",
-                        "@stoplight/yaml": "2.x.x",
-                        "ajv": "6.x.x",
-                        "chalk": "^2.4.2",
-                        "jsonpath": "git+https://github.com/stoplightio/jsonpath.git#f1c0e9e634da2d45671b7639fa0a99afc807da17",
-                        "lodash": ">=4.17.5",
-                        "node-fetch": "2.x.x",
-                        "strip-ansi": "^5.2.0",
-                        "text-table": "^0.2.0"
-                    }
-                },
-                "@stoplight/types": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-4.1.0.tgz",
-                    "integrity": "sha512-2zcUn/jtD4tqonsBoX4QHNNKXE6llNMaS7V4PkRDFkssIIVPB0gZjLWLeR//dY/aaFriO7kdhNss1UAMTLNvcA==",
-                    "dev": true
-                },
-                "@types/urijs": {
-                    "version": "1.15.38",
-                    "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.15.38.tgz",
-                    "integrity": "sha512-5VWXqu6V2IxXsPuSXYwCZHbh25U7pE+UJTFtKnNQRJLZA7o0D7fOQRJdgwBTMLNY0uc5F9GsFSang1VwNcPguA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/jquery": "*"
-                    }
-                },
-                "ajv": {
-                    "version": "6.10.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-                    "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "fast-deep-equal": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-                    "dev": true
-                },
-                "fast-json-patch": {
-                    "version": "2.0.7",
-                    "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.0.7.tgz",
-                    "integrity": "sha512-DQeoEyPYxdTtfmB3yDlxkLyKTdbJ6ABfFGcMynDqjvGhPYLto/pZyb/dG2Nyd/n9CArjEWN9ZST++AFmgzgbGw==",
-                    "dev": true,
-                    "requires": {
-                        "deep-equal": "^1.0.1"
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "immer": {
-                    "version": "2.1.5",
-                    "resolved": "https://registry.npmjs.org/immer/-/immer-2.1.5.tgz",
-                    "integrity": "sha512-xyjQyTBYIeiz6jd02Hg12jV+9QISwF1crLcwTlzHpWH4e0ryNWj1kacpTwimK3bJV5NKKXw458G2vpqoB/inFA==",
-                    "dev": true
                 },
                 "is-buffer": {
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
                     "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
-                    "dev": true
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "is-buffer": {
-                            "version": "1.1.6",
-                            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-                            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-                            "dev": true
-                        },
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-                    "dev": true
-                },
-                "micromatch": {
-                    "version": "3.1.10",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
-                    }
-                },
-                "node-fetch": {
-                    "version": "2.6.0",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-                    "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-                    "dev": true
-                },
-                "openapi3-ts": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-1.2.0.tgz",
-                    "integrity": "sha512-oWRW8aI58UPD1ufx54y4QOCwqdQPedCRBKmqgwRUtetz4+NUJD2opWn3a0Te4yLzlFdf9eGinrKvc3uvD2Wegw==",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-                    "dev": true,
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
-                    }
-                },
-                "tslib": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-                    "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
                     "dev": true
                 }
             }
@@ -2306,29 +2025,11 @@
                         "is-buffer": "^2.0.2"
                     }
                 },
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
                 "fast-deep-equal": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
                     "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
                     "dev": true
-                },
-                "follow-redirects": {
-                    "version": "1.5.10",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-                    "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-                    "dev": true,
-                    "requires": {
-                        "debug": "=3.1.0"
-                    }
                 },
                 "is-buffer": {
                     "version": "2.0.3",
@@ -2341,12 +2042,127 @@
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
                     "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
                     "dev": true
+                }
+            }
+        },
+        "@stoplight/spectral": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-3.1.0.tgz",
+            "integrity": "sha512-kAm7UlWNafzZg7Qv8E2haB+4571KoZS2YYnDWf2BngKUc/xc6VI1OUExqEmE3iasCMFFbOziYY3CdJoFc43OvQ==",
+            "dev": true,
+            "requires": {
+                "@oclif/command": "^1.0",
+                "@oclif/config": "^1.12.11",
+                "@oclif/plugin-help": "^2.0",
+                "@stoplight/json": "^2.1.0",
+                "@stoplight/json-ref-resolver": "^1.5.0",
+                "@stoplight/types": "^7.0.1",
+                "@stoplight/yaml": "^2.3.0",
+                "ajv": "6.x.x",
+                "ajv-oai": "^1.1.1",
+                "chalk": "^2.4.2",
+                "jsonpath": "git+https://github.com/stoplightio/jsonpath.git#f1c0e9e634da2d45671b7639fa0a99afc807da17",
+                "lodash": ">=4.17.5",
+                "node-fetch": "2.x.x",
+                "strip-ansi": "^5.2.0",
+                "text-table": "^0.2.0",
+                "typescript-json-schema": "^0.38.0"
+            },
+            "dependencies": {
+                "@stoplight/json-ref-resolver": {
+                    "version": "1.5.3",
+                    "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-1.5.3.tgz",
+                    "integrity": "sha512-gyw1lRc90mheXD3DPvaG/dUQbGJ8JkAkZTaHvSB5WYTTabFzA86Ovo0x4GfLdUYeDJEMozLjRRS8X9IhX6opmA==",
+                    "dev": true,
+                    "requires": {
+                        "@stoplight/json": "^2.1",
+                        "@types/urijs": "^1.19",
+                        "dependency-graph": "^0.8",
+                        "fast-memoize": "^2.4",
+                        "immer": "^3.0",
+                        "lodash": "^4.17.5",
+                        "urijs": "^1.19"
+                    }
                 },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                "@stoplight/types": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-7.1.0.tgz",
+                    "integrity": "sha512-V+6ap1S9FP+WeP2D17LZrmmIyRGvVOHPZWDe0yK/yj9U+sYiITX0ix8/3OOSj1PIY+s88fFRlP0CgfIZJLAD3A==",
                     "dev": true
+                },
+                "ajv": {
+                    "version": "6.10.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+                    "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
+                },
+                "node-fetch": {
+                    "version": "2.6.0",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+                    "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
                 }
             }
         },
@@ -2436,15 +2252,6 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
-        "@types/jquery": {
-            "version": "3.3.30",
-            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.30.tgz",
-            "integrity": "sha512-chB+QbLulamShZAFcTJtl8opZwHFBpDOP6nRLrPGkhC6N1aKWrDXg2Nc71tEg6ny6E8SQpRwbWSi9GdstH5VJA==",
-            "dev": true,
-            "requires": {
-                "@types/sizzle": "*"
-            }
-        },
         "@types/json-schema": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
@@ -2488,28 +2295,22 @@
                 "@types/react": "*"
             }
         },
-        "@types/sizzle": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
-            "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
-            "dev": true
-        },
         "@types/stack-utils": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
             "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
             "dev": true
         },
-        "@types/swagger-schema-official": {
-            "version": "2.0.18",
-            "resolved": "https://registry.npmjs.org/@types/swagger-schema-official/-/swagger-schema-official-2.0.18.tgz",
-            "integrity": "sha512-zQsYKjtPf7Hvnp6KR4DTypXZ12tlH7k670d4QXuxzkofefBy9e2GwRKyV06lgTi3qw/OH/JFTDYe/x3uQmnusQ==",
-            "dev": true
-        },
         "@types/unist": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
             "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+            "dev": true
+        },
+        "@types/urijs": {
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.2.tgz",
+            "integrity": "sha512-8Q7e4XLsVuqWkvl5Q9osdxi4R2nciXOu2sNWaroAY1rL58PEiSFU23q/elrAAUQdsHMaHk4kwsiOZh1rZ+7APA==",
             "dev": true
         },
         "@types/vfile": {
@@ -3772,6 +3573,15 @@
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "requires": {
+                "fill-range": "^7.0.1"
             }
         },
         "brcast": {
@@ -5675,6 +5485,12 @@
                 "semver": "^5.6.0"
             }
         },
+        "eol": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
+            "integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==",
+            "dev": true
+        },
         "errno": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -6219,18 +6035,16 @@
             }
         },
         "eslint-plugin-react": {
-            "version": "7.14.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.2.tgz",
-            "integrity": "sha512-jZdnKe3ip7FQOdjxks9XPN0pjUKZYq48OggNMd16Sk+8VXx6JOvXmlElxROCgp7tiUsTsze3jd78s/9AFJP2mA==",
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz",
+            "integrity": "sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==",
             "dev": true,
             "requires": {
                 "array-includes": "^3.0.3",
                 "doctrine": "^2.1.0",
                 "has": "^1.0.3",
                 "jsx-ast-utils": "^2.1.0",
-                "object.entries": "^1.1.0",
                 "object.fromentries": "^2.0.0",
-                "object.values": "^1.1.0",
                 "prop-types": "^15.7.2",
                 "resolve": "^1.10.1"
             }
@@ -6828,6 +6642,15 @@
             "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
             "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
             "dev": true
+        },
+        "fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "requires": {
+                "to-regex-range": "^5.0.1"
+            }
         },
         "finalhandler": {
             "version": "1.1.2",
@@ -8574,6 +8397,12 @@
             "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
             "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
         },
+        "immer": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-3.1.3.tgz",
+            "integrity": "sha512-HG5SXTXTTVy9lGNwS075cNhQoV375jHsIJO3UtMjuUWJOuwlMr0u42FlsKTJcppt5AzsFAsmj9r4kHvsSHh3hQ==",
+            "dev": true
+        },
         "immutable": {
             "version": "3.7.6",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
@@ -8900,6 +8729,12 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
             "integrity": "sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8="
+        },
+        "is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
         },
         "is-number-object": {
             "version": "1.0.3",
@@ -10920,7 +10755,6 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "jsonify": "~0.0.0"
             }
@@ -10980,8 +10814,7 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "jsonpath": {
             "version": "git+https://github.com/stoplightio/jsonpath.git#f1c0e9e634da2d45671b7639fa0a99afc807da17",
@@ -11884,6 +11717,16 @@
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
         },
+        "micromatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+            "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+            "dev": true,
+            "requires": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.0.5"
+            }
+        },
         "miller-rabin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -12626,6 +12469,12 @@
             "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
             "integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
         },
+        "openapi3-ts": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-1.3.0.tgz",
+            "integrity": "sha512-Xk3hsB0PzB4dzr/r/FdmK+VfQbZH7lQQ2iipMS1/1eoz1wUvh5R7rmOakYvw0bQJJE6PYrOLx8UHsYmzgTr+YQ==",
+            "dev": true
+        },
         "opencollective": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
@@ -13005,6 +12854,12 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "picomatch": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+            "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+            "dev": true
         },
         "pify": {
             "version": "4.0.1",
@@ -17463,6 +17318,15 @@
                 "safe-regex": "^1.1.0"
             }
         },
+        "to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "requires": {
+                "is-number": "^7.0.0"
+            }
+        },
         "toidentifier": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -17626,6 +17490,24 @@
             "version": "0.0.35",
             "resolved": "https://registry.npmjs.org/typeface-roboto/-/typeface-roboto-0.0.35.tgz",
             "integrity": "sha512-DDFZZFSWzi7fSsHWQrxHXmi5KgGQ3EJKdfFaj+hfTghpUyLWT+fPs5I7G3q+KH/z6ZOxabjkrr1FpNLYpzT9JQ=="
+        },
+        "typescript": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+            "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+            "dev": true
+        },
+        "typescript-json-schema": {
+            "version": "0.38.3",
+            "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.38.3.tgz",
+            "integrity": "sha512-+13qUoBUQwOXqxUoYQWtLA9PEM7ojfv8r+hYc2ebeqqVwVM4+yI5JSlsYRBlJKKewc9q1FHqrMR6L6d9TNX9Dw==",
+            "dev": true,
+            "requires": {
+                "glob": "~7.1.4",
+                "json-stable-stringify": "^1.0.1",
+                "typescript": "^3.5.1",
+                "yargs": "^13.2.4"
+            }
         },
         "ua-parser-js": {
             "version": "0.7.20",
@@ -18082,6 +17964,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
             "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+            "dev": true
+        },
+        "vscode-uri": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.0.2.tgz",
+            "integrity": "sha512-VebpIxm9tG0fG2sBOhnsSPzDYuNUPP1UQW4K3mwthlca4e4f3d6HKq3HkITC2OPFomOaB7pHTSjcpdFWjfYTzg==",
             "dev": true
         },
         "w3c-blob": {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/package.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/package.json
@@ -1,7 +1,7 @@
 {
     "name": "wso2_apim_publisher",
     "version": "3.0.0",
-    "description": "WSO2 API Manager Publisher Web App",
+    "description": "WSO2 API Manager Publisher Web App Note: `eslint-plugin-react` have a fixed version due to implementing prop-types does mark nested destructed props from `eslint-plugin-react` next version onwards",
     "main": "app.jsx",
     "scripts": {
         "test": "jest",
@@ -70,7 +70,7 @@
         "@babel/preset-env": "^7.4.4",
         "@babel/preset-react": "^7.0.0",
         "@babel/register": "^7.4.4",
-        "@stoplight/prism-http": "^3.0.0-alpha.15",
+        "@stoplight/prism-http": "^3.0.0-beta.3",
         "babel-eslint": "^10.0.1",
         "babel-jest": "^24.8.0",
         "babel-loader": "^8.0.6",
@@ -84,7 +84,7 @@
         "eslint-plugin-import": "^2.9.0",
         "eslint-plugin-jest": "^22.6.4",
         "eslint-plugin-jsx-a11y": "^6.0.3",
-        "eslint-plugin-react": "^7.7.0",
+        "eslint-plugin-react": "v7.13.0",
         "jest": "^24.8.0",
         "jest-puppeteer": "^4.2.0",
         "less": "^2.7.2",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/Tests/Utils/MockAPIModel.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/Tests/Utils/MockAPIModel.js
@@ -20,7 +20,7 @@
  * Swagger-parser library(https://apidevtools.org/swagger-parser/) is used for parsing the swagger YAML file
  * Prism-HTTP module is used for generating the mock data from the swagger definition
  */
-import { generateStatic } from '@stoplight/prism-http/lib/mocker/generator/JSONSchema';
+import { generateStatic } from '@stoplight/prism-http/dist/mocker/generator/JSONSchema';
 import SwaggerParser from 'swagger-parser';
 import path from 'path';
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/ApiCreate.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/ApiCreate.jsx
@@ -56,7 +56,7 @@ function ApiCreate(props) {
 }
 
 ApiCreate.propTypes = {
-    classes: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({ content: PropTypes.string }).isRequired,
 };
 
 export default withStyles(styles)(ApiCreate);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/index.jsx
@@ -433,7 +433,12 @@ Details.subPaths = {
 Object.freeze(Details.paths);
 
 Details.propTypes = {
-    classes: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({
+        LeftMenu: PropTypes.string,
+        content: PropTypes.string,
+        leftLInkMain: PropTypes.string,
+        contentInside: PropTypes.string,
+    }).isRequired,
     match: PropTypes.shape({
         params: PropTypes.object,
     }).isRequired,
@@ -443,7 +448,11 @@ Details.propTypes = {
     history: PropTypes.shape({
         push: PropTypes.object,
     }).isRequired,
-    theme: PropTypes.shape({}).isRequired,
+    theme: PropTypes.shape({
+        custom: PropTypes.shape({
+            leftMenuIconMainSize: PropTypes.number,
+        }),
+    }).isRequired,
 };
 
 export default withStyles(styles, { withTheme: true })(Details);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Listing/Listing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Listing/Listing.jsx
@@ -186,7 +186,10 @@ Listing.propTypes = {
     location: PropTypes.shape({
         pathname: PropTypes.string,
     }).isRequired,
-    classes: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({
+        content: PropTypes.string,
+        contentInside: PropTypes.string,
+    }).isRequired,
     theme: PropTypes.shape({
         custom: PropTypes.string,
     }).isRequired,

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Base/Header/avatar/Avatar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Base/Header/avatar/Avatar.jsx
@@ -131,7 +131,11 @@ class Avatar extends Component {
     }
 }
 Avatar.propTypes = {
-    classes: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({
+        userLink: PropTypes.string,
+        profileMenu: PropTypes.string,
+        accountIcon: PropTypes.string,
+    }).isRequired,
     user: PropTypes.shape({ name: PropTypes.string.isRequired }).isRequired,
     toggleTheme: PropTypes.func.isRequired,
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Base/Header/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Base/Header/index.jsx
@@ -120,9 +120,18 @@ Header.defaultProps = {
 };
 
 Header.propTypes = {
-    classes: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({
+        appBar: PropTypes.string,
+        menuIcon: PropTypes.string,
+        toolbar: PropTypes.string,
+    }).isRequired,
     avatar: PropTypes.element,
-    theme: PropTypes.shape({}).isRequired,
+    theme: PropTypes.shape({
+        custom: PropTypes.shape({
+            logo: PropTypes.string,
+            title: PropTypes.string,
+        }),
+    }).isRequired,
 };
 
 export default withStyles(styles, { withTheme: true })(Header);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Base/Header/navbar/GlobalNavBar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Base/Header/navbar/GlobalNavBar.jsx
@@ -80,8 +80,20 @@ const GlobalNavBar = (props) => {
 GlobalNavBar.propTypes = {
     open: PropTypes.bool.isRequired,
     toggleGlobalNavBar: PropTypes.func.isRequired,
-    classes: PropTypes.shape({}).isRequired,
-    theme: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({
+        drawerStyles: PropTypes.string,
+        list: PropTypes.string,
+        listText: PropTypes.string,
+    }).isRequired,
+    theme: PropTypes.shape({
+        palette: PropTypes.shape({
+            getContrastText: PropTypes.func,
+            background: PropTypes.shape({
+                drawer: PropTypes.string,
+                leftMenu: PropTypes.string,
+            }),
+        }),
+    }).isRequired,
 };
 
 export default withStyles(styles, { withTheme: true })(GlobalNavBar);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/AppErrorBoundary.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/AppErrorBoundary.jsx
@@ -166,8 +166,20 @@ class AppErrorBoundary extends React.Component {
 
 AppErrorBoundary.propTypes = {
     children: PropTypes.node.isRequired,
-    classes: PropTypes.shape({}).isRequired,
-    theme: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({
+        appBar: PropTypes.string,
+        toolbar: PropTypes.string,
+        errorDisplay: PropTypes.string,
+        errorDisplayContent: PropTypes.string,
+        errorTitle: PropTypes.string,
+        link: PropTypes.string,
+    }).isRequired,
+    theme: PropTypes.shape({
+        custom: PropTypes.shape({
+            logo: PropTypes.string,
+            title: PropTypes.string,
+        }),
+    }).isRequired,
 };
 
 export default withStyles(styles, { withTheme: true })(AppErrorBoundary);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/InlineMessage.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/InlineMessage.jsx
@@ -47,7 +47,11 @@ class InlineMessage extends React.Component {
 }
 
 InlineMessage.propTypes = {
-    classes: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({
+        root: PropTypes.string,
+        iconItem: PropTypes.string,
+        content: PropTypes.string,
+    }).isRequired,
     height: PropTypes.number,
     type: PropTypes.string,
     children: PropTypes.shape({}).isRequired,

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/InteractiveButton.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/InteractiveButton.jsx
@@ -109,7 +109,11 @@ InteractiveButton.propTypes = {
     loading: PropTypes.bool,
     success: PropTypes.bool,
     children: PropTypes.node.isRequired,
-    classes: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({
+        buttonSuccess: PropTypes.string,
+        wrapper: PropTypes.string,
+        buttonProgress: PropTypes.string,
+    }).isRequired,
     /**
      * The color of the component. It supports those theme colors that make sense for this component.
      */

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/LeftMenuItem.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/LeftMenuItem.jsx
@@ -130,8 +130,30 @@ function LeftMenuItem(props) {
     );
 }
 LeftMenuItem.propTypes = {
-    classes: PropTypes.shape({}).isRequired,
-    theme: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({
+        divider: PropTypes.string,
+        leftLInk: PropTypes.string,
+        leftLink_IconLeft: PropTypes.string,
+        noIcon: PropTypes.string,
+        leftLink_Icon: PropTypes.string,
+        leftLInkText: PropTypes.string,
+        leftLInkText_IconLeft: PropTypes.string,
+        leftLInkText_NoText: PropTypes.string,
+    }).isRequired,
+    theme: PropTypes.shape({
+        custom: PropTypes.shape({
+            leftMenu: PropTypes.string,
+            leftMenuIconSize: PropTypes.number,
+        }),
+        palette: PropTypes.shape({
+            getContrastText: PropTypes.func,
+            background: PropTypes.shape({
+                leftMenu: PropTypes.string,
+                appBar: PropTypes.string,
+            }),
+            leftMenu: PropTypes.string,
+        }),
+    }).isRequired,
     Icon: PropTypes.element.isRequired,
     text: PropTypes.string.isRequired,
     handleMenuSelect: PropTypes.func.isRequired,

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/Message.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/Message.jsx
@@ -86,7 +86,11 @@ Message.iconTypes = {
 };
 
 Message.propTypes = {
-    classes: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({
+        root: PropTypes.string,
+        close: PropTypes.string,
+
+    }).isRequired,
     message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
     handleClose: PropTypes.func.isRequired,
     type: PropTypes.string.isRequired,

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/VerticalDivider.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/VerticalDivider.jsx
@@ -22,7 +22,9 @@ function VerticalDivider(props) {
 }
 
 VerticalDivider.propTypes = {
-    classes: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({
+        divider: PropTypes.string,
+    }).isRequired,
     height: PropTypes.shape({}).isRequired,
     marginLeft: PropTypes.shape({}).isRequired,
     marginRight: PropTypes.shape({}).isRequired,


### PR DESCRIPTION
In this PR:

- Fixed the `eslint-plugin-react` version to `v7.13.0`
  - Because in [v7.14.0](https://github.com/yannickcr/eslint-plugin-react/releases/tag/v7.14.0) they have fixed the nested props validation issue https://github.com/yannickcr/eslint-plugin-react/issues/296. Since we haven't added the validations for nested props objects i:e `classes, theme, api` etc. We could update this plugin to the later version until we add the validation to the code or disabling the eslint validation for `react/prop-types`

- Change the import path for '@stoplight/prism-http/**dist**/mocker/generator/JSONSchema'