### PR TITLE
Implement SOAP to REST API creation

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/package-lock.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/package-lock.json
@@ -991,6 +991,286 @@
             "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-2.6.2.tgz",
             "integrity": "sha512-JD6O2yCF2NuefU3+R7va6WmeetvajWO/ab0s4xjGpxnIMu6p9dtjTQfAhW2+NG+4Dc8MYKYo1wbJ8j02mZ1stw=="
         },
+        "@hapi/accept": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.3.tgz",
+            "integrity": "sha512-qEzsOJkCAJZxwj3iF83bSG9Lxy8Bpbrt8mRLNdvSALT6vlU2cYh6ZEHKEZPy4h/Mo31Su3j0rJgFF91+W1RWDQ==",
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "8.x.x"
+            }
+        },
+        "@hapi/address": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
+            "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+        },
+        "@hapi/ammo": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.1.tgz",
+            "integrity": "sha512-NYFK27VSPGyQ/KmOQedpQH4PSjE7awLntepX68vrYtRvuJO21W1kX0bK2p3C+6ltUwtCQSvmNT8a4uMVAysC6Q==",
+            "requires": {
+                "@hapi/hoek": "8.x.x"
+            }
+        },
+        "@hapi/b64": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
+            "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
+            "requires": {
+                "@hapi/hoek": "8.x.x"
+            }
+        },
+        "@hapi/boom": {
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.3.tgz",
+            "integrity": "sha512-3di+R+BcGS7HKy67Zi6mIga8orf67GdR0ubDEVBG1oqz3y9B70LewsuCMCSvWWLKlI6V1+266zqhYzjMrPGvZw==",
+            "requires": {
+                "@hapi/hoek": "8.x.x"
+            }
+        },
+        "@hapi/bounce": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.1.tgz",
+            "integrity": "sha512-/ecFQTRBom2MEbjMHvKKE6FZ/e1gYK72CeUIFzz++dKK1kYJ0KbRJ72mXroWoTT2hIv+8H0ua/eOkO0+hRdHcw==",
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "8.x.x"
+            }
+        },
+        "@hapi/bourne": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+            "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+        },
+        "@hapi/call": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.1.tgz",
+            "integrity": "sha512-M6fC+9+K/ZB4hIdVQ8i0kc/6J5PWlW3PEWYKAAZpw0sk+28LiRTSF8BjOWwmiIjZWWs42AnEIiFJA0YrvcDnlw==",
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "8.x.x"
+            }
+        },
+        "@hapi/catbox": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.2.tgz",
+            "integrity": "sha512-a4KejaKqDOMdwo/PIYoAaObVMmkfkG3RS85kPqNTTURjWnIV1+rrZ938f6RCz5EbrroKbuNC0bcvAt7lAD5LNg==",
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "8.x.x",
+                "@hapi/joi": "15.x.x",
+                "@hapi/podium": "3.x.x"
+            }
+        },
+        "@hapi/catbox-memory": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.1.tgz",
+            "integrity": "sha512-T6Hdy8DExzG0jY7C8yYWZB4XHfc0v+p1EGkwxl2HoaPYAmW7I3E59M/IvmSVpis8RPcIoBp41ZpO2aZPBpM2Ww==",
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "8.x.x"
+            }
+        },
+        "@hapi/content": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.0.tgz",
+            "integrity": "sha512-hv2Czsl49hnWDEfRZOFow/BmYbKyfEknmk3k83gOp6moFn5ceHB4xVcna8OwsGfy8dxO81lhpPy+JgQEaU4SWw==",
+            "requires": {
+                "@hapi/boom": "7.x.x"
+            }
+        },
+        "@hapi/cryptiles": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.0.tgz",
+            "integrity": "sha512-P+ioMP1JGhwDOKPRuQls6sT/ln6Fk+Ks6d90mlBi6HcOu5itvdUiFv5Ynq2DvLadPDWaA43lwNxkfZrjE9s2MA==",
+            "requires": {
+                "@hapi/boom": "7.x.x"
+            }
+        },
+        "@hapi/file": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
+            "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ=="
+        },
+        "@hapi/hapi": {
+            "version": "18.3.2",
+            "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.3.2.tgz",
+            "integrity": "sha512-UJogSyMPe4VFfzjQW5v2ixLvTLZLSfPs1XV/DRnAl2znzsGCaNJI+tgNxjM9lszOjEEkMfxLgoXZadk9exnIxw==",
+            "requires": {
+                "@hapi/accept": "3.x.x",
+                "@hapi/ammo": "3.x.x",
+                "@hapi/boom": "7.x.x",
+                "@hapi/bounce": "1.x.x",
+                "@hapi/call": "5.x.x",
+                "@hapi/catbox": "10.x.x",
+                "@hapi/catbox-memory": "4.x.x",
+                "@hapi/heavy": "6.x.x",
+                "@hapi/hoek": "8.x.x",
+                "@hapi/joi": "15.x.x",
+                "@hapi/mimos": "4.x.x",
+                "@hapi/podium": "3.x.x",
+                "@hapi/shot": "4.x.x",
+                "@hapi/somever": "2.x.x",
+                "@hapi/statehood": "6.x.x",
+                "@hapi/subtext": "6.x.x",
+                "@hapi/teamwork": "3.x.x",
+                "@hapi/topo": "3.x.x"
+            }
+        },
+        "@hapi/heavy": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.1.tgz",
+            "integrity": "sha512-uaEyC4AtGCGKt/LLBbdDQxJP1bFAbxiot6n/fwa4kyo6w8ULpXXCh8FxLlJ5mC06lqbAxQv45JyozIB6P4Dsig==",
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "8.x.x",
+                "@hapi/joi": "15.x.x"
+            }
+        },
+        "@hapi/hoek": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz",
+            "integrity": "sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg=="
+        },
+        "@hapi/iron": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.1.tgz",
+            "integrity": "sha512-QYfm6nofZ19pIxm8LR0lsANBabrdxqe0vUYKKI+0w9VdCetoove+dxfbLfduVDM72kh/RNOQG6E5/xyI826PcA==",
+            "requires": {
+                "@hapi/b64": "4.x.x",
+                "@hapi/boom": "7.x.x",
+                "@hapi/cryptiles": "4.x.x",
+                "@hapi/hoek": "8.x.x"
+            }
+        },
+        "@hapi/joi": {
+            "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+            "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+            "requires": {
+                "@hapi/address": "2.x.x",
+                "@hapi/bourne": "1.x.x",
+                "@hapi/hoek": "8.x.x",
+                "@hapi/topo": "3.x.x"
+            }
+        },
+        "@hapi/mimos": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",
+            "integrity": "sha512-CXoi/zfcTWfKYX756eEea8rXJRIb9sR4d7VwyAH9d3BkDyNgAesZxvqIdm55npQc6S9mU3FExinMAQVlIkz0eA==",
+            "requires": {
+                "@hapi/hoek": "8.x.x",
+                "mime-db": "1.x.x"
+            }
+        },
+        "@hapi/nigel": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.1.tgz",
+            "integrity": "sha512-R9YWx4S8yu0gcCBrMUDCiEFm1SQT895dMlYoeNBp8I6YhF1BFF1iYPueKA2Kkp9BvyHdjmvrxCOns7GMmpl+Fw==",
+            "requires": {
+                "@hapi/hoek": "8.x.x",
+                "@hapi/vise": "3.x.x"
+            }
+        },
+        "@hapi/pez": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.1.tgz",
+            "integrity": "sha512-TUa2C7Xk6J69HWrm+Ad+O6dFvdVAG0BiFUYaRsmkdWjFIfwHBCaOI1dWT/juNukSb39Lj6/mDVyjN+H4nKB3xg==",
+            "requires": {
+                "@hapi/b64": "4.x.x",
+                "@hapi/boom": "7.x.x",
+                "@hapi/content": "4.x.x",
+                "@hapi/hoek": "8.x.x",
+                "@hapi/nigel": "3.x.x"
+            }
+        },
+        "@hapi/podium": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.1.tgz",
+            "integrity": "sha512-WbwYr5nK+GIrCdgEbN8R7Mh7z+j9AgntOLQ/YQdeLtBp+uScVmW9FoycKdNS5uweO74xwICr28Ob0DU74a2zmg==",
+            "requires": {
+                "@hapi/hoek": "8.x.x",
+                "@hapi/joi": "15.x.x"
+            }
+        },
+        "@hapi/shot": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.1.tgz",
+            "integrity": "sha512-TrsqCyaq24XcdvD0bSi26hjwyQQy5q/nzpasbPNgPLoGnxW3sCWE7ws3ba6dd6Atb8TEh9QBD7mBQDCrMMz2Ig==",
+            "requires": {
+                "@hapi/hoek": "8.x.x",
+                "@hapi/joi": "15.x.x"
+            }
+        },
+        "@hapi/somever": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.1.tgz",
+            "integrity": "sha512-cic5Sto4KGd9B0oQSdKTokju+rYhCbdpzbMb0EBnrH5Oc1z048hY8PaZ1lx2vBD7I/XIfTQVQetBH57fU51XRA==",
+            "requires": {
+                "@hapi/bounce": "1.x.x",
+                "@hapi/hoek": "8.x.x"
+            }
+        },
+        "@hapi/statehood": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.1.tgz",
+            "integrity": "sha512-tMfS6B8QdrqTaKRUhHv6Ur7oPK6kcEZcnnvBK4IuaPZA9ma5UsyprTXkzbiB0V+0E56dMg3RabO1SABeZkzy6g==",
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/bounce": "1.x.x",
+                "@hapi/bourne": "1.x.x",
+                "@hapi/cryptiles": "4.x.x",
+                "@hapi/hoek": "8.x.x",
+                "@hapi/iron": "5.x.x",
+                "@hapi/joi": "15.x.x"
+            }
+        },
+        "@hapi/subtext": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.1.tgz",
+            "integrity": "sha512-Y7NjKFRPwlzKRw5IdwRou42hR4IBQZolT+/DlvfSr/CBjGyu38n5+9LKfNKzqB/0AVEk+xynCijsx1o1UVWX8A==",
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/bourne": "1.x.x",
+                "@hapi/content": "4.x.x",
+                "@hapi/file": "1.x.x",
+                "@hapi/hoek": "8.x.x",
+                "@hapi/pez": "4.x.x",
+                "@hapi/wreck": "15.x.x"
+            }
+        },
+        "@hapi/teamwork": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
+            "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ=="
+        },
+        "@hapi/topo": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz",
+            "integrity": "sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==",
+            "requires": {
+                "@hapi/hoek": "8.x.x"
+            }
+        },
+        "@hapi/vise": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.1.tgz",
+            "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
+            "requires": {
+                "@hapi/hoek": "8.x.x"
+            }
+        },
+        "@hapi/wreck": {
+            "version": "15.0.2",
+            "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.0.2.tgz",
+            "integrity": "sha512-D/7sGmx3XxxkaMWHZDKTMai8rIEfIgE+DnoZeKfmxhKGgvIpMu1f8BBmLADbdniccGer79w74IWWdXleNrT1Rw==",
+            "requires": {
+                "@hapi/boom": "7.x.x",
+                "@hapi/bourne": "1.x.x",
+                "@hapi/hoek": "8.x.x"
+            }
+        },
         "@icons/material": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/package-lock.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/package-lock.json
@@ -6773,6 +6773,14 @@
                 "loader-utils": "^1.0.2"
             }
         },
+        "file-selector": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.12.tgz",
+            "integrity": "sha512-Kx7RTzxyQipHuiqyZGf+Nz4vY9R1XGxuQl/hLoJwq+J4avk/9wxxgZyHKtbyIPJmbD4A66DWGYfyykWNpcYutQ==",
+            "requires": {
+                "tslib": "^1.9.0"
+            }
+        },
         "filesize": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
