### PR TITLE
Adding missing HTML boilerplate tags to error pages

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/pages/error-pages/401.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/pages/error-pages/401.html
@@ -1,7 +1,7 @@
-
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/pages/error-pages/403.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/pages/error-pages/403.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/pages/error-pages/404.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/pages/error-pages/404.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/pages/error-pages/500.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/pages/error-pages/500.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/pages/error-pages/error-page.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/pages/error-pages/error-page.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/pages/error-pages/401.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/pages/error-pages/401.html
@@ -1,7 +1,7 @@
-
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/pages/error-pages/403.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/pages/error-pages/403.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/pages/error-pages/404.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/pages/error-pages/404.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/pages/error-pages/500.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/pages/error-pages/500.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/pages/error-pages/error-page.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/pages/error-pages/error-page.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/pages/error-pages/401.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/pages/error-pages/401.html
@@ -1,7 +1,7 @@
-
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/pages/error-pages/403.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/pages/error-pages/403.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/pages/error-pages/404.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/pages/error-pages/404.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/pages/error-pages/500.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/pages/error-pages/500.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/pages/error-pages/error-page.html
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store/site/pages/error-pages/error-page.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-
+    <meta charset="UTF-8">
 </head>
 
 <body>


### PR DESCRIPTION
HTML does not specify charset in the error pages in publisher, store and admin.