### PR TITLE
Fix get document request with invalid id issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -1364,6 +1364,9 @@ public abstract class AbstractAPIManager implements APIManager {
             GenericArtifactManager artifactManager = getAPIGenericArtifactManagerFromUtil(registryType, APIConstants
                     .DOCUMENTATION_KEY);
             GenericArtifact artifact = artifactManager.getGenericArtifact(docId);
+            if(artifact == null) {
+                return documentation;
+            }
             APIIdentifier apiIdentifier = APIUtil.getAPIIdentifier(artifact.getPath());
             checkAccessControlPermission(apiIdentifier);
             if (null != artifact) {


### PR DESCRIPTION
Issue:
/api/am/publisher/v1.0/apis/{apiId}/documents/{docId} and /api/am/store/v1.0/apis/{apiId}/documents/{docId} throws NPE with 500 status code if an invalid docId is provided

Fix:
404 not found error is provided as a fix 

Closes https://github.com/wso2/product-apim/issues/1643