### PR TITLE
Improvements  to Publisher app 

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/pom.xml
@@ -185,6 +185,11 @@
                         </goals>
                         <phase>initialize</phase>
                         <configuration>
+                            <environmentVariables>
+                                <PUPPETEER_SKIP_CHROMIUM_DOWNLOAD>
+                                    true
+                                </PUPPETEER_SKIP_CHROMIUM_DOWNLOAD>
+                            </environmentVariables>
                             <workingDirectory>${basedir}/src/main/resources/publisher-new</workingDirectory>
                             <executable>${npm.executable}</executable>
                             <arguments>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/.npmrc
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/.npmrc
@@ -1,3 +1,2 @@
 package-lock=true
-puppeteer_skip_chromium_download=true
 unsafe-perm=true

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/constants.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/constants.jag
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+ // TODO: Wrap these consts with an object and do `require` when needed ~tmkb
 var MGT_TRANSPORT = "https://";
 var HOST = "localhost";
 var SETTINGS_REST_API_URL_SUFFIX = "/api/am/publisher/v1.0/settings";

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/login/introspect.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/login/introspect.jag
@@ -16,11 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+    include("/services/constants.jag");
+    include("/services/jagg.jag");
 
     var log = new Log("Jaggery service for token introspection");
 
-    var userInfoEndpoint = "https://localhost:8243/userinfo";
-    var introspectEndpoint = "https://localhost:9443/oauth2/introspect"
+    var userInfoEndpoint = MGT_TRANSPORT + HOST + ":" + getServerPort() + "/oauth2/userinfo";
+    var introspectEndpoint = MGT_TRANSPORT + HOST + ":" + getServerPort() + "/oauth2/introspect";
     var tokenP1 = request.getCookie("WSO2_AM_TOKEN_1_Default").value;
     var tokenP2 = request.getCookie("AM_ACC_TOKEN_DEFAULT_P2").value;
     var token = tokenP1 + tokenP2;
@@ -35,7 +37,7 @@
         "Content-Type": "application/x-www-form-urlencoded"
     });
 
-    log.debug("Intropspection result json: " + introspectResult);
+    log.debug("Introspection result json: " + introspectResult);
     response.contentType = "application/json";
 
     var scopes = "apim:api_delete apim:api_view apim:api_create apim:api_publish apim:tier_view apim:tier_manage apim:subscription_view apim:subscription_block apim:mediation_policy_view apim:api_workflow openid"; // TODO: fetch from introspect request

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/site/public/theme/defaultTheme.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/site/public/theme/defaultTheme.js
@@ -149,6 +149,9 @@ const Configurations = {
             },
         },
     },
