### PR TITLE
Fix cross domain requests in basic auth

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticator.java
@@ -225,7 +225,7 @@ public class BasicAuthAuthenticator implements Authenticator {
         String password = credentials[1];
 
         // If end user tenant domain does not match the API publisher's tenant domain, return error
-        if(!MultitenantUtils.getTenantDomain(username).equals(synCtx.getProperty(PUBLISHER_TENANT_DOMAIN))) {
+        if (!MultitenantUtils.getTenantDomain(username).equals(synCtx.getProperty(PUBLISHER_TENANT_DOMAIN))) {
             log.error("Basic Authentication failure: tenant domain mismatch for user :" + username);
             return new AuthenticationResponse(false, isMandatory, true,
                     APISecurityConstants.API_AUTH_FORBIDDEN,

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticator.java
@@ -50,6 +50,7 @@ public class BasicAuthAuthenticator implements Authenticator {
 
     private static final Log log = LogFactory.getLog(BasicAuthAuthenticator.class);
     private final String basicAuthKeyHeaderSegment = "Basic";
+    static final String PUBLISHER_TENANT_DOMAIN = "tenant.info.domain";
 
     private String securityHeader;
     private String requestOrigin;
@@ -222,6 +223,14 @@ public class BasicAuthAuthenticator implements Authenticator {
         }
         String username = getEndUserName(credentials[0]);
         String password = credentials[1];
+
+        // If end user tenant domain does not match the API publisher's tenant domain, return error
+        if(!MultitenantUtils.getTenantDomain(username).equals(synCtx.getProperty(PUBLISHER_TENANT_DOMAIN))) {
+            log.error("Basic Authentication failure: tenant domain mismatch for user :" + username);
+            return new AuthenticationResponse(false, isMandatory, true,
+                    APISecurityConstants.API_AUTH_FORBIDDEN,
+                    APISecurityConstants.API_AUTH_FORBIDDEN_MESSAGE);
+        }
 
         boolean authenticated = false;
         try {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticatorTest.java
@@ -39,7 +39,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.util.TreeMap;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({OpenAPIUtils.class, MultitenantUtils.class})
+@PrepareForTest(OpenAPIUtils.class)
 public class BasicAuthAuthenticatorTest {
     private MessageContext messageContext;
     private org.apache.axis2.context.MessageContext axis2MsgCntxt;

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticatorTest.java
@@ -34,11 +34,12 @@ import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityException;
 import org.wso2.carbon.apimgt.gateway.handlers.security.AuthenticationResponse;
 import org.wso2.carbon.apimgt.gateway.utils.OpenAPIUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.TreeMap;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(OpenAPIUtils.class)
+@PrepareForTest({OpenAPIUtils.class, MultitenantUtils.class})
 public class BasicAuthAuthenticatorTest {
     private MessageContext messageContext;
     private org.apache.axis2.context.MessageContext axis2MsgCntxt;
@@ -86,6 +87,8 @@ public class BasicAuthAuthenticatorTest {
                     return false;
                 });
         basicAuthAuthenticator.setBasicAuthCredentialValidator(basicAuthCredentialValidator);
+        Mockito.when(messageContext.getProperty(BasicAuthAuthenticator.PUBLISHER_TENANT_DOMAIN)).
+                thenReturn("carbon.super");
     }
 
     @Test

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticatorTest.java
@@ -16,7 +16,6 @@
 
 package org.wso2.carbon.apimgt.gateway.handlers.security.basicauth;
 
-
 import io.swagger.v3.oas.models.OpenAPI;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
@@ -34,7 +33,6 @@ import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityException;
 import org.wso2.carbon.apimgt.gateway.handlers.security.AuthenticationResponse;
 import org.wso2.carbon.apimgt.gateway.utils.OpenAPIUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
-import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.TreeMap;
 


### PR DESCRIPTION
Cross tenant domain requests shouldn't be allowed for basic auth.