### PR TITLE
Add headings to Subscription elements

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Subscriptions/SubscriptionAvailability.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Subscriptions/SubscriptionAvailability.jsx
@@ -22,7 +22,7 @@ import Button from '@material-ui/core/Button';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
-import FormLabel from '@material-ui/core/FormLabel';
+import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import PropTypes from 'prop-types';
@@ -40,7 +40,7 @@ const useStyles = makeStyles(theme => ({
     },
     formControl: {
         margin: theme.spacing.unit * 1,
-        minWidth: 300,
+        minWidth: 400,
     },
     textControl: {
         margin: theme.spacing.unit * 1,
@@ -136,18 +136,22 @@ export default function SimpleSelect(props) {
     }
     return (
         <Grid item xs={12} md={12} lg={12}>
+            <Typography variant='h4' style={{ marginTop: '20px' }}>
+                <FormattedMessage
+                    id='Apis.Details.Subscriptions.SubscriptionAvailability.subscription.availability'
+                    defaultMessage='Subscription Availability'
+                />
+            </Typography>
+            <Typography variant='caption' gutterBottom>
+                <FormattedMessage
+                    id='Apis.Details.Subscriptions.SubscriptionAvailability.sub.heading'
+                    defaultMessage='Make subscriptions available to tenants'
+                />
+            </Typography>
             <Paper className={classes.subscriptionAvailabilityPaper}>
                 <form className={classes.root} autoComplete='off' onSubmit={(e) => { e.preventDefault(); }}>
                     <Grid container xs={12} spacing={1} className={classes.grid}>
-                        <Grid item xs={4} className={classes.gridLabel}>
-                            <FormLabel>
-                                <FormattedMessage
-                                    id='Apis.Details.Subscriptions.SubscriptionPoliciesManage.subscription.availability'
-                                    defaultMessage='Subscription Availability'
-                                /> {' : '}
-                            </FormLabel>
-                        </Grid>
-                        <Grid item xs={6}>
+                        <Grid item xs={10}>
                             <FormControl
                                 variant='outlined'
                                 className={classes.formControl}
@@ -199,7 +203,7 @@ export default function SimpleSelect(props) {
                             </Button>
                         </Grid>
                         {isSpecificTenants ? (
-                            <Grid item xs={8} >
+                            <Grid item xs={8} style={{ height: '100px' }} >
                                 <TenantAutocomplete setTenantList={setTenantList} api={api} />
                             </Grid>
                         ) : <Grid item xs={8} />}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Subscriptions/SubscriptionAvailability.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Subscriptions/SubscriptionAvailability.jsx
@@ -64,6 +64,12 @@ const useStyles = makeStyles(theme => ({
     saveButton: {
         marginTop: theme.spacing.unit * 2,
     },
+    heading: {
+        marginTop: theme.spacing(3),
+    },
+    tenantsList: {
+        height: theme.spacing(12),
+    },
 }));
 
 /**
@@ -136,7 +142,7 @@ export default function SimpleSelect(props) {
     }
     return (
         <Grid item xs={12} md={12} lg={12}>
-            <Typography variant='h4' style={{ marginTop: '20px' }}>
+            <Typography variant='h4' className={classes.heading}>
                 <FormattedMessage
                     id='Apis.Details.Subscriptions.SubscriptionAvailability.subscription.availability'
                     defaultMessage='Subscription Availability'
@@ -203,7 +209,7 @@ export default function SimpleSelect(props) {
                             </Button>
                         </Grid>
                         {isSpecificTenants ? (
-                            <Grid item xs={8} style={{ height: '100px' }} >
+                            <Grid item xs={8} className={classes.tenantsList} >
                                 <TenantAutocomplete setTenantList={setTenantList} api={api} />
                             </Grid>
                         ) : <Grid item xs={8} />}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Subscriptions/Subscriptions.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Subscriptions/Subscriptions.jsx
@@ -36,6 +36,10 @@ const useStyles = makeStyles(theme => ({
     emptyBox: {
         marginTop: theme.spacing.unit * 2,
     },
+    heading: {
+        marginTop: theme.spacing(3),
+        marginBottom: theme.spacing(2),
+    },
 }));
 
 /**
@@ -70,7 +74,7 @@ function Subscriptions(props) {
             {tenants !== 0 && (
                 <SubscriptionAvailability api={api} updateAPI={updateAPI} />
             )}
-            <div style={{ marginTop: '20px', marginBottom: '20px' }}>
+            <div className={classes.heading}>
                 <Typography variant='h4'>
                     <FormattedMessage
                         id='Apis.Details.Subscriptions.SubscriptionsTable.manage.subscriptions'

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Subscriptions/Subscriptions.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Subscriptions/Subscriptions.jsx
@@ -70,6 +70,20 @@ function Subscriptions(props) {
             {tenants !== 0 && (
                 <SubscriptionAvailability api={api} updateAPI={updateAPI} />
             )}
+            <div style={{ marginTop: '20px', marginBottom: '20px' }}>
+                <Typography variant='h4'>
+                    <FormattedMessage
+                        id='Apis.Details.Subscriptions.SubscriptionsTable.manage.subscriptions'
+                        defaultMessage='Manage Subscriptions'
+                    />
+                </Typography>
+                <Typography variant='caption' gutterBottom >
+                    <FormattedMessage
+                        id='Apis.Details.Subscriptions.SubscriptionsTable.sub.heading'
+                        defaultMessage='Manage subscriptions of the API'
+                    />
+                </Typography>
+            </div>
             {subscriptions !== 0 ? (
                 <SubscriptionsTable api={api} />
             ) : (

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Subscriptions/SubscriptionsTable.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Subscriptions/SubscriptionsTable.jsx
@@ -35,7 +35,6 @@ import TableHead from '@material-ui/core/TableHead';
 import TablePagination from '@material-ui/core/TablePagination';
 import TableRow from '@material-ui/core/TableRow';
 import Tooltip from '@material-ui/core/Tooltip';
-import Typography from '@material-ui/core/Typography';
 import withStyles from '@material-ui/core/styles/withStyles';
 import PropTypes from 'prop-types';
 
@@ -630,14 +629,6 @@ class SubscriptionsTable extends Component {
         const { classes, intl, api } = this.props;
         return (
             <React.Fragment>
-                <div className={classes.titleWrapper}>
-                    <Typography variant='h4' align='left' className={classes.mainTitle}>
-                        <FormattedMessage
-                            id='Apis.Details.Subscriptions.SubscriptionsTable.manage.subscriptions'
-                            defaultMessage='Manage Subscriptions'
-                        />
-                    </Typography>
-                </div>
                 <Paper>
                     <Tooltip
                         title={intl.formatMessage({


### PR DESCRIPTION
This PR has the following changes,
- Fixes issue https://github.com/wso2/product-apim/issues/6424
- Remove extra space when selecting specific tenants
- Remove subscription availability label

<img width="1462" alt="Screen Shot 2019-10-16 at 10 42 19 AM" src="https://user-images.githubusercontent.com/19324135/66890052-459c9000-f002-11e9-8b13-42e53eac4426.png">


