### PR TITLE
Update retrieval of URITemplates, scopes and roles from swagger in the local entry

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthCredentialValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthCredentialValidator.java
@@ -36,7 +36,6 @@ import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.caching.CacheProvider;
 import org.wso2.carbon.authenticator.stub.AuthenticationAdminStub;
 import org.wso2.carbon.authenticator.stub.LoginAuthenticationExceptionException;
-import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.um.ws.api.stub.RemoteUserStoreManagerServiceStub;
 import org.wso2.carbon.um.ws.api.stub.RemoteUserStoreManagerServiceUserStoreExceptionException;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -55,7 +54,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 
 /**
  * This class will validate the basic auth credentials.
@@ -188,15 +186,7 @@ public class BasicAuthCredentialValidator {
             String resourceRoles = null;
             String resourceScope = OpenAPIUtils.getScopesOfResource(openAPI, synCtx);
             if (resourceScope != null) {
-                ArrayList<LinkedHashMap> apiScopes = OpenAPIUtils.getScopeToRoleMappingOfApi(openAPI, synCtx);
-                if (apiScopes != null) {
-                    for (LinkedHashMap scope : apiScopes) {
-                        if (resourceScope.equals(scope.get(APIConstants.SWAGGER_SCOPE_KEY))) {
-                            resourceRoles = (String) scope.get(APIConstants.SWAGGER_ROLES);
-                            break;
-                        }
-                    }
-                }
+                resourceRoles = OpenAPIUtils.getRolesOfScope(openAPI, synCtx, resourceScope);
             }
 
             if (StringUtils.isNotBlank(resourceRoles)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidatorTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidatorTestCase.java
@@ -416,7 +416,8 @@ public class APIKeyValidatorTestCase {
         Mockito.when(APIUtil.getAPIInfoDTOCacheKey("", "1.0")).thenReturn("abc");
         Mockito.when((VerbInfoDTO) CacheProvider.getResourceCache().get("abc"))
                 .thenReturn(verbInfoDTO1);
-        VerbInfoDTO verbInfoDTOFromAPIData = apiKeyValidator.getVerbInfoDTOFromAPIData(context, apiVersion,
+        MessageContext messageContext = Mockito.mock(MessageContext.class);
+        VerbInfoDTO verbInfoDTOFromAPIData = apiKeyValidator.getVerbInfoDTOFromAPIData(messageContext, context, apiVersion,
                 requestPath, httpMethod);
         Assert.assertEquals("", verbDTO, verbInfoDTOFromAPIData);
 
@@ -460,8 +461,10 @@ public class APIKeyValidatorTestCase {
         Mockito.when(APIUtil.getAPIInfoDTOCacheKey("", "1.0")).thenReturn("abc");
         Mockito.when((VerbInfoDTO) CacheProvider.getResourceCache().get("abc"))
                 .thenReturn(verbInfoDTO1);
+        MessageContext messageContext = Mockito.mock(MessageContext.class);
+
         Assert.assertEquals("", verbDTO,
-                apiKeyValidator.getVerbInfoDTOFromAPIData(context, apiVersion, requestPath, httpMethod));
+                apiKeyValidator.getVerbInfoDTOFromAPIData(messageContext, context, apiVersion, requestPath, httpMethod));
 
     }
 
@@ -495,8 +498,9 @@ public class APIKeyValidatorTestCase {
         PowerMockito.when(cacheProvider.getDefaultCacheTimeout()).thenReturn((long) 900);
 
         Mockito.when(CacheProvider.getResourceCache()).thenReturn(cache);
+        MessageContext messageContext = Mockito.mock(MessageContext.class);
         Assert.assertEquals("", null,
-                apiKeyValidator.getVerbInfoDTOFromAPIData(context, apiVersion, requestPath, httpMethod));
+                apiKeyValidator.getVerbInfoDTOFromAPIData(messageContext, context, apiVersion, requestPath, httpMethod));
 
     }
 
@@ -621,7 +625,7 @@ public class APIKeyValidatorTestCase {
             }
 
             @Override
-            protected ArrayList<URITemplate> getAllURITemplates(String context, String apiVersion) throws
+            protected ArrayList<URITemplate> getAllURITemplates(MessageContext messageContext, String context, String apiVersion) throws
                     APISecurityException {
                 return urlTemplates;
             }


### PR DESCRIPTION
- This will enable the scope and role validation in the JWT and Basic Auth flow

This will fix https://github.com/wso2/product-apim/issues/6224

- Allow retrieval of URITemplates from swagger in the local entry in OAuth2 flow