### PR TITLE
Fix the issue in validating API context

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
@@ -84,7 +84,7 @@ const documentSchema = Joi.extend(joi => ({
 const definition = {
     apiName: Joi.string().regex(/^[a-zA-Z0-9]{1,50}$/),
     apiVersion: Joi.string().regex(/^[a-zA-Z0-9.]{1,30}$/),
-    apiContext: Joi.string().regex(/^[a-zA-Z0-9{}/]{1,50}$/),
+    apiContext: Joi.string().regex(/(?!.*\/t\/.*|.*\/t$)^[/a-zA-Z0-9/]{1,50}$/),
     role: roleSchema.systemRole().role(),
     url: Joi.string().uri(),
     userRole: userRoleSchema.userRole().role(),


### PR DESCRIPTION
This PR fixes the issue https://github.com/wso2/product-apim/issues/5848. After this change, "/t" or "/t/" cannot be used in the context