### PR TITLE
Update .travis.yml to get the caching work 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: true
 dist: trusty
 
 # Using -q Quiet output which only show errors, to overcome TravisCI log limit issue
-script: mvn clean install -Dmaven.test.skip -q -B -V | grep -v DEBUG; exit "${PIPESTATUS[0]}";
+script: mvn clean install -Dmaven.test.skip -q -B -V | grep -v DEBUG; test ${PIPESTATUS[0]} -eq 0;
 
 cache:
   directories:


### PR DESCRIPTION
Changed the `.travis.yml` as suggested in [here](https://travis-ci.community/t/java-maven-build-completes-successfully-but-m2-local-repository-is-not-getting-cached/4380/3). And now the [caching](https://travis-ci.org/wso2/carbon-apimgt/caches) is back 🙏 😃  . Hopefully, this will reduce the build execution time.