### PR TITLE
Rename alert configuration siddhi apps

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/alert/AlertTypesPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/alert/AlertTypesPublisher.java
@@ -84,7 +84,7 @@ public class AlertTypesPublisher {
             alertTypeDTO.setPublisher(false);
             alertTypeDTO.setAdmin(true);
         }
-        String appName = "APIM_ALERT_STAKEHOLDER";
+        String appName = "APIM_STAKEHOLDER_ALERT";
         String query = "select '" + alertTypeDTO.getUserName() + "' as userId, '" + alertTypeDTO.getAlertTypes()
                 + "' as alertTypes, '" + alertTypeDTO.getEmails() + "' as emails, " + alertTypeDTO.isSubscriber()
                 + " as isSubscriber, " + alertTypeDTO.isPublisher() + " as isPublisher, " + alertTypeDTO.isAdmin()
@@ -172,7 +172,7 @@ public class AlertTypesPublisher {
             alertTypeDTO.setPublisher(false);
             alertTypeDTO.setAdmin(true);
         }
-        String appName = "APIM_ALERT_STAKEHOLDER";
+        String appName = "APIM_STAKEHOLDER_ALERT";
         String query =
                 "delete ApimAlertStakeholderInfo  on ApimAlertStakeholderInfo.userId == '" + alertTypeDTO.getUserName()
                         + "' and " + conditionClause;

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/alert/AlertTypesPublisher1Test.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/alert/AlertTypesPublisher1Test.java
@@ -63,8 +63,8 @@ public class AlertTypesPublisher1Test {
                 + " ApimAlertStakeholderInfo.isSubscriber = isSubscriber, ApimAlertStakeholderInfo.isPublisher = isPublisher, "
                 + "ApimAlertStakeholderInfo.isAdmin = isAdmin on ApimAlertStakeholderInfo.userId == userId and "
                 + "ApimAlertStakeholderInfo.isAdmin == isAdmin";
-        BDDMockito.given(APIUtil.executeQueryOnStreamProcessor("APIM_ALERT_STAKEHOLDER", query1)).willReturn(obj);
-        BDDMockito.given(APIUtil.executeQueryOnStreamProcessor("APIM_ALERT_STAKEHOLDER", query2)).willReturn(obj);
+        BDDMockito.given(APIUtil.executeQueryOnStreamProcessor("APIM_STAKEHOLDER_ALERT", query1)).willReturn(obj);
+        BDDMockito.given(APIUtil.executeQueryOnStreamProcessor("APIM_STAKEHOLDER_ALERT", query2)).willReturn(obj);
         AlertTypesPublisher alertTypesPublisher = new AlertTypesPublisherWrapper(apiMgtDAO);
         alertTypesPublisher.publisher = apiMgtUsageDataPublisher;
         alertTypesPublisher.enabled = true;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/alertmgt/AlertMgtConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/alertmgt/AlertMgtConstants.java
@@ -24,8 +24,8 @@ import java.util.Map;
 public class AlertMgtConstants {
 
     public static final String PUBLISHER_AGENT = "publisher";
-    public static final String APIM_ALERT_STAKEHOLDER_APP = "APIM_ALERT_STAKEHOLDER";
-    public static final String APIM_ALERT_CONFIG_APP = "APIM_ALERT_CONFIGURATION";
+    public static final String APIM_STAKEHOLDER_ALERT_APP = "APIM_STAKEHOLDER_ALERT";
+    public static final String APIM_ALERT_CONFIG_APP = "APIM_CONFIGURATION_ALERT";
     public static final String API_NAME_KEY = "apiName";
     public static final String API_CREATOR_KEY = "apiCreator";
     public static final String API_VERSION_KEY = "apiVersion";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/alertmgt/PublisherAlertConfigurator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/alertmgt/PublisherAlertConfigurator.java
@@ -60,7 +60,7 @@ public class PublisherAlertConfigurator extends AlertConfigurator {
                         + "ApimAlertStakeholderInfo.isAdmin = isAdmin on "
                         + "ApimAlertStakeholderInfo.userId == userId and "
                         + "ApimAlertStakeholderInfo.isPublisher == isPublisher";
-        APIUtil.executeQueryOnStreamProcessor(AlertMgtConstants.APIM_ALERT_STAKEHOLDER_APP, query);
+        APIUtil.executeQueryOnStreamProcessor(AlertMgtConstants.APIM_STAKEHOLDER_ALERT_APP, query);
         apiMgtDAO.addAlertTypesConfigInfo(userName, emails, alertTypesMap.get("ids"),
                 AlertMgtConstants.PUBLISHER_AGENT);
     }
@@ -70,7 +70,7 @@ public class PublisherAlertConfigurator extends AlertConfigurator {
         apiMgtDAO.unSubscribeAlerts(userName, AlertMgtConstants.PUBLISHER_AGENT);
         String query = "delete ApimAlertStakeholderInfo on ApimAlertStakeholderInfo.userId == '" + userName + "' and "
                 + "ApimAlertStakeholderInfo.isPublisher == true";
-        APIUtil.executeQueryOnStreamProcessor(AlertMgtConstants.APIM_ALERT_STAKEHOLDER_APP, query);
+        APIUtil.executeQueryOnStreamProcessor(AlertMgtConstants.APIM_STAKEHOLDER_ALERT_APP, query);
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/alertmgt/StoreAlertConfigurator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/alertmgt/StoreAlertConfigurator.java
@@ -68,7 +68,7 @@ public class StoreAlertConfigurator extends AlertConfigurator {
                         + "ApimAlertStakeholderInfo.userId == userId and "
                         + "ApimAlertStakeholderInfo.isSubscriber == isSubscriber";
 
-        APIUtil.executeQueryOnStreamProcessor(AlertMgtConstants.APIM_ALERT_STAKEHOLDER_APP, query);
+        APIUtil.executeQueryOnStreamProcessor(AlertMgtConstants.APIM_STAKEHOLDER_ALERT_APP, query);
         apiMgtDAO.addAlertTypesConfigInfo(userName, emails, alertTypesMap.get("ids"), AlertMgtConstants.STORE_AGENT);
     }
 
@@ -78,7 +78,7 @@ public class StoreAlertConfigurator extends AlertConfigurator {
         apiMgtDAO.unSubscribeAlerts(userName, AlertMgtConstants.STORE_AGENT);
         String query = "delete ApimAlertStakeholderInfo on ApimAlertStakeholderInfo.userId == '" + userName + "' and "
                 + "ApimAlertStakeholderInfo.isSubscriber == true";
-        APIUtil.executeQueryOnStreamProcessor(AlertMgtConstants.APIM_ALERT_STAKEHOLDER_APP, query);
+        APIUtil.executeQueryOnStreamProcessor(AlertMgtConstants.APIM_STAKEHOLDER_ALERT_APP, query);
 
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-old/modules/configure-alert/alerts.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher-old/modules/configure-alert/alerts.jag
@@ -15,7 +15,7 @@ var getPublisherAlertConfigs  = function (type) {
         var MultitenantUtils = Packages.org.wso2.carbon.utils.multitenancy.MultitenantUtils;
         var domainName = MultitenantUtils.getTenantDomain(username);
 
-        var appName = "APIM_ALERT_CONFIGURATION"; 
+        var appName = "APIM_CONFIGURATION_ALERT";
         var query =  "from ApiCreatorAlertConfiguration on apiCreator=='" 
                     + username + "' and apiCreatorTenantDomain=='" + domainName + "' and "
                     + typeColName +"!=0 select apiName,apiVersion,apiCreator,apiCreatorTenantDomain, " + typeColName + "; ";
@@ -63,7 +63,7 @@ var addOrUpdatePublisherAlertConfigs  = function (apiName, apiVersion, type, val
         var username = jagg.getUser().username;
         var MultitenantUtils = Packages.org.wso2.carbon.utils.multitenancy.MultitenantUtils;
         var domainName = MultitenantUtils.getTenantDomain(username);
-        var appName = "APIM_ALERT_CONFIGURATION"; 
+        var appName = "APIM_CONFIGURATION_ALERT";
    
         if (typeColName == 'thresholdBackendTime') {
             thresholdBackendTime = value;
@@ -107,7 +107,7 @@ var deletePublisherAlertConfigs = function (apiName, apiVersion, type) {
         var username = jagg.getUser().username;
         var MultitenantUtils = Packages.org.wso2.carbon.utils.multitenancy.MultitenantUtils;
         var domainName = MultitenantUtils.getTenantDomain(username);
-        var appName = "APIM_ALERT_CONFIGURATION"; 
+        var appName = "APIM_CONFIGURATION_ALERT";
 
         var query = "select '"+apiName+"' as apiName, '"+apiVersion+"' as apiVersion, '"
             + username + "' as apiCreator, '" + domainName + "' as apiCreatorTenantDomain,"

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-old/modules/configure-alert/alerts.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/store-old/modules/configure-alert/alerts.jag
@@ -6,7 +6,7 @@ var getStoreAlertConfigs  = function () {
         var APIUtil = org.wso2.carbon.apimgt.impl.utils.APIUtil;
         var tenantAwareUserName = jagg.getUser().username;
 
-        var appName = "APIM_ALERT_CONFIGURATION"; 
+        var appName = "APIM_CONFIGURATION_ALERT";
         var query =  "from ApiSubAlertConf on subscriber == '" + tenantAwareUserName + "' select applicationId ,apiName , apiVersion , thresholdRequestCountPerMin;";
         var objArr = [];
 
@@ -47,7 +47,7 @@ var addOrUpdateStoreAlertConfigs  = function (applicationId, apiName, apiVersion
         var APIUtil = org.wso2.carbon.apimgt.impl.utils.APIUtil;
         var tenantAwareUserName = jagg.getUser().username;
 
-        var appName = "APIM_ALERT_CONFIGURATION";
+        var appName = "APIM_CONFIGURATION_ALERT";
         var query = "select '" + applicationId + "' as applicationId, '" + tenantAwareUserName + "' as subscriber, '" + apiName + "' as apiName,'"
             + apiVersion + "' as apiVersion, " + parseInt(thresholdRequestCountPerMin)
             + " as thresholdRequestCountPerMin update or insert into ApiSubAlertConf "
@@ -80,7 +80,7 @@ var deleteStoreAlertConfigs  = function (applicationId, apiName, apiVersion) {
         var APIUtil = org.wso2.carbon.apimgt.impl.utils.APIUtil;
         var tenantAwareUserName = jagg.getUser().username;
 
-        var appName = "APIM_ALERT_CONFIGURATION"; 
+        var appName = "APIM_CONFIGURATION_ALERT";
         var query = "delete ApiSubAlertConf on ApiSubAlertConf.applicationId == '"
             + applicationId + "' and ApiSubAlertConf.apiName == '" + apiName
             + "' and ApiSubAlertConf.subscriber == '" + tenantAwareUserName


### PR DESCRIPTION
Rename alert configuration siddhi apps, in order to fix error which occurs when configuring alerts from store/publisher without enabling alerts in analytics server

Related PR: https://github.com/wso2/analytics-apim/pull/704