### PR TITLE
Handle reject subscription if it exists

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -829,6 +829,9 @@ public class ApiMgtDAO {
                             applicationName + " was blocked");
                     throw new SubscriptionBlockedException("Subscription to API/API Product " + identifier.getName() + " through " +
                             "application " + applicationName + " was blocked");
+                } else if (APIConstants.SubscriptionStatus.REJECTED.equals(subStatus)) {
+                    throw new SubscriptionBlockedException("Subscription to API " + identifier.getName()
+                            + " through application " + applicationName + " was rejected");
                 }
             }
 


### PR DESCRIPTION
This PR handles rejected subscriptions if it exists while adding subscriptions when creating a new version of an API.