### PR TITLE
Add Permission validation on the Publisher UI

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -42,7 +42,7 @@
       },
       {
         "Name": "apim:subscription_view",
-        "Roles": "admin,Internal/creator"
+        "Roles": "admin,Internal/creator,Internal/publisher"
       },
       {
         "Name": "apim:subscription_block",
@@ -50,11 +50,11 @@
       },
       {
         "Name": "apim:mediation_policy_view",
-        "Roles": "admin"
+        "Roles": "admin,Internal/creator"
       },
       {
         "Name": "apim:mediation_policy_create",
-        "Roles": "admin"
+        "Roles": "admin,Internal/creator"
       },
       {
         "Name": "apim:api_workflow",

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json
@@ -42,7 +42,7 @@
       },
       {
         "Name": "apim:subscription_view",
-        "Roles": "admin,Internal/creator"
+        "Roles": "admin,Internal/creator,Internal/publisher"
       },
       {
         "Name": "apim:subscription_block",
@@ -50,11 +50,11 @@
       },
       {
         "Name": "apim:mediation_policy_view",
-        "Roles": "admin"
+        "Roles": "admin,Internal/creator"
       },
       {
         "Name": "apim:mediation_policy_create",
-        "Roles": "admin"
+        "Roles": "admin,Internal/creator"
       },
       {
         "Name": "apim:api_workflow",

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/tenant/tenant-conf.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/tenant/tenant-conf.json
@@ -42,7 +42,7 @@
       },
       {
         "Name": "apim:subscription_view",
-        "Roles": "admin,Internal/creator"
+        "Roles": "admin,Internal/creator,Internal/publisher"
       },
       {
         "Name": "apim:subscription_block",
@@ -50,11 +50,11 @@
       },
       {
         "Name": "apim:mediation_policy_view",
-        "Roles": "admin"
+        "Roles": "admin,Internal/creator"
       },
       {
         "Name": "apim:mediation_policy_create",
-        "Roles": "admin"
+        "Roles": "admin,Internal/creator"
       },
       {
         "Name": "apim:api_workflow",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
@@ -27,6 +27,7 @@ import {
 } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl } from 'react-intl';
+import { isRestricted } from 'AppData/AuthManager';
 import cloneDeep from 'lodash.clonedeep';
 
 import EndpointListing from './EndpointListing';