+    app: {
+        context: '/publisher-new',
+    },
 };
 if (typeof module !== 'undefined') {
     module.exports = Configurations; // Added for tests

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/Tests/README.md
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/Tests/README.md
@@ -35,7 +35,7 @@ Jest will pickup the files for test which are ending with `.test.jsx` or `.test.
 
 # Troubleshooting
 
-> Feel free to update this guide , If you able to find better alternatives
+> Feel free to update this guide , If you able to find better alternatives or if you find anything that is worth adding here
 
 ## Mounted wrapper does not contain the expected rendered react elements
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/Publisher.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/Publisher.jsx
@@ -25,6 +25,9 @@ import Utils from 'AppData/Utils';
 import Logout from 'AppComponents/Logout';
 import Progress from 'AppComponents/Shared/Progress';
 import PublisherRootErrorBoundary from 'AppComponents/Shared/PublisherRootErrorBoundary';
+import RedirectToLogin from 'AppComponents/Shared/RedirectToLogin';
+import Configurations from 'Config';
+
 // Localization
 import { IntlProvider, addLocaleData, defineMessages } from 'react-intl';
 
@@ -159,12 +162,12 @@ class Publisher extends React.Component {
             return <Progress />;
         }
         if (!user) {
-            window.location = '/publisher-new/services/auth/login';
+            return <RedirectToLogin />;
         }
         return (
             <IntlProvider locale={language} messages={this.state.messages}>
                 <PublisherRootErrorBoundary appName='Publisher Application'>
-                    <Router basename='/publisher-new'>
+                    <Router basename={Configurations.app.context}>
                         <Switch>
                             <Redirect exact from='/login' to='/apis' />
                             <Route path='/logout' component={Logout} />

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/ProtectedApp.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/ProtectedApp.jsx
@@ -30,6 +30,7 @@ import Header from 'AppComponents/Base/Header';
 import Avatar from 'AppComponents/Base/Header/avatar/Avatar';
 import Configurations from 'Config';
 import AppErrorBoundary from 'AppComponents/Shared/AppErrorBoundary';
+import RedirectToLogin from 'AppComponents/Shared/RedirectToLogin';
 
 const themes = [];
 themes.push(createMuiTheme(Configurations.themes.light));
@@ -91,7 +92,7 @@ export default class Protected extends Component {
         const header = <Header avatar={<Avatar toggleTheme={this.toggleTheme} user={user} />} user={user} />;
 
         if (!user) {
-            window.location = '/publisher-new/services/auth/login';
+            return <RedirectToLogin />;
         }
         return (
             <MuiThemeProvider theme={themes[this.state.themeIndex % 2]}>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
@@ -38,6 +38,8 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import MonacoEditor from 'react-monaco-editor';
 import yaml from 'js-yaml';
 import Alert from 'AppComponents/Shared/Alert';
+import { doRedirectToLogin } from 'AppComponents/Shared/RedirectToLogin';
+
 import Dropzone from 'react-dropzone';
 import json2yaml from 'json2yaml';
 import SwaggerParser from 'swagger-parser';
@@ -135,11 +137,10 @@ class APIDefinition extends React.Component {
                 if (status === 404) {
                     this.setState({ notFound: true });
                 } else if (status === 401) {
-                    window.location = '/publisher-new/services/auth/login';
+                    doRedirectToLogin();
                 }
             });
     }
-
 
     /**
      * Handles the file upload.
@@ -223,7 +224,7 @@ class APIDefinition extends React.Component {
         if (typeof definition !== 'string') return false;
         try {
             const result = JSON.parse(definition);
-            return (result && typeof result === 'object');
+            return result && typeof result === 'object';
         } catch (err) {
             return false;
         }
@@ -302,25 +303,27 @@ class APIDefinition extends React.Component {
             }
         }
         const promise = api.updateSwagger(parsedContent);
-        promise.then((response) => {
-            if (response) {
-                Alert.success(intl.formatMessage({
-                    id: 'API.Definition.Updated.Successfully',
-                    defaultMessage: 'API Definition Updated Successfully',
-                }));
-                if (specFormat && toFormat) {
-                    this.setState({ swagger: swaggerContent, format: specFormat, convertTo: toFormat });
-                } else {
-                    this.setState({ swagger: swaggerContent });
+        promise
+            .then((response) => {
+                if (response) {
+                    Alert.success(intl.formatMessage({
+                        id: 'API.Definition.Updated.Successfully',
+                        defaultMessage: 'API Definition Updated Successfully',
+                    }));
+                    if (specFormat && toFormat) {
+                        this.setState({ swagger: swaggerContent, format: specFormat, convertTo: toFormat });
+                    } else {
+                        this.setState({ swagger: swaggerContent });
+                    }
                 }
-            }
-        }).catch((err) => {
-            console.log(err);
-            Alert.error(intl.formatMessage({
-                id: 'Error.while.updating.the.API.Definition',
-                defaultMessage: 'Error while updating the API Definition',
-            }));
-        });
+            })
+            .catch((err) => {
+                console.log(err);
+                Alert.error(intl.formatMessage({
+                    id: 'Error.while.updating.the.API.Definition',
+                    defaultMessage: 'Error while updating the API Definition',
+                }));
+            });
     }
 
     /**
@@ -368,25 +371,18 @@ class APIDefinition extends React.Component {
                         >
                             <Button size='small' className={classes.button}>
                                 <CloudUploadRounded className={classes.buttonIcon} />
-                                <FormattedMessage
-                                    id='Import.definition'
-                                    defaultMessage='Import Definition'
-                                />
+                                <FormattedMessage id='Import.definition' defaultMessage='Import Definition' />
                             </Button>
                         </Dropzone>
-                        <a
-                            className={classes.downloadLink}
-                            href={downloadLink}
-                            download={fileName}
-                        >
-                            <Button size='small' className={classes.button} >
+                        <a className={classes.downloadLink} href={downloadLink} download={fileName}>
+                            <Button size='small' className={classes.button}>
                                 <CloudDownloadRounded className={classes.buttonIcon} />
                                 <FormattedMessage id='Download.Definition' defaultMessage='Download Definition' />
                             </Button>
                         </a>
                     </div>
                     <div className={classes.converterWrapper}>
-                        <Button size='small' className={classes.button} onClick={this.onChangeFormatClick} >
+                        <Button size='small' className={classes.button} onClick={this.onChangeFormatClick}>
                             <FormattedMessage id='Convert.to' defaultMessage='Convert to:' />
                             {convertTo}
                         </Button>
@@ -401,12 +397,7 @@ class APIDefinition extends React.Component {
                         options={editorOptions}
                     />
                 </div>
-                <Dialog
-                    fullScreen
-                    open={openEditor}
-                    onClose={this.closeEditor}
-                    TransitionComponent={this.transition}
-                >
+                <Dialog fullScreen open={openEditor} onClose={this.closeEditor} TransitionComponent={this.transition}>
                     <Paper square className={classes.popupHeader}>
                         <IconButton
                             className={classes.button}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Documents/Details.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Documents/Details.jsx
@@ -37,6 +37,7 @@ import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import Input from '@material-ui/core/Input';
 import { Link } from 'react-router-dom';
+import { doRedirectToLogin } from 'AppComponents/Shared/RedirectToLogin';
 
 /**
  * API Details Document page component
@@ -132,7 +133,7 @@ class Details extends React.Component {
                 if (status === 404) {
                     this.setState({ notFound: true });
                 } else if (status === 401) {
-                    window.location = '/publisher-new/services/auth/login';
+                    doRedirectToLogin();
                 }
             });
     }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/NewOverview/Resources.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/NewOverview/Resources.jsx
@@ -27,6 +27,7 @@ import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import Api from 'AppData/api';
+import { doRedirectToLogin } from 'AppComponents/Shared/RedirectToLogin';
 
 function RenderMethodBase(props) {
     const { theme, method } = props;
@@ -85,7 +86,7 @@ class Resources extends React.Component {
                 if (status === 404) {
                     this.setState({ notFound: true });
                 } else if (status === 401) {
-                    window.location = '/publisher-new/services/auth/login';
+                    doRedirectToLogin();
                 }
             });
     }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Resources/Resources.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Resources/Resources.jsx
@@ -46,6 +46,7 @@ import Api from 'AppData/api';
 import Resource from './Resource';
 import { Progress } from 'AppComponents/Shared';
 import ApiPermissionValidation from 'AppData/ApiPermissionValidation';
+import { doRedirectToLogin } from 'AppComponents/Shared/RedirectToLogin';
 
 const styles = theme => ({
     root: {
@@ -102,7 +103,7 @@ const styles = theme => ({
         padding: theme.spacing.unit*2,
     },
     radioGroup: {
-        display: 'flex', 
+        display: 'flex',
         flexDirection: 'row',
         width: 300,
     },
@@ -498,7 +499,7 @@ class Resources extends React.Component {
         const { api, showAddResource, apiScopes, showScopes, isAuthorize } = this.state;
 
         if (!isAuthorize) {
-            window.location = '/publisher-new/services/auth/login';
+            doRedirectToLogin();
         }
         if (this.state.notFound) {
             return <ResourceNotFound message={this.props.resourceNotFountMessage} />;
@@ -522,11 +523,11 @@ class Resources extends React.Component {
                     </Button>
                     <Button size="small" className={classes.button} onClick={this.toggleAssignScopes}>
                         <ScopesIcon className={classes.buttonIcon} />
-                        Assign Global Scope for API 
+                        Assign Global Scope for API
                     </Button>
                 </div>
                 <div className={classes.contentWrapper}>
-                    {showAddResource && 
+                    {showAddResource &&
                     <React.Fragment>
                         <div className={classes.addNewWrapper}>
                             <Typography className={classes.addNewHeader}>
@@ -540,10 +541,10 @@ class Resources extends React.Component {
                                     label="URL Pattern"
                                     margin="normal"
                                     variant="outlined"
-                                    id='tmpResourceName' 
+                                    id='tmpResourceName'
                                     className={classes.addResource}
-                                    value={this.state.tmpResourceName} 
-                                    onChange={this.onChangeInput('tmpResourceName')} 
+                                    value={this.state.tmpResourceName}
+                                    onChange={this.onChangeInput('tmpResourceName')}
                                     />
                                     <div className={classes.radioGroup}>
                                         {plainOptions.map((option, index) => (
@@ -603,7 +604,7 @@ class Resources extends React.Component {
                           </div>
                       </React.Fragment>
                     }
-                    
+
                     <List>
                         {this.state.paths && (
                             <ListItem>
@@ -622,7 +623,7 @@ class Resources extends React.Component {
                             const that = this;
                             return <div>
                                 <ExpansionPanel defaultExpanded className={classes.expansionPanel}>
-                                    <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}> 
+                                    <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
                                     <Typography className={classes.heading} variant='h6'>{key}</Typography>
                                     </ExpansionPanelSummary>
                                     <ExpansionPanelDetails className={classes.expansionPanelDetails}>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Listing/Listing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Listing/Listing.jsx
@@ -21,6 +21,8 @@ import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import API from 'AppData/api.js';
 import { Progress } from 'AppComponents/Shared';
+import { doRedirectToLogin } from 'AppComponents/Shared/RedirectToLogin';
+
 import ResourceNotFound from 'AppComponents/Base/Errors/ResourceNotFound';
 import SampleAPI from './SampleAPI/SampleAPI';
 import CardView from './CardView/CardView';
@@ -75,7 +77,7 @@ class Listing extends React.Component {
                 if (status === 404) {
                     this.setState({ notFound: true });
                 } else if (status === 401) {
-                    window.location = '/publisher-new/services/auth/login';
+                    doRedirectToLogin();
                 }
             });
     }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Logout.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Logout.jsx
@@ -16,12 +16,13 @@
  * under the License.
  */
 
-import { Component } from 'react';
+import React, { Component } from 'react';
 import qs from 'qs';
 import Alert from 'AppComponents/Shared/Alert';
 import PropTypes from 'prop-types';
 
 import AuthManager from 'AppData/AuthManager';
+import RedirectToLogin from 'AppComponents/Shared/RedirectToLogin';
 
 /**
  *
@@ -73,7 +74,7 @@ class Logout extends Component {
     render() {
         const { logoutSuccess } = this.state;
         if (logoutSuccess) {
-            window.location = '/publisher-new/services/auth/login';
+            return <RedirectToLogin />;
         }
         return logoutSuccess;
     }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/RedirectToLogin.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Shared/RedirectToLogin.jsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import Configurations from 'Config';
+
+
+const page = Configurations.app.context + '/services/auth/login';
+
+/**
+ *
+ * Just doing the redirection, If you want to trigger redirection to login page , Import this util method and use.
+ * Note: Don't use this method inside a render method. It will cause to cancel the initial request in Chrome
+ * and re-trigger same request
+ * Sample usage:
+ * import { doRedirectToLogin } from 'AppComponents/Shared/RedirectToLogin'
+ *
+ * componentDidMount() {
+ *      doRedirectToLogin();
+ * }
+ * @export
+ */
+export function doRedirectToLogin() {
+    window.location = page;
+}
+
+/**
+ * This component is created to unify the login process from react UI.
+ * If we need to change the login process in the future, Changing here will reflect
+ * all the login redirection done in other places of the code
+ * @class RedirectToLogin
+ */
+export default class RedirectToLogin extends React.Component {
+    /**
+     *
+     * @inheritdoc
+     * @memberof RedirectToLogin
+     */
+    componentDidMount() {
+        doRedirectToLogin();
+    }
+
+    /**
+     *
+     * @inheritdoc
+     * @returns {React.Component}
+     * @memberof RedirectToLogin
+     */
+    render() {
+        return `You will be redirected to ${page}`;
+    }
+}


### PR DESCRIPTION
In this PR:

- Remove the `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` env variable from `.npmrc` and added it to pom file as mojo plugin configuration. This env variable will be set when building the project.
  - TODO: Since we have moved the integration tests to `product-apim` repo https://github.com/wso2/product-apim/pull/5175, We no longer need the puppeteer dependency in SPA apps. We check the usages and remove the dependency safely. 
- Replace hardcoded management hostname and port in introspect.jag which had caused login issues
- Move the application context into `defaultTheme.js` and make the app context configurable.
- Add new `RedirectToLogin` component and util method to handle login redirects.