### PR TITLE
Add Publisher Store UI for publishing APIs for external stores

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
@@ -64,13 +64,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
@@ -240,9 +238,8 @@ public class APIExportUtil {
                     //Inline/Markdown content file name would be same as the documentation name
                     //Markdown content files will also be stored in InlineContents directory
                     localFileName = doc.getName();
-                    resourcePath = APIUtil.getAPIDocPath(apiIdentifier) + RegistryConstants.PATH_SEPARATOR
-                            + APIConstants.INLINE_DOCUMENT_CONTENT_DIR + RegistryConstants.PATH_SEPARATOR
-                            + localFileName;
+                    resourcePath = APIUtil.getAPIDocPath(apiIdentifier) + APIConstants.INLINE_DOCUMENT_CONTENT_DIR
+                            + RegistryConstants.PATH_SEPARATOR + localFileName;
                     localDocDirectoryPath += File.separator + APIImportExportConstants.INLINE_DOCUMENT_DIRECTORY;
                 }
 
@@ -258,10 +255,11 @@ public class APIExportUtil {
                             IOUtils.copy(fileInputStream, outputStream);
                         }
                     } else {
+                        //Log error and avoid throwing as we give capability to export document artifact without the
+                        //content if does not exists
                         String errorMessage = "Documentation resource for API: " + apiIdentifier.getApiName()
                                 + " not found in " + resourcePath;
                         log.error(errorMessage);
-                        throw new APIImportExportException(errorMessage);
                     }
                 }
             }
