### PR TITLE
Adding react-intl-auto for autogenerating i18n ids for Store app

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/babel.config.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/babel.config.js
@@ -27,7 +27,12 @@ module.exports = {
         },
         development: {
             presets: ['@babel/preset-env', '@babel/preset-react'],
-            plugins: ['@babel/plugin-syntax-dynamic-import', '@babel/plugin-proposal-class-properties'],
+            plugins: ['@babel/plugin-syntax-dynamic-import', '@babel/plugin-proposal-class-properties', [
+                'react-intl-auto',
+                {
+                    removePrefix: 'source.src.app.components',
+                },
+            ]],
         },
     },
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package.json
@@ -7,10 +7,11 @@
         "test": "jest",
         "test:integration": "jest -c source/Tests/Integration/jest.config.js",
         "test:coverage": "jest --coverage",
-        "build:prod": "NODE_ENV=production NODE_OPTIONS=--max_old_space_size=4096 webpack -p --display errors-only --hide-modules",
+        "build:prod": "extract-messages -l=en -d en -o site/public/locales --flat true 'source/src/app/components/**/*.jsx'; NODE_ENV=production NODE_OPTIONS=--max_old_space_size=4096 webpack -p --display errors-only --hide-modules",
         "build:dev": "NODE_ENV=development webpack -d --watch ",
         "analysis": "NODE_ENV=development webpack --env.analysis -p --progress",
-        "lint": "eslint source/**/*.js source/**/*.jsx source/src/app/**/*.jsx"
+        "lint": "eslint source/**/*.js source/**/*.jsx source/src/app/**/*.jsx",
+        "i18n": "extract-messages -l=en -d en -o site/public/locales --flat true 'source/src/app/components/**/*.jsx'"
     },
     "repository": {
         "type": "git",
@@ -63,6 +64,8 @@
         "babel-jest": "^24.8.0",
         "babel-loader": "^8.0.6",
         "babel-plugin-dynamic-import-node": "^2.2.0",
+        "babel-plugin-react-intl": "^4.0.1",
+        "babel-plugin-react-intl-auto": "^1.7.0",
         "chai": "^4.0.2",
         "css-loader": "^0.28.9",
         "enzyme": "^3.8.0",
@@ -74,6 +77,8 @@
         "eslint-plugin-jest": "^22.6.4",
         "eslint-plugin-jsx-a11y": "^6.0.3",
         "eslint-plugin-react": "^7.7.0",
+        "extract-react-intl": "^0.7.1",
+        "extract-react-intl-messages": "^1.0.1",
         "jest": "^24.8.0",
         "jest-puppeteer": "^4.2.0",
         "less": "^2.7.2",

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/site/public/locales/en.json
@@ -1,10 +1,16 @@
 {
-  "created.by": "Created by",
-  "last.update": "Last update",
-  "throttling.policies": "Throttling Policies",
-  "tags": "Tags",
-  "transport": "Transport",
-  "not.set.for.this.api": "NOT SET FOR THIS API",
+  "access.token": "Access Token",
+  "access.token.validity.period": "Access token validity period",
+  "api.console.require.access.token": "You require an access token to try the API. Please log in and subscribe to the API to generate an access token. If you already have an access token, please provide it below.",
+  "api.gateways": "API Gateways",
+  "applications": "Applications",
+  "enter.access.token": "Enter access Token",
+  "environment": "Environment",
   "grant.types": "Grant Types",
-  "token.type":"Token Type"
+  "key": "Key",
+  "micro.gateways": "Micro Gateways",
+  "notice": "Notice",
+  "require.application.subscribe": "Please subscribe to an application",
+  "subscription.scopes.description": "When you generate access tokens to APIs protected by scope/s, you can select the scope/s and then generate the token for it. Scopes enable fine-grained access control to API resources based on user roles. You define scopes to an API resource. When a user invokes the API, his/her OAuth 2 bearer token cannot grant access to any API resource beyond its associated scopes.",
+  "token.expiration.description": "You can set an expiration period to determine the validity period of the token after generation. Set this to a negative value to ensure that the token never expires."
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/ProtectedApp.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/ProtectedApp.jsx
@@ -170,7 +170,7 @@ export default class ProtectedApp extends Component {
             .then((data) => {
                 // eslint-disable-next-line global-require, import/no-dynamic-require
                 addLocaleData(require(`react-intl/locale-data/${locale}`));
-                this.setState({ messages: defineMessages(data) });
+                this.setState({ messages: defineMessages({ ...data }) });
             });
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Shared/AppsAndKeys/Tokens.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Shared/AppsAndKeys/Tokens.jsx
@@ -161,7 +161,7 @@ class Tokens extends React.Component {
                             shrink: true,
                         }}
                         helperText={<FormattedMessage
-                            id='subscription.scopes.description'
+                            id='token.expiration.description'
                             defaultMessage={'You can set an expiration period to determine the validity period of ' +
                             'the token after generation. Set this to a negative value to ensure that the token never' +
                             ' expires.'}


### PR DESCRIPTION
Uses https://github.com/akameco/extract-react-intl-messages for autogenerating ids for i18n supported messages. 

- Use `npm run i18n' for regenerating ids.
- npm production build automatically regenerate all ids.