### PR TITLE
Add url mapping filter

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/filter/URLMappingFilter.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/filter/URLMappingFilter.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl.filter;
+
+
+import javax.servlet.Filter;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import java.io.File;
+import java.io.IOException;
+import java.io.FileInputStream;
+
+
+public class URLMappingFilter implements Filter {
+
+    private FilterConfig filterConfig = null;
+    private String appPath = "./repository/deployment/server/jaggeryapps";
+    private String replaceValue= "public";
+    private String customeValue = "override";
+
+    public void init(FilterConfig filterConfig) throws ServletException {
+        this.filterConfig = filterConfig;
+    }
+
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest request1 = (HttpServletRequest) request;
+        File file = new File( appPath +
+                request1.getRequestURI().replace(replaceValue, customeValue));
+        boolean exists = file.exists();
+
+        if (exists) {
+            //init array with file length
+            byte[] bytesArray = new byte[(int) file.length()];
+
+            FileInputStream fis = new FileInputStream(file);
+            fis.read(bytesArray); //read file into bytes[]
+            fis.close();
+            response.getOutputStream().write(bytesArray);
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    public void destroy() {
+        filterConfig = null;
+    }
+}


### PR DESCRIPTION
Fix: https://github.com/wso2/product-apim/issues/6480
Add the facility to override store webapp's static files ( css, images, fonts etc.. ).

Add following property to jaggery.conf to enable it.

          "filters":[
            {
                "name":"URLMappingFilter",
                "class":"org.wso2.carbon.apimgt.impl.filter.URLMappingFilter"
            }
          ]
       

        "filterMappings":[
           {
                "name":"URLMappingFilter",
                "url":"/site/public/*"
            }
        ]

