### PR TITLE
Improve regex of API name and context

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
@@ -134,7 +134,7 @@ const definition = {
         });
         return tmpErrors;
     }),
-    apiContext: Joi.string().max(60).regex(/(?!.*\/t\/.*|.*\/t$)^[^~!@#:%^&*+=\|\\<>"',&\s]*$/).required()
+    apiContext: Joi.string().max(60).regex(/(?!.*\/t\/.*|.*\/t$)^[^~!@#:%^&*+=|\\<>"',&\s]*$/).required()
         .error((errors) => {
             return errors.map(error => ({ ...error, message: 'Context ' + getMessage(error.type) }));
         }),

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
@@ -121,7 +121,7 @@ const documentSchema = Joi.extend(joi => ({
 }));
 
 const definition = {
-    apiName: Joi.string().max(30).regex(/^[^~!@#;:%^*()+={}|\\<>"',&/$]+$/).required()
+    apiName: Joi.string().max(30).regex(/^[^~!@#;:%^*()+={}|\\<>"',&$\s+]*$/).required()
         .error((errors) => {
             return errors.map(error => ({ ...error, message: 'Name ' + getMessage(error.type) }));
         }),
@@ -134,7 +134,7 @@ const definition = {
         });
         return tmpErrors;
     }),
-    apiContext: Joi.string().max(60).regex(/^[^~!@#;:%^*()+={}|\\<>"',&$]+$/).required()
+    apiContext: Joi.string().max(60).regex(/(?!.*\/t\/.*|.*\/t$)^[^~!@#;:%^*()+={}|\\<>"',&$\s+]*$/).required()
         .error((errors) => {
             return errors.map(error => ({ ...error, message: 'Context ' + getMessage(error.type) }));
         }),

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
@@ -134,7 +134,7 @@ const definition = {
         });
         return tmpErrors;
     }),
-    apiContext: Joi.string().max(60).regex(/(?!.*\/t\/.*|.*\/t$)^[^~!@#;:%^*()+={}|\\<>"',&$\s+]*$/).required()
+    apiContext: Joi.string().max(60).regex(/(?!.*\/t\/.*|.*\/t$)^[^~!@#:%^&*+=\|\\<>"',&\s]*$/).required()
         .error((errors) => {
             return errors.map(error => ({ ...error, message: 'Context ' + getMessage(error.type) }));
         }),


### PR DESCRIPTION
- This PR improves the regex of API name and context.
- This PR will get rid of the space error displayed when nothing is entered to the text box.

<img width="812" alt="Screen Shot 2019-10-17 at 1 36 42 PM" src="https://user-images.githubusercontent.com/19324135/66990099-32adbc80-f0e3-11e9-802b-e9efba8f4db9.png">
