### PR TITLE
Fixing white space issue when redirected to dev portal

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
@@ -166,8 +166,11 @@ export default function CustomizedSteppers() {
                             <a
                                 target='_blank'
                                 rel='noopener noreferrer'
-                                href={`${window.location.origin}${Configuration.app.storeContext}/apis/
-                                ${api.id}/overview`}
+                                href={
+                                    `${window.location.origin}${Configuration.app.storeContext}/apis/` +
+                                    api.id +
+                                    '/overview'
+                                }
                                 className={classes.viewInStoreLauncher}
                             >
                                 <Typography variant='caption'>


### PR DESCRIPTION
This PR fixes the white space issue in the URL when redirected to dev portal in the overview component.