### PR TITLE
Fix for product-apim#6040

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Tags.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Tags.jsx
@@ -54,7 +54,10 @@ export default function Tags(props) {
                     />
                 )}
                 onAdd={(tag) => {
-                    configDispatcher({ action: 'tags', value: [...api.tags, tag] });
+                    configDispatcher({
+                        action: 'tags',
+                        value: [...api.tags, tag.length > 30 ? tag.substring(0, 30) : tag],
+                    });
                 }}
                 onDelete={(tag) => {
                     configDispatcher({ action: 'tags', value: api.tags.filter(oldTag => oldTag !== tag) });


### PR DESCRIPTION
Resolves https://github.com/wso2/product-apim/issues/6040

Restricted the maximum characters allowed to 30 as in [1]

[1] https://github.com/wso2/carbon-apimgt/blob/master/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-old/site/themes/wso2/templates/item-design/js/api-design.js#L1484