### PR TITLE
Add spacing after the icon

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Base/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Base/index.jsx
@@ -117,6 +117,9 @@ const styles = (theme) => {
             borderLeft: theme.custom.page.border,
             borderRight: theme.custom.page.border,
         },
+        icons: {
+            marginRight: theme.spacing(),
+        },
     };
 };
 
@@ -303,7 +306,7 @@ class Layout extends React.Component {
                                     onClick={() => setTenantDomain('INVALID')}
                                 >
                                     <Button className={classes.publicStore}>
-                                        <Icon>public</Icon>
+                                        <Icon className={classes.icons}>public</Icon>
                                         <FormattedMessage
                                             id='Base.index.go.to.public.store'
                                             defaultMessage='Go to public Dev Portal'
@@ -322,7 +325,7 @@ class Layout extends React.Component {
                                 <React.Fragment>
                                     <Link to='/settings'>
                                         <Button className={classes.userLink}>
-                                            <Icon>settings</Icon>
+                                            <Icon className={classes.icons}>settings</Icon>
                                             <FormattedMessage
                                                 id='Base.index.settings.caption'
                                                 defaultMessage='Settings'
@@ -338,7 +341,7 @@ class Layout extends React.Component {
                                         onClick={this.handleToggleUserMenu}
                                         className={classes.userLink}
                                     >
-                                        <Icon>person</Icon>
+                                        <Icon className={classes.icons}>person</Icon>
                                         {user.name}
                                     </Button>
                                     <Popper


### PR DESCRIPTION
This PR adds spacing after the icons in devportal.

<img width="475" alt="Screen Shot 2019-10-20 at 1 36 16 PM" src="https://user-images.githubusercontent.com/19324135/67156717-0347bb80-f340-11e9-94c8-5d0ec4825a72.png">
