### PR TITLE
Fix jwt token retrieval issues in publisher profile

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
@@ -107,11 +107,14 @@ public class APIHandlerServiceComponent {
                         webServiceThrottleDataRetriever.startWebServiceThrottleDataRetriever();
                         KeyTemplateRetriever webServiceBlockConditionsRetriever = new KeyTemplateRetriever();
                         webServiceBlockConditionsRetriever.startKeyTemplateDataRetriever();
+
+                        // Start web service based revoked JWT tokens retriever.
+                        // Advanced throttle properties & blocking conditions have to be enabled for JWT token retrieval due to the throttle config dependency for this feature.
+                        RevokedJWTTokensRetriever webServiceRevokedJWTTokensRetriever = new RevokedJWTTokensRetriever();
+                        webServiceRevokedJWTTokensRetriever.startRevokedJWTTokensRetriever();
                     }
                 }
-                // Start web service based revoked JWT tokens retriever.
-                RevokedJWTTokensRetriever webServiceRevokedJWTTokensRetriever = new RevokedJWTTokensRetriever();
-                webServiceRevokedJWTTokensRetriever.startRevokedJWTTokensRetriever();
+
 
                 // Start JWT revoked map cleaner.
                 RevokedJWTMapCleaner revokedJWTMapCleaner = new RevokedJWTMapCleaner();


### PR DESCRIPTION
- We are currently depending on throttle web app and throttle configs for revoked JWT token retrieval. 
- The publisher profile is removing this webapp with its profile optimizer and disabling blocking conditions config. 
- In order to stop the web service call in this profile, we are going to depend on blocking conditions config.