### PR TITLE
Displaying multiple access urls separated by commas

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -203,7 +203,7 @@ export default function Environments() {
                                         {row.name}
                                     </TableCell>
                                     <TableCell align='left'>{row.description}</TableCell>
-                                    <TableCell align='left'>{row.access_urls}</TableCell>
+                                    <TableCell align='left'>{row.access_urls.join(', ')}</TableCell>
                                 </TableRow>
                             ))}
                         </TableBody>


### PR DESCRIPTION
Displaying multiple access urls for microgateway labels separated by commas
<img width="1356" alt="Screen Shot 2019-09-19 at 10 17 14 AM" src="https://user-images.githubusercontent.com/19324135/65214363-58857880-dac7-11e9-9bf1-6407c9d2f05e.png">
