### PR TITLE
Add API import-export REST API and implementation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -328,7 +328,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/APIImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/APIImportExportConstants.java
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.importexport;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class contains all the constants required for API Import and Export.
+ */
+public final class APIImportExportConstants {
+
+    //System independent file separator for zip files
+    public static final char ZIP_FILE_SEPARATOR = '/';
+    //length of the name of the temporary directory
+    public static final int TEMP_FILENAME_LENGTH = 5;
+    //name of the uploaded zip file
+    public static final String UPLOAD_FILE_NAME = "APIArchive.zip";
+    //location of the api YAML file
+    public static final String YAML_API_FILE_LOCATION = File.separator + "Meta-information" + File.separator +
+            "api.yaml";
+    //location of the api YAML file
+    public static final String JSON_API_FILE_LOCATION = File.separator + "Meta-information" + File.separator +
+            "api.json";
+    //name of the id element tag of the api.json file
+    public static final String ID_ELEMENT = "id";
+    //name of the api provider element tag of the api.json file
+    public static final String PROVIDER_ELEMENT = "providerName";
+    //location of the api swagger definition file
+    public static final String JSON_SWAGGER_DEFINITION_LOCATION = File.separator
+            + APIImportExportConstants.META_INFO_DIRECTORY + File.separator + "swagger.json";
+    //location of the api swagger definition file
+    public static final String YAML_SWAGGER_DEFINITION_LOCATION = File.separator
+            + APIImportExportConstants.META_INFO_DIRECTORY + File.separator + "swagger.yaml";
+    //Image resource
+    public static final String IMAGE_RESOURCE = "Image";
+    //Sequences resource
+    public static final String SEQUENCES_RESOURCE = "Sequences";
+    //Custom type
+    public static final String CUSTOM_TYPE = "Custom";
+    //location of the image
+    public static final String IMAGE_FILE_LOCATION = File.separator + IMAGE_RESOURCE + File.separator;
+    //location of the documents JSON file
+    public static final String JSON_DOCUMENT_FILE_LOCATION = File.separator + APIImportExportConstants.DOCUMENT_DIRECTORY
+            + File.separator + "docs.json";
+    //location of the documents YAML file
+    public static final String YAML_DOCUMENT_FILE_LOCATION = File.separator + APIImportExportConstants.DOCUMENT_DIRECTORY
+            + File.separator + "docs.yaml";
+    //name of the physical file type
+    public static final String FILE_DOC_TYPE = "FILE";
+    //location of the in sequence
+    public static final String IN_SEQUENCE_LOCATION = File.separator + APIImportExportConstants.SEQUENCES_RESOURCE
+            + File.separator + "in-sequence" + File.separator;
+    //location of the out sequence
+    public static final String OUT_SEQUENCE_LOCATION = File.separator + APIImportExportConstants.SEQUENCES_RESOURCE
+            + File.separator + "out-sequence" + File.separator;
+    //location of the fault sequence
+    public static final String FAULT_SEQUENCE_LOCATION = File.separator + APIImportExportConstants.SEQUENCES_RESOURCE
+            + File.separator + "fault-sequence" + File.separator;
+    //location of the wsdl file
+    public static final String WSDL_LOCATION = File.separator + "WSDL" + File.separator;
+
+    public static final String WSDL_URL = "wsdlUrl";
+
+    public static final String DOCUMENT_DIRECTORY = "Docs";
+
+    public static final String INLINE_DOCUMENT_DIRECTORY = "InlineContents";
+
+    public static final String FILE_DOCUMENT_DIRECTORY = "FileContents";
+
+    public static final String CHARSET = "UTF-8";
+
+    public static final String META_INFO_DIRECTORY = "Meta-information";
+
+    public static final String YAML_ENDPOINTS_CERTIFICATE_FILE = File.separator
+            + APIImportExportConstants.META_INFO_DIRECTORY + File.separator + "endpoint_certificates.yaml";
+
+    public static final String JSON_ENDPOINTS_CERTIFICATE_FILE = File.separator
+            + APIImportExportConstants.META_INFO_DIRECTORY + File.separator + "endpoint_certificates.json";
+
+    public static final String HOSTNAME_JSON_KEY = "hostName";
+
+    public static final String ALIAS_JSON_KEY = "alias";
+
+    public static final String CERTIFICATE_CONTENT_JSON_KEY = "certificate";
+
+    public static final String NODE_TRANSITION = "transition";
+
+    public static final Map<String, String> fileExtensionMapping = new HashMap<>();
+
+    static {
+        fileExtensionMapping.put("image/png", "png");
+        fileExtensionMapping.put("image/jpeg", "jpeg");
+        fileExtensionMapping.put("image/jpg", "jpg");
+        fileExtensionMapping.put("image/bmp", "bmp");
+        fileExtensionMapping.put("image/gif", "gif");
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/APIImportExportException.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/APIImportExportException.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.importexport;
+
+/**
+ * This is the class to represent APIImportException. This exception is used to indicate the
+ * exceptions that might be occurred during API import process.
+ */
+public class APIImportExportException extends Exception {
+
+    public APIImportExportException(String errorMessage) {
+        super(errorMessage);
+    }
+
+    public APIImportExportException(String msg, Throwable e) {
+        super(msg, e);
+    }
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/APIImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/APIImportExportManager.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.importexport;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIProvider;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.importexport.utils.APIExportUtil;
+import org.wso2.carbon.apimgt.impl.importexport.utils.APIImportUtil;
+import org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil;
+
+import java.io.File;
+import java.io.InputStream;
+
+/**
+ * This class is responsible for providing helper functions to import and export APIs.
+ */
+public class APIImportExportManager {
+
+    private static final Log log = LogFactory.getLog(APIImportExportManager.class);
+    private APIProvider apiProvider;
+    private String loggedInUsername;
+
+    /**
+     * Constructor to initialize APIImportExportManager by APIProvider and current user.
+     *
+     * @param apiProvider      API Provider for logged in user
+     * @param loggedInUsername Current username
+     */
+    public APIImportExportManager(APIProvider apiProvider, String loggedInUsername) {
+        this.apiProvider = apiProvider;
+        this.loggedInUsername = loggedInUsername;
+    }
+
+    public APIProvider getApiProvider() {
+        return apiProvider;
+    }
+
+    /**
+     * This method is used to export the given API as an archive (zip file).
+     *
+     * @param apiToReturn       Requested API to export
+     * @param isStatusPreserved Is API status preserved or not
+     * @param exportFormat      Export file format of the API
+     * @return Archive file for the requested API
+     * @throws APIImportExportException If an error occurs while exporting the API and creating the archive
+     */
+    public File exportAPIArchive(API apiToReturn, boolean isStatusPreserved, ExportFormat exportFormat)
+            throws APIImportExportException {
+
+        APIIdentifier apiIdentifier = apiToReturn.getId();
+        //create temp location for storing API data to generate archive
+        File exportFolder = CommonUtil.createTempDirectory();
+        String archiveBasePath = exportFolder.toString();
+
+        //Retrieve the API and related artifacts and populate the archive folder in the temp location
+        APIExportUtil.retrieveApiToExport(archiveBasePath, apiToReturn, apiProvider, loggedInUsername, isStatusPreserved,
+                exportFormat);
+        CommonUtil.archiveDirectory(archiveBasePath);
+        log.info("API" + apiIdentifier.getApiName() + "-" + apiIdentifier.getVersion() + " exported successfully");
+        return new File(archiveBasePath + APIConstants.ZIP_FILE_EXTENSION);
+    }
+
+    /**
+     * This method is used to import the given API archive file. Importing an API as a new API and overwriting an existing
+     * API both are supported. In both cases, the state of the API will be preserved.
+     *
+     * @param uploadedInputStream Input stream for importing API archive file
+     * @param isProviderPreserved Is API Provider preserved or not
+     * @param overwrite           Whether to overwrite an existing API (update API)
+     * @throws APIImportExportException If an error occurs while importing the API
+     */
+    public void importAPIArchive(InputStream uploadedInputStream, Boolean isProviderPreserved, Boolean overwrite)
+            throws APIImportExportException {
+        //Temporary directory is used to create the required folders
+        File importFolder = CommonUtil.createTempDirectory();
+        String uploadFileName = APIImportExportConstants.UPLOAD_FILE_NAME;
+        String absolutePath = importFolder.getAbsolutePath() + File.separator;
+        CommonUtil.transferFile(uploadedInputStream, uploadFileName, absolutePath);
+
+        String extractedFolderName = CommonUtil.extractArchive(new File(absolutePath + uploadFileName), absolutePath);
+
+        APIImportUtil.importAPI(absolutePath + extractedFolderName, loggedInUsername, isProviderPreserved,
+                apiProvider, overwrite);
+        importFolder.deleteOnExit();
+    }
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/CertificateDetail.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/CertificateDetail.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.importexport;
+
+/**
+ * Class to hold certificate information detail hostname/alias/certificate which will write to a json file.
+ */
+public class CertificateDetail {
+    private String hostName;
+    private String alias;
+    private String certificate;
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public void setCertificate(String certificate) {
+        this.certificate = certificate;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public String getCertificate() {
+        return certificate;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ExportFormat.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ExportFormat.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.importexport;
+
+/**
+ * Enum to hold the export file format of API artifacts.
+ */
+public enum ExportFormat {
+    JSON,
+    YAML
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/lifecycle/LifeCycle.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/lifecycle/LifeCycle.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.importexport.lifecycle;
+
+import java.util.HashMap;
+
+/**
+ * Represent lifecycle of an API.
+ */
+public class LifeCycle {
+    private HashMap<String, LifeCycleTransition> stateHashMap;
+
+    /**
+     * Initialize lifecycle.
+     */
+    public LifeCycle() {
+        this.stateHashMap = new HashMap<>();
+    }
+
+    /**
+     * Adds a state for a lifecycle.
+     *
+     * @param state      State to be added
+     * @param transition Transition associated with state
+     */
+    public void addLifeCycleState(String state, LifeCycleTransition transition) {
+        stateHashMap.put(state, transition);
+    }
+
+    /**
+     * Returns the transition associated with state.
+     *
+     * @param state State to get transitions
+     * @return Transition associated with state
+     */
+    public LifeCycleTransition getTransition(String state) {
+        if (!stateHashMap.containsKey(state)) {
+            return null;
+        }
+        return stateHashMap.get(state);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/lifecycle/LifeCycleTransition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/lifecycle/LifeCycleTransition.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.importexport.lifecycle;
+
+import java.util.HashMap;
+
+/**
+ * This class represents lifecycle transition.
+ */
+public class LifeCycleTransition {
+    private HashMap<String, String> transitions;
+
+    /**
+     * Initialize class
+     */
+    public LifeCycleTransition() {
+        this.transitions = new HashMap<>();
+    }
+
+    /**
+     * Returns action required to transit to state.
+     *
+     * @param state State to get action
+     * @return lifecycle action associated or null if not found
+     */
+    public String getAction(String state) {
+        if (!transitions.containsKey(state)) {
+            return null;
+        }
+        return transitions.get(state);
+    }
+
+    /**
+     * Adds a transition.
+     *
+     * @param targetStatus target status
+     * @param action       action associated with target
+     */
+    public void addTransition(String targetStatus, String action) {
+        transitions.put(targetStatus, action);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
@@ -117,8 +117,7 @@ public class APIExportUtil {
             if (!docList.isEmpty()) {
                 exportAPIDocumentation(archivePath, docList, apiIDToReturn, registry, exportFormat);
             } else if (log.isDebugEnabled()) {
-                log.debug("No documentation found for API: " + apiIDToReturn
-                        + ". Skipping API documentation export.");
+                log.debug("No documentation found for API: " + apiIDToReturn + ". Skipping API documentation export.");
             }
 
             //export wsdl
@@ -182,7 +181,8 @@ public class APIExportUtil {
                         IOUtils.copy(imageDataStream, outputStream);
                         if (log.isDebugEnabled()) {
                             log.debug("Thumbnail image retrieved successfully for API: " + apiIdentifier.getApiName()
-                                    + " version: " + apiIdentifier.getVersion());
+                                    + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": "
+                                    + apiIdentifier.getVersion());
                         }
                     }
                 } else {
@@ -191,8 +191,8 @@ public class APIExportUtil {
                 }
             } else if (log.isDebugEnabled()) {
                 log.debug("Thumbnail URL [" + thumbnailUrl + "] does not exists in registry for API: "
-                        + apiIdentifier.getApiName() + " version: " + apiIdentifier.getVersion()
-                        + ". Skipping thumbnail export.");
+                        + apiIdentifier.getApiName() + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": "
+                        + apiIdentifier.getVersion() + ". Skipping thumbnail export.");
 
             }
         } catch (RegistryException e) {
@@ -279,16 +279,17 @@ public class APIExportUtil {
 
             if (log.isDebugEnabled()) {
                 log.debug("API Documentation retrieved successfully for API: " + apiIdentifier.getApiName()
-                        + " version: " + apiIdentifier.getVersion());
+                        + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": " + apiIdentifier.getVersion());
             }
         } catch (IOException e) {
             String errorMessage = "I/O error while writing API documentation to file for API: "
-                    + apiIdentifier.getApiName() + " version: " + apiIdentifier.getVersion();
+                    + apiIdentifier.getApiName() + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": "
+                    + apiIdentifier.getVersion();
             log.error(errorMessage, e);
             throw new APIImportExportException(errorMessage, e);
         } catch (RegistryException e) {
             String errorMessage = "Error while retrieving documentation for API: " + apiIdentifier.getApiName()
-                    + " version: " + apiIdentifier.getVersion();
+                    + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": " + apiIdentifier.getVersion();
             log.error(errorMessage, e);
             throw new APIImportExportException(errorMessage, e);
         }
@@ -373,14 +374,15 @@ public class APIExportUtil {
                         //If sequence doesn't exist in 'apimgt/customsequences/{in/out/fault}' directory check in API
                         //specific registry path
                         sequenceDetails = getAPISpecificSequence(api.getId(), sequenceName, direction, registry);
-                        pathToExportedSequence += "Custom";
+                        pathToExportedSequence += APIImportExportConstants.CUSTOM_TYPE;
                     }
                     writeSequenceToFile(pathToExportedSequence, sequenceDetails, apiIdentifier);
                 }
             }
         } else if (log.isDebugEnabled()) {
-            log.debug("No custom sequences available for API: " + apiIdentifier.getApiName() + " version: "
-                    + apiIdentifier.getVersion() + ". Skipping custom sequence export.");
+            log.debug("No custom sequences available for API: " + apiIdentifier.getApiName() + StringUtils.SPACE
+                    + APIConstants.API_DATA_VERSION + ": " + apiIdentifier.getVersion()
+                    + ". Skipping custom sequence export.");
         }
     }
 
@@ -564,17 +566,18 @@ public class APIExportUtil {
 
                 if (log.isDebugEnabled()) {
                     log.debug("Meta information retrieved successfully for API: " + apiToReturn.getId().getApiName()
-                            + " version: " + apiToReturn.getId().getVersion());
+                            + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": " + apiToReturn.getId().getVersion());
                 }
             }
         } catch (APIManagementException e) {
             String errorMessage = "Error while retrieving Swagger definition for API: "
-                    + apiToReturn.getId().getApiName() + " version: " + apiToReturn.getId().getVersion();
+                    + apiToReturn.getId().getApiName() + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": "
+                    + apiToReturn.getId().getVersion();
             log.error(errorMessage, e);
             throw new APIImportExportException(errorMessage, e);
         } catch (IOException e) {
             String errorMessage = "Error while retrieving saving as YAML for API: " + apiToReturn.getId().getApiName()
-                    + " version: " + apiToReturn.getId().getVersion();
+                    + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": " + apiToReturn.getId().getVersion();
             log.error(errorMessage, e);
             throw new APIImportExportException(errorMessage, e);
         }
@@ -650,8 +653,8 @@ public class APIExportUtil {
                                 element);
                 }
             } else if (log.isDebugEnabled()) {
-                log.debug("No endpoint certificates available for API: " + api.getId().getApiName() + " version: "
-                        + api.getId().getVersion() + ". Skipping certificate export.");
+                log.debug("No endpoint certificates available for API: " + api.getId().getApiName() + StringUtils.SPACE
+                        + APIConstants.API_DATA_VERSION + ": " + api.getId().getVersion() + ". Skipping certificate export.");
             }
         } catch (JSONException e) {
             String errorMsg = "Error in converting Endpoint config to JSON object in API: " + api.getId().getApiName();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
@@ -193,7 +193,6 @@ public class APIExportUtil {
                 log.debug("Thumbnail URL [" + thumbnailUrl + "] does not exists in registry for API: "
                         + apiIdentifier.getApiName() + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": "
                         + apiIdentifier.getVersion() + ". Skipping thumbnail export.");
-
             }
         } catch (RegistryException e) {
             log.error("Error while retrieving API Thumbnail " + thumbnailUrl, e);
@@ -366,8 +365,7 @@ public class APIExportUtil {
                 AbstractMap.SimpleEntry<String, OMElement> sequenceDetails;
                 String sequenceName = sequence.getValue();
                 String direction = sequence.getKey();
-                String pathToExportedSequence = seqArchivePath + File.separator + direction + "-sequence"
-                        + File.separator;
+                String pathToExportedSequence = seqArchivePath + File.separator + direction + "-sequence" + File.separator;
                 if (sequenceName != null) {
                     sequenceDetails = getCustomSequence(sequenceName, direction, registry);
                     if (sequenceDetails == null) {
@@ -411,7 +409,7 @@ public class APIExportUtil {
     }
 
     /**
-     * Retrieve API Specific sequence details from the registry
+     * Retrieve API Specific sequence details from the registry.
      *
      * @param sequenceName Name of the sequence
      * @param type         Sequence type
@@ -424,10 +422,9 @@ public class APIExportUtil {
                                                                                      Registry registry)
             throws APIImportExportException {
 
-        String regPath = APIConstants.API_ROOT_LOCATION + RegistryConstants.PATH_SEPARATOR + api
-                .getProviderName() + RegistryConstants.PATH_SEPARATOR + api.getApiName() +
-                RegistryConstants.PATH_SEPARATOR + api.getVersion() + RegistryConstants.PATH_SEPARATOR + type;
-
+        String regPath = APIConstants.API_ROOT_LOCATION + RegistryConstants.PATH_SEPARATOR + api.getProviderName()
+                + RegistryConstants.PATH_SEPARATOR + api.getApiName() + RegistryConstants.PATH_SEPARATOR
+                + api.getVersion() + RegistryConstants.PATH_SEPARATOR + type;
         return getSeqDetailsFromRegistry(sequenceName, regPath, registry);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
@@ -1,0 +1,785 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.importexport.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
+import org.apache.axiom.om.OMElement;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.wso2.carbon.apimgt.api.APIDefinition;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.APIProvider;
+import org.wso2.carbon.apimgt.api.dto.CertificateMetadataDTO;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.Documentation;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.definitions.APIDefinitionFromOpenAPISpec;
+import org.wso2.carbon.apimgt.impl.importexport.APIImportExportConstants;
+import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
+import org.wso2.carbon.apimgt.impl.importexport.CertificateDetail;
+import org.wso2.carbon.apimgt.impl.importexport.ExportFormat;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.registry.api.Collection;
+import org.wso2.carbon.registry.api.Registry;
+import org.wso2.carbon.registry.api.RegistryException;
+import org.wso2.carbon.registry.api.Resource;
+import org.wso2.carbon.registry.core.RegistryConstants;
+import org.wso2.carbon.registry.core.session.UserRegistry;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+
+/**
+ * This is the util class which consists of all the functions for exporting API.
+ */
+public class APIExportUtil {
+
+    private static final Log log = LogFactory.getLog(APIExportUtil.class);
+
+    private APIExportUtil() {
+    }
+
+    /**
+     * This method retrieves all meta information and registry resources required for an API to
+     * recreate.
+     *
+     * @param apiToReturn       Exporting API
+     * @param userName          User name of the requester
+     * @param exportFormat      Export format of the API meta data, could be yaml or json
+     * @param isStatusPreserved Whether API status is preserved while export
+     * @throws APIImportExportException If an error occurs while retrieving API related resources
+     */
+    public static void retrieveApiToExport(String archiveBasePath, API apiToReturn, APIProvider provider, String userName,
+                                           boolean isStatusPreserved, ExportFormat exportFormat)
+            throws APIImportExportException {
+
+        UserRegistry registry;
+        APIIdentifier apiIDToReturn = apiToReturn.getId();
+        String archivePath = archiveBasePath.concat(File.separator + apiIDToReturn.getApiName() + "-"
+                + apiIDToReturn.getVersion());
+        int tenantId = APIUtil.getTenantId(userName);
+
+        try {
+            registry = ServiceReferenceHolder.getInstance().getRegistryService().getGovernanceSystemRegistry(tenantId);
+            //directory creation
+            CommonUtil.createDirectory(archivePath);
+
+            //export thumbnail
+            exportAPIThumbnail(archivePath, apiIDToReturn, registry);
+
+            //export documents
+            List<Documentation> docList = provider.getAllDocumentation(apiIDToReturn, userName);
+            if (!docList.isEmpty()) {
+                exportAPIDocumentation(archivePath, docList, apiIDToReturn, registry, exportFormat);
+            } else if (log.isDebugEnabled()) {
+                log.debug("No documentation found for API: " + apiIDToReturn
+                        + ". Skipping API documentation export.");
+            }
+
+            //export wsdl
+            if (StringUtils.isNotEmpty(apiToReturn.getWsdlUrl())) {
+                exportWSDL(archivePath, apiIDToReturn, registry);
+            } else if (log.isDebugEnabled()) {
+                log.debug("No WSDL URL found for API: " + apiIDToReturn + ". Skipping WSDL export.");
+            }
+
+            //export sequences
+            exportSequences(archivePath, apiToReturn, registry);
+
+            //set API status to created if status is not preserved
+            if (!isStatusPreserved) {
+                apiToReturn.setStatus(APIConstants.CREATED);
+            }
+
+            //export certificates
+            exportEndpointCertificates(archivePath, apiToReturn, tenantId, provider, exportFormat);
+
+            //export meta information
+            exportMetaInformation(archivePath, apiToReturn, registry, exportFormat);
+        } catch (APIManagementException e) {
+            String errorMessage = "Unable to retrieve API Documentation for API: " + apiIDToReturn.getApiName()
+                    + StringUtils.SPACE + APIConstants.API_DATA_VERSION + " : " + apiIDToReturn.getVersion();
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (RegistryException e) {
+            String errorMessage = "Error while getting governance registry for tenant: " + tenantId;
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Retrieve thumbnail image for the exporting API and store it in the archive directory.
+     *
+     * @param apiIdentifier ID of the requesting API
+     * @param registry      Current tenant registry
+     * @throws APIImportExportException If an error occurs while retrieving image from the registry or
+     *                                  storing in the archive directory
+     */
+    private static void exportAPIThumbnail(String archivePath, APIIdentifier apiIdentifier, Registry registry)
+            throws APIImportExportException {
+
+        String thumbnailUrl = APIConstants.API_IMAGE_LOCATION + RegistryConstants.PATH_SEPARATOR
+                + apiIdentifier.getProviderName() + RegistryConstants.PATH_SEPARATOR + apiIdentifier.getApiName()
+                + RegistryConstants.PATH_SEPARATOR + apiIdentifier.getVersion() + RegistryConstants.PATH_SEPARATOR
+                + APIConstants.API_ICON_IMAGE;
+        String localImagePath = archivePath + File.separator + APIImportExportConstants.IMAGE_RESOURCE;
+        try {
+            if (registry.resourceExists(thumbnailUrl)) {
+                Resource icon = registry.get(thumbnailUrl);
+                String mediaType = icon.getMediaType();
+                String extension = APIImportExportConstants.fileExtensionMapping.get(mediaType);
+                if (extension != null) {
+                    CommonUtil.createDirectory(localImagePath);
+                    try (InputStream imageDataStream = icon.getContentStream();
+                         OutputStream outputStream = new FileOutputStream(localImagePath + File.separator
+                                 + APIConstants.API_ICON_IMAGE + APIConstants.DOT + extension)) {
+                        IOUtils.copy(imageDataStream, outputStream);
+                        if (log.isDebugEnabled()) {
+                            log.debug("Thumbnail image retrieved successfully for API: " + apiIdentifier.getApiName()
+                                    + " version: " + apiIdentifier.getVersion());
+                        }
+                    }
+                } else {
+                    //api gets imported without thumbnail
+                    log.error("Unsupported media type for icon " + mediaType + ". Skipping thumbnail export.");
+                }
+            } else if (log.isDebugEnabled()) {
+                log.debug("Thumbnail URL [" + thumbnailUrl + "] does not exists in registry for API: "
+                        + apiIdentifier.getApiName() + " version: " + apiIdentifier.getVersion()
+                        + ". Skipping thumbnail export.");
+
+            }
+        } catch (RegistryException e) {
+            log.error("Error while retrieving API Thumbnail " + thumbnailUrl, e);
+        } catch (IOException e) {
+            //Exception is ignored by logging due to the reason that Thumbnail is not essential for
+            //an API to be recreated.
+            log.error("I/O error while writing API Thumbnail: " + thumbnailUrl + " to file", e);
+        }
+    }
+
+    /**
+     * Retrieve documentation for the exporting API and store it in the archive directory.
+     * FILE, INLINE, MARKDOWN and URL documentations are handled.
+     *
+     * @param apiIdentifier ID of the requesting API
+     * @param registry      Current tenant registry
+     * @param docList       documentation list of the exporting API
+     * @param exportFormat  Format for export
+     * @throws APIImportExportException If an error occurs while retrieving documents from the
+     *                                  registry or storing in the archive directory
+     */
+    private static void exportAPIDocumentation(String archivePath, List<Documentation> docList,
+                                               APIIdentifier apiIdentifier, Registry registry, ExportFormat exportFormat)
+            throws APIImportExportException {
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        String docDirectoryPath = File.separator + APIImportExportConstants.DOCUMENT_DIRECTORY;
+        CommonUtil.createDirectory(archivePath + docDirectoryPath);
+        try {
+            for (Documentation doc : docList) {
+                String sourceType = doc.getSourceType().name();
+                String resourcePath = null;
+                String localFilePath;
+                String localFileName = null;
+                String localDocDirectoryPath = docDirectoryPath;
+                if (Documentation.DocumentSourceType.FILE.toString().equalsIgnoreCase(sourceType)) {
+                    localFileName = doc.getFilePath().substring(
+                            doc.getFilePath().lastIndexOf(RegistryConstants.PATH_SEPARATOR) + 1);
+                    resourcePath = APIUtil.getDocumentationFilePath(apiIdentifier, localFileName);
+                    localDocDirectoryPath += File.separator + APIImportExportConstants.FILE_DOCUMENT_DIRECTORY;
+                    doc.setFilePath(localFileName);
+                } else if (Documentation.DocumentSourceType.INLINE.toString().equalsIgnoreCase(sourceType)
+                        || Documentation.DocumentSourceType.MARKDOWN.toString().equalsIgnoreCase(sourceType)) {
+                    //Inline/Markdown content file name would be same as the documentation name
+                    //Markdown content files will also be stored in InlineContents directory
+                    localFileName = doc.getName();
+                    resourcePath = APIUtil.getAPIDocPath(apiIdentifier) + RegistryConstants.PATH_SEPARATOR
+                            + APIConstants.INLINE_DOCUMENT_CONTENT_DIR + RegistryConstants.PATH_SEPARATOR
+                            + localFileName;
+                    localDocDirectoryPath += File.separator + APIImportExportConstants.INLINE_DOCUMENT_DIRECTORY;
+                }
+
+                if (resourcePath != null) {
+                    //Write content separately for Inline/Markdown/File type documentations only
+                    //check whether resource exists in the registry
+                    if (registry.resourceExists(resourcePath)) {
+                        CommonUtil.createDirectory(archivePath + localDocDirectoryPath);
+                        localFilePath = localDocDirectoryPath + File.separator + localFileName;
+                        Resource docFile = registry.get(resourcePath);
+                        try (OutputStream outputStream = new FileOutputStream(archivePath + localFilePath);
+                             InputStream fileInputStream = docFile.getContentStream()) {
+                            IOUtils.copy(fileInputStream, outputStream);
+                        }
+                    } else {
+                        String errorMessage = "Documentation resource for API: " + apiIdentifier.getApiName()
+                                + " not found in " + resourcePath;
+                        log.error(errorMessage);
+                        throw new APIImportExportException(errorMessage);
+                    }
+                }
+            }
+
+            String json = gson.toJson(docList);
+            switch (exportFormat) {
+                case JSON:
+                    CommonUtil.writeFile(archivePath + APIImportExportConstants.JSON_DOCUMENT_FILE_LOCATION, json);
+                    break;
+                case YAML:
+                    String yaml = CommonUtil.jsonToYaml(json);
+                    CommonUtil.writeFile(archivePath + APIImportExportConstants.YAML_DOCUMENT_FILE_LOCATION, yaml);
+                    break;
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("API Documentation retrieved successfully for API: " + apiIdentifier.getApiName()
+                        + " version: " + apiIdentifier.getVersion());
+            }
+        } catch (IOException e) {
+            String errorMessage = "I/O error while writing API documentation to file for API: "
+                    + apiIdentifier.getApiName() + " version: " + apiIdentifier.getVersion();
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (RegistryException e) {
+            String errorMessage = "Error while retrieving documentation for API: " + apiIdentifier.getApiName()
+                    + " version: " + apiIdentifier.getVersion();
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Retrieve WSDL for the exporting API and store it in the archive directory.
+     *
+     * @param apiIdentifier ID of the requesting API
+     * @param registry      Current tenant registry
+     * @throws APIImportExportException If an error occurs while retrieving WSDL from the registry or
+     *                                  storing in the archive directory
+     */
+    private static void exportWSDL(String archivePath, APIIdentifier apiIdentifier, Registry registry)
+            throws APIImportExportException {
+
+        String wsdlPath = APIConstants.API_WSDL_RESOURCE_LOCATION + apiIdentifier.getProviderName() + "--"
+                + apiIdentifier.getApiName() + apiIdentifier.getVersion() + APIConstants.WSDL_FILE_EXTENSION;
+        try {
+            if (registry.resourceExists(wsdlPath)) {
+                CommonUtil.createDirectory(archivePath + File.separator + "WSDL");
+                Resource wsdl = registry.get(wsdlPath);
+                try (InputStream wsdlStream = wsdl.getContentStream();
+                     OutputStream outputStream = new FileOutputStream(archivePath + File.separator + "WSDL"
+                             + File.separator + apiIdentifier.getApiName() + "-" + apiIdentifier.getVersion()
+                             + APIConstants.WSDL_FILE_EXTENSION)) {
+                    IOUtils.copy(wsdlStream, outputStream);
+                    if (log.isDebugEnabled()) {
+                        log.debug("WSDL file: " + wsdlPath + " retrieved successfully");
+                    }
+                }
+            } else if (log.isDebugEnabled()) {
+                log.debug("WSDL resource does not exists in path: " + wsdlPath + ". Skipping WSDL export.");
+            }
+        } catch (IOException e) {
+            String errorMessage = "I/O error while writing WSDL: " + wsdlPath + " to file";
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (RegistryException e) {
+            String errorMessage = "Error while retrieving WSDL: " + wsdlPath + " to file";
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Retrieve available custom sequences and API specific sequences for API export.
+     *
+     * @param api      exporting API
+     * @param registry current tenant registry
+     * @throws APIImportExportException If an error occurs while exporting sequences
+     */
+    private static void exportSequences(String archivePath, API api, Registry registry) throws APIImportExportException {
+
+        Map<String, String> sequences = new HashMap<>();
+        APIIdentifier apiIdentifier = api.getId();
+        String seqArchivePath = archivePath.concat(File.separator + "Sequences");
+
+        if (api.getInSequence() != null) {
+            sequences.put(APIConstants.API_CUSTOM_SEQUENCE_TYPE_IN, api.getInSequence());
+        }
+
+        if (api.getOutSequence() != null) {
+            sequences.put(APIConstants.API_CUSTOM_SEQUENCE_TYPE_OUT, api.getOutSequence());
+        }
+
+        if (api.getFaultSequence() != null) {
+            sequences.put(APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT, api.getFaultSequence());
+        }
+
+        if (!sequences.isEmpty()) {
+            CommonUtil.createDirectory(seqArchivePath);
+            for (Map.Entry<String, String> sequence : sequences.entrySet()) {
+                AbstractMap.SimpleEntry<String, OMElement> sequenceDetails;
+                String sequenceName = sequence.getValue();
+                String direction = sequence.getKey();
+                String pathToExportedSequence = seqArchivePath + File.separator + direction + "-sequence"
+                        + File.separator;
+                if (sequenceName != null) {
+                    sequenceDetails = getCustomSequence(sequenceName, direction, registry);
+                    if (sequenceDetails == null) {
+                        //If sequence doesn't exist in 'apimgt/customsequences/{in/out/fault}' directory check in API
+                        //specific registry path
+                        sequenceDetails = getAPISpecificSequence(api.getId(), sequenceName, direction, registry);
+                        pathToExportedSequence += "Custom";
+                    }
+                    writeSequenceToFile(pathToExportedSequence, sequenceDetails, apiIdentifier);
+                }
+            }
+        } else if (log.isDebugEnabled()) {
+            log.debug("No custom sequences available for API: " + apiIdentifier.getApiName() + " version: "
+                    + apiIdentifier.getVersion() + ". Skipping custom sequence export.");
+        }
+    }
+
+    /**
+     * Retrieve custom sequence details from the registry.
+     *
+     * @param sequenceName Name of the sequence
+     * @param type         Sequence type
+     * @param registry     Current tenant registry
+     * @return Registry resource name of the sequence and its content
+     * @throws APIImportExportException If an error occurs while retrieving registry elements
+     */
+    private static AbstractMap.SimpleEntry<String, OMElement> getCustomSequence(String sequenceName, String type,
+                                                                                Registry registry)
+            throws APIImportExportException {
+
+        String regPath = null;
+        if (APIConstants.API_CUSTOM_SEQUENCE_TYPE_IN.equals(type)) {
+            regPath = APIConstants.API_CUSTOM_INSEQUENCE_LOCATION;
+        } else if (APIConstants.API_CUSTOM_SEQUENCE_TYPE_OUT.equals(type)) {
+            regPath = APIConstants.API_CUSTOM_OUTSEQUENCE_LOCATION;
+        } else if (APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT.equals(type)) {
+            regPath = APIConstants.API_CUSTOM_FAULTSEQUENCE_LOCATION;
+        }
+        return getSeqDetailsFromRegistry(sequenceName, regPath, registry);
+    }
+
+    /**
+     * Retrieve API Specific sequence details from the registry
+     *
+     * @param sequenceName Name of the sequence
+     * @param type         Sequence type
+     * @param registry     Current tenant registry
+     * @return Registry resource name of the sequence and its content
+     * @throws APIImportExportException If an error occurs while retrieving registry elements
+     */
+    private static AbstractMap.SimpleEntry<String, OMElement> getAPISpecificSequence(APIIdentifier api,
+                                                                                     String sequenceName, String type,
+                                                                                     Registry registry)
+            throws APIImportExportException {
+
+        String regPath = APIConstants.API_ROOT_LOCATION + RegistryConstants.PATH_SEPARATOR + api
+                .getProviderName() + RegistryConstants.PATH_SEPARATOR + api.getApiName() +
+                RegistryConstants.PATH_SEPARATOR + api.getVersion() + RegistryConstants.PATH_SEPARATOR + type;
+
+        return getSeqDetailsFromRegistry(sequenceName, regPath, registry);
+    }
+
+    /**
+     * Retrieve sequence details from registry by given registry path.
+     *
+     * @param sequenceName Sequence Name
+     * @param regPath      Registry path
+     * @param registry     Registry
+     * @return Sequence details as a simple entry
+     * @throws APIImportExportException If an error occurs while retrieving sequence details from registry
+     */
+    private static AbstractMap.SimpleEntry<String, OMElement> getSeqDetailsFromRegistry(String sequenceName,
+                                                                                        String regPath, Registry registry)
+            throws APIImportExportException {
+
+        AbstractMap.SimpleEntry<String, OMElement> sequenceDetails = null;
+        Collection seqCollection;
+
+        try {
+            seqCollection = (Collection) registry.get(regPath);
+            if (seqCollection != null) {
+                String[] childPaths = seqCollection.getChildren();
+                for (String childPath : childPaths) {
+                    Resource sequence = registry.get(childPath);
+                    OMElement seqElement = APIUtil.buildOMElement(sequence.getContentStream());
+                    if (sequenceName.equals(seqElement.getAttributeValue(new QName("name")))) {
+                        String sequenceFileName = sequence.getPath().
+                                substring(sequence.getPath().lastIndexOf(RegistryConstants.PATH_SEPARATOR));
+                        sequenceDetails = new AbstractMap.SimpleEntry<>(sequenceFileName, seqElement);
+                        break;
+                    }
+                }
+            }
+        } catch (RegistryException e) {
+            String errorMessage = "Error while retrieving sequence: " + sequenceName + " from the path: " + regPath;
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (Exception e) {
+            //APIUtil.buildOMElement() throws a generic exception
+            String errorMessage = "Error while reading content for sequence: " + sequenceName + " from the registry";
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+        return sequenceDetails;
+    }
+
+    /**
+     * Store API Specific or custom sequences in the archive directory.
+     *
+     * @param sequenceDetails Details of the sequence
+     * @param apiIdentifier   ID of the requesting API
+     * @throws APIImportExportException If an error occurs while serializing XML stream or storing in
+     *                                  archive directory
+     */
+    private static void writeSequenceToFile(String pathToExportedSequence,
+                                            AbstractMap.SimpleEntry<String, OMElement> sequenceDetails,
+                                            APIIdentifier apiIdentifier)
+            throws APIImportExportException {
+
+        if (sequenceDetails != null) {
+            String sequenceFileName = sequenceDetails.getKey();
+            OMElement sequenceConfig = sequenceDetails.getValue();
+            CommonUtil.createDirectory(pathToExportedSequence);
+            String exportedSequenceFile = pathToExportedSequence + sequenceFileName;
+            try (OutputStream outputStream = new FileOutputStream(exportedSequenceFile)) {
+                sequenceConfig.serialize(outputStream);
+                if (log.isDebugEnabled()) {
+                    log.debug(sequenceFileName + " of API: " + apiIdentifier.getApiName() + " retrieved successfully");
+                }
+            } catch (IOException e) {
+                String errorMessage = "Unable to find file: " + exportedSequenceFile;
+                log.error(errorMessage, e);
+                throw new APIImportExportException(errorMessage, e);
+            } catch (XMLStreamException e) {
+                String errorMessage = "Error while processing XML stream ";
+                log.error(errorMessage, e);
+                throw new APIImportExportException(errorMessage, e);
+            }
+        } else {
+            String errorMessage = "Error while writing sequence of API: " + apiIdentifier.getApiName() + " to file.";
+            log.error(errorMessage);
+            throw new APIImportExportException(errorMessage);
+        }
+    }
+
+    /**
+     * Retrieve meta information of the API to export.
+     * URL template information are stored in swagger.json definition while rest of the required
+     * data are in api.json
+     *
+     * @param apiToReturn  API to be exported
+     * @param registry     Current tenant registry
+     * @param exportFormat Export format of file
+     * @throws APIImportExportException If an error occurs while exporting meta information
+     */
+    private static void exportMetaInformation(String archivePath, API apiToReturn, Registry registry,
+                                              ExportFormat exportFormat) throws APIImportExportException {
+
+        APIDefinition definitionFromOpenAPISpec = new APIDefinitionFromOpenAPISpec();
+        CommonUtil.createDirectory(archivePath + File.separator + APIImportExportConstants.META_INFO_DIRECTORY);
+        //Remove unnecessary data from exported Api
+        cleanApiDataToExport(apiToReturn);
+
+        try {
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            String apiInJson = gson.toJson(apiToReturn);
+            switch (exportFormat) {
+                case JSON:
+                    CommonUtil.writeFile(archivePath + APIImportExportConstants.JSON_API_FILE_LOCATION, apiInJson);
+                    break;
+                case YAML:
+                    String apiInYaml = CommonUtil.jsonToYaml(apiInJson);
+                    CommonUtil.writeFile(archivePath + APIImportExportConstants.YAML_API_FILE_LOCATION, apiInYaml);
+                    break;
+            }
+
+            //If a web socket API is exported, it does not contain a swagger file.
+            //Therefore swagger export is only required for REST or SOAP based APIs
+            if (!APIConstants.APITransportType.WS.toString().equalsIgnoreCase(apiToReturn.getType())) {
+                String swaggerDefinition = definitionFromOpenAPISpec.getAPIDefinition(apiToReturn.getId(), registry);
+                JsonParser parser = new JsonParser();
+                JsonObject json = parser.parse(swaggerDefinition).getAsJsonObject();
+                String formattedSwaggerJson = gson.toJson(json);
+
+                switch (exportFormat) {
+                    case YAML:
+                        String swaggerInYaml = CommonUtil.jsonToYaml(formattedSwaggerJson);
+                        CommonUtil.writeFile(archivePath + APIImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION,
+                                swaggerInYaml);
+                        break;
+                    case JSON:
+                        CommonUtil.writeFile(archivePath + APIImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION,
+                                formattedSwaggerJson);
+                }
+
+                if (log.isDebugEnabled()) {
+                    log.debug("Meta information retrieved successfully for API: " + apiToReturn.getId().getApiName()
+                            + " version: " + apiToReturn.getId().getVersion());
+                }
+            }
+        } catch (APIManagementException e) {
+            String errorMessage = "Error while retrieving Swagger definition for API: "
+                    + apiToReturn.getId().getApiName() + " version: " + apiToReturn.getId().getVersion();
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (IOException e) {
+            String errorMessage = "Error while retrieving saving as YAML for API: " + apiToReturn.getId().getApiName()
+                    + " version: " + apiToReturn.getId().getVersion();
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Clean api by removing unnecessary details.
+     *
+     * @param api API to be exported
+     */
+    private static void cleanApiDataToExport(API api) {
+        // Thumbnail will be set according to the importing environment. Therefore current URL is removed
+        api.setThumbnailUrl(null);
+        // WSDL file path will be set according to the importing environment. Therefore current path is removed
+        api.setWsdlUrl(null);
+        // Swagger.json contains complete details about scopes and URI templates. Therefore scope and URI template
+        // details are removed from api.json
+        api.setScopes(new LinkedHashSet<>());
+        // Secure endpoint password is removed, as it causes security issues. When importing need to add it manually,
+        // if Secure Endpoint is enabled.
+        if (api.getEndpointUTPassword() != null) {
+            api.setEndpointUTPassword(StringUtils.EMPTY);
+        }
+    }
+
+    /**
+     * Export endpoint certificates.
+     *
+     * @param api          API to be exported
+     * @param tenantId     tenant id of the user
+     * @param apiProvider  api Provider
+     * @param exportFormat Export format of file
+     * @throws APIImportExportException If an error occurs while exporting endpoint certificates
+     */
+    private static void exportEndpointCertificates(String archivePath, API api, int tenantId, APIProvider apiProvider,
+                                                   ExportFormat exportFormat) throws APIImportExportException {
+
+        JSONObject endpointConfig;
+        JSONTokener tokener = new JSONTokener(api.getEndpointConfig());
+        List<String> productionHostNames;
+        List<String> sandboxEndpoints;
+        Set<String> uniqueHostNames = new HashSet<>();
+        List<CertificateDetail> endpointCertificatesDetails = new ArrayList<>();
+
+        try {
+            endpointConfig = new JSONObject(tokener);
+            productionHostNames = getHostNames(endpointConfig, APIConstants.API_DATA_PRODUCTION_ENDPOINTS,
+                    api.getId().getApiName());
+            sandboxEndpoints = getHostNames(endpointConfig, APIConstants.API_DATA_SANDBOX_ENDPOINTS,
+                    api.getId().getApiName());
+            uniqueHostNames.addAll(productionHostNames); // Remove duplicate and append result
+            uniqueHostNames.addAll(sandboxEndpoints);
+            for (String hostname : uniqueHostNames) {
+                List<CertificateDetail> list = getCertificateContentAndMetaData(tenantId, hostname, apiProvider);
+                endpointCertificatesDetails.addAll(list);
+            }
+            if (!endpointCertificatesDetails.isEmpty()) {
+                CommonUtil.createDirectory(archivePath + File.separator
+                        + APIImportExportConstants.META_INFO_DIRECTORY);
+                Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                String element = gson.toJson(endpointCertificatesDetails,
+                        new TypeToken<ArrayList<CertificateDetail>>() {
+                        }.getType());
+
+                switch (exportFormat) {
+                    case YAML:
+                        String yaml = CommonUtil.jsonToYaml(element);
+                        CommonUtil.writeFile(archivePath + APIImportExportConstants.YAML_ENDPOINTS_CERTIFICATE_FILE,
+                                yaml);
+                        break;
+                    case JSON:
+                        CommonUtil.writeFile(archivePath + APIImportExportConstants.JSON_ENDPOINTS_CERTIFICATE_FILE,
+                                element);
+                }
+            } else if (log.isDebugEnabled()) {
+                log.debug("No endpoint certificates available for API: " + api.getId().getApiName() + " version: "
+                        + api.getId().getVersion() + ". Skipping certificate export.");
+            }
+        } catch (JSONException e) {
+            String errorMsg = "Error in converting Endpoint config to JSON object in API: " + api.getId().getApiName();
+            throw new APIImportExportException(errorMsg, e);
+        } catch (IOException e) {
+            String errorMessage = "Error while retrieving saving endpoint certificate details for API: "
+                    + api.getId().getApiName() + " as YAML";
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Get the hostname from a given endpoint url.
+     *
+     * @param url url of the endpoint
+     * @return host address of the endpoint
+     */
+    private static String getHostAddress(URL url) {
+        String host = url.getHost();
+        String protocol = url.getProtocol();
+        int port = url.getPort();
+        String address;
+        if (port != -1) {
+            address = protocol + "://" + host + ":" + port;
+        } else {
+            address = protocol + "://" + host;
+        }
+        return address;
+    }
+
+    /**
+     * Get hostname list from endpoint config.
+     *
+     * @param endpointConfig JSON converted endpoint config
+     * @param type           end point type - production/sandbox
+     * @return list of hostnames
+     */
+    private static List<String> getHostNames(JSONObject endpointConfig, String type, String apiName) {
+        List<String> hostNames = new ArrayList<>();
+        List<String> urls = new ArrayList<>();
+        if (endpointConfig != null) {
+            try {
+                Object item;
+                item = endpointConfig.get(type);
+                if (item instanceof JSONArray) {
+                    JSONArray endpointsJSON = new JSONArray(endpointConfig.getJSONArray(type).toString());
+                    for (int i = 0; i < endpointsJSON.length(); i++) {
+                        try {
+                            String urlValue = endpointsJSON.getJSONObject(i).get(APIConstants.API_DATA_URL).toString();
+                            urls.add(urlValue);
+                        } catch (JSONException ex) {
+                            log.error("Endpoint URL extraction from endpoints JSON object failed in API: "
+                                    + apiName, ex);
+                        }
+                    }
+                } else if (item instanceof JSONObject) {
+                    JSONObject endpointJSON = new JSONObject(endpointConfig.getJSONObject(type).toString());
+                    try {
+                        String urlValue = endpointJSON.get(APIConstants.API_DATA_URL).toString();
+                        urls.add(urlValue);
+                    } catch (JSONException ex) {
+                        log.error("Endpoint URL extraction from endpoint JSON object failed in API: " + apiName, ex);
+                    }
+                }
+                for (String url : urls) {
+                    try {
+                        URL urlObj = new URL(url);
+                        String address = getHostAddress(urlObj);
+                        hostNames.add(address);
+                    } catch (MalformedURLException e) {
+                        log.error("URL object creation from extracted endpoint URL: " + url + " failed in API: "
+                                + apiName);
+                    }
+                }
+            } catch (JSONException ex) {
+                log.info("Endpoint type: " + type + " not found in API: " + apiName);
+            }
+        }
+        return hostNames;
+    }
+
+    /**
+     * Get Certificate MetaData and Certificate detail and build JSON list.
+     *
+     * @param tenantId    tenant id of the user
+     * @param hostname    hostname of the endpoint
+     * @param apiProvider api Provider
+     * @return list of certificate detail JSON objects
+     * @throws APIImportExportException If an error occurs while retrieving endpoint certificate metadata and content
+     */
+    private static List<CertificateDetail> getCertificateContentAndMetaData(int tenantId, String hostname,
+                                                                            APIProvider apiProvider)
+            throws APIImportExportException {
+        List<CertificateDetail> certificateDetails = new ArrayList<>();
+        List<CertificateMetadataDTO> certificateMetadataDTOS;
+        try {
+            certificateMetadataDTOS = apiProvider.searchCertificates(tenantId, null, hostname);
+        } catch (APIManagementException e) {
+            String errorMsg = "Error retrieving certificate meta data. For tenantId: " + tenantId + " hostname: "
+                    + hostname;
+            throw new APIImportExportException(errorMsg, e);
+        }
+
+        certificateMetadataDTOS.forEach(metadataDTO -> {
+            ByteArrayInputStream certificate = null;
+            try {
+                certificate = apiProvider.getCertificateContent(metadataDTO.getAlias());
+                certificate.close();
+                byte[] certificateContent = IOUtils.toByteArray(certificate);
+                String encodedCertificate = new String(Base64.encodeBase64(certificateContent));
+                CertificateDetail certificateDetail = new CertificateDetail();
+                certificateDetail.setHostName(hostname);
+                certificateDetail.setAlias(metadataDTO.getAlias());
+                certificateDetail.setCertificate(encodedCertificate);
+                certificateDetails.add(certificateDetail);
+            } catch (APIManagementException e) {
+                log.error("Error retrieving certificate content. For tenantId: " + tenantId + " hostname: "
+                        + hostname + " alias: " + metadataDTO.getAlias(), e);
+            } catch (IOException e) {
+                log.error("Error while converting certificate content to Byte Array. For tenantId: " + tenantId
+                        + " hostname: " + hostname + " alias: " + metadataDTO.getAlias(), e);
+            } finally {
+                if (certificate != null) {
+                    IOUtils.closeQuietly(certificate);
+                }
+            }
+        });
+        return certificateDetails;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -282,8 +282,8 @@ public final class APIImportUtil {
                 APIIdentifier apiIdentifier = new APIIdentifier(APIUtil.replaceEmailDomain(provider), apiName, apiVersion);
                 // Checking whether the API exists
                 if (!apiProvider.isAPIAvailable(apiIdentifier)) {
-                    String errorMessage = "Error occurred while updating. API: " + apiName + " version: " + apiVersion
-                            + " not found";
+                    String errorMessage = "Error occurred while updating. API: " + apiName + StringUtils.SPACE
+                            + APIConstants.API_DATA_VERSION + ": " + apiVersion + " not found";
                     throw new APIMgtResourceNotFoundException(errorMessage);
                 }
                 targetApi = apiProvider.getAPI(apiIdentifier);
@@ -402,7 +402,8 @@ public final class APIImportUtil {
         } catch (APIManagementException e) {
             String errorMessage = "Error while importing API: ";
             if (importedApi != null) {
-                errorMessage += importedApi.getId().getApiName() + " version: " + importedApi.getId().getVersion();
+                errorMessage += importedApi.getId().getApiName() + StringUtils.SPACE + APIConstants.API_DATA_VERSION
+                        + ": " + importedApi.getId().getVersion();
             }
             log.error(errorMessage, e);
             throw new APIImportExportException(errorMessage, e);
@@ -756,7 +757,7 @@ public final class APIImportUtil {
             apiProvider.saveSwagger20Definition(apiId, swaggerContent);
         } catch (APIManagementException e) {
             String errorMessage = "Error in adding Swagger definition for the API: " + apiId.getApiName()
-                    + " version: " + apiId.getVersion();
+                    + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": " + apiId.getVersion();
             log.error(errorMessage, e);
             throw new APIImportExportException(errorMessage, e);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -1,0 +1,843 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.importexport.utils;
+
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.wso2.carbon.apimgt.api.APIDefinition;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.APIMgtAuthorizationFailedException;
+import org.wso2.carbon.apimgt.api.APIMgtResourceAlreadyExistsException;
+import org.wso2.carbon.apimgt.api.APIMgtResourceNotFoundException;
+import org.wso2.carbon.apimgt.api.APIProvider;
+import org.wso2.carbon.apimgt.api.FaultGatewaysException;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.APIStatus;
+import org.wso2.carbon.apimgt.api.model.Documentation;
+import org.wso2.carbon.apimgt.api.model.ResourceFile;
+import org.wso2.carbon.apimgt.api.model.Scope;
+import org.wso2.carbon.apimgt.api.model.Tier;
+import org.wso2.carbon.apimgt.api.model.URITemplate;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.certificatemgt.ResponseCode;
+import org.wso2.carbon.apimgt.impl.definitions.APIDefinitionFromOpenAPISpec;
+import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
+import org.wso2.carbon.apimgt.impl.importexport.APIImportExportConstants;
+import org.wso2.carbon.apimgt.impl.importexport.lifecycle.LifeCycle;
+import org.wso2.carbon.apimgt.impl.importexport.lifecycle.LifeCycleTransition;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.registry.core.Registry;
+import org.wso2.carbon.registry.core.RegistryConstants;
+import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.registry.api.RegistryException;
+import org.wso2.carbon.registry.core.session.UserRegistry;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+import org.xml.sax.SAXException;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+/**
+ * This class provides the functions utilized to import an API from an API archive.
+ */
+public final class APIImportUtil {
+
+    private static final Log log = LogFactory.getLog(APIImportUtil.class);
+
+    /**
+     * This method returns the lifecycle action which can be used to transit from currentStatus to targetStatus.
+     *
+     * @param tenantDomain  Tenant domain
+     * @param currentStatus Current status to do status transition
+     * @param targetStatus  Target status to do status transition
+     * @return Lifecycle action or null if target is not reachable
+     * @throws APIImportExportException If getting lifecycle action failed
+     */
+    private static String getLifeCycleAction(String tenantDomain, String currentStatus, String targetStatus,
+                                             APIProvider provider) throws APIImportExportException {
+        LifeCycle lifeCycle = new LifeCycle();
+        // Parse DOM of APILifeCycle
+        try {
+            String data = provider.getLifecycleConfiguration(tenantDomain);
+            DocumentBuilderFactory factory = APIUtil.getSecuredDocumentBuilder();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
+            Document doc = builder.parse(inputStream);
+            Element root = doc.getDocumentElement();
+
+            // Get all nodes with state
+            NodeList states = root.getElementsByTagName("state");
+            int nStates = states.getLength();
+            for (int i = 0; i < nStates; i++) {
+                Node node = states.item(i);
+                Node id = node.getAttributes().getNamedItem("id");
+                if (id != null && !id.getNodeValue().isEmpty()) {
+                    LifeCycleTransition lifeCycleTransition = new LifeCycleTransition();
+                    NodeList transitions = node.getChildNodes();
+                    int nTransitions = transitions.getLength();
+                    for (int j = 0; j < nTransitions; j++) {
+                        Node transition = transitions.item(j);
+                        // Add transitions
+                        if (APIImportExportConstants.NODE_TRANSITION.equals(transition.getNodeName())) {
+                            Node target = transition.getAttributes().getNamedItem("target");
+                            Node action = transition.getAttributes().getNamedItem("event");
+                            if (target != null && action != null) {
+                                lifeCycleTransition.addTransition(target.getNodeValue().toLowerCase(), action.getNodeValue());
+                            }
+                        }
+                    }
+                    lifeCycle.addLifeCycleState(id.getNodeValue().toLowerCase(), lifeCycleTransition);
+                }
+            }
+        } catch (ParserConfigurationException | SAXException e) {
+            String errorMessage = "Error parsing APILifeCycle for tenant: " + tenantDomain;
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (UnsupportedEncodingException e) {
+            String errorMessage = "Error parsing unsupported encoding for APILifeCycle in tenant: " + tenantDomain;
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (IOException e) {
+            String errorMessage = "Error reading APILifeCycle for tenant: " + tenantDomain;
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (APIManagementException e) {
+            String errorMessage = "Error retrieving APILifeCycle for tenant: " + tenantDomain;
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+
+        // Retrieve lifecycle action
+        LifeCycleTransition transition = lifeCycle.getTransition(currentStatus.toLowerCase());
+        if (transition != null) {
+            return transition.getAction(targetStatus.toLowerCase());
+        }
+        return null;
+    }
+
+    /**
+     * Load a swagger document from archive. This method lookup for swagger as YAML or JSON.
+     *
+     * @param pathToArchive Path to archive
+     * @return Swagger content as a JSON
+     * @throws IOException When swagger document not found
+     */
+    private static String loadSwaggerFile(String pathToArchive) throws IOException {
+        if (CommonUtil.checkFileExistence(pathToArchive
+                + APIImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Found swagger file " + pathToArchive
+                        + APIImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION);
+            }
+            String yamlContent = FileUtils.readFileToString(
+                    new File(pathToArchive + APIImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION));
+            return CommonUtil.yamlToJson(yamlContent);
+        } else if (CommonUtil.checkFileExistence(pathToArchive
+                + APIImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Found swagger file " + pathToArchive
+                        + APIImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION);
+            }
+            return FileUtils.readFileToString(
+                    new File(pathToArchive + APIImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION));
+        }
+        throw new IOException("Missing swagger file. Either swagger.json or swagger.yaml should present");
+    }
+
+    /**
+     * This method imports an API.
+     *
+     * @param pathToArchive            location of the extracted folder of the API
+     * @param currentUser              the current logged in user
+     * @param isDefaultProviderAllowed decision to keep or replace the provider
+     * @throws APIImportExportException if there is an error in importing an API
+     */
+    public static void importAPI(String pathToArchive, String currentUser, boolean isDefaultProviderAllowed,
+                                 APIProvider apiProvider, Boolean overwrite)
+            throws APIImportExportException {
+
+        String jsonContent = null;
+        API importedApi = null;
+        API targetApi; //target API when overwrite is true
+        String prevProvider;
+        String currentTenantDomain;
+        String currentStatus;
+        String targetStatus;
+        String lifecycleAction = null;
+        APIDefinition definitionFromOpenAPISpec = new APIDefinitionFromOpenAPISpec();
+        String pathToYamlFile = pathToArchive + APIImportExportConstants.YAML_API_FILE_LOCATION;
+        String pathToJsonFile = pathToArchive + APIImportExportConstants.JSON_API_FILE_LOCATION;
+        UserRegistry registry;
+        int tenantId = APIUtil.getTenantId(currentUser);
+
+        try {
+            registry = ServiceReferenceHolder.getInstance().getRegistryService().getGovernanceSystemRegistry(tenantId);
+
+            // load yaml representation first if it is present
+            if (CommonUtil.checkFileExistence(pathToYamlFile)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Found api definition file " + pathToYamlFile);
+                }
+                String yamlContent = FileUtils.readFileToString(new File(pathToYamlFile));
+                jsonContent = CommonUtil.yamlToJson(yamlContent);
+            } else if (CommonUtil.checkFileExistence(pathToJsonFile)) {
+                // load as a json fallback
+                if (log.isDebugEnabled()) {
+                    log.debug("Found api definition file " + pathToJsonFile);
+                }
+                jsonContent = FileUtils.readFileToString(new File(pathToJsonFile));
+            }
+            if (jsonContent == null) {
+                throw new IOException("Cannot find API definition. api.json or api.yaml should present");
+            }
+            JsonElement configElement = new JsonParser().parse(jsonContent);
+            JsonObject configObject = configElement.getAsJsonObject();
+
+            //locate the "providerName" within the "id" and set it as the current user
+            JsonObject apiId = configObject.getAsJsonObject(APIImportExportConstants.ID_ELEMENT);
+            prevProvider = apiId.get(APIImportExportConstants.PROVIDER_ELEMENT).getAsString();
+            String prevTenantDomain = MultitenantUtils
+                    .getTenantDomain(APIUtil.replaceEmailDomainBack(prevProvider));
+            currentTenantDomain = MultitenantUtils
+                    .getTenantDomain(APIUtil.replaceEmailDomainBack(currentUser));
+
+            // If the original provider is preserved,
+            if (isDefaultProviderAllowed) {
+                if (!StringUtils.equals(prevTenantDomain, currentTenantDomain)) {
+                    String errorMessage = "Tenant mismatch! Please enable preserveProvider property "
+                            + "for cross tenant API Import.";
+                    throw new APIMgtAuthorizationFailedException(errorMessage);
+                }
+                importedApi = new Gson().fromJson(configElement, API.class);
+            } else {
+                String prevProviderWithDomain = APIUtil.replaceEmailDomain(prevProvider);
+                String currentUserWithDomain = APIUtil.replaceEmailDomain(currentUser);
+                apiId.addProperty(APIImportExportConstants.PROVIDER_ELEMENT, currentUserWithDomain);
+                if (configObject.get(APIImportExportConstants.WSDL_URL) != null) {
+                    // If original provider is not preserved, replace provider name in the wsdl URL
+                    // with the current user with domain name
+                    configObject.addProperty(APIImportExportConstants.WSDL_URL,
+                            configObject.get(APIImportExportConstants.WSDL_URL).getAsString()
+                                    .replace(prevProviderWithDomain, currentUserWithDomain));
+                }
+
+                importedApi = new Gson().fromJson(configElement, API.class);
+                //Replace context to match with current provider
+                setCurrentProviderToAPIProperties(importedApi, currentTenantDomain, prevTenantDomain);
+            }
+
+            // Store imported API status
+            targetStatus = importedApi.getStatus();
+
+            String apiName = importedApi.getId().getName();
+            String apiVersion = importedApi.getId().getVersion();
+            if (Boolean.TRUE.equals(overwrite)) {
+                String provider = APIUtil.getAPIProviderFromAPINameVersionTenant(apiName, apiVersion, currentTenantDomain);
+                APIIdentifier apiIdentifier = new APIIdentifier(APIUtil.replaceEmailDomain(provider), apiName, apiVersion);
+                // Checking whether the API exists
+                if (!apiProvider.isAPIAvailable(apiIdentifier)) {
+                    String errorMessage = "Error occurred while updating. API: " + apiName + " version: " + apiVersion
+                            + " not found";
+                    throw new APIMgtResourceNotFoundException(errorMessage);
+                }
+                targetApi = apiProvider.getAPI(apiIdentifier);
+                // Store target API status
+                currentStatus = targetApi.getStatus();
+            } else {
+                if (apiProvider.isAPIAvailable(importedApi.getId())
+                        || apiProvider.isApiNameWithDifferentCaseExist(apiName)) {
+                    String errorMessage = "Error occurred while adding the API. A duplicate API already exists " +
+                            "for " + importedApi.getId().getApiName() + '-' + importedApi.getId().getVersion();
+                    throw new APIMgtResourceAlreadyExistsException(errorMessage);
+                }
+
+                if (apiProvider.isContextExist(importedApi.getContext())) {
+                    String errMsg = "Error occurred while adding the API [" + importedApi.getId().getApiName()
+                            + '-' + importedApi.getId().getVersion() + "]. A duplicate context["
+                            + importedApi.getContext() + "] already exists";
+                    throw new APIMgtResourceAlreadyExistsException(errMsg);
+                }
+
+                // Initialize to CREATED when import
+                currentStatus = APIStatus.CREATED.toString();
+            }
+            //set the status of imported API to CREATED (importing API) or current status of target API when updating
+            importedApi.setStatus(currentStatus);
+
+            // check whether targetStatus is reachable from current status, if not throw an exception
+            if (!currentStatus.equals(targetStatus)) {
+                lifecycleAction = getLifeCycleAction(currentTenantDomain, currentStatus, targetStatus,
+                        apiProvider);
+                if (lifecycleAction == null) {
+                    String errMsg = "Error occurred while importing the API. " + targetStatus + " is not reachable from "
+                            + currentStatus;
+                    log.error(errMsg);
+                    throw new APIImportExportException(errMsg);
+                }
+            }
+
+            Set<Tier> allowedTiers;
+            Set<Tier> unsupportedTiersList;
+            allowedTiers = apiProvider.getTiers();
+
+            if (!(allowedTiers.isEmpty())) {
+                unsupportedTiersList = Sets.difference(importedApi.getAvailableTiers(), allowedTiers);
+
+                //If at least one unsupported tier is found, it should be removed before adding API
+                if (!(unsupportedTiersList.isEmpty())) {
+                    //Process is continued with a warning and only supported tiers are added to the importer API
+                    unsupportedTiersList.forEach(unsupportedTier ->
+                            log.warn("Tier name : " + unsupportedTier.getName() + " is not supported."));
+                    //Remove the unsupported tiers before adding the API
+                    importedApi.removeAvailableTiers(unsupportedTiersList);
+                }
+            }
+            if (Boolean.FALSE.equals(overwrite)) {
+                //Add API in CREATED state
+                importedApi.setAsDefaultVersion(false);
+                apiProvider.addAPI(importedApi);
+            }
+
+            //Swagger definition will only be available of API type HTTP. Web socket API does not have it.
+            if (!APIConstants.APITransportType.WS.toString().equalsIgnoreCase(importedApi.getType())) {
+                String swaggerContent = loadSwaggerFile(pathToArchive);
+                addSwaggerDefinition(importedApi.getId(), swaggerContent, apiProvider);
+
+                //Load required properties from swagger to the API
+                Set<URITemplate> uriTemplates = definitionFromOpenAPISpec.getURITemplates(importedApi, swaggerContent);
+                for (URITemplate uriTemplate : uriTemplates) {
+                    Scope scope = uriTemplate.getScope();
+                    if (scope != null && !(APIUtil.isWhiteListedScope(scope.getKey()))
+                            && apiProvider.isScopeKeyAssigned(importedApi.getId(), scope.getKey(), tenantId)) {
+                        String errorMessage =
+                                "Error in adding API. Scope " + scope.getKey() + " is already assigned "
+                                        + "by another API.";
+                        log.error(errorMessage);
+                        throw new APIImportExportException(errorMessage);
+
+                    }
+                }
+                importedApi.setUriTemplates(uriTemplates);
+                Set<Scope> scopes = definitionFromOpenAPISpec.getScopes(swaggerContent);
+                importedApi.setScopes(scopes);
+            }
+
+            // This is required to make url templates and scopes get effected
+            apiProvider.updateAPI(importedApi);
+
+            //Since Image, documents, sequences and WSDL are optional, exceptions are logged and ignored in implementation
+            addAPIImage(pathToArchive, importedApi, apiProvider);
+            addAPIDocuments(pathToArchive, importedApi, apiProvider);
+            addAPISequences(pathToArchive, importedApi, registry);
+            addAPISpecificSequences(pathToArchive, importedApi, registry);
+            addAPIWsdl(pathToArchive, importedApi, apiProvider, registry);
+            addEndpointCertificates(pathToArchive, importedApi, apiProvider, tenantId);
+
+            // Change API lifecycle if state transition is required
+            if (StringUtils.isNotEmpty(lifecycleAction)) {
+                log.info("Changing lifecycle from " + currentStatus + " to " + targetStatus);
+                apiProvider.changeLifeCycleStatus(importedApi.getId(), lifecycleAction);
+                //Change the status of the imported API to targetStatus
+                importedApi.setStatus(targetStatus);
+            }
+        } catch (IOException e) {
+            //Error is logged and APIImportExportException is thrown because adding API and swagger are mandatory steps
+            String errorMessage = "Error while reading API meta information from path: " + pathToArchive;
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (FaultGatewaysException e) {
+            String errorMessage = "Error while updating API: " + importedApi.getId().getApiName();
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (RegistryException e) {
+            String errorMessage = "Error while getting governance registry for tenant: " + tenantId;
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (APIManagementException e) {
+            String errorMessage = "Error while importing API: ";
+            if (importedApi != null) {
+                errorMessage += importedApi.getId().getApiName() + " version: " + importedApi.getId().getVersion();
+            }
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Replace original provider name from imported API properties with the logged in username
+     * This method is used when "preserveProvider" property is set to false.
+     *
+     * @param importedApi    Imported API
+     * @param currentDomain  current domain name
+     * @param previousDomain original domain name
+     */
+    private static void setCurrentProviderToAPIProperties(API importedApi, String currentDomain, String previousDomain) {
+
+        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(currentDomain) &&
+                !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(previousDomain)) {
+            importedApi.setContext(importedApi.getContext().replace(APIConstants.TENANT_PREFIX + previousDomain,
+                    StringUtils.EMPTY));
+            importedApi.setContextTemplate(importedApi.getContextTemplate().replace(
+                    APIConstants.TENANT_PREFIX + previousDomain, StringUtils.EMPTY));
+        } else if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(currentDomain) &&
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(previousDomain)) {
+            importedApi.setContext(APIConstants.TENANT_PREFIX + currentDomain + importedApi.getContext());
+            importedApi.setContextTemplate(APIConstants.TENANT_PREFIX + currentDomain + importedApi
+                    .getContextTemplate());
+        } else if (!StringUtils.equalsIgnoreCase(currentDomain, previousDomain)) {
+            importedApi.setContext(importedApi.getContext().replace(previousDomain, currentDomain));
+            importedApi.setContextTemplate(importedApi.getContextTemplate().replace
+                    (previousDomain, currentDomain));
+        }
+    }
+
+    /**
+     * This method update the API with the icon to be displayed at the API store.
+     *
+     * @param pathToArchive location of the extracted folder of the API
+     * @param importedApi   the imported API object
+     */
+    private static void addAPIImage(String pathToArchive, API importedApi, APIProvider apiProvider) {
+
+        //Adding image icon to the API if there is any
+        File imageFolder = new File(pathToArchive + APIImportExportConstants.IMAGE_FILE_LOCATION);
+        File[] fileArray = imageFolder.listFiles();
+        if (imageFolder.isDirectory() && fileArray != null) {
+            //This loop locates the icon of the API
+            for (File imageFile : fileArray) {
+                if (imageFile != null && imageFile.getName().contains(APIConstants.API_ICON_IMAGE)) {
+                    updateAPIWithThumbnail(imageFile, importedApi, apiProvider);
+                    //the loop is terminated after successfully locating the icon
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * This method update the API with the thumbnail image from imported API.
+     *
+     * @param imageFile   Image file
+     * @param importedApi API to update
+     * @param apiProvider API Provider
+     */
+    private static void updateAPIWithThumbnail(File imageFile, API importedApi, APIProvider apiProvider) {
+        APIIdentifier apiIdentifier = importedApi.getId();
+        String mimeType = URLConnection.guessContentTypeFromName(imageFile.getName());
+        try (FileInputStream inputStream = new FileInputStream(imageFile.getAbsolutePath())) {
+            ResourceFile apiImage = new ResourceFile(inputStream, mimeType);
+            String thumbPath = APIUtil.getIconPath(apiIdentifier);
+            String thumbnailUrl = apiProvider.addResourceFile(thumbPath, apiImage);
+            importedApi.setThumbnailUrl(APIUtil.prependTenantPrefix(thumbnailUrl,
+                    apiIdentifier.getProviderName()));
+            APIUtil.setResourcePermissions(apiIdentifier.getProviderName(), null, null,
+                    thumbPath);
+            apiProvider.updateAPI(importedApi);
+        } catch (FaultGatewaysException e) {
+            //This is logged and process is continued because icon is optional for an API
+            log.error("Failed to update API after adding icon. ", e);
+        } catch (APIManagementException e) {
+            log.error("Failed to add icon to the API: " + apiIdentifier.getApiName(), e);
+        } catch (FileNotFoundException e) {
+            log.error("Icon for API: " + apiIdentifier.getApiName() + " is not found.", e);
+        } catch (IOException e) {
+            log.error("Failed to import icon for API:" + apiIdentifier.getApiName());
+        }
+    }
+
+    /**
+     * This method adds the documents to the imported API.
+     *
+     * @param pathToArchive location of the extracted folder of the API
+     * @param importedApi   the imported API object
+     */
+    private static void addAPIDocuments(String pathToArchive, API importedApi, APIProvider apiProvider) {
+
+        String jsonContent = null;
+        String pathToYamlFile = pathToArchive + APIImportExportConstants.YAML_DOCUMENT_FILE_LOCATION;
+        String pathToJsonFile = pathToArchive + APIImportExportConstants.JSON_DOCUMENT_FILE_LOCATION;
+        APIIdentifier apiIdentifier = importedApi.getId();
+        Documentation[] documentations;
+        String docDirectoryPath = pathToArchive + File.separator + APIImportExportConstants.DOCUMENT_DIRECTORY;
+
+        try {
+            //load document file if exists
+            if (CommonUtil.checkFileExistence(pathToYamlFile)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Found documents definition file " + pathToYamlFile);
+                }
+                String yamlContent = FileUtils.readFileToString(new File(pathToYamlFile));
+                jsonContent = CommonUtil.yamlToJson(yamlContent);
+            } else if (CommonUtil.checkFileExistence(pathToJsonFile)) {
+                //load as a json fallback
+                if (log.isDebugEnabled()) {
+                    log.debug("Found documents definition file " + pathToJsonFile);
+                }
+                jsonContent = FileUtils.readFileToString(new File(pathToJsonFile));
+            }
+            if (jsonContent == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("No document definition found, Skipping documentation import for API: "
+                            + importedApi.getId().getApiName());
+                }
+                return;
+            }
+
+            documentations = new Gson().fromJson(jsonContent, Documentation[].class);
+            //For each type of document separate action is performed
+            for (Documentation doc : documentations) {
+
+                String docSourceType = doc.getSourceType().toString();
+                boolean docContentExists = Documentation.DocumentSourceType.INLINE.toString().equalsIgnoreCase(docSourceType)
+                        || Documentation.DocumentSourceType.MARKDOWN.toString().equalsIgnoreCase(docSourceType);
+                String inlineContent = null;
+
+                if (docContentExists) {
+                    try (FileInputStream inputStream = new FileInputStream(docDirectoryPath + File.separator
+                            + APIImportExportConstants.INLINE_DOCUMENT_DIRECTORY + File.separator + doc.getName())) {
+
+                        inlineContent = IOUtils.toString(inputStream, APIImportExportConstants.CHARSET);
+                    }
+                } else if (APIImportExportConstants.FILE_DOC_TYPE.equalsIgnoreCase(docSourceType)) {
+                    String filePath = doc.getFilePath();
+                    try (FileInputStream inputStream = new FileInputStream(docDirectoryPath + File.separator
+                            + APIImportExportConstants.FILE_DOCUMENT_DIRECTORY + File.separator + filePath)) {
+                        String docExtension = FilenameUtils.getExtension(pathToArchive + File.separator
+                                + APIImportExportConstants.DOCUMENT_DIRECTORY + File.separator + filePath);
+                        ResourceFile apiDocument = new ResourceFile(inputStream, docExtension);
+                        String visibleRolesList = importedApi.getVisibleRoles();
+                        String[] visibleRoles = new String[0];
+                        if (visibleRolesList != null) {
+                            visibleRoles = visibleRolesList.split(",");
+                        }
+                        String filePathDoc = APIUtil.getDocumentationFilePath(apiIdentifier, filePath);
+                        APIUtil.setResourcePermissions(importedApi.getId().getProviderName(),
+                                importedApi.getVisibility(), visibleRoles, filePathDoc);
+                        doc.setFilePath(apiProvider.addResourceFile(filePathDoc, apiDocument));
+                    }
+                }
+
+                //Check if documentations exists with same name for given API name, provider and version.
+                //Update or create documentation accordingly.
+                if (apiProvider.isDocumentationExist(apiIdentifier, doc.getName())) {
+                    apiProvider.updateDocumentation(apiIdentifier, doc);
+                } else {
+                    apiProvider.addDocumentation(apiIdentifier, doc);
+                }
+                if (docContentExists) {
+                    //APIProvider.addDocumentationContent method handles both create/update documentation content
+                    apiProvider.addDocumentationContent(importedApi, doc.getName(), inlineContent);
+                }
+            }
+        } catch (FileNotFoundException e) {
+            //this error is logged and ignored because documents are optional in an API
+            log.error("Failed to locate the document files of the API: " + apiIdentifier.getApiName(), e);
+        } catch (APIManagementException | IOException e) {
+            //this error is logged and ignored because documents are optional in an API
+            log.error("Failed to add Documentations to API: " + apiIdentifier.getApiName(), e);
+        }
+    }
+
+    /**
+     * This method adds API sequences to the imported API. If the sequence is a newly defined one, it is added.
+     *
+     * @param pathToArchive location of the extracted folder of the API
+     * @param importedApi   the imported API object
+     */
+    private static void addAPISequences(String pathToArchive, API importedApi, Registry registry) {
+
+        String inSequenceFileName = importedApi.getInSequence() + APIConstants.XML_EXTENSION;
+        String inSequenceFileLocation = pathToArchive + APIImportExportConstants.IN_SEQUENCE_LOCATION
+                + inSequenceFileName;
+        String regResourcePath;
+
+        //Adding in-sequence, if any
+        if (CommonUtil.checkFileExistence(inSequenceFileLocation)) {
+            regResourcePath = APIConstants.API_CUSTOM_INSEQUENCE_LOCATION + inSequenceFileName;
+            addSequenceToRegistry(false, registry, inSequenceFileLocation, regResourcePath);
+        }
+
+        String outSequenceFileName = importedApi.getOutSequence() + APIConstants.XML_EXTENSION;
+        String outSequenceFileLocation = pathToArchive + APIImportExportConstants.OUT_SEQUENCE_LOCATION
+                + outSequenceFileName;
+
+        //Adding out-sequence, if any
+        if (CommonUtil.checkFileExistence(outSequenceFileLocation)) {
+            regResourcePath = APIConstants.API_CUSTOM_OUTSEQUENCE_LOCATION + outSequenceFileName;
+            addSequenceToRegistry(false, registry, outSequenceFileLocation, regResourcePath);
+        }
+
+        String faultSequenceFileName = importedApi.getFaultSequence() + APIConstants.XML_EXTENSION;
+        String faultSequenceFileLocation = pathToArchive + APIImportExportConstants.FAULT_SEQUENCE_LOCATION
+                + faultSequenceFileName;
+
+        //Adding fault-sequence, if any
+        if (CommonUtil.checkFileExistence(faultSequenceFileLocation)) {
+            regResourcePath = APIConstants.API_CUSTOM_FAULTSEQUENCE_LOCATION + faultSequenceFileName;
+            addSequenceToRegistry(false, registry, faultSequenceFileLocation, regResourcePath);
+        }
+    }
+
+    /**
+     * This method adds API Specific sequences added through the Publisher to the imported API. If the specific
+     * sequence already exists, it is updated.
+     *
+     * @param pathToArchive location of the extracted folder of the API
+     * @param importedApi   the imported API object
+     */
+    private static void addAPISpecificSequences(String pathToArchive, API importedApi, Registry registry) {
+
+        String regResourcePath = APIConstants.API_ROOT_LOCATION + RegistryConstants.PATH_SEPARATOR +
+                importedApi.getId().getProviderName() + RegistryConstants.PATH_SEPARATOR +
+                importedApi.getId().getApiName() + RegistryConstants.PATH_SEPARATOR +
+                importedApi.getId().getVersion() + RegistryConstants.PATH_SEPARATOR;
+
+        String inSequenceFileName = importedApi.getInSequence();
+        String inSequenceFileLocation = pathToArchive + APIImportExportConstants.IN_SEQUENCE_LOCATION
+                + APIImportExportConstants.CUSTOM_TYPE + File.separator + inSequenceFileName;
+
+        //Adding in-sequence, if any
+        if (CommonUtil.checkFileExistence(inSequenceFileLocation)) {
+            String inSequencePath = APIConstants.API_CUSTOM_SEQUENCE_TYPE_IN +
+                    RegistryConstants.PATH_SEPARATOR + inSequenceFileName;
+            addSequenceToRegistry(true, registry, inSequenceFileLocation, regResourcePath + inSequencePath);
+        }
+
+        String outSequenceFileName = importedApi.getOutSequence();
+        String outSequenceFileLocation = pathToArchive + APIImportExportConstants.OUT_SEQUENCE_LOCATION
+                + APIImportExportConstants.CUSTOM_TYPE + File.separator + outSequenceFileName;
+
+        //Adding out-sequence, if any
+        if (CommonUtil.checkFileExistence(outSequenceFileLocation)) {
+            String outSequencePath = APIConstants.API_CUSTOM_SEQUENCE_TYPE_OUT +
+                    RegistryConstants.PATH_SEPARATOR + outSequenceFileName;
+            addSequenceToRegistry(true, registry, outSequenceFileLocation, regResourcePath + outSequencePath);
+        }
+
+        String faultSequenceFileName = importedApi.getFaultSequence();
+        String faultSequenceFileLocation = pathToArchive + APIImportExportConstants.FAULT_SEQUENCE_LOCATION
+                + APIImportExportConstants.CUSTOM_TYPE + File.separator + faultSequenceFileName;
+
+        //Adding fault-sequence, if any
+        if (CommonUtil.checkFileExistence(faultSequenceFileLocation)) {
+            String faultSequencePath = APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT +
+                    RegistryConstants.PATH_SEPARATOR + faultSequenceFileName;
+            addSequenceToRegistry(true, registry, faultSequenceFileLocation, regResourcePath + faultSequencePath);
+        }
+    }
+
+    /**
+     * This method adds the sequence files to the registry. This updates the API specific sequences if already exists.
+     *
+     * @param isAPISpecific        whether the adding sequence is API specific
+     * @param registry             the registry instance
+     * @param sequenceFileLocation location of the sequence file
+     */
+    private static void addSequenceToRegistry(Boolean isAPISpecific, Registry registry, String sequenceFileLocation,
+                                              String regResourcePath) {
+
+        try {
+            if (registry.resourceExists(regResourcePath) && !isAPISpecific) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Sequence already exists in registry path: " + regResourcePath);
+                }
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Adding Sequence to the registry path : " + regResourcePath);
+                }
+                File sequenceFile = new File(sequenceFileLocation);
+                try (InputStream seqStream = new FileInputStream(sequenceFile);) {
+                    byte[] inSeqData = IOUtils.toByteArray(seqStream);
+                    Resource inSeqResource = registry.newResource();
+                    inSeqResource.setContent(inSeqData);
+                    registry.put(regResourcePath, inSeqResource);
+                }
+            }
+        } catch (RegistryException e) {
+            //this is logged and ignored because sequences are optional
+            log.error("Failed to add sequences into the registry : " + regResourcePath, e);
+        } catch (IOException e) {
+            //this is logged and ignored because sequences are optional
+            log.error("I/O error while writing sequence data to the registry : " + regResourcePath, e);
+        }
+    }
+
+    /**
+     * This method adds the WSDL to the registry, if there is a WSDL associated with the API.
+     *
+     * @param pathToArchive location of the extracted folder of the API
+     * @param importedApi   the imported API object
+     */
+    private static void addAPIWsdl(String pathToArchive, API importedApi, APIProvider apiProvider, Registry registry) {
+
+        String wsdlFileName = importedApi.getId().getApiName() + "-" + importedApi.getId().getVersion()
+                + APIConstants.WSDL_FILE_EXTENSION;
+        String wsdlPath = pathToArchive + APIImportExportConstants.WSDL_LOCATION + wsdlFileName;
+
+        if (CommonUtil.checkFileExistence(wsdlPath)) {
+            try {
+                URL wsdlFileUrl = new File(wsdlPath).toURI().toURL();
+                importedApi.setWsdlUrl(wsdlFileUrl.toString());
+                APIUtil.createWSDL(registry, importedApi);
+                apiProvider.updateAPI(importedApi);
+            } catch (MalformedURLException e) {
+                //this exception is logged and ignored since WSDL is optional for an API
+                log.error("Error in getting WSDL URL. ", e);
+            } catch (org.wso2.carbon.registry.core.exceptions.RegistryException e) {
+                //this exception is logged and ignored since WSDL is optional for an API
+                log.error("Error in putting the WSDL resource to registry. ", e);
+            } catch (APIManagementException e) {
+                //this exception is logged and ignored since WSDL is optional for an API
+                log.error("Error in creating the WSDL resource in the registry. ", e);
+            } catch (FaultGatewaysException e) {
+                //This is logged and process is continued because WSDL is optional for an API
+                log.error("Failed to update API after adding WSDL. ", e);
+            }
+        }
+    }
+
+    /**
+     * This method adds Swagger API definition to registry.
+     *
+     * @param apiId          Identifier of the imported API
+     * @param swaggerContent Content of Swagger file
+     * @throws APIImportExportException if there is an error occurs when adding Swagger definition
+     */
+    private static void addSwaggerDefinition(APIIdentifier apiId, String swaggerContent, APIProvider apiProvider)
+            throws APIImportExportException {
+
+        try {
+            apiProvider.saveSwagger20Definition(apiId, swaggerContent);
+        } catch (APIManagementException e) {
+            String errorMessage = "Error in adding Swagger definition for the API: " + apiId.getApiName()
+                    + " version: " + apiId.getVersion();
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * This method import endpoint certificate.
+     *
+     * @param pathToArchive location of the extracted folder of the API
+     * @param importedApi   the imported API object
+     * @throws APIImportExportException If an error occurs while importing endpoint certificates from file
+     */
+    private static void addEndpointCertificates(String pathToArchive, API importedApi, APIProvider apiProvider,
+                                                int tenantId)
+            throws APIImportExportException {
+
+        String jsonContent = null;
+        String pathToYamlFile = pathToArchive + APIImportExportConstants.YAML_ENDPOINTS_CERTIFICATE_FILE;
+        String pathToJsonFile = pathToArchive + APIImportExportConstants.YAML_ENDPOINTS_CERTIFICATE_FILE;
+
+        try {
+            // try loading file as YAML
+            if (CommonUtil.checkFileExistence(pathToYamlFile)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Found certificate file " + pathToYamlFile);
+                }
+                String yamlContent = FileUtils.readFileToString(new File(pathToYamlFile));
+                jsonContent = CommonUtil.yamlToJson(yamlContent);
+            } else if (CommonUtil.checkFileExistence(pathToJsonFile)) {
+                // load as a json fallback
+                if (log.isDebugEnabled()) {
+                    log.debug("Found certificate file " + pathToJsonFile);
+                }
+                jsonContent = FileUtils.readFileToString(new File(pathToJsonFile));
+            }
+            if (jsonContent == null) {
+                log.debug("No certificate file found to be added, skipping certificate import.");
+                return;
+            }
+
+            JsonElement configElement = new JsonParser().parse(jsonContent);
+            JsonArray certificates = configElement.getAsJsonArray().getAsJsonArray();
+            certificates.forEach(certificate -> updateAPIWithCertificate(certificate, apiProvider, importedApi,
+                    tenantId));
+        } catch (IOException e) {
+            String errorMessage = "Error in reading " + APIImportExportConstants.YAML_ENDPOINTS_CERTIFICATE_FILE
+                    + " file";
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Update API with the certificate. If certificate alias is already exists for tenant, cert will be added and if
+     * the certificate is already exists is in trust store, this method will update the cert in trust store.
+     *
+     * @param certificate Certificate JSON element
+     * @param apiProvider API Provider
+     * @param importedApi API to import
+     * @param tenantId    Tenant Id
+     */
+    private static void updateAPIWithCertificate(JsonElement certificate, APIProvider apiProvider, API importedApi,
+                                                 int tenantId) {
+
+        String certificateContent = certificate.getAsJsonObject()
+                .get(APIImportExportConstants.CERTIFICATE_CONTENT_JSON_KEY).getAsString();
+        String alias = certificate.getAsJsonObject().get(APIImportExportConstants.ALIAS_JSON_KEY).getAsString();
+        String endpoint = certificate.getAsJsonObject().get(APIImportExportConstants.HOSTNAME_JSON_KEY)
+                .getAsString();
+        try {
+            if (apiProvider.isCertificatePresent(tenantId, alias)
+                    || (ResponseCode.ALIAS_EXISTS_IN_TRUST_STORE.getResponseCode() ==
+                    (apiProvider.addCertificate(APIUtil.replaceEmailDomainBack(importedApi.getId().getProviderName()),
+                            certificateContent, alias, endpoint)))) {
+                apiProvider.updateCertificate(certificateContent, alias);
+            }
+        } catch (APIManagementException e) {
+            String errorMessage = "Error while importing certificate endpoint [" + endpoint + " ]" + "alias ["
+                    + alias + " ] tenant user ["
+                    + APIUtil.replaceEmailDomainBack(importedApi.getId().getProviderName()) + "]";
+            log.error(errorMessage, e);
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -101,6 +101,7 @@ public final class APIImportUtil {
      */
     private static String getLifeCycleAction(String tenantDomain, String currentStatus, String targetStatus,
                                              APIProvider provider) throws APIImportExportException {
+
         LifeCycle lifeCycle = new LifeCycle();
         // Parse DOM of APILifeCycle
         try {
@@ -169,20 +170,17 @@ public final class APIImportUtil {
      * @throws IOException When swagger document not found
      */
     private static String loadSwaggerFile(String pathToArchive) throws IOException {
-        if (CommonUtil.checkFileExistence(pathToArchive
-                + APIImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION)) {
+
+        if (CommonUtil.checkFileExistence(pathToArchive + APIImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION)) {
             if (log.isDebugEnabled()) {
-                log.debug("Found swagger file " + pathToArchive
-                        + APIImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION);
+                log.debug("Found swagger file " + pathToArchive + APIImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION);
             }
             String yamlContent = FileUtils.readFileToString(
                     new File(pathToArchive + APIImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION));
             return CommonUtil.yamlToJson(yamlContent);
-        } else if (CommonUtil.checkFileExistence(pathToArchive
-                + APIImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION)) {
+        } else if (CommonUtil.checkFileExistence(pathToArchive + APIImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION)) {
             if (log.isDebugEnabled()) {
-                log.debug("Found swagger file " + pathToArchive
-                        + APIImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION);
+                log.debug("Found swagger file " + pathToArchive + APIImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION);
             }
             return FileUtils.readFileToString(
                     new File(pathToArchive + APIImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION));
@@ -356,11 +354,9 @@ public final class APIImportUtil {
                     if (scope != null && !(APIUtil.isWhiteListedScope(scope.getKey()))
                             && apiProvider.isScopeKeyAssigned(importedApi.getId(), scope.getKey(), tenantId)) {
                         String errorMessage =
-                                "Error in adding API. Scope " + scope.getKey() + " is already assigned "
-                                        + "by another API.";
+                                "Error in adding API. Scope " + scope.getKey() + " is already assigned by another API.";
                         log.error(errorMessage);
                         throw new APIImportExportException(errorMessage);
-
                     }
                 }
                 importedApi.setUriTemplates(uriTemplates);
@@ -424,17 +420,15 @@ public final class APIImportUtil {
                 !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(previousDomain)) {
             importedApi.setContext(importedApi.getContext().replace(APIConstants.TENANT_PREFIX + previousDomain,
                     StringUtils.EMPTY));
-            importedApi.setContextTemplate(importedApi.getContextTemplate().replace(
-                    APIConstants.TENANT_PREFIX + previousDomain, StringUtils.EMPTY));
+            importedApi.setContextTemplate(importedApi.getContextTemplate().replace(APIConstants.TENANT_PREFIX
+                    + previousDomain, StringUtils.EMPTY));
         } else if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(currentDomain) &&
                 MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(previousDomain)) {
             importedApi.setContext(APIConstants.TENANT_PREFIX + currentDomain + importedApi.getContext());
-            importedApi.setContextTemplate(APIConstants.TENANT_PREFIX + currentDomain + importedApi
-                    .getContextTemplate());
+            importedApi.setContextTemplate(APIConstants.TENANT_PREFIX + currentDomain + importedApi.getContextTemplate());
         } else if (!StringUtils.equalsIgnoreCase(currentDomain, previousDomain)) {
             importedApi.setContext(importedApi.getContext().replace(previousDomain, currentDomain));
-            importedApi.setContextTemplate(importedApi.getContextTemplate().replace
-                    (previousDomain, currentDomain));
+            importedApi.setContextTemplate(importedApi.getContextTemplate().replace(previousDomain, currentDomain));
         }
     }
 
@@ -469,6 +463,7 @@ public final class APIImportUtil {
      * @param apiProvider API Provider
      */
     private static void updateAPIWithThumbnail(File imageFile, API importedApi, APIProvider apiProvider) {
+
         APIIdentifier apiIdentifier = importedApi.getId();
         String mimeType = URLConnection.guessContentTypeFromName(imageFile.getName());
         try (FileInputStream inputStream = new FileInputStream(imageFile.getAbsolutePath())) {
@@ -477,8 +472,7 @@ public final class APIImportUtil {
             String thumbnailUrl = apiProvider.addResourceFile(thumbPath, apiImage);
             importedApi.setThumbnailUrl(APIUtil.prependTenantPrefix(thumbnailUrl,
                     apiIdentifier.getProviderName()));
-            APIUtil.setResourcePermissions(apiIdentifier.getProviderName(), null, null,
-                    thumbPath);
+            APIUtil.setResourcePermissions(apiIdentifier.getProviderName(), null, null, thumbPath);
             apiProvider.updateAPI(importedApi);
         } catch (FaultGatewaysException e) {
             //This is logged and process is continued because icon is optional for an API
@@ -506,7 +500,6 @@ public final class APIImportUtil {
         APIIdentifier apiIdentifier = importedApi.getId();
         Documentation[] documentations;
         String docDirectoryPath = pathToArchive + File.separator + APIImportExportConstants.DOCUMENT_DIRECTORY;
-
         try {
             //load document file if exists
             if (CommonUtil.checkFileExistence(pathToYamlFile)) {
@@ -634,10 +627,10 @@ public final class APIImportUtil {
      */
     private static void addAPISpecificSequences(String pathToArchive, API importedApi, Registry registry) {
 
-        String regResourcePath = APIConstants.API_ROOT_LOCATION + RegistryConstants.PATH_SEPARATOR +
-                importedApi.getId().getProviderName() + RegistryConstants.PATH_SEPARATOR +
-                importedApi.getId().getApiName() + RegistryConstants.PATH_SEPARATOR +
-                importedApi.getId().getVersion() + RegistryConstants.PATH_SEPARATOR;
+        String regResourcePath = APIConstants.API_ROOT_LOCATION + RegistryConstants.PATH_SEPARATOR
+                + importedApi.getId().getProviderName() + RegistryConstants.PATH_SEPARATOR
+                + importedApi.getId().getApiName() + RegistryConstants.PATH_SEPARATOR
+                + importedApi.getId().getVersion() + RegistryConstants.PATH_SEPARATOR;
 
         String inSequenceFileName = importedApi.getInSequence();
         String inSequenceFileLocation = pathToArchive + APIImportExportConstants.IN_SEQUENCE_LOCATION
@@ -645,8 +638,8 @@ public final class APIImportUtil {
 
         //Adding in-sequence, if any
         if (CommonUtil.checkFileExistence(inSequenceFileLocation)) {
-            String inSequencePath = APIConstants.API_CUSTOM_SEQUENCE_TYPE_IN +
-                    RegistryConstants.PATH_SEPARATOR + inSequenceFileName;
+            String inSequencePath = APIConstants.API_CUSTOM_SEQUENCE_TYPE_IN + RegistryConstants.PATH_SEPARATOR
+                    + inSequenceFileName;
             addSequenceToRegistry(true, registry, inSequenceFileLocation, regResourcePath + inSequencePath);
         }
 
@@ -656,8 +649,8 @@ public final class APIImportUtil {
 
         //Adding out-sequence, if any
         if (CommonUtil.checkFileExistence(outSequenceFileLocation)) {
-            String outSequencePath = APIConstants.API_CUSTOM_SEQUENCE_TYPE_OUT +
-                    RegistryConstants.PATH_SEPARATOR + outSequenceFileName;
+            String outSequencePath = APIConstants.API_CUSTOM_SEQUENCE_TYPE_OUT + RegistryConstants.PATH_SEPARATOR
+                    + outSequenceFileName;
             addSequenceToRegistry(true, registry, outSequenceFileLocation, regResourcePath + outSequencePath);
         }
 
@@ -667,8 +660,8 @@ public final class APIImportUtil {
 
         //Adding fault-sequence, if any
         if (CommonUtil.checkFileExistence(faultSequenceFileLocation)) {
-            String faultSequencePath = APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT +
-                    RegistryConstants.PATH_SEPARATOR + faultSequenceFileName;
+            String faultSequencePath = APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT + RegistryConstants.PATH_SEPARATOR
+                    + faultSequenceFileName;
             addSequenceToRegistry(true, registry, faultSequenceFileLocation, regResourcePath + faultSequencePath);
         }
     }
@@ -797,7 +790,6 @@ public final class APIImportUtil {
                 log.debug("No certificate file found to be added, skipping certificate import.");
                 return;
             }
-
             JsonElement configElement = new JsonParser().parse(jsonContent);
             JsonArray certificates = configElement.getAsJsonArray().getAsJsonArray();
             certificates.forEach(certificate -> updateAPIWithCertificate(certificate, apiProvider, importedApi,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/CommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/CommonUtil.java
@@ -1,0 +1,332 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.importexport.utils;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.importexport.APIImportExportConstants;
+import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * This is the util class which consists of all the common functions for importing and exporting API.
+ */
+public class CommonUtil {
+    private static final Log log = LogFactory.getLog(CommonUtil.class);
+
+    /**
+     * Create directory at the given path.
+     *
+     * @param path Path of the directory
+     * @throws APIImportExportException If directory creation failed
+     */
+    public static void createDirectory(String path) throws APIImportExportException {
+
+        if (path != null) {
+            File file = new File(path);
+            if (!file.exists() && !file.mkdirs()) {
+                String errorMessage = "Error while creating directory : " + path;
+                log.error(errorMessage);
+                throw new APIImportExportException(errorMessage);
+            }
+        }
+    }
+
+    /**
+     * Create temporary directory in temporary location.
+     *
+     * @throws APIImportExportException If an error occurs while creating temporary location
+     */
+    public static File createTempDirectory() throws APIImportExportException {
+
+        String currentDirectory = System.getProperty(APIConstants.JAVA_IO_TMPDIR);
+        String createdDirectories = File.separator + RandomStringUtils
+                .randomAlphanumeric(APIImportExportConstants.TEMP_FILENAME_LENGTH) + File.separator;
+        File tempDirectory = new File(currentDirectory + createdDirectories);
+        createDirectory(tempDirectory.getPath());
+        return tempDirectory;
+    }
+
+    /**
+     * Archive a provided source directory to a zipped file.
+     *
+     * @param sourceDirectory Source directory
+     * @throws APIImportExportException If an error occurs while generating archive
+     */
+    public static void archiveDirectory(String sourceDirectory) throws APIImportExportException {
+
+        File directoryToZip = new File(sourceDirectory);
+        List<File> fileList = new ArrayList<>();
+        getAllFiles(directoryToZip, fileList);
+        writeArchiveFile(directoryToZip, fileList);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Archived API generated successfully from source: " + sourceDirectory);
+        }
+    }
+
+    /**
+     * Recursively retrieve all the files included in the source directory to be archived.
+     *
+     * @param sourceDirectory Source directory
+     * @param fileList        List of files
+     */
+    private static void getAllFiles(File sourceDirectory, List<File> fileList) {
+
+        File[] files = sourceDirectory.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                fileList.add(file);
+                if (file.isDirectory()) {
+                    getAllFiles(file, fileList);
+                }
+            }
+        }
+    }
+
+    /**
+     * Generate archive file.
+     *
+     * @param directoryToZip Location of the archive
+     * @param fileList       List of files to be included in the archive
+     * @throws APIImportExportException If an error occurs while adding files to the archive
+     */
+    private static void writeArchiveFile(File directoryToZip, List<File> fileList) throws APIImportExportException {
+
+        try (FileOutputStream fileOutputStream = new FileOutputStream(directoryToZip.getPath() + ".zip");
+             ZipOutputStream zipOutputStream = new ZipOutputStream(fileOutputStream)) {
+            for (File file : fileList) {
+                if (!file.isDirectory()) {
+                    addToArchive(directoryToZip, file, zipOutputStream);
+                }
+            }
+        } catch (IOException e) {
+            String errorMessage = "I/O error while adding files to archive";
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Add files of the directory to the archive.
+     *
+     * @param directoryToZip  Location of the archive
+     * @param file            File to be included in the archive
+     * @param zipOutputStream Output stream
+     * @throws APIImportExportException If an error occurs while writing files to the archive
+     */
+    private static void addToArchive(File directoryToZip, File file, ZipOutputStream zipOutputStream)
+            throws APIImportExportException {
+
+        try (FileInputStream fileInputStream = new FileInputStream(file)) {
+            // Get relative path from archive directory to the specific file
+            String zipFilePath = file.getCanonicalPath().substring(directoryToZip.getCanonicalPath().length() + 1);
+            if (File.separatorChar != APIImportExportConstants.ZIP_FILE_SEPARATOR) {
+                zipFilePath = zipFilePath.replace(File.separatorChar, APIImportExportConstants.ZIP_FILE_SEPARATOR);
+            }
+            ZipEntry zipEntry = new ZipEntry(zipFilePath);
+            zipOutputStream.putNextEntry(zipEntry);
+
+            IOUtils.copy(fileInputStream, zipOutputStream);
+
+            zipOutputStream.closeEntry();
+        } catch (IOException e) {
+            String errorMessage = "I/O error while writing files to archive";
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Write content to file.
+     *
+     * @param path    Location of the file
+     * @param content Content to be written
+     * @throws APIImportExportException If an error occurs while writing to file
+     */
+    public static void writeFile(String path, String content) throws APIImportExportException {
+
+        try (FileWriter writer = new FileWriter(path)) {
+            IOUtils.copy(new StringReader(content), writer);
+        } catch (IOException e) {
+            String errorMessage = "I/O error while writing to file: " + path;
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * This method checks whether a given file exists in a given location.
+     *
+     * @param fileLocation location of the file
+     * @return true if the file exists, false otherwise
+     */
+    public static boolean checkFileExistence(String fileLocation) {
+
+        File testFile = new File(fileLocation);
+        return testFile.exists();
+    }
+
+    /**
+     * Converts a YAML file into JSON.
+     *
+     * @param yaml yaml representation
+     * @return yaml file as a json
+     * @throws IOException If an error occurs while converting YAML to JSON
+     */
+    public static String yamlToJson(String yaml) throws IOException {
+
+        ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+        Object obj = yamlReader.readValue(yaml, Object.class);
+
+        ObjectMapper jsonWriter = new ObjectMapper();
+        return jsonWriter.writeValueAsString(obj);
+    }
+
+    /**
+     * Converts JSON to YAML.
+     *
+     * @param json json representation
+     * @return json file as a yaml document
+     * @throws IOException If an error occurs while converting JSON to YAML
+     */
+    public static String jsonToYaml(String json) throws IOException {
+
+        ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory()
+                .enable(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER));
+        JsonNode jsonNodeTree = yamlReader.readTree(json);
+        YAMLMapper yamlMapper = new YAMLMapper()
+                .disable(YAMLGenerator.Feature.SPLIT_LINES)
+                .enable(YAMLGenerator.Feature.INDENT_ARRAYS)
+                .disable(YAMLGenerator.Feature.LITERAL_BLOCK_STYLE)
+                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+                .enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS);
+        return yamlMapper.writeValueAsString(jsonNodeTree);
+    }
+
+    /**
+     * This method uploads a given file to specified location
+     *
+     * @param uploadedInputStream input stream of the file
+     * @param newFileName         name of the file to be created
+     * @param storageLocation     destination of the new file
+     * @throws APIImportExportException If the file transfer fails
+     */
+    public static void transferFile(InputStream uploadedInputStream, String newFileName, String storageLocation)
+            throws APIImportExportException {
+
+        try (FileOutputStream outFileStream = new FileOutputStream(new File(storageLocation, newFileName))) {
+            int read;
+            byte[] bytes = new byte[1024];
+            while ((read = uploadedInputStream.read(bytes)) != -1) {
+                outFileStream.write(bytes, 0, read);
+            }
+        } catch (IOException e) {
+            String errorMessage = "Error in transferring files.";
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * This method decompresses API the archive.
+     *
+     * @param sourceFile  The archive containing the API
+     * @param destination location of the archive to be extracted
+     * @return Name of the extracted directory
+     * @throws APIImportExportException If the decompressing fails
+     */
+    public static String extractArchive(File sourceFile, String destination) throws APIImportExportException {
+
+        String archiveName = null;
+        try (ZipFile zip = new ZipFile(sourceFile)) {
+
+            Enumeration zipFileEntries = zip.entries();
+            int index = 0;
+
+            // Process each entry
+            while (zipFileEntries.hasMoreElements()) {
+
+                // grab a zip file entry
+                ZipEntry entry = (ZipEntry) zipFileEntries.nextElement();
+                String currentEntry = entry.getName();
+
+                //This index variable is used to get the extracted folder name; that is root directory
+                if (index == 0) {
+                    archiveName = currentEntry.substring(0, currentEntry.indexOf(
+                            APIImportExportConstants.ZIP_FILE_SEPARATOR));
+                    --index;
+                }
+
+                File destinationFile = new File(destination, currentEntry);
+                File destinationParent = destinationFile.getParentFile();
+                String canonicalizedDestinationFilePath = destinationFile.getCanonicalPath();
+                if (!canonicalizedDestinationFilePath.startsWith(new File(destination).getCanonicalPath())) {
+                    String errorMessage = "Attempt to upload invalid zip archive with file at " + currentEntry +
+                            ". File path is outside target directory";
+                    log.error(errorMessage);
+                    throw new APIImportExportException(errorMessage);
+                }
+
+                // create the parent directory structure
+                if (destinationParent.mkdirs()) {
+                    log.info("Creation of folder is successful. Directory Name : " + destinationParent.getName());
+                }
+
+                if (!entry.isDirectory()) {
+                    // write the current file to the destination
+                    try (InputStream zipInputStream = zip.getInputStream(entry);
+                         BufferedInputStream inputStream = new BufferedInputStream(zipInputStream);
+                         FileOutputStream outputStream = new FileOutputStream(destinationFile)) {
+                        IOUtils.copy(inputStream, outputStream);
+                    }
+                }
+            }
+            return archiveName;
+        } catch (IOException e) {
+            String errorMessage = "Failed to extract the archive (zip) file. ";
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ExportApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ExportApi.java
@@ -27,6 +27,26 @@ public class ExportApi  {
    private final ExportApiService delegate = ExportApiServiceFactory.getExportApi();
 
     @GET
+    @Path("/api")
+    @Consumes({ "application/json" })
+    @Produces({ "application/zip" })
+    @io.swagger.annotations.ApiOperation(value = "Export an API", notes = "This operation can be used to export the details of a particular API as a zip file.\n", response = File.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "OK.\nExport Successful.\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Not Found.\nRequested API does not exist.\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.\nError in exporting API.\n") })
+
+    public Response exportApiGet(@ApiParam(value = "API Name\n",required=true) @QueryParam("name")  String name,
+    @ApiParam(value = "Version of the API\n",required=true) @QueryParam("version")  String version,
+    @ApiParam(value = "Provider name of the API\n",required=true) @QueryParam("providerName")  String providerName,
+    @ApiParam(value = "Format of output documents. Can be YAML or JSON.\n",required=true, allowableValues="{values=[JSON, YAML]}") @QueryParam("format")  String format,
+    @ApiParam(value = "Preserve API Status on export\n") @QueryParam("preserveStatus")  Boolean preserveStatus)
+    {
+    return delegate.exportApiGet(name,version,providerName,format,preserveStatus);
+    }
+    @GET
     @Path("/applications")
     @Consumes({ "application/json" })
     @Produces({ "application/json", "application/zip" })

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ExportApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ExportApiService.java
@@ -14,6 +14,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import javax.ws.rs.core.Response;
 
 public abstract class ExportApiService {
+    public abstract Response exportApiGet(String name,String version,String providerName,String format,Boolean preserveStatus);
     public abstract Response exportApplicationsGet(String appName,String appOwner,Boolean withKeys);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ImportApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ImportApi.java
@@ -7,8 +7,8 @@ import org.wso2.carbon.apimgt.rest.api.admin.factories.ImportApiServiceFactory;
 import io.swagger.annotations.ApiParam;
 
 import org.wso2.carbon.apimgt.rest.api.admin.dto.ErrorDTO;
-import org.wso2.carbon.apimgt.rest.api.admin.dto.ApplicationInfoDTO;
 import java.io.File;
+import org.wso2.carbon.apimgt.rest.api.admin.dto.ApplicationInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.dto.APIInfoListDTO;
 
 import java.util.List;
@@ -28,6 +28,29 @@ public class ImportApi  {
 
    private final ImportApiService delegate = ImportApiServiceFactory.getImportApi();
 
+    @POST
+    @Path("/api")
+    @Consumes({ "multipart/form-data" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Import an API", notes = "This operation can be used to import an API.\n", response = void.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Created.\nAPI Imported Successfully.\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 403, message = "Forbidden\nNot Authorized to import.\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Not Found.\nRequested API to update not found.\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 409, message = "Conflict.\nAPI to import already exists.\n"),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.\nError in importing API.\n") })
+
+    public Response importApiPost(@ApiParam(value = "Zip archive consisting on exported api configuration\n") @Multipart(value = "file") InputStream fileInputStream,
+    @ApiParam(value = "Zip archive consisting on exported api configuration\n : details") @Multipart(value = "file" ) Attachment fileDetail,
+    @ApiParam(value = "Preserve Original Provider of the API. This is the user choice to keep or replace the API provider.\n") @QueryParam("preserveProvider")  Boolean preserveProvider,
+    @ApiParam(value = "Whether to update the API or not. This is used when updating already existing APIs.\n") @QueryParam("overwrite")  Boolean overwrite)
+    {
+    return delegate.importApiPost(fileInputStream,fileDetail,preserveProvider,overwrite);
+    }
     @POST
     @Path("/applications")
     @Consumes({ "multipart/form-data" })

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ImportApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ImportApiService.java
@@ -4,8 +4,8 @@ import org.wso2.carbon.apimgt.rest.api.admin.*;
 import org.wso2.carbon.apimgt.rest.api.admin.dto.*;
 
 import org.wso2.carbon.apimgt.rest.api.admin.dto.ErrorDTO;
-import org.wso2.carbon.apimgt.rest.api.admin.dto.ApplicationInfoDTO;
 import java.io.File;
+import org.wso2.carbon.apimgt.rest.api.admin.dto.ApplicationInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.dto.APIInfoListDTO;
 
 import java.util.List;
@@ -16,6 +16,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import javax.ws.rs.core.Response;
 
 public abstract class ImportApiService {
+    public abstract Response importApiPost(InputStream fileInputStream,Attachment fileDetail,Boolean preserveProvider,Boolean overwrite);
     public abstract Response importApplicationsPost(InputStream fileInputStream,Attachment fileDetail,Boolean preserveOwner,Boolean skipSubscriptions,String appOwner,Boolean skipApplicationKeys,Boolean update);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImpl.java
@@ -27,8 +27,15 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.APIKey;
+import org.wso2.carbon.apimgt.api.APIProvider;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.OAuthApplicationInfo;
+import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
+import org.wso2.carbon.apimgt.impl.importexport.APIImportExportManager;
+import org.wso2.carbon.apimgt.impl.importexport.ExportFormat;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.admin.ExportApiService;
 import org.wso2.carbon.apimgt.rest.api.admin.utils.FileBasedApplicationImportExportManager;
 import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
@@ -48,6 +55,75 @@ public class ExportApiServiceImpl extends ExportApiService {
     private static final String DEFAULT_APPLICATION_EXPORT_DIR = "exported-application";
     private static final String PRODUCTION = "PRODUCTION";
     private static final String SANDBOX = "SANDBOX";
+
+    /**
+     * Exports an API from API Manager for a given API ID. Meta information, API icon, documentation, WSDL
+     * and sequences are exported. This service generates a zipped archive which contains all the above mentioned
+     * resources for a given API.
+     *
+     * @param name           Name of the API that needs to be exported
+     * @param version        Version of the API that needs to be exported
+     * @param providerName   Provider name of the API that needs to be exported
+     * @param format         Format of output documents. Can be YAML or JSON
+     * @param preserveStatus Preserve API status on export
+     * @return Zipped file containing exported API
+     */
+    @Override
+    public Response exportApiGet(String name, String version, String providerName, String format,
+                                 Boolean preserveStatus) {
+
+        ExportFormat exportFormat;
+        API api;
+        APIImportExportManager apiImportExportManager;
+        String userName;
+        APIIdentifier apiIdentifier;
+        APIProvider apiProvider;
+        String apiDomain;
+        String apiRequesterDomain;
+        //If not specified status is preserved by default
+        boolean isStatusPreserved = preserveStatus == null || preserveStatus;
+
+        if (name == null || version == null || providerName == null) {
+            RestApiUtil.handleBadRequest("Invalid API Information ", log);
+        }
+
+        try {
+            //Default export format is YAML
+            exportFormat = StringUtils.isNotEmpty(format) ? ExportFormat.valueOf(format.toUpperCase()) :
+                    ExportFormat.YAML;
+
+            userName = RestApiUtil.getLoggedInUsername();
+            //provider names with @ signs are only accepted
+            apiDomain = MultitenantUtils.getTenantDomain(providerName);
+            apiRequesterDomain = RestApiUtil.getLoggedInUserTenantDomain();
+
+            if (!StringUtils.equals(apiDomain, apiRequesterDomain)) {
+                //not authorized to export requested API
+                RestApiUtil.handleAuthorizationFailure(RestApiConstants.RESOURCE_API +
+                        " name:" + name + " version:" + version + " provider:" + providerName, (String) null, log);
+            }
+
+            apiIdentifier = new APIIdentifier(APIUtil.replaceEmailDomain(providerName), name, version);
+            apiProvider = RestApiUtil.getLoggedInUserProvider();
+            // Checking whether the API exists
+            if (!apiProvider.isAPIAvailable(apiIdentifier)) {
+                String errorMessage = "Error occurred while updating. API: " + name + " version: " + version
+                        + " not found";
+                RestApiUtil.handleResourceNotFoundError(errorMessage, log);
+            }
+
+            api = apiProvider.getAPI(apiIdentifier);
+            apiImportExportManager = new APIImportExportManager(apiProvider, userName);
+            File file = apiImportExportManager.exportAPIArchive(api, isStatusPreserved, exportFormat);
+            return Response.ok(file)
+                    .header(RestApiConstants.HEADER_CONTENT_DISPOSITION, "attachment; filename=\""
+                            + file.getName() + "\"")
+                    .build();
+        } catch (APIManagementException | APIImportExportException e) {
+            RestApiUtil.handleInternalServerError("Error while exporting " + RestApiConstants.RESOURCE_API, e, log);
+        }
+        return null;
+    }
 
     /**
      * Export an existing Application

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/resources/admin-api.yaml
@@ -87,6 +87,10 @@ x-wso2-security:
         key: apim:app_import_export
       - description: ""
         roles: admin
+        name: apim:api_import_export
+        key: apim:api_import_export
+      - description: ""
+        roles: admin
         name: apim:label_manage
         key: apim:label_manage
       - description: ""
@@ -2028,6 +2032,152 @@ paths:
           description: |
             Not Acceptable.
             The requested media type is not supported
+          schema:
+            $ref: '#/definitions/Error'
+
+######################################################
+# Import Resource API
+######################################################
+  /import/api:
+
+    post:
+      x-scope: apim:api_import_export
+      consumes:
+        - multipart/form-data
+      x-wso2-curl: "curl -k -F \"file=@exported.zip\" -X POST -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/admin/v0.14/import/api?preserveProvider=false&overwrite=false"
+      x-wso2-request: |
+        POST https://localhost:9443/api/am/admin/v0.14/import/apis
+        Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8
+      x-wso2-response: "HTTP/1.1 200 OK\nAPI imported successfully."
+      summary: Import an API
+      description: |
+        This operation can be used to import an API.
+      parameters:
+        - name: file
+          in: formData
+          description: |
+            Zip archive consisting on exported api configuration
+          required: true
+          type: file
+        - name: preserveProvider
+          in: query
+          description: |
+            Preserve Original Provider of the API. This is the user choice to keep or replace the API provider.
+          required: false
+          type: boolean
+        - name: overwrite
+          in: query
+          description: |
+            Whether to update the API or not. This is used when updating already existing APIs.
+          required: false
+          type: boolean
+      tags:
+        - API (Individual)
+      responses:
+        200:
+          description: |
+            Created.
+            API Imported Successfully.
+        403:
+          description: |
+            Forbidden
+            Not Authorized to import.
+          schema:
+            $ref: '#/definitions/Error'
+        404:
+          description: |
+            Not Found.
+            Requested API to update not found.
+          schema:
+            $ref: '#/definitions/Error'
+        409:
+          description: |
+            Conflict.
+            API to import already exists.
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: |
+            Internal Server Error.
+            Error in importing API.
+          schema:
+            $ref: '#/definitions/Error'
+
+######################################################
+# Export Resource API
+######################################################
+  /export/api:
+
+    get:
+      x-scope: apim:api_import_export
+      produces:
+        - application/zip
+      x-wso2-curl: "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X GET https://localhost:9443/api/am/admin/v0.14/export/api?name=PizzaShackAPI&version=1.0.0&providerName=admin > exportAPI.zip"
+      x-wso2-request: |
+        GET https://localhost:9443/api/am/admin/v0.14/export/api?name=SampleAPI&version=1.0.0&providerName=admin
+        Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8
+      x-wso2-response: "HTTP/1.1 200 OK\n Connection: keep-alive\n  Content-Disposition: attachment; filename=\"exported-api.zip\"\n  Content-Type: application/zip"
+      summary: Export an API
+      description: |
+        This operation can be used to export the details of a particular API as a zip file.
+      parameters:
+        - name: name
+          in: query
+          description: |
+            API Name
+          required: true
+          type: string
+        - name: version
+          in: query
+          description: |
+            Version of the API
+          required: true
+          type: string
+        - name: providerName
+          in: query
+          description: |
+            Provider name of the API
+          required: true
+          type: string
+        - name: format
+          in: query
+          description: |
+            Format of output documents. Can be YAML or JSON.
+          type: string
+          enum:
+            - JSON
+            - YAML
+          required: true
+        - name: preserveStatus
+          in: query
+          description: |
+            Preserve API Status on export
+          required: false
+          type: boolean
+      tags:
+        - API (Individual)
+      responses:
+        200:
+          description: |
+            OK.
+            Export Successful.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              type: string
+          schema:
+            type: file
+        404:
+          description: |
+            Not Found.
+            Requested API does not exist.
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: |
+            Internal Server Error.
+            Error in exporting API.
           schema:
             $ref: '#/definitions/Error'
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/webapp/WEB-INF/beans.xml
@@ -6,11 +6,11 @@
     <import resource="classpath:META-INF/cxf/cxf.xml"/>
     <context:property-placeholder/>
     <context:annotation-config/>
-    <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer"> 
+    <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
 	  <property name="environment">
 	    <bean class="org.springframework.web.context.support.StandardServletEnvironment" />
-	  </property> 
-    </bean> 
+	  </property>
+    </bean>
     <bean class="org.springframework.beans.factory.config.PreferencesPlaceholderConfigurer"/>
     <jaxrs:server id="services" address="/">
         <jaxrs:serviceBeans>
@@ -34,17 +34,16 @@
     </jaxrs:server>
 
     <bean id="PreAuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.PreAuthenticationInterceptor" />
-
-    <!-- For Basic Authentication scheme please comment the AuthenticationInterceptor which contains "OAuthAuthenticationInterceptor"
-            and uncomment the AuthenticationInterceptor which contains "BasicAuthenticationInterceptor"-->
     <bean id="AuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.auth.OAuthAuthenticationInterceptor" />
-    <!--<bean id="AuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.auth.BasicAuthenticationInterceptor" />-->
-
+    <bean id="BasicAuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.auth.BasicAuthenticationInterceptor" />
+    <bean id="PostAuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.PostAuthenticationInterceptor" />
     <bean id="ValidationInInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.validation.ValidationInInterceptor"/>
     <cxf:bus>
         <cxf:inInterceptors>
             <ref bean="PreAuthenticationInterceptor"/>
             <ref bean="AuthenticationInterceptor"/>
+            <ref bean="BasicAuthenticationInterceptor"/>
+            <ref bean="PostAuthenticationInterceptor"/>
             <ref bean="ValidationInInterceptor"/>
         </cxf:inInterceptors>
     </cxf:bus>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/admin-api.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/admin-api.json
@@ -79,6 +79,12 @@
         {
           "description": "",
           "roles": "admin",
+          "name": "apim:api_import_export",
+          "key": "apim:api_import_export"
+        },
+        {
+          "description": "",
+          "roles": "admin",
           "name": "apim:label_manage",
           "key": "apim:label_manage"
         },
@@ -1932,6 +1938,13 @@
             "description": "Owner of the Application\n",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "withKeys",
+            "in": "query",
+            "description": "Export application keys\n",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -2009,6 +2022,20 @@
             "in": "query",
             "description": "Expected Owner of the Application in the Import Environment\n",
             "type": "string"
+          },
+          {
+            "name": "skipApplicationKeys",
+            "in": "query",
+            "description": "Skip importing Keys of the Application\n",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "update",
+            "in": "query",
+            "description": "Update if application exists\n",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -2041,6 +2068,157 @@
           },
           "406": {
             "description": "Not Acceptable.\nThe requested media type is not supported\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/import/api": {
+      "post": {
+        "x-scope": "apim:api_import_export",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "x-wso2-curl": "curl -k -F \"file=@exported.zip\" -X POST -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/admin/v0.14/import/api?preserveProvider=false&overwrite=false",
+        "x-wso2-request": "POST https://localhost:9443/api/am/admin/v0.14/import/apis\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\nAPI imported successfully.",
+        "summary": "Import an API",
+        "description": "This operation can be used to import an API.\n",
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "description": "Zip archive consisting on exported api configuration\n",
+            "required": true,
+            "type": "file"
+          },
+          {
+            "name": "preserveProvider",
+            "in": "query",
+            "description": "Preserve Original Provider of the API. This is the user choice to keep or replace the API provider.\n",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "overwrite",
+            "in": "query",
+            "description": "Whether to update the API or not. This is used when updating already existing APIs.\n",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "API (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "Created.\nAPI Imported Successfully.\n"
+          },
+          "403": {
+            "description": "Forbidden\nNot Authorized to import.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nRequested API to update not found.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "409": {
+            "description": "Conflict.\nAPI to import already exists.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error.\nError in importing API.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/export/api": {
+      "get": {
+        "x-scope": "apim:api_import_export",
+        "produces": [
+          "application/zip"
+        ],
+        "x-wso2-curl": "curl -k -H \"Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\" -X GET https://localhost:9443/api/am/admin/v0.14/export/api?name=PizzaShackAPI&version=1.0.0&providerName=admin > exportAPI.zip",
+        "x-wso2-request": "GET https://localhost:9443/api/am/admin/v0.14/export/api?name=SampleAPI&version=1.0.0&providerName=admin\nAuthorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8\n",
+        "x-wso2-response": "HTTP/1.1 200 OK\n Connection: keep-alive\n  Content-Disposition: attachment; filename=\"exported-api.zip\"\n  Content-Type: application/zip",
+        "summary": "Export an API",
+        "description": "This operation can be used to export the details of a particular API as a zip file.\n",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "API Name\n",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "description": "Version of the API\n",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "providerName",
+            "in": "query",
+            "description": "Provider name of the API\n",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Format of output documents. Can be YAML or JSON.\n",
+            "type": "string",
+            "enum": [
+              "JSON",
+              "YAML"
+            ],
+            "required": true
+          },
+          {
+            "name": "preserveStatus",
+            "in": "query",
+            "description": "Preserve API Status on export\n",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "API (Individual)"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK.\nExport Successful.\n",
+            "headers": {
+              "Content-Type": {
+                "description": "The content type of the body.\n",
+                "type": "string"
+              }
+            },
+            "schema": {
+              "type": "file"
+            }
+          },
+          "404": {
+            "description": "Not Found.\nRequested API does not exist.\n",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error.\nError in exporting API.\n",
             "schema": {
               "$ref": "#/definitions/Error"
             }


### PR DESCRIPTION
This PR adds API import-export functionality to Admin REST API. The same logic which was previously there in product-apim/modules/api-import-export is moved to carbon.apimgt.rest.api.admin and carbon.apimgt.impl modules. In addition, the following changes are applied on top of that.

1. Remove "'PUT /{apiId}" resource to update API. Add the same support to "POST /import/api" with optional query parameter "overwrite".
2. Fixed the issue of throwing an error when updating the thumbnail (calling update API with the state "CREATED").
3. Instead of searchAPI to find duplicate API name/context when importing new API, use isAPIAvailable() and isApiNameWithDifferentCaseExist() provider methods.
4. Fixed the issue of throwing gateway deploy error while importing a Published API or updating API state to Published when there are API specific custom sequences, 
5. Fixed the issue of API specific custom sequences not getting updated, when updating API.
6. Fixed the issue of updating backend certificates when importing/updating API.
