### PR TITLE
Invoking identity OAuth2TokenValidationServices directly instead of using KeyManager instance

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -436,15 +436,8 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
         token.setTokenType("bearer");
         requestDTO.setAccessToken(token);
 
-        //TODO: If these values are not set, validation will fail giving an NPE. Need to see why that happens
-        OAuth2TokenValidationRequestDTO.TokenValidationContextParam contextParam = requestDTO.new
-                TokenValidationContextParam();
-        contextParam.setKey("dummy");
-        contextParam.setValue("dummy");
-
         OAuth2TokenValidationRequestDTO.TokenValidationContextParam[] contextParams =
                 new OAuth2TokenValidationRequestDTO.TokenValidationContextParam[1];
-        contextParams[0] = contextParam;
         requestDTO.setContext(contextParams);
 
         OAuth2ClientApplicationDTO clientApplicationDTO = findOAuthConsumerIfTokenIsValid(requestDTO);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/WebAppAuthenticatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/WebAppAuthenticatorImpl.java
@@ -22,14 +22,13 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.message.Message;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.*;
+import org.wso2.carbon.apimgt.impl.AMDefaultKeyManagerImpl;
 import org.wso2.carbon.apimgt.impl.APIConstants;
-import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.util.authenticators.WebAppAuthenticator;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -37,8 +36,6 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import org.wso2.uri.template.URITemplateException;
 
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * This web app authenticator class specifically implemented for API Manager store and publisher rest APIs
@@ -60,7 +57,7 @@ public class WebAppAuthenticatorImpl implements WebAppAuthenticator {
                 RestApiConstants.REGEX_BEARER_PATTERN, RestApiConstants.AUTH_HEADER_NAME);
         AccessTokenInfo tokenInfo = null;
         try {
-            tokenInfo = KeyManagerHolder.getKeyManagerInstance().getTokenMetaData(accessToken);
+            tokenInfo = new AMDefaultKeyManagerImpl().getTokenMetaData(accessToken);
         } catch (APIManagementException e) {
             log.error("Error while retrieving token information for token: " + accessToken, e);
         }


### PR DESCRIPTION
## Issue
OAuth token authentication needs to be independent of the defined Key-Manager. It can be extensible when using 3rd party KM and if the same implementation is used in Store/Publisher UI related tasks it can break the flow because the requests are going to the 3rd party KM instead of using ours.

## Methodology

Directly accessing getTokenMetaData() method by creating an AMDefaultKeyManagerImpl class object instead of accessing the method through key-manager instance.