### PR TITLE
Fix simple typo in Create Credentials component

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
@@ -288,7 +288,7 @@ class Credentials extends React.Component {
                                         id='Apis.Details.Credentials.Credentials.'
                                         defaultMessage={`API Credentials are grouped in to applications. An application 
                                         is primarily used to decouple the consumer from the APIs. It allows you to 
-                                        Generate and use a single key for multiple APIs and subscribe multiple times to 
+                                        generate and use a single key for multiple APIs and subscribe multiple times to 
                                         a single API with different SLA levels.`}
                                     />
                                 </Typography>


### PR DESCRIPTION
Fixes one issue stated in [wso2/product-apim#6454](https://github.com/wso2/product-apim/issues/6454)