### PR TITLE
Fix issue in listing docs in overview page

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Overview.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Overview.jsx
@@ -179,6 +179,7 @@ function Overview(props) {
     const { classes, theme } = props;
     const { api, applicationsAvailable, subscribedApplications } = useContext(ApiContext);
     const [totalComments, setCount] = useState(0);
+    const [totalDocuments, setDocsCount] = useState(0);
     const [overviewDocOverride, setOverviewDocOverride] = useState(null);
     useEffect(() => {
         const restApi = new API();
@@ -426,7 +427,7 @@ function Overview(props) {
                                     ),
                                 }}
                             >
-                                {api && totalComments !== 0 && (
+                                {api && (
                                     <Comments apiId={api.id} showLatest isOverview setCount={setCount} />
                                 )}
                                 {totalComments === 0 && (
@@ -520,10 +521,10 @@ function Overview(props) {
                         </Typography>
                     </ExpansionPanelSummary>
                     <ExpansionPanelDetails
-                        classes={{ root: classNames({ [classes.noDocumentRoot]: totalComments === 0 }) }}
+                        classes={{ root: classNames({ [classes.noDocumentRoot]: totalDocuments === 0 }) }}
                     >
                         <Grid container className={classes.root} spacing={2}>
-                            <OverviewDocuments apiId={api.id} />
+                            <OverviewDocuments apiId={api.id} setDocsCount={setDocsCount}/>
                         </Grid>
                     </ExpansionPanelDetails>
                     <Divider />

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/OverviewDocuments.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/OverviewDocuments.jsx
@@ -84,13 +84,14 @@ function OverviewDocuments(props) {
 
     useEffect(() => {
         const restApi = new API();
-        const { apiId } = props;
+        const { apiId, setDocsCount } = props;
         const promisedApi = restApi.getDocumentsByAPIId(apiId);
         promisedApi
             .then((response) => {
                 if (response.obj.list.length > 0) {
                     // Rearanging the response to group them by the sourceType property.
                     setDocs(response.obj.list);
+                    setDocsCount(response.obj.count);
                 }
             })
             .catch((error) => {


### PR DESCRIPTION
There is an issue in displaying documents in overview page (total number of comments are used - [1]). This PR fixes it.

[1] https://github.com/wso2/carbon-apimgt/blob/master/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Overview.jsx#L523