### PR TITLE
Fix Create an API using WSDL UI

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.jsx
@@ -50,6 +50,8 @@ const useStyles = makeStyles(theme => ({
 export default function ProvideWSDL(props) {
     const { apiInputs, inputsDispatcher, onValidate } = props;
     const isFileInput = apiInputs.inputType === 'file';
+    const isArchiveInput = apiInputs.inputType === 'archive';
+    const isGenerateRESTAPI = apiInputs.type === 'SOAPtoREST';
     const classes = useStyles();
     const [isError, setValidity] = useState(); // If valid value is `null` else an error object will be there
     const [isValidating, setIsValidating] = useState(false);
@@ -100,62 +102,6 @@ export default function ProvideWSDL(props) {
                             <React.Fragment>
                                 <sup className={classes.mandatoryStar}>*</sup>{' '}
                                 <FormattedMessage
-                                    id='Apis.Create.WSDL.Steps.ProvideWSDL.Input.type'
-                                    defaultMessage='Input type'
-                                />
-                            </React.Fragment>
-                        </FormLabel>
-                        <RadioGroup
-                            aria-label='Input type'
-                            value={apiInputs.inputType}
-                            onChange={event => inputsDispatcher({ action: 'inputType', value: event.target.value })}
-                        >
-                            <FormControlLabel value='url' control={<Radio />} label='WSDL URL' />
-                            <FormControlLabel value='file' control={<Radio />} label='WSDL Archive/File' />
-                        </RadioGroup>
-                    </FormControl>
-                </Grid>
-                <Grid item md={7}>
-                    {isFileInput ? (
-                        // TODO: Pass message saying accepting only one file ~tmkb
-                        <DropZoneLocal onDrop={onDrop} files={apiInputs.inputValue} />
-                    ) : (
-                        <TextField
-                            autoFocus
-                            id='outlined-full-width'
-                            label='WSDL URL'
-                            placeholder='Enter WSDL URL'
-                            fullWidth
-                            margin='normal'
-                            variant='outlined'
-                            onChange={({ target: { value } }) => inputsDispatcher({ action: 'inputValue', value })}
-                            value={apiInputs.inputValue}
-                            InputLabelProps={{
-                                shrink: true,
-                            }}
-                            InputProps={{
-                                onBlur: ({ target: { value } }) => {
-                                    validate(APIValidation.url.required().validate(value).error);
-                                },
-                                endAdornment: isValidating && (
-                                    <InputAdornment position='end'>
-                                        <CircularProgress />
-                                    </InputAdornment>
-                                ),
-                            }}
-                            // 'Give the URL of WSDL endpoint'
-                            helperText={isError && isError.message}
-                            error={Boolean(isError)}
-                            disabled={isValidating}
-                        />
-                    )}
-                </Grid>
-                <Grid item md={12}>
-                    <FormControl component='fieldset'>
-                        <FormLabel component='legend'>
-                            <React.Fragment>
-                                <sup className={classes.mandatoryStar}>*</sup>{' '}
-                                <FormattedMessage
                                     id='Apis.Create.WSDL.Steps.ProvideWSDL.implementation.type'
                                     defaultMessage='Implementation type'
                                 />
@@ -163,12 +109,11 @@ export default function ProvideWSDL(props) {
                         </FormLabel>
                         <RadioGroup
                             aria-label='Implementation type'
-                            value={isFileInput ? 'PASS' : apiInputs.type}
+                            value={apiInputs.type}
                             onChange={event => inputsDispatcher({ action: 'type', value: event.target.value })}
                         >
                             <FormControlLabel value='PASS' control={<Radio />} label='Pass Through' />
                             <FormControlLabel
-                                disabled={isFileInput}
                                 value='SOAPtoREST'
                                 control={<Radio />}
                                 label='Generate REST APIs'
@@ -180,13 +125,70 @@ export default function ProvideWSDL(props) {
                         </FormHelperText>
                     </FormControl>
                 </Grid>
+                <Grid item md={12}>
+                    <FormControl component='fieldset'>
+                        <FormLabel component='legend'>
+                            <React.Fragment>
+                                <sup className={classes.mandatoryStar}>*</sup>{' '}
+                                <FormattedMessage
+                                    id='Apis.Create.WSDL.Steps.ProvideWSDL.Input.type'
+                                    defaultMessage='Input type'
+                                />
+                            </React.Fragment>
+                        </FormLabel>
+                        <RadioGroup
+                            aria-label='Input type'
+                            value={apiInputs.inputType}
+                            onChange={event => inputsDispatcher({ action: 'inputType', value: event.target.value })}
+                        >
+                            <FormControlLabel value='url' control={<Radio />} label='WSDL URL' />
+                            <FormControlLabel value='file' control={<Radio />} label='WSDL File' />
+                            <FormControlLabel disabled={isGenerateRESTAPI} value='archive' control={<Radio />} label='WSDL Archive' />
+                        </RadioGroup>
+                    </FormControl>
+                </Grid>
+                <Grid item md={7}>
+                    {(isFileInput || isArchiveInput) ? (
+                        // TODO: Pass message saying accepting only one file ~tmkb
+                        <DropZoneLocal onDrop={onDrop} files={apiInputs.inputValue} />
+                    ) : (
+                            <TextField
+                                autoFocus
+                                id='outlined-full-width'
+                                label='WSDL URL'
+                                placeholder='Enter WSDL URL'
+                                fullWidth
+                                margin='normal'
+                                variant='outlined'
+                                onChange={({ target: { value } }) => inputsDispatcher({ action: 'inputValue', value })}
+                                value={apiInputs.inputValue}
+                                InputLabelProps={{
+                                    shrink: true,
+                                }}
+                                InputProps={{
+                                    onBlur: ({ target: { value } }) => {
+                                        validate(APIValidation.url.required().validate(value).error);
+                                    },
+                                    endAdornment: isValidating && (
+                                        <InputAdornment position='end'>
+                                            <CircularProgress />
+                                        </InputAdornment>
+                                    ),
+                                }}
+                                // 'Give the URL of WSDL endpoint'
+                                helperText={isError && isError.message}
+                                error={Boolean(isError)}
+                                disabled={isValidating}
+                            />
+                        )}
+                </Grid>
             </Grid>
         </React.Fragment>
     );
 }
 
 ProvideWSDL.defaultProps = {
-    onValidate: () => {},
+    onValidate: () => { },
 };
 ProvideWSDL.propTypes = {
     apiInputs: PropTypes.shape({

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.jsx
@@ -115,12 +115,18 @@ export default function ProvideWSDL(props) {
                             <FormControlLabel
                                 value='PASS'
                                 control={<Radio />}
-                                label={<FormattedMessage id='Apis.Create.WSDL.Steps.ProvideWSDL.passthrough.label' defaultMessage='Pass Through' />}
+                                label={<FormattedMessage
+                                    id='Apis.Create.WSDL.Steps.ProvideWSDL.passthrough.label'
+                                    defaultMessage='Pass Through'
+                                />}
                             />
                             <FormControlLabel
                                 value='SOAPtoREST'
                                 control={<Radio />}
-                                label={<FormattedMessage id='Apis.Create.WSDL.Steps.ProvideWSDL.SOAPtoREST.label' defaultMessage='Generate REST APIs' />}
+                                label={<FormattedMessage
+                                    id='Apis.Create.WSDL.Steps.ProvideWSDL.SOAPtoREST.label'
+                                    defaultMessage='Generate REST APIs'
+                                />}
                             />
                         </RadioGroup>
                         <FormHelperText>
@@ -148,18 +154,27 @@ export default function ProvideWSDL(props) {
                             <FormControlLabel
                                 value='url'
                                 control={<Radio />}
-                                label={<FormattedMessage id='Apis.Create.WSDL.Steps.ProvideWSDL.url.label' defaultMessage='WSDL URL' />}
+                                label={<FormattedMessage
+                                    id='Apis.Create.WSDL.Steps.ProvideWSDL.url.label'
+                                    defaultMessage='WSDL URL'
+                                />}
                             />
                             <FormControlLabel
                                 value='file'
                                 control={<Radio />}
-                                label={<FormattedMessage id='Apis.Create.WSDL.Steps.ProvideWSDL.file.label' defaultMessage='WSDL File' />}
+                                label={<FormattedMessage
+                                    id='Apis.Create.WSDL.Steps.ProvideWSDL.file.label'
+                                    defaultMessage='WSDL File'
+                                />}
                             />
                             <FormControlLabel
                                 disabled={isGenerateRESTAPI}
                                 value='archive'
                                 control={<Radio />}
-                                label={<FormattedMessage id='Apis.Create.WSDL.Steps.ProvideWSDL.archive.label' defaultMessage='WSDL Archive' />}
+                                label={<FormattedMessage
+                                    id='Apis.Create.WSDL.Steps.ProvideWSDL.archive.label'
+                                    defaultMessage='WSDL Archive'
+                                />}
                             />
                         </RadioGroup>
                     </FormControl>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.jsx
@@ -112,11 +112,15 @@ export default function ProvideWSDL(props) {
                             value={apiInputs.type}
                             onChange={event => inputsDispatcher({ action: 'type', value: event.target.value })}
                         >
-                            <FormControlLabel value='PASS' control={<Radio />} label='Pass Through' />
+                            <FormControlLabel
+                                value='PASS'
+                                control={<Radio />}
+                                label={<FormattedMessage id='Apis.Create.WSDL.Steps.ProvideWSDL.passthrough.label' defaultMessage='Pass Through' />}
+                            />
                             <FormControlLabel
                                 value='SOAPtoREST'
                                 control={<Radio />}
-                                label='Generate REST APIs'
+                                label={<FormattedMessage id='Apis.Create.WSDL.Steps.ProvideWSDL.SOAPtoREST.label' defaultMessage='Generate REST APIs' />}
                             />
                         </RadioGroup>
                         <FormHelperText>
@@ -141,9 +145,22 @@ export default function ProvideWSDL(props) {
                             value={apiInputs.inputType}
                             onChange={event => inputsDispatcher({ action: 'inputType', value: event.target.value })}
                         >
-                            <FormControlLabel value='url' control={<Radio />} label='WSDL URL' />
-                            <FormControlLabel value='file' control={<Radio />} label='WSDL File' />
-                            <FormControlLabel disabled={isGenerateRESTAPI} value='archive' control={<Radio />} label='WSDL Archive' />
+                            <FormControlLabel
+                                value='url'
+                                control={<Radio />}
+                                label={<FormattedMessage id='Apis.Create.WSDL.Steps.ProvideWSDL.url.label' defaultMessage='WSDL URL' />}
+                            />
+                            <FormControlLabel
+                                value='file'
+                                control={<Radio />}
+                                label={<FormattedMessage id='Apis.Create.WSDL.Steps.ProvideWSDL.file.label' defaultMessage='WSDL File' />}
+                            />
+                            <FormControlLabel
+                                disabled={isGenerateRESTAPI}
+                                value='archive'
+                                control={<Radio />}
+                                label={<FormattedMessage id='Apis.Create.WSDL.Steps.ProvideWSDL.archive.label' defaultMessage='WSDL Archive' />}
+                            />
                         </RadioGroup>
                     </FormControl>
                 </Grid>
@@ -152,35 +169,35 @@ export default function ProvideWSDL(props) {
                         // TODO: Pass message saying accepting only one file ~tmkb
                         <DropZoneLocal onDrop={onDrop} files={apiInputs.inputValue} />
                     ) : (
-                            <TextField
-                                autoFocus
-                                id='outlined-full-width'
-                                label='WSDL URL'
-                                placeholder='Enter WSDL URL'
-                                fullWidth
-                                margin='normal'
-                                variant='outlined'
-                                onChange={({ target: { value } }) => inputsDispatcher({ action: 'inputValue', value })}
-                                value={apiInputs.inputValue}
-                                InputLabelProps={{
-                                    shrink: true,
-                                }}
-                                InputProps={{
-                                    onBlur: ({ target: { value } }) => {
-                                        validate(APIValidation.url.required().validate(value).error);
-                                    },
-                                    endAdornment: isValidating && (
-                                        <InputAdornment position='end'>
-                                            <CircularProgress />
-                                        </InputAdornment>
-                                    ),
-                                }}
-                                // 'Give the URL of WSDL endpoint'
-                                helperText={isError && isError.message}
-                                error={Boolean(isError)}
-                                disabled={isValidating}
-                            />
-                        )}
+                        <TextField
+                            autoFocus
+                            id='outlined-full-width'
+                            label='WSDL URL'
+                            placeholder='Enter WSDL URL'
+                            fullWidth
+                            margin='normal'
+                            variant='outlined'
+                            onChange={({ target: { value } }) => inputsDispatcher({ action: 'inputValue', value })}
+                            value={apiInputs.inputValue}
+                            InputLabelProps={{
+                                shrink: true,
+                            }}
+                            InputProps={{
+                                onBlur: ({ target: { value } }) => {
+                                    validate(APIValidation.url.required().validate(value).error);
+                                },
+                                endAdornment: isValidating && (
+                                    <InputAdornment position='end'>
+                                        <CircularProgress />
+                                    </InputAdornment>
+                                ),
+                            }}
+                            // 'Give the URL of WSDL endpoint'
+                            helperText={isError && isError.message}
+                            error={Boolean(isError)}
+                            disabled={isValidating}
+                        />
+                    )}
                 </Grid>
             </Grid>
         </React.Fragment>


### PR DESCRIPTION
Change Create an API using WSDL UI so that File Input type is dependent on the Implementation type.

<img width="1154" alt="Screen Shot 2019-09-05 at 2 43 19 PM" src="https://user-images.githubusercontent.com/19324135/64328822-cae85a00-cfeb-11e9-9a6d-670819eb0f17.png">
