### PR TITLE
Add fix for wso2/product-apim#5577

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/CORSRequestHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/CORSRequestHandler.java
@@ -51,6 +51,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class CORSRequestHandler extends AbstractHandler implements ManagedLifecycle {
 
@@ -362,6 +364,15 @@ public class CORSRequestHandler extends AbstractHandler implements ManagedLifecy
         } else if (allowedOrigins.contains(origin)) {
             return origin;
         } else {
+            for (String allowedOrigin : allowedOrigins) {
+                if (allowedOrigin.contains("*")) {
+                    Pattern pattern = Pattern.compile(allowedOrigin.replace("*", ".*"));
+                    Matcher matcher = pattern.matcher(origin);
+                    if (matcher.find()) {
+                        return origin;
+                    }
+                }
+            }
             return null;
         }
     }


### PR DESCRIPTION
This PR contains changes to fix the issue reported in https://github.com/wso2/product-apim/issues/5577. As per current implementation, wildcard character - *, is not allowed to have within Access-Control-Allow-Origin. 