### PR TITLE
Remove rest.api.util jar from web-apps lib directory

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/pom.xml
@@ -118,6 +118,7 @@
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
@@ -128,10 +128,10 @@
             <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
@@ -130,6 +130,7 @@
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/pom.xml
@@ -118,6 +118,7 @@
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/pom.xml
@@ -121,6 +121,7 @@
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store/pom.xml
@@ -113,6 +113,7 @@
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/pom.xml
@@ -32,14 +32,16 @@
     <url>http://wso2.org</url>
     <description>This feature contains required bundles for API Manager Rest API for API Admin Portal functionality</description>
 
-
     <dependencies>
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.admin</artifactId>
             <type>war</type>
         </dependency>
-
+        <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.axis2.wso2</groupId>
             <artifactId>axis2</artifactId>
@@ -159,6 +161,7 @@
                             </adviceFile>
                             <bundles>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.entitlement.stub:${carbon.identity.version}</bundleDef>
+                                <bundleDef>org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.rest.api.util:${carbon.apimgt.version}</bundleDef>
                             </bundles>
                         </configuration>
                     </execution>

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.dcr.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.dcr.feature/pom.xml
@@ -40,6 +40,10 @@
             <type>war</type>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.axis2.wso2</groupId>
             <artifactId>axis2</artifactId>
         </dependency>
@@ -120,6 +124,9 @@
                                     </propertyDef>
                                 </properties>
                             </adviceFile>
+                            <bundles>
+                                <bundleDef>org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.rest.api.util:${carbon.apimgt.version}</bundleDef>
+                            </bundles>
                         </configuration>
                     </execution>
                 </executions>

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
@@ -32,7 +32,6 @@
     <url>http://wso2.org</url>
     <description>This feature contains required bundles for API Manager Rest API for API publisher functionality</description>
 
-
     <dependencies>
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
@@ -43,6 +42,10 @@
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.publisher.v1</artifactId>
             <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.axis2.wso2</groupId>
@@ -186,7 +189,8 @@
                                 </properties>
                             </adviceFile>
                             <bundles>
-                            <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.entitlement.stub:${carbon.identity.version}</bundleDef>
+                                <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.entitlement.stub:${carbon.identity.version}</bundleDef>
+                                <bundleDef>org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.rest.api.util:${carbon.apimgt.version}</bundleDef>
                             </bundles>
                         </configuration>
                     </execution>

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
@@ -44,7 +44,10 @@
             <artifactId>org.wso2.carbon.apimgt.rest.api.store.v1</artifactId>
             <type>war</type>
         </dependency>
-
+        <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.axis2.wso2</groupId>
             <artifactId>axis2</artifactId>
@@ -188,6 +191,7 @@
                             </adviceFile>
                             <bundles>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.entitlement.stub:${carbon.identity.version}</bundleDef>
+                                <bundleDef>org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.rest.api.util:${carbon.apimgt.version}</bundleDef>
                             </bundles>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This PR removes the org.wso2.carbon.apimgt.rest.api.util jar from each web-app's lib directory and adds the same jar into <APIM-HOME>/lib/runtimes/cxf3/ directory, so that it will be picked in the runtime.