### PR TITLE
Tenant listing for API Store

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -273,9 +273,14 @@ public enum ExceptionCodes implements ErrorHandler {
     NEED_ADMIN_PERMISSION(901100, "Admin permission needed", 403,
             "This user is not an admin"),
 
-    //External Stores related codes
+        //External Stores related codes
     EXTERNAL_STORE_ID_NOT_FOUND(901200,"External Store Not Found", 404, "Error while publishing to external stores. " +
-            "External Store Not Found");
+            "External Store Not Found"),
+
+
+    // Tenant related
+    INVALID_TENANT(901300,"Tenant Not Found", 400, "Tenant Not Found");
+
 
     private final long errorCode;
     private final String errorMessage;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApiProductsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApiProductsApiServiceImpl.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.rest.api.store.v1.impl;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.APIProduct;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.impl.ApiProductsApiServiceImpl;
@@ -103,7 +104,8 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
             APIConsumer apiConsumer = RestApiUtil.getLoggedInUserConsumer();
 
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
 
             APIProduct product = apiConsumer.getAPIProductbyUUID(apiProductId, requestedTenantDomain);
@@ -153,7 +155,8 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
             }
 
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
 
             APIProduct product = apiConsumer.getAPIProductbyUUID(apiProductId, requestedTenantDomain);
@@ -216,7 +219,8 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
             APIConsumer apiConsumer = RestApiUtil.getConsumer(username);
 
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
             Map<String, Object> result = apiConsumer.searchPaginatedAPIProducts(searchQuery, requestedTenantDomain, offset, limit);
             Set<APIProduct> apiProducts = (Set<APIProduct>) result.get("products");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApisApiServiceImpl.java
@@ -28,6 +28,7 @@ import org.json.simple.JSONObject;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIRating;
@@ -80,7 +81,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             APIConsumer apiConsumer = RestApiUtil.getConsumer(username);
 
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
             String newSearchQuery = APIUtil.constructNewSearchQuery(query);
 
@@ -295,7 +297,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             APIConsumer apiConsumer = RestApiUtil.getLoggedInUserConsumer();
 
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
 
             //this will fail if user does not have access to the API or the API does not exist
