### PR TITLE
Condition group loading

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsDataHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsDataHolder.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.gateway.conditiongroup;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -78,5 +79,25 @@ public class ConditionGroupsDataHolder {
      */
     public static ConditionGroupsDataHolder getInstance() {
         return instance;
+    }
+
+    /**
+     * Returns the condition groups related to an API Policy.
+     * @return an array of condition groups.
+     */
+    public ConditionGroupDTO[] getConditionGroupsOfPolicy(String key) {
+        ConditionGroupDTO[] conditionGroupDTOS = conditionGroupsMap.get(key);
+
+        if (conditionGroupDTOS == null) {
+            conditionGroupDTOS = new ConditionGroupDTO[1];
+        } else {
+            conditionGroupDTOS = Arrays.copyOf(conditionGroupDTOS, conditionGroupDTOS.length + 1);
+        }
+
+        ConditionGroupDTO defaultGroup = new ConditionGroupDTO();
+        defaultGroup.setConditionGroupId(APIConstants.THROTTLE_POLICY_DEFAULT);
+        conditionGroupDTOS[conditionGroupDTOS.length - 1] = defaultGroup;
+
+        return conditionGroupDTOS;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsDataHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsDataHolder.java
@@ -19,10 +19,9 @@ package org.wso2.carbon.apimgt.gateway.conditiongroup;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.apimgt.api.dto.ConditionDTO;
 import org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO;
-import org.wso2.carbon.apimgt.impl.APIConstants;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -40,10 +39,17 @@ public class ConditionGroupsDataHolder {
      * @param key key to be added.
      * @param value value to be added.
      */
-    public void addConditionGroupToMap(String key, ConditionGroupDTO[] value) {
+    public void addConditionGroupToMap(String key, ConditionGroupDTO value) {
         if (key != null && value != null) {
+            ConditionGroupDTO[] conditionGroupDTOS = conditionGroupsMap.get(key);
+            if (conditionGroupDTOS == null) {
+                conditionGroupDTOS = new ConditionGroupDTO[1];
+            } else {
+                conditionGroupDTOS = Arrays.copyOf(conditionGroupDTOS, conditionGroupDTOS.length + 1);
+            }
+            conditionGroupDTOS[conditionGroupDTOS.length - 1] = value;
             log.debug("Adding condition group key, value pair to the map :" + key + " , " + value);
-            conditionGroupsMap.put(key, value);
+            conditionGroupsMap.put(key, conditionGroupDTOS);
         }
     }
 
@@ -60,15 +66,9 @@ public class ConditionGroupsDataHolder {
         return conditionGroupsMap;
     }
 
-    public void updatePolicyConditionGroup(String key, ConditionDTO[] conditionDTOs) {
+    public void updatePolicyConditionGroup(String key, ConditionGroupDTO[] conditionGroupsDTOS) {
         if (key != null) {
-            ConditionGroupDTO[] oldConditionGroupDTOs = conditionGroupsMap.get(key);
-
-            for (ConditionGroupDTO conditionGroupDTO: oldConditionGroupDTOs) {
-                if (!APIConstants.THROTTLE_POLICY_DEFAULT.equals(conditionGroupDTO.getConditionGroupId())) {
-                    conditionGroupDTO.setConditions(conditionDTOs);
-                }
-            }
+            conditionGroupsMap.put(key, conditionGroupsDTOS);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsDataHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsDataHolder.java
@@ -19,7 +19,9 @@ package org.wso2.carbon.apimgt.gateway.conditiongroup;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.dto.ConditionDTO;
 import org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -56,6 +58,18 @@ public class ConditionGroupsDataHolder {
      */
     Map<String, ConditionGroupDTO[]> getConditionGroupsMap() {
         return conditionGroupsMap;
+    }
+
+    public void updatePolicyConditionGroup(String key, ConditionDTO[] conditionDTOs) {
+        if (key != null) {
+            ConditionGroupDTO[] oldConditionGroupDTOs = conditionGroupsMap.get(key);
+
+            for (ConditionGroupDTO conditionGroupDTO: oldConditionGroupDTOs) {
+                if (!APIConstants.THROTTLE_POLICY_DEFAULT.equals(conditionGroupDTO.getConditionGroupId())) {
+                    conditionGroupDTO.setConditions(conditionDTOs);
+                }
+            }
+        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsDataHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsDataHolder.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.conditiongroup;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ *  Singleton which stores the condition groups map
+ */
+public class ConditionGroupsDataHolder {
+
+    private static final Log log = LogFactory.getLog(ConditionGroupsDataHolder.class);
+    private static Map<String, ConditionGroupDTO[]> conditionGroupsMap = new ConcurrentHashMap<>();
+    private static ConditionGroupsDataHolder instance = new ConditionGroupsDataHolder();
+
+    /**
+     * Adds a given key,value pair to the condition groups map.
+     * @param key key to be added.
+     * @param value value to be added.
+     */
+    public void addConditionGroupToMap(String key, ConditionGroupDTO[] value) {
+        if (key != null && value != null) {
+            log.debug("Adding condition group key, value pair to the map :" + key + " , " + value);
+            conditionGroupsMap.put(key, value);
+        }
+    }
+
+
+    private ConditionGroupsDataHolder() {
+
+    }
+
+    /**
+     * Fetches the condition groups map.
+     * @return
+     */
+    Map<String, ConditionGroupDTO[]> getConditionGroupsMap() {
+        return conditionGroupsMap;
+    }
+
+    /**
+     * This method can be used to get the singleton instance of this class.
+     * @return the singleton instance.
+     */
+    public static ConditionGroupsDataHolder getInstance() {
+        return instance;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsDataHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsDataHolder.java
@@ -73,6 +73,12 @@ public class ConditionGroupsDataHolder {
         }
     }
 
+    public void deletePolicy(String key) {
+        if (key != null) {
+            conditionGroupsMap.remove(key);
+        }
+    }
+
     /**
      * This method can be used to get the singleton instance of this class.
      * @return the singleton instance.

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsRetriever.java
@@ -30,7 +30,6 @@ import org.wso2.carbon.apimgt.api.model.policy.*;
 import org.wso2.carbon.apimgt.gateway.dto.ConditionDTO;
 import org.wso2.carbon.apimgt.gateway.dto.ConditionGroupDTO;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
-import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dto.ThrottleProperties;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsRetriever.java
@@ -1,0 +1,197 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.conditiongroup;
+
+import com.google.gson.Gson;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+import org.wso2.carbon.apimgt.api.model.policy.*;
+import org.wso2.carbon.apimgt.gateway.dto.ConditionDTO;
+import org.wso2.carbon.apimgt.gateway.dto.ConditionGroupDTO;
+import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.dto.ThrottleProperties;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Class which is responsible to fetch the condition groups via webservice from database during startup
+ */
+public class ConditionGroupsRetriever extends TimerTask {
+
+    private static final Log log = LogFactory.getLog(ConditionGroupsRetriever.class);
+    private static final int conditionGroupsRetrievalTimeoutInSeconds = 15;
+    private static final int conditionGroupsRetrievalRetries = 15;
+
+    @Override
+    public void run() {
+
+        log.debug("Starting web service based condition groups retrieving process.");
+        loadConditionGroupsFromWebService();
+    }
+
+    /**
+     * This method will retrieve condition groups by calling a web service.
+     *
+     * @return List of ConditionGroupDTOs.
+     */
+    private ConditionGroupDTO[] retrieveConditionGroupsData() {
+
+        try {
+            // The resource resides in the throttle web app. Hence reading throttle configs
+            ThrottleProperties.BlockCondition blockConditionRetrieverConfiguration = getThrottleProperties()
+                    .getBlockCondition();
+            String url = blockConditionRetrieverConfiguration.getServiceUrl() + "/conditionGroups";
+            HttpGet method = new HttpGet(url);
+            byte[] credentials = Base64.encodeBase64((blockConditionRetrieverConfiguration.getUsername() + ":" +
+                    blockConditionRetrieverConfiguration.getPassword()).getBytes
+                    (StandardCharsets.UTF_8));
+            method.setHeader("Authorization", "Basic " + new String(credentials, StandardCharsets.UTF_8));
+            URL keyMgtURL = new URL(url);
+            int keyMgtPort = keyMgtURL.getPort();
+            String keyMgtProtocol = keyMgtURL.getProtocol();
+            HttpClient httpClient = APIUtil.getHttpClient(keyMgtPort, keyMgtProtocol);
+            HttpResponse httpResponse = null;
+            int retryCount = 0;
+            boolean retry;
+            do {
+                try {
+                    httpResponse = httpClient.execute(method);
+                    retry = false;
+                } catch (IOException ex) {
+                    retryCount++;
+                    if (retryCount < conditionGroupsRetrievalRetries) {
+                        retry = true;
+                        log.warn("Failed retrieving condition groups from remote endpoint: " +
+                                ex.getMessage() + ". Retrying after " + conditionGroupsRetrievalTimeoutInSeconds +
+                                " seconds...");
+                        Thread.sleep(conditionGroupsRetrievalTimeoutInSeconds * 1000);
+                    } else {
+                        throw ex;
+                    }
+                }
+            } while (retry);
+
+            String responseString = EntityUtils.toString(httpResponse.getEntity(), "UTF-8");
+            if (responseString != null && !responseString.isEmpty()) {
+                return new Gson().fromJson(responseString, org.wso2.carbon.apimgt.gateway.dto.ConditionGroupDTO[].class);
+            }
+        } catch (IOException | InterruptedException e) {
+            log.error("Exception when retrieving revoked JWT tokens from remote endpoint ", e);
+        }
+        return null;
+    }
+
+    private void loadConditionGroupsFromWebService() {
+        ConditionGroupDTO[] conditionGroupDTOS = retrieveConditionGroupsData();
+        if(conditionGroupDTOS != null) {
+            for (ConditionGroupDTO conditionGroupDTO : conditionGroupDTOS) {
+                org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO[] convertedConditionGroupDTOS = new org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO[2];
+
+                org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO defaultGroup = new org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO();
+                defaultGroup.setConditionGroupId(APIConstants.THROTTLE_POLICY_DEFAULT);
+                convertedConditionGroupDTOS[0] = defaultGroup;
+
+                convertedConditionGroupDTOS[1] = convertConditionGroupDTO(conditionGroupDTO);
+
+                ConditionGroupsDataHolder.getInstance().addConditionGroupToMap(
+                        conditionGroupDTO.getTenantId() + "-" + conditionGroupDTO.getPolicyName(),
+                        convertedConditionGroupDTOS);
+                if(log.isDebugEnabled()) {
+                    log.debug("Condition Groups for throttle policy : " + conditionGroupDTO.getPolicyName()
+                            + " is added to the map.");
+                }
+            }
+        } else {
+            log.debug("No condition groups are retrieved via web service");
+        }
+    }
+
+    /**
+     *  Initiates the timer task to fetch data from the web service.
+     *  Timer task will not run after the retry count is completed.
+     */
+    public void startConditionGroupsRetriever() {
+        //using same initDelay as in keytemplates,blocking conditions retriever
+        new Timer().schedule(this, getThrottleProperties().getBlockCondition().getInitDelay());
+    }
+
+    protected ThrottleProperties getThrottleProperties() {
+        return ServiceReferenceHolder
+                .getInstance().getThrottleProperties();
+    }
+
+    private org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO convertConditionGroupDTO(ConditionGroupDTO retrievedConditionGroupDTO) {
+        org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO convertedConditionGroupDTO = new org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO();
+
+        //Convert
+        convertedConditionGroupDTO.setConditionGroupId(String.valueOf(retrievedConditionGroupDTO.getConditionGroupId()));
+
+        org.wso2.carbon.apimgt.api.dto.ConditionDTO[] conditions =
+                new org.wso2.carbon.apimgt.api.dto.ConditionDTO[retrievedConditionGroupDTO.getConditions().length];
+        int i = 0;
+        for (ConditionDTO retrievedConditionDTO: retrievedConditionGroupDTO.getConditions()) {
+            org.wso2.carbon.apimgt.api.dto.ConditionDTO conditionDTO = new org.wso2.carbon.apimgt.api.dto.ConditionDTO();
+            conditionDTO.isInverted(retrievedConditionDTO.isInverted());
+
+            if ("IP".equals(retrievedConditionDTO.getCategory())) {
+                if (retrievedConditionDTO.getSpecificIP() != null && !"".equals(retrievedConditionDTO.getSpecificIP())) {
+                    conditionDTO.setConditionType(PolicyConstants.IP_SPECIFIC_TYPE);
+                    conditionDTO.setConditionName(PolicyConstants.IP_SPECIFIC_TYPE);
+                    conditionDTO.setConditionValue(retrievedConditionDTO.getSpecificIP());
+
+                } else if (retrievedConditionDTO.getStartingIP() != null &&
+                        !"".equals(retrievedConditionDTO.getStartingIP())) {
+                    conditionDTO.setConditionType(PolicyConstants.IP_RANGE_TYPE);
+                    conditionDTO.setConditionName(retrievedConditionDTO.getStartingIP());
+                    conditionDTO.setConditionValue(retrievedConditionDTO.getEndingIP());
+
+                }
+            } else if ("HEADER".equals(retrievedConditionDTO.getCategory())) {
+                conditionDTO.setConditionType(PolicyConstants.HEADER_TYPE);
+                conditionDTO.setConditionName(retrievedConditionDTO.getHeaderFieldName());
+                conditionDTO.setConditionValue(retrievedConditionDTO.getHeaderFieldValue());
+            } else if ("JWT_CLAIM".equals(retrievedConditionDTO.getCategory())) {
+                conditionDTO.setConditionType(PolicyConstants.JWT_CLAIMS_TYPE);
+                conditionDTO.setConditionName(retrievedConditionDTO.getClaimUri());
+                conditionDTO.setConditionValue(retrievedConditionDTO.getClaimAttrib());
+            } else if ("QUERY_PARAM".equals(retrievedConditionDTO.getCategory())) {
+                conditionDTO.setConditionType(PolicyConstants.QUERY_PARAMETER_TYPE);
+                conditionDTO.setConditionName(retrievedConditionDTO.getParameterName());
+                conditionDTO.setConditionValue(retrievedConditionDTO.getParameterValue());
+            }
+            conditions[i] = conditionDTO;
+            i++;
+        }
+
+        convertedConditionGroupDTO.setConditions(conditions);
+        return convertedConditionGroupDTO;
+    }
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/conditiongroup/ConditionGroupsRetriever.java
@@ -110,21 +110,13 @@ public class ConditionGroupsRetriever extends TimerTask {
 
     private void loadConditionGroupsFromWebService() {
         ConditionGroupDTO[] conditionGroupDTOS = retrieveConditionGroupsData();
-        if(conditionGroupDTOS != null) {
+        if (conditionGroupDTOS != null && conditionGroupDTOS.length > 0) {
             for (ConditionGroupDTO conditionGroupDTO : conditionGroupDTOS) {
-                org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO[] convertedConditionGroupDTOS = new org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO[2];
-
-                org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO defaultGroup = new org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO();
-                defaultGroup.setConditionGroupId(APIConstants.THROTTLE_POLICY_DEFAULT);
-                convertedConditionGroupDTOS[0] = defaultGroup;
-
-                convertedConditionGroupDTOS[1] = convertConditionGroupDTO(conditionGroupDTO);
-
                 ConditionGroupsDataHolder.getInstance().addConditionGroupToMap(
                         conditionGroupDTO.getTenantId() + "-" + conditionGroupDTO.getPolicyName(),
-                        convertedConditionGroupDTOS);
-                if(log.isDebugEnabled()) {
-                    log.debug("Condition Groups for throttle policy : " + conditionGroupDTO.getPolicyName()
+                        convertConditionGroupDTO(conditionGroupDTO));
+                if (log.isDebugEnabled()) {
+                    log.debug("Condition Group for throttle policy : " + conditionGroupDTO.getPolicyName()
                             + " is added to the map.");
                 }
             }
@@ -151,7 +143,7 @@ public class ConditionGroupsRetriever extends TimerTask {
         org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO convertedConditionGroupDTO = new org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO();
 
         //Convert
-        convertedConditionGroupDTO.setConditionGroupId(String.valueOf(retrievedConditionGroupDTO.getConditionGroupId()));
+        convertedConditionGroupDTO.setConditionGroupId(retrievedConditionGroupDTO.getConditionGroupId());
 
         org.wso2.carbon.apimgt.api.dto.ConditionDTO[] conditions =
                 new org.wso2.carbon.apimgt.api.dto.ConditionDTO[retrievedConditionGroupDTO.getConditions().length];

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/dto/ConditionDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/dto/ConditionDTO.java
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.dto;
+
+/**
+ *  DTO of Condition
+ */
+public class ConditionDTO {
+
+    private String conditionType;
+    private String conditionName;
+    private String conditionValue;
+    private boolean isInverted;
+    private String category;
+    private String headerFieldName;
+    private String headerFieldValue;
+    private String startingIP;
+    private String endingIP;
+    private String specificIP;
+    private String claimUri;
+    private String claimAttrib;
+    private String parameterName;
+    private String parameterValue;
+
+    public String getConditionType() {
+        return conditionType;
+    }
+
+    public void setConditionType(String conditionType) {
+        this.conditionType = conditionType;
+    }
+
+    public String getConditionName() {
+        return conditionName;
+    }
+
+    public void setConditionName(String conditionName) {
+        this.conditionName = conditionName;
+    }
+
+    public String getConditionValue() {
+        return conditionValue;
+    }
+
+    public void setConditionValue(String conditionValue) {
+        this.conditionValue = conditionValue;
+    }
+
+    public boolean isInverted() {
+        return isInverted;
+    }
+
+    public void setInverted(boolean inverted) {
+        isInverted = inverted;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getHeaderFieldName() {
+        return headerFieldName;
+    }
+
+    public void setHeaderFieldName(String headerFieldName) {
+        this.headerFieldName = headerFieldName;
+    }
+
+    public String getHeaderFieldValue() {
+        return headerFieldValue;
+    }
+
+    public void setHeaderFieldValue(String headerFieldValue) {
+        this.headerFieldValue = headerFieldValue;
+    }
+
+    public String getStartingIP() {
+        return startingIP;
+    }
+
+    public void setStartingIP(String startingIP) {
+        this.startingIP = startingIP;
+    }
+
+    public String getEndingIP() {
+        return endingIP;
+    }
+
+    public void setEndingIP(String endingIP) {
+        this.endingIP = endingIP;
+    }
+
+    public String getSpecificIP() {
+        return specificIP;
+    }
+
+    public void setSpecificIP(String specificIP) {
+        this.specificIP = specificIP;
+    }
+
+    public String getClaimUri() {
+        return claimUri;
+    }
+
+    public void setClaimUri(String claimUri) {
+        this.claimUri = claimUri;
+    }
+
+    public String getClaimAttrib() {
+        return claimAttrib;
+    }
+
+    public void setClaimAttrib(String claimAttrib) {
+        this.claimAttrib = claimAttrib;
+    }
+
+    public String getParameterName() {
+        return parameterName;
+    }
+
+    public void setParameterName(String parameterName) {
+        this.parameterName = parameterName;
+    }
+
+    public String getParameterValue() {
+        return parameterValue;
+    }
+
+    public void setParameterValue(String parameterValue) {
+        this.parameterValue = parameterValue;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/dto/ConditionGroupDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/dto/ConditionGroupDTO.java
@@ -22,7 +22,7 @@ package org.wso2.carbon.apimgt.gateway.dto;
  */
 public class ConditionGroupDTO {
 
-    private int conditionGroupId;
+    private String conditionGroupId;
 
     private String policyName;
 
@@ -30,11 +30,11 @@ public class ConditionGroupDTO {
 
     private ConditionDTO[] conditions;
 
-    public int getConditionGroupId() {
+    public String getConditionGroupId() {
         return conditionGroupId;
     }
 
-    public void setConditionGroupId(int conditionGroupId) {
+    public void setConditionGroupId(String conditionGroupId) {
         this.conditionGroupId = conditionGroupId;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/dto/ConditionGroupDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/dto/ConditionGroupDTO.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.dto;
+
+/**
+ *  DTO of condition group
+ */
+public class ConditionGroupDTO {
+
+    private int conditionGroupId;
+
+    private String policyName;
+
+    private int tenantId;
+
+    private ConditionDTO[] conditions;
+
+    public int getConditionGroupId() {
+        return conditionGroupId;
+    }
+
+    public void setConditionGroupId(int conditionGroupId) {
+        this.conditionGroupId = conditionGroupId;
+    }
+
+    public String getPolicyName() {
+        return policyName;
+    }
+
+    public void setPolicyName(String policyName) {
+        this.policyName = policyName;
+    }
+
+    public int getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(int tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public ConditionDTO[] getConditions() {
+        return conditions;
+    }
+
+    public void setConditions(ConditionDTO[] conditions) {
+        this.conditions = conditions;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
@@ -31,6 +31,7 @@ import org.json.JSONObject;
 import org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.MethodStats;
+import org.wso2.carbon.apimgt.gateway.conditiongroup.ConditionGroupsDataHolder;
 import org.wso2.carbon.apimgt.gateway.handlers.security.jwt.JWTValidator;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.handlers.security.*;
@@ -42,6 +43,7 @@ import org.wso2.carbon.apimgt.impl.dto.VerbInfoDTO;
 import org.wso2.carbon.apimgt.tracing.TracingSpan;
 import org.wso2.carbon.apimgt.tracing.TracingTracer;
 import org.wso2.carbon.apimgt.tracing.Util;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.metrics.manager.Level;
 import org.wso2.carbon.metrics.manager.MetricManager;
 import org.wso2.carbon.metrics.manager.Timer;
@@ -216,10 +218,10 @@ public class OAuthAuthenticator implements Authenticator {
                 }
                 List<VerbInfoDTO> verbInfoList;
                 //set default condition group
-                ConditionGroupDTO[] conditionGroups = new ConditionGroupDTO[1];
+                ConditionGroupDTO[] conditionGroupsWithDefaultGroup = new ConditionGroupDTO[1];
                 ConditionGroupDTO defaultGroup = new ConditionGroupDTO();
                 defaultGroup.setConditionGroupId(APIConstants.THROTTLE_POLICY_DEFAULT);
-                conditionGroups[0] = defaultGroup;
+                conditionGroupsWithDefaultGroup[0] = defaultGroup;
 
                 if (APIConstants.GRAPHQL_API.equals(synCtx.getProperty(APIConstants.API_TYPE))) {
                     HashMap<String, Boolean> operationAuthSchemeMappingList =
@@ -242,7 +244,14 @@ public class OAuthAuthenticator implements Authenticator {
                         verbInfoDTO.setHttpVerb(httpMethod);
                         verbInfoDTO.setThrottling(operationThrottlingMappingList.get(operation));
                         verbInfoDTO.setRequestKey(apiContext + "/" + apiVersion + operation + ":" + httpMethod);
-                        verbInfoDTO.setConditionGroups(conditionGroups);
+                        // Set condition groups
+                        ConditionGroupDTO[] conditionGroups = ConditionGroupsDataHolder.getInstance().getConditionGroupsOfPolicy(
+                                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId() + "-" + verbInfoDTO.getThrottling());
+                        if (conditionGroups == null) {
+                            verbInfoDTO.setConditionGroups(conditionGroupsWithDefaultGroup);
+                        } else {
+                            verbInfoDTO.setConditionGroups(conditionGroups);
+                        }
                         verbInfoList.add(verbInfoDTO);
                     }
                 } else {
@@ -253,7 +262,14 @@ public class OAuthAuthenticator implements Authenticator {
                     verbInfoDTO.setAuthType(authenticationScheme);
                     verbInfoDTO.setThrottling(OpenAPIUtils.getResourceThrottlingTier(openAPI, synCtx));
                     verbInfoDTO.setRequestKey(apiContext + "/" + apiVersion + matchingResource + ":" + httpMethod);
-                    verbInfoDTO.setConditionGroups(conditionGroups);
+                    // Set condition groups
+                    ConditionGroupDTO[] conditionGroups = ConditionGroupsDataHolder.getInstance().getConditionGroupsOfPolicy(
+                            PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId() + "-" + verbInfoDTO.getThrottling());
+                    if (conditionGroups == null) {
+                        verbInfoDTO.setConditionGroups(conditionGroupsWithDefaultGroup);
+                    } else {
+                        verbInfoDTO.setConditionGroups(conditionGroups);
+                    }
                     verbInfoList.add(verbInfoDTO);
                 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
@@ -25,6 +25,7 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
+import org.wso2.carbon.apimgt.gateway.conditiongroup.ConditionGroupsRetriever;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityUtils;
 import org.wso2.carbon.apimgt.gateway.handlers.security.keys.APIKeyValidatorClientPool;
 import org.wso2.carbon.apimgt.gateway.jwt.RevokedJWTMapCleaner;
@@ -116,6 +117,10 @@ public class APIHandlerServiceComponent {
                 // Start JWT revoked map cleaner.
                 RevokedJWTMapCleaner revokedJWTMapCleaner = new RevokedJWTMapCleaner();
                 revokedJWTMapCleaner.startJWTRevokedMapCleaner();
+
+                // Start web service based condition groups retriever.
+                ConditionGroupsRetriever webServiceConditionGroupsRetriever = new ConditionGroupsRetriever();
+                webServiceConditionGroupsRetriever.startConditionGroupsRetriever();
 
                 // Read the trust store
                 ServerConfiguration config = CarbonUtils.getServerConfiguration();

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponentTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponentTestCase.java
@@ -31,6 +31,7 @@ import org.osgi.service.component.ComponentContext;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.gateway.conditiongroup.ConditionGroupsRetriever;
 import org.wso2.carbon.apimgt.gateway.handlers.security.keys.APIKeyValidatorClientPool;
 import org.wso2.carbon.apimgt.gateway.jwt.RevokedJWTMapCleaner;
 import org.wso2.carbon.apimgt.gateway.jwt.RevokedJWTTokensRetriever;
@@ -128,6 +129,9 @@ public class APIHandlerServiceComponentTestCase {
         RevokedJWTMapCleaner revokedJWTMapCleaner = Mockito.mock(RevokedJWTMapCleaner.class);
         PowerMockito.whenNew(RevokedJWTMapCleaner.class).withAnyArguments().thenReturn(revokedJWTMapCleaner);
         PowerMockito.doNothing().when(revokedJWTMapCleaner).startJWTRevokedMapCleaner();
+        ConditionGroupsRetriever conditionGroupsRetriever = Mockito.mock(ConditionGroupsRetriever.class);
+        PowerMockito.whenNew(ConditionGroupsRetriever.class).withAnyArguments().thenReturn(conditionGroupsRetriever);
+        PowerMockito.doNothing().when(conditionGroupsRetriever).startConditionGroupsRetriever();
         PowerMockito.mockStatic(Cache.class);
         Cache cache = Mockito.mock(Cache.class);
         PowerMockito.mockStatic(org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder.class);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -447,6 +447,7 @@ public final class APIConstants {
     public static final String PUBLISHING_TIME_OUT = "publishTimeout";
     public static final String NON_BLOCKING = "non-blocking";
     public static final String BLOCKING_CONDITIONS_STREAM_ID = "org.wso2.blocking.request.stream:1.0.0";
+    public static final String API_POLICY_STREAM_ID = "org.wso2.apipolicy.request.stream:1.0.0";
     public static final String TOKEN_REVOCATION_STREAM_ID = "org.wso2.apimgt.token.revocation.stream:1.0.0";
     public static final String KEY_TEMPLATE_STREM_ID = "org.wso2.keytemplate.request.stream:1.0.0";
 
@@ -792,6 +793,7 @@ public final class APIConstants {
 
     public static final String UNAUTHENTICATED_TIER = "Unauthenticated";
     public static final String BLOCKING_EVENT_PUBLISHER = "blockingEventPublisher";
+    public static final String API_POLICY_EVENT_PUBLISHER = "apiPolicyEventPublisher";
     public static final String TOKEN_REVOCATION_EVENT_PUBLISHER = "tokenRevocationPublisher";
 
     public static final int AM_CREATOR_APIMGT_EXECUTION_ID = 200;
@@ -1403,6 +1405,14 @@ public final class APIConstants {
     public static final String BLOCKING_CONDITIONS_API = "API";
     public static final String BLOCKING_CONDITIONS_USER = "USER";
     public static final String BLOCKING_CONDITIONS_IP = "IP";
+
+    public static final String API_POLICY_KEY = "apiPolicyKey";
+    public static final String API_POLICY_TENANT_ID = "tenantId";
+    public static final String API_POLICY_CONDITIONS = "conditions";
+    public static final String API_POLICY_CONDITION_INVERTED = "isInverted";
+    public static final String API_POLICY_CONDITION_TYPE = "conditionType";
+    public static final String API_POLICY_CONDITION_NAME = "conditionName";
+    public static final String API_POLICY_CONDITION_VALUE = "conditionValue";
 
     public static final String REVOKED_TOKEN_KEY = "revokedToken";
     public static final String REVOKED_TOKEN_EXPIRY_TIME = "expiryTime";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1408,6 +1408,7 @@ public final class APIConstants {
 
     public static final String API_POLICY_KEY = "apiPolicyKey";
     public static final String API_POLICY_TENANT_ID = "tenantId";
+    public static final String API_POLICY_DELETE_STATE = "deleteState";
     public static final String API_POLICY_CONDITION_GROUPS = "conditionGroups";
     public static final String API_POLICY_CONDITIONS = "conditions";
     public static final String API_POLICY_CONDITION_INVERTED = "isInverted";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1408,11 +1408,13 @@ public final class APIConstants {
 
     public static final String API_POLICY_KEY = "apiPolicyKey";
     public static final String API_POLICY_TENANT_ID = "tenantId";
+    public static final String API_POLICY_CONDITION_GROUPS = "conditionGroups";
     public static final String API_POLICY_CONDITIONS = "conditions";
     public static final String API_POLICY_CONDITION_INVERTED = "isInverted";
     public static final String API_POLICY_CONDITION_TYPE = "conditionType";
     public static final String API_POLICY_CONDITION_NAME = "conditionName";
     public static final String API_POLICY_CONDITION_VALUE = "conditionValue";
+    public static final String API_POLICY_CONDITION_GROUP_ID = "conditionGroupId";
 
     public static final String REVOKED_TOKEN_KEY = "revokedToken";
     public static final String REVOKED_TOKEN_EXPIRY_TIME = "expiryTime";

--- a/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/main/java/org/wso2/carbon/apimgt/jms/listener/utils/JMSMessageListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/main/java/org/wso2/carbon/apimgt/jms/listener/utils/JMSMessageListener.java
@@ -302,9 +302,13 @@ public class JMSMessageListener implements MessageListener {
 
         String policyName = map.get(APIConstants.API_POLICY_KEY).toString();
         int tenantId = (int) map.get(APIConstants.API_POLICY_TENANT_ID);
-        ConditionGroupDTO[] conditionGroups =  new Gson().fromJson(map.get(APIConstants.API_POLICY_CONDITION_GROUPS).toString(),
-                ConditionGroupDTO[].class);
-
-        ConditionGroupsDataHolder.getInstance().updatePolicyConditionGroup(tenantId + "-" + policyName, conditionGroups);
+        boolean deleteState = (boolean) map.get(APIConstants.API_POLICY_DELETE_STATE);
+        if (deleteState) {
+            ConditionGroupsDataHolder.getInstance().deletePolicy(tenantId + "-" + policyName);
+        } else {
+            ConditionGroupDTO[] conditionGroups = new Gson().fromJson(map.get(APIConstants.API_POLICY_CONDITION_GROUPS).toString(),
+                    ConditionGroupDTO[].class);
+            ConditionGroupsDataHolder.getInstance().updatePolicyConditionGroup(tenantId + "-" + policyName, conditionGroups);
+        }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/main/java/org/wso2/carbon/apimgt/jms/listener/utils/JMSMessageListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/main/java/org/wso2/carbon/apimgt/jms/listener/utils/JMSMessageListener.java
@@ -26,6 +26,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.simple.parser.ParseException;
 import org.wso2.carbon.apimgt.api.dto.ConditionDTO;
+import org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO;
 import org.wso2.carbon.apimgt.gateway.conditiongroup.ConditionGroupsDataHolder;
 import org.wso2.carbon.apimgt.gateway.handlers.Utils;
 import org.wso2.carbon.apimgt.gateway.handlers.throttling.APIThrottleConstants;
@@ -301,9 +302,9 @@ public class JMSMessageListener implements MessageListener {
 
         String policyName = map.get(APIConstants.API_POLICY_KEY).toString();
         int tenantId = (int) map.get(APIConstants.API_POLICY_TENANT_ID);
-        ConditionDTO[] conditions =  new Gson().fromJson(map.get(APIConstants.API_POLICY_CONDITIONS).toString(),
-                ConditionDTO[].class);
+        ConditionGroupDTO[] conditionGroups =  new Gson().fromJson(map.get(APIConstants.API_POLICY_CONDITION_GROUPS).toString(),
+                ConditionGroupDTO[].class);
 
-        ConditionGroupsDataHolder.getInstance().updatePolicyConditionGroup(tenantId + "-" + policyName, conditions);
+        ConditionGroupsDataHolder.getInstance().updatePolicyConditionGroup(tenantId + "-" + policyName, conditionGroups);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/ConditionGroupsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/ConditionGroupsApi.java
@@ -1,0 +1,44 @@
+package org.wso2.carbon.throttle.service;
+
+import org.wso2.carbon.throttle.service.dto.*;
+import org.wso2.carbon.throttle.service.ConditionGroupsApiService;
+import org.wso2.carbon.throttle.service.factories.ConditionGroupsApiServiceFactory;
+
+import io.swagger.annotations.ApiParam;
+
+import org.wso2.carbon.throttle.service.dto.ErrorDTO;
+import org.wso2.carbon.throttle.service.dto.ConditionGroupListDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.*;
+
+@Path("/conditionGroups")
+
+@Produces({ "application/json" })
+@io.swagger.annotations.Api(value = "/conditionGroups", description = "the conditionGroups API")
+public class ConditionGroupsApi  {
+
+   private final ConditionGroupsApiService delegate = ConditionGroupsApiServiceFactory.getConditionGroupsApi();
+
+    @GET
+    
+    
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Condition groups", notes = "This will provide condition groups in database.\n", response = ConditionGroupListDTO.class, responseContainer = "List")
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "An array of condition groups"),
+        
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Unexpected error") })
+
+    public Response conditionGroupsGet()
+    {
+    return delegate.conditionGroupsGet();
+    }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/ConditionGroupsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/ConditionGroupsApiService.java
@@ -1,0 +1,19 @@
+package org.wso2.carbon.throttle.service;
+
+import org.wso2.carbon.throttle.service.*;
+import org.wso2.carbon.throttle.service.dto.*;
+
+import org.wso2.carbon.throttle.service.dto.ErrorDTO;
+import org.wso2.carbon.throttle.service.dto.ConditionGroupListDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+
+import javax.ws.rs.core.Response;
+
+public abstract class ConditionGroupsApiService {
+    public abstract Response conditionGroupsGet();
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/dto/ConditionDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/dto/ConditionDTO.java
@@ -1,0 +1,251 @@
+package org.wso2.carbon.throttle.service.dto;
+
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class ConditionDTO  {
+  
+  
+  
+  private String conditionType = null;
+  
+  
+  private String conditionName = null;
+  
+  
+  private String conditionValue = null;
+  
+  
+  private Boolean isInverted = null;
+  
+  
+  private String category = null;
+  
+  
+  private String headerFieldName = null;
+  
+  
+  private String headerFieldValue = null;
+  
+  
+  private String startingIP = null;
+  
+  
+  private String endingIP = null;
+  
+  
+  private String specificIP = null;
+  
+  
+  private String claimUri = null;
+  
+  
+  private String claimAttrib = null;
+  
+  
+  private String parameterName = null;
+  
+  
+  private String parameterValue = null;
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("conditionType")
+  public String getConditionType() {
+    return conditionType;
+  }
+  public void setConditionType(String conditionType) {
+    this.conditionType = conditionType;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("conditionName")
+  public String getConditionName() {
+    return conditionName;
+  }
+  public void setConditionName(String conditionName) {
+    this.conditionName = conditionName;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("conditionValue")
+  public String getConditionValue() {
+    return conditionValue;
+  }
+  public void setConditionValue(String conditionValue) {
+    this.conditionValue = conditionValue;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("isInverted")
+  public Boolean getIsInverted() {
+    return isInverted;
+  }
+  public void setIsInverted(Boolean isInverted) {
+    this.isInverted = isInverted;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("category")
+  public String getCategory() {
+    return category;
+  }
+  public void setCategory(String category) {
+    this.category = category;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("headerFieldName")
+  public String getHeaderFieldName() {
+    return headerFieldName;
+  }
+  public void setHeaderFieldName(String headerFieldName) {
+    this.headerFieldName = headerFieldName;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("headerFieldValue")
+  public String getHeaderFieldValue() {
+    return headerFieldValue;
+  }
+  public void setHeaderFieldValue(String headerFieldValue) {
+    this.headerFieldValue = headerFieldValue;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("startingIP")
+  public String getStartingIP() {
+    return startingIP;
+  }
+  public void setStartingIP(String startingIP) {
+    this.startingIP = startingIP;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("endingIP")
+  public String getEndingIP() {
+    return endingIP;
+  }
+  public void setEndingIP(String endingIP) {
+    this.endingIP = endingIP;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("specificIP")
+  public String getSpecificIP() {
+    return specificIP;
+  }
+  public void setSpecificIP(String specificIP) {
+    this.specificIP = specificIP;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("claimUri")
+  public String getClaimUri() {
+    return claimUri;
+  }
+  public void setClaimUri(String claimUri) {
+    this.claimUri = claimUri;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("claimAttrib")
+  public String getClaimAttrib() {
+    return claimAttrib;
+  }
+  public void setClaimAttrib(String claimAttrib) {
+    this.claimAttrib = claimAttrib;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("parameterName")
+  public String getParameterName() {
+    return parameterName;
+  }
+  public void setParameterName(String parameterName) {
+    this.parameterName = parameterName;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("parameterValue")
+  public String getParameterValue() {
+    return parameterValue;
+  }
+  public void setParameterValue(String parameterValue) {
+    this.parameterValue = parameterValue;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ConditionDTO {\n");
+    
+    sb.append("  conditionType: ").append(conditionType).append("\n");
+    sb.append("  conditionName: ").append(conditionName).append("\n");
+    sb.append("  conditionValue: ").append(conditionValue).append("\n");
+    sb.append("  isInverted: ").append(isInverted).append("\n");
+    sb.append("  category: ").append(category).append("\n");
+    sb.append("  headerFieldName: ").append(headerFieldName).append("\n");
+    sb.append("  headerFieldValue: ").append(headerFieldValue).append("\n");
+    sb.append("  startingIP: ").append(startingIP).append("\n");
+    sb.append("  endingIP: ").append(endingIP).append("\n");
+    sb.append("  specificIP: ").append(specificIP).append("\n");
+    sb.append("  claimUri: ").append(claimUri).append("\n");
+    sb.append("  claimAttrib: ").append(claimAttrib).append("\n");
+    sb.append("  parameterName: ").append(parameterName).append("\n");
+    sb.append("  parameterValue: ").append(parameterValue).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/dto/ConditionGroupDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/dto/ConditionGroupDTO.java
@@ -18,7 +18,7 @@ public class ConditionGroupDTO  {
   
   
   
-  private Integer conditionGroupId = null;
+  private String conditionGroupId = null;
   
   
   private String policyName = null;
@@ -34,10 +34,10 @@ public class ConditionGroupDTO  {
    **/
   @ApiModelProperty(value = "")
   @JsonProperty("conditionGroupId")
-  public Integer getConditionGroupId() {
+  public String getConditionGroupId() {
     return conditionGroupId;
   }
-  public void setConditionGroupId(Integer conditionGroupId) {
+  public void setConditionGroupId(String conditionGroupId) {
     this.conditionGroupId = conditionGroupId;
   }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/dto/ConditionGroupDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/dto/ConditionGroupDTO.java
@@ -1,0 +1,94 @@
+package org.wso2.carbon.throttle.service.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.throttle.service.dto.ConditionDTO;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class ConditionGroupDTO  {
+  
+  
+  
+  private Integer conditionGroupId = null;
+  
+  
+  private String policyName = null;
+  
+  
+  private Integer tenantId = null;
+  
+  
+  private List<ConditionDTO> conditions = new ArrayList<ConditionDTO>();
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("conditionGroupId")
+  public Integer getConditionGroupId() {
+    return conditionGroupId;
+  }
+  public void setConditionGroupId(Integer conditionGroupId) {
+    this.conditionGroupId = conditionGroupId;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("policyName")
+  public String getPolicyName() {
+    return policyName;
+  }
+  public void setPolicyName(String policyName) {
+    this.policyName = policyName;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("tenantId")
+  public Integer getTenantId() {
+    return tenantId;
+  }
+  public void setTenantId(Integer tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("conditions")
+  public List<ConditionDTO> getConditions() {
+    return conditions;
+  }
+  public void setConditions(List<ConditionDTO> conditions) {
+    this.conditions = conditions;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ConditionGroupDTO {\n");
+    
+    sb.append("  conditionGroupId: ").append(conditionGroupId).append("\n");
+    sb.append("  policyName: ").append(policyName).append("\n");
+    sb.append("  tenantId: ").append(tenantId).append("\n");
+    sb.append("  conditions: ").append(conditions).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/dto/ConditionGroupListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/dto/ConditionGroupListDTO.java
@@ -1,0 +1,30 @@
+package org.wso2.carbon.throttle.service.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.throttle.service.dto.ConditionGroupDTO;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class ConditionGroupListDTO extends ArrayList<ConditionGroupDTO> {
+  
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ConditionGroupListDTO {\n");
+    sb.append("  " + super.toString()).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/factories/ConditionGroupsApiServiceFactory.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/gen/java/org/wso2/carbon/throttle/service/factories/ConditionGroupsApiServiceFactory.java
@@ -1,0 +1,14 @@
+package org.wso2.carbon.throttle.service.factories;
+
+import org.wso2.carbon.throttle.service.ConditionGroupsApiService;
+import org.wso2.carbon.throttle.service.impl.ConditionGroupsApiServiceImpl;
+
+public class ConditionGroupsApiServiceFactory {
+
+   private final static ConditionGroupsApiService service = new ConditionGroupsApiServiceImpl();
+
+   public static ConditionGroupsApiService getConditionGroupsApi()
+   {
+      return service;
+   }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/main/java/org/wso2/carbon/throttle/service/impl/BlockConditionDBUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/main/java/org/wso2/carbon/throttle/service/impl/BlockConditionDBUtil.java
@@ -288,7 +288,7 @@ public final class BlockConditionDBUtil {
                 int tenantId = rs.getInt("TENANT_ID");
 
                 ConditionGroupDTO conditionGroupDTO = new ConditionGroupDTO();
-                conditionGroupDTO.setConditionGroupId(conditionGroupId);
+                conditionGroupDTO.setConditionGroupId("_condition_" + conditionGroupId);
                 conditionGroupDTO.setPolicyName(policyName);
                 conditionGroupDTO.setTenantId(tenantId);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/main/java/org/wso2/carbon/throttle/service/impl/ConditionGroupsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/main/java/org/wso2/carbon/throttle/service/impl/ConditionGroupsApiServiceImpl.java
@@ -1,0 +1,22 @@
+package org.wso2.carbon.throttle.service.impl;
+
+import org.wso2.carbon.throttle.service.*;
+import org.wso2.carbon.throttle.service.dto.*;
+
+
+import org.wso2.carbon.throttle.service.dto.ErrorDTO;
+import org.wso2.carbon.throttle.service.dto.ConditionGroupListDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+
+import javax.ws.rs.core.Response;
+
+public class ConditionGroupsApiServiceImpl extends ConditionGroupsApiService {
+    @Override
+    public Response conditionGroupsGet(){
+        return Response.ok().entity(BlockConditionDBUtil.getConditionGroups()).build();
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/main/resources/api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/main/resources/api.yaml
@@ -230,7 +230,7 @@ definitions:
   ConditionGroup:
     properties:
       conditionGroupId:
-        type: integer
+        type: string
       policyName:
         type: string
       tenantId:

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/main/resources/api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/main/resources/api.yaml
@@ -149,6 +149,22 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /conditionGroups:
+    get:
+      summary: Condition groups
+      description: |
+        This will provide condition groups in database.
+      responses:
+        200:
+          description: An array of condition groups
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/ConditionGroupList'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
 definitions:
   ThrottledEvent:
     properties:
@@ -207,3 +223,50 @@ definitions:
         type: integer
         format: int64
         description: expiry timestamp.
+  ConditionGroupList:
+    type: array
+    items:
+      $ref: '#/definitions/ConditionGroup'
+  ConditionGroup:
+    properties:
+      conditionGroupId:
+        type: integer
+      policyName:
+        type: string
+      tenantId:
+        type: integer
+      conditions:
+        type: array
+        items:
+          $ref: '#/definitions/Condition'
+  Condition:
+    properties:
+      conditionType:
+        type: string
+      conditionName:
+        type: string
+      conditionValue:
+        type: string
+      isInverted:
+        type: boolean
+      category:
+        type: string
+      headerFieldName:
+        type: string
+      headerFieldValue:
+        type: string
+      startingIP:
+        type: string
+      endingIP:
+        type: string
+      specificIP:
+        type: string
+      claimUri:
+        type: string
+      claimAttrib:
+        type: string
+      parameterName:
+        type: string
+      parameterValue:
+        type: string
+

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.service/src/main/webapp/WEB-INF/beans.xml
@@ -19,6 +19,7 @@
             <bean class="org.wso2.carbon.throttle.service.IsThrottledApi"/>
             <bean class="org.wso2.carbon.throttle.service.BlockApi"/>
             <bean class="org.wso2.carbon.throttle.service.RevokedjwtApi"/>
+            <bean class="org.wso2.carbon.throttle.service.ConditionGroupsApi"/>
         </jaxrs:serviceBeans>
         <jaxrs:providers>
             <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>

--- a/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventpublishers/apiPolicyEventJMSPublisher.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventpublishers/apiPolicyEventJMSPublisher.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<eventPublisher name="apiPolicyEventJMSPublisher" statistics="disable"
+  trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
+  <from streamName="org.wso2.apipolicy.request.stream" version="1.0.0"/>
+  <mapping customMapping="disable" type="map"/>
+  <to eventAdapterType="jms">
+    <property name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</property>
+    <property name="java.naming.provider.url">repository/conf/jndi.properties</property>
+    <property name="transport.jms.DestinationType">topic</property>
+    <property name="transport.jms.Destination">throttleData</property>
+    <property name="transport.jms.ConcurrentPublishers">allow</property>
+    <property name="transport.jms.ConnectionFactoryJNDIName">TopicConnectionFactory</property>
+  </to>
+</eventPublisher>

--- a/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventreceivers/apiPolicyWso2EventReceiver.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventreceivers/apiPolicyWso2EventReceiver.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<eventReceiver name="apiPolicyWso2EventReceiver" statistics="disable"
+    trace="disable" xmlns="http://wso2.org/carbon/eventreceiver">
+    <from eventAdapterType="wso2event">
+        <property name="events.duplicated.in.cluster">false</property>
+    </from>
+    <mapping customMapping="disable" type="wso2event"/>
+    <to streamName="org.wso2.apipolicy.request.stream" version="1.0.0"/>
+</eventReceiver>

--- a/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventstreams/org.wso2.apipolicy.request.stream_1.0.0.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventstreams/org.wso2.apipolicy.request.stream_1.0.0.json
@@ -13,7 +13,7 @@
       "type": "INT"
     },
     {
-      "name": "conditions",
+      "name": "conditionGroups",
       "type": "STRING"
     }
   ]

--- a/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventstreams/org.wso2.apipolicy.request.stream_1.0.0.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventstreams/org.wso2.apipolicy.request.stream_1.0.0.json
@@ -1,0 +1,20 @@
+{
+  "name": "org.wso2.apipolicy.request.stream",
+  "version": "1.0.0",
+  "nickName": "",
+  "description": "API Policy Event Stream",
+  "payloadData": [
+    {
+      "name": "apiPolicyKey",
+      "type": "STRING"
+    },
+    {
+      "name": "tenantId",
+      "type": "INT"
+    },
+    {
+      "name": "conditions",
+      "type": "STRING"
+    }
+  ]
+}

--- a/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventstreams/org.wso2.apipolicy.request.stream_1.0.0.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventstreams/org.wso2.apipolicy.request.stream_1.0.0.json
@@ -15,6 +15,10 @@
     {
       "name": "conditionGroups",
       "type": "STRING"
+    },
+    {
+      "name": "deleteState",
+      "type": "BOOL"
     }
   ]
 }


### PR DESCRIPTION
This will add the functionalities mentioned below. 

- Retrieving condition groups of all tenants at the startup and storing it in a Map at the Gateway. 

- When an Advanced Throttle Policy is added/updated/deleted, the map will be updated through JMS.

- When verbInfoDTO is populated, the condition groups retrieved from the map will be used.

Fixes https://github.com/wso2/product-apim/issues/6432