### PR TITLE
Display subscription availability box only when tenants are there

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Subscriptions/Subscriptions.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Subscriptions/Subscriptions.jsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import withStyles from '@material-ui/core/styles/withStyles';
 import API from 'AppData/api';

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Subscriptions/Subscriptions.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Subscriptions/Subscriptions.jsx
@@ -19,7 +19,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import withStyles from '@material-ui/core/styles/withStyles';
-
+import API from 'AppData/api';
+import CONSTS from 'AppData/Constants';
 import SubscriptionsTable from './SubscriptionsTable';
 import SubscriptionPoliciesManage from './SubscriptionPoliciesManage';
 import SubscriptionAvailability from './SubscriptionAvailability';
@@ -38,12 +39,22 @@ const styles = theme => ({
  */
 function Subscriptions(props) {
     const { api, updateAPI } = props;
+    const restApi = new API();
+    const [tenants, setTenants] = useState([]);
+    useEffect(() => {
+        restApi.getTenantsByState(CONSTS.TENANT_STATE_ACTIVE)
+            .then((result) => {
+                setTenants(result.body.count);
+            });
+    }, []);
 
     return (
         <div>
             <SubscriptionsTable api={api} />
             <SubscriptionPoliciesManage api={api} updateAPI={updateAPI} />
-            <SubscriptionAvailability api={api} updateAPI={updateAPI} />
+            {tenants !== 0 && (
+                <SubscriptionAvailability api={api} updateAPI={updateAPI} />
+            )}
         </div>
     );
 }


### PR DESCRIPTION
This PR displays subscription availability box only when tenants are available. If tenants are not available the subscription availability box will not be displayed.

<img width="1463" alt="Screen Shot 2019-09-12 at 4 24 45 PM" src="https://user-images.githubusercontent.com/19324135/65033464-ae8cdb80-d962-11e9-932c-af8100eeb506.png">
