### PR TITLE
Fixing basic authentication for APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthCredentialValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthCredentialValidator.java
@@ -69,8 +69,6 @@ public class BasicAuthCredentialValidator {
 
     protected Log log = LogFactory.getLog(getClass());
     private APIKeyMgtRemoteUserStoreMgtServiceStub apiKeyMgtRemoteUserStoreMgtServiceStub;
-    private static final int TIMEOUT_IN_MILLIS = 15 * 60 * 1000;
-
 
     /**
      * Initialize the validator with the synapse environment.
@@ -96,9 +94,6 @@ public class BasicAuthCredentialValidator {
                     "APIKeyMgtRemoteUserStoreMgtService");
             ServiceClient client = apiKeyMgtRemoteUserStoreMgtServiceStub._getServiceClient();
             Options options = client.getOptions();
-            options.setTimeOutInMilliSeconds(TIMEOUT_IN_MILLIS);
-            options.setProperty(HTTPConstants.SO_TIMEOUT, TIMEOUT_IN_MILLIS);
-            options.setProperty(HTTPConstants.CONNECTION_TIMEOUT, TIMEOUT_IN_MILLIS);
             options.setCallTransportCleanup(true);
             options.setManageSession(true);
             CarbonUtils.setBasicAccessSecurityHeaders(username, password, client);

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyMgtRemoteUserStoreMgtService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyMgtRemoteUserStoreMgtService.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.keymgt.service;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.core.AbstractAdmin;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+public class APIKeyMgtRemoteUserStoreMgtService extends AbstractAdmin {
+
+    private static final Log log = LogFactory.getLog(APIKeyMgtRemoteUserStoreMgtService.class);
+
+    /**
+     * validates a username,password combination. Works for any tenant
+     * @param username username of the user(including tenant domain)
+     * @param password password of the user
+     * @return true if username,password is correct
+     * @throws APIManagementException
+     */
+    public boolean authenticate(String username, String password) throws APIManagementException {
+
+        String tenantDomain = MultitenantUtils.getTenantDomain(username);
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+
+        UserStoreManager userStoreManager;
+        boolean isAuthenticated = false;
+        try {
+            userStoreManager =
+                    CarbonContext.getThreadLocalCarbonContext().getUserRealm().getUserStoreManager();
+            String tenantAwareUserName = MultitenantUtils.getTenantAwareUsername(username);
+
+            isAuthenticated = userStoreManager.authenticate(tenantAwareUserName, password);
+        } catch (UserStoreException e) {
+            APIUtil.handleException("Error occurred while validating credentials of user " + username, e);
+
+        } finally {
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().endTenantFlow();
+        }
+        return isAuthenticated;
+    }
+
+    /**
+     * Get the role list of a user
+     * @param username username with tenant domain
+     * @return list of roles
+     * @throws APIManagementException
+     */
+    public String[] getUserRoles(String username) throws APIManagementException {
+
+        String userRoles[] = null;
+        String tenantDomain = MultitenantUtils.getTenantDomain(username);
+
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+
+        UserStoreManager userStoreManager;
+        try {
+            userStoreManager = CarbonContext.getThreadLocalCarbonContext().getUserRealm().getUserStoreManager();
+            userRoles = userStoreManager.getRoleListOfUser(MultitenantUtils.getTenantAwareUsername(username));
+        } catch (UserStoreException e) {
+            APIUtil.handleException("Error occurred retrieving roles of user " + username, e);
+        } finally {
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().endTenantFlow();
+        }
+        return userRoles;
+    }
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyMgtRemoteUserStoreMgtService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyMgtRemoteUserStoreMgtService.java
@@ -33,7 +33,7 @@ public class APIKeyMgtRemoteUserStoreMgtService extends AbstractAdmin {
     private static final Log log = LogFactory.getLog(APIKeyMgtRemoteUserStoreMgtService.class);
 
     /**
-     * validates a username,password combination. Works for any tenant
+     * validates a username,password combination. Works for any tenant domain.
      * @param username username of the user(including tenant domain)
      * @param password password of the user
      * @return true if username,password is correct
@@ -63,7 +63,7 @@ public class APIKeyMgtRemoteUserStoreMgtService extends AbstractAdmin {
     }
 
     /**
-     * Get the role list of a user
+     * Get the role list of a user. Works for any tenant domain.
      * @param username username with tenant domain
      * @return list of roles
      * @throws APIManagementException

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyMgtRemoteUserStoreMgtService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyMgtRemoteUserStoreMgtService.java
@@ -55,7 +55,6 @@ public class APIKeyMgtRemoteUserStoreMgtService extends AbstractAdmin {
             isAuthenticated = userStoreManager.authenticate(tenantAwareUserName, password);
         } catch (UserStoreException e) {
             APIUtil.handleException("Error occurred while validating credentials of user " + username, e);
-
         } finally {
             PrivilegedCarbonContext.getThreadLocalCarbonContext().endTenantFlow();
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/resources/META-INF/services.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/resources/META-INF/services.xml
@@ -47,7 +47,7 @@
     <service name="APIKeyMgtRemoteUserStoreMgtService" scope="transportsession">
         <transports><transport>https</transport></transports>
         <schema schemaNamespace="http://org.apache.axis2/xsd" elementFormDefaultQualified="true" />
-        <description>API Key Mgt functionality related to application developers.</description>
+        <description>API Key Mgt functionality related to user management.</description>
         <parameter name="ServiceClass">org.wso2.carbon.apimgt.keymgt.service.APIKeyMgtRemoteUserStoreMgtService</parameter>
         <parameter name="DoAuthentication" locked="true">true</parameter>
         <parameter name="AuthorizationAction" locked="true">/permission/admin/login</parameter>

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/resources/META-INF/services.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/resources/META-INF/services.xml
@@ -44,6 +44,15 @@
         <parameter name="AuthorizationAction" locked="true">/permission/admin/manage</parameter>
     </service>
 
+    <service name="APIKeyMgtRemoteUserStoreMgtService" scope="transportsession">
+        <transports><transport>https</transport></transports>
+        <schema schemaNamespace="http://org.apache.axis2/xsd" elementFormDefaultQualified="true" />
+        <description>API Key Mgt functionality related to application developers.</description>
+        <parameter name="ServiceClass">org.wso2.carbon.apimgt.keymgt.service.APIKeyMgtRemoteUserStoreMgtService</parameter>
+        <parameter name="DoAuthentication" locked="true">true</parameter>
+        <parameter name="AuthorizationAction" locked="true">/permission/admin/login</parameter>
+    </service>
+
     <parameter name="adminService" locked="true">true</parameter>
     <parameter name="hiddenService" locked="true">true</parameter>
 </serviceGroup>

--- a/service-stubs/apimgt/org.wso2.carbon.apimgt.keymgt.stub/pom.xml
+++ b/service-stubs/apimgt/org.wso2.carbon.apimgt.keymgt.stub/pom.xml
@@ -65,6 +65,10 @@
                                     <arg line="-uri src/main/resources/APIKeyValidationService.wsdl -u -uw -o target/generated-code -p org.wso2.carbon.apimgt.keymgt.stub.validator -ns2p http://service.keymgt.apimgt.carbon.wso2.org=org.wso2.carbon.apimgt.keymgt.stub.validator,http://keymgt.apimgt.carbon.wso2.org/xsd=org.wso2.carbon.apimgt.keymgt.stub.types.carbon,http://org.apache.axis2/xsd=org.wso2.carbon.apimgt.keymgt.stub.types.axis2,http://dto.keymgt.apimgt.carbon.wso2.org/xsd=org.wso2.carbon.apimgt.keymgt.stub.types.dto" />
                                     <classpath refid="wsdl2java.classpath" />
                                 </java>
+                                <java classname="org.apache.axis2.wsdl.WSDL2Java" fork="true">
+                                    <arg line="-uri src/main/resources/APIKeyMgtRemoteUserStoreMgtService.wsdl -u -uw -o target/generated-code -p org.wso2.carbon.apimgt.keymgt.stub.usermanager -ns2p http://service.keymgt.apimgt.carbon.wso2.org=org.wso2.carbon.apimgt.keymgt.stub.usermanager,http://keymgt.apimgt.carbon.wso2.org/xsd=org.wso2.carbon.apimgt.keymgt.stub.types.carbon,http://org.apache.axis2/xsd=org.wso2.carbon.apimgt.keymgt.stub.types.axis2,http://dto.keymgt.apimgt.carbon.wso2.org/xsd=org.wso2.carbon.apimgt.keymgt.stub.types.dto" />
+                                    <classpath refid="wsdl2java.classpath" />
+                                </java>
                             </tasks>
                         </configuration>
                     </execution>

--- a/service-stubs/apimgt/org.wso2.carbon.apimgt.keymgt.stub/src/main/resources/APIKeyMgtRemoteUserStoreMgtService.wsdl
+++ b/service-stubs/apimgt/org.wso2.carbon.apimgt.keymgt.stub/src/main/resources/APIKeyMgtRemoteUserStoreMgtService.wsdl
@@ -1,0 +1,172 @@
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax2139="http://api.apimgt.carbon.wso2.org/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://service.keymgt.apimgt.carbon.wso2.org" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://service.keymgt.apimgt.carbon.wso2.org">
+<wsdl:documentation>APIKeyMgtRemoteUserStoreMgtService</wsdl:documentation>
+    <wsdl:types>
+        <xs:schema xmlns:ax2140="http://api.apimgt.carbon.wso2.org/xsd" xmlns:ns="http://org.apache.axis2/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.axis2/xsd">
+            <xs:import namespace="http://api.apimgt.carbon.wso2.org/xsd"/>
+            <xs:element name="APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="APIManagementException" nillable="true" type="ax2140:APIManagementException"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="authenticate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="password" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="authenticateResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getUserRoles">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getUserRolesResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:schema>
+        <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://api.apimgt.carbon.wso2.org/xsd">
+            <xs:complexType name="APIManagementException">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="errorHandler" nillable="true" type="ax2139:ErrorHandler"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType abstract="true" name="ErrorHandler">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="errorCode" type="xs:long"/>
+                    <xs:element minOccurs="0" name="errorDescription" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="errorMessage" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="httpStatusCode" type="xs:int"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:schema>
+    </wsdl:types>
+    <wsdl:message name="authenticateRequest">
+        <wsdl:part name="parameters" element="ns1:authenticate"/>
+    </wsdl:message>
+    <wsdl:message name="authenticateResponse">
+        <wsdl:part name="parameters" element="ns1:authenticateResponse"/>
+    </wsdl:message>
+    <wsdl:message name="APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException">
+        <wsdl:part name="parameters" element="ns1:APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException"/>
+    </wsdl:message>
+    <wsdl:message name="getUserRolesRequest">
+        <wsdl:part name="parameters" element="ns1:getUserRoles"/>
+    </wsdl:message>
+    <wsdl:message name="getUserRolesResponse">
+        <wsdl:part name="parameters" element="ns1:getUserRolesResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="APIKeyMgtRemoteUserStoreMgtServicePortType">
+        <wsdl:operation name="authenticate">
+            <wsdl:input message="tns:authenticateRequest" wsaw:Action="urn:authenticate"/>
+            <wsdl:output message="tns:authenticateResponse" wsaw:Action="urn:authenticateResponse"/>
+            <wsdl:fault message="tns:APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException" name="APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException" wsaw:Action="urn:authenticateAPIKeyMgtRemoteUserStoreMgtServiceAPIManagementException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getUserRoles">
+            <wsdl:input message="tns:getUserRolesRequest" wsaw:Action="urn:getUserRoles"/>
+            <wsdl:output message="tns:getUserRolesResponse" wsaw:Action="urn:getUserRolesResponse"/>
+            <wsdl:fault message="tns:APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException" name="APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException" wsaw:Action="urn:getUserRolesAPIKeyMgtRemoteUserStoreMgtServiceAPIManagementException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="APIKeyMgtRemoteUserStoreMgtServiceSoap11Binding" type="tns:APIKeyMgtRemoteUserStoreMgtServicePortType">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+        <wsdl:operation name="authenticate">
+            <soap:operation soapAction="urn:authenticate" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException">
+                <soap:fault use="literal" name="APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getUserRoles">
+            <soap:operation soapAction="urn:getUserRoles" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException">
+                <soap:fault use="literal" name="APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:binding name="APIKeyMgtRemoteUserStoreMgtServiceSoap12Binding" type="tns:APIKeyMgtRemoteUserStoreMgtServicePortType">
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+        <wsdl:operation name="authenticate">
+            <soap12:operation soapAction="urn:authenticate" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException">
+                <soap12:fault use="literal" name="APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getUserRoles">
+            <soap12:operation soapAction="urn:getUserRoles" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException">
+                <soap12:fault use="literal" name="APIKeyMgtRemoteUserStoreMgtServiceAPIManagementException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:binding name="APIKeyMgtRemoteUserStoreMgtServiceHttpBinding" type="tns:APIKeyMgtRemoteUserStoreMgtServicePortType">
+        <http:binding verb="POST"/>
+        <wsdl:operation name="authenticate">
+            <http:operation location="authenticate"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getUserRoles">
+            <http:operation location="getUserRoles"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="APIKeyMgtRemoteUserStoreMgtService">
+        <wsdl:port name="APIKeyMgtRemoteUserStoreMgtServiceHttpsSoap11Endpoint" binding="tns:APIKeyMgtRemoteUserStoreMgtServiceSoap11Binding">
+            <soap:address location="https://Fazlans-MacBook-Pro.local:8243/services/APIKeyMgtRemoteUserStoreMgtService.APIKeyMgtRemoteUserStoreMgtServiceHttpsSoap11Endpoint"/>
+        </wsdl:port>
+        <wsdl:port name="APIKeyMgtRemoteUserStoreMgtServiceHttpsSoap12Endpoint" binding="tns:APIKeyMgtRemoteUserStoreMgtServiceSoap12Binding">
+            <soap12:address location="https://Fazlans-MacBook-Pro.local:8243/services/APIKeyMgtRemoteUserStoreMgtService.APIKeyMgtRemoteUserStoreMgtServiceHttpsSoap12Endpoint"/>
+        </wsdl:port>
+        <wsdl:port name="APIKeyMgtRemoteUserStoreMgtServiceHttpsEndpoint" binding="tns:APIKeyMgtRemoteUserStoreMgtServiceHttpBinding">
+            <http:address location="https://Fazlans-MacBook-Pro.local:8243/services/APIKeyMgtRemoteUserStoreMgtService.APIKeyMgtRemoteUserStoreMgtServiceHttpsEndpoint"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Current implementation is using authAdminService to authenticate a user. This does not work when the user doesn't have login permission.

This PR introduces a new APIMKeyMgt service for authentication and role retrieval. The service needs to be authenticated with super admin credential. However, the operations can be called for any tenant user.