### PR TITLE
Fixing issue in Overview page and import schema

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
@@ -213,7 +213,7 @@ class APIDefinition extends React.Component {
      */
     validateAndImportSchema(file) {
         const { api, intl } = this.props;
-        const promisedValidation = api.validateGraphQLFile(file);
+        const promisedValidation = API.validateGraphQLFile(file);
         promisedValidation
             .then((response) => {
                 const { isValid, graphQLInfo } = response.obj;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/Operations.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/Operations.jsx
@@ -20,17 +20,25 @@ import React from 'react';
 import { withStyles, withTheme } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import Chip from '@material-ui/core/Chip';
+import LaunchIcon from '@material-ui/icons/Launch';
+import Box from '@material-ui/core/Box';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import Table from '@material-ui/core/Table';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
-
-import classNames from 'classnames';
-import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
-import Button from '@material-ui/core/Button';
 import ApiContext from '../components/ApiContext';
+
+
+const styles = theme => ({
+    contentWrapper: {
+        marginTop: theme.spacing(2),
+        maxHeight: '250px',
+        overflowY: 'auto',
+    },
+});
+
 
 /**
  *
@@ -38,19 +46,22 @@ import ApiContext from '../components/ApiContext';
  */
 function RenderMethodBase(props) {
     const { theme, method } = props;
+    const methodLower = method.toLowerCase();
     let chipColor = theme.custom.operationChipColor ?
-        theme.custom.operationChipColor[method]
+        theme.custom.operationChipColor[methodLower]
         : null;
     let chipTextColor = '#000000';
     if (!chipColor) {
         console.log('Check the theme settings. The resourceChipColors is not populated properlly');
         chipColor = '#cccccc';
     } else {
-        chipTextColor = theme.palette.getContrastText(theme.custom.operationChipColor[method]);
+        chipTextColor = theme.palette.getContrastText(theme.custom.operationChipColor[methodLower]);
     }
     return (<Chip
-        label={method.toUpperCase()}
-        style={{ backgroundColor: chipColor, color: chipTextColor, height: 20 }}
+        label={method}
+        style={{
+            backgroundColor: chipColor, color: chipTextColor, height: 20, fontSize: 9,
+        }}
     />);
 }
 
@@ -61,29 +72,16 @@ RenderMethodBase.propTypes = {
 };
 
 const RenderMethod = withTheme(RenderMethodBase);
-
-const styles = {
-    root: {
-        display: 'flex',
-        flexDirection: 'row',
-        alignItems: 'center',
-        marginBottom: 10,
-    },
-    heading: {
-        marginRight: 20,
-    },
-};
-
 /**
  *
  * @param {*} props
  */
 function Operations(props) {
-    const { parentClasses } = props;
+    const { classes, parentClasses } = props;
     return (
         <ApiContext.Consumer>
             {({ api }) => (
-                <Paper className={classNames({ [parentClasses.root]: true, [parentClasses.specialGap]: true })}>
+                <React.Fragment>
                     <div className={parentClasses.titleWrapper}>
                         <Typography variant='h5' component='h3' className={parentClasses.title}>
                             <FormattedMessage
@@ -91,34 +89,42 @@ function Operations(props) {
                                 defaultMessage='Operations'
                             />
                         </Typography>
-                        <Link to={'/apis/' + api.id + '/operations'}>
-                            <Button variant='contained' color='default'>
-                                <FormattedMessage
-                                    id='Apis.Details.NewOverview.Operations.edit'
-                                    defaultMessage='Edit'
-                                />
-                            </Button>
-                        </Link>
                     </div>
-                    <div className={parentClasses.contentWrapper}>
+                    <div className={classes.contentWrapper}>
                         <Table>
                             {api.operations
                             && api.operations.length !== 0
                             && api.operations.map(item => (
                                 <TableRow style={{ borderStyle: 'hidden' }}>
-                                    <TableCell>
+                                    <TableCell style={{ padding: 8 }}>
                                         <Typography className={parentClasses.heading} component='p' variant='body1'>
                                             {item.target}
                                         </Typography>
                                     </TableCell>
-                                    <TableCell>
+                                    <TableCell style={{ padding: 8 }}>
                                         <RenderMethod method={item.verb} />
                                     </TableCell>
                                 </TableRow>
                             ))}
                         </Table>
                     </div>
-                </Paper>
+                    <Box py={2} style={{ marginLeft: 400 }}>
+                        <Link to={'/apis/' + api.id + '/operations'}>
+                            <Typography
+                                className={classes.subHeading}
+                                color='primary'
+                                display='inline'
+                                variant='caption'
+                            >
+                                <FormattedMessage
+                                    id='Apis.Details.NewOverview.Operations.ShowMore'
+                                    defaultMessage='Show More'
+                                />
+                                <LaunchIcon style={{ marginLeft: '2px' }} fontSize='small' />
+                            </Typography>
+                        </Link>
+                    </Box>
+                </React.Fragment>
             )}
         </ApiContext.Consumer>
     );
@@ -126,6 +132,7 @@ function Operations(props) {
 
 Operations.propTypes = {
     parentClasses: PropTypes.shape({}).isRequired,
+    classes: PropTypes.shape({}).isRequired,
 };
 
 export default withStyles(styles)(Operations);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/Operations.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/Operations.jsx
@@ -30,7 +30,6 @@ import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
 import ApiContext from '../components/ApiContext';
 
-
 const styles = theme => ({
     contentWrapper: {
         marginTop: theme.spacing(2),
@@ -38,7 +37,6 @@ const styles = theme => ({
         overflowY: 'auto',
     },
 });
-
 
 /**
  *

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/Resources.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/Resources.jsx
@@ -22,6 +22,8 @@ import PropTypes from 'prop-types';
 import Chip from '@material-ui/core/Chip';
 import { FormattedMessage } from 'react-intl';
 import Box from '@material-ui/core/Box';
+import { Link } from 'react-router-dom';
+import LaunchIcon from '@material-ui/icons/Launch';
 
 import Typography from '@material-ui/core/Typography';
 import Api from 'AppData/api';
@@ -65,6 +67,10 @@ const styles = {
     },
     heading: {
         marginRight: 20,
+    },
+    contentWrapper: {
+        maxHeight: '250px',
+        overflowY: 'auto',
     },
 };
 
@@ -156,6 +162,20 @@ class Resources extends React.Component {
                             })}
                         </div>
                     </div>
+                    <Link to={'/apis/' + api.id + '/resources'}>
+                        <Typography
+                            className={classes.subHeading}
+                            color='primary'
+                            display='inline'
+                            variant='caption'
+                        >
+                            <FormattedMessage
+                                id='Apis.Details.NewOverview.Operations.ShowMore'
+                                defaultMessage='Show More'
+                            />
+                            <LaunchIcon style={{ marginLeft: '2px' }} fontSize='small' />
+                        </Typography>
+                    </Link>
                 </Box>
             </React.Fragment>
         );

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Operations/Operation.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Operations/Operation.jsx
@@ -217,9 +217,9 @@ class Operation extends React.Component {
                 </TableCell>
                 <TableCell>
                     <Chip
-                        label={operation.verb.toLowerCase()}
+                        label={operation.verb}
                         style={{
-                            backgroundColor: chipColor, color: chipTextColor, height: 20, width: 40,
+                            backgroundColor: chipColor, color: chipTextColor, height: 20, width: 40, fontSize: 9,
                         }}
                         className={classes.chipActive}
                     />


### PR DESCRIPTION
Fixes: 
When the API contains many resources/operations, they have been displayed in a scrollable div and once click the Show More button, it will be redirected to the corresponding resource/operation pages.

For Graphqls
1. https://github.com/wso2/product-apim/issues/6030
![Screen Shot 2019-10-08 at 1 31 13 PM](https://user-images.githubusercontent.com/29066805/66379781-c391e300-e9d3-11e9-9b9f-f7a74e05a070.jpg)

For Rest APIs
![Screen Shot 2019-10-08 at 1 31 27 PM](https://user-images.githubusercontent.com/29066805/66379785-c5f43d00-e9d3-11e9-8afc-590fef36e163.jpg)

2. https://github.com/wso2/product-apim/issues/5903
  Fix the issue in Graphql Import

