### PR TITLE
Adding Throttling and auth scheme to local entry for graphql APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandler.java
@@ -229,6 +229,8 @@ public class GraphQLAPIHandler extends AbstractHandler {
 
         messageContext.setProperty(SCOPE_ROLE_MAPPING, scopeRoleMappingList);
         messageContext.setProperty(SCOPE_OPERATION_MAPPING, operationScopeMappingList);
+        messageContext.setProperty(OPERATION_THROTTLING_MAPPING, operationThrottlingMappingList);
+        messageContext.setProperty(OPERATION_AUTH_SCHEME_MAPPING, operationAuthSchemeMappingList);
         messageContext.setProperty(API_TYPE, GRAPHQL_API);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandler.java
@@ -194,7 +194,7 @@ public class GraphQLAPIHandler extends AbstractHandler {
         @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
         HashMap<String, String> operationThrottlingMappingList = new HashMap<>();
         @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
-        HashMap<String, String> operationAuthSchemeMappingList = new HashMap<>();
+        HashMap<String, Boolean> operationAuthSchemeMappingList = new HashMap<>();
         HashMap<String, String> operationScopeMappingList = new HashMap<>();
         HashMap<String, ArrayList<String>> scopeRoleMappingList = new HashMap<>();
 
@@ -214,7 +214,11 @@ public class GraphQLAPIHandler extends AbstractHandler {
                     } else if (additionalType.getName().contains(APIConstants.OPERATION_THROTTLING_MAPPING)) {
                         operationThrottlingMappingList.put(additionalTypeName, type.getName());
                     } else if (additionalType.getName().contains(APIConstants.OPERATION_AUTH_SCHEME_MAPPING)) {
-                        operationAuthSchemeMappingList.put(additionalTypeName, type.getName());
+                        boolean isSecurityEnabled = true;
+                        if (APIConstants.OPERATION_SECURITY_DISABLED.equalsIgnoreCase(type.getName())) {
+                            isSecurityEnabled = false;
+                        }
+                        operationAuthSchemeMappingList.put(additionalTypeName, isSecurityEnabled);
                     }
                 }
                 if (!roleArrayList.isEmpty()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandler.java
@@ -70,10 +70,6 @@ public class GraphQLAPIHandler extends AbstractHandler {
     private static final String HTTP_VERB = "HTTP_VERB";
     private static final String UNICODE_TRANSFORMATION_FORMAT = "UTF-8";
     private static final String INVALID_QUERY = "INVALID QUERY";
-    private static final String SCOPE_ROLE_MAPPING = "ScopeRoleMapping";
-    private static final String SCOPE_OPERATION_MAPPING = "ScopeOperationMapping";
-    private static final String OPERATION_THROTTLING_MAPPING = "OperationThrottlingMapping";
-    private static final String OPERATION_AUTH_SCHEME_MAPPING = "OperationAuthSchemeMapping";
     private static final String GRAPHQL_IDENTIFIER = "_graphQL";
     private static final String CLASS_NAME_AND_METHOD = "_GraphQLAPIHandler_handleRequest";
     private static final Log log = LogFactory.getLog(GraphQLAPIHandler.class);
@@ -208,16 +204,16 @@ public class GraphQLAPIHandler extends AbstractHandler {
                 String additionalTypeName = additionalType.getName().split("_", 2)[1];
                 String base64DecodedAdditionalType = new String(Base64.getUrlDecoder().decode(additionalTypeName));
                 for (GraphQLType type : additionalType.getChildren()) {
-                    if (additionalType.getName().contains(SCOPE_ROLE_MAPPING)) {
+                    if (additionalType.getName().contains(APIConstants.SCOPE_ROLE_MAPPING)) {
                         String base64DecodedURLRole = new String(Base64.getUrlDecoder().decode(type.getName()));
                         roleArrayList = new ArrayList<>();
                         roleArrayList.add(base64DecodedURLRole);
-                    } else if (additionalType.getName().contains(SCOPE_OPERATION_MAPPING)) {
+                    } else if (additionalType.getName().contains(APIConstants.SCOPE_OPERATION_MAPPING)) {
                         String base64DecodedURLScope = new String(Base64.getUrlDecoder().decode(type.getName()));
                         operationScopeMappingList.put(base64DecodedAdditionalType, base64DecodedURLScope);
-                    } else if (additionalType.getName().contains(OPERATION_THROTTLING_MAPPING)) {
+                    } else if (additionalType.getName().contains(APIConstants.OPERATION_THROTTLING_MAPPING)) {
                         operationThrottlingMappingList.put(additionalTypeName, type.getName());
-                    } else if (additionalType.getName().contains(OPERATION_AUTH_SCHEME_MAPPING)) {
+                    } else if (additionalType.getName().contains(APIConstants.OPERATION_AUTH_SCHEME_MAPPING)) {
                         operationAuthSchemeMappingList.put(additionalTypeName, type.getName());
                     }
                 }
@@ -227,10 +223,10 @@ public class GraphQLAPIHandler extends AbstractHandler {
             }
         }
 
-        messageContext.setProperty(SCOPE_ROLE_MAPPING, scopeRoleMappingList);
-        messageContext.setProperty(SCOPE_OPERATION_MAPPING, operationScopeMappingList);
-        messageContext.setProperty(OPERATION_THROTTLING_MAPPING, operationThrottlingMappingList);
-        messageContext.setProperty(OPERATION_AUTH_SCHEME_MAPPING, operationAuthSchemeMappingList);
+        messageContext.setProperty(APIConstants.SCOPE_ROLE_MAPPING, scopeRoleMappingList);
+        messageContext.setProperty(APIConstants.SCOPE_OPERATION_MAPPING, operationScopeMappingList);
+        messageContext.setProperty(APIConstants.OPERATION_THROTTLING_MAPPING, operationThrottlingMappingList);
+        messageContext.setProperty(APIConstants.OPERATION_AUTH_SCHEME_MAPPING, operationAuthSchemeMappingList);
         messageContext.setProperty(API_TYPE, GRAPHQL_API);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -995,6 +995,10 @@ public final class APIConstants {
     public static final String GRAPHQL_QUERY = "Query";
     public static final String GRAPHQL_MUTATION = "Mutation";
     public static final String GRAPHQL_SUBSCRIPTION = "Subscription";
+    public static final String SCOPE_ROLE_MAPPING = "ScopeRoleMapping";
+    public static final String SCOPE_OPERATION_MAPPING = "ScopeOperationMapping";
+    public static final String OPERATION_THROTTLING_MAPPING = "OperationThrottlingMapping";
+    public static final String OPERATION_AUTH_SCHEME_MAPPING = "OperationAuthSchemeMapping";
 
     //URI Authentication Schemes
     public static final Set<String> GRAPHQL_SUPPORTED_METHOD_LIST =

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -999,6 +999,8 @@ public final class APIConstants {
     public static final String SCOPE_OPERATION_MAPPING = "ScopeOperationMapping";
     public static final String OPERATION_THROTTLING_MAPPING = "OperationThrottlingMapping";
     public static final String OPERATION_AUTH_SCHEME_MAPPING = "OperationAuthSchemeMapping";
+    public static final String OPERATION_SECURITY_ENABLED = "Enabled";
+    public static final String OPERATION_SECURITY_DISABLED = "Disabled";
 
     //URI Authentication Schemes
     public static final Set<String> GRAPHQL_SUPPORTED_METHOD_LIST =

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/GraphQLSchemaDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/GraphQLSchemaDefinition.java
@@ -176,15 +176,15 @@ public class GraphQLSchemaDefinition {
 
             if (operationAuthSchemeMap.size() > 0) {
                 String operationAuthSchemeType;
-                boolean isSecurityEnabled;
+                String isSecurityEnabled;
                 for (Map.Entry<String, String> entry : operationAuthSchemeMap.entrySet()) {
                     if (entry.getValue().equalsIgnoreCase(APIConstants.AUTH_NO_AUTHENTICATION)) {
-                        isSecurityEnabled = false;
+                        isSecurityEnabled = APIConstants.OPERATION_SECURITY_ENABLED;
                     } else {
-                        isSecurityEnabled = true;
+                        isSecurityEnabled = APIConstants.OPERATION_SECURITY_DISABLED;
                     }
                     operationAuthSchemeType = "type OperationAuthSchemeMapping_" +
-                            entry.getKey() + "{\n" + isSecurityEnabled + ": Boolean\n}\n";
+                            entry.getKey() + "{\n" + isSecurityEnabled + ": String\n}\n";
                     operationAuthSchemeMappingBuilder.append(operationAuthSchemeType);
                 }
                 schemaDefinitionBuilder.append(operationAuthSchemeMappingBuilder.toString());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/GraphQLSchemaDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/GraphQLSchemaDefinition.java
@@ -176,15 +176,15 @@ public class GraphQLSchemaDefinition {
 
             if (operationAuthSchemeMap.size() > 0) {
                 String operationAuthSchemeType;
-                String isSecurityEnabled;
+                boolean isSecurityEnabled;
                 for (Map.Entry<String, String> entry : operationAuthSchemeMap.entrySet()) {
                     if (entry.getValue().equalsIgnoreCase(APIConstants.AUTH_NO_AUTHENTICATION)) {
-                        isSecurityEnabled = "securityEnabled";
+                        isSecurityEnabled = false;
                     } else {
-                        isSecurityEnabled = "securityDisabled";
+                        isSecurityEnabled = true;
                     }
                     operationAuthSchemeType = "type OperationAuthSchemeMapping_" +
-                            entry.getKey() + "{\n" + isSecurityEnabled + ": String\n}\n";
+                            entry.getKey() + "{\n" + isSecurityEnabled + ": Boolean\n}\n";
                     operationAuthSchemeMappingBuilder.append(operationAuthSchemeType);
                 }
                 schemaDefinitionBuilder.append(operationAuthSchemeMappingBuilder.toString());


### PR DESCRIPTION
To Graphql APIs to support Basic Authentication and JWT, as scope related details, it is needed to be added throttling per operation and auth scheme per operation to local entry, since the swagger definition has not been stored such details.