@@ -14404,12 +14412,13 @@
             }
         },
         "react-dropzone": {
-            "version": "3.13.4",
-            "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-3.13.4.tgz",
-            "integrity": "sha1-hNomgVxAM5aRxJtFRMLvehaRLMw=",
+            "version": "10.1.7",
+            "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-10.1.7.tgz",
+            "integrity": "sha512-PT4DHJCQrY/2vVljupveqnlwzVRQGK7U6mhoO0ox6kSJV0EK6W1ZmZpRyHMA1S6/KUOzN+1pASUMSqV/4uAIXg==",
             "requires": {
-                "attr-accept": "^1.0.3",
-                "prop-types": "^15.5.7"
+                "attr-accept": "^1.1.3",
+                "file-selector": "^0.1.11",
+                "prop-types": "^15.7.2"
             }
         },
         "react-file-download": {
@@ -17292,8 +17301,7 @@
         "tslib": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-            "dev": true
+            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
         },
         "tty-browserify": {
             "version": "0.0.0",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/package.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "test": "jest",
         "test:coverage": "jest --coverage",
-        "build:prod": "NODE_ENV=production NODE_OPTIONS=--max_old_space_size=4096 webpack -p --display errors-only --hide-modules;npm run i18n",
+        "build:prod": "NODE_ENV=production NODE_OPTIONS=--max_old_space_size=4096 webpack -p --display errors-only --hide-modules",
         "build:dev": "NODE_ENV=development webpack -d --watch ",
         "analysis": "NODE_ENV=development webpack --env.analysis -p --progress",
         "lint": "eslint source",
@@ -47,7 +47,7 @@
         "react-color": "^2.17.3",
         "react-dom": "^16.8.6",
         "react-draft-wysiwyg": "^1.13.2",
-        "react-dropzone": "^3.13.4",
+        "react-dropzone": "^v10.1.7",
         "react-intl": "v3.1.6",
         "react-loadable": "^5.5.0",
         "react-markdown": "^4.0.8",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/package.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/package.json
@@ -19,6 +19,7 @@
     "author": "WSO2 Org",
     "license": "Apache-2.0",
     "dependencies": {
+        "@hapi/hapi": "^18.3.2",
         "@material-ui/core": "^v4.3.1",
         "@material-ui/icons": "^v4.2.1",
         "antd": "^2.11.2",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.jsx
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useReducer, useState, useEffect } from 'react';
+import React, { useReducer, useState } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.jsx
@@ -15,458 +15,166 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useReducer, useState } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import { FormattedMessage } from 'react-intl';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
 import Button from '@material-ui/core/Button';
-import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
-import { FormattedMessage } from 'react-intl';
-import Paper from '@material-ui/core/Paper';
-import API from 'AppData/api';
-import Alert from 'AppComponents/Shared/Alert';
-import APIInputForm from 'AppComponents/Apis/Create/Components/APIInputForm';
-import Progress from 'AppComponents/Shared/Progress';
-
+import { Link } from 'react-router-dom';
 import ProvideWSDL from './Steps/ProvideWSDL';
-import BindingInfo from './BindingInfo';
-import APICreateTopMenu from '../Components/APICreateTopMenu';
-
-const styles = theme => ({
-    instructions: {
-        marginTop: theme.spacing.unit,
-        marginBottom: theme.spacing.unit,
-    },
-    root: {
-        flexGrow: 1,
-        marginLeft: 0,
-        marginTop: 0,
-        paddingLeft: theme.spacing.unit * 4,
-        paddingTop: theme.spacing.unit * 2,
-        paddingBottom: theme.spacing.unit * 2,
-        width: theme.custom.contentAreaWidth,
-    },
-    buttonProgress: {
-        position: 'relative',
-        marginTop: theme.spacing.unit * 5,
-        marginLeft: theme.spacing.unit * 6.25,
-    },
-    button: {
-        marginTop: theme.spacing.unit * 2,
-        marginRight: theme.spacing.unit,
-    },
-    buttonSection: {
-        paddingTop: theme.spacing.unit * 2,
-    },
-    subTitle: {
-        color: theme.palette.grey[500],
-        marginBottom: theme.spacing.unit * 2,
-    },
-    stepper: {
-        paddingLeft: 0,
-        marginLeft: 0,
-        width: 400,
-    },
-});
+import DefaultAPIForm from './Steps/DefaultAPIForm';
 
 /**
+ * Base component for all API create forms
  *
- *
- * @returns
+ * @param {Object} props title and children components are expected
+ * @returns {React.Component} Base element
  */
