### PR TITLE
Revoke access tokens when user logging out using OIDC logout

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/pom.xml
@@ -48,6 +48,10 @@
             <artifactId>org.wso2.carbon.identity.oauth</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.datapublisher.authentication</groupId>
+            <artifactId>org.wso2.carbon.identity.data.publisher.application.authentication</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/SessionDataPublisherImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/SessionDataPublisherImpl.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.keymgt.handlers;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.data.publisher.application.authentication.AbstractAuthenticationDataPublisher;
+import org.wso2.carbon.identity.data.publisher.application.authentication.model.AuthenticationData;
+import org.wso2.carbon.identity.data.publisher.application.authentication.model.SessionData;
+import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
+import org.wso2.carbon.identity.oauth.OAuthUtil;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDAO;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
+import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
+
+import static org.wso2.carbon.identity.oauth.OAuthUtil.handleError;
+
+/**
+ * In this implementation, when a user logout, all the access tokens related to 'admin_store' or 'admin_publisher'
+ * applications for that particular user will be revoked.
+ */
+public class SessionDataPublisherImpl extends AbstractAuthenticationDataPublisher {
+
+    public static final Log log = LogFactory.getLog(SessionDataPublisherImpl.class);
+    private static final String handlerName = "APIMSessionDataPublisherImpl";
+
+    @Override public void doPublishAuthenticationStepSuccess(AuthenticationData authenticationData) {
+
+    }
+
+    @Override public void doPublishAuthenticationStepFailure(AuthenticationData authenticationData) {
+
+    }
+
+    @Override public void doPublishAuthenticationSuccess(AuthenticationData authenticationData) {
+
+    }
+
+    @Override public void doPublishAuthenticationFailure(AuthenticationData authenticationData) {
+
+    }
+
+    @Override public void doPublishSessionCreation(SessionData sessionData) {
+
+    }
+
+    @Override public void doPublishSessionUpdate(SessionData sessionData) {
+
+    }
+
+    @Override public void doPublishSessionTermination(SessionData sessionData) {
+
+    }
+
+    @Override public String getName() {
+        return handlerName;
+    }
+
+    @Override public boolean isEnabled(MessageContext messageContext) {
+        return true;
+    }
+
+    /**
+     * Overridden method which implements the access token revocation
+     * @param request termination request
+     * @param context termination context
+     * @param sessionContext termination sessionContext
+     * @param params termination params
+     */
+    @Override public void publishSessionTermination(HttpServletRequest request, AuthenticationContext context,
+            SessionContext sessionContext, Map<String, Object> params) {
+
+        OAuthConsumerAppDTO[] appDTOs = new OAuthConsumerAppDTO[0];
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) params.get("user");
+        String username = authenticatedUser.getUserName();
+        String tenantDomain = authenticatedUser.getTenantDomain();
+        String userStoreDomain = authenticatedUser.getUserStoreDomain();
+        AuthenticatedUser federatedUser;
+
+        if (authenticatedUser.isFederatedUser()) {
+            try {
+                federatedUser = buildAuthenticatedUser(authenticatedUser);
+                authenticatedUser = federatedUser;
+            } catch (IdentityOAuth2Exception e) {
+                log.error("Error thrown while building authenticated user in logout flow for user " + authenticatedUser
+                        .getUserName(), e);
+            }
+        }
+        try {
+            appDTOs = getAppsAuthorizedByUser(authenticatedUser);
+            if (appDTOs.length > 0) {
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "The user: " + authenticatedUser.getUserName() + " has " + appDTOs.length + " OAuth apps");
+                }
+            }
+        } catch (IdentityOAuthAdminException e) {
+            log.error("Error while retrieving applications authorized for the user " + authenticatedUser.getUserName(),
+                    e);
+        }
+
+        for (OAuthConsumerAppDTO appDTO : appDTOs) {
+            if (StringUtils.equalsIgnoreCase("admin_store", appDTO.getApplicationName()) || StringUtils
+                    .equalsIgnoreCase("admin_publisher", appDTO.getApplicationName())) {
+                Set<AccessTokenDO> accessTokenDOs = null;
+                try {
+                    // Retrieve all ACTIVE or EXPIRED access tokens for particular client authorized by this user
+                    accessTokenDOs = OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
+                            .getAccessTokens(appDTO.getOauthConsumerKey(), authenticatedUser,
+                                    authenticatedUser.getUserStoreDomain(), true);
+                } catch (IdentityOAuth2Exception e) {
+                    log.error("Error while retrieving access tokens for the application " + appDTO.getApplicationName()
+                            + "and the for user " + authenticatedUser.getUserName(), e);
+                }
+                AuthenticatedUser authzUser;
+                if (accessTokenDOs != null) {
+                    for (AccessTokenDO accessTokenDO : accessTokenDOs) {
+                        //Clear cache with AccessTokenDO
+                        authzUser = accessTokenDO.getAuthzUser();
+                        OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), authzUser,
+                                OAuth2Util.buildScopeString(accessTokenDO.getScope()));
+                        OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), authzUser);
+                        OAuthUtil.clearOAuthCache(accessTokenDO.getAccessToken());
+                        AccessTokenDO scopedToken = null;
+                        try {
+                            // Retrieve latest access token for particular client, user and scope combination if
+                            // its ACTIVE or EXPIRED.
+                            scopedToken = OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
+                                    .getLatestAccessToken(appDTO.getOauthConsumerKey(), authenticatedUser,
+                                            userStoreDomain, OAuth2Util.buildScopeString(accessTokenDO.getScope()),
+                                            true);
+                        } catch (IdentityOAuth2Exception e) {
+                            log.error("Error while retrieving scoped access tokens for the application " + appDTO
+                                    .getApplicationName() + "and the for user " + authenticatedUser.getUserName(), e);
+                        }
+                        if (scopedToken != null) {
+                            //Revoking token from database
+                            try {
+                                OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
+                                        .revokeAccessTokens(new String[] { scopedToken.getAccessToken() });
+
+                            } catch (IdentityOAuth2Exception e) {
+                                log.error("Error while revoking access tokens related for the application " + appDTO
+                                                .getApplicationName() + "and the for user " + authenticatedUser.getUserName(),
+                                        e);
+                            }
+                            //Revoking the oauth consent from database.
+                            try {
+                                OAuthTokenPersistenceFactory.getInstance().getTokenManagementDAO()
+                                        .revokeOAuthConsentByApplicationAndUser(
+                                                authzUser.getAuthenticatedSubjectIdentifier(), tenantDomain, username);
+                            } catch (IdentityOAuth2Exception e) {
+                                log.error("Error while revoking access tokens related for the application " + appDTO
+                                                .getApplicationName() + "and the for user " + authenticatedUser.getUserName(),
+                                        e);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Method to retrieve applications authorized for user
+     * @param authenticatedUser authenticated user info
+     * @return array of authorized applications
+     * @throws IdentityOAuthAdminException exception
+     */
+    private OAuthConsumerAppDTO[] getAppsAuthorizedByUser(AuthenticatedUser authenticatedUser)
+            throws IdentityOAuthAdminException {
+
+        OAuthAppDAO appDAO = new OAuthAppDAO();
+        String tenantAwareusername = authenticatedUser.getUserName();
+        String tenantDomain = authenticatedUser.getTenantDomain();
+        String username = UserCoreUtil.addTenantDomainToEntry(tenantAwareusername, tenantDomain);
+        String userStoreDomain = authenticatedUser.getUserStoreDomain();
+        Set<String> clientIds;
+        try {
+            clientIds = OAuthTokenPersistenceFactory.getInstance().getTokenManagementDAO()
+                    .getAllTimeAuthorizedClientIds(authenticatedUser);
+        } catch (IdentityOAuth2Exception e) {
+            throw handleError("Error occurred while retrieving apps authorized by User ID : " + username, e);
+        }
+        Set<OAuthConsumerAppDTO> appDTOs = new HashSet<>();
+        for (String clientId : clientIds) {
+            Set<AccessTokenDO> accessTokenDOs;
+            try {
+                accessTokenDOs = OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
+                        .getAccessTokens(clientId, authenticatedUser, userStoreDomain, true);
+            } catch (IdentityOAuth2Exception e) {
+                throw handleError(
+                        "Error occurred while retrieving access tokens issued for " + "Client ID : " + clientId
+                                + ", User ID : " + username, e);
+            }
+            if (!accessTokenDOs.isEmpty()) {
+                Set<String> distinctClientUserScopeCombo = new HashSet<>();
+                for (AccessTokenDO accessTokenDO : accessTokenDOs) {
+                    AccessTokenDO scopedToken;
+                    String scopeString = OAuth2Util.buildScopeString(accessTokenDO.getScope());
+                    try {
+                        scopedToken = OAuthTokenPersistenceFactory.getInstance().
+                                getAccessTokenDAO()
+                                .getLatestAccessToken(clientId, authenticatedUser, userStoreDomain, scopeString, true);
+                        if (scopedToken != null && !distinctClientUserScopeCombo.contains(clientId + ":" + username)) {
+                            OAuthAppDO appDO;
+                            try {
+                                appDO = appDAO.getAppInformation(scopedToken.getConsumerKey());
+                                appDTOs.add(buildConsumerAppDTO(appDO));
+                                if (log.isDebugEnabled()) {
+                                    log.debug("Found App: " + appDO.getApplicationName() + " for user: " + username);
+                                }
+                            } catch (InvalidOAuthClientException e) {
+                                String errorMsg = "Invalid Client ID : " + scopedToken.getConsumerKey();
+                                log.error(errorMsg, e);
+                                throw new IdentityOAuthAdminException(errorMsg);
+                            } catch (IdentityOAuth2Exception e) {
+                                String errorMsg =
+                                        "Error occurred while retrieving app information " + "for Client ID : "
+                                                + scopedToken.getConsumerKey();
+                                log.error(errorMsg, e);
+                                throw new IdentityOAuthAdminException(errorMsg);
+                            }
+                            distinctClientUserScopeCombo.add(clientId + ":" + username);
+                        }
+                    } catch (IdentityOAuth2Exception e) {
+                        String errorMsg =
+                                "Error occurred while retrieving latest access token issued for Client ID :" + " "
+                                        + clientId + ", User ID : " + username + " and Scope : " + scopeString;
+                        throw handleError(errorMsg, e);
+                    }
+                }
+            }
+        }
+        return appDTOs.toArray(new OAuthConsumerAppDTO[0]);
+    }
+
+    /**
+     * Method to build a OAuthConsumerAppDTO type object
+     * @param appDO required param
+     * @return OAuthConsumerAppDTO type object
+     */
+    private OAuthConsumerAppDTO buildConsumerAppDTO(OAuthAppDO appDO) {
+
+        OAuthConsumerAppDTO dto = new OAuthConsumerAppDTO();
+        dto.setApplicationName(appDO.getApplicationName());
+        dto.setCallbackUrl(appDO.getCallbackUrl());
+        dto.setOauthConsumerKey(appDO.getOauthConsumerKey());
+        dto.setOauthConsumerSecret(appDO.getOauthConsumerSecret());
+        dto.setOAuthVersion(appDO.getOauthVersion());
+        dto.setGrantTypes(appDO.getGrantTypes());
+        dto.setScopeValidators(appDO.getScopeValidators());
+        dto.setUsername(appDO.getAppOwner().toFullQualifiedUsername());
+        dto.setState(appDO.getState());
+        dto.setPkceMandatory(appDO.isPkceMandatory());
+        dto.setPkceSupportPlain(appDO.isPkceSupportPlain());
+        dto.setUserAccessTokenExpiryTime(appDO.getUserAccessTokenExpiryTime());
+        dto.setApplicationAccessTokenExpiryTime(appDO.getApplicationAccessTokenExpiryTime());
+        dto.setRefreshTokenExpiryTime(appDO.getRefreshTokenExpiryTime());
+        dto.setIdTokenExpiryTime(appDO.getIdTokenExpiryTime());
+        dto.setAudiences(appDO.getAudiences());
+        dto.setRequestObjectSignatureValidationEnabled(appDO.isRequestObjectSignatureValidationEnabled());
+        dto.setIdTokenEncryptionEnabled(appDO.isIdTokenEncryptionEnabled());
+        dto.setIdTokenEncryptionAlgorithm(appDO.getIdTokenEncryptionAlgorithm());
+        dto.setIdTokenEncryptionMethod(appDO.getIdTokenEncryptionMethod());
+        dto.setBackChannelLogoutUrl(appDO.getBackChannelLogoutUrl());
+        dto.setTokenType(appDO.getTokenType());
+        dto.setBypassClientCredentials(appDO.isBypassClientCredentials());
+        return dto;
+    }
+
+    /**
+     * Method to build a AuthenticatedUser type object
+     * @param authenticatedUser required param
+     * @return AuthenticatedUser type object
+     * @throws IdentityOAuth2Exception exception
+     */
+    private AuthenticatedUser buildAuthenticatedUser(AuthenticatedUser authenticatedUser)
+            throws IdentityOAuth2Exception {
+
+        AuthenticatedUser user = new AuthenticatedUser();
+        String tenantAwareusername = authenticatedUser.getUserName();
+        String tenantDomain = authenticatedUser.getTenantDomain();
+        user.setUserName(UserCoreUtil.removeDomainFromName(tenantAwareusername));
+        user.setTenantDomain(tenantDomain);
+        user.setUserStoreDomain(IdentityUtil.extractDomainFromName(tenantAwareusername));
+        user.setFederatedUser(true);
+        user.setUserStoreDomain(OAuth2Util.getUserStoreForFederatedUser(authenticatedUser));
+        return user;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/internal/APIKeyMgtServiceComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/internal/APIKeyMgtServiceComponent.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
 import org.wso2.carbon.apimgt.impl.dto.ThrottleProperties;
 import org.wso2.carbon.apimgt.keymgt.ScopesIssuer;
 import org.wso2.carbon.apimgt.keymgt.events.APIMOAuthEventInterceptor;
+import org.wso2.carbon.apimgt.keymgt.handlers.SessionDataPublisherImpl;
 import org.wso2.carbon.apimgt.keymgt.issuers.AbstractScopesIssuer;
 import org.wso2.carbon.apimgt.keymgt.issuers.PermissionBasedScopeIssuer;
 import org.wso2.carbon.apimgt.keymgt.issuers.RoleBasedScopesIssuer;
@@ -35,6 +36,7 @@ import org.wso2.carbon.apimgt.keymgt.util.APIKeyMgtDataHolder;
 import org.wso2.carbon.event.output.adapter.core.OutputEventAdapterConfiguration;
 import org.wso2.carbon.event.output.adapter.core.OutputEventAdapterService;
 import org.wso2.carbon.event.output.adapter.core.exception.OutputEventAdapterException;
+import org.wso2.carbon.identity.application.authentication.framework.AuthenticationDataPublisher;
 import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
@@ -84,6 +86,14 @@ public class APIKeyMgtServiceComponent {
                 log.debug("Key Manager OAuth Event Interceptor is enabled.");
             } else {
                 log.debug("Token Revocation Notifier Feature is disabled.");
+            }
+            // registering logout token revoke listener
+            try {
+                SessionDataPublisherImpl dataPublisher = new SessionDataPublisherImpl();
+                ctxt.getBundleContext().registerService(AuthenticationDataPublisher.class.getName(), dataPublisher, null);
+                log.debug("SessionDataPublisherImpl bundle is activated");
+            } catch (Throwable e) {
+                log.error("SessionDataPublisherImpl bundle activation Failed", e);
             }
             // loading white listed scopes
             List<String> whitelist = null;

--- a/pom.xml
+++ b/pom.xml
@@ -948,6 +948,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.wso2.carbon.identity.datapublisher.authentication</groupId>
+                <artifactId>org.wso2.carbon.identity.data.publisher.application.authentication</artifactId>
+                <version>${carbon.identity-data-publisher-application-authentication.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.user.registration.stub</artifactId>
                 <version>${carbon.identity.version}</version>
@@ -1582,6 +1588,7 @@
         <carbon.identity-inbound-auth-openid.version>5.4.0</carbon.identity-inbound-auth-openid.version>
         <carbon.identity-local-auth-basicauth.version>6.2.0</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.2.3</carbon.identity-outbound-auth-samlsso.version>
+        <carbon.identity-data-publisher-application-authentication.version>5.1.8</carbon.identity-data-publisher-application-authentication.version>
         <graphql.java.version>13.0.wso2v1</graphql.java.version>
 
         <carbon.governance.version>4.8.2</carbon.governance.version>


### PR DESCRIPTION
## Issue 
product-apim: https://github.com/wso2/product-apim/issues/5120

## Methodology
- We have implemented a custom listener extending AbstractAuthenticationDataPublisher and overriding the publishSessionTermination() to invoke the token revocation when OIDC logout happens.
- Here, all the tokens for that particular user for all sessions will be revoked. Therefore, this will revoke any tokens from other active concurrent sessions for that particular user for relevant applications(admin_store,admin_publisher).
- Although, we are retrieving all the user authorized applications, we are revoking token related to 'admin_store' and 'admin_publisher' applications.
- This will not revoke any tokens related to user created applications.