### PR TITLE
Add scope related to Internal/analytics role

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -185,6 +185,10 @@
         "Roles": "admin,Internal/subscriber"
       },
       {
+        "Name": "apim_analytics:analytics_viewer",
+        "Roles": "admin,Internal/analytics"
+      },
+      {
         "Name": "apim_analytics:everyone",
         "Roles": "Internal/everyone"
       },

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json
@@ -185,6 +185,10 @@
         "Roles": "admin,Internal/subscriber"
       },
       {
+        "Name": "apim_analytics:analytics_viewer",
+        "Roles": "admin,Internal/analytics"
+      },
+      {
         "Name": "apim_analytics:everyone",
         "Roles": "Internal/everyone"
       },

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/tenant/tenant-conf.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/tenant/tenant-conf.json
@@ -185,6 +185,10 @@
         "Roles": "admin,Internal/subscriber"
       },
       {
+        "Name": "apim_analytics:analytics_viewer",
+        "Roles": "admin,Internal/analytics"
+      },
+      {
         "Name": "apim_analytics:everyone",
         "Roles": "Internal/everyone"
       },


### PR DESCRIPTION
This PR adds scope related to the Internal/analytics role which is going to be used in the analytics-apim distribution. 