### PR TITLE
Null check fix for revoked token notifier properties

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/events/APIMOAuthEventInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/events/APIMOAuthEventInterceptor.java
@@ -53,8 +53,10 @@ public class APIMOAuthEventInterceptor extends AbstractOAuthEventInterceptor {
         log.debug("Initializing OAuth interceptor");
         realtimeNotifierProperties = APIManagerConfiguration.getRealtimeTokenRevocationNotifierProperties();
         persistentNotifierProperties = APIManagerConfiguration.getPersistentTokenRevocationNotifiersProperties();
-        realtimeNotifierEnabled = !realtimeNotifierProperties.isEmpty();
-        persistentNotifierEnabled = !persistentNotifierProperties.isEmpty();
+
+        realtimeNotifierEnabled = realtimeNotifierProperties != null;
+        persistentNotifierEnabled = persistentNotifierProperties != null;
+
         String className = APIManagerConfiguration.getTokenRevocationClassName();
         try {
             tokenRevocationNotifier = (TokenRevocationNotifier) Class.forName(className).getConstructor()


### PR DESCRIPTION
## Issue

product-apim: https://github.com/wso2/product-apim/issues/5247

## Methodology

Using null check instead of isEmpty() method in revoked token properties.