### PR TITLE
fixes for enableSchemaValidation REST API property

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -532,10 +532,9 @@ public class ApisApiServiceImpl implements ApisApiService {
             }
             API apiToUpdate = APIMappingUtil.fromDTOtoAPI(body, apiIdentifier.getProviderName());
             apiToUpdate.setThumbnailUrl(originalAPI.getThumbnailUrl());
-            apiToUpdate.setEnableSchemaValidation(originalAPI.isEnabledSchemaValidation());
+
             //attach micro-geteway labels
             assignLabelsToDTO(body, apiToUpdate);
-
             apiProvider.updateAPI(apiToUpdate);
 
             if (!isWSAPI) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/APIMappingUtil.java
@@ -150,6 +150,7 @@ public class APIMappingUtil {
         model.setImplementation(dto.getEndpointImplementationType().toString());
         model.setWsdlUrl(dto.getWsdlUri());
         model.setType(dto.getType().toString());
+        model.setEnableSchemaValidation(dto.isEnableSchemaValidation());
 
         if (dto.getLifeCycleStatus() != null) {
             model.setStatus((dto.getLifeCycleStatus() != null) ? dto.getLifeCycleStatus().toUpperCase() : null);


### PR DESCRIPTION
This PR contains the REST API update property. 
This will comply with the JSON schema validation enable switch in API details configure page.