### PR TITLE
Fix for add and clear button in resources page is too close

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Resources/components/AddOperation.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Resources/components/AddOperation.jsx
@@ -206,7 +206,7 @@ export default function AddOperation(props) {
                     >
                         <Fab
                             disabled={isAdding}
-                            style={{ marginLeft: '20px', marginBottom: '15px' }}
+                            style={{ marginLeft: '20px', marginBottom: '15px', marginRight: '20px' }}
                             size='small'
                             color='primary'
                             aria-label='add'


### PR DESCRIPTION
Fixes [wso2/product-apim#5719](https://github.com/wso2/product-apim/issues/5719)

![image](https://user-images.githubusercontent.com/32578617/66290987-42b4e780-e8fe-11e9-97c3-ae3fc7d40fe1.png)
