### PR TITLE
improves error messages in response validator

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -46,7 +46,7 @@ public class APIMgtGatewayConstants {
     public static final String REVOKED_ACCESS_TOKEN = "RevokedAccessToken";
     public static final String DEACTIVATED_ACCESS_TOKEN = "DeactivatedAccessToken";
     public static final String SCOPES = "Scopes";
-    public static final String REQUEST_EXECUTION_START_TIME ="request.execution.start.time";
+    public static final String REQUEST_EXECUTION_START_TIME = "request.execution.start.time";
     public static final String SYNAPSE_ENDPOINT_ADDRESS = "ENDPOINT_ADDRESS";
     public static final String DUMMY_ENDPOINT_ADDRESS = "dummy_endpoint_address";
 
@@ -56,7 +56,7 @@ public class APIMgtGatewayConstants {
     public static final String RESOURCE_NOT_FOUND_ERROR_MSG = "No matching resource found for given API Request";
     public static final String REQUEST_TYPE_FAIL_MSG = "Neither request method nor content type is matched with" +
             " the validator.";
-    
+
     public static final String BACKEND_LATENCY = "backend_latency";
     public static final String SECURITY_LATENCY = "security_latency";
     public static final String THROTTLING_LATENCY = "throttling_latency";
@@ -71,7 +71,7 @@ public class APIMgtGatewayConstants {
     public static final String REGEX_PATTERN = "regex";
     public static final String ENABLED_CHECK_BODY = "enabledCheckBody";
     public static final String ENABLED_CHECK_PATHPARAM = "enabledCheckPathParams";
-    public static final String ENABLED_CHECK_HEADERS  = "enabledCheckHeaders";
+    public static final String ENABLED_CHECK_HEADERS = "enabledCheckHeaders";
     public static final String REST_URL_POSTFIX = "REST_URL_POSTFIX";
     public static final String TRANSPORT_HEADERS = "TRANSPORT_HEADERS";
     public static final String SERVICE_PREFIX = "SERVICE_PREFIX";
@@ -91,6 +91,7 @@ public class APIMgtGatewayConstants {
     public static final String THREAT_MSG = "THREAT_MSG";
     public static final String THREAT_DESC = "THREAT_DESC";
     public static final String BAD_REQUEST = "Bad Request";
+    public static final String BAD_RESPONSE = "Bad Response";
     public static final String THREAT_TYPE = "threatType";
     public static final String THREAT_FAULT = "_threat_fault_";
     public static final String XML_VALIDATION = "xmlValidation";
@@ -100,9 +101,9 @@ public class APIMgtGatewayConstants {
 
     /**
      * Web socket header for jwt assertion.
-     * */
+     */
     public static final String WS_JWT_TOKEN_HEADER = "websocket.custom.header.X-JWT-Assertion";
-    
+
     public static final String GATEWAY_TYPE = "SYNAPSE";
     public static final String SYNAPDE_GW_LABEL = "Synapse";
     public static final String CLIENT_USER_AGENT = "clientUserAgent";
@@ -110,7 +111,7 @@ public class APIMgtGatewayConstants {
 
     /**
      * Constants for Open Tracing
-     * */
+     */
     public static final String SERVICE_NAME = "API:Latency";
     public static final String RESPONSE_LATENCY = "API:Response_Latency";
     public static final String BACKEND_LATENCY_SPAN = "API:Backend_Latency";
@@ -158,6 +159,9 @@ public class APIMgtGatewayConstants {
     public static final char JSONPATH_SEPARATE = '.';
     public static final String JSON_RESPONSES = ".responses.";
     public static final String EMPTY_ARRAY = "[]";
+    public static final String INTERNAL_ERROR_CODE = "500";
+    public static final String DEFINITIONS = "definitions";
+
     public static final char HASH = '#';
     public static final String EMPTY = "";
     public static final String BACKWARD_SLASH = "\"";
@@ -172,7 +176,7 @@ public class APIMgtGatewayConstants {
 
     /**
      * Constants for trust store access
-     * */
+     */
     public static final String TRUST_STORE_PASSWORD = "Security.TrustStore.Password";
     public static final String TRUST_STORE_LOCATION = "Security.TrustStore.Location";
     public static final String HTTP_RESPONSE_STATUS_CODE = "HTTP_RESPONSE_STATUS_CODE";

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -152,27 +152,31 @@ public class APIMgtGatewayConstants {
     public static final String HTTP_REQUEST_METHOD = "HTTP_METHOD_OBJECT";
     public static final String APPLICATION_JSON = "application/json";
     public static final String REST_CONTENT_TYPE = "ContentType";
-    public static final String HTTP_RESPONSE_METHOD = "api.ut.HTTP_METHOD";
     public static final String SCHEMA_REFERENCE = "$ref";
     public static final String PATHS = "$..paths..";
+    public static final String BODY_CONTENT = "..requestBody.content.application/json.schema";
     public static final String JSON_PATH = "$.";
+    public static final String ITEMS = "items";
+    public static final String OPEN_API = ".openapi";
     public static final char JSONPATH_SEPARATE = '.';
+    public static final String PARAM_SCHEMA = ".parameters..schema";
+    public static final String REQUEST_BODY = "..requestBody";
     public static final String JSON_RESPONSES = ".responses.";
+    public static final String DEFAULT = "default";
+    public static final String CONTENT = ".content";
+    public static final String JSON_CONTENT = ".application/json.schema.$ref";
+    public static final String SCHEMA = ".schema";
     public static final String EMPTY_ARRAY = "[]";
     public static final String INTERNAL_ERROR_CODE = "500";
     public static final String DEFINITIONS = "definitions";
-
+    public static final String COMPONENT_SCHEMA = "components/schemas";
     public static final char HASH = '#';
     public static final String EMPTY = "";
     public static final String BACKWARD_SLASH = "\"";
     public static final char FORWARD_SLASH = '/';
     public static final String REQUESTBODY_SCHEMA = "components.requestBodies.";
-    public static final String CONTENT_TYPE = "synapse.internal.rest.contentType";
-    public static final String SOAP_CONTENT_TYPE = "ContentType";
-    public static final String API_CONTEXT = "REST_API_CONTEXT";
-    public static final String TEXT_XML = "text/xml";
-    public static final String APPLICATION_XML = "application/xml";
-    public static final String TEXT_JSON = "text/json";
+    public static final String JSONPATH_SCHEMAS = "$..components.schemas.";
+    public static final String JSON_SCHEMA = ".content.application/json.schema";
 
     /**
      * Constants for trust store access

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
@@ -102,13 +102,13 @@ public class SchemaValidator extends AbstractHandler {
             JSONObject payloadObject = getMessageContent(messageContext);
             if (!APIConstants.SupportedHTTPVerbs.GET.name().equals(requestMethod) &&
                     payloadObject != null && !APIMgtGatewayConstants.EMPTY_ARRAY.equals(payloadObject)) {
-                    validateRequest(messageContext);
+                validateRequest(messageContext);
             }
         } catch (IOException | XMLStreamException e) {
             logger.error("Error occurred while building the API request", e);
-        }  catch (APIManagementException e) {
-        logger.error("Error occurred while validating the API request", e);
-    }
+        } catch (APIManagementException e) {
+            logger.error("Error occurred while validating the API request", e);
+        }
         return true;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
@@ -526,11 +526,13 @@ public class SchemaValidator extends AbstractHandler {
             int index = path.lastIndexOf(APIMgtGatewayConstants.FORWARD_SLASH);
             searchLastIndex = path.substring(index + 1);
         }
+        
         String nodeVal = path.replaceAll("" + APIMgtGatewayConstants.FORWARD_SLASH, ".");
         String name = null;
         Object object = JsonPath.read(swagger, APIMgtGatewayConstants.JSON_PATH + nodeVal);
-        ObjectMapper mapper = new ObjectMapper();
         String value;
+        ObjectMapper mapper = new ObjectMapper();
+
         JsonNode jsonSchema = mapper.convertValue(object, JsonNode.class);
         if (jsonSchema.get(0) != null) {
             value = jsonSchema.get(0).toString();
@@ -584,7 +586,6 @@ public class SchemaValidator extends AbstractHandler {
             ).append(searchLastIndex);
             Object nameObj = JsonPath.read(swagger, requestSchemaPath.toString());
             mapper = new ObjectMapper();
-
             try {
                 JsonNode jsonNode = mapper.convertValue(nameObj, JsonNode.class);
                 generateSchema(jsonNode);
@@ -598,7 +599,6 @@ public class SchemaValidator extends AbstractHandler {
                         "the particular request", e);
             }
             schemaContent = name;
-
         } else {
             schemaContent = value;
             return schemaContent;

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
@@ -102,15 +102,13 @@ public class SchemaValidator extends AbstractHandler {
             JSONObject payloadObject = getMessageContent(messageContext);
             if (!APIConstants.SupportedHTTPVerbs.GET.name().equals(requestMethod) &&
                     payloadObject != null && !APIMgtGatewayConstants.EMPTY_ARRAY.equals(payloadObject)) {
-                try {
                     validateRequest(messageContext);
-                } catch (APIManagementException e) {
-                    logger.error("Error occurred while validating the API request", e);
-                }
             }
         } catch (IOException | XMLStreamException e) {
             logger.error("Error occurred while building the API request", e);
-        }
+        }  catch (APIManagementException e) {
+        logger.error("Error occurred while validating the API request", e);
+    }
         return true;
     }
 
@@ -128,7 +126,6 @@ public class SchemaValidator extends AbstractHandler {
         try {
             RelayUtils.buildMessage(axis2MC);
             logger.info("Successfully built the response message");
-
         } catch (IOException e) {
             logger.error("Error occurred while building the API response", e);
         } catch (XMLStreamException e) {
@@ -143,7 +140,6 @@ public class SchemaValidator extends AbstractHandler {
         } catch (APIManagementException e) {
             logger.error("Error occurred while validating the API response", e);
         }
-
         return true;
     }
 
@@ -279,7 +275,6 @@ public class SchemaValidator extends AbstractHandler {
     private String extractSchemaFromRequest(MessageContext messageContext) {
         org.apache.axis2.context.MessageContext axis2MC = ((Axis2MessageContext)
                 messageContext).getAxis2MessageContext();
-
         String resourcePath = messageContext.getProperty(APIMgtGatewayConstants.API_ELECTED_RESOURCE).toString();
         String requestMethod = axis2MC.getProperty(APIMgtGatewayConstants.HTTP_REQUEST_METHOD).toString();
         String schema;
@@ -348,7 +343,6 @@ public class SchemaValidator extends AbstractHandler {
         if (schemaCon != null) {
             if (!schemaCon.toString().equals("[]")) {
                 return extractReference(schemaCon.toString());
-
             } else {
                 StringBuilder pathBuilder = new StringBuilder();
                 pathBuilder.append(APIMgtGatewayConstants.PATHS).append(electedResource).
@@ -526,7 +520,7 @@ public class SchemaValidator extends AbstractHandler {
             int index = path.lastIndexOf(APIMgtGatewayConstants.FORWARD_SLASH);
             searchLastIndex = path.substring(index + 1);
         }
-        
+
         String nodeVal = path.replaceAll("" + APIMgtGatewayConstants.FORWARD_SLASH, ".");
         String name = null;
         Object object = JsonPath.read(swagger, APIMgtGatewayConstants.JSON_PATH + nodeVal);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
@@ -171,13 +171,15 @@ public class SchemaValidator extends AbstractHandler {
                 finalMessage.append(message).append(", ");
             }
             if (messageContext.isResponse()) {
-                logger.error("Schema validation failed in the Response : " + e.getMessage(), e);
+                String message = "Schema validation failed in the Response: ";
+                logger.error(message  + e.getMessage(), e);
                 GatewayUtils.handleThreat(messageContext, APIMgtGatewayConstants.INTERNAL_ERROR_CODE,
-                        "Schema validation failed in the Response : " + finalMessage);
+                        message + finalMessage);
             } else {
-                logger.error("Schema validation failed in the Request : " + e.getMessage(), e);
+                String errMessage = "Schema validation failed in the Request: ";
+                logger.error(errMessage + e.getMessage(), e);
                 GatewayUtils.handleThreat(messageContext, APIMgtGatewayConstants.HTTP_SC_CODE,
-                        "Schema validation failed in the Request : " + finalMessage);
+                        errMessage + finalMessage);
             }
 
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
@@ -83,7 +83,7 @@ public class SchemaValidator extends AbstractHandler {
         }
         contentType = objContentType.toString();
         if (logger.isDebugEnabled()) {
-            logger.debug("Content type of the request message : " + contentType);
+            logger.debug("Content type of the request message: " + contentType);
         }
         try {
             RelayUtils.buildMessage(axis2MC);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/threatprotection/analyzer/XMLAnalyzer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/threatprotection/analyzer/XMLAnalyzer.java
@@ -59,7 +59,6 @@ public class XMLAnalyzer implements APIMThreatAnalyzer {
         Integer maxElementCount = config.getMaxElementCount();
         Integer maxAttributeCount = config.getMaxAttributeCount();
         Integer maxAttributeLength = config.getMaxAttributeLength();
-        Integer entityExpansionLimit = config.getEntityExpansionLimit();
         Integer maxChildrenPerElement = config.getMaxChildrenPerElement();
         factory.setProperty(XMLInputFactory.SUPPORT_DTD, dtdEnabled);
         factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, externalEntitiesEnabled);
@@ -67,7 +66,6 @@ public class XMLAnalyzer implements APIMThreatAnalyzer {
         factory.setProperty(ThreatProtectorConstants.P_MAX_ATTRIBUTES_PER_ELEMENT, maxAttributeCount);
         factory.setProperty(ThreatProtectorConstants.P_MAX_ELEMENT_DEPTH, maxDepth);
         factory.setProperty(ThreatProtectorConstants.P_MAX_CHILDREN_PER_ELEMENT, maxChildrenPerElement);
-        factory.setProperty(ThreatProtectorConstants.P_MAX_ENTITY_COUNT, entityExpansionLimit);
         factory.setProperty(ThreatProtectorConstants.P_MAX_ELEMENT_COUNT, maxElementCount);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/threatprotection/utils/ThreatProtectorConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/threatprotection/utils/ThreatProtectorConstants.java
@@ -47,7 +47,6 @@ public class ThreatProtectorConstants {
     public static final String P_MAX_CHILDREN_PER_ELEMENT = "com.ctc.wstx.maxChildrenPerElement";
     public static final String P_MAX_ELEMENT_COUNT = "com.ctc.wstx.maxElementCount";
     public static final String P_MAX_ELEMENT_DEPTH = "com.ctc.wstx.maxElementDepth";
-    public static final String P_MAX_ENTITY_COUNT = "com.ctc.wstx.maxEntityCount";
     public static final String REQUEST_BUFFER_SIZE = "RequestMessageBufferSize";
     public static final String XML = "XML";
     public static final String ORIGINAL = "Original";

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -316,7 +316,11 @@ public class GatewayUtils {
                                        String errorCode, String desc) {
         messageContext.setProperty(APIMgtGatewayConstants.THREAT_FOUND, true);
         messageContext.setProperty(APIMgtGatewayConstants.THREAT_CODE, errorCode);
-        messageContext.setProperty(APIMgtGatewayConstants.THREAT_MSG, APIMgtGatewayConstants.BAD_REQUEST);
+        if (messageContext.isResponse()) {
+            messageContext.setProperty(APIMgtGatewayConstants.THREAT_MSG, APIMgtGatewayConstants.BAD_RESPONSE);
+        } else {
+            messageContext.setProperty(APIMgtGatewayConstants.THREAT_MSG, APIMgtGatewayConstants.BAD_REQUEST);
+        }
         messageContext.setProperty(APIMgtGatewayConstants.THREAT_DESC, desc);
         Mediator sequence = messageContext.getSequence(APIMgtGatewayConstants.THREAT_FAULT);
         // Invoke the custom error handler specified by the user


### PR DESCRIPTION
When error count is more than one, it gives a common error message in below.

<am:fault xmlns:am="http://wso2.org/apimanager">
  <am:code>400</am:code>
  <am:message>Bad Request</am:message>
  <am:description> # 2 errors in the request </am:description>
</am:fault>

Now it gives specific error messages.
Sample error message:

<am:fault xmlns:am="http://wso2.org/apimanager">
  <am:code>400</am:code>
  <am:message>Bad Request</am:message>
  <am:description>**Schema validation failed in the Request :#/photoUrls: expected type: JSONArray, found: String, #/tags: expected type: JSONArray, found: JSONObject** </am:description>
</am:fault>
