### PR TITLE
Add newmethod retrieveAllScopes() to URITemplate model to support multiple RESTAPI Scopes in Swagger 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
@@ -376,4 +376,8 @@ public class URITemplate implements Serializable{
     public void setId(int id) {
         this.id = id;
     }
+
+    public List<Scope> retrieveAllScopes() {
+        return this.scopes;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/WebAppAuthenticatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/WebAppAuthenticatorImpl.java
@@ -153,11 +153,8 @@ public class WebAppAuthenticatorImpl implements WebAppAuthenticator {
                             }
                             return true;
                         }
-                    } else if (((URITemplate) template).getScopes() != null) {
-                        //todo: fix template.getScopes() properly to return all scopes
-                        List<Scope> scopesList = new ArrayList<Scope>() {{
-                            add(((URITemplate) template).getScopes());
-                        }};
+                    } else if (!((URITemplate) template).retrieveAllScopes().isEmpty()) {
+                        List<Scope> scopesList = ((URITemplate) template).retrieveAllScopes();
                         for (Scope scpObj : scopesList) {
                             if (scope.equalsIgnoreCase(scpObj.getKey())) {
                                 //we found scopes matches


### PR DESCRIPTION
This PR adds a new method retrieveAllScopes() to URITemplate model. The method name is added as "retrieveAllScopes" instead of "getAllScopes", because when latter is used, API key validation fails while getting URI templates, as the URI template response will contain an empty element "allScopes". Hence to avoid the error, and to return the scope list array using the new method only when needed, we should use a methodname which does not contain "get" prefix.