### PR TITLE
Fix build failure due to loadash import

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/index.jsx
@@ -32,7 +32,7 @@ import MonetizationIcon from '@material-ui/icons/LocalAtm';
 import { withStyles } from '@material-ui/core/styles';
 import { injectIntl, defineMessages } from 'react-intl';
 import { Redirect, Route, Switch, Link, matchPath } from 'react-router-dom';
-import isEmpty from 'lodash.isEmpty';
+import isEmpty from 'lodash/isEmpty';
 import Utils from 'AppData/Utils';
 import ResourceNotFound from 'AppComponents/Base/Errors/ResourceNotFound';
 import CustomIcon from 'AppComponents/Shared/CustomIcon';


### PR DESCRIPTION
Fixes the below issue

ERROR in ./source/src/app/components/Apis/Details/index.jsx
Module not found: Error: Can't resolve 'lodash.isEmpty' in '/home/jenkins/workspace/platform-builds/carbon-apimgt/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details'
 @ ./source/src/app/components/Apis/Details/index.jsx 59:0-37 401:18-25
 @ ./source/src/app/components/Apis/Apis.jsx
 @ ./source/src/app/ProtectedApp.jsx
 @ ./source/src/Publisher.jsx
 @ ./source/index.jsx