### PR TITLE
Add new 'Endpoint Add' landing page.

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
@@ -30,7 +30,7 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import cloneDeep from 'lodash.clonedeep';
 
 import EndpointListing from './EndpointListing';
-import { getEndpointTemplateByType, getEndpointTypeProperty } from './endpointUtils';
+import { getEndpointTemplateByType, getEndpointTypeProperty, createEndpointConfig } from './endpointUtils';
 import GeneralConfiguration from './GeneralConfiguration';
 import GenericEndpoint from './GenericEndpoint';
 import LoadBalanceConfig from './LoadBalanceConfig';
@@ -103,7 +103,10 @@ const styles = theme => ({
 });
 
 const endpointTypes = [{ key: 'http', value: 'HTTP/REST Endpoint' },
-    { key: 'address', value: 'HTTP/SOAP Endpoint' }, { key: 'default', value: 'Dynamic Endpoints' }];
+    { key: 'address', value: 'HTTP/SOAP Endpoint' },
+    { key: 'default', value: 'Dynamic Endpoints' },
+    { key: 'awslambda', value: 'AWS Lambda Endpoint' },
+];
 
 /**
  * The endpoint overview component. This component holds the views of endpoint creation and configuration.
@@ -140,6 +143,8 @@ function EndpointOverview(props) {
             return endpointTypes[1];
         } else if (type === 'default') {
             return endpointTypes[2];
+        } else if (type === 'awslambda') {
+            return endpointTypes[3];
         } else {
             const prodEndpoints = endpointConfig.production_endpoints;
             if (Array.isArray(prodEndpoints)) {
@@ -276,31 +281,9 @@ function EndpointOverview(props) {
             return type.key === selectedKey;
         })[0];
 
-        let endpointTemplate = {};
-        if (selectedKey === 'address') {
-            endpointTemplate = {
-                endpoint_type: 'address',
-                template_not_supported: false,
-                url: '',
-            };
-        } else if (selectedKey === 'default') {
-            endpointTemplate = {
-                url: 'default',
-            };
-        } else {
-            endpointTemplate = {
-                url: '',
-            };
-        }
+        const generatedEndpointConfig = createEndpointConfig(selectedKey);
 
-        const endpointConfigCopy = {
-            endpoint_type: selectedKey,
-            production_endpoints: endpointTemplate,
-            sandbox_endpoints: endpointTemplate,
-            failOver: 'False',
-        };
-
-        setEpConfig(endpointConfigCopy);
+        setEpConfig(generatedEndpointConfig);
         setEndpointType(selectedType);
     };
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
@@ -141,7 +141,7 @@ function Endpoints(props) {
     const generateEndpointConfig = (endpointType, implementationType) => {
         const config = createEndpointConfig(endpointType, implementationType);
         setModifiedAPI(() => {
-            if (endpointType === 'prototype') {
+            if (endpointType === 'prototyped') {
                 if (implementationType === 'mock') {
                     return { ...apiObject, endpointConfig: config, endpointImplementationType: 'INLINE' };
                 }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/NewEndpointCreate.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/NewEndpointCreate.jsx
@@ -1,0 +1,196 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import React, { useState } from 'react';
+import { Typography, Grid, withStyles, RadioGroup, FormControlLabel, Radio, FormControl } from '@material-ui/core';
+import { FormattedMessage, injectIntl } from 'react-intl';
+import PropTypes from 'prop-types';
+import InlineMessage from 'AppComponents/Shared/InlineMessage';
+import Button from '@material-ui/core/Button';
+
+const styles = theme => ({
+    inlineMessageContainer: {
+        marginBottom: theme.spacing(),
+    },
+    actions: {
+        marginTop: theme.spacing(),
+    },
+});
+
+/**
+ * Component to create new endpoint.
+ * This component will render if the api object does not have an endpoint configuration, letting users to create a
+ * new endpoint configuration based on their requirement.
+ * Following endpoint types are supported.
+ * 1. HTTP/ SOAP endpoints
+ * 2. Prototyped/ Mock endpoints
+ * 3. AWS Lambda endpoints
+ * 4. Dynamic Endpoints
+ *
+ * @param {any} props The input props.
+ * @return {any} The HTML representation of the component.
+ * */
+function NewEndpointCreate(props) {
+    const { classes, intl, generateEndpointConfig } = props;
+    const [endpointImplType, setImplType] = useState('mock');
+    const endpointTypes = [
+        {
+            type: 'http',
+            name: intl.formatMessage({
+                id: 'Apis.Details.Endpoints.NewEndpointCreate.create.http.endpoint',
+                defaultMessage: 'HTTP/ REST Endpoint',
+            }),
+            description: intl.formatMessage({
+                id: 'Apis.Details.Endpoints.NewEndpointCreate.create.http.endpoint.description',
+                defaultMessage: 'A REST API endpoint based on a URI template.',
+            }),
+            options: null,
+        },
+        {
+            type: 'address',
+            name: intl.formatMessage({
+                id: 'Apis.Details.Endpoints.NewEndpointCreate.create.soap.endpoint',
+                defaultMessage: 'HTTP/ SOAP Endpoint',
+            }),
+            description: intl.formatMessage({
+                id: 'Apis.Details.Endpoints.NewEndpointCreate.create.soap.endpoint.description',
+                defaultMessage: 'The Direct URI of the web service.',
+            }),
+            options: null,
+        },
+        {
+            type: 'prototyped',
+            name: intl.formatMessage({
+                id: 'Apis.Details.Endpoints.NewEndpointCreate.create.prototype.endpoint',
+                defaultMessage: 'Prototype Endpoint',
+            }),
+            description: intl.formatMessage({
+                id: 'Apis.Details.Endpoints.NewEndpointCreate.create.prototype.endpoint.description',
+                defaultMessage: 'Use the inbuilt JavaScript engine to prototype the API or provide an endpoint' +
+                    ' to a prototype API. The inbuilt JavaScript engine does not have support to prototype SOAP APIs',
+            }),
+            options: [
+                {
+                    type: 'mock',
+                    name: intl.formatMessage({
+                        id: 'Apis.Details.Endpoints.NewEndpointCreate.mock.endpoints',
+                        defaultMessage: 'Mock Endpoint',
+                    }),
+                },
+                {
+                    type: 'prototyped',
+                    name: intl.formatMessage({
+                        id: 'Apis.Details.Endpoints.NewEndpointCreate.mock.endpoints',
+                        defaultMessage: 'Prototype Endpoint',
+                    }),
+                },
+            ],
+        },
+        {
+            type: 'dynamic',
+            name: intl.formatMessage({
+                id: 'Apis.Details.Endpoints.NewEndpointCreate.create.dynamic.endpoint',
+                defaultMessage: 'Dynamic Endpoint',
+            }),
+            description: intl.formatMessage({
+                id: 'Apis.Details.Endpoints.NewEndpointCreate.create.dynamic.endpoint.description',
+                defaultMessage: 'If you need to send the request to the URI specified in the TO header.',
+            }),
+            options: null,
+        },
+        {
+            type: 'aws',
+            name: intl.formatMessage({
+                id: 'Apis.Details.Endpoints.NewEndpointCreate.create.aws.endpoint',
+                defaultMessage: 'AWS Lambda Endpoint',
+            }),
+            description: intl.formatMessage({
+                id: 'Apis.Details.Endpoints.NewEndpointCreate.create.aws.endpoint.description',
+                defaultMessage: '',
+            }),
+            options: null,
+        },
+    ];
+
+    return (
+        <React.Fragment>
+            <Grid container direction='column'>
+                {endpointTypes.map(((type) => {
+                    return (
+                        <Grid item className={classes.inlineMessageContainer}>
+                            <InlineMessage>
+                                <div className={classes.contentWrapper}>
+                                    <Typography variant='h5' component='h3' className={classes.head}>
+                                        {type.name}
+                                    </Typography>
+                                    <Typography component='p' className={classes.content}>
+                                        {type.description}
+                                    </Typography>
+                                    {type.options ?
+                                        <div>
+                                            <FormControl component='fieldset' className={classes.formControl}>
+                                                <RadioGroup
+                                                    aria-label='EndpointType'
+                                                    name='endpointType'
+                                                    className={classes.radioGroup}
+                                                    value={endpointImplType}
+                                                    onChange={(event) => { setImplType(event.target.value); }}
+                                                >
+                                                    {type.options.map((option) => {
+                                                        return (
+                                                            <FormControlLabel
+                                                                value={option.type}
+                                                                control={<Radio />}
+                                                                label={option.name}
+                                                            />
+                                                        );
+                                                    })}
+                                                </RadioGroup>
+                                            </FormControl>
+                                        </div> :
+                                        <div /> }
+                                    <div className={classes.actions}>
+                                        <Button
+                                            variant='contained'
+                                            color='primary'
+                                            className={classes.button}
+                                            onClick={() => generateEndpointConfig(type.type, endpointImplType)}
+                                        >
+                                            <FormattedMessage
+                                                id='Apis.Details.Endpoints.NewEndpointCreate.create.button'
+                                                defaultMessage='Add'
+                                            />
+                                        </Button>
+                                    </div>
+                                </div>
+                            </InlineMessage>
+                        </Grid>
+                    );
+                }))}
+            </Grid>
+        </React.Fragment>
+    );
+}
+
+NewEndpointCreate.propTypes = {
+    classes: PropTypes.shape({}).isRequired,
+    intl: PropTypes.shape({}).isRequired,
+    generateEndpointConfig: PropTypes.func.isRequired,
+};
+
+export default withStyles(styles)(injectIntl(NewEndpointCreate));

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/NewEndpointCreate.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/NewEndpointCreate.jsx
@@ -114,7 +114,7 @@ function NewEndpointCreate(props) {
             options: null,
         },
         {
-            type: 'aws',
+            type: 'awslambda',
             name: intl.formatMessage({
                 id: 'Apis.Details.Endpoints.NewEndpointCreate.create.aws.endpoint',
                 defaultMessage: 'AWS Lambda Endpoint',

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/NewEndpointCreate.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/NewEndpointCreate.jsx
@@ -69,7 +69,7 @@ function NewEndpointCreate(props) {
             }),
             description: intl.formatMessage({
                 id: 'Apis.Details.Endpoints.NewEndpointCreate.create.soap.endpoint.description',
-                defaultMessage: 'The Direct URI of the web service.',
+                defaultMessage: 'The direct URI of the web service.',
             }),
             options: null,
         },
@@ -121,7 +121,7 @@ function NewEndpointCreate(props) {
             }),
             description: intl.formatMessage({
                 id: 'Apis.Details.Endpoints.NewEndpointCreate.create.aws.endpoint.description',
-                defaultMessage: '',
+                defaultMessage: 'If you need to invoke AWS Lambda functions through WSO2 API gateway.',
             }),
             options: null,
         },

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/Prototype/GenericResource.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/Prototype/GenericResource.jsx
@@ -104,7 +104,7 @@ function GenericResource(props) {
                             theme='vs-dark'
                             value={scriptContent}
                             options={{ selectOnLineNumbers: true }}
-                            language='xml'
+                            language='javascript'
                             onChange={content => onChange(content, resourcePath, resourceMethod)}
                         />
                     </Grid>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/Prototype/PrototypeEndpoints.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/Prototype/PrototypeEndpoints.jsx
@@ -30,6 +30,7 @@ import {
 import { FormattedMessage } from 'react-intl';
 import InlineEndpoints from 'AppComponents/Apis/Details/Endpoints/Prototype/InlineEndpoints';
 import GenericEndpoint from 'AppComponents/Apis/Details/Endpoints/GenericEndpoint';
+import cloneDeep from 'lodash.clonedeep';
 
 const endpointImplementationTypes = [{ key: 'INLINE', value: 'Inline' }, { key: 'ENDPOINT', value: 'Endpoint' }];
 
@@ -78,7 +79,7 @@ function PrototypeEndpoints(props) {
      * @param {any} event The change event.
      * */
     const handleImplementationTypeChange = (event) => {
-        const tmpApi = JSON.parse(JSON.stringify(api));
+        const tmpApi = cloneDeep(api);
         modifyAPI({ ...tmpApi, endpointImplementationType: event.target.value });
     };
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/endpointUtils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/endpointUtils.js
@@ -150,7 +150,16 @@ function getEndpointConfigByImpl(implementationType) {
 }
 
 /**
+ * Get the endpoint config based on the selected endpoint type.
+ * Supported endpoint types:
+ * 1. http
+ * 2. address
+ * 3. prototyped
+ * 4. awslambda
+ * 5. default (Dynamic)
  *
+ * @param {string} endpointType The selected endpoint type.
+ * @return {endpointConfig} Endpoint config object.
  * */
 function createEndpointConfig(endpointType) {
     const tmpEndpointConfig = {};
@@ -178,8 +187,8 @@ function createEndpointConfig(endpointType) {
         case 'prototyped':
             tmpEndpointConfig.implementation_status = 'prototyped';
             tmpEndpointConfig.endpoint_type = 'http';
-            tmpEndpointConfig.production_endpoints = { url: 'http://localhost' };
-            tmpEndpointConfig.sandbox_endpoints = { url: 'http://localhost' };
+            tmpEndpointConfig.production_endpoints = { config: null, url: 'http://localhost' };
+            tmpEndpointConfig.sandbox_endpoints = { config: null, url: 'http://localhost' };
             break;
         case 'awslambda':
             tmpEndpointConfig.endpoint_type = 'awslambda';

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/endpointUtils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/endpointUtils.js
@@ -142,9 +142,56 @@ function getEndpointConfigByImpl(implementationType) {
         tmpEndpointConfig.sandbox_endpoints = { config: null, url: 'http://localhost' };
     } else {
         tmpEndpointConfig.endpoint_type = 'http';
-        tmpEndpointConfig.production_endpoints = { url: 'http://myservice/resource' };
-        tmpEndpointConfig.sandbox_endpoints = { url: 'http://myservice/resource' };
+        tmpEndpointConfig.production_endpoints = { url: '' };
+        tmpEndpointConfig.sandbox_endpoints = { url: '' };
         tmpEndpointConfig.failOver = 'False';
+    }
+    return tmpEndpointConfig;
+}
+
+/**
+ *
+ * */
+function createEndpointConfig(endpointType) {
+    const tmpEndpointConfig = {};
+    switch (endpointType) {
+        case 'http':
+            tmpEndpointConfig.endpoint_type = 'http';
+            tmpEndpointConfig.production_endpoints = { url: '' };
+            tmpEndpointConfig.sandbox_endpoints = { url: '' };
+            tmpEndpointConfig.failOver = 'False';
+            break;
+        case 'address':
+            tmpEndpointConfig.endpoint_type = 'address';
+            tmpEndpointConfig.production_endpoints = {
+                url: '',
+                endpoint_type: 'address',
+                template_not_supported: false,
+            };
+            tmpEndpointConfig.sandbox_endpoints = {
+                url: '',
+                endpoint_type: 'address',
+                template_not_supported: false,
+            };
+            tmpEndpointConfig.failOver = 'False';
+            break;
+        case 'prototyped':
+            tmpEndpointConfig.implementation_status = 'prototyped';
+            tmpEndpointConfig.endpoint_type = 'http';
+            tmpEndpointConfig.production_endpoints = { url: 'http://localhost' };
+            tmpEndpointConfig.sandbox_endpoints = { url: 'http://localhost' };
+            break;
+        case 'aws':
+            tmpEndpointConfig.endpoint_type = 'aws';
+            tmpEndpointConfig.client_key = 'aws';
+            tmpEndpointConfig.secret = 'aws';
+            break;
+        default:
+            tmpEndpointConfig.endpoint_type = 'default';
+            tmpEndpointConfig.production_endpoints = { url: 'default' };
+            tmpEndpointConfig.sandbox_endpoints = { url: 'default' };
+            tmpEndpointConfig.failOver = 'False';
+            break;
     }
     return tmpEndpointConfig;
 }
@@ -155,4 +202,5 @@ export {
     getEndpointTemplateByType,
     endpointsToList,
     getEndpointConfigByImpl,
+    createEndpointConfig,
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/endpointUtils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/endpointUtils.js
@@ -181,10 +181,10 @@ function createEndpointConfig(endpointType) {
             tmpEndpointConfig.production_endpoints = { url: 'http://localhost' };
             tmpEndpointConfig.sandbox_endpoints = { url: 'http://localhost' };
             break;
-        case 'aws':
-            tmpEndpointConfig.endpoint_type = 'aws';
-            tmpEndpointConfig.client_key = 'aws';
-            tmpEndpointConfig.secret = 'aws';
+        case 'awslambda':
+            tmpEndpointConfig.endpoint_type = 'awslambda';
+            tmpEndpointConfig.accessKey = '';
+            tmpEndpointConfig.secretKey = '';
             break;
         default:
             tmpEndpointConfig.endpoint_type = 'default';


### PR DESCRIPTION
This PR introduces a new landing page for creating endpoints when the api is created without adding the endpoint. 
Following endpoint types are supported.
- HTTP/REST
- HTTP/SOAP
- Dynamic
- Prototyped/ Mock
- AWS Lambda

![Screenshot (2)](https://user-images.githubusercontent.com/10165411/64231108-4f63ab80-cf0c-11e9-95b2-5e569a5bb858.png)