-function getSteps() {
-    const steps = [
-        <FormattedMessage id='select.wsdl' defaultMessage='Select WSDL' />,
-        <FormattedMessage id='create.api' defaultMessage='Create API' />,
-    ];
-    return steps;
-}
-
-/**
- *
- * Simple util method to check whether provided object is empty
- * @param {Object} obj any
- * @returns {boolean} check
- */
-function isEmpty(obj) {
-    return Object.entries(obj).length === 0 && obj.constructor === Object;
-}
-
-/**
- *
- *
- * @class APICreateWSDL
- * @extends {React.Component}
- */
-class APICreateWSDL extends React.Component {
-    /**
-     * Creates an instance of ApiCreateWSDL.
-     * @param {any} props @inheritDoc
-     * @memberof ApiCreateWSDL
-     */
-    constructor(props) {
-        super(props);
-        this.state = {
-            doValidate: false,
-            wsdlBean: {},
-            activeStep: 0,
-            api: new API('', 'v1.0.0'),
-            loading: false,
-            valid: {
-                wsdlUrl: { empty: false, invalidUrl: false },
-                wsdlFile: { empty: false, invalidFile: false },
-                name: { empty: false, alreadyExists: false },
-                context: { empty: false, alreadyExists: false },
-                version: { empty: false },
-                endpoint: { empty: false },
-            },
-        };
-        this.updateWSDLBean = this.updateWSDLBean.bind(this);
-        this.updateApiInputs = this.updateApiInputs.bind(this);
-        this.createWSDLAPI = this.createWSDLAPI.bind(this);
-        this.updateFileErrors = this.updateFileErrors.bind(this);
-        this.provideWSDL = null;
-    }
-
-    /**
-     * Check the WSDL file or URL validity through REST API
-     * @param {Object} wsdlBean Bean object holding WSDL file/url info
-     * @memberof ApiCreateWSDL
-     */
-    updateWSDLBean(wsdlBean) {
-        console.info(wsdlBean);
-        this.setState({
-            wsdlBean,
-        });
-    }
-
-    /**
-     * Update user inputs in the form with onChange event trigger
-     * @param {React.SyntheticEvent} event Event containing user action
-     * @memberof ApiCreateWSDL
-     */
-    updateApiInputs({ target }) {
-        const { name, value } = target;
-        this.setState(({ api, valid }) => {
-            const changes = api;
-            if (name === 'endpoint') {
-                changes[name] = [
-                    {
-                        inline: {
-                            name: `${api.name}_inline_prod`,
-                            endpointConfig: {
-                                list: [
-                                    {
-                                        url: value,
-                                        timeout: '1000',
-                                    },
-                                ],
-                                endpointType: 'SINGLE',
-                            },
-                            type: 'soap',
-                            endpointSecurity: {
-                                enabled: false,
-                            },
-                        },
-                        type: 'Production',
-                    },
-                    {
-                        inline: {
-                            name: `${api.name}_inline_sandbx`,
-                            endpointConfig: {
-                                list: [
-                                    {
-                                        url: value,
-                                        timeout: '1000',
-                                    },
-                                ],
-                                endpointType: 'SINGLE',
-                            },
-                            type: 'soap',
-                            endpointSecurity: {
-                                enabled: false,
-                            },
-                        },
-                        type: 'Sandbox',
-                    },
-                ];
-            } else {
-                changes[name] = value;
-            }
-
-            // Checking validity.
-            const validUpdated = valid;
-            validUpdated.name.empty = !api.name;
-            validUpdated.context.empty = !api.context;
-            validUpdated.version.empty = !api.version;
-            validUpdated.endpoint.empty = !api.endpoint;
-            // TODO we need to add the already existing error for
-            // (context) by doing an api call ( the swagger definition does not contain such api call)
-            return { api: changes, valid: validUpdated };
-        });
-    }
-
-    /**
-     * Make API POST call and create send WSDL file or URL
-     * @memberof ApiCreateWSDL
-     */
-    createWSDLAPI() {
-        this.setState({ loading: true });
-        const newApi = new API();
-        const { wsdlBean, api } = this.state;
-        const {
-            name, version, context, endpoint, implementationType,
-        } = api;
-        const uploadMethod = wsdlBean.url ? 'url' : 'file';
-        const apiAttributes = {
-            name,
-            version,
-            context,
-            endpoint,
-        };
-        const apiData = {
-            additionalProperties: JSON.stringify(apiAttributes),
-            implementationType,
-            [uploadMethod]: wsdlBean[uploadMethod],
-        };
-
-        newApi
-            .importWSDL(apiData)
-            .then((response) => {
-                Alert.success(`${name} API Created Successfully.`);
-                const uuid = response.obj.id;
-                const redirectURL = '/apis/' + uuid + '/overview';
-                this.setState({ loading: false });
-                this.props.history.push(redirectURL);
-            })
-            .catch((errorResponse) => {
-                this.setState({ loading: false });
-                console.error(errorResponse);
-                const error = errorResponse.response.obj;
-                const messageTxt = 'Error[' + error.code + ']: ' + error.description + ' | ' + error.message + '.';
-                Alert.error(messageTxt);
-            });
-    }
-    updateFileErrors(newValid) {
-        this.setState({ valid: newValid });
-    }
-    handleNext = () => {
-        const { activeStep, wsdlBean, valid } = this.state;
-        let uploadMethod;
-        if (this.provideWSDL) {
-            uploadMethod = this.provideWSDL.getUploadMethod();
-        } else if (wsdlBean.file) {
-            uploadMethod = 'file';
-        } else {
-            uploadMethod = 'url';
-        }
-        const validNew = JSON.parse(JSON.stringify(valid));
-
-        // Handling next ( getting wsdl file/url info and validating)
-        if (activeStep === 0) {
-            if (isEmpty(wsdlBean)) {
-                if (uploadMethod === 'file') {
-                    validNew.wsdlFile.empty = true;
-                } else {
-                    validNew.wsdlUrl.empty = true;
-                }
-                this.setState({ valid: validNew });
-                return;
-            } else {
-                if (wsdlBean.file && uploadMethod === 'url') {
-                    validNew.wsdlUrl.empty = true;
-                    this.setState({ valid: validNew });
-                    return;
-                }
-                if (wsdlBean.url && uploadMethod === 'file') {
-                    validNew.wsdlFile.empty = true;
-                    this.setState({ valid: validNew });
-                    return;
-                }
-            }
-            // No errors so let's fill the inputs with the wsdlBean
-            if (wsdlBean.info) {
-                if (wsdlBean.info.version) {
-                    this.updateApiInputs({ target: { name: 'version', value: wsdlBean.info.version } });
-                }
-                if (wsdlBean.info.endpoints && wsdlBean.info.endpoints.length > 0) {
-                    this.updateApiInputs({ target: { name: 'endpoint', value: wsdlBean.info.endpoints[0].location } });
-                }
-            }
-            this.setState({
-                activeStep: activeStep + 1,
-            });
-        } else if (activeStep === 1) {
-            // Handling Finish step ( validating the input fields )
-            const { api: currentAPI } = this.state;
-            if (!currentAPI.name || !currentAPI.context || !currentAPI.version || !currentAPI.endpoint) {
-                // Checking the api name,version,context undefined or empty states
-                this.setState((oldState) => {
-                    const { valid: isValid, api } = oldState;
-                    const validUpdated = isValid;
-                    validUpdated.name.empty = !api.name;
-                    validUpdated.context.empty = !api.context;
-                    validUpdated.version.empty = !api.version;
-                    validUpdated.endpoint.empty = !api.endpoint;
-                    return { valid: validUpdated };
-                });
-                return;
-            }
-            this.createWSDLAPI();
-        }
-    };
-
-    handleBack = () => {
-        this.setState(state => ({
-            activeStep: state.activeStep - 1,
-        }));
-    };
-
-    handleReset = () => {
-        this.setState({
-            activeStep: 0,
-        });
-    };
-
-    /**
-     *
-     *
-     * @returns
-     * @memberof APICreateWSDL
-     */
-    render() {
-        const { classes } = this.props;
-        const steps = getSteps();
-        const {
-            doValidate, activeStep, wsdlBean, api, valid, loading,
-        } = this.state;
-        const uploadMethod = wsdlBean.url ? 'url' : 'file';
-        const provideWSDLProps = {
-            uploadMethod,
-            [uploadMethod]: wsdlBean[uploadMethod],
-            updateWSDLBean: this.updateWSDLBean,
-            validate: doValidate,
-            valid,
-            updateFileErrors: this.updateFileErrors,
-        };
-        if (loading) {
-            return <Progress />;
-        }
-        return (
-            <React.Fragment>
-                <APICreateTopMenu />
-                <Grid container spacing={7} className={classes.root}>
-                    <Grid item xs={12}>
-                        <div className={classes.titleWrapper}>
-                            <Typography variant='h4' align='left' className={classes.mainTitle}>
-                                <FormattedMessage
-                                    id='design.a.new.rest.api.using.wsdl'
-                                    defaultMessage='Design a new REST API using WSDL'
-                                />
-                            </Typography>
-                            <Typography variant='caption' align='left' className={classes.subTitle} component='div'>
-                                {uploadMethod === 'file' && (
-                                    <FormattedMessage
-                                        id='design.a.new.rest.api.using.wsdl.help.file'
-                                        defaultMessage='Provide an api definition file'
-                                    />
-                                )}
-                                {uploadMethod === 'url' && (
-                                    <FormattedMessage
-                                        id='design.a.new.rest.api.using.wsdl.help.url'
-                                        defaultMessage='Provide a url for the api deninition'
-                                    />
-                                )}
-                            </Typography>
-                        </div>
-                        <Paper>
-                            <Stepper activeStep={activeStep} className={classes.stepper}>
-                                {steps.map((label) => {
-                                    const props = {};
-                                    const labelProps = {};
-
-                                    return (
-                                        <Step key={label} {...props}>
-                                            <StepLabel {...labelProps}>{label}</StepLabel>
-                                        </Step>
-                                    );
-                                })}
-                            </Stepper>
-                        </Paper>
-                        <div>
-                            {activeStep === 0 && (
-                                <ProvideWSDL
-                                    {...provideWSDLProps}
-                                    innerRef={(instance) => {
-                                        this.provideWSDL = instance;
-                                    }}
-                                />
-                            )}
-                            {activeStep === 1 && (
-                                <React.Fragment>
-                                    <APIInputForm api={api} handleInputChange={this.updateApiInputs} valid={valid} />
-                                    <BindingInfo
-                                        updateApiInputs={this.updateApiInputs}
-                                        wsdlBean={wsdlBean}
-                                        classes={classes}
-                                        api={api}
-                                    />
-                                </React.Fragment>
-                            )}
-                        </div>
-                        <div>
-                            {activeStep === steps.length ? (
-                                <div>
-                                    <Typography className={classes.instructions}>
-                                        All steps completed - you&quot;re finished
-                                    </Typography>
-                                    <Button onClick={this.handleReset} className={classes.button}>
-                                        Reset
-                                    </Button>
-                                </div>
-                            ) : (
-                                <div>
-                                    <div>
-                                        <Button
-                                            disabled={activeStep === 0}
-                                            onClick={this.handleBack}
-                                            className={classes.button}
-                                        >
-                                            Back
-                                        </Button>
-                                        <Button
-                                            variant='contained'
-                                            color='primary'
-                                            onClick={this.handleNext}
-                                            className={classes.button}
-                                            disabled={
-                                                (valid.wsdlFile.invalidFile && uploadMethod === 'file') ||
-                                                (valid.wsdlUrl.invalidUrl && uploadMethod === 'url')
-                                            }
-                                        >
-                                            {activeStep === steps.length - 1 ? (
-                                                'Finish'
-                                            ) : (
-                                                <FormattedMessage id='next' defaultMessage='Next' />
-                                            )}
-                                        </Button>
-                                    </div>
-                                </div>
-                            )}
-                        </div>
+function APICreateBase(props) {
+    const { title, children } = props;
+    return (
+        <Grid container spacing={3}>
+            <Grid item sm={12} md={12} />
+            {/*
+            Following two grids control the placement of whole create page
+            For centering the content better use `container` props, but instead used an empty grid item for flexibility
+             */}
+            <Grid item sm={0} md={3} />
+            <Grid item sm={12} md={6}>
+                <Grid container spacing={5}>
+                    <Grid item md={12}>
+                        {title}
+                    </Grid>
+                    <Grid item md={12}>
+                        <Paper elevation={0}>{children}</Paper>
                     </Grid>
                 </Grid>
-            </React.Fragment>
-        );
-    }
+            </Grid>
+        </Grid>
+    );
 }
-
-APICreateWSDL.propTypes = {
-    classes: PropTypes.shape({}).isRequired,
-    history: PropTypes.shape({ push: PropTypes.func }).isRequired,
+APICreateBase.propTypes = {
+    title: PropTypes.element.isRequired,
+    children: PropTypes.element.isRequired,
 };
+/**
+ * Handle API creation from WSDL.
+ *
+ * @export
+ * @param {*} props
+ * @returns
+ */
+export default function SOAPToREST() {
+    const [wizardStep, setWizardStep] = useState(0);
 
-export default withStyles(styles)(APICreateWSDL);
+    /**
+     *
+     * Reduce the events triggered from API input fields to current state
+     */
+    function apiInputsReducer(currentState, inputAction) {
+        const { action, value } = inputAction;
+        switch (action) {
+            case 'type':
+            case 'inputValue':
+            case 'name':
+            case 'version':
+            case 'endpoint':
+            case 'context':
+            case 'policies':
+                return { ...currentState, [action]: value };
+            case 'inputType':
+                return { ...currentState, [action]: value, inputValue: value === 'url' ? '' : [] };
+            default:
+                return currentState;
+        }
+    }
+
+    const [apiInputs, inputsDispatcher] = useReducer(apiInputsReducer, {
+        type: 'SOAPtoREST',
+        inputType: 'url',
+        inputValue: '',
+    });
+
+    /**
+     *
+     *
+     * @param {*} event
+     */
+    function handleOnChange(event) {
+        const { name: action, value } = event.target;
+        inputsDispatcher({ action, value });
+    }
+
+    return (
+        <APICreateBase
+            title={
+                <React.Fragment>
+                    <Typography variant='h5'>
+                        <FormattedMessage
+                            id='Apis.Create.WSDL.ApiCreateWSDL.heading'
+                            defaultMessage='Create an API using WSDL'
+                        />
+                    </Typography>
+                    <Typography variant='caption'>
+                        <FormattedMessage
+                            id='Apis.Create.WSDL.ApiCreateWSDL.sub.heading'
+                            defaultMessage={
+                                'Use an existing SOAP endpoint to create a managed API.' +
+                                ' Import the WSDL of the SOAP service.'
+                            }
+                        />
+                    </Typography>
+                </React.Fragment>
+            }
+        >
+            <Paper elevation={1}>
+                <Stepper activeStep={0}>
+                    <Step>
+                        <StepLabel>Provide WSDL</StepLabel>
+                    </Step>
+
+                    <Step>
+                        <StepLabel>Create API</StepLabel>
+                    </Step>
+                </Stepper>
+            </Paper>
+
+            <Grid container spacing={3}>
+                <Grid item md={12} />
+                <Grid item md={1} />
+                <Grid item md={11}>
+                    {wizardStep === 0 && <ProvideWSDL apiInputs={apiInputs} inputsDispatcher={inputsDispatcher} />}
+                    {wizardStep === 1 && <DefaultAPIForm onChange={handleOnChange} api={apiInputs} />}
+                </Grid>
+                <Grid item md={1} />
+                <Grid item md={9}>
+                    <Grid container direction='row' justify='space-between'>
+                        <Grid item>
+                            {wizardStep === 0 && (
+                                <Link to='/apis/'>
+                                    <Button>
+                                        <FormattedMessage
+                                            id='Apis.Details.Configuration.Configuration.cancel'
+                                            defaultMessage='Cancel'
+                                        />
+                                    </Button>
+                                </Link>
+                            )}
+                            {wizardStep === 1 && <Button onClick={() => setWizardStep(step => step - 1)}>Back</Button>}
+                        </Grid>
+                        <Grid item>
+                            <Button onClick={() => setWizardStep(step => step + 1)} variant='contained' color='primary'>
+                                Next
+                            </Button>
+                        </Grid>
+                    </Grid>
+                </Grid>
+            </Grid>
+        </APICreateBase>
+    );
+}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.jsx
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useReducer, useState } from 'react';
+import React, { useReducer, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
@@ -71,6 +71,11 @@ APICreateBase.propTypes = {
  */
 export default function SOAPToREST() {
     const [wizardStep, setWizardStep] = useState(0);
+    useEffect(() => {
+        if (wizardStep === 1) {
+            // Do the API submission
+        }
+    }, [wizardStep]);
 
     /**
      *
@@ -86,6 +91,7 @@ export default function SOAPToREST() {
             case 'endpoint':
             case 'context':
             case 'policies':
+            case 'isFormValid':
                 return { ...currentState, [action]: value };
             case 'inputType':
                 return { ...currentState, [action]: value, inputValue: value === 'url' ? '' : [] };
@@ -98,6 +104,7 @@ export default function SOAPToREST() {
         type: 'SOAPtoREST',
         inputType: 'url',
         inputValue: '',
+        formValidity: true,
     });
 
     /**
@@ -108,6 +115,20 @@ export default function SOAPToREST() {
     function handleOnChange(event) {
         const { name: action, value } = event.target;
         inputsDispatcher({ action, value });
+    }
+
+    /**
+     *
+     * Set the validity of the API Inputs form
+     * @param {*} isValidForm
+     * @param {*} validationState
+     */
+    function handleOnValidate(isFormValid) {
+        // API Name , Version & Context is a must that's why `&&` chain
+        inputsDispatcher({
+            action: 'isFormValid',
+            value: isFormValid && Boolean(apiInputs.name) && Boolean(apiInputs.version) && Boolean(apiInputs.context),
+        });
     }
 
     return (
@@ -149,7 +170,9 @@ export default function SOAPToREST() {
                 <Grid item md={1} />
                 <Grid item md={11}>
                     {wizardStep === 0 && <ProvideWSDL apiInputs={apiInputs} inputsDispatcher={inputsDispatcher} />}
-                    {wizardStep === 1 && <DefaultAPIForm onChange={handleOnChange} api={apiInputs} />}
+                    {wizardStep === 1 && (
+                        <DefaultAPIForm onValidate={handleOnValidate} onChange={handleOnChange} api={apiInputs} />
+                    )}
                 </Grid>
                 <Grid item md={1} />
                 <Grid item md={9}>
@@ -168,9 +191,20 @@ export default function SOAPToREST() {
                             {wizardStep === 1 && <Button onClick={() => setWizardStep(step => step - 1)}>Back</Button>}
                         </Grid>
                         <Grid item>
-                            <Button onClick={() => setWizardStep(step => step + 1)} variant='contained' color='primary'>
-                                Next
-                            </Button>
+                            {wizardStep === 0 && (
+                                <Button
+                                    onClick={() => setWizardStep(step => step + 1)}
+                                    variant='contained'
+                                    color='primary'
+                                >
+                                    Next
+                                </Button>
+                            )}
+                            {wizardStep === 1 && (
+                                <Button variant='contained' color='primary' disabled={!apiInputs.isFormValid}>
+                                    Create
+                                </Button>
+                            )}
                         </Grid>
                     </Grid>
                 </Grid>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.old.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.old.jsx
@@ -1,0 +1,472 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Stepper from '@material-ui/core/Stepper';
+import Step from '@material-ui/core/Step';
+import StepLabel from '@material-ui/core/StepLabel';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import { FormattedMessage } from 'react-intl';
+import Paper from '@material-ui/core/Paper';
+import API from 'AppData/api';
+import Alert from 'AppComponents/Shared/Alert';
+import APIInputForm from 'AppComponents/Apis/Create/Components/APIInputForm';
+import Progress from 'AppComponents/Shared/Progress';
+
+import ProvideWSDL from './Steps/ProvideWSDL';
+import BindingInfo from './BindingInfo';
+import APICreateTopMenu from '../Components/APICreateTopMenu';
+
+const styles = theme => ({
+    instructions: {
+        marginTop: theme.spacing.unit,
+        marginBottom: theme.spacing.unit,
+    },
+    root: {
+        flexGrow: 1,
+        marginLeft: 0,
+        marginTop: 0,
+        paddingLeft: theme.spacing.unit * 4,
+        paddingTop: theme.spacing.unit * 2,
+        paddingBottom: theme.spacing.unit * 2,
+        width: theme.custom.contentAreaWidth,
+    },
+    buttonProgress: {
+        position: 'relative',
+        marginTop: theme.spacing.unit * 5,
+        marginLeft: theme.spacing.unit * 6.25,
+    },
+    button: {
+        marginTop: theme.spacing.unit * 2,
+        marginRight: theme.spacing.unit,
+    },
+    buttonSection: {
+        paddingTop: theme.spacing.unit * 2,
+    },
+    subTitle: {
+        color: theme.palette.grey[500],
+        marginBottom: theme.spacing.unit * 2,
+    },
+    stepper: {
+        paddingLeft: 0,
+        marginLeft: 0,
+        width: 400,
+    },
+});
+
+/**
+ *
+ *
+ * @returns
+ */
+function getSteps() {
+    const steps = [
+        <FormattedMessage id='select.wsdl' defaultMessage='Select WSDL' />,
+        <FormattedMessage id='create.api' defaultMessage='Create API' />,
+    ];
+    return steps;
+}
+
+/**
+ *
+ * Simple util method to check whether provided object is empty
+ * @param {Object} obj any
+ * @returns {boolean} check
+ */
+function isEmpty(obj) {
+    return Object.entries(obj).length === 0 && obj.constructor === Object;
+}
+
+/**
+ *
+ *
+ * @class APICreateWSDL
+ * @extends {React.Component}
+ */
+class APICreateWSDL extends React.Component {
+    /**
+     * Creates an instance of ApiCreateWSDL.
+     * @param {any} props @inheritDoc
+     * @memberof ApiCreateWSDL
+     */
+    constructor(props) {
+        super(props);
+        this.state = {
+            doValidate: false,
+            wsdlBean: {},
+            activeStep: 0,
+            api: new API('', 'v1.0.0'),
+            loading: false,
+            valid: {
+                wsdlUrl: { empty: false, invalidUrl: false },
+                wsdlFile: { empty: false, invalidFile: false },
+                name: { empty: false, alreadyExists: false },
+                context: { empty: false, alreadyExists: false },
+                version: { empty: false },
+                endpoint: { empty: false },
+            },
+        };
+        this.updateWSDLBean = this.updateWSDLBean.bind(this);
+        this.updateApiInputs = this.updateApiInputs.bind(this);
+        this.createWSDLAPI = this.createWSDLAPI.bind(this);
+        this.updateFileErrors = this.updateFileErrors.bind(this);
+        this.provideWSDL = null;
+    }
+
+    /**
+     * Check the WSDL file or URL validity through REST API
+     * @param {Object} wsdlBean Bean object holding WSDL file/url info
+     * @memberof ApiCreateWSDL
+     */
+    updateWSDLBean(wsdlBean) {
+        console.info(wsdlBean);
+        this.setState({
+            wsdlBean,
+        });
+    }
+
+    /**
+     * Update user inputs in the form with onChange event trigger
+     * @param {React.SyntheticEvent} event Event containing user action
+     * @memberof ApiCreateWSDL
+     */
+    updateApiInputs({ target }) {
+        const { name, value } = target;
+        this.setState(({ api, valid }) => {
+            const changes = api;
+            if (name === 'endpoint') {
+                changes[name] = [
+                    {
+                        inline: {
+                            name: `${api.name}_inline_prod`,
+                            endpointConfig: {
+                                list: [
+                                    {
+                                        url: value,
+                                        timeout: '1000',
+                                    },
+                                ],
+                                endpointType: 'SINGLE',
+                            },
+                            type: 'soap',
+                            endpointSecurity: {
+                                enabled: false,
+                            },
+                        },
+                        type: 'Production',
+                    },
+                    {
+                        inline: {
+                            name: `${api.name}_inline_sandbx`,
+                            endpointConfig: {
+                                list: [
+                                    {
+                                        url: value,
+                                        timeout: '1000',
+                                    },
+                                ],
+                                endpointType: 'SINGLE',
+                            },
+                            type: 'soap',
+                            endpointSecurity: {
+                                enabled: false,
+                            },
+                        },
+                        type: 'Sandbox',
+                    },
+                ];
+            } else {
+                changes[name] = value;
+            }
+
+            // Checking validity.
+            const validUpdated = valid;
+            validUpdated.name.empty = !api.name;
+            validUpdated.context.empty = !api.context;
+            validUpdated.version.empty = !api.version;
+            validUpdated.endpoint.empty = !api.endpoint;
+            // TODO we need to add the already existing error for
+            // (context) by doing an api call ( the swagger definition does not contain such api call)
+            return { api: changes, valid: validUpdated };
+        });
+    }
+
+    /**
+     * Make API POST call and create send WSDL file or URL
+     * @memberof ApiCreateWSDL
+     */
+    createWSDLAPI() {
+        this.setState({ loading: true });
+        const newApi = new API();
+        const { wsdlBean, api } = this.state;
+        const {
+            name, version, context, endpoint, implementationType,
+        } = api;
+        const uploadMethod = wsdlBean.url ? 'url' : 'file';
+        const apiAttributes = {
+            name,
+            version,
+            context,
+            endpoint,
+        };
+        const apiData = {
+            additionalProperties: JSON.stringify(apiAttributes),
+            implementationType,
+            [uploadMethod]: wsdlBean[uploadMethod],
+        };
+
+        newApi
+            .importWSDL(apiData)
+            .then((response) => {
+                Alert.success(`${name} API Created Successfully.`);
+                const uuid = response.obj.id;
+                const redirectURL = '/apis/' + uuid + '/overview';
+                this.setState({ loading: false });
+                this.props.history.push(redirectURL);
+            })
+            .catch((errorResponse) => {
+                this.setState({ loading: false });
+                console.error(errorResponse);
+                const error = errorResponse.response.obj;
+                const messageTxt = 'Error[' + error.code + ']: ' + error.description + ' | ' + error.message + '.';
+                Alert.error(messageTxt);
+            });
+    }
+    updateFileErrors(newValid) {
+        this.setState({ valid: newValid });
+    }
+    handleNext = () => {
+        const { activeStep, wsdlBean, valid } = this.state;
+        let uploadMethod;
+        if (this.provideWSDL) {
+            uploadMethod = this.provideWSDL.getUploadMethod();
+        } else if (wsdlBean.file) {
+            uploadMethod = 'file';
+        } else {
+            uploadMethod = 'url';
+        }
+        const validNew = JSON.parse(JSON.stringify(valid));
+
+        // Handling next ( getting wsdl file/url info and validating)
+        if (activeStep === 0) {
+            if (isEmpty(wsdlBean)) {
+                if (uploadMethod === 'file') {
+                    validNew.wsdlFile.empty = true;
+                } else {
+                    validNew.wsdlUrl.empty = true;
+                }
+                this.setState({ valid: validNew });
+                return;
+            } else {
+                if (wsdlBean.file && uploadMethod === 'url') {
+                    validNew.wsdlUrl.empty = true;
+                    this.setState({ valid: validNew });
+                    return;
+                }
+                if (wsdlBean.url && uploadMethod === 'file') {
+                    validNew.wsdlFile.empty = true;
+                    this.setState({ valid: validNew });
+                    return;
+                }
+            }
+            // No errors so let's fill the inputs with the wsdlBean
+            if (wsdlBean.info) {
+                if (wsdlBean.info.version) {
+                    this.updateApiInputs({ target: { name: 'version', value: wsdlBean.info.version } });
+                }
+                if (wsdlBean.info.endpoints && wsdlBean.info.endpoints.length > 0) {
+                    this.updateApiInputs({ target: { name: 'endpoint', value: wsdlBean.info.endpoints[0].location } });
+                }
+            }
+            this.setState({
+                activeStep: activeStep + 1,
+            });
+        } else if (activeStep === 1) {
+            // Handling Finish step ( validating the input fields )
+            const { api: currentAPI } = this.state;
+            if (!currentAPI.name || !currentAPI.context || !currentAPI.version || !currentAPI.endpoint) {
+                // Checking the api name,version,context undefined or empty states
+                this.setState((oldState) => {
+                    const { valid: isValid, api } = oldState;
+                    const validUpdated = isValid;
+                    validUpdated.name.empty = !api.name;
+                    validUpdated.context.empty = !api.context;
+                    validUpdated.version.empty = !api.version;
+                    validUpdated.endpoint.empty = !api.endpoint;
+                    return { valid: validUpdated };
+                });
+                return;
+            }
+            this.createWSDLAPI();
+        }
+    };
+
+    handleBack = () => {
+        this.setState(state => ({
+            activeStep: state.activeStep - 1,
+        }));
+    };
+
+    handleReset = () => {
+        this.setState({
+            activeStep: 0,
+        });
+    };
+
+    /**
+     *
+     *
+     * @returns
+     * @memberof APICreateWSDL
+     */
+    render() {
+        const { classes } = this.props;
+        const steps = getSteps();
+        const {
+            doValidate, activeStep, wsdlBean, api, valid, loading,
+        } = this.state;
+        const uploadMethod = wsdlBean.url ? 'url' : 'file';
+        const provideWSDLProps = {
+            uploadMethod,
+            [uploadMethod]: wsdlBean[uploadMethod],
+            updateWSDLBean: this.updateWSDLBean,
+            validate: doValidate,
+            valid,
+            updateFileErrors: this.updateFileErrors,
+        };
+        if (loading) {
+            return <Progress />;
+        }
+        return (
+            <React.Fragment>
+                <APICreateTopMenu />
+                <Grid container spacing={7} className={classes.root}>
+                    <Grid item xs={12}>
+                        <div className={classes.titleWrapper}>
+                            <Typography variant='h4' align='left' className={classes.mainTitle}>
+                                <FormattedMessage
+                                    id='design.a.new.rest.api.using.wsdl'
+                                    defaultMessage='Design a new REST API using WSDL'
+                                />
+                            </Typography>
+                            <Typography variant='caption' align='left' className={classes.subTitle} component='div'>
+                                {uploadMethod === 'file' && (
+                                    <FormattedMessage
+                                        id='design.a.new.rest.api.using.wsdl.help.file'
+                                        defaultMessage='Provide an api definition file'
+                                    />
+                                )}
+                                {uploadMethod === 'url' && (
+                                    <FormattedMessage
+                                        id='design.a.new.rest.api.using.wsdl.help.url'
+                                        defaultMessage='Provide a url for the api deninition'
+                                    />
+                                )}
+                            </Typography>
+                        </div>
+                        <Paper>
+                            <Stepper activeStep={activeStep} className={classes.stepper}>
+                                {steps.map((label) => {
+                                    const props = {};
+                                    const labelProps = {};
+
+                                    return (
+                                        <Step key={label} {...props}>
+                                            <StepLabel {...labelProps}>{label}</StepLabel>
+                                        </Step>
+                                    );
+                                })}
+                            </Stepper>
+                        </Paper>
+                        <div>
+                            {activeStep === 0 && (
+                                <ProvideWSDL
+                                    {...provideWSDLProps}
+                                    innerRef={(instance) => {
+                                        this.provideWSDL = instance;
+                                    }}
+                                />
+                            )}
+                            {activeStep === 1 && (
+                                <React.Fragment>
+                                    <APIInputForm api={api} handleInputChange={this.updateApiInputs} valid={valid} />
+                                    <BindingInfo
+                                        updateApiInputs={this.updateApiInputs}
+                                        wsdlBean={wsdlBean}
+                                        classes={classes}
+                                        api={api}
+                                    />
+                                </React.Fragment>
+                            )}
+                        </div>
+                        <div>
+                            {activeStep === steps.length ? (
+                                <div>
+                                    <Typography className={classes.instructions}>
+                                        All steps completed - you&quot;re finished
+                                    </Typography>
+                                    <Button onClick={this.handleReset} className={classes.button}>
+                                        Reset
+                                    </Button>
+                                </div>
+                            ) : (
+                                <div>
+                                    <div>
+                                        <Button
+                                            disabled={activeStep === 0}
+                                            onClick={this.handleBack}
+                                            className={classes.button}
+                                        >
+                                            Back
+                                        </Button>
+                                        <Button
+                                            variant='contained'
+                                            color='primary'
+                                            onClick={this.handleNext}
+                                            className={classes.button}
+                                            disabled={
+                                                (valid.wsdlFile.invalidFile && uploadMethod === 'file') ||
+                                                (valid.wsdlUrl.invalidUrl && uploadMethod === 'url')
+                                            }
+                                        >
+                                            {activeStep === steps.length - 1 ? (
+                                                'Finish'
+                                            ) : (
+                                                <FormattedMessage id='next' defaultMessage='Next' />
+                                            )}
+                                        </Button>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    </Grid>
+                </Grid>
+            </React.Fragment>
+        );
+    }
+}
+
+APICreateWSDL.propTypes = {
+    classes: PropTypes.shape({}).isRequired,
+    history: PropTypes.shape({ push: PropTypes.func }).isRequired,
+};
+
+export default withStyles(styles)(APICreateWSDL);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/DefaultAPIForm.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/DefaultAPIForm.jsx
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import TextField from '@material-ui/core/TextField';
 import Grid from '@material-ui/core/Grid';
@@ -42,18 +42,23 @@ const useStyles = makeStyles(theme => ({
 export default function DefaultAPIForm(props) {
     const { onChange, onValidate, api } = props;
     const classes = useStyles();
-    const [validation, setValidation] = useState({});
+    const [validity, setValidity] = useState({});
 
+    // Check the provided API validity on mount, TODO: Better to use Joi schema here ~tmkb
+    useEffect(() => {
+        onValidate(Boolean(api.name) && Boolean(api.version) && Boolean(api.context));
+    });
     /**
      * Trigger the provided onValidate call back on each input validation run
      * Do the validation state aggregation and call the onValidate method with aggregated value
      * @param {Object} state Validation state object
      */
     function validate(state) {
-        setValidation(state);
-        const isFormValid = Object.values(state)
+        setValidity(state);
+        let isFormValid = Object.values(state)
             .map(value => value === null || value === undefined) // Map the validation entries to booleans
             .reduce((acc, cVal) => acc && cVal); // Aggregate the individual validation states
+        isFormValid = isFormValid && Boolean(api.name) && Boolean(api.version) && Boolean(api.context);
         onValidate(isFormValid, state);
     }
     return (
@@ -63,7 +68,7 @@ export default function DefaultAPIForm(props) {
                     autoFocus
                     fullWidth
                     id='outlined-name'
-                    error={validation.name}
+                    error={validity.name}
                     label={
                         <React.Fragment>
                             <sup className={classes.mandatoryStar}>*</sup>{' '}
@@ -71,7 +76,7 @@ export default function DefaultAPIForm(props) {
                         </React.Fragment>
                     }
                     helperText={
-                        (validation.name && validation.name.message) ||
+                        (validity.name && validity.name.message) ||
                         'API name can not contain spaces or any special characters'
                     }
                     value={api.name}
@@ -80,7 +85,7 @@ export default function DefaultAPIForm(props) {
                     InputProps={{
                         onBlur: ({ target: { value } }) => {
                             validate({
-                                ...validation,
+                                ...validity,
                                 name: APIValidation.apiName.required().validate(value).error,
                             });
                         },
@@ -92,7 +97,7 @@ export default function DefaultAPIForm(props) {
                     <Grid item md={4}>
                         <TextField
                             fullWidth
-                            error={validation.version}
+                            error={validity.version}
                             id='outlined-name'
                             label={
                                 <React.Fragment>
@@ -109,12 +114,12 @@ export default function DefaultAPIForm(props) {
                             InputProps={{
                                 onBlur: ({ target: { value } }) => {
                                     validate({
-                                        ...validation,
+                                        ...validity,
                                         version: APIValidation.apiVersion.required().validate(value).error,
                                     });
                                 },
                             }}
-                            helperText={validation.version && validation.version.message}
+                            helperText={validity.version && validity.version.message}
                             margin='normal'
                             variant='outlined'
                         />
@@ -123,7 +128,7 @@ export default function DefaultAPIForm(props) {
                         <TextField
                             fullWidth
                             id='outlined-name'
-                            error={validation.context}
+                            error={validity.context}
                             label={
                                 <React.Fragment>
                                     <sup className={classes.mandatoryStar}>*</sup>{' '}
@@ -139,13 +144,13 @@ export default function DefaultAPIForm(props) {
                             InputProps={{
                                 onBlur: ({ target: { value } }) => {
                                     validate({
-                                        ...validation,
+                                        ...validity,
                                         context: APIValidation.apiContext.required().validate(value).error,
                                     });
                                 },
                             }}
                             helperText={
-                                (validation.context && validation.context.message) ||
+                                (validity.context && validity.context.message) ||
                                 'API will be exposed in this context at the gateway'
                             }
                             margin='normal'
@@ -163,13 +168,13 @@ export default function DefaultAPIForm(props) {
                     InputProps={{
                         onBlur: ({ target: { value } }) => {
                             validate({
-                                ...validation,
+                                ...validity,
                                 endpointURL: value ? APIValidation.url.validate(value).error : null,
                             });
                         },
                     }}
                     helperText={
-                        validation.endpointURL && (
+                        validity.endpointURL && (
                             <span>
                                 Enter a valid {''}
                                 <a rel='noopener noreferrer' target='_blank' href='http://tools.ietf.org/html/rfc3986'>
@@ -179,7 +184,7 @@ export default function DefaultAPIForm(props) {
                             </span>
                         )
                     }
-                    error={validation.endpointURL}
+                    error={validity.endpointURL}
                     margin='normal'
                     variant='outlined'
                 />

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/DefaultAPIForm.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/DefaultAPIForm.jsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import TextField from '@material-ui/core/TextField';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import { FormattedMessage } from 'react-intl';
+
+import SelectPolicies from './components/SelectPolicies';
+
+const useStyles = makeStyles(theme => ({
+    mandatoryStar: {
+        color: theme.palette.error.main,
+    },
+}));
+
+/**
+ * Improved API create default form
+ *
+ * @export
+ * @param {*} props
+ * @returns
+ */
+export default function DefaultAPIForm(props) {
+    const { onChange, api } = props;
+    const classes = useStyles();
+
+    return (
+        <Grid item md={9}>
+            <form noValidate autoComplete='off'>
+                <TextField
+                    autoFocus
+                    fullWidth
+                    id='outlined-name'
+                    label={
+                        <React.Fragment>
+                            <sup className={classes.mandatoryStar}>*</sup>{' '}
+                            <FormattedMessage id='Apis.Create.WSDL.Steps.DefaultAPIForm.name' defaultMessage='Name' />
+                        </React.Fragment>
+                    }
+                    helperText='API name can not contain spaces or any special characters'
+                    value={api.name}
+                    name='name'
+                    onChange={onChange}
+                    margin='normal'
+                    variant='outlined'
+                />
+                <Grid container spacing={2}>
+                    <Grid item md={4}>
+                        <TextField
+                            fullWidth
+                            id='outlined-name'
+                            label={
+                                <React.Fragment>
+                                    <sup className={classes.mandatoryStar}>*</sup>{' '}
+                                    <FormattedMessage
+                                        id='Apis.Create.WSDL.Steps.DefaultAPIForm.version'
+                                        defaultMessage='Version'
+                                    />
+                                </React.Fragment>
+                            }
+                            name='version'
+                            value={api.version}
+                            onChange={onChange}
+                            margin='normal'
+                            variant='outlined'
+                        />
+                    </Grid>
+                    <Grid item md={8}>
+                        <TextField
+                            fullWidth
+                            id='outlined-name'
+                            label={
+                                <React.Fragment>
+                                    <sup className={classes.mandatoryStar}>*</sup>{' '}
+                                    <FormattedMessage
+                                        id='Apis.Create.WSDL.Steps.DefaultAPIForm.context'
+                                        defaultMessage='Context'
+                                    />
+                                </React.Fragment>
+                            }
+                            helperText='API will be exposed in this context at the gateway'
+                            name='context'
+                            value={api.context}
+                            onChange={onChange}
+                            margin='normal'
+                            variant='outlined'
+                        />
+                    </Grid>
+                </Grid>
+
+                <TextField
+                    fullWidth
+                    id='outlined-name'
+                    label='Endpoint'
+                    name='endpoint'
+                    value={api.endpoint}
+                    onChange={onChange}
+                    margin='normal'
+                    variant='outlined'
+                />
+
+                <SelectPolicies policies={api.policies} onChange={onChange} />
+            </form>
+            <Grid container direction='row' justify='flex-end' alignItems='center'>
+                <Grid item>
+                    <Typography variant='caption' display='block' gutterBottom>
+                        <sup style={{ color: 'red' }}>*</sup> Mandatory fields
+                    </Typography>
+                </Grid>
+            </Grid>
+        </Grid>
+    );
+}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -11,398 +11,132 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { Component } from 'react';
-import {
-    withStyles,
-    RadioGroup,
-    Radio,
-    Button,
-    FormControl,
-    FormHelperText,
-    FormControlLabel,
-} from '@material-ui/core';
-import ErrorOutline from '@material-ui/icons/ErrorOutline';
-import Typography from '@material-ui/core/Typography';
-import TextField from '@material-ui/core/TextField';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import Progress from 'AppComponents/Shared/Progress';
-import { FormattedMessage } from 'react-intl';
-import Dropzone from 'react-dropzone';
-import classNames from 'classnames';
-import Backup from '@material-ui/icons/Backup';
-import API from 'AppData/api';
-
-const styles = theme => ({
-    radioWrapper: {
-        display: 'flex',
-        flexDirection: 'row',
-    },
-    dropZoneInside: {},
-    dropZone: {
-        color: theme.palette.grey[500],
-        border: 'dashed 1px ' + theme.palette.grey[500],
-        background: theme.palette.grey[100],
-        padding: theme.spacing.unit * 4,
-        textAlign: 'center',
-        cursor: 'pointer',
-    },
-    dropZoneIcon: {
-        color: theme.palette.grey[500],
-        width: 100,
-        height: 100,
-    },
-    dropZoneError: {
-        color: theme.palette.error.main,
-    },
-    dropZoneErrorBox: {
-        border: 'dashed 1px ' + theme.palette.error.main,
-    },
-    errorMessage: {
-        color: theme.palette.error.main,
-    },
-    errorIcon: {
-        color: theme.palette.error.main,
-        marginRight: theme.spacing.unit * 2,
-    },
-    fileNameWrapper: {
-        display: 'flex',
-        flexDirection: 'row',
-        alignItems: 'center',
-        '& div': {
-            display: 'flex',
-            flexDirection: 'row',
-            alignItems: 'center',
-        },
-    },
-    FormControl: {
-        padding: 0,
-        width: '100%',
-        marginTop: 0,
-    },
-    errorMessageWrapper: {
-        display: 'flex',
-        alignItems: 'center',
-    },
-    urlWrapper: {
-        display: 'flex',
-        alignItems: 'center',
-    },
-    button: {
-        whiteSpace: 'nowrap',
-    },
-});
+import Radio from '@material-ui/core/Radio';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormControl from '@material-ui/core/FormControl';
+import FormLabel from '@material-ui/core/FormLabel';
+import DropZoneLocal from './components/DropZoneLocal';
 
 /**
+ * Source https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
+ * TODO: Needs to replace this kind of ad-hoc validation methods with proper library
  *
- * @class ProvideWSDL
- * @extends {Component}
+ * @param {*} str
+ * @returns {Boolean} Whether the given string is a valid URL or not
  */
-class ProvideWSDL extends Component {
-    /**
-     * Creates an instance of ProvideWSDL.
-     * @param {any} props @inheritDoc
-     * @memberof ProvideWSDL
-     */
-    constructor(props) {
-        super(props);
-        const { uploadMethod, file, url } = props;
-        this.state = {
-            uploadMethod,
-            file,
-            url,
-            isValid: null,
-            errorMessage: '',
-            loading: false,
-        };
-        this.validateWSDL = this.validateWSDL.bind(this);
-        this.updateURL = this.updateURL.bind(this);
-    }
-
-    /**
-     * @inheritDoc
-     * @param {any} nextProps New props received
-     * @memberof ProvideWSDL
-     */
-    componentWillReceiveProps(nextProps) {
-        const { validate, updateWSDLValidity } = nextProps;
-        if (validate) {
-            this.validateWSDL(updateWSDLValidity);
-        }
-    }
-
-    getUploadMethod() {
-        return this.state.uploadMethod;
-    }
-
-    toggleType = (event) => {
-        if (event.target.value === 'file') {
-            this.setState({ uploadMethod: event.target.value, file: null });
-        } else {
-            this.setState({ uploadMethod: event.target.value });
-        }
-        // this.validateWSDL();
-    };
-
-    handleUploadFile = (acceptedFiles) => {
-        this.validateWSDL((isValid, wsdlBean) => {
-            console.info('(isValid, wsdlBean) = ', isValid, wsdlBean);
-        });
-        this.setState({ file: acceptedFiles[0] });
-    };
-
+function isURL(str) {
+    const pattern = new RegExp(
+        '^(https?:\\/\\/)?' + // protocol
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.?)+[a-z]{2,}|' + // domain name
+        '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
+        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+            '(\\#[-a-z\\d_]*)?$',
+        'i',
+    ); // fragment locator
+    return pattern.test(str);
+}
+/**
+ * Sub component of API Create using WSDL UI, This is handling the taking input of WSDL file or URL from the user
+ * In the create API using WSDL wizard first step out of 2 steps
+ * @export
+ * @param {*} props
+ * @returns {React.Component} @inheritdoc
+ */
+export default function ProvideWSDL(props) {
+    const { apiInputs, inputsDispatcher } = props;
+    const isFileInput = apiInputs.inputType === 'file';
+    const [validity, setValidity] = useState({ url: true, file: true });
     /**
      *
-     * @param {React.SyntheticEvent} event Event handler for URL input field
-     * @memberof ProvideWSDL
-     */
-    updateURL(event) {
-        const { value } = event.target;
-        this.setState({ url: value });
-    }
-    /**
      *
-     * @param validity {Function} Call back function to trigger after pass/fail the validation
+     * @param {*} files
      */
-    validateWSDL() {
-        // do not invoke callback in case of React SyntheticMouseEvent
-        const { uploadMethod, url, file } = this.state;
-        const { valid, updateFileErrors, updateWSDLBean } = this.props;
-        this.setState({ loading: true });
-        const newAPI = new API();
-        let promisedValidation;
-        const wsdlBean = {};
-        const validNew = JSON.parse(JSON.stringify(valid));
-        if (uploadMethod === 'file') {
-            if (!file) {
-                // Update the parent's state
-                validNew.wsdlFile.empty = true;
-                updateFileErrors(validNew);
-                return;
-            }
-            // Update the parent's state
-            validNew.wsdlFile.empty = false;
-            updateFileErrors(validNew);
-
-            wsdlBean.file = file;
-            promisedValidation = newAPI.validateWSDLFile(file);
-        } else {
-            if (!url) {
-                // Update the parent's state
-                validNew.wsdlUrl.empty = true;
-                updateFileErrors(validNew);
-                return;
-            }
-
-            // Update the parent's state
-            validNew.wsdlUrl.empty = false;
-            updateFileErrors(validNew);
-
-            wsdlBean.url = url;
-            promisedValidation = newAPI.validateWSDLUrl(url);
-        }
-        promisedValidation
-            .then((response) => {
-                const { isValid, wsdlInfo } = response.obj;
-                wsdlBean.info = wsdlInfo;
-
-                // Update the parent's state
-                if (uploadMethod === 'file') {
-                    validNew.wsdlFile.invalidFile = false;
-                    updateFileErrors(validNew);
-                } else {
-                    validNew.wsdlUrl.invalidUrl = false;
-                    updateFileErrors(validNew);
-                }
-                this.setState({ isValid, loading: false, file });
-                updateWSDLBean(wsdlBean);
-            })
-            .catch((error) => {
-                // Update the parent's state
-                if (uploadMethod === 'file') {
-                    validNew.wsdlFile.invalidFile = true;
-                    updateFileErrors(validNew);
-                } else {
-                    validNew.wsdlUrl.invalidUrl = true;
-                    updateFileErrors(validNew);
-                }
-                updateWSDLBean(wsdlBean);
-                const response = error.response && error.response.obj;
-                const message =
-                    'Error while validating WSDL!! ' + response && '[' + response.message + '] ' + response.description;
-                this.setState({ isValid: false, errorMessage: message, loading: false });
-                console.error(error);
-            });
+    function onDrop(files) {
+        // Why `files[0]` below is , We only handle one wsdl file at a time, So if use provide multiple, We would only
+        // accept the first file. This information is shown in the dropdown helper text
+        inputsDispatcher({ action: 'inputValue', value: [files[0]] });
     }
-
-    /**
-     * @inheritDoc
-     * @returns {React.Component}
-     * @memberof ProvideWSDL
-     */
-    render() {
-        const {
-            isValid, errorMessage, uploadMethod, file, url, loading,
-        } = this.state;
-        const { classes, valid } = this.props;
-        const error = isValid === false; // Because of null case, which means validation haven't done yet
-        if (loading) {
-            return <Progress error={error} />;
-        }
-        return (
-            <React.Fragment>
-                <FormControl className={classes.FormControl}>
-                    <RadioGroup
-                        aria-label='swagger-upload-method'
-                        name='swagger-upload-method'
-                        value={uploadMethod}
-                        onChange={this.toggleType}
-                        className={classes.radioWrapper}
-                    >
-                        <FormControlLabel
-                            value='file'
-                            control={<Radio />}
-                            label={
-                                <FormattedMessage
-                                    id='Apis.Create.WSDL.Steps.ProvideWSDL.uploaded.file'
-                                    defaultMessage='File'
-                                />
-                            }
-                            className={classes.radioGroup}
-                        />
-                        <FormControlLabel
-                            value='url'
-                            control={<Radio />}
-                            label={
-                                <FormattedMessage
-                                    id='Apis.Create.WSDL.Steps.ProvideWSDL.uploaded.url'
-                                    defaultMessage='URL'
-                                />
-                            }
-                            className={classes.radioGroup}
-                        />
-                    </RadioGroup>
-                </FormControl>
-                {uploadMethod === 'file' ? (
-                    <React.Fragment>
-                        {file && (
-                            <div className={classes.fileNameWrapper}>
-                                <Typography variant='subtitle2' gutterBottom>
-                                    <FormattedMessage id='uploaded.file' defaultMessage='Uploaded file' /> :
-                                </Typography>
-                                <div className={classes.fileName}>
-                                    <Typography variant='body1' gutterBottom>
-                                        {file.name} - {file.size} bytes
-                                    </Typography>
-                                </div>
-                            </div>
-                        )}
-                        {valid.wsdlFile.invalidFile && (
-                            <div className={classes.errorMessageWrapper}>
-                                <ErrorOutline className={classes.errorIcon} />
-                                <Typography variant='body1' gutterBottom className={classes.errorMessage}>
-                                    {errorMessage}
-                                </Typography>
-                            </div>
-                        )}
-                        <Dropzone
-                            onDrop={this.handleUploadFile}
-                            multiple={false}
-                            className={classNames(classes.dropZone, {
-                                [classes.dropZoneErrorBox]: valid.wsdlFile.empty,
-                            })}
+    return (
+        <React.Fragment>
+            <Grid container spacing={5}>
+                <Grid item md={12}>
+                    <FormControl component='fieldset'>
+                        <FormLabel component='legend'>Input type</FormLabel>
+                        <RadioGroup
+                            aria-label='Input type'
+                            value={apiInputs.inputType}
+                            onChange={event => inputsDispatcher({ action: 'inputType', value: event.target.value })}
                         >
-                            <Backup className={classes.dropZoneIcon} />
-                            <div>
-                                <FormattedMessage
-                                    id='try.dropping.some.files.here.or.click.to.select.files.to.upload'
-                                    defaultMessage='Try dropping some files here, or click to select files to upload.'
-                                />
-                            </div>
-                        </Dropzone>
-                        <FormHelperText className={classes.errorMessage}>
-                            {valid.wsdlFile.empty && (
-                                <FormattedMessage id='error.empty' defaultMessage='This field can not be empty.' />
-                            )}
-                            {valid.wsdlFile.invalidFile && (
-                                <FormattedMessage id='error.invalid.wsdl.file' defaultMessage='Invalid WSDL File' />
-                            )}
+                            <FormControlLabel value='url' control={<Radio />} label='WSDL URL' />
+                            <FormControlLabel value='file' control={<Radio />} label='WSDL Archive/File' />
+                        </RadioGroup>
+                    </FormControl>
+                </Grid>
+                <Grid item md={7}>
+                    {isFileInput ? (
+                        // TODO: Pass message saying accepting only one file ~tmkb
+                        <DropZoneLocal onDrop={onDrop} files={apiInputs.inputValue} />
+                    ) : (
+                        <TextField
+                            id='outlined-full-width'
+                            label='WSDL URL'
+                            inputProps={{ onBlur: event => console.log(event.target.value) }}
+                            placeholder='Enter WSDL URL'
+                            error={isURL(apiInputs.inputValue)}
+                            helperText='Give the URL of WSDL endpoint'
+                            fullWidth
+                            margin='normal'
+                            variant='outlined'
+                            onChange={({ target: { value } }) => inputsDispatcher({ action: 'inputValue', value })}
+                            value={apiInputs.inputValue}
+                            InputLabelProps={{
+                                shrink: true,
+                            }}
+                        />
+                    )}
+                </Grid>
+                <Grid item md={12}>
+                    <FormControl component='fieldset'>
+                        <FormLabel component='legend'>Implementation type</FormLabel>
+                        <RadioGroup
+                            aria-label='Implementation type'
+                            value={isFileInput ? 'PASS' : apiInputs.type}
+                            onChange={event => inputsDispatcher({ action: 'type', value: event.target.value })}
+                        >
+                            <FormControlLabel value='PASS' control={<Radio />} label='Pass Through' />
+                            <FormControlLabel
+                                disabled={isFileInput}
+                                value='SOAPtoREST'
+                                control={<Radio />}
+                                label='Generate REST APIs'
+                            />
+                        </RadioGroup>
+                        <FormHelperText>
+                            <sup>*</sup>
+                            <b>Generate REST APIs</b> option is only available for WSDL URL input type
                         </FormHelperText>
-                    </React.Fragment>
-                ) : (
-                    <form>
-                        <FormControl fullWidth aria-describedby='url-text'>
-                            <div className={classes.urlWrapper}>
-                                <TextField
-                                    error={valid.wsdlUrl.empty}
-                                    fullWidth
-                                    id='url'
-                                    label='WSDL Url'
-                                    placeholder={
-                                        'eg: ' +
-                                        'https://graphical.weather.gov/xml/SOAP_server/ndfdXMLserver.php?wsdl'
-                                    }
-                                    helperText={
-                                        <FormattedMessage
-                                            id='create.new.wsdl.help'
-                                            defaultMessage={
-                                                'Give a WSDL url such as' +
-                                                ' https://graphical.weather.gov/xml/SOAP_server/ndfdXMLserver.php?wsdl'
-                                            }
-                                        />
-                                    }
-                                    InputLabelProps={{
-                                        shrink: true,
-                                    }}
-                                    type='text'
-                                    name='url'
-                                    margin='normal'
-                                    value={url}
-                                    onChange={this.updateURL}
-                                />
-                                <Button
-                                    variant='outlined'
-                                    color='primary'
-                                    className={classes.button}
-                                    onClick={this.validateWSDL}
-                                >
-                                    LOAD WSDL
-                                </Button>
-                            </div>
-
-                            <FormHelperText className={classes.errorMessage}>
-                                {valid.wsdlUrl.empty && (
-                                    <FormattedMessage id='error.empty' defaultMessage='This field can not be empty.' />
-                                )}
-                                {valid.wsdlUrl.invalidUrl && 'Invalid WSDL Url'}
-                            </FormHelperText>
-                        </FormControl>
-                    </form>
-                )}
-            </React.Fragment>
-        );
-    }
+                    </FormControl>
+                </Grid>
+            </Grid>
+        </React.Fragment>
+    );
 }
 
-ProvideWSDL.defaultProps = {
-    uploadMethod: 'file',
-    url: '',
-    file: {},
-};
-
 ProvideWSDL.propTypes = {
-    url: PropTypes.string,
-    updateWSDLBean: PropTypes.func.isRequired,
-    uploadMethod: PropTypes.string,
-    validate: PropTypes.bool.isRequired,
-    valid: PropTypes.shape({}).isRequired,
-    file: PropTypes.shape({}),
-    classes: PropTypes.shape({}).isRequired,
-    updateFileErrors: PropTypes.func.isRequired,
-    updateWSDLValidity: PropTypes.func.isRequired,
+    apiInputs: PropTypes.shape({
+        type: PropTypes.string,
+        inputType: PropTypes.string,
+    }).isRequired,
+    inputsDispatcher: PropTypes.func.isRequired,
 };
-
-export default withStyles(styles)(ProvideWSDL);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.jsx
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Radio from '@material-ui/core/Radio';
 import Grid from '@material-ui/core/Grid';
@@ -56,7 +56,7 @@ function isURL(str) {
 export default function ProvideWSDL(props) {
     const { apiInputs, inputsDispatcher } = props;
     const isFileInput = apiInputs.inputType === 'file';
-    const [validity, setValidity] = useState({ url: true, file: true });
+    // const [validity, setValidity] = useState({ url: true, file: true });
     /**
      *
      *

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.old.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.old.jsx
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { Component } from 'react';
+import {
+    withStyles,
+    RadioGroup,
+    Radio,
+    Button,
+    FormControl,
+    FormHelperText,
+    FormControlLabel,
+} from '@material-ui/core';
+import ErrorOutline from '@material-ui/icons/ErrorOutline';
+import Typography from '@material-ui/core/Typography';
+import TextField from '@material-ui/core/TextField';
+import PropTypes from 'prop-types';
+import Progress from 'AppComponents/Shared/Progress';
+import { FormattedMessage } from 'react-intl';
+import Dropzone from 'react-dropzone';
+import classNames from 'classnames';
+import Backup from '@material-ui/icons/Backup';
+import API from 'AppData/api';
+
+const styles = theme => ({
+    radioWrapper: {
+        display: 'flex',
+        flexDirection: 'row',
+    },
+    dropZoneInside: {},
+    dropZone: {
+        color: theme.palette.grey[500],
+        border: 'dashed 1px ' + theme.palette.grey[500],
+        background: theme.palette.grey[100],
+        padding: theme.spacing.unit * 4,
+        textAlign: 'center',
+        cursor: 'pointer',
+    },
+    dropZoneIcon: {
+        color: theme.palette.grey[500],
+        width: 100,
+        height: 100,
+    },
+    dropZoneError: {
+        color: theme.palette.error.main,
+    },
+    dropZoneErrorBox: {
+        border: 'dashed 1px ' + theme.palette.error.main,
+    },
+    errorMessage: {
+        color: theme.palette.error.main,
+    },
+    errorIcon: {
+        color: theme.palette.error.main,
+        marginRight: theme.spacing.unit * 2,
+    },
+    fileNameWrapper: {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        '& div': {
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+        },
+    },
+    FormControl: {
+        padding: 0,
+        width: '100%',
+        marginTop: 0,
+    },
+    errorMessageWrapper: {
+        display: 'flex',
+        alignItems: 'center',
+    },
+    urlWrapper: {
+        display: 'flex',
+        alignItems: 'center',
+    },
+    button: {
+        whiteSpace: 'nowrap',
+    },
+});
+
+/**
+ *
+ * @class ProvideWSDL
+ * @extends {Component}
+ */
+class ProvideWSDL extends Component {
+    /**
+     * Creates an instance of ProvideWSDL.
+     * @param {any} props @inheritDoc
+     * @memberof ProvideWSDL
+     */
+    constructor(props) {
+        super(props);
+        const { uploadMethod, file, url } = props;
+        this.state = {
+            uploadMethod,
+            file,
+            url,
+            isValid: null,
+            errorMessage: '',
+            loading: false,
+        };
+        this.validateWSDL = this.validateWSDL.bind(this);
+        this.updateURL = this.updateURL.bind(this);
+    }
+
+    /**
+     * @inheritDoc
+     * @param {any} nextProps New props received
+     * @memberof ProvideWSDL
+     */
+    componentWillReceiveProps(nextProps) {
+        const { validate, updateWSDLValidity } = nextProps;
+        if (validate) {
+            this.validateWSDL(updateWSDLValidity);
+        }
+    }
+
+    getUploadMethod() {
+        return this.state.uploadMethod;
+    }
+
+    toggleType = (event) => {
+        if (event.target.value === 'file') {
+            this.setState({ uploadMethod: event.target.value, file: null });
+        } else {
+            this.setState({ uploadMethod: event.target.value });
+        }
+        // this.validateWSDL();
+    };
+
+    handleUploadFile = (acceptedFiles) => {
+        this.validateWSDL((isValid, wsdlBean) => {
+            console.info('(isValid, wsdlBean) = ', isValid, wsdlBean);
+        });
+        this.setState({ file: acceptedFiles[0] });
+    };
+
+    /**
+     *
+     * @param {React.SyntheticEvent} event Event handler for URL input field
+     * @memberof ProvideWSDL
+     */
+    updateURL(event) {
+        const { value } = event.target;
+        this.setState({ url: value });
+    }
+    /**
+     *
+     * @param validity {Function} Call back function to trigger after pass/fail the validation
+     */
+    validateWSDL() {
+        // do not invoke callback in case of React SyntheticMouseEvent
+        const { uploadMethod, url, file } = this.state;
+        const { valid, updateFileErrors, updateWSDLBean } = this.props;
+        this.setState({ loading: true });
+        const newAPI = new API();
+        let promisedValidation;
+        const wsdlBean = {};
+        const validNew = JSON.parse(JSON.stringify(valid));
+        if (uploadMethod === 'file') {
+            if (!file) {
+                // Update the parent's state
+                validNew.wsdlFile.empty = true;
+                updateFileErrors(validNew);
+                return;
+            }
+            // Update the parent's state
+            validNew.wsdlFile.empty = false;
+            updateFileErrors(validNew);
+
+            wsdlBean.file = file;
+            promisedValidation = newAPI.validateWSDLFile(file);
+        } else {
+            if (!url) {
+                // Update the parent's state
+                validNew.wsdlUrl.empty = true;
+                updateFileErrors(validNew);
+                return;
+            }
+
+            // Update the parent's state
+            validNew.wsdlUrl.empty = false;
+            updateFileErrors(validNew);
+
+            wsdlBean.url = url;
+            promisedValidation = newAPI.validateWSDLUrl(url);
+        }
+        promisedValidation
+            .then((response) => {
+                const { isValid, wsdlInfo } = response.obj;
+                wsdlBean.info = wsdlInfo;
+
+                // Update the parent's state
+                if (uploadMethod === 'file') {
+                    validNew.wsdlFile.invalidFile = false;
+                    updateFileErrors(validNew);
+                } else {
+                    validNew.wsdlUrl.invalidUrl = false;
+                    updateFileErrors(validNew);
+                }
+                this.setState({ isValid, loading: false, file });
+                updateWSDLBean(wsdlBean);
+            })
+            .catch((error) => {
+                // Update the parent's state
+                if (uploadMethod === 'file') {
+                    validNew.wsdlFile.invalidFile = true;
+                    updateFileErrors(validNew);
+                } else {
+                    validNew.wsdlUrl.invalidUrl = true;
+                    updateFileErrors(validNew);
+                }
+                updateWSDLBean(wsdlBean);
+                const response = error.response && error.response.obj;
+                const message =
+                    'Error while validating WSDL!! ' + response && '[' + response.message + '] ' + response.description;
+                this.setState({ isValid: false, errorMessage: message, loading: false });
+                console.error(error);
+            });
+    }
+
+    /**
+     * @inheritDoc
+     * @returns {React.Component}
+     * @memberof ProvideWSDL
+     */
+    render() {
+        const {
+            isValid, errorMessage, uploadMethod, file, url, loading,
+        } = this.state;
+        const { classes, valid } = this.props;
+        const error = isValid === false; // Because of null case, which means validation haven't done yet
+        if (loading) {
+            return <Progress error={error} />;
+        }
+        return (
+            <React.Fragment>
+                <FormControl className={classes.FormControl}>
+                    <RadioGroup
+                        aria-label='swagger-upload-method'
+                        name='swagger-upload-method'
+                        value={uploadMethod}
+                        onChange={this.toggleType}
+                        className={classes.radioWrapper}
+                    >
+                        <FormControlLabel
+                            value='file'
+                            control={<Radio />}
+                            label={
+                                <FormattedMessage
+                                    id='Apis.Create.WSDL.Steps.ProvideWSDL.uploaded.file'
+                                    defaultMessage='File'
+                                />
+                            }
+                            className={classes.radioGroup}
+                        />
+                        <FormControlLabel
+                            value='url'
+                            control={<Radio />}
+                            label={
+                                <FormattedMessage
+                                    id='Apis.Create.WSDL.Steps.ProvideWSDL.uploaded.url'
+                                    defaultMessage='URL'
+                                />
+                            }
+                            className={classes.radioGroup}
+                        />
+                    </RadioGroup>
+                </FormControl>
+                {uploadMethod === 'file' ? (
+                    <React.Fragment>
+                        {file && (
+                            <div className={classes.fileNameWrapper}>
+                                <Typography variant='subtitle2' gutterBottom>
+                                    <FormattedMessage id='uploaded.file' defaultMessage='Uploaded file' /> :
+                                </Typography>
+                                <div className={classes.fileName}>
+                                    <Typography variant='body1' gutterBottom>
+                                        {file.name} - {file.size} bytes
+                                    </Typography>
+                                </div>
+                            </div>
+                        )}
+                        {valid.wsdlFile.invalidFile && (
+                            <div className={classes.errorMessageWrapper}>
+                                <ErrorOutline className={classes.errorIcon} />
+                                <Typography variant='body1' gutterBottom className={classes.errorMessage}>
+                                    {errorMessage}
+                                </Typography>
+                            </div>
+                        )}
+                        <Dropzone
+                            onDrop={this.handleUploadFile}
+                            multiple={false}
+                            className={classNames(classes.dropZone, {
+                                [classes.dropZoneErrorBox]: valid.wsdlFile.empty,
+                            })}
+                        >
+                            <Backup className={classes.dropZoneIcon} />
+                            <div>
+                                <FormattedMessage
+                                    id='try.dropping.some.files.here.or.click.to.select.files.to.upload'
+                                    defaultMessage='Try dropping some files here, or click to select files to upload.'
+                                />
+                            </div>
+                        </Dropzone>
+                        <FormHelperText className={classes.errorMessage}>
+                            {valid.wsdlFile.empty && (
+                                <FormattedMessage id='error.empty' defaultMessage='This field can not be empty.' />
+                            )}
+                            {valid.wsdlFile.invalidFile && (
+                                <FormattedMessage id='error.invalid.wsdl.file' defaultMessage='Invalid WSDL File' />
+                            )}
+                        </FormHelperText>
+                    </React.Fragment>
+                ) : (
+                    <form>
+                        <FormControl fullWidth aria-describedby='url-text'>
+                            <div className={classes.urlWrapper}>
+                                <TextField
+                                    error={valid.wsdlUrl.empty}
+                                    fullWidth
+                                    id='url'
+                                    label='WSDL Url'
+                                    placeholder={
+                                        'eg: ' +
+                                        'https://graphical.weather.gov/xml/SOAP_server/ndfdXMLserver.php?wsdl'
+                                    }
+                                    helperText={
+                                        <FormattedMessage
+                                            id='create.new.wsdl.help'
+                                            defaultMessage={
+                                                'Give a WSDL url such as' +
+                                                ' https://graphical.weather.gov/xml/SOAP_server/ndfdXMLserver.php?wsdl'
+                                            }
+                                        />
+                                    }
+                                    InputLabelProps={{
+                                        shrink: true,
+                                    }}
+                                    type='text'
+                                    name='url'
+                                    margin='normal'
+                                    value={url}
+                                    onChange={this.updateURL}
+                                />
+                                <Button
+                                    variant='outlined'
+                                    color='primary'
+                                    className={classes.button}
+                                    onClick={this.validateWSDL}
+                                >
+                                    LOAD WSDL
+                                </Button>
+                            </div>
+
+                            <FormHelperText className={classes.errorMessage}>
+                                {valid.wsdlUrl.empty && (
+                                    <FormattedMessage id='error.empty' defaultMessage='This field can not be empty.' />
+                                )}
+                                {valid.wsdlUrl.invalidUrl && 'Invalid WSDL Url'}
+                            </FormHelperText>
+                        </FormControl>
+                    </form>
+                )}
+            </React.Fragment>
+        );
+    }
+}
+
+ProvideWSDL.defaultProps = {
+    uploadMethod: 'file',
+    url: '',
+    file: {},
+};
+
+ProvideWSDL.propTypes = {
+    url: PropTypes.string,
+    updateWSDLBean: PropTypes.func.isRequired,
+    uploadMethod: PropTypes.string,
+    validate: PropTypes.bool.isRequired,
+    valid: PropTypes.shape({}).isRequired,
+    file: PropTypes.shape({}),
+    classes: PropTypes.shape({}).isRequired,
+    updateFileErrors: PropTypes.func.isRequired,
+    updateWSDLValidity: PropTypes.func.isRequired,
+};
+
+export default withStyles(styles)(ProvideWSDL);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/components/DropZoneLocal.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/components/DropZoneLocal.jsx
@@ -15,11 +15,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useDropzone } from 'react-dropzone';
 
-function humanFileSize(bytes, si = false) {
+
+/**
+ *
+ * Convert raw byte values to human readable format
+ * @param {Number} bytes number of bytes
+ * @param {boolean} [si=false]
+ * @returns {String} Human readable string format
+ */
+function humanFileSize(bytesParam, si = false) {
+    let bytes = bytesParam; // To prevent `no-param-reassign` eslint rule violation
     const thresh = si ? 1000 : 1024;
     if (Math.abs(bytes) < thresh) {
         return bytes + ' B';

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/components/DropZoneLocal.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/components/DropZoneLocal.jsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useMemo, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useDropzone } from 'react-dropzone';
+
+function humanFileSize(bytes, si = false) {
+    const thresh = si ? 1000 : 1024;
+    if (Math.abs(bytes) < thresh) {
+        return bytes + ' B';
+    }
+    const units = si
+        ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+        : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+    let u = -1;
+    do {
+        bytes /= thresh;
+        ++u;
+    } while (Math.abs(bytes) >= thresh && u < units.length - 1);
+    return bytes.toFixed(1) + ' ' + units[u];
+}
+
+const baseStyle = {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    padding: '20px',
+    borderWidth: 2,
+    borderRadius: 2,
+    borderColor: '#eeeeee',
+    borderStyle: 'dashed',
+    backgroundColor: '#fafafa',
+    color: '#bdbdbd',
+    outline: 'none',
+    transition: 'border .24s ease-in-out',
+};
+
+const activeStyle = {
+    borderColor: '#2196f3',
+};
+
+const acceptStyle = {
+    borderColor: '#00e676',
+};
+
+const rejectStyle = {
+    borderColor: '#ff1744',
+};
+/**
+ *
+ *
+ * @export
+ * @returns
+ */
+export default function DropZoneLocal(props) {
+    const { message, onDrop, files } = props;
+    const dropZoneObject = useDropzone({ onDrop });
+    const {
+        getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject,
+    } = dropZoneObject;
+    let { acceptedFiles } = dropZoneObject;
+    acceptedFiles = files || acceptedFiles;
+    const filesList = acceptedFiles.map(file => (
+        <li key={file.path}>
+            {file.path} - {humanFileSize(file.size)}
+        </li>
+    ));
+    const style = useMemo(
+        () => ({
+            ...baseStyle,
+            ...(isDragActive ? activeStyle : {}),
+            ...(isDragAccept ? acceptStyle : {}),
+            ...(isDragReject ? rejectStyle : {}),
+        }),
+        [isDragActive, isDragReject],
+    );
+    return (
+        <section className='container'>
+            <div {...getRootProps({ style })}>
+                <input {...getInputProps()} />
+                <p>{message}</p>
+            </div>
+            <aside>
+                <h4>Files</h4>
+                <ul>{filesList}</ul>
+            </aside>
+        </section>
+    );
+}
+DropZoneLocal.defaultProps = {
+    message: "Drag 'n' drop some files here, or click to select files",
+    onDrop: () => {},
+    files: null,
+};
+DropZoneLocal.propTypes = {
+    message: PropTypes.string,
+    onDrop: PropTypes.func,
+    files: PropTypes.arrayOf(PropTypes.object),
+};

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/components/SelectPolicies.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/components/SelectPolicies.jsx
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react';
+import TextField from '@material-ui/core/TextField';
+import MenuItem from '@material-ui/core/MenuItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import Checkbox from '@material-ui/core/Checkbox';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Typography from '@material-ui/core/Typography';
+
+import API from 'AppData/api';
+
+/**
+ * Trottling Policies dropdown selector used in minimized API Create form
+ * @export
+ * @param {*} props
+ * @returns {React.Component}
+ */
+export default function SelectPolicies(props) {
+    const { onChange, policies: currentPolicies } = props;
+    const [policies, setPolicies] = useState({});
+    useEffect(() => {
+        API.policies('subscription').then(response => setPolicies(response.body));
+    }, []);
+
+    if (!policies.list) {
+        return <CircularProgress />;
+    } else {
+        return (
+            <TextField
+                fullWidth
+                id='outlined-select-currency'
+                select
+                label='Business plan(s)'
+                value={currentPolicies}
+                name='policies'
+                onChange={onChange}
+                SelectProps={{
+                    multiple: true,
+                    renderValue: selected => selected.join(', '),
+                }}
+                helperText='Select one or multiple throttling policy for the API'
+                margin='normal'
+                variant='outlined'
+            >
+                {policies.list.map(policy => (
+                    <MenuItem dense disableGutters key={policy.name} value={policy.displayName}>
+                        <Checkbox checked={currentPolicies.includes(policy.name)} />
+                        <ListItemText primary={policy.displayName} secondary={policy.description} />
+                    </MenuItem>
+                ))}
+            </TextField>
+        );
+    }
+}
+
+SelectPolicies.defaultProps = {
+    policies: [],
+};

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/components/SelectPolicies.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/components/SelectPolicies.jsx
@@ -4,7 +4,6 @@ import MenuItem from '@material-ui/core/MenuItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Checkbox from '@material-ui/core/Checkbox';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import Typography from '@material-ui/core/Typography';
 
 import API from 'AppData/api';
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Configuration/Configuration.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Configuration/Configuration.jsx
@@ -156,13 +156,15 @@ export default function Configuration() {
                             newState[action].includes(API_SECURITY_BASIC_AUTH)
                         )
                     ) {
-                        const noMandatoryOAuthBasicAuth = newState[action].filter(schema => schema !== API_SECURITY_OAUTH_BASIC_AUTH_MANDATORY);
+                        const noMandatoryOAuthBasicAuth = newState[action]
+                            .filter(schema => schema !== API_SECURITY_OAUTH_BASIC_AUTH_MANDATORY);
                         return {
                             ...newState,
                             [action]: noMandatoryOAuthBasicAuth,
                         };
                     } else if (!newState[action].includes(API_SECURITY_MUTUAL_SSL)) {
-                        const noMandatoryMutualSSL = newState[action].filter(schema => schema !== API_SECURITY_MUTUAL_SSL_MANDATORY);
+                        const noMandatoryMutualSSL = newState[action]
+                            .filter(schema => schema !== API_SECURITY_MUTUAL_SSL_MANDATORY);
                         return {
                             ...newState,
                             [action]: noMandatoryMutualSSL,

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Base/Header/headersearch/SearchUtils.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Base/Header/headersearch/SearchUtils.jsx
@@ -31,8 +31,8 @@ import DocumentsIcon from '@material-ui/icons/LibraryBooks';
 import API from 'AppData/api';
 import SearchParser from './SearchParser';
 /* Utility methods defined here are described in
-* react-autosuggest documentation https://github.com/moroshko/react-autosuggest
-*/
+ * react-autosuggest documentation https://github.com/moroshko/react-autosuggest
+ */
 
 /**
  *
@@ -72,15 +72,17 @@ function renderInput(inputProps) {
 function renderSuggestion(suggestion, { query, isHighlighted }) {
     const matches = match(suggestion.name, query);
     const parts = parse(suggestion.name, matches);
-    const path = suggestion.type === 'API' ? `/apis/${suggestion.id}/overview` :
-        `/apis/${suggestion.apiUUID}/documents/${suggestion.id}/details`;
+    const path =
+        suggestion.type === 'API'
+            ? `/apis/${suggestion.id}/overview`
+            : `/apis/${suggestion.apiUUID}/documents/${suggestion.id}/details`;
     // TODO: Style the version ( and apiName if docs) apearing in the menu item
-    const suffix = suggestion.type === 'API' ? suggestion.version : (suggestion.apiName + ' ' + suggestion.apiVersion);
+    const suffix = suggestion.type === 'API' ? suggestion.version : suggestion.apiName + ' ' + suggestion.apiVersion;
     return (
         <React.Fragment>
             <Link to={path}>
                 <MenuItem selected={isHighlighted} component='div'>
-                    { suggestion.type === 'API' ? <APIsIcon /> : <DocumentsIcon /> }
+                    {suggestion.type === 'API' ? <APIsIcon /> : <DocumentsIcon />}
 
                     {parts.map((part, index) => {
                         return part.highlight ? (
@@ -93,7 +95,8 @@ function renderSuggestion(suggestion, { query, isHighlighted }) {
                             </strong>
                         );
                     })}
-                    <pre /><pre />
+                    <pre />
+                    <pre />
                     {suffix}
                 </MenuItem>
             </Link>
@@ -118,7 +121,7 @@ function getSuggestionValue(suggestion) {
  * @param searchText
  * @returns {string}
  */
-function buildSearchQuery(searchText){
+function buildSearchQuery(searchText) {
     const inputValue = searchText.trim().toLowerCase();
     return SearchParser.parse(inputValue);
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/data/APIValidation.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/data/APIValidation.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import Joi from '@hapi/joi';
+
+const definition = {
+    apiName: Joi.string()
+        .regex(/^[a-zA-Z0-9]{1,30}$/),
+    apiVersion: Joi.string()
+        .regex(/^[a-zA-Z0-9]{1,30}$/),
+    apiContext: Joi.string()
+        .regex(/^[a-zA-Z0-9]{1,30}$/),
+    url: Joi.string()
+        .uri(),
+};
+
+
+export default definition;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/data/Wsdl.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/data/Wsdl.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import APIClientFactory from './APIClientFactory';
+import Utils from './Utils';
+import Resource from './Resource';
+
+/**
+ * An abstract representation of a Scopes
+ */
+class Wsdl extends Resource {
+    /**
+     *
+     *
+     * @static
+     * @param {*} scope
+     * @memberof Scopes
+     */
+    static validate(input) {
+        const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment()).client;
+        return apiClient.then((client) => {
+            return client.apis.Validation.validateWSDLDefinition({ url: input, returnContent: true });
+        });
+    }
+
+    /**
+     *
+     *
+     * @static
+     * @param {*} resource
+     * @param {*} additionalProperties
+     * @param {*} implementationType SOAPTOREST
+     * @memberof Wsdl
+     */
+    static import(input, additionalProperties, implementationType = 'SOAP') {
+        const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment()).client;
+        return apiClient.then((client) => {
+            return client.apis.APIs.importWSDLDefinition({
+                url: input,
+                additionalProperties,
+                implementationType,
+            });
+        });
+    }
+}
+
+export default Wsdl;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/webpack.config.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/webpack.config.js
@@ -30,7 +30,8 @@ const config = {
         publicPath: 'site/public/dist/',
     },
     node: {
-        fs: 'empty'
+        fs: 'empty',
+        net: 'empty', // To fix joi issue: https://github.com/hapijs/joi/issues/665#issuecomment-113713020
     },
     watch: false,
     devtool: 'source-map', // todo: Commented out the source


### PR DESCRIPTION
In this PR:

- Implement the SOAP to REST API creation wizard
- Add [hapijs/joi](https://github.com/hapijs/joi) for data validation as discussed in `dev@wso2.org:APIM React UI input validation`
- Update [`react-dropzone`](https://github.com/wso2/carbon-apimgt/pull/6872/files#diff-6c484a9723a4898e52fa13ae9a2b8ce7R51) library
  - TODO: Need to fix regression issues of this upgrade
- Fix build issue https://github.com/wso2/product-apim/issues/5361
- Fix eslint issues which were shadowed by the above build issue
- Add joi [input validation](https://github.com/wso2/carbon-apimgt/pull/6872/files#diff-2663d0eea59f3a17a62ba034e5f5d72aR1) regex 
- Add new [data file](https://github.com/wso2/carbon-apimgt/pull/6872/files#diff-6d8822c9335410120e4f805becd85676R1) to validate & import WSDL definitions