### PR TITLE
Fix bot detection cache initialization.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/BotDetectionMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/BotDetectionMediator.java
@@ -24,7 +24,8 @@ import java.util.Map;
 public class BotDetectionMediator extends APIMgtCommonExecutionPublisher {
     private static final Log log = LogFactory.getLog(BotDetectionMediator.class);
     private static final String BOT_ACCESS_COUNT_CACHE = "BOT_ACCESS_CACHE";
-    private final Cache botAccessCountCache;
+    private static final Cache botAccessCountCache = APIUtil.getCache(APIConstants.API_MANAGER_CACHE_MANAGER,
+            BOT_ACCESS_COUNT_CACHE, 60, 60);
     private int throttleLimit = 2;
 
     /**
@@ -32,7 +33,6 @@ public class BotDetectionMediator extends APIMgtCommonExecutionPublisher {
      */
     public BotDetectionMediator() {
         super();
-        botAccessCountCache = APIUtil.getCache(APIConstants.API_MANAGER_CACHE_MANAGER, BOT_ACCESS_COUNT_CACHE, 60, 60);
     }
 
     @Override


### PR DESCRIPTION
This fixes an error thrown when the _OpenService synapse file for bot detection is modified and deployed after startup(hot deployed). 