### PR TITLE
Fix certificate export issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -840,8 +840,11 @@ public final class APIImportUtil {
     }
 
     /**
-     * Update API with the certificate. If certificate alias is already exists for tenant, cert will be added and if
-     * the certificate is already exists is in trust store, this method will update the cert in trust store.
+     * Update API with the certificate.
+     * If certificate alias already exists for tenant in database, certificate content will be
+     * updated in trust store. If cert alias does not exits in database for that tenant, add the certificate to
+     * publisher and gateway nodes. In such case if alias already exits in the trust store, update the certificate
+     * content for that alias.
      *
      * @param certificate Certificate JSON element
      * @param apiProvider API Provider


### PR DESCRIPTION
Fix https://github.com/wso2/product-apim/issues/6143

In APIM 3.0, we store cert alias with the full endpoint URL in the endpoint-conf where we previously used the hostname extracted from the URL.   