@@ -539,7 +537,6 @@ public class APIExportUtil {
                 JsonParser parser = new JsonParser();
                 JsonObject json = parser.parse(swaggerDefinition).getAsJsonObject();
                 String formattedSwaggerJson = gson.toJson(json);
-                apiToReturn.setUriTemplates(Collections.EMPTY_SET);
                 switch (exportFormat) {
                     case YAML:
                         String swaggerInYaml = CommonUtil.jsonToYaml(formattedSwaggerJson);
@@ -594,6 +591,7 @@ public class APIExportUtil {
         // Swagger.json contains complete details about scopes and URI templates. Therefore scope and URI template
         // details are removed from api.json
         api.setScopes(new LinkedHashSet<>());
+        api.setUriTemplates(new LinkedHashSet<>());
         // Secure endpoint password is removed, as it causes security issues. When importing need to add it manually,
         // if Secure Endpoint is enabled.
         if (api.getEndpointUTPassword() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIDTO.java
@@ -10,6 +10,7 @@ import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIBusinessInformationDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIEndpointURLsDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIOperationsDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APITiersDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.AdvertiseInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.LabelDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ScopeInfoDTO;
 import javax.validation.constraints.*;
@@ -50,6 +51,7 @@ public class APIDTO   {
     private List<String> environmentList = new ArrayList<>();
     private List<ScopeInfoDTO> scopes = new ArrayList<>();
     private String avgRating = null;
+    private AdvertiseInfoDTO advertiseInfo = null;
 
   /**
    * UUID of the api 
@@ -499,6 +501,24 @@ public class APIDTO   {
     this.avgRating = avgRating;
   }
 
+  /**
+   * The advertise info of the API
+   **/
+  public APIDTO advertiseInfo(AdvertiseInfoDTO advertiseInfo) {
+    this.advertiseInfo = advertiseInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "The advertise info of the API")
+  @JsonProperty("advertiseInfo")
+  public AdvertiseInfoDTO getAdvertiseInfo() {
+    return advertiseInfo;
+  }
+  public void setAdvertiseInfo(AdvertiseInfoDTO advertiseInfo) {
+    this.advertiseInfo = advertiseInfo;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -533,12 +553,13 @@ public class APIDTO   {
         Objects.equals(labels, API.labels) &&
         Objects.equals(environmentList, API.environmentList) &&
         Objects.equals(scopes, API.scopes) &&
-        Objects.equals(avgRating, API.avgRating);
+        Objects.equals(avgRating, API.avgRating) &&
+        Objects.equals(advertiseInfo, API.advertiseInfo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, context, version, provider, apiDefinition, wsdlUri, lifeCycleStatus, isDefaultVersion, type, transport, operations, authorizationHeader, securityScheme, tags, tiers, hasThumbnail, additionalProperties, endpointURLs, businessInformation, labels, environmentList, scopes, avgRating);
+    return Objects.hash(id, name, description, context, version, provider, apiDefinition, wsdlUri, lifeCycleStatus, isDefaultVersion, type, transport, operations, authorizationHeader, securityScheme, tags, tiers, hasThumbnail, additionalProperties, endpointURLs, businessInformation, labels, environmentList, scopes, avgRating, advertiseInfo);
   }
 
   @Override
@@ -571,6 +592,7 @@ public class APIDTO   {
     sb.append("    environmentList: ").append(toIndentedString(environmentList)).append("\n");
     sb.append("    scopes: ").append(toIndentedString(scopes)).append("\n");
     sb.append("    avgRating: ").append(toIndentedString(avgRating)).append("\n");
+    sb.append("    advertiseInfo: ").append(toIndentedString(advertiseInfo)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIInfoDTO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;
 import java.util.List;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.AdvertiseInfoDTO;
 import javax.validation.constraints.*;
 
 
@@ -28,6 +29,7 @@ public class APIInfoDTO   {
     private String thumbnailUri = null;
     private String avgRating = null;
     private List<String> throttlingPolicies = new ArrayList<>();
+    private AdvertiseInfoDTO advertiseInfo = null;
 
   /**
    **/
@@ -219,6 +221,24 @@ public class APIInfoDTO   {
     this.throttlingPolicies = throttlingPolicies;
   }
 
+  /**
+   * The advertise info of the API
+   **/
+  public APIInfoDTO advertiseInfo(AdvertiseInfoDTO advertiseInfo) {
+    this.advertiseInfo = advertiseInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "The advertise info of the API")
+  @JsonProperty("advertiseInfo")
+  public AdvertiseInfoDTO getAdvertiseInfo() {
+    return advertiseInfo;
+  }
+  public void setAdvertiseInfo(AdvertiseInfoDTO advertiseInfo) {
+    this.advertiseInfo = advertiseInfo;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -239,12 +259,13 @@ public class APIInfoDTO   {
         Objects.equals(lifeCycleStatus, apIInfo.lifeCycleStatus) &&
         Objects.equals(thumbnailUri, apIInfo.thumbnailUri) &&
         Objects.equals(avgRating, apIInfo.avgRating) &&
-        Objects.equals(throttlingPolicies, apIInfo.throttlingPolicies);
+        Objects.equals(throttlingPolicies, apIInfo.throttlingPolicies) &&
+        Objects.equals(advertiseInfo, apIInfo.advertiseInfo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, context, version, type, provider, lifeCycleStatus, thumbnailUri, avgRating, throttlingPolicies);
+    return Objects.hash(id, name, description, context, version, type, provider, lifeCycleStatus, thumbnailUri, avgRating, throttlingPolicies, advertiseInfo);
   }
 
   @Override
@@ -263,6 +284,7 @@ public class APIInfoDTO   {
     sb.append("    thumbnailUri: ").append(toIndentedString(thumbnailUri)).append("\n");
     sb.append("    avgRating: ").append(toIndentedString(avgRating)).append("\n");
     sb.append("    throttlingPolicies: ").append(toIndentedString(throttlingPolicies)).append("\n");
+    sb.append("    advertiseInfo: ").append(toIndentedString(advertiseInfo)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/AdvertiseInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/AdvertiseInfoDTO.java
@@ -1,0 +1,116 @@
+package org.wso2.carbon.apimgt.rest.api.store.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.util.annotations.Scope;
+
+
+
+public class AdvertiseInfoDTO   {
+  
+    private Boolean advertised = null;
+    private String originalStoreUrl = null;
+    private String apiOwner = null;
+
+  /**
+   **/
+  public AdvertiseInfoDTO advertised(Boolean advertised) {
+    this.advertised = advertised;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("advertised")
+  public Boolean isAdvertised() {
+    return advertised;
+  }
+  public void setAdvertised(Boolean advertised) {
+    this.advertised = advertised;
+  }
+
+  /**
+   **/
+  public AdvertiseInfoDTO originalStoreUrl(String originalStoreUrl) {
+    this.originalStoreUrl = originalStoreUrl;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "https://localhost:9443/store", value = "")
+  @JsonProperty("originalStoreUrl")
+  public String getOriginalStoreUrl() {
+    return originalStoreUrl;
+  }
+  public void setOriginalStoreUrl(String originalStoreUrl) {
+    this.originalStoreUrl = originalStoreUrl;
+  }
+
+  /**
+   **/
+  public AdvertiseInfoDTO apiOwner(String apiOwner) {
+    this.apiOwner = apiOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "admin", value = "")
+  @JsonProperty("apiOwner")
+  public String getApiOwner() {
+    return apiOwner;
+  }
+  public void setApiOwner(String apiOwner) {
+    this.apiOwner = apiOwner;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AdvertiseInfoDTO advertiseInfo = (AdvertiseInfoDTO) o;
+    return Objects.equals(advertised, advertiseInfo.advertised) &&
+        Objects.equals(originalStoreUrl, advertiseInfo.originalStoreUrl) &&
+        Objects.equals(apiOwner, advertiseInfo.apiOwner);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(advertised, originalStoreUrl, apiOwner);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AdvertiseInfoDTO {\n");
+    
+    sb.append("    advertised: ").append(toIndentedString(advertised)).append("\n");
+    sb.append("    originalStoreUrl: ").append(toIndentedString(originalStoreUrl)).append("\n");
+    sb.append("    apiOwner: ").append(toIndentedString(apiOwner)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -51,6 +51,7 @@ import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APITiersDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIProductURLsDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIURLsDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.AdvertiseInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.LabelDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.PaginationDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.RatingDTO;
@@ -197,6 +198,8 @@ public class APIMappingUtil {
         if (model.getApiSecurity() != null) {
             dto.setSecurityScheme(Arrays.asList(model.getApiSecurity().split(",")));
         }
+
+        dto.setAdvertiseInfo(extractAdvertiseInfo(model));
         return dto;
     }
 
@@ -433,6 +436,7 @@ public class APIMappingUtil {
         //        if (!StringUtils.isBlank(api.getThumbnailUrl())) {
         //            apiInfoDTO.setThumbnailUri(getThumbnailUri(api.getUUID()));
         //        }
+        apiInfoDTO.setAdvertiseInfo(extractAdvertiseInfo(api));
         return apiInfoDTO;
     }
 
@@ -759,4 +763,19 @@ public class APIMappingUtil {
                 .getPaginationDTO(limit, offset, size, paginatedNext, paginatedPrevious);
         apiProductListDTO.setPagination(paginationDTO);
     }
+
+    /**
+     * Maps external store advertise API properties to AdvertiseInfoDTO object.
+     *
+     * @param api API object
+     * @return AdvertiseInfoDTO
+     */
+    public static AdvertiseInfoDTO extractAdvertiseInfo(API api) {
+        AdvertiseInfoDTO advertiseInfoDTO = new AdvertiseInfoDTO();
+        advertiseInfoDTO.setAdvertised(api.isAdvertiseOnly());
+        advertiseInfoDTO.setOriginalStoreUrl(api.getRedirectURL());
+        advertiseInfoDTO.setApiOwner(api.getApiOwner());
+        return advertiseInfoDTO;
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
@@ -4235,6 +4235,9 @@ definitions:
         items:
           type: string
         example: ["Unlimited", "Bronze"]
+      advertiseInfo:
+        description: The advertise info of the API
+        $ref: '#/definitions/AdvertiseInfo'
 
 #-----------------------------------------------------
 # The Standard API resource
@@ -4440,6 +4443,9 @@ definitions:
         type: string
         description: The average rating of the API
         example: 4.5
+      advertiseInfo:
+        description: The advertise info of the API
+        $ref: '#/definitions/AdvertiseInfo'
 #-----------------------------------------------------
 # The API List resource
 #-----------------------------------------------------
@@ -5648,6 +5654,23 @@ definitions:
           $ref: '#/definitions/Tenant'
       pagination:
         $ref: '#/definitions/Pagination'
+
+#-----------------------------------------------------
+# The API Advertise Info resource
+#-----------------------------------------------------
+  AdvertiseInfo :
+    title: API Advertise info object with advertise details
+    properties:
+      advertised:
+        type: boolean
+        example: true
+      originalStoreUrl:
+        type: string
+        example: https://localhost:9443/store
+      apiOwner:
+        type: string
+        example: admin
+
 #-----------------------------------------------------
 # END-OF-FILE
 #-----------------------------------------------------

--- a/docs/apidocs/store/v1/index.html
+++ b/docs/apidocs/store/v1/index.html
@@ -392,6 +392,11 @@
                         </li>
                         <li class="section-box">
                             <ul class="nav nav-stacked">
+                                <li id="def-AdvertiseInfo"><a href="#!/models#AdvertiseInfo">AdvertiseInfo</a></li>
+                            </ul>
+                        </li>
+                        <li class="section-box">
+                            <ul class="nav nav-stacked">
                                 <li id="def-Application"><a href="#!/models#Application">Application</a></li>
                             </ul>
                         </li>

--- a/docs/apidocs/store/v1/models/API.html
+++ b/docs/apidocs/store/v1/models/API.html
@@ -394,6 +394,21 @@
                         <td class="parameter"> <p class="marked">null</p></td>
                         <td class="parameter"> <p class="marked">4.5</p></td>
                     </tr>
+                    <tr>
+                        <td class="parameter">
+                            <p>advertiseInfo</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked">The advertise info of the API</p></td>
+                        <td class="parameter">
+                                <a href="#!/models#AdvertiseInfo">AdvertiseInfo</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked"></p></td>
+                    </tr>
                 </tbody>
             </table>
 </div>

--- a/docs/apidocs/store/v1/models/APIInfo.html
+++ b/docs/apidocs/store/v1/models/APIInfo.html
@@ -184,6 +184,21 @@
                         <td class="parameter"> <p class="marked">null</p></td>
                         <td class="parameter"> <p class="marked">[&quot;Unlimited&quot;,&quot;Bronze&quot;]</p></td>
                     </tr>
+                    <tr>
+                        <td class="parameter">
+                            <p>advertiseInfo</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked">The advertise info of the API</p></td>
+                        <td class="parameter">
+                                <a href="#!/models#AdvertiseInfo">AdvertiseInfo</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked"></p></td>
+                    </tr>
                 </tbody>
             </table>
 </div>

--- a/docs/apidocs/store/v1/models/AdvertiseInfo.html
+++ b/docs/apidocs/store/v1/models/AdvertiseInfo.html
@@ -1,0 +1,69 @@
+<div class="main-content">
+
+        <h2>AdvertiseInfo</h2>
+            <table class="table table-hover">
+                <colgroup>
+                    <col style="width: 10%;"/>
+                    <col style="width: 30%;"/>
+                    <col style="width: 10%;"/>
+                    <col style="width: 20%;"/>
+                    <col style="width: 30%;"/>
+                </colgroup>
+                <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Schema</th>
+                    <th>Default</th>
+                    <th>Example</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="parameter">
+                            <p>advertised</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked"></p></td>
+                        <td class="parameter">
+                                <a href="#!/models#boolean">boolean</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked">true</p></td>
+                    </tr>
+                    <tr>
+                        <td class="parameter">
+                            <p>originalStoreUrl</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked"></p></td>
+                        <td class="parameter">
+                                <a href="#!/models#string">string</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked">https://localhost:9443/store</p></td>
+                    </tr>
+                    <tr>
+                        <td class="parameter">
+                            <p>apiOwner</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked"></p></td>
+                        <td class="parameter">
+                                <a href="#!/models#string">string</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked">admin</p></td>
+                    </tr>
+                </tbody>
+            </table>
+</div>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
@@ -156,8 +156,8 @@ export default function ExternalStores() {
                             <TableRow>
                                 <StyledTableCell />
                                 <StyledTableCell>Name</StyledTableCell>
-                                <StyledTableCell align='right'>Type</StyledTableCell>
-                                <StyledTableCell align='right'>Endpoint</StyledTableCell>
+                                <StyledTableCell>Type</StyledTableCell>
+                                <StyledTableCell>Endpoint</StyledTableCell>
                             </TableRow>
                         </TableHead>
                         <TableBody>
@@ -187,8 +187,8 @@ export default function ExternalStores() {
                                     <StyledTableCell component='th' scope='row'>
                                         {row.displayName}
                                     </StyledTableCell>
-                                    <StyledTableCell align='right'>{row.type}</StyledTableCell>
-                                    <StyledTableCell align='right'>
+                                    <StyledTableCell>{row.type}</StyledTableCell>
+                                    <StyledTableCell>
                                         <a
                                             target='_blank'
                                             rel='noopener noreferrer'

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
@@ -21,7 +21,7 @@ import { APIContext } from 'AppComponents/Apis/Details/components/ApiContext';
 import { useAppContext } from 'AppComponents/Shared/AppContext';
 
 import 'react-tagsinput/react-tagsinput.css';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
@@ -48,7 +48,7 @@ const useStyles = makeStyles(theme => ({
         minWidth: 650,
     },
     viewInExStoreLink: {
-        color: 'black',
+        color: theme.palette.common.black,
         textDecoration: 'underline',
     },
 }));
@@ -74,12 +74,13 @@ export default function ExternalStores() {
     const [publishedExternalStores, setPublishedExternalStores] = useState([]);
     const [isUpdating, setUpdating] = useState(false);
     const classes = useStyles();
+    const intl = useIntl();
     if (!settings.externalStoresEnabled) {
         return (
             <div className='message message-warning'>
                 <h4>
                     <FormattedMessage
-                        id='ExternalStores.Errors.StoresNotFound.header'
+                        id='Apis.Details.ExternalStores.ExternalStores.external.stores.not.found.for.api'
                         defaultMessage='External Stores not found for api: '
                     />
                     <span style={{ color: 'green' }}> {api.id} </span>
@@ -97,11 +98,12 @@ export default function ExternalStores() {
                 setPublishedExternalStores(publishedStoreIds);
             })
             .catch((error) => {
-                if (error.response) {
-                    Alert.error(error.response.body.description);
-                } else {
-                    Alert.error('Something went wrong while getting published external stores');
-                }
+                const response = error.response && error.response.obj;
+                Alert.error(intl.formatMessage({
+                    id: 'Apis.Details.ExternalStores.ExternalStores.error.getting.published.external.stores',
+                    defaultMessage: 'Error while getting published external stores!! '
+                        + (response && ('[' + response.message + '] ' + response.description)),
+                }));
             });
     }
 
@@ -119,15 +121,19 @@ export default function ExternalStores() {
         setUpdating(true);
         API.publishAPIToExternalStores(api.id, publishedExternalStores)
             .then((response) => {
-                Alert.success('Successfully Published to external stores: '
-                    + response.body.list.map(store => store.id));
+                Alert.success(intl.formatMessage({
+                    id: 'Apis.Details.ExternalStores.ExternalStores.successfully.published.to.external.stores',
+                    defaultMessage: 'Successfully Published to external stores: '
+                        + response.body.list.map(store => store.id),
+                }));
             })
             .catch((error) => {
-                if (error.response) {
-                    Alert.error(error.response.body.description);
-                } else {
-                    Alert.error('Something went wrong while updating the external stores');
-                }
+                const response = error.response && error.response.obj;
+                Alert.error(intl.formatMessage({
+                    id: 'Apis.Details.ExternalStores.ExternalStores.error.while.updating.external.stores',
+                    defaultMessage: 'Error while updating external stores!! '
+                        + (response && ('[' + response.message + '] ' + response.description)),
+                }));
             })
             .finally(() => {
                 setUpdating(false);
@@ -140,7 +146,7 @@ export default function ExternalStores() {
             <div>
                 <Typography variant='h4' align='left' >
                     <FormattedMessage
-                        id='Apis.Details.Environments.Environments.External-Stores'
+                        id='Apis.Details.ExternalStores.ExternalStores.external-stores'
                         defaultMessage='External Stores'
                     />
                 </Typography>
@@ -213,7 +219,7 @@ export default function ExternalStores() {
                                 onClick={updateStores}
                             >
                                 <FormattedMessage
-                                    id='Apis.Details.Environments.ExternalStores.save'
+                                    id='Apis.Details.ExternalStores.ExternalStores.save'
                                     defaultMessage='Save'
                                 />
                                 {isUpdating && <CircularProgress size={20} />}
@@ -223,7 +229,7 @@ export default function ExternalStores() {
                             <Link to={'/apis/' + api.id + '/overview'}>
                                 <Button>
                                     <FormattedMessage
-                                        id='Apis.Details.Environments.ExternalStores.cancel'
+                                        id='Apis.Details.ExternalStores.ExternalStores.cancel'
                                         defaultMessage='Cancel'
                                     />
                                 </Button>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
@@ -99,11 +99,11 @@ export default function ExternalStores() {
             })
             .catch((error) => {
                 const response = error.response && error.response.obj;
+                const reason = response && ('[' + response.message + '] ' + response.description);
                 Alert.error(intl.formatMessage({
                     id: 'Apis.Details.ExternalStores.ExternalStores.error.getting.published.external.stores',
-                    defaultMessage: 'Error while getting published external stores!! '
-                        + (response && ('[' + response.message + '] ' + response.description)),
-                }));
+                    defaultMessage: 'Error while getting published external stores!! {reason}',
+                }, { reason }));
             });
     }
 
@@ -121,19 +121,19 @@ export default function ExternalStores() {
         setUpdating(true);
         API.publishAPIToExternalStores(api.id, publishedExternalStores)
             .then((response) => {
+                const successfulStores = response.body.list.map(store => store.id);
                 Alert.success(intl.formatMessage({
                     id: 'Apis.Details.ExternalStores.ExternalStores.successfully.published.to.external.stores',
-                    defaultMessage: 'Successfully Published to external stores: '
-                        + response.body.list.map(store => store.id),
-                }));
+                    defaultMessage: 'Successfully Published to external stores: ',
+                }, { successfulStores }));
             })
             .catch((error) => {
                 const response = error.response && error.response.obj;
+                const reason = response && ('[' + response.message + '] ' + response.description);
                 Alert.error(intl.formatMessage({
                     id: 'Apis.Details.ExternalStores.ExternalStores.error.while.updating.external.stores',
-                    defaultMessage: 'Error while updating external stores!! '
-                        + (response && ('[' + response.message + '] ' + response.description)),
-                }));
+                    defaultMessage: 'Error while updating external stores!! {reason}',
+                }, { reason }));
             })
             .finally(() => {
                 setUpdating(false);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
@@ -19,6 +19,7 @@
 import React, { useContext, useState, useEffect } from 'react';
 import { APIContext } from 'AppComponents/Apis/Details/components/ApiContext';
 import { useAppContext } from 'AppComponents/Shared/AppContext';
+import { isRestricted } from 'AppData/AuthManager';
 
 import 'react-tagsinput/react-tagsinput.css';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -166,7 +167,8 @@ export default function ExternalStores() {
                                     <StyledTableCell padding='checkbox'>
                                         <Checkbox
                                             checked={publishedExternalStores.includes(row.id)}
-                                            disabled={api.lifeCycleStatus !== 'PUBLISHED'}
+                                            disabled={api.lifeCycleStatus !== 'PUBLISHED'
+                                            || isRestricted(['apim:api_publish'], api)}
                                             onChange={
                                                 (event) => {
                                                     const { checked, name } = event.target;
@@ -215,7 +217,8 @@ export default function ExternalStores() {
                                 type='submit'
                                 variant='contained'
                                 color='primary'
-                                disabled={isUpdating || api.lifeCycleStatus !== 'PUBLISHED'}
+                                disabled={isUpdating || api.lifeCycleStatus !== 'PUBLISHED'
+                                    || isRestricted(['apim:api_publish'], api)}
                                 onClick={updateStores}
                             >
                                 <FormattedMessage

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useContext, useState, useEffect } from 'react';
+import { APIContext } from 'AppComponents/Apis/Details/components/ApiContext';
+
+import 'react-tagsinput/react-tagsinput.css';
+import { FormattedMessage } from 'react-intl';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { Link } from 'react-router-dom';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Checkbox from '@material-ui/core/Checkbox';
+import Alert from 'AppComponents/Shared/Alert';
+import Paper from '@material-ui/core/Paper';
+import API from '../../../../data/api';
+
+const useStyles = makeStyles(theme => ({
+    root: {
+        width: theme.custom.contentAreaWidth,
+        marginTop: theme.spacing(3),
+        overflowX: 'auto',
+    },
+    table: {
+        minWidth: 650,
+    },
+}));
+
+const StyledTableCell = withStyles(theme => ({
+    head: {
+        backgroundColor: theme.palette.background.leftMenu,
+        color: theme.palette.common.white,
+        fontSize: 14,
+    },
+    body: {
+        fontSize: 14,
+    },
+}))(TableCell);
+
+const StyledTableRow = withStyles(theme => ({
+    root: {
+        '&:nth-of-type(odd)': {
+            backgroundColor: theme.palette.background.default,
+        },
+    },
+}))(TableRow);
+
+/**
+ * Renders an External Store list
+ * @class ExternalStores
+ * @extends {React.Component}
+ */
+export default function ExternalStores() {
+    const { api } = useContext(APIContext);
+    const [allExternalStores, setAllExternalStores] = useState([]);
+    const [publishedExternalStores, setPublishedExternalStores] = useState([]);
+    const [isUpdating, setUpdating] = useState(false);
+    const classes = useStyles();
+
+    /**
+     * Gets published external stores
+     */
+    function getPublishedExternalStores() {
+        API.getPublishedExternalStores(api.id)
+            .then((response) => {
+                const publishedStoreIds = response.body.list.map(store => store.id);
+                setPublishedExternalStores(publishedStoreIds);
+            })
+            .catch((error) => {
+                if (error.response) {
+                    Alert.error(error.response.body.description);
+                } else {
+                    Alert.error('Something went wrong while getting published external stores');
+                }
+            });
+    }
+
+    useEffect(() => {
+        API.getAllExternalStores().then((response) => {
+            setAllExternalStores([...response.body.list]);
+        });
+        getPublishedExternalStores();
+    }, []);
+
+    /**
+     * Handle publish to external store button action
+     */
+    function updateStores() {
+        setUpdating(true);
+        API.publishAPIToExternalStores(api.id, publishedExternalStores)
+            .then((response) => {
+                Alert.success('Successfully Published to external stores: '
+                    + response.body.list.map(store => store.id));
+            })
+            .catch((error) => {
+                if (error.response) {
+                    Alert.error(error.response.body.description);
+                } else {
+                    Alert.error('Something went wrong while updating the external stores');
+                }
+            })
+            .finally(() => {
+                setUpdating(false);
+                getPublishedExternalStores();
+            });
+    }
+
+    return (
+        <div>
+            {allExternalStores.length > 0 &&
+                <div>
+                    <Typography variant='h4' align='left' >
+                        <FormattedMessage
+                            id='Apis.Details.Environments.Environments.External-Stores'
+                            defaultMessage='External Stores'
+                        />
+                    </Typography>
+                    <Paper className={classes.root}>
+                        <Table className={classes.table}>
+                            <TableHead>
+                                <TableRow>
+                                    <StyledTableCell />
+                                    <StyledTableCell>Name</StyledTableCell>
+                                    <StyledTableCell align='right'>Type</StyledTableCell>
+                                    <StyledTableCell align='right'>Endpoint</StyledTableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                {allExternalStores.map(row => (
+                                    <StyledTableRow key={row.id}>
+                                        <StyledTableCell padding='checkbox'>
+                                            <Checkbox
+                                                checked={publishedExternalStores.includes(row.id)}
+                                                disabled={api.lifeCycleStatus !== 'PUBLISHED'}
+                                                onChange={
+                                                    (event) => {
+                                                        const { checked, name } = event.target;
+                                                        if (checked) {
+                                                            if (!publishedExternalStores.includes(name)) {
+                                                                setPublishedExternalStores([
+                                                                    ...publishedExternalStores, name]);
+                                                            }
+                                                        } else {
+                                                            setPublishedExternalStores(publishedExternalStores
+                                                                .filter(store => store !== name));
+                                                        }
+                                                    }
+                                                }
+                                                name={row.id}
+                                            />
+                                        </StyledTableCell>
+                                        <StyledTableCell component='th' scope='row'>
+                                            {row.displayName}
+                                        </StyledTableCell>
+                                        <StyledTableCell align='right'>{row.type}</StyledTableCell>
+                                        <StyledTableCell align='right'>
+                                            <a
+                                                target='_blank'
+                                                rel='noopener noreferrer'
+                                                href={row.endpoint}
+                                            >{row.endpoint}
+                                            </a>
+                                        </StyledTableCell>
+                                    </StyledTableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </Paper>
+                    <Grid container>
+                        <Grid
+                            container
+                            direction='row'
+                            alignItems='center'
+                            spacing={4}
+                            style={{ marginTop: 20 }}
+                        >
+                            <Grid item>
+                                <Button
+                                    type='submit'
+                                    variant='contained'
+                                    color='primary'
+                                    disabled={isUpdating || api.lifeCycleStatus !== 'PUBLISHED'}
+                                    onClick={updateStores}
+                                >
+                                    <FormattedMessage
+                                        id='Apis.Details.Environments.ExternalStores.save'
+                                        defaultMessage='Save'
+                                    />
+                                    {isUpdating && <CircularProgress size={20} />}
+                                </Button>
+                            </Grid>
+                            <Grid item>
+                                <Link to={'/apis/' + api.id + '/overview'}>
+                                    <Button>
+                                        <FormattedMessage
+                                            id='Apis.Details.Environments.ExternalStores.cancel'
+                                            defaultMessage='Cancel'
+                                        />
+                                    </Button>
+                                </Link>
+                            </Grid>
+                        </Grid>
+                    </Grid>
+                </div>
+            }
+        </div>
+    );
+}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
@@ -47,6 +47,10 @@ const useStyles = makeStyles(theme => ({
     table: {
         minWidth: 650,
     },
+    viewInExStoreLink: {
+        color: 'black',
+        textDecoration: 'underline',
+    },
 }));
 
 const StyledTableCell = withStyles(() => ({
@@ -183,6 +187,7 @@ export default function ExternalStores() {
                                             target='_blank'
                                             rel='noopener noreferrer'
                                             href={row.endpoint}
+                                            className={classes.viewInExStoreLink}
                                         >{row.endpoint}
                                         </a>
                                     </StyledTableCell>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/index.jsx
@@ -625,7 +625,7 @@ class Details extends Component {
                                 />
                                 <Route
                                     path={Details.subPaths.EXTERNAL_STORES}
-                                    component={() => <ExternalStores api={api} />}
+                                    component={ExternalStores}
                                 />
                                 <Route
                                     path={Details.subPaths.MEDIATION_POLICIES}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/index.jsx
@@ -31,6 +31,7 @@ import ConfigurationIcon from '@material-ui/icons/Build';
 import PropertiesIcon from '@material-ui/icons/List';
 import SubscriptionsIcon from '@material-ui/icons/RssFeed';
 import MonetizationIcon from '@material-ui/icons/LocalAtm';
+import StoreIcon from '@material-ui/icons/Store';
 import { withStyles } from '@material-ui/core/styles';
 import { injectIntl, defineMessages } from 'react-intl';
 import { Redirect, Route, Switch, Link, matchPath } from 'react-router-dom';
@@ -45,6 +46,7 @@ import APIProduct from 'AppData/APIProduct';
 import { Progress } from 'AppComponents/Shared';
 import Alert from 'AppComponents/Shared/Alert';
 import { doRedirectToLogin } from 'AppComponents/Shared/RedirectToLogin';
+import AppContext from 'AppComponents/Shared/AppContext';
 import Overview from './NewOverview/Overview';
 import Configuration from './Configuration/Configuration';
 import LifeCycle from './LifeCycle/LifeCycle';
@@ -65,6 +67,7 @@ import MediationPoliciesOverview from './MediationPolicies/Overview';
 import BusinessInformation from './BusinessInformation/BusinessInformation';
 import Properties from './Properties/Properties';
 import Monetization from './Monetization';
+import ExternalStores from './ExternalStores/ExternalStores';
 import { APIProvider } from './components/ApiContext';
 import CreateNewVersion from './NewVersion/NewVersion';
 
@@ -366,6 +369,8 @@ class Details extends Component {
             location: { pathname }, // nested destructuring
         } = this.props;
 
+        const settingsContext = this.context.settings;
+
         // pageLocation renaming is to prevent es-lint errors saying can't use global name location
         if (!Details.isValidURL(pathname)) {
             return <PageNotFound location={pageLocation} />;
@@ -522,6 +527,16 @@ class Details extends Component {
                                 to={pathPrefix + 'monetization'}
                                 Icon={<MonetizationIcon />}
                             />)}
+                        {settingsContext.externalStoresEnabled &&
+                            <LeftMenuItem
+                                text={intl.formatMessage({
+                                    id: 'Apis.Details.index.external-stores',
+                                    defaultMessage: 'external stores',
+                                })}
+                                to={pathPrefix + 'external-stores'}
+                                Icon={<StoreIcon />}
+                            />
+                        }
                     </div>
                     <div className={classes.content}>
                         <APIDetailsTopMenu api={api} isAPIProduct={isAPIProduct} />
@@ -609,6 +624,10 @@ class Details extends Component {
                                     component={() => <Monetization api={api} />}
                                 />
                                 <Route
+                                    path={Details.subPaths.EXTERNAL_STORES}
+                                    component={() => <ExternalStores api={api} />}
+                                />
+                                <Route
                                     path={Details.subPaths.MEDIATION_POLICIES}
                                     component={() => <MediationPoliciesOverview api={api} />}
                                 />
@@ -621,6 +640,7 @@ class Details extends Component {
     }
 }
 
+Details.contextType = AppContext;
 // Add your path here and refer it in above <Route/> component,
 // Paths that are not defined here will be returned with Not Found error
 // key name doesn't matter here, Use an appropriate name as the key
@@ -655,6 +675,7 @@ Details.subPaths = {
     NEW_VERSION: '/apis/:api_uuid/new_version',
     MONETIZATION: '/apis/:api_uuid/monetization',
     MEDIATION_POLICIES: '/apis/:api_uuid/Mediation Policies',
+    EXTERNAL_STORES: '/apis/:api_uuid/external-stores',
 };
 
 // To make sure that paths will not change by outsiders, Basically an enum

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/data/api.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/data/api.js
@@ -1798,7 +1798,7 @@ class API extends Resource {
     /**
      * Update the available mediation policies by the mediation policy uuid and api.
      * @param {String} seqId mediation policy uuid
-     * @param {String} apiId uuid 
+     * @param {String} apiId uuid
      * @returns {Promise}
      *
      */
@@ -1866,6 +1866,55 @@ class API extends Resource {
                 mediationPolicyId: mediationPolicyId,
             },
                 this._requestMetaData(),
+            );
+        });
+    }
+
+    /**
+     * @static
+     * Get all the external stores configured for the current environment
+     * @returns {Promise}
+     */
+    static getAllExternalStores() {
+        const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment()).client;
+        return apiClient.then(client => {
+            return client.apis['External Stores'].getAllExternalStores(
+                this._requestMetaData(),
+            );
+        });
+    }
+
+    /**
+     * @static
+     * Get published external stores for the given API
+     * @param {String} apiId uuid
+     * @returns {Promise}
+     */
+    static getPublishedExternalStores(apiId) {
+        const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment()).client;
+        return apiClient.then(client => {
+            return client.apis['External Stores'].getAllPublishedExternalStoresByAPI(
+                { apiId: apiId },
+                this._requestMetaData,
+            );
+        });
+    }
+
+    /**
+     * @static
+     * Publish the given API to given set of external stores and remove from others which are not specified
+     * @param {String} apiId uuid
+     * @param {Array} externalStoreIds 
+     */
+    static publishAPIToExternalStores(apiId, externalStoreIds) {
+        const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment()).client;
+        return apiClient.then(client => {
+            return client.apis['External Stores'].publishAPIToExternalStores(
+                {
+                    apiId: apiId,
+                    externalStoreIds: externalStoreIds
+                }
+                , this._requestMetaData,
             );
         });
     }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/InfoBar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/InfoBar.jsx
@@ -28,6 +28,7 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import Grade from '@material-ui/icons/Grade';
+import LaunchIcon from '@material-ui/icons/Launch';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import API from 'AppData/api';
 import StarRatingBar from 'AppComponents/Apis/Listing/StarRatingBar';
@@ -240,6 +241,16 @@ const styles = theme => ({
     contentToTop: {
         verticlaAlign: 'top',
     },
+    viewInPubStoreLauncher: {
+        display: 'flex',
+        flexDirection: 'column',
+        color: theme.palette.getContrastText(theme.palette.background.paper),
+        textAlign: 'center',
+        textDecoration: 'none',
+    },
+    linkText: {
+        fontSize: theme.typography.fontSize,
+    },
 });
 
 /**
@@ -343,6 +354,23 @@ class InfoBar extends React.Component {
                             </div>
                             <VerticalDivider height={70} />
                             {user && <StarRatingBar apiId={api.id} isEditable={false} showSummary />}
+                            {api.advertiseInfo.advertised && (
+                                <React.Fragment>
+                                    {user && <VerticalDivider height={70} />}
+                                    <a
+                                        target='_blank'
+                                        rel='noopener noreferrer'
+                                        href={api.advertiseInfo.originalStoreUrl}
+                                        className={classes.viewInPubStoreLauncher}
+                                    >
+                                        <div>
+                                            <LaunchIcon />
+                                        </div>
+                                        <div className={classes.linkText}>Visit Publisher Store</div>
+                                    </a>
+                                    <VerticalDivider height={70} />
+                                </React.Fragment>
+                            )}
                         </div>
 
                         {showOverview && (
@@ -424,7 +452,11 @@ class InfoBar extends React.Component {
                                                             </div>
                                                         </TableCell>
                                                         <TableCell>
-                                                            <StarRatingBar apiId={api.id} isEditable showSummary={false} />
+                                                            <StarRatingBar
+                                                                apiId={api.id}
+                                                                isEditable={!api.advertiseInfo.advertised}
+                                                                showSummary={false}
+                                                            />
                                                         </TableCell>
                                                     </TableRow>
                                                 )}
@@ -457,22 +489,45 @@ class InfoBar extends React.Component {
                                                         </TableCell>
                                                     </TableRow>
                                                 )}
-                                                <TableRow>
-                                                    <TableCell component='th' scope='row' className={classes.contentToTop}>
-                                                        <div className={classes.iconAligner}>
-                                                            <Icon className={classes.iconEven}>desktop_windows</Icon>
-                                                            <span className={classes.iconTextWrapper}>
-                                                                <FormattedMessage
-                                                                    id='Apis.Details.InfoBar.available.environments'
-                                                                    defaultMessage='Available Environments'
-                                                                />
-                                                            </span>
-                                                        </div>
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <Environments />
-                                                    </TableCell>
-                                                </TableRow>
+                                                {!api.advertiseInfo.advertised ? (
+                                                    <TableRow>
+                                                        <TableCell
+                                                            component='th'
+                                                            scope='row'
+                                                            className={classes.contentToTop}
+                                                        >
+                                                            <div className={classes.iconAligner}>
+                                                                <Icon className={classes.iconEven}>
+                                                                    desktop_windows
+                                                                </Icon>
+                                                                <span className={classes.iconTextWrapper}>
+                                                                    <FormattedMessage
+                                                                        id='Apis.Details.InfoBar.available.environments'
+                                                                        defaultMessage='Available Environments'
+                                                                    />
+                                                                </span>
+                                                            </div>
+                                                        </TableCell>
+                                                        <TableCell>
+                                                            <Environments />
+                                                        </TableCell>
+                                                    </TableRow>
+                                                ) : (
+                                                    <TableRow>
+                                                        <TableCell component='th' scope='row'>
+                                                            <div className={classes.iconAligner}>
+                                                                <Icon className={classes.iconOdd}>account_circle</Icon>
+                                                                <span className={classes.iconTextWrapper}>
+                                                                    <FormattedMessage
+                                                                        id='Apis.Details.InfoBar.owner'
+                                                                        defaultMessage='Owner'
+                                                                    />
+                                                                </span>
+                                                            </div>
+                                                        </TableCell>
+                                                        <TableCell>{api.advertiseInfo.apiOwner}</TableCell>
+                                                    </TableRow>
+                                                )}
                                             </TableBody>
                                         </Table>
                                     </div>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/InfoBar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/InfoBar.jsx
@@ -353,10 +353,10 @@ class InfoBar extends React.Component {
                                 </Typography>
                             </div>
                             <VerticalDivider height={70} />
-                            {user && <StarRatingBar apiId={api.id} isEditable={false} showSummary />}
+                            {(!api.advertiseInfo.advertised && user)
+                                && <StarRatingBar apiId={api.id} isEditable={false} showSummary />}
                             {api.advertiseInfo.advertised && (
                                 <React.Fragment>
-                                    {user && <VerticalDivider height={70} />}
                                     <a
                                         target='_blank'
                                         rel='noopener noreferrer'
@@ -438,7 +438,7 @@ class InfoBar extends React.Component {
                                                     </TableCell>
                                                     <TableCell>21 May 2018</TableCell>
                                                 </TableRow> */}
-                                                {user && (
+                                                {(user && !api.advertiseInfo.advertised) && (
                                                     <TableRow>
                                                         <TableCell component='th' scope='row'>
                                                             <div className={classes.iconAligner}>
@@ -454,7 +454,7 @@ class InfoBar extends React.Component {
                                                         <TableCell>
                                                             <StarRatingBar
                                                                 apiId={api.id}
-                                                                isEditable={!api.advertiseInfo.advertised}
+                                                                isEditable
                                                                 showSummary={false}
                                                             />
                                                         </TableCell>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Overview.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/Overview.jsx
@@ -112,14 +112,12 @@ const ExpansionPanelSummary = withStyles({
 
 ExpansionPanelSummary.muiName = 'ExpansionPanelSummary';
 
+/**
+ * Handles the Overview page for APIs and API Products.
+ * @param {*} props properties passed by parent element
+ * @memberof Overview
+ */
 function Overview(props) {
-    /**
-     *
-     *
-     * @returns
-     * @memberof Overview
-     */
-
     const { classes, theme } = props;
     const [totalComments, setCount] = useState(0);
     const getResourcesForAPIs = (apiType, api) => {
@@ -143,98 +141,101 @@ function Overview(props) {
         <ApiContext.Consumer>
             {({ api, applicationsAvailable, subscribedApplications }) => (
                 <Grid container className={classes.root} spacing={16}>
-                    <Grid item xs={12} lg={6}>
-                        <ExpansionPanel defaultExpanded>
-                            <ExpansionPanelSummary>
-                                <CustomIcon
-                                    strokeColor={theme.palette.secondary.main}
-                                    className={classes.iconClass}
-                                    width={24}
-                                    height={24}
-                                    icon='credentials'
-                                />
-
-                                <Typography className={classes.heading} variant='h6'>
-                                    <FormattedMessage
-                                        id='Apis.Details.Overview.api.credentials'
-                                        defaultMessage='API Credentials'
-                                    />
-                                </Typography>
-                            </ExpansionPanelSummary>
-                            <ExpansionPanelDetails>
-                                <Grid container className={classes.root} spacing={16}>
-                                    <Grid item xs={12}>
-                                        <div className={classes.subscriptionTop}>
-                                            <div className={classes.boxBadge}>{subscribedApplications.length}</div>
-                                            <Link
-                                                to={'/apis/' + api.id + '/credentials'}
-                                                className={classes.linkStyle}
-                                            >
-                                                <FormattedMessage
-                                                    id='Apis.Details.Overview.subscriptions'
-                                                    defaultMessage='Subscriptions'
-                                                />
-                                            </Link>
-                                        </div>
-                                    </Grid>
-                                    <Grid item xs={12}>
-                                        <Typography variant='subtitle2'>
+                    {!api.advertiseInfo.advertised
+                        && (
+                            <Grid item xs={12} lg={6}>
+                                <ExpansionPanel defaultExpanded>
+                                    <ExpansionPanelSummary>
+                                        <CustomIcon
+                                            strokeColor={theme.palette.secondary.main}
+                                            className={classes.iconClass}
+                                            width={24}
+                                            height={24}
+                                            icon='credentials'
+                                        />
+                                        <Typography className={classes.heading} variant='h6'>
                                             <FormattedMessage
-                                                id='Apis.Details.Overview.subscribe.to.application'
-                                                defaultMessage='Subscribe to an Application'
+                                                id='Apis.Details.Overview.api.credentials'
+                                                defaultMessage='API Credentials'
                                             />
                                         </Typography>
-                                        <div className={classes.subscriptionBox}>
-                                            {applicationsAvailable.length > 0 && (
-                                                <React.Fragment>
+                                    </ExpansionPanelSummary>
+                                    <ExpansionPanelDetails>
+                                        <Grid container className={classes.root} spacing={16}>
+                                            <Grid item xs={12}>
+                                                <div className={classes.subscriptionTop}>
+                                                    <div className={classes.boxBadge}>
+                                                        {subscribedApplications.length}
+                                                    </div>
                                                     <Link
                                                         to={'/apis/' + api.id + '/credentials'}
                                                         className={classes.linkStyle}
                                                     >
                                                         <FormattedMessage
-                                                            id='Apis.Details.Overview.with.an.existing'
-                                                            defaultMessage='With an Existing Application'
+                                                            id='Apis.Details.Overview.subscriptions'
+                                                            defaultMessage='Subscriptions'
                                                         />
                                                     </Link>
-                                                    <Typography variant='caption'>
-                                                        {applicationsAvailable.length}
-                                                        {' '}
+                                                </div>
+                                            </Grid>
+                                            <Grid item xs={12}>
+                                                <Typography variant='subtitle2'>
+                                                    <FormattedMessage
+                                                        id='Apis.Details.Overview.subscribe.to.application'
+                                                        defaultMessage='Subscribe to an Application'
+                                                    />
+                                                </Typography>
+                                                <div className={classes.subscriptionBox}>
+                                                    {applicationsAvailable.length > 0 && (
+                                                        <React.Fragment>
+                                                            <Link
+                                                                to={'/apis/' + api.id + '/credentials'}
+                                                                className={classes.linkStyle}
+                                                            >
+                                                                <FormattedMessage
+                                                                    id='Apis.Details.Overview.with.an.existing'
+                                                                    defaultMessage='With an Existing Application'
+                                                                />
+                                                            </Link>
+                                                            <Typography variant='caption'>
+                                                                {applicationsAvailable.length}
+                                                                {' '}
+                                                                <FormattedMessage
+                                                                    id='Apis.Details.Overview.subscribe.to.an.application'
+                                                                    defaultMessage='Applications Available'
+                                                                />
+                                                            </Typography>
+                                                        </React.Fragment>
+                                                    )}
+                                                    <Link
+                                                        to={{
+                                                            pathname: '/apis/' + api.id + '/credentials',
+                                                            state: {
+                                                                openWizard: true,
+                                                            },
+                                                        }}
+                                                        className={classes.linkStyle}
+                                                    >
                                                         <FormattedMessage
-                                                            id='Apis.Details.Overview.subscribe.to.an.application'
-                                                            defaultMessage='Applications Available'
+                                                            id='Apis.Details.Overview.with.a.new.application'
+                                                            defaultMessage='With a New Application'
                                                         />
-                                                    </Typography>
-                                                </React.Fragment>
-                                            )}
-
-                                            <Link
-                                                to={{
-                                                    pathname: '/apis/' + api.id + '/credentials',
-                                                    state: {
-                                                        openWizard: true,
-                                                    },
-                                                }}
-                                                className={classes.linkStyle}
-                                            >
-                                                <FormattedMessage
-                                                    id='Apis.Details.Overview.with.a.new.application'
-                                                    defaultMessage='With a New Application'
-                                                />
-                                            </Link>
-                                        </div>
-                                    </Grid>
-                                    <Grid item xs={12}>
-                                        <Typography>
-                                            <FormattedMessage
-                                                id='Apis.Details.Overview.with.a.new.application.help'
-                                                defaultMessage='API Credentials are grouped in to applications. An application is primarily used to decouple the consumer from the APIs. It allows you to Generate and use a single key for multiple APIs and subscribe multiple times to a single API with different SLA levels.'
-                                            />
-                                        </Typography>
-                                    </Grid>
-                                </Grid>
-                            </ExpansionPanelDetails>
-                        </ExpansionPanel>
-                    </Grid>
+                                                    </Link>
+                                                </div>
+                                            </Grid>
+                                            <Grid item xs={12}>
+                                                <Typography>
+                                                    <FormattedMessage
+                                                        id='Apis.Details.Overview.with.a.new.application.help'
+                                                        defaultMessage='API Credentials are grouped in to applications. An application is primarily used to decouple the consumer from the APIs. It allows you to Generate and use a single key for multiple APIs and subscribe multiple times to a single API with different SLA levels.'
+                                                    />
+                                                </Typography>
+                                            </Grid>
+                                        </Grid>
+                                    </ExpansionPanelDetails>
+                                </ExpansionPanel>
+                            </Grid>
+                        )}
                     <Grid item xs={12} lg={6}>
                         <ExpansionPanel defaultExpanded>
                             <ExpansionPanelSummary>
@@ -251,99 +252,111 @@ function Overview(props) {
                             <ExpansionPanelDetails className={classes.resourceWrapper}>
                                 {getResourcesForAPIs(api.type, api)}
                             </ExpansionPanelDetails>
-                            <Divider />
-                            <ExpansionPanelActions className={classes.actionPanel}>
-                                <Link to={'/apis/' + api.id + '/test'} className={classes.linkToTest}>
-                                    <Button size='small' color='primary'>
-                                        <FormattedMessage
-                                            id='Apis.Details.Overview.resources.show.more'
-                                            defaultMessage='Test >>'
-                                        />
-                                    </Button>
-                                </Link>
-                            </ExpansionPanelActions>
+                            {!api.advertiseInfo.advertised
+                                && (
+                                    <React.Fragment>
+                                        <Divider />
+                                        <ExpansionPanelActions className={classes.actionPanel}>
+                                            <Link to={'/apis/' + api.id + '/test'} className={classes.linkToTest}>
+                                                <Button size='small' color='primary'>
+                                                    <FormattedMessage
+                                                        id='Apis.Details.Overview.resources.show.more'
+                                                        defaultMessage='Test >>'
+                                                    />
+                                                </Button>
+                                            </Link>
+                                        </ExpansionPanelActions>
+                                    </React.Fragment>
+                                )}
                         </ExpansionPanel>
                     </Grid>
-                    <Grid item xs={12} lg={6}>
-                        <ExpansionPanel defaultExpanded>
-                            <ExpansionPanelSummary>
-                                <CustomIcon
-                                    strokeColor={theme.palette.secondary.main}
-                                    className={classes.iconClass}
-                                    width={24}
-                                    height={24}
-                                    icon='comments'
-                                />
-                                <Typography className={classes.heading} variant='h6'>
-                                    <FormattedMessage
-                                        id='Apis.Details.Overview.comments.title'
-                                        defaultMessage='Comments'
-                                    />
-                                </Typography>
-                                <Typography className={classes.subheading}>
-                                    {" " + (totalComments > 3 ? 3 : totalComments) + ' of ' + totalComments}
-                                </Typography>
-                            </ExpansionPanelSummary>
-                            <ExpansionPanelDetails className={classes.resourceWrapper}>
-                                {api && <Comments apiId={api.id} showLatest isOverview={true} setCount={setCount} />}
-                            </ExpansionPanelDetails>
-                            <Divider />
-                            <ExpansionPanelActions className={classes.actionPanel} >
-                                <Link to={'/apis/' + api.id + '/comments'} className={classes.button}>
-                                    <Button size='small' color='primary'>
-                                        <FormattedMessage
-                                            id='Apis.Details.Overview.comments.show.more'
-                                            defaultMessage='Show More >>'
-                                        />
-                                    </Button>
-                                </Link>
-                            </ExpansionPanelActions>
-                        </ExpansionPanel>
-                    </Grid>
-                    <Grid item xs={6}>
-                        <ExpansionPanel defaultExpanded>
-                            <ExpansionPanelSummary>
-                                <CustomIcon
-                                    strokeColor={theme.palette.secondary.main}
-                                    className={classes.iconClass}
-                                    width={24}
-                                    height={24}
-                                    icon='sdk'
-                                />
-
-                                <Typography className={classes.heading} variant='h6'>
-                                    <FormattedMessage
-                                        id='Apis.Details.Overview.sdk.generation.title'
-                                        defaultMessage='SDK Generation'
-                                    />
-                                </Typography>
-                            </ExpansionPanelSummary>
-                            <ExpansionPanelDetails className={classes.resourceWrapper}>
-                                <Grid container className={classes.root} spacing={16}>
-                                    {api && <Sdk apiId={api.id} onlyIcons />}
-                                    <Grid item xs={12}>
-                                        <Typography>
-                                            <FormattedMessage
-                                                id='Apis.Details.Overview.sdk.generation.description'
-                                                defaultMessage='If you wants to create a software application to consume the subscribed APIs, you can generate client side SDK for a supported language/framework and use it as a start point to write the software application.'
+                    {!api.advertiseInfo.advertised
+                        && (
+                            <React.Fragment>
+                                <Grid item xs={12} lg={6}>
+                                    <ExpansionPanel defaultExpanded>
+                                        <ExpansionPanelSummary>
+                                            <CustomIcon
+                                                strokeColor={theme.palette.secondary.main}
+                                                className={classes.iconClass}
+                                                width={24}
+                                                height={24}
+                                                icon='comments'
                                             />
-                                        </Typography>
-                                    </Grid>
+                                            <Typography className={classes.heading} variant='h6'>
+                                                <FormattedMessage
+                                                    id='Apis.Details.Overview.comments.title'
+                                                    defaultMessage='Comments'
+                                                />
+                                            </Typography>
+                                            <Typography className={classes.subheading}>
+                                                {' ' + (totalComments > 3 ? 3 : totalComments) + ' of ' + totalComments}
+                                            </Typography>
+                                        </ExpansionPanelSummary>
+                                        <ExpansionPanelDetails className={classes.resourceWrapper}>
+                                            {api
+                                                && <Comments apiId={api.id} showLatest isOverview setCount={setCount} />
+                                            }
+                                        </ExpansionPanelDetails>
+                                        <Divider />
+                                        <ExpansionPanelActions className={classes.actionPanel}>
+                                            <Link to={'/apis/' + api.id + '/comments'} className={classes.button}>
+                                                <Button size='small' color='primary'>
+                                                    <FormattedMessage
+                                                        id='Apis.Details.Overview.comments.show.more'
+                                                        defaultMessage='Show More >>'
+                                                    />
+                                                </Button>
+                                            </Link>
+                                        </ExpansionPanelActions>
+                                    </ExpansionPanel>
                                 </Grid>
-                            </ExpansionPanelDetails>
-                            <Divider />
-                            <ExpansionPanelActions className={classes.actionPanel}>
-                                <Link to={'/apis/' + api.id + '/sdk'} className={classes.linkToTest}>
-                                    <Button size='small' color='primary'>
-                                        <FormattedMessage
-                                            id='Apis.Details.Overview.sdk.generation.show.more'
-                                            defaultMessage='Show More >>'
-                                        />
-                                    </Button>
-                                </Link>
-                            </ExpansionPanelActions>
-                        </ExpansionPanel>
-                    </Grid>
+                                <Grid item xs={6}>
+                                    <ExpansionPanel defaultExpanded>
+                                        <ExpansionPanelSummary>
+                                            <CustomIcon
+                                                strokeColor={theme.palette.secondary.main}
+                                                className={classes.iconClass}
+                                                width={24}
+                                                height={24}
+                                                icon='sdk'
+                                            />
+                                            <Typography className={classes.heading} variant='h6'>
+                                                <FormattedMessage
+                                                    id='Apis.Details.Overview.sdk.generation.title'
+                                                    defaultMessage='SDK Generation'
+                                                />
+                                            </Typography>
+                                        </ExpansionPanelSummary>
+                                        <ExpansionPanelDetails className={classes.resourceWrapper}>
+                                            <Grid container className={classes.root} spacing={16}>
+                                                {api && <Sdk apiId={api.id} onlyIcons />}
+                                                <Grid item xs={12}>
+                                                    <Typography>
+                                                        <FormattedMessage
+                                                            id='Apis.Details.Overview.sdk.generation.description'
+                                                            defaultMessage='If you wants to create a software application to consume the subscribed APIs, you can generate client side SDK for a supported language/framework and use it as a start point to write the software application.'
+                                                        />
+                                                    </Typography>
+                                                </Grid>
+                                            </Grid>
+                                        </ExpansionPanelDetails>
+                                        <Divider />
+                                        <ExpansionPanelActions className={classes.actionPanel}>
+                                            <Link to={'/apis/' + api.id + '/sdk'} className={classes.linkToTest}>
+                                                <Button size='small' color='primary'>
+                                                    <FormattedMessage
+                                                        id='Apis.Details.Overview.sdk.generation.show.more'
+                                                        defaultMessage='Show More >>'
+                                                    />
+                                                </Button>
+                                            </Link>
+                                        </ExpansionPanelActions>
+                                    </ExpansionPanel>
+                                </Grid>
+                            </React.Fragment>
+                        )
+                    }
                     <Grid item xs={12} lg={6}>
                         <ExpansionPanel defaultExpanded>
                             <ExpansionPanelSummary>
@@ -362,7 +375,7 @@ function Overview(props) {
                                     />
                                 </Typography>
                             </ExpansionPanelSummary>
-                            <ExpansionPanelDetails>
+                            <ExpansionPanelDetails className={classes.resourceWrapper}>
                                 <Grid container className={classes.root} spacing={16}>
                                     <OverviewDocuments apiId={api.id} />
                                 </Grid>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Apis/Details/index.jsx
@@ -84,7 +84,7 @@ const LoadableSwitch = withRouter(Loadable.Map({
         ),
     },
     render(loaded, props) {
-        const { apiType, match } = props;
+        const { apiType, match, advertised } = props;
         const ApiConsole = loaded.ApiConsole.default;
         const Overview = loaded.Overview.default;
         const Documentation = loaded.Documentation.default;
@@ -106,11 +106,17 @@ const LoadableSwitch = withRouter(Loadable.Map({
                     render={props => (
                         <Overview {...props} />)}
                 />
-                <Route path='/apis/:apiUuid/credentials' component={Credentials} />
-                <Route path='/apis/:apiUuid/comments' component={Comments} />
-                <Route path='/apis/:apiUuid/test' component={ApiConsole} />
+                {!advertised
+                    && (
+                        <React.Fragment>
+                            <Route path='/apis/:apiUuid/credentials' component={Credentials} />
+                            <Route path='/apis/:apiUuid/comments' component={Comments} />
+                            <Route path='/apis/:apiUuid/test' component={ApiConsole} />
+                            <Route path='/apis/:apiUuid/sdk' component={Sdk} />
+                        </React.Fragment>
+                    )
+                }
                 <Route path='/apis/:apiUuid/docs' component={Documentation} />
-                <Route path='/apis/:apiUuid/sdk' component={Sdk} />
                 <Redirect exact from='/api-products/:apiUuid' to={redirectURL} />
                 <Route
                     path='/api-products/:apiUuid/overview'
@@ -387,16 +393,35 @@ class Details extends React.Component {
                         </div>
                     </Link>
                     <LeftMenuItem text='overview' handleMenuSelect={this.handleMenuSelect} active={active} />
-                    <LeftMenuItem text='credentials' handleMenuSelect={this.handleMenuSelect} active={active} />
-                    {/* TODO: uncomment when the feature is working */}
-                    <LeftMenuItem text='comments' handleMenuSelect={this.handleMenuSelect} active={active} />
-                    <LeftMenuItem text='test' handleMenuSelect={this.handleMenuSelect} active={active} />
+                    {!api.advertiseInfo.advertised
+                        && (
+                            <React.Fragment>
+                                <LeftMenuItem
+                                    text='credentials'
+                                    handleMenuSelect={this.handleMenuSelect}
+                                    active={active}
+                                />
+                                <LeftMenuItem
+                                    text='comments'
+                                    handleMenuSelect={this.handleMenuSelect}
+                                    active={active}
+                                />
+                                <LeftMenuItem
+                                    text='test'
+                                    handleMenuSelect={this.handleMenuSelect}
+                                    active={active}
+                                />
+                            </React.Fragment>
+                        )
+                    }
                     <LeftMenuItem text='docs' handleMenuSelect={this.handleMenuSelect} active={active} />
-                    <LeftMenuItem text='sdk' handleMenuSelect={this.handleMenuSelect} active={active} />
+                    {!api.advertiseInfo.advertised
+                        && <LeftMenuItem text='sdk' handleMenuSelect={this.handleMenuSelect} active={active} />
+                    }
                 </div>
                 <div className={classes.content}>
                     <InfoBar apiId={apiUuid} innerRef={node => (this.infoBar = node)} intl={intl} />
-                    <LoadableSwitch api_uuid={apiUuid} apiType={apiType} />
+                    <LoadableSwitch api_uuid={apiUuid} apiType={apiType} advertised={api.advertiseInfo.advertised} />
                 </div>
                 {theme.custom.showApiHelp && <RightPanel />}
             </ApiContext.Provider>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Applications/Details/Subscriptions.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-new/source/src/app/components/Applications/Details/Subscriptions.jsx
@@ -220,7 +220,7 @@ class Subscriptions extends React.Component {
                 const { list } = response.obj;
                 const subscribedIds = this.getIdsOfSubscribedEntities();
                 const unsubscribedAPIList = list
-                    .filter(api => !subscribedIds.includes(api.id))
+                    .filter(api => !subscribedIds.includes(api.id) && !api.advertiseInfo.advertised)
                     .map((filteredApi) => {
                         return {
                             Id: filteredApi.id,


### PR DESCRIPTION
This PR adds Publisher UI for publishing APIs for external stores. The capability of publishing to external stores is given only for  API is "PUBLISHED" state. 

![Screenshot from 2019-09-17 01-55-09](https://user-images.githubusercontent.com/12208083/64990966-86639500-d8ee-11e9-85c4-6eb0257ac48f.png)

This PR updates the Store UI for displaying advertised APIs (published as external store APIs).  Only API Documents and API resource views are available for the advertised APIs. 

![Screenshot from 2019-09-17 01-52-10](https://user-images.githubusercontent.com/12208083/64990958-82377780-d8ee-11e9-85db-b2fbcf4e5330.png)
![Screenshot from 2019-09-17 01-52-55](https://user-images.githubusercontent.com/12208083/64990962-8499d180-d8ee-11e9-8096-2bf5357e75f4.png)