@@ -354,7 +357,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             APIConsumer apiConsumer = RestApiUtil.getConsumer(username);
 
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
 
             if (!RestAPIStoreUtils.isUserAccessAllowedForAPIByUUID(apiId, requestedTenantDomain)) {
@@ -395,7 +399,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             APIConsumer apiConsumer = RestApiUtil.getConsumer(username);
 
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
 
             //this will fail if user doesn't have access to the API or the API does not exist
@@ -438,7 +443,8 @@ public class ApisApiServiceImpl implements ApisApiService {
         try {
             String username = RestApiUtil.getLoggedInUsername();
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
             APIConsumer apiConsumer = RestApiUtil.getConsumer(username);
             API api = apiConsumer.getLightweightAPIByUUID(apiId, requestedTenantDomain);
@@ -543,7 +549,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             }
 
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
             
             String apiSwagger = null;
@@ -576,7 +583,8 @@ public class ApisApiServiceImpl implements ApisApiService {
         try {
             APIConsumer apiConsumer = RestApiUtil.getLoggedInUserConsumer();
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
             //this will fail if user does not have access to the API or the API does not exist
             APIIdentifier apiIdentifier = APIMappingUtil.getAPIIdentifierFromUUID(apiId, requestedTenantDomain);
@@ -613,7 +621,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             int rating = 0;
             String username = RestApiUtil.getLoggedInUsername();
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
             APIConsumer apiConsumer = RestApiUtil.getConsumer(username);
             //this will fail if user doesn't have access to the API or the API does not exist
@@ -684,7 +693,8 @@ public class ApisApiServiceImpl implements ApisApiService {
         try {
             String username = RestApiUtil.getLoggedInUsername();
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
             APIConsumer apiConsumer = RestApiUtil.getConsumer(username);
             //this will fail if user doesn't have access to the API or the API does not exist
@@ -721,7 +731,8 @@ public class ApisApiServiceImpl implements ApisApiService {
         try {
             String username = RestApiUtil.getLoggedInUsername();
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
             APIConsumer apiConsumer = RestApiUtil.getConsumer(username);
             //this will fail if user doesn't have access to the API or the API does not exist
@@ -780,7 +791,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             APIConsumer apiConsumer = RestApiUtil.getLoggedInUserConsumer();
 
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
 
             API api = apiConsumer.getAPIbyUUID(apiId, requestedTenantDomain);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SearchApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SearchApiServiceImpl.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.impl.APIConstants;
@@ -62,7 +63,8 @@ public class SearchApiServiceImpl implements SearchApiService {
         try {
 
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
             if (!query.contains(":")) {
                 query = (APIConstants.CONTENT_SEARCH_TYPE_PREFIX + ":" + query);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/TagsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/TagsApiServiceImpl.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.Tag;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.TagsApiService;
@@ -53,7 +54,8 @@ public class TagsApiServiceImpl implements TagsApiService {
         List<Tag> tagList = new ArrayList<>();
         try {
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
 
             String username = RestApiUtil.getLoggedInUsername();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ThrottlingPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ThrottlingPoliciesApiServiceImpl.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.api.model.TierPermission;
 import org.wso2.carbon.apimgt.impl.APIConstants;
@@ -53,7 +54,8 @@ public class ThrottlingPoliciesApiServiceImpl implements ThrottlingPoliciesApiSe
         try {
 
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
 
             ThrottlingPolicyDTO.PolicyLevelEnum policyType;
@@ -110,7 +112,8 @@ public class ThrottlingPoliciesApiServiceImpl implements ThrottlingPoliciesApiSe
 
         try {
             if (!APIUtil.isTenantAvailable(requestedTenantDomain)) {
-                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid", log);
+                RestApiUtil.handleBadRequest("Provided tenant domain '" + xWSO2Tenant + "' is invalid",
+                        ExceptionCodes.INVALID_TENANT.getErrorCode(), log);
             }
 
             if (StringUtils.isBlank(policyLevel)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
@@ -488,6 +488,18 @@ public class RestApiUtil {
      * Returns a new BadRequestException
      *
      * @param description description of the exception
+     * @param code error code
+     * @return a new BadRequestException with the specified details as a response DTO
+     */
+    public static BadRequestException buildBadRequestException(String description, Long code) {
+        ErrorDTO errorDTO = getErrorDTO(RestApiConstants.STATUS_BAD_REQUEST_MESSAGE_DEFAULT, code, description);
+        return new BadRequestException(errorDTO);
+    }
+
+    /**
+     * Returns a new BadRequestException
+     *
+     * @param description description of the exception
      * @return a new BadRequestException with the specified details as a response DTO
      */
     public static BadRequestException buildBadRequestException(String description, Throwable e) {
@@ -652,6 +664,20 @@ public class RestApiUtil {
      */
     public static void handleBadRequest(String msg, Log log) throws BadRequestException {
         BadRequestException badRequestException = buildBadRequestException(msg);
+        log.error(msg);
+        throw badRequestException;
+    }
+
+    /**
+     * Logs the error, builds a BadRequestException with specified details and throws it
+     *
+     * @param msg error message
+     * @param log Log instance
+     * @param code error code
+     * @throws BadRequestException
+     */
+    public static void handleBadRequest(String msg, Long code, Log log) throws BadRequestException {
+        BadRequestException badRequestException = buildBadRequestException(msg, code);
         log.error(msg);
         throw badRequestException;
     }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -483,6 +483,10 @@
     <RESTAPI>
         <!--Configure white-listed URIs of REST API. Accessing white-listed URIs does not require credentials (does not require Authorization header). -->
         <WhiteListedURIs>
+             <WhiteListedURI>
+                <URI>/api/am/store/{version}/tenants</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+             </WhiteListedURI>
             <WhiteListedURI>
                 <URI>/api/am/publisher/{version}/swagger.json</URI>
                 <HTTPMethods>GET,HEAD</HTTPMethods>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package-lock.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package-lock.json
@@ -13165,7 +13165,7 @@
             "dependencies": {
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package-lock.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package-lock.json
@@ -9031,6 +9031,11 @@
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
             "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
         },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
         "lodash.isundefined": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package.json
@@ -22,8 +22,8 @@
     "dependencies": {
         "@material-ui/core": "^3.9.0",
         "@material-ui/icons": "^4.2.1",
-        "autosuggest-highlight": "^3.1.1",
         "async-mutex": "^0.1.3",
+        "autosuggest-highlight": "^3.1.1",
         "axios": "^0.16.1",
         "caniuse-api": "^1.6.1",
         "cleanup-dependencies": "0.0.6",
@@ -34,6 +34,7 @@
         "file-loader": "^0.11.2",
         "js-file-download": "^0.4.1",
         "lodash.clonedeep": "^4.5.0",
+        "lodash.isplainobject": "^4.0.6",
         "material-design-icons": "^3.0.1",
         "material-ui-chip-input": "^1.0.0",
         "mui-datatables": "^2.8.1",

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/package.json
@@ -33,6 +33,7 @@
         "eslint-plugin-jsx-a11y": "^6.1.2",
         "file-loader": "^0.11.2",
         "js-file-download": "^0.4.1",
+        "lodash.clonedeep": "^4.5.0",
         "material-design-icons": "^3.0.1",
         "material-ui-chip-input": "^1.0.0",
         "mui-datatables": "^2.8.1",

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/site/public/css/main.css
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/site/public/css/main.css
@@ -369,3 +369,8 @@
   background: #f05107;
   color: rgb(255, 255, 255);
 }
+
+body {
+  margin: 0;
+  height: 100%;
+}

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/index.jsx
@@ -24,7 +24,7 @@ import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import Config from 'Config';
 import Store from './src/App';
 
-const theme = createMuiTheme(Config);
+const theme = createMuiTheme(Config.themes.light);
 
 ReactDOM.render(
     <MuiThemeProvider theme={theme}>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/App.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/App.jsx
@@ -25,7 +25,7 @@ import SignUp from './app/components/AnonymousView/SignUp';
 import Progress from './app/components/Shared/Progress';
 import { SettingsProvider } from './app/components/Shared/SettingsContext';
 import AuthManager from './app/data/AuthManager';
-import BrowserRouter from './app/CustomRouter/BrowserRouter';
+import BrowserRouter from './app/components/Base/CustomRouter/BrowserRouter';
 
 const LoadableProtectedApp = Loadable({
     loader: () => import(// eslint-disable-line function-paren-newline

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/App.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/App.jsx
@@ -17,7 +17,6 @@
  */
 
 import React from 'react';
-
 import { Route, Switch } from 'react-router-dom';
 import Loadable from 'react-loadable';
 import Login from './app/components/Login/Login';

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/App.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/App.jsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import Loadable from 'react-loadable';
 import Login from './app/components/Login/Login';
 import Logout from './app/components/Logout';
@@ -26,6 +26,7 @@ import SignUp from './app/components/AnonymousView/SignUp';
 import Progress from './app/components/Shared/Progress';
 import { SettingsProvider } from './app/components/Shared/SettingsContext';
 import AuthManager from './app/data/AuthManager';
+import BrowserRouter from './app/CustomRouter/BrowserRouter';
 
 const LoadableProtectedApp = Loadable({
     loader: () => import(// eslint-disable-line function-paren-newline
@@ -38,7 +39,7 @@ const LoadableProtectedApp = Loadable({
 
 
 /**
- *Root Store component
+ * Root Store component
  *
  * @class Store
  * @extends {React.Component}
@@ -54,6 +55,7 @@ class Store extends React.Component {
         LoadableProtectedApp.preload();
         this.state = {
             settings: null,
+            tenantDomain: null,
         };
     }
 
@@ -72,24 +74,33 @@ class Store extends React.Component {
     }
 
     /**
-     *Reners the Store component
-     *
+     * Set the tenant domain to state
+     * @param {String} tenantDomain tenant domain
+     * @memberof Store
+     */
+    setTenantDomain = (tenantDomain) => {
+        this.setState({ tenantDomain });
+    }
+
+    /**
+     * Reners the Store component
      * @returns {JSX} this is the description
      * @memberof Store
      */
     render() {
-        const { settings } = this.state;
+        const { settings, tenantDomain } = this.state;
+
         return (
             settings && (
-                <SettingsProvider value={{ settings }}>
-                    <Router basename='/store-new'>
+                <SettingsProvider value={{ settings, tenantDomain, setTenantDomain: this.setTenantDomain }}>
+                    <BrowserRouter basename='/store-new'>
                         <Switch>
                             <Route path='/login' render={() => <Login appName='store-new' appLabel='STORE' />} />
                             <Route path='/logout' component={Logout} />
                             <Route path='/sign-up' component={SignUp} />
                             <Route component={LoadableProtectedApp} />
                         </Switch>
-                    </Router>
+                    </BrowserRouter>
                 </SettingsProvider>
             )
         );

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/AppRouts.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/AppRouts.jsx
@@ -14,7 +14,10 @@ import EditApp from './components/Applications/Edit/EditApp';
  * @returns {*}
  */
 function AppRouts(props) {
-    const { isAuthenticated, isUserFound, theme } = props;
+    const {
+        isAuthenticated, isUserFound, theme,
+    } = props;
+
     return (
         <Switch>
             <Redirect exact from='/' to={theme.custom.landingPage.active ? '/home' : '/apis'} />

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/AppRouts.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/AppRouts.jsx
@@ -8,6 +8,11 @@ import ApplicationCreate from './components/Shared/AppsAndKeys/ApplicationCreate
 import { PageNotFound, ScopeNotFound } from './components/Base/Errors';
 import EditApp from './components/Applications/Edit/EditApp';
 
+/**
+ * Handle routes
+ * @param {*} props properties
+ * @returns {*}
+ */
 function AppRouts(props) {
     const { isAuthenticated, isUserFound, theme } = props;
     return (

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/CustomRouter/BrowserRouter.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/CustomRouter/BrowserRouter.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { createBrowserHistory } from 'history';
+import { Router } from 'react-router';
+import isPlainObject from 'lodash/isplainobject';
+import Settings from 'AppComponents/Shared/SettingsContext';
+import queryString from 'query-string';
+import PropTypes from 'prop-types';
+
+/**
+ * This class wrapps the default router object of react router and adds custom history function
+ * to track the history and uses that to add an interceptor which is called in every route.
+ * @class BrowserRouter
+ * @extends {React.Component}
+ */
+class BrowserRouter extends React.Component {
+    static contextType = Settings
+
+    /**
+     * Creates an instance of BrowserRouter.
+     * @param {*} props properties
+     * @memberof BrowserRouter
+     */
+    constructor(props) {
+        super(props);
+        this.historyEnhancer = (originalHistory) => {
+            return {
+                ...originalHistory,
+                push: (path, ...args) => originalHistory.push(this.pathInterceptor(path), ...args),
+                replace: (path, ...args) => originalHistory.replace(this.pathInterceptor(path), ...args),
+            };
+        };
+        this.history = this.historyEnhancer(createBrowserHistory(this.props));
+    }
+
+    /**
+     * Interceptor that is called in every route call. This will get the tenant
+     * domain from the context and append it to the query param list
+     * @param {*} originalPath request path or object with path details
+     * @memberof BrowserRouter
+     * @returns {String}
+     */
+    pathInterceptor = (originalPath) => {
+        const { tenantDomain } = this.context;
+        let path = '';
+        let queryStringsRaw = '';
+        if (isPlainObject(originalPath)) {
+            path = originalPath.pathname;
+            queryStringsRaw = originalPath.search;
+        } else {
+            [path, queryStringsRaw] = originalPath.split('?');
+        }
+        const queryObject = queryString.parse(queryStringsRaw);
+        if (!queryObject.tenant && tenantDomain) {
+            queryObject.tenant = tenantDomain;
+        }
+        return `${path}?${queryString.stringify(queryObject)}`;
+    };
+
+    /**
+     * @inheritdoc
+     * @memberof BrowserRouter
+     * @returns {Component}
+     */
+    render() {
+        const { children } = this.props;
+        return (
+            <Router history={this.history}>
+                {children}
+            </Router>
+        );
+    }
+}
+BrowserRouter.propTypes = {
+    children: PropTypes.shape({}).isRequired,
+};
+
+export default BrowserRouter;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/ProtectedApp.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/ProtectedApp.jsx
@@ -21,14 +21,13 @@ import qs from 'qs';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { addLocaleData, defineMessages, IntlProvider } from 'react-intl';
 import Configurations from 'Config';
+import Tenants from 'AppData/Tenants';
 import Base from './components/Base/index';
 import AuthManager from './data/AuthManager';
 import Loading from './components/Base/Loading/Loading';
-// import 'typeface-roboto'
 import Utils from './data/Utils';
 import ConfigManager from './data/ConfigManager';
 import AppRouts from './AppRouts';
-
 /**
  * Language.
  * @type {string}
@@ -57,6 +56,7 @@ export default class ProtectedApp extends Component {
             messages: {},
             userResolved: false,
             scopesFound: false,
+            hasTenants: false,
         };
         this.environments = [];
         this.loadLocale = this.loadLocale.bind(this);
@@ -67,6 +67,8 @@ export default class ProtectedApp extends Component {
      *  Check if data available ,if not get the user info from existing token information
      */
     componentDidMount() {
+        const tenantApi = new Tenants();
+        tenantApi.getTenantsByState();
         ConfigManager.getConfigs()
             .environments.then((response) => {
                 this.environments = response.data.environments;
@@ -177,7 +179,7 @@ export default class ProtectedApp extends Component {
      * @returns {Component}
      */
     render() {
-        const { userResolved } = this.state;
+        const { userResolved, hasTenants } = this.state;
         if (!userResolved) {
             return <Loading />;
         }
@@ -197,7 +199,7 @@ export default class ProtectedApp extends Component {
             <IntlProvider locale={language} messages={messages}>
                 <MuiThemeProvider theme={createMuiTheme(Configurations.themes.light)}>
                     <Base>
-                        <AppRouts isAuthenticated={isAuthenticated} isUserFound={isUserFound} />
+                        <AppRouts hasTenants={hasTenants} isAuthenticated={isAuthenticated} isUserFound={isUserFound} />
                     </Base>
                 </MuiThemeProvider>
             </IntlProvider>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/ProtectedApp.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/ProtectedApp.jsx
@@ -218,11 +218,9 @@ export default class ProtectedApp extends Component {
          */
         return (
             <IntlProvider locale={language} messages={messages}>
-                <MuiThemeProvider theme={createMuiTheme(Configurations.themes.light)}>
-                    <Base>
-                        <AppRouts isAuthenticated={isAuthenticated} isUserFound={isUserFound} />
-                    </Base>
-                </MuiThemeProvider>
+                <Base>
+                    <AppRouts isAuthenticated={isAuthenticated} isUserFound={isUserFound} />
+                </Base>
             </IntlProvider>
         );
     }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/ProtectedApp.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/ProtectedApp.jsx
@@ -56,7 +56,7 @@ export default class ProtectedApp extends Component {
             messages: {},
             userResolved: false,
             scopesFound: false,
-            tenantList: [],
+            tenantList: null,
         };
         this.environments = [];
         this.loadLocale = this.loadLocale.bind(this);
@@ -74,7 +74,7 @@ export default class ProtectedApp extends Component {
 
         // Check if tenant domain is present as a query param if not retrieve the tenant list
         if (tenant) {
-            setTenantDomain(tenant);
+            this.setState({ tenantList: [] }, setTenantDomain(tenant));
         } else {
             tenantApi.getTenantsByState().then((response) => {
                 this.setState({ tenantList: response.body.list });
@@ -205,6 +205,10 @@ export default class ProtectedApp extends Component {
             isAuthenticated = true;
         }
 
+        // Waiting till the tenant list is retrieved
+        if (tenantList === null && tenantDomain === null) {
+            return <Loading />;
+        }
         // user is redirected to tenant listing page if there are any tenants present and
         // if the user is not authenticated and if there is no tenant domain prsent in the context
         if (tenantList.length > 0 && !isAuthenticated && tenantDomain === null) {

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/ProtectedApp.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/ProtectedApp.jsx
@@ -18,7 +18,6 @@
 
 import React, { Component } from 'react';
 import qs from 'qs';
-import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { addLocaleData, defineMessages, IntlProvider } from 'react-intl';
 import Configurations from 'Config';
 import Tenants from 'AppData/Tenants';
@@ -206,12 +205,13 @@ export default class ProtectedApp extends Component {
         }
 
         // Waiting till the tenant list is retrieved
-        if (tenantList === null && tenantDomain === null) {
+        if (tenantList === null) {
             return <Loading />;
         }
         // user is redirected to tenant listing page if there are any tenants present and
-        // if the user is not authenticated and if there is no tenant domain prsent in the context
-        if (tenantList.length > 0 && !isAuthenticated && tenantDomain === null) {
+        // if the user is not authenticated and if there is no tenant domain present in the context
+        // tenantDomain contains INVALID when the tenant does not exist
+        if (tenantDomain === 'INVALID' || (tenantList.length > 0 && !isAuthenticated && tenantDomain === null)) {
             return <TenantListing tenantList={tenantList} />;
         }
         /**

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/ProtectedApp.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/ProtectedApp.jsx
@@ -22,12 +22,17 @@ import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { addLocaleData, defineMessages, IntlProvider } from 'react-intl';
 import Configurations from 'Config';
 import Tenants from 'AppData/Tenants';
+import SettingsContext from 'AppComponents/Shared/SettingsContext';
+import queryString from 'query-string';
+import PropTypes from 'prop-types';
 import Base from './components/Base/index';
 import AuthManager from './data/AuthManager';
 import Loading from './components/Base/Loading/Loading';
 import Utils from './data/Utils';
 import ConfigManager from './data/ConfigManager';
 import AppRouts from './AppRouts';
+import TenantListing from './TenantListing';
+
 /**
  * Language.
  * @type {string}
@@ -36,16 +41,11 @@ const language = (navigator.languages && navigator.languages[0])
     || navigator.language || navigator.userLanguage;
 
 /**
- * Language without region code.
- */
-const languageWithoutRegionCode = language.toLowerCase().split(/[_-]+/)[0];
-
-// import './materialize.css'
-
-/**
  * Render protected application paths
  */
 export default class ProtectedApp extends Component {
+    static contextType = SettingsContext;
+
     /**
      *  constructor
      * @param {*} props props passed to constructor
@@ -56,7 +56,7 @@ export default class ProtectedApp extends Component {
             messages: {},
             userResolved: false,
             scopesFound: false,
-            hasTenants: false,
+            tenantList: [],
         };
         this.environments = [];
         this.loadLocale = this.loadLocale.bind(this);
@@ -67,8 +67,22 @@ export default class ProtectedApp extends Component {
      *  Check if data available ,if not get the user info from existing token information
      */
     componentDidMount() {
+        const { location: { search } } = this.props;
+        const { setTenantDomain } = this.context;
+        const { tenant } = queryString.parse(search);
         const tenantApi = new Tenants();
-        tenantApi.getTenantsByState();
+
+        // Check if tenant domain is present as a query param if not retrieve the tenant list
+        if (tenant) {
+            setTenantDomain(tenant);
+        } else {
+            tenantApi.getTenantsByState().then((response) => {
+                this.setState({ tenantList: response.body.list });
+            }).catch((error) => {
+                console.error('error when getting tenants ' + error);
+            });
+        }
+
         ConfigManager.getConfigs()
             .environments.then((response) => {
                 this.environments = response.data.environments;
@@ -150,10 +164,10 @@ export default class ProtectedApp extends Component {
      */
     handleEnvironmentQueryParam() {
         const { location } = this.props;
-        let queryString = location.search;
-        queryString = queryString.replace(/^\?/, '');
+        const { search } = { ...location };
+        const query = search.replace(/^\?/, '');
         /* With QS version up we can directly use {ignoreQueryPrefix: true} option */
-        const queryParams = qs.parse(queryString);
+        const queryParams = qs.parse(query);
         const environmentName = queryParams.environment;
 
         if (!environmentName || Utils.getEnvironment() === environmentName) {
@@ -179,7 +193,8 @@ export default class ProtectedApp extends Component {
      * @returns {Component}
      */
     render() {
-        const { userResolved, hasTenants } = this.state;
+        const { userResolved, tenantList } = this.state;
+        const { tenantDomain } = this.context;
         if (!userResolved) {
             return <Loading />;
         }
@@ -188,6 +203,12 @@ export default class ProtectedApp extends Component {
         let isAuthenticated = false;
         if (scopesFound && isUserFound) {
             isAuthenticated = true;
+        }
+
+        // user is redirected to tenant listing page if there are any tenants present and
+        // if the user is not authenticated and if there is no tenant domain prsent in the context
+        if (tenantList.length > 0 && !isAuthenticated && tenantDomain === null) {
+            return <TenantListing tenantList={tenantList} />;
         }
         /**
          * Note: AuthManager.getUser() method is a passive check, which simply
@@ -199,10 +220,15 @@ export default class ProtectedApp extends Component {
             <IntlProvider locale={language} messages={messages}>
                 <MuiThemeProvider theme={createMuiTheme(Configurations.themes.light)}>
                     <Base>
-                        <AppRouts hasTenants={hasTenants} isAuthenticated={isAuthenticated} isUserFound={isUserFound} />
+                        <AppRouts isAuthenticated={isAuthenticated} isUserFound={isUserFound} />
                     </Base>
                 </MuiThemeProvider>
             </IntlProvider>
         );
     }
 }
+ProtectedApp.propTypes = {
+    location: PropTypes.shape({
+        search: PropTypes.string.isRequired,
+    }).isRequired,
+};

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/TenantListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/TenantListing.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Settings from 'AppComponents/Shared/SettingsContext';
 import { withStyles } from '@material-ui/core/styles';
@@ -6,6 +6,7 @@ import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
+import Tenants from 'AppData/Tenants';
 
 
 const styles = theme => ({
@@ -45,11 +46,26 @@ const styles = theme => ({
 
 const tenantListing = (props) => {
     const settingContext = useContext(Settings);
+    const [tenants, setTenants] = useState([]);
     const { tenantList, classes, theme } = props;
+
+    useEffect(() => {
+        if (tenantList || tenantList.length === 0) {
+            const tenantApi = new Tenants();
+            tenantApi.getTenantsByState().then((response) => {
+                setTenants(response.body.list);
+            }).catch((error) => {
+                console.error('error when getting tenants ' + error);
+            });
+        } else {
+            setTenants(tenantList);
+        }
+    }, []);
+
     return (
         <div className={classes.root}>
             <Grid container md={4} justify='left' spacing={0} className={classes.list}>
-                {tenantList.map(({ domain }) => {
+                {tenants.map(({ domain }) => {
                     return (
                         <Grid item xs={12} md={12} className={classes.listItem}>
                             <Link

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/TenantListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/TenantListing.jsx
@@ -2,11 +2,46 @@ import React, { useEffect, useState, useContext } from 'react';
 import Tenants from 'AppData/Tenants';
 import { Link } from 'react-router-dom';
 import Settings from 'AppComponents/Shared/SettingsContext';
+import { withStyles, withTheme } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import { classes } from 'istanbul-lib-coverage';
+import Typography from '@material-ui/core/Typography';
+
+
+const styles = theme => ({
+    root: {
+        flexGrow: 1,
+        display: 'flex',
+        background: theme.palette.background.default,
+        height: '100%',
+
+    },
+    paper: {
+        padding: theme.spacing.unit * 2,
+        textAlign: 'center',
+        color: theme.palette.text.secondary,
+        margin: 'auto',
+        '-webkit-box-shadow': '0px 0px 2px 0px rgba(0,0,0,0.5)',
+        '-moz-box-shadow': '0px 0px 2px 0px rgba(0,0,0,0.5)',
+        'box-shadow': '0px 0px 2px 0px rgba(0,0,0,0.5)',
+    },
+    list: {
+        background: theme.palette.background.paper,
+        display: 'block',
+        // height: theme.spacing.unit * 12,
+    },
+    listItem: {
+        margin: 'auto',
+    },
+});
+
 
 const tenantListing = (props) => {
     // const [tenantList, setTenantList] = useState([]);
     const settingContext = useContext(Settings);
-    const { tenantList } = props;
+    const { tenantList, classes, theme } = props;
+    console.info('inside funciotn', theme);
     useEffect(() => {
         // const tenantApi = new Tenants();
         // tenantApi.getTenantsByState().then((response) => {
@@ -18,18 +53,39 @@ const tenantListing = (props) => {
     console.log(tenantList);
     console.log(settingContext);
     return (
-        <div>
-            {tenantList.map(({ domain }) => {
-                return (
-                    <Link to={`/apis?tenant=${domain}`} onClick={() => settingContext.setTenantDomain(domain)}>
-                        {domain}
-                        {' '}
-                    </Link>
-                );
-            })}
+        <div className={classes.root}>
+            {/* <Grid container md={6} justify='center' spacing={0} className={classes.list}>
 
+                <Grid item xs={12} md={5} className={classes.listItem}>
+                    <Paper elevation={0} square className={classes.paper}>
+                        <Typography noWrap>carbon1</Typography>
+                    </Paper>
+                </Grid>
+                <Grid item xs={12} md={5} className={classes.listItem}>
+                    <Paper elevation={0} square className={classes.paper}>
+                        <Typography noWrap>carbon2</Typography>
+                    </Paper>
+                </Grid>
+
+
+            </Grid> */}
+            <Grid container md={6} justify='center' spacing={0} className={classes.list}>
+                {tenantList.map(({ domain }) => {
+                    return (
+                    // <Link to={`/apis?tenant=${domain}`} onClick={() => settingContext.setTenantDomain(domain)}>
+                    // {domain}
+                    // {' '}
+                    // </Link>
+                        <Grid item xs={12} md={5} className={classes.listItem}>
+                            <Paper elevation={0} square className={classes.paper}>
+                                <Typography noWrap>{domain}</Typography>
+                            </Paper>
+                        </Grid>
+                    );
+                })}
+            </Grid>
         </div>
     );
 };
 
-export default tenantListing;
+export default withStyles(styles, { withTheme: true })(tenantListing);

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/TenantListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/TenantListing.jsx
@@ -25,7 +25,7 @@ const styles = theme => ({
         '-moz-box-shadow': '0px 0px 2px 0px rgba(0,0,0,0.5)',
         'box-shadow': '0px 0px 2px 0px rgba(0,0,0,0.5)',
         '&:hover': {
-            background: '#eeeeee',
+            background: theme.palette.grey[100],
             cursor: 'grab',
         },
     },
@@ -35,6 +35,7 @@ const styles = theme => ({
         margin: 'auto',
         'margin-top': '100px',
         padding: `${theme.spacing.unit * 3}px ${theme.spacing.unit * 2}px`,
+        overflow: scroll,
     },
     listItem: {
         margin: 'auto',

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/TenantListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/TenantListing.jsx
@@ -8,7 +8,6 @@ import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import Tenants from 'AppData/Tenants';
 
-
 const styles = theme => ({
     root: {
         flexGrow: 1,

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/TenantListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/TenantListing.jsx
@@ -1,12 +1,11 @@
-import React, { useEffect, useState, useContext } from 'react';
-import Tenants from 'AppData/Tenants';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import Settings from 'AppComponents/Shared/SettingsContext';
-import { withStyles, withTheme } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
-import { classes } from 'istanbul-lib-coverage';
 import Typography from '@material-ui/core/Typography';
+import PropTypes from 'prop-types';
 
 
 const styles = theme => ({
@@ -19,17 +18,23 @@ const styles = theme => ({
     },
     paper: {
         padding: theme.spacing.unit * 2,
-        textAlign: 'center',
+        textAlign: 'left',
         color: theme.palette.text.secondary,
         margin: 'auto',
         '-webkit-box-shadow': '0px 0px 2px 0px rgba(0,0,0,0.5)',
         '-moz-box-shadow': '0px 0px 2px 0px rgba(0,0,0,0.5)',
         'box-shadow': '0px 0px 2px 0px rgba(0,0,0,0.5)',
+        '&:hover': {
+            background: '#eeeeee',
+            cursor: 'grab',
+        },
     },
     list: {
         background: theme.palette.background.paper,
         display: 'block',
-        // height: theme.spacing.unit * 12,
+        margin: 'auto',
+        'margin-top': '100px',
+        padding: `${theme.spacing.unit * 3}px ${theme.spacing.unit * 2}px`,
     },
     listItem: {
         margin: 'auto',
@@ -38,48 +43,33 @@ const styles = theme => ({
 
 
 const tenantListing = (props) => {
-    // const [tenantList, setTenantList] = useState([]);
     const settingContext = useContext(Settings);
     const { tenantList, classes, theme } = props;
-    console.info('inside funciotn', theme);
-    useEffect(() => {
-        // const tenantApi = new Tenants();
-        // tenantApi.getTenantsByState().then((response) => {
-        //     setTenantList(response.body);
-        // }).catch((error) => {
-        //     console.log('error when getting tenants ' + error);
-        // });
-    }, []);
-    console.log(tenantList);
-    console.log(settingContext);
     return (
         <div className={classes.root}>
-            {/* <Grid container md={6} justify='center' spacing={0} className={classes.list}>
-
-                <Grid item xs={12} md={5} className={classes.listItem}>
-                    <Paper elevation={0} square className={classes.paper}>
-                        <Typography noWrap>carbon1</Typography>
-                    </Paper>
-                </Grid>
-                <Grid item xs={12} md={5} className={classes.listItem}>
-                    <Paper elevation={0} square className={classes.paper}>
-                        <Typography noWrap>carbon2</Typography>
-                    </Paper>
-                </Grid>
-
-
-            </Grid> */}
-            <Grid container md={6} justify='center' spacing={0} className={classes.list}>
+            <Grid container md={4} justify='left' spacing={0} className={classes.list}>
                 {tenantList.map(({ domain }) => {
                     return (
-                    // <Link to={`/apis?tenant=${domain}`} onClick={() => settingContext.setTenantDomain(domain)}>
-                    // {domain}
-                    // {' '}
-                    // </Link>
-                        <Grid item xs={12} md={5} className={classes.listItem}>
-                            <Paper elevation={0} square className={classes.paper}>
-                                <Typography noWrap>{domain}</Typography>
-                            </Paper>
+                        <Grid item xs={12} md={12} className={classes.listItem}>
+                            <Link
+                                style={{
+                                    textDecoration: 'none',
+                                }}
+                                to={`/apis?tenant=${domain}`}
+                                onClick={() => settingContext.setTenantDomain(domain)}
+                            >
+                                <Paper elevation={0} square className={classes.paper}>
+                                    <Typography
+                                        noWrap
+                                        style={{
+                                            fontSize: theme.typography.h5.fontSize,
+                                            fontWeight: theme.typography.h1.fontWeight,
+                                        }}
+                                    >
+                                        {domain}
+                                    </Typography>
+                                </Paper>
+                            </Link>
                         </Grid>
                     );
                 })}
@@ -88,4 +78,23 @@ const tenantListing = (props) => {
     );
 };
 
+tenantListing.propTypes = {
+    classes: PropTypes.shape({
+        root: PropTypes.string,
+        list: PropTypes.string,
+        paper: PropTypes.string,
+        listItem: PropTypes.string,
+    }).isRequired,
+    tenantList: PropTypes.arrayOf(PropTypes.string).isRequired,
+    theme: PropTypes.shape({
+        typography: PropTypes.shape({
+            h5: PropTypes.shape({
+                fontSize: PropTypes.string.isRequired,
+            }).isRequired,
+            h1: PropTypes.shape({
+                fontWeight: PropTypes.string.isRequired,
+            }).isRequired,
+        }).isRequired,
+    }).isRequired,
+};
 export default withStyles(styles, { withTheme: true })(tenantListing);

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/TenantListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/TenantListing.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState, useContext } from 'react';
+import Tenants from 'AppData/Tenants';
+import { Link } from 'react-router-dom';
+import Settings from 'AppComponents/Shared/SettingsContext';
+
+const tenantListing = (props) => {
+    // const [tenantList, setTenantList] = useState([]);
+    const settingContext = useContext(Settings);
+    const { tenantList } = props;
+    useEffect(() => {
+        // const tenantApi = new Tenants();
+        // tenantApi.getTenantsByState().then((response) => {
+        //     setTenantList(response.body);
+        // }).catch((error) => {
+        //     console.log('error when getting tenants ' + error);
+        // });
+    }, []);
+    console.log(tenantList);
+    console.log(settingContext);
+    return (
+        <div>
+            {tenantList.map(({ domain }) => {
+                return (
+                    <Link to={`/apis?tenant=${domain}`} onClick={() => settingContext.setTenantDomain(domain)}>
+                        {domain}
+                        {' '}
+                    </Link>
+                );
+            })}
+
+        </div>
+    );
+};
+
+export default tenantListing;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Apis.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Apis.jsx
@@ -18,7 +18,6 @@
 
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
-
 import CONSTS from 'AppData/Constants';
 import CommonListing from './Listing/CommonListing';
 import Details from './Details/index';

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
@@ -125,13 +125,13 @@ class Credentials extends React.Component {
         } else {
             updateSubscriptionData(this.updateData);
         }
-        const { history: { location: { state } } } = this.props;
+        const { history: { location: { state, pathname }, replace } } = this.props;
         if (state) {
             const { openWizard } = state;
             if (openWizard) {
                 this.setState({ wizardOn: true, openNew: true });
-                this.props.history.replace({
-                    pathname: this.props.location.pathname,
+                replace({
+                    pathname,
                     state: {},
                 });
             }
@@ -381,6 +381,15 @@ Credentials.propTypes = {
         titleSub: PropTypes.shape({}),
         tableMain: PropTypes.shape({}),
         th: PropTypes.shape({}),
+    }).isRequired,
+    history: PropTypes.shape({
+        location: PropTypes.shape({
+            state: PropTypes.shape({
+                openWizard: PropTypes.bool.isRequired,
+            }).isRequired,
+            pathname: PropTypes.string.isRequired,
+        }).isRequired,
+        replace: PropTypes.func.isRequired,
     }).isRequired,
     intl: PropTypes.func.isRequired,
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
@@ -125,20 +125,19 @@ class Credentials extends React.Component {
         } else {
             updateSubscriptionData(this.updateData);
         }
-        const { history: { location: {state} }} = this.props;
-        if(state) {
-            const {openWizard} = state;
-            if(openWizard) {
-                this.setState({wizardOn: true, openNew: true});
+        const { history: { location: { state } } } = this.props;
+        if (state) {
+            const { openWizard } = state;
+            if (openWizard) {
+                this.setState({ wizardOn: true, openNew: true });
                 this.props.history.replace({
                     pathname: this.props.location.pathname,
-                    state: {}
+                    state: {},
                 });
             }
         }
-            
     }
-    
+
     updateData = () => {
         const { api, applicationsAvailable } = this.context;
         const { subscriptionRequest } = this.state;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Wizard/Wizard.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Credentials/Wizard/Wizard.jsx
@@ -28,7 +28,6 @@ import { Typography } from '@material-ui/core';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
-import Button from '@material-ui/core/Button';
 import { Redirect } from 'react-router-dom';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import CreateAppStep from './CreateAppStep';

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/index.jsx
@@ -28,6 +28,8 @@ import APIProduct from 'AppData/APIProduct';
 import Api from 'AppData/api';
 import CONSTS from 'AppData/Constants';
 import AuthManager from 'AppData/AuthManager';
+import withSettings from 'AppComponents/Shared/withSettingsContext';
+import Alert from 'AppComponents/Shared/Alert';
 import CustomIcon from '../../Shared/CustomIcon';
 import LeftMenuItem from '../../Shared/LeftMenuItem';
 import { PageNotFound } from '../../Base/Errors/index';
@@ -35,7 +37,6 @@ import InfoBar from './InfoBar';
 import RightPanel from './RightPanel';
 import { ApiContext } from './ApiContext';
 import Progress from '../../Shared/Progress';
-
 
 const LoadableSwitch = withRouter(Loadable.Map({
     loader: {
@@ -220,10 +221,18 @@ class Details extends React.Component {
             promisedAPI.then((api) => {
                 this.setState({ api: api.body });
             }).catch((error) => {
-                if (process.env.NODE_ENV !== 'production') {
-                    console.log(error);
+                const { status, response } = error;
+                const { setTenantDomain, intl } = this.props;
+
+                const message = intl.formatMessage({
+                    defaultMessage: 'Invalid tenant domain',
+                    id: 'Apis.Details.index.invalid.tenant.domain',
+                });
+                if (response && response.body.code === 901300) {
+                    setTenantDomain('INVALID');
+                    Alert.error(message);
                 }
-                const { status } = error;
+                console.error('Error when getting apis', error);
                 if (status === 404) {
                     this.setState({ notFound: true });
                 }
@@ -407,4 +416,4 @@ Details.propTypes = {
     }).isRequired,
 };
 
-export default injectIntl(withStyles(styles, { withTheme: true })(Details));
+export default withSettings(injectIntl(withStyles(styles, { withTheme: true })(Details)));

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Listing/ApiTableView.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Listing/ApiTableView.jsx
@@ -27,65 +27,66 @@ import APIProduct from 'AppData/APIProduct';
 import CONSTS from 'AppData/Constants';
 import Configurations from 'Config';
 import StarRatingBar from 'AppComponents/Apis/Listing/StarRatingBar';
+import withSettings from 'AppComponents/Shared/withSettingsContext';
+import Alert from 'AppComponents/Shared/Alert';
 import ImageGenerator from './ImageGenerator';
 import ApiThumb from './ApiThumb';
 import DocThumb from './DocThumb';
 import { ApiContext } from '../Details/ApiContext';
 
-class StarRatingColumn extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            rating: null,
-        };
-        this.api = new API();
-    }
-
-    componentDidMount() {
-        const promised_rating = this.api.getRatingFromUser(this.props.apiId, null);
-        promised_rating
-            .then((response) => {
-                const rating = response.obj;
-                this.setState({
-                    rating: rating.userRating,
-                });
-            })
-            .catch((error) => {
-                if (process.env.NODE_ENV !== 'production') {
-                    console.log(error);
-                }
-                const status = error.status;
-                if (status === 404) {
-                    this.setState({ notFound: true });
-                }
-            });
-    }
-
-    render() {
-        const { rating } = this.state;
-        return rating && <StarRatingBar rating={rating} />;
-    }
-}
-
-const styles = (theme) => ({
+const styles = theme => ({
     rowImageOverride: {
         '& .material-icons': {
             marginTop: 5,
-            color: `${theme.custom.thumbnail.iconColor} !important` ,
-            fontSize: `${theme.custom.thumbnail.listViewIconSize}px !important` ,
-        }
-    }
+            color: `${theme.custom.thumbnail.iconColor} !important`,
+            fontSize: `${theme.custom.thumbnail.listViewIconSize}px !important`,
+        },
+    },
 });
+/**
+ * Table view for api listing
+ *
+ * @class ApiTableView
+ * @extends {React.Component}
+ */
 class ApiTableView extends React.Component {
+    /**
+     * @inheritdoc
+     * @param {*} props properties
+     * @memberof ApiTableView
+     */
     constructor(props) {
         super(props);
         this.state = {
             data: [],
+            redirect: false,
         };
         this.page = 0;
         this.count = 100;
         this.rowsPerPage = 10;
         this.pageType = null;
+    }
+
+    /**
+     *
+     * @memberof ApiTableView
+     */
+    componentDidMount() {
+        this.apiType = this.context.apiType;
+        this.getData();
+    }
+
+    /**
+     * @param {*} prevProps previous props
+     * @memberof ApiTableView
+     */
+    componentDidUpdate(prevProps) {
+        const { query, selectedTag } = this.props;
+        if ((this.apiType !== this.context.apiType) || query !== prevProps.query
+            || (prevProps.selectedTag !== selectedTag)) {
+            this.apiType = this.context.apiType;
+            this.getData();
+        }
     }
 
     getMuiTheme = () => {
@@ -151,20 +152,6 @@ class ApiTableView extends React.Component {
         return createMuiTheme(muiTheme);
     };
 
-    componentDidMount() {
-        this.apiType = this.context.apiType;
-        this.getData();
-    }
-
-    componentDidUpdate(prevProps) {
-        const { query, selectedTag } = this.props;
-        if ((this.apiType !== this.context.apiType) || query !== prevProps.query ||
-            (prevProps.selectedTag !== selectedTag)) {
-            this.apiType = this.context.apiType;
-            this.getData();
-        }
-    }
-
     // get data
     getData = () => {
         this.xhrRequest().then((data) => {
@@ -173,6 +160,18 @@ class ApiTableView extends React.Component {
             const { total } = pagination;
             this.count = total;
             this.setState({ data: list });
+        }).catch((error) => {
+            const { setTenantDomain, intl } = this.props;
+            const { response } = error;
+            const message = intl.formatMessage({
+                defaultMessage: 'Invalid tenant domain',
+                id: 'Apis.Listing.ApiTableView.invalid.tenant.domain',
+            });
+            if (response && response.body.code === 901300) {
+                setTenantDomain('INVALID');
+                Alert.error(message);
+            }
+            console.error('Error when getting apis', error);
         });
     };
 
@@ -210,8 +209,11 @@ class ApiTableView extends React.Component {
         });
     };
 
-   
-
+    /**
+     * @inheritdoc
+     * @returns {Component}x
+     * @memberof ApiTableView
+     */
     render() {
         const { intl, gridView } = this.props;
         const columns = [
@@ -225,7 +227,7 @@ class ApiTableView extends React.Component {
             {
                 name: 'name',
                 options: {
-                    customBodyRender: (value, tableMeta, updateValue,tableViewObj = this) => {
+                    customBodyRender: (value, tableMeta, updateValue, tableViewObj = this) => {
                         if (tableMeta.rowData) {
                             const artifact = tableViewObj.state.data[tableMeta.rowIndex];
                             return <ImageGenerator api={artifact} width={30} height={30} />;
@@ -255,7 +257,7 @@ class ApiTableView extends React.Component {
                                     if (artifact.type === 'DOC') {
                                         return (
                                             <Link to={'/apis/' + artifact.apiUUID + '/docs'}>
-                                            <ImageGenerator api={artifact} width={30} height={30} />
+                                                <ImageGenerator api={artifact} width={30} height={30} />
                                                 <FormattedMessage
                                                     id='Apis.Listing.TableView.TableView.doc.flag'
                                                     defaultMessage='[Doc] '
@@ -266,13 +268,23 @@ class ApiTableView extends React.Component {
                                     }
                                     return (
                                         <Link to={'/apis/' + apiId + '/overview'} className={classes.rowImageOverride}>
-                                            <ImageGenerator api={artifact} width={30} height={30}/>{apiName}</Link>);
+                                            <ImageGenerator api={artifact} width={30} height={30} />
+                                            {apiName}
+
+                                        </Link>
+                                    );
                                 }
                             } else {
-                                return (<Link
-                                    to={'/api-products/' + apiId + '/overview'}
-                                    className={classes.rowImageOverride}>
-                                    <ImageGenerator api={artifact} width={30} height={30}/>{apiName}</Link>);
+                                return (
+                                    <Link
+                                        to={'/api-products/' + apiId + '/overview'}
+                                        className={classes.rowImageOverride}
+                                    >
+                                        <ImageGenerator api={artifact} width={30} height={30} />
+                                        {apiName}
+
+                                    </Link>
+                                );
                             }
                         }
                     },
@@ -331,12 +343,14 @@ class ApiTableView extends React.Component {
                                 if (artifact.type !== 'DOC') {
                                     const apiId = tableMeta.rowData[0];
                                     const avgRating = tableMeta.rowData[7];
-                                    return <StarRatingBar
-                                        apiRating={avgRating}
-                                        apiId={apiId}
-                                        isEditable={false}
-                                        showSummary={false}
-                                    />;
+                                    return (
+                                        <StarRatingBar
+                                            apiRating={avgRating}
+                                            apiId={apiId}
+                                            isEditable={false}
+                                            showSummary={false}
+                                        />
+                                    );
                                 }
                             }
                         }
@@ -373,8 +387,8 @@ class ApiTableView extends React.Component {
             selectableRows: 'none',
             rowsPerPage,
             onChangeRowsPerPage: (numberOfRows) => {
-                const { page, count, } = this;
-                if( page*numberOfRows > count){
+                const { page, count } = this;
+                if (page * numberOfRows > count) {
                     this.page = 0;
                 }
                 this.rowsPerPage = numberOfRows;
@@ -400,7 +414,7 @@ class ApiTableView extends React.Component {
             options.viewColumns = false;
             options.customToolbar = false;
         }
-        if(page === 0 && this.count <= rowsPerPage){
+        if (page === 0 && this.count <= rowsPerPage) {
             options.pagination = false;
         }
         return (
@@ -413,4 +427,4 @@ class ApiTableView extends React.Component {
 
 ApiTableView.contextType = ApiContext;
 
-export default injectIntl(withStyles(styles)(ApiTableView));
+export default withSettings(injectIntl(withStyles(styles)(ApiTableView)));

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Listing/ApiTableView.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Listing/ApiTableView.jsx
@@ -59,7 +59,6 @@ class ApiTableView extends React.Component {
         super(props);
         this.state = {
             data: [],
-            redirect: false,
         };
         this.page = 0;
         this.count = 100;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Listing/CommonListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Listing/CommonListing.jsx
@@ -104,9 +104,7 @@ class CommonListing extends React.Component {
                 }
             })
             .catch((error) => {
-                if (process.env.NODE_ENV !== 'production') {
-                    console.log(error);
-                }
+                console.log(error);
             });
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Listing/CommonListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Listing/CommonListing.jsx
@@ -129,7 +129,7 @@ class CommonListing extends React.Component {
      */
     render() {
         const {
-            apis, apiType, theme, classes, location: { search }
+            apis, apiType, theme, classes, location: { search },
         } = this.props;
         const { listType, allTags } = this.state;
         const strokeColorMain = theme.palette.getContrastText(theme.palette.background.paper);
@@ -174,7 +174,7 @@ class CommonListing extends React.Component {
                             {listType === 'list'
                             && (
                                 <ApiContext.Provider value={{ apiType }}>
-                                    <ApiTableView gridView={false} query={search}/>
+                                    <ApiTableView gridView={false} query={search} />
                                 </ApiContext.Provider>
                             )}
                         </div>
@@ -199,6 +199,6 @@ CommonListing.defaultProps = {
     location: PropTypes.shape({
         search: '',
     }),
-}
+};
 
-export default  withStyles(styles, { withTheme: true })(CommonListing);
+export default withStyles(styles, { withTheme: true })(CommonListing);

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/CustomRouter/BrowserRouter.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/CustomRouter/BrowserRouter.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createBrowserHistory } from 'history';
 import { Router } from 'react-router';
-import isPlainObject from 'lodash/isplainobject';
+import isPlainObject from 'lodash.isplainobject';
 import Settings from 'AppComponents/Shared/SettingsContext';
 import queryString from 'query-string';
 import PropTypes from 'prop-types';

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/CustomRouter/BrowserRouter.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/CustomRouter/BrowserRouter.jsx
@@ -71,7 +71,7 @@ class BrowserRouter extends React.Component {
     }
 }
 BrowserRouter.propTypes = {
-    children: PropTypes.shape({}).isRequired,
+    children: PropTypes.node.isRequired,
 };
 
 export default BrowserRouter;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/Header/GlobalNavbar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/Header/GlobalNavbar.jsx
@@ -15,8 +15,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useState, } from 'react';
-import { Link, withRouter, } from 'react-router-dom';
+import React, { useEffect, useState, useContext } from 'react';
+import { Link, withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import classNames from 'classnames';
@@ -25,6 +25,7 @@ import {
     ListItemIcon, List, withStyles, ListItem, ListItemText,
 } from '@material-ui/core';
 import CustomIcon from '../../Shared/CustomIcon';
+
 /**
  *
  *

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/index.jsx
@@ -198,16 +198,6 @@ class Layout extends React.Component {
         this.setState({ openUserMenu: false });
     };
 
-    componentWillMount() {
-        document.body.style.height = '100%';
-        document.body.style.margin = '0';
-    }
-
-    componentWillUnmount() {
-        document.body.style.height = null;
-        document.body.style.margin = null;
-    }
-
     render() {
         const { classes, theme } = this.props;
         const { openNavBar } = this.state;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/index.jsx
@@ -37,11 +37,12 @@ import Paper from '@material-ui/core/Paper';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import { FormattedMessage } from 'react-intl';
 import Drawer from '@material-ui/core/Drawer';
+import HeaderSearch from 'AppComponents/Base/Header/Search/HeaderSearch';
+import Settings from 'AppComponents/Shared/SettingsContext';
 import AuthManager from '../../data/AuthManager';
 import ConfigManager from '../../data/ConfigManager';
 import EnvironmentMenu from './Header/EnvironmentMenu';
 import GlobalNavBar from './Header/GlobalNavbar';
-import HeaderSearch from 'AppComponents/Base/Header/Search/HeaderSearch';
 import Utils from '../../data/Utils';
 import VerticalDivider from '../Shared/VerticalDivider';
 
@@ -58,6 +59,9 @@ const styles = theme => ({
         fontSize: 35,
     },
     userLink: {
+        color: theme.palette.getContrastText(theme.palette.background.appBar),
+    },
+    publicStore: {
         color: theme.palette.getContrastText(theme.palette.background.appBar),
     },
     // Page layout styles
@@ -105,11 +109,23 @@ const styles = theme => ({
         '& ul': {
             display: 'flex',
             flexDirection: 'row',
-        }
-    }
+        },
+    },
 });
 
+/**
+ *
+ * @class Layout
+ * @extends {React.Component}
+ */
 class Layout extends React.Component {
+    static contextType = Settings
+
+    /**
+     * @inheritdoc
+     * @param {*} props
+     * @memberof Layout
+     */
     constructor(props) {
         super(props);
         this.toggleGlobalNavBar = this.toggleGlobalNavBar.bind(this);
@@ -198,9 +214,15 @@ class Layout extends React.Component {
         this.setState({ openUserMenu: false });
     };
 
+    /**
+     * @inheritdoc
+     * @returns {Component}
+     * @memberof Layout
+     */
     render() {
         const { classes, theme } = this.props;
         const { openNavBar } = this.state;
+        const { setTenantDomain, tenantDomain } = this.context;
         const user = AuthManager.getUser();
         // TODO: Refer to fix: https://github.com/mui-org/material-ui/issues/10076#issuecomment-361232810 ~tmkb
         const commonStyle = {
@@ -228,7 +250,7 @@ class Layout extends React.Component {
                             <Hidden smDown>
                                 <VerticalDivider height={32} />
                                 <div className={classes.listInline}>
-                                    <GlobalNavBar smallView={true} />
+                                    <GlobalNavBar smallView />
                                 </div>
                             </Hidden>
                             <Hidden mdUp>
@@ -255,6 +277,24 @@ class Layout extends React.Component {
                             </Hidden>
                             <VerticalDivider height={32} />
                             <HeaderSearch />
+                            {tenantDomain && (
+                                <Link
+                                    style={{
+                                        textDecoration: 'none',
+                                        color: '#ffffff',
+                                    }}
+                                    to='/'
+                                    onClick={() => setTenantDomain('INVALID')}
+                                >
+                                    <Button className={classes.publicStore}>
+                                        <Icon>public</Icon>
+                                        <FormattedMessage
+                                            id='Base.index.go.to.public.store'
+                                            defaultMessage='Go to public store'
+                                        />
+                                    </Button>
+                                </Link>
+                            )}
                             <VerticalDivider height={72} />
                             {/* Environment menu */}
                             <EnvironmentMenu

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Shared/withSettingsContext.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Shared/withSettingsContext.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { SettingsConsumer } from './SettingsContext';
+
+const withSettings = (WrappedComponent) => {
+    /**
+     * Higher order component with settings
+     * @param {*} props properties
+     * @returns {Context.Consumer}
+     */
+    function HOCWithSettings(props) {
+        return (
+            <SettingsConsumer>
+                {
+                    context => <WrappedComponent {...context} {...props} />
+                }
+            </SettingsConsumer>
+        );
+    }
+    return HOCWithSettings;
+};
+
+export default withSettings;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/data/Tenants.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/data/Tenants.js
@@ -36,7 +36,7 @@ class Tenants {
      */
     getTenantsByState = (state = 'active') => {
         return this.client.then((client) => {
-            console.log(client);
+            return client.apis.tenants.get_tenants({ state });
         });
     }
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/data/Tenants.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/data/Tenants.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import APIClientFactory from './APIClientFactory';
+import Utils from './Utils';
+
+/**
+ * This class contains tenant related api requests
+ */
+class Tenants {
+    /**
+     * @inheritdoc
+     */
+    constructor() {
+        this.client = new APIClientFactory().getAPIClient(Utils.getEnvironment().label).client;
+    }
+
+    /**
+     * Gets tenants by state. If no state is passed it returns tenants who are active
+     * @param {String} state tenant state either active or inactive
+     * @memberof Tenants
+     * @returns {promise} tenants
+     */
+    getTenantsByState = (state = 'active') => {
+        return this.client.then((client) => {
+            console.log(client);
+        });
+    }
+}
+
+export default Tenants;


### PR DESCRIPTION
Following PR will add the tenant listing UI  and handle loading of data based on tenant for API Store. 

The Store REST API (v1) will now return the error code of **901300** if we have added a invalid tenant domain to x-wso2-tenant header.

To handle the routing of the tenant listing we will be adding an interceptor for the react router. This would require us to extend the currently react router implementation and its history implementation to plugin our custom interceptor [1].

I have added a basic UI to display the tenants, the UI/UX will be needed to be improved. I have created an issue to track this [2] 

[1] - https://github.com/dushansilva/carbon-apimgt/blob/8c139b28baef0543fc6b6bebf19a860c67f77e33/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Base/CustomRouter/BrowserRouter.jsx#L43

[2] - https://github.com/wso2/product-apim/issues/5530
