### PR TITLE
Add modified (simplified) error messages for api create form.

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
@@ -118,7 +118,7 @@ const definition = {
         });
         return tmpErrors;
     }),
-    apiContext: Joi.string().regex(/^[a-zA-Z0-9{}/]{1,50}$/).required().error((errors) => {
+    apiContext: Joi.string().regex(/(?!.*\/t\/.*|.*\/t$)^[/a-zA-Z0-9/]{1,50}$/).required().error((errors) => {
         const tmpErrors = [...errors];
         errors.forEach((err, index) => {
             const tmpError = { ...err };

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
@@ -19,6 +19,24 @@
 import Joi from '@hapi/joi';
 import API from 'AppData/api';
 
+/**
+ * Get the base error message for error types.
+ * This error overrides the default error messages of joi and adds simple error messages.
+ *
+ * @param {string} errorType The joi error type
+ * @return {string} simplified error message.
+ * */
+function getMessage(errorType) {
+    switch (errorType) {
+        case 'any.empty':
+            return 'should not be empty';
+        case 'string.regex.base':
+            return 'should not contain spaces or special characters';
+        default:
+            return 'should not be empty';
+    }
+}
+
 /*
 * eslint validation rule for no-unused-vars has been disabled in this component.
 * According to the Joi extension, it is required to provide required four input
@@ -82,9 +100,33 @@ const documentSchema = Joi.extend(joi => ({
 }));
 
 const definition = {
-    apiName: Joi.string().regex(/^[a-zA-Z0-9]{1,50}$/),
-    apiVersion: Joi.string().regex(/^[a-zA-Z0-9.]{1,30}$/),
-    apiContext: Joi.string().regex(/(?!.*\/t\/.*|.*\/t$)^[/a-zA-Z0-9/]{1,50}$/),
+    apiName: Joi.string().regex(/^[a-zA-Z0-9]{1,50}$/).required().error((errors) => {
+        const tmpErrors = [...errors];
+        errors.forEach((err, index) => {
+            const tmpError = { ...err };
+            tmpError.message = 'API Name ' + getMessage(err.type);
+            tmpErrors[index] = tmpError;
+        });
+        return tmpErrors;
+    }),
+    apiVersion: Joi.string().regex(/^[a-zA-Z0-9.]{1,30}$/).required().error((errors) => {
+        const tmpErrors = [...errors];
+        errors.forEach((err, index) => {
+            const tmpError = { ...err };
+            tmpError.message = 'API Version ' + getMessage(err.type);
+            tmpErrors[index] = tmpError;
+        });
+        return tmpErrors;
+    }),
+    apiContext: Joi.string().regex(/^[a-zA-Z0-9{}/]{1,50}$/).required().error((errors) => {
+        const tmpErrors = [...errors];
+        errors.forEach((err, index) => {
+            const tmpError = { ...err };
+            tmpError.message = 'API Context ' + getMessage(err.type);
+            tmpErrors[index] = tmpError;
+        });
+        return tmpErrors;
+    }),
     role: roleSchema.systemRole().role(),
     url: Joi.string().uri(),
     userRole: userRoleSchema.userRole().role(),


### PR DESCRIPTION
Fixes https://github.com/wso2/product-apim/issues/5541 (1 and 2)

![64774176-51171a00-d571-11e9-8d34-cb121386f5f6](https://user-images.githubusercontent.com/10165411/66466777-e3dba380-eaa0-11e9-827b-1ba8e065ff1e.png)

1. The error message should be more user-friendly (without a regex preferably)
2. "value" should be fixed

![Screenshot (14)](https://user-images.githubusercontent.com/10165411/66466904-1eddd700-eaa1-11e9-9f9f-0938333a2445.png)
