### PR TITLE
Adding feature to remove stored user details in localstorage when logging out

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/jaggery.conf
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/jaggery.conf
@@ -22,6 +22,10 @@
             "path": "/site/public/pages/index.html"
         },
         {
+            "url": "/logout/*",
+            "path": "/site/public/pages/index.html"
+        },
+        {
             "url": "/services/logout",
             "path": "/services/logout/logout.jag"
         },

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/logout/logout_callback.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/services/logout/logout_callback.jag
@@ -87,7 +87,7 @@
     };
     response.addCookie(cookie);
 
-    log.debug("redirecting to login");
-    response.sendRedirect(site.context + "/login");
+    log.debug("redirecting to logout");
+    response.sendRedirect(site.context + "/logout");
 
 %>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/Publisher.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/Publisher.jsx
@@ -25,7 +25,6 @@ import Utils from 'AppData/Utils';
 import Logout from 'AppComponents/Logout';
 import Progress from 'AppComponents/Shared/Progress';
 import PublisherRootErrorBoundary from 'AppComponents/Shared/PublisherRootErrorBoundary';
-import RedirectToLogin from 'AppComponents/Shared/RedirectToLogin';
 import Configurations from 'Config';
 
 // Localization
@@ -156,13 +155,6 @@ class Publisher extends React.Component {
         const locale = languageWithoutRegionCode || language;
         if (!userResolved) {
             return <Progress />;
-        }
-        if (!user) {
-            return (
-                <IntlProvider locale={locale} messages={messages}>
-                    <RedirectToLogin />
-                </IntlProvider>
-            );
         }
         return (
             <IntlProvider locale={locale} messages={messages}>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Logout.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Logout.jsx
@@ -17,12 +17,10 @@
  */
 
 import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
 import qs from 'qs';
-import Alert from 'AppComponents/Shared/Alert';
-import PropTypes from 'prop-types';
-
-import AuthManager from 'AppData/AuthManager';
-import RedirectToLogin from 'AppComponents/Shared/RedirectToLogin';
+import Utils from 'AppData/Utils';
+import User from 'AppData/User';
 
 /**
  *
@@ -38,13 +36,9 @@ class Logout extends Component {
      */
     constructor(props) {
         super(props);
-        const { search } = window.location;
-        const queryString = search.replace(/^\?/, '');
-        /* With QS version up we can directly use {ignoreQueryPrefix: true} option */
-        const queryParams = qs.parse(queryString);
-        this.referrer = qs.stringify({ referrer: queryParams.referrer || '/' });
         this.state = {
             logoutSuccess: false,
+            referrer: '/apis',
         };
     }
 
@@ -54,15 +48,17 @@ class Logout extends Component {
      * @memberof Logout
      */
     componentDidMount() {
-        const authManager = new AuthManager();
-        const promisedLogout = authManager.logoutFromEnvironments();
-        promisedLogout
-            .then(() => this.setState({ logoutSuccess: true }))
-            .catch((error) => {
-                const message = 'Error while logging out';
-                Alert.error(message);
-                console.log(error);
-            });
+        const environmentName = Utils.getCurrentEnvironment().label;
+        localStorage.removeItem(`${User.CONST.LOCAL_STORAGE_USER}_${environmentName}`);
+        const newState = { logoutSuccess: true };
+        let { search } = window.location;
+        search = search.replace(/^\?/, '');
+        /* With QS version up we can directly use {ignoreQueryPrefix: true} option */
+        const params = qs.parse(search);
+        if (params.referrer) {
+            newState.referrer = params.referrer;
+        }
+        this.setState(newState);
     }
 
     /**
@@ -72,18 +68,9 @@ class Logout extends Component {
      * @memberof Logout
      */
     render() {
-        const { logoutSuccess } = this.state;
-        if (logoutSuccess) {
-            return <RedirectToLogin />;
-        }
-        return logoutSuccess;
+        const { logoutSuccess, referrer } = this.state;
+        return logoutSuccess && <Redirect to={referrer} />;
     }
 }
-
-Logout.propTypes = {
-    location: PropTypes.shape({
-        search: PropTypes.string,
-    }).isRequired,
-};
 
 export default Logout;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/jaggery.conf
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/jaggery.conf
@@ -41,6 +41,10 @@
              "path": "/site/public/pages/index.html"
         },
         {
+             "url":"/logout/*",
+             "path": "/site/public/pages/index.html"
+        },
+        {
             "url": "/services/configs",
             "path": "/services/login/idp.jag"
         },

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/logout/logout_callback.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/services/logout/logout_callback.jag
@@ -35,7 +35,7 @@
     cookie = {'name': 'AM_ID_TOKEN_DEFAULT_P1', 'value':'', 'path': site.context + "/services/logout", "secure": true, "maxAge": 2};
     response.addCookie(cookie);
 
-    log.debug("redirecting to anonymous view");
-    response.sendRedirect(site.context + "/apis");
+    log.debug("redirecting to logout");
+    response.sendRedirect(site.context + "/logout");
 
 %>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Logout.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Logout.jsx
@@ -19,12 +19,12 @@
 import React, { Component } from 'react';
 import { Redirect } from 'react-router-dom';
 import qs from 'qs';
-import PropTypes from 'prop-types';
-import { injectIntl, } from 'react-intl';
 import AuthManager from '../data/AuthManager';
+import User from '../data/User';
+import Utils from '../data/Utils';
+
 /**
  * Logout component
- *
  * @class Logout
  * @extends {Component} Logout component
  */
@@ -34,7 +34,7 @@ class Logout extends Component {
         this.authManager = new AuthManager();
         this.state = {
             logoutSuccess: false,
-            referrer: '/login',
+            referrer: '/home',
         };
     }
 
@@ -44,25 +44,17 @@ class Logout extends Component {
      * @memberof Logout
      */
     componentDidMount() {
-        const promisedLogout = this.authManager.logout();
-        const { location, intl } = this.props;
-        promisedLogout
-            .then(() => {
-                const newState = { logoutSuccess: true };
-                let queryString = location.search;
-                queryString = queryString.replace(/^\?/, '');
-                /* With QS version up we can directly use {ignoreQueryPrefix: true} option */
-                const params = qs.parse(queryString);
-                if (params.referrer) {
-                    newState.referrer = params.referrer;
-                }
-                this.setState(newState);
-            })
-            .catch(() => {
-                console.log(intl.formatMessage({
-                    id: 'Logout.error',
-                    defaultMessage: 'Error while logging out'}));
-            });
+        const environmentName = Utils.getEnvironment().label;
+        localStorage.removeItem(`${User.CONST.LOCALSTORAGE_USER}_${environmentName}`);
+        const newState = { logoutSuccess: true };
+        let { search } = window.location;
+        search = search.replace(/^\?/, '');
+        /* With QS version up we can directly use {ignoreQueryPrefix: true} option */
+        const params = qs.parse(search);
+        if (params.referrer) {
+            newState.referrer = params.referrer;
+        }
+        this.setState(newState);
     }
 
     /**
@@ -76,8 +68,5 @@ class Logout extends Component {
         return logoutSuccess && <Redirect to={referrer} />;
     }
 }
-Logout.propTypes = {
-    location: PropTypes.instanceOf(Object).isRequired,
-};
 
-export default injectIntl(Logout);
+export default Logout;


### PR DESCRIPTION
## Issue
product-apim: https://github.com/wso2/product-apim/issues/5422

## Methodology

After user get's logged out from IDP session(where access tokens also get's revoked) and then in the logout callback jag cookies get's cleaned up and then user will be now redirected to /logout endpoint in react app where the user details in the local storage also gets removed.