### PR TITLE
Fix capitalization issue in Settings button

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/avatar/Avatar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/avatar/Avatar.jsx
@@ -19,6 +19,7 @@ const styles = theme => ({
         color: theme.palette.getContrastText(theme.palette.background.appBar),
         fontSize: theme.typography.fontSize,
         textTransform: 'uppercase',
+        fontWeight: 'bold',
     },
     accountIcon: {
         marginRight: 10,

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/settings/SettingsButton.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/settings/SettingsButton.jsx
@@ -16,7 +16,7 @@
  *  under the License.
  */
 import React from 'react';
-import { Icon, IconButton, withStyles, Typography } from '@material-ui/core';
+import { Icon, IconButton, withStyles } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
@@ -25,6 +25,8 @@ const styles = theme => ({
     settingsIconbtn: {
         color: theme.palette.getContrastText(theme.palette.background.appBar),
         fontSize: theme.typography.fontSize,
+        textTransform: 'uppercase',
+        fontWeight: 'bold',
     },
     settinsIcon: {
         marginRight: theme.spacing(),
@@ -46,12 +48,10 @@ const SettingsButton = (props) => {
                     <Icon className={classes.settinsIcon}>
                         settings
                     </Icon>
-                    <Typography>
-                        <FormattedMessage
-                            id='Apis.Base.Header.settings.SettingsButton.settings.caption'
-                            defaultMessage='Settings'
-                        />
-                    </Typography>
+                    <FormattedMessage
+                        id='Apis.Base.Header.settings.SettingsButton.settings.caption'
+                        defaultMessage='Settings'
+                    />
                 </IconButton>
             </Link>
         </React.Fragment>


### PR DESCRIPTION
This PR fixes the following

- Capitalization issue in Settings button
- Made logged in user and settings button bold

<img width="294" alt="Screen Shot 2019-10-20 at 1 19 40 PM" src="https://user-images.githubusercontent.com/19324135/67156525-1a38de80-f33d-11e9-971c-b1d1c1779b6f.png">
.