### PR TITLE
Fix for adding case sensitive Micro-gateway label and disable editing the label name 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -85,9 +85,6 @@ public class APIAdminImpl implements APIAdmin {
      * @throws APIManagementException if failed to update label
      */
     public Label updateLabel(String tenantDomain, Label label) throws APIManagementException {
-        if (isLableNameExists(tenantDomain, label)) {
-            APIUtil.handleException("Label with name " + label.getName() + " already exists");
-        }
         return apiMgtDAO.updateLabel(label);
     }
 
@@ -101,7 +98,7 @@ public class APIAdminImpl implements APIAdmin {
         List<Label> ExistingLables = apiMgtDAO.getAllLabels(tenantDomain);
         if (!ExistingLables.isEmpty()) {
             for (Label labels : ExistingLables) {
-                if (labels.getName().equals(label.getName())) {
+                if (labels.getName().equalsIgnoreCase(label.getName())) {
                     return true;
                 }
             }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/label/label-add/template.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/site/themes/wso2/templates/label/label-add/template.jag
@@ -12,6 +12,7 @@
     if(uuid != null){
         pageTitle = i18n.localize("Edit Microgateway");
         var labelTypes = session.get("labelList");
+        nameFieldDisableStatus = "readonly";
     	var Label = Packages.org.wso2.carbon.apimgt.api.model.Label;
   		var label = new Label();
 
@@ -64,7 +65,7 @@
     <div class="form-group">
 		<label class="control-label col-sm-3"><%=i18n.localize("Label")%>  <span class="requiredAstrix">*</span></label>
 		<div class="col-md-9">
-		    <input class="form-control" type="text" id="labelName" name="labelName"/>
+		    <input class="form-control" type="text" id="labelName" name="labelName"  <%=nameFieldDisableStatus%>/>
 		</div>
 	</div>
     <div class="form-group">


### PR DESCRIPTION
This PR allows avoiding abnormal behaviors in Publisher when micro-gateway label is attached.
https://github.com/wso2/product-apim/issues/6063
https://github.com/wso2/product-apim/issues/6064
Avoid case insensitive label name  when adding:(related-https://github.com/wso2/product-apim/issues/6111 )