### PR TITLE
Fix api documentation update/create permssion issues

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/UserAwareAPIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/UserAwareAPIProvider.java
@@ -204,7 +204,11 @@ public class UserAwareAPIProvider extends APIProviderImpl {
     @Override
     public void addDocumentation(Identifier id,
                                  Documentation documentation) throws APIManagementException {
-        checkCreatePermission();
+
+        if (!checkCreateOrPublishPermission()) {
+            throw new APIManagementException("User '" + username + "' has neither '" + APIConstants.Permissions.API_CREATE
+                    + "' nor the '" + APIConstants.Permissions.API_PUBLISH + "' permission to add API documentation");
+        }
         //todo : implement access control check for api products too
         if (id instanceof APIIdentifier) {
             checkAccessControlPermission((APIIdentifier) id);
@@ -254,7 +258,11 @@ public class UserAwareAPIProvider extends APIProviderImpl {
     @Override
     public void updateDocumentation(APIIdentifier apiId,
                                     Documentation documentation) throws APIManagementException {
-        checkCreatePermission();
+        if (!checkCreateOrPublishPermission()) {
+            throw new APIManagementException("User '" + username + "' has neither '" +
+                    APIConstants.Permissions.API_CREATE + "' nor the '" + APIConstants.Permissions.API_PUBLISH +
+                    "' permission to update API documentation");
+        }
         checkAccessControlPermission(apiId);
         super.updateDocumentation(apiId, documentation);
     }
@@ -262,7 +270,12 @@ public class UserAwareAPIProvider extends APIProviderImpl {
     @Override
     public void addDocumentationContent(API api, String documentationName,
                                         String text) throws APIManagementException {
-        checkCreatePermission();
+
+        if (!checkCreateOrPublishPermission()) {
+            throw new APIManagementException("User '" + username + "' has neither '" +
+                    APIConstants.Permissions.API_CREATE + "' nor the '" + APIConstants.Permissions.API_PUBLISH +
+                    "' permission to add content for API documentation");
+        }
         if (api != null) {
             checkAccessControlPermission(api.getId());
         }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/Delete.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/Delete.jsx
@@ -74,7 +74,7 @@ function Delete(props) {
     const { apiName } = props;
     return (
         <div>
-            <Button onClick={toggleOpen} disabled={isRestricted(['apim:api_create'], api)}>
+            <Button onClick={toggleOpen} disabled={isRestricted(['apim:api_create', 'apim:api_publish'], api)}>
                 <Icon>delete_forever</Icon>
                 <FormattedMessage id='Apis.Details.Documents.Delete.document.delete' defaultMessage='Delete' />
             </Button>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/Delete.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/Delete.jsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
@@ -30,10 +30,12 @@ import APIProduct from 'AppData/APIProduct';
 import Icon from '@material-ui/core/Icon';
 import Alert from 'AppComponents/Shared/Alert';
 import { isRestricted } from 'AppData/AuthManager';
+import APIContext from 'AppComponents/Apis/Details/components/ApiContext';
 
 function Delete(props) {
-    const { intl, api } = props;
+    const { intl } = props;
     const [open, setOpen] = useState(false);
+    const { api } = useContext(APIContext);
 
     const runAction = (action) => {
         if (action === 'yes') {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/Edit.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/Edit.jsx
@@ -122,7 +122,7 @@ function Edit(props) {
     const { classes, docId, apiId, api} = props;
     return (
         <div>
-            <Button onClick={toggleOpen} disabled={isRestricted(['apim:api_create'], api)}>
+            <Button onClick={toggleOpen} disabled={isRestricted(['apim:api_create', 'apim:api_publish'], api)}>
                 <Icon>edit</Icon>
                 <FormattedMessage
                     id='Apis.Details.Documents.Edit.documents.text.editor.edit'

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/Edit.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/Edit.jsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useState, useRef } from 'react';
+import React, {useState, useRef, useContext} from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
@@ -31,6 +31,7 @@ import Alert from 'AppComponents/Shared/Alert';
 import CreateEditForm from './CreateEditForm';
 import Api from 'AppData/api';
 import { isRestricted } from 'AppData/AuthManager';
+import APIContext from 'AppComponents/Apis/Details/components/ApiContext';
 
 const styles = {
     appBar: {
@@ -68,6 +69,7 @@ function Edit(props) {
     const [open, setOpen] = useState(false);
     const [saveDisabled, setSaveDisabled] = useState(false);
     let createEditForm = useRef(null);
+    const { api } = useContext(APIContext);
 
     const toggleOpen = () => {
         setOpen(!open);
@@ -119,7 +121,7 @@ function Edit(props) {
             });
     };
 
-    const { classes, docId, apiId, api} = props;
+    const { classes, docId, apiId } = props;
     return (
         <div>
             <Button onClick={toggleOpen} disabled={isRestricted(['apim:api_create', 'apim:api_publish'], api)}>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/Listing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/Listing.jsx
@@ -416,8 +416,9 @@ class Listing extends React.Component {
                             resourcePath={isAPIProduct ? resourcePath.API_PRODUCTS : resourcePath.API_CHANGE_LC}
                             resourceMethod={resourceMethod.POST}
                         >
-                            <Link to={!isRestricted(['apim:api_create'], api) && url}>
-                                <Button size='small' className={classes.button} disabled={isRestricted(['apim:api_create'], api)}>
+                            <Link to={!isRestricted(['apim:api_create', 'apim:api_publish'], api) && url}>
+                                <Button size='small' className={classes.button}
+                                        disabled={isRestricted(['apim:api_create', 'apim:api_publish'], api)}>
                                     <AddCircle className={classes.buttonIcon} />
                                     <FormattedMessage
                                         id='Apis.Details.Documents.Listing.add.new.document.button'
@@ -459,8 +460,9 @@ class Listing extends React.Component {
                                     />
                                 </Typography>
                                 <div className={classes.actions}>
-                                    <Link to={!isRestricted(['apim:api_create'], api) && url}>
-                                        <Button variant='contained' color='primary' className={classes.button} disabled={isRestricted(['apim:api_create'], api)}>
+                                    <Link to={!isRestricted(['apim:api_create', 'apim:api_publish'], api) && url}>
+                                        <Button variant='contained' color='primary' className={classes.button}
+                                                disabled={isRestricted(['apim:api_create','apim:api_publish'], api)}>
                                             <FormattedMessage
                                                 id='Apis.Details.Documents.Listing.add.new.msg.button'
                                                 defaultMessage='Add New Document'

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/TextEditor.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/TextEditor.jsx
@@ -136,7 +136,7 @@ function TextEditor(props) {
     const { classes } = props;
     return (
         <div>
-            <Button onClick={toggleOpen} disabled={isRestricted(['apim:api_create'], api)}>
+            <Button onClick={toggleOpen} disabled={isRestricted(['apim:api_create', 'apim:api_publish'], api)}>
                 <Icon>description</Icon>
                 <FormattedMessage id='Apis.Details.Documents.TextEditor.edit.content' defaultMessage='Edit Content' />
             </Button>


### PR DESCRIPTION
Fixes https://github.com/wso2/product-apim/issues/5824

This adds the api docs edit/delete permission to the publisher users too. (it was set to allow for only creator users before this). Change the permission conditions in the UI too accordingly.