@@ -495,12 +496,20 @@ function EndpointOverview(props) {
                                             >
                                                 <FormControlLabel
                                                     value='failover'
-                                                    control={<Radio />}
+                                                    control={
+                                                        <Radio
+                                                            disabled={(isRestricted(['apim:api_create'], api))}
+                                                        />
+                                                    }
                                                     label='Failover'
                                                 />
                                                 <FormControlLabel
                                                     value='load_balance'
-                                                    control={<Radio />}
+                                                    control={
+                                                        <Radio
+                                                            disabled={(isRestricted(['apim:api_create'], api))}
+                                                        />
+                                                    }
                                                     label='Load balance'
                                                 />
                                             </RadioGroup>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/Certificates.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/Certificates.jsx
@@ -17,7 +17,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { isRestricted } from 'AppData/AuthManager';
 import { APIContext } from 'AppComponents/Apis/Details/components/ApiContext';
-import React, { useEffect, useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/Certificates.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/Certificates.jsx
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import React, { useContext, useEffect, useState } from 'react';
+import { isRestricted } from 'AppData/AuthManager';
+import { APIContext } from 'AppComponents/Apis/Details/components/ApiContext';
 import React, { useEffect, useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
@@ -93,6 +96,7 @@ function Certificates(props) {
     const [isDeleting, setDeleting] = useState(false);
     const [uploadCertificateOpen, setUploadCertificateOpen] = useState(false);
     const classes = useStyles();
+    const { api } = useContext(APIContext);
 
 
     /**
@@ -202,6 +206,7 @@ function Certificates(props) {
                 <List>
                     <ListItem
                         button
+                        disabled={(isRestricted(['apim:api_create'], api))}
                         className={classes.addCertificateBtn}
                         onClick={() => setUploadCertificateOpen(true)}
                     >

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/GenericEndpoint.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/GenericEndpoint.jsx
@@ -102,6 +102,7 @@ function GenericEndpoint(props) {
                                     className={classes.iconButton}
                                     aria-label='Settings'
                                     onClick={() => setAdvancedConfigOpen(index, type, category)}
+                                    disabled={(isRestricted(['apim:api_create'], api))}
                                 >
                                     <Icon>
                                         settings
@@ -115,6 +116,7 @@ function GenericEndpoint(props) {
                                     aria-label='Delete'
                                     color='secondary'
                                     onClick={() => deleteEndpoint(index, type, category)}
+                                    disabled={(isRestricted(['apim:api_create'], api))}
                                 >
                                     <Icon>
                                         delete

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/Prototype/GenericResource.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Endpoints/Prototype/GenericResource.jsx
@@ -16,7 +16,9 @@
  *  under the License.
  */
 
-import React from 'react';
+import React, { useContext } from 'react';
+import { isRestricted } from 'AppData/AuthManager';
+import { APIContext } from 'AppComponents/Apis/Details/components/ApiContext';
 import {
     Chip,
     ExpansionPanel,
@@ -57,6 +59,7 @@ function GenericResource(props) {
     const {
         resourcePath, resourceMethod, scriptContent, classes, theme, onChange,
     } = props;
+    const { api } = useContext(APIContext);
     let chipColor = theme.custom.resourceChipColors ? theme.custom.resourceChipColors[resourceMethod] : null;
     let chipTextColor = '#000000';
     if (!chipColor) {
@@ -103,7 +106,10 @@ function GenericResource(props) {
                             width='100%'
                             theme='vs-dark'
                             value={scriptContent}
-                            options={{ selectOnLineNumbers: true }}
+                            options={{
+                                selectOnLineNumbers: true,
+                                readOnly: `${(isRestricted(['apim:api_create'], api))}`,
+                            }}
                             language='javascript'
                             onChange={content => onChange(content, resourcePath, resourceMethod)}
                         />

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
@@ -238,6 +238,19 @@ export default function ExternalStores() {
                                 </Button>
                             </Link>
                         </Grid>
+                        {(isRestricted(['apim:api_publish'], api))
+                            && (
+                                <Grid item>
+                                    <Typography variant='body2' color='primary'>
+                                        <FormattedMessage
+                                            id='Apis.Details.ExternalStores.ExternalStores.update.not.allowed'
+                                            defaultMessage={'* You are not authorized to publish the API' +
+                                            ' to external stores due to insufficient permissions'}
+                                        />
+                                    </Typography>
+                                </Grid>
+                            )
+                        }
                     </Grid>
                 </Grid>
             </div>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/LifeCycle/LifeCycle.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/LifeCycle/LifeCycle.jsx
@@ -24,6 +24,8 @@ import Api from 'AppData/api';
 import { Progress } from 'AppComponents/Shared';
 import { withStyles } from '@material-ui/core/styles';
 import { FormattedMessage } from 'react-intl';
+import { isRestricted } from 'AppData/AuthManager';
+import ApiContext from 'AppComponents/Apis/Details/components/ApiContext';
 
 import LifeCycleUpdate from './LifeCycleUpdate';
 import LifeCycleHistory from './LifeCycleHistory';
@@ -157,6 +159,28 @@ class LifeCycle extends Component {
     render() {
         const { classes } = this.props;
         const { api, lcState, privateJetModeEnabled, checkList, lcHistory } = this.state;
+        const apiFromContext = this.context.api;
+        if (apiFromContext && isRestricted(['apim:api_publish'], apiFromContext)) {
+            return (
+                <Grid
+                    container
+                    direction='row'
+                    alignItems='center'
+                    spacing={4}
+                    style={{ marginTop: 20 }}
+                >
+                    <Grid item>
+                        <Typography variant='body2' color='primary'>
+                            <FormattedMessage
+                                id='Apis.Details.LifeCycle.LifeCycle.change.not.allowed'
+                                defaultMessage={'* You are not authorized to change the life cycle state of the API' +
+                                    ' due to insufficient permissions'}
+                            />
+                        </Typography>
+                    </Grid>
+                </Grid>
+            );
+        }
 
         if (!lcState) {
             return <Progress />;
@@ -200,5 +224,7 @@ class LifeCycle extends Component {
 LifeCycle.propTypes = {
     classes: PropTypes.object.isRequired,
 };
+
+LifeCycle.contextType = ApiContext;
 
 export default withStyles(styles)(LifeCycle);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/MediationPolicies/FaultFlow.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/MediationPolicies/FaultFlow.jsx
@@ -19,6 +19,7 @@ import React, { useState, useEffect } from 'react';
 import FormControl from '@material-ui/core/FormControl';
 import { FormattedMessage } from 'react-intl';
 import { withStyles, Switch, FormControlLabel } from '@material-ui/core';
+import { isRestricted } from 'AppData/AuthManager';
 import PropTypes from 'prop-types';
 import API from 'AppData/api.js';
 import Alert from 'AppComponents/Shared/Alert';
@@ -86,7 +87,12 @@ function FaultFlow(props) {
             <FormControlLabel
                 value='start'
                 checked={editable}
-                control={<Switch color='primary' />}
+                control={
+                    <Switch
+                        color='primary'
+                        disabled={isRestricted(['apim:api_create'], api)}
+                    />
+                }
                 label={<FormattedMessage
                     id='Apis.Details.MediationPolicies.MediationPolicies.fault.flow.desc'
                     defaultMessage='Fault Flow'

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/MediationPolicies/InFlow.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/MediationPolicies/InFlow.jsx
@@ -22,6 +22,7 @@ import { withStyles, Switch, FormControlLabel } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import API from 'AppData/api.js';
 import Alert from 'AppComponents/Shared/Alert';
+import { isRestricted } from 'AppData/AuthManager';
 import EngagedInMediationPolicy from './Engaged/EngagedInMediationPolicy';
 import EditInMediationPolicy from './Edit/EditInMediationPolicy';
 
@@ -94,7 +95,11 @@ function InFlow(props) {
             <FormControlLabel
                 value='start'
                 checked={editable}
-                control={<Switch color='primary' />}
+                control={
+                    <Switch
+                        color='primary'
+                        disabled={isRestricted(['apim:api_create'], api)}
+                    />}
                 label={<FormattedMessage
                     id='Apis.Details.MediationPolicies.MediationPolicies.in.flow.desc'
                     defaultMessage='In Flow'

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/MediationPolicies/OutFlow.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/MediationPolicies/OutFlow.jsx
@@ -20,6 +20,7 @@ import React, { useState, useEffect } from 'react';
 import FormControl from '@material-ui/core/FormControl';
 import { FormattedMessage } from 'react-intl';
 import { withStyles, Switch, FormControlLabel } from '@material-ui/core';
+import { isRestricted } from 'AppData/AuthManager';
 import PropTypes from 'prop-types';
 import API from 'AppData/api.js';
 import Alert from 'AppComponents/Shared/Alert';
@@ -85,7 +86,11 @@ function OutFlow(props) {
             <FormControlLabel
                 value='start'
                 checked={editable}
-                control={<Switch color='primary' />}
+                control={
+                    <Switch
+                        color='primary'
+                        disabled={isRestricted(['apim:api_create'], api)}
+                    />}
                 label={<FormattedMessage
                     id='Apis.Details.MediationPolicies.out.flow.desc'
                     defaultMessage='Out Flow'

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/MediationPolicies/Overview.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/MediationPolicies/Overview.jsx
@@ -31,6 +31,7 @@ import { FormattedMessage } from 'react-intl';
 import { withStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import ApiContext from 'AppComponents/Apis/Details/components/ApiContext';
+import { isRestricted } from 'AppData/AuthManager';
 import Alert from 'AppComponents/Shared/Alert';
 import isEmpty from 'lodash/isEmpty';
 import InFlow from './InFlow';
@@ -139,9 +140,10 @@ function Overview(props) {
                         <Grid
                             container
                             direction='row'
-                            alignItems='flex-start'
-                            spacing={16}
+                            alignItems='center'
+                            spacing={4}
                             className={classes.buttonSection}
+                            style={{ marginTop: 20 }}
                         >
                             <Grid item>
                                 <div>
@@ -149,15 +151,22 @@ function Overview(props) {
                                         variant='contained'
                                         color='primary'
                                         onClick={() => saveAPI(updateAPI)}
+                                        disabled={isRestricted(['apim:api_create'], api)}
                                     >
-                                        <FormattedMessage id='save' defaultMessage='Save' />
+                                        <FormattedMessage
+                                            id='Apis.Details.MediationPolicies.Overview.save'
+                                            defaultMessage='Save'
+                                        />
                                     </Button>
                                 </div>
                             </Grid>
                             <Grid item>
                                 <Link to={'/apis/' + api.id + '/overview'}>
                                     <Button>
-                                        <FormattedMessage id='cancel' defaultMessage='Cancel' />
+                                        <FormattedMessage
+                                            id='Apis.Details.MediationPolicies.Overview.cancel'
+                                            defaultMessage='Cancel'
+                                        />
                                     </Button>
                                 </Link>
                             </Grid>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Monetization/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Monetization/index.jsx
@@ -137,7 +137,7 @@ class Monetization extends Component {
                     <Grid item>
                         <Typography variant='body2' color='primary'>
                             <FormattedMessage
-                                id='Apis.Details.Monetization.index.update.not.allowed'
+                                id='Apis.Details.Monetization.Index.update.not.allowed'
                                 defaultMessage={'* You are not authorized to update API monetization'
                                     + ' due to insufficient permissions'}
                             />

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Monetization/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Monetization/index.jsx
@@ -125,6 +125,27 @@ class Monetization extends Component {
     render() {
         const { api, classes } = this.props;
         const { monetizationAttributes, monStatus } = this.state;
+        if (api && isRestricted(['apim:api_publish'], api)) {
+            return (
+                <Grid
+                    container
+                    direction='row'
+                    alignItems='center'
+                    spacing={4}
+                    style={{ marginTop: 20 }}
+                >
+                    <Grid item>
+                        <Typography variant='body2' color='primary'>
+                            <FormattedMessage
+                                id='Apis.Details.Monetization.index.update.not.allowed'
+                                defaultMessage={'* You are not authorized to update API monetization'
+                                    + ' due to insufficient permissions'}
+                            />
+                        </Typography>
+                    </Grid>
+                </Grid>
+            );
+        }
         if (!monetizationAttributes || monStatus === null) {
             return <Progress />;
         }
@@ -137,7 +158,7 @@ class Monetization extends Component {
                     <FormControlLabel
                         control={
                             <Checkbox
-                                disabled={isRestricted(['apim:api_create', 'apim:api_publish'], api)}
+                                disabled={isRestricted(['apim:api_publish'], api)}
                                 id='monStatus'
                                 name='monStatus'
                                 checked={monStatus}
@@ -160,7 +181,7 @@ class Monetization extends Component {
                                     (monetizationAttributes.length > 0) ?
                                         (monetizationAttributes.map((monetizationAttribute, i) => (
                                             <TextField
-                                                disabled={isRestricted(['apim:api_create', 'apim:api_publish'], api)}
+                                                disabled={isRestricted(['apim:api_publish'], api)}
                                                 fullWidth
                                                 id={'attribute' + i}
                                                 label={monetizationAttribute.displayName}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Properties/Properties.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Properties/Properties.jsx
@@ -339,6 +339,7 @@ function Properties(props) {
                                     color='primary'
                                     className={classes.button}
                                     onClick={toggleAddProperty}
+                                    disabled={isRestricted(['apim:api_create', 'apim:api_publish'], api)}
                                 >
                                     <FormattedMessage
                                         id='Apis.Details.Properties.Properties.add.new.property'

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Subscriptions/SubscriptionPoliciesManage.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/Subscriptions/SubscriptionPoliciesManage.jsx
@@ -31,6 +31,7 @@ import Paper from '@material-ui/core/Paper';
 import Alert from 'AppComponents/Shared/Alert';
 import Progress from 'AppComponents/Shared/Progress';
 import API from 'AppData/api';
+import { isRestricted } from 'AppData/AuthManager';
 
 const styles = theme => ({
     subscriptionPoliciesPaper: {
@@ -140,6 +141,7 @@ class SubscriptionPoliciesManage extends Component {
                                     <FormControlLabel
                                         key={value[1].name}
                                         control={<Checkbox
+                                            disabled={isRestricted(['apim:api_publish', 'apim:api_create'], api)}
                                             color='primary'
                                             checked={api.policies.includes(value[1].name)}
                                             onChange={e => this.handleChange(e)}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/index.jsx
@@ -19,6 +19,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
+import { isRestricted } from 'AppData/AuthManager';
 import LifeCycleIcon from '@material-ui/icons/Autorenew';
 import EndpointIcon from '@material-ui/icons/GamesOutlined';
 import PersonPinCircleOutlinedIcon from '@material-ui/icons/PersonPinCircleOutlined';
@@ -469,8 +470,8 @@ class Details extends Component {
                             />
                         )}
                         {this.getLeftMenuItemForAPIType(api.type)}
-                        {!isAPIProduct && (
-                            <LeftMenuItem
+                        {(!isAPIProduct && !isRestricted(['apim:api_publish'], api))
+                            && (<LeftMenuItem
                                 text={intl.formatMessage({
                                     id: 'Apis.Details.index.lifecycle',
                                     defaultMessage: 'lifecycle',

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-new/source/src/app/components/Apis/Details/index.jsx
@@ -528,15 +528,16 @@ class Details extends Component {
                             to={pathPrefix + 'mediation policies'}
                             Icon={<ScopesIcon />}
                         />
-                        {!isAPIProduct && (
-                            <LeftMenuItem
-                                text={intl.formatMessage({
-                                    id: 'Apis.Details.index.monetization',
-                                    defaultMessage: 'monetization',
-                                })}
-                                to={pathPrefix + 'monetization'}
-                                Icon={<MonetizationIcon />}
-                            />)}
+                        {(!isAPIProduct && !isRestricted(['apim:api_publish'], api))
+                            && (
+                                <LeftMenuItem
+                                    text={intl.formatMessage({
+                                        id: 'Apis.Details.index.monetization',
+                                        defaultMessage: 'monetization',
+                                    })}
+                                    to={pathPrefix + 'monetization'}
+                                    Icon={<MonetizationIcon />}
+                                />)}
                         {settingsContext.externalStoresEnabled &&
                             <LeftMenuItem
                                 text={intl.formatMessage({


### PR DESCRIPTION
Restrict publisher UI elements for users with creator permissions and publisher permissions accordingly. [1]

[1] https://github.com/wso2/carbon-apimgt/wiki/Permission-validation-on-the-Publisher-UI-elemets-for-API-update