### PR TITLE
Update .travis.yml to improve the build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 sudo: true
+install:
+  - ""
 # Can't update to xenial distribution (ubuntu 16.04) bause of the Java JDK restriction (Not supporting )
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 dist: trusty
 
 # Using -q Quiet output which only show errors, to overcome TravisCI log limit issue
-script: mvn clean install -Dmaven.test.skip -q -B -V | grep -v DEBUG; test ${PIPESTATUS[0]} -eq 0;
+script: mvn clean install -q -B -V | grep -v DEBUG; test ${PIPESTATUS[0]} -eq 0;
 
 cache:
   directories:


### PR DESCRIPTION
In this PR

- Improve the build time
  - Without tests ![image](https://user-images.githubusercontent.com/3313885/61938980-e9e8da80-afaf-11e9-99d3-9f2ec3494ea0.png)
  - With tests ![image](https://user-images.githubusercontent.com/3313885/61941238-b3618e80-afb4-11e9-8924-eb157923caea.png)
  - Log file size with tests is `1846448`Bytes ~ 1.76 MB . We need to make sure it doesn’t exceed 4MB [limit](https://docs.travis-ci.com/user/common-build-problems/#log-length-exceeded)
- Skip the prebuild in Travis for java projects as mentioned in [here](https://docs.travis-ci.com/user/languages/java/#projects-using-maven)
- Remove skipping tests

