### PR TITLE
Making the overview infor collapsabe panel expanded by default

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/site/public/theme/defaultTheme.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/site/public/theme/defaultTheme.js
@@ -218,6 +218,35 @@ const Configurations = {
                         hasIcon: false,
                     },
                 },
+                social: {
+                    showRating: true,
+                },
+                apiDetailPages: {
+                    showCredentials: true,
+                    showComments: true,
+                    showTryout: true,
+                    showDocuments: true,
+                    showSdks: true,
+                    onlyShowSdks: [], // You can put an array of strings to enable only a given set of sdks. Leave empty to show all. ex: ['java','javascript'] 
+                },
+                banner: {
+                    active: false, // make it true to display a banner image
+                    style: 'text', // 'can take 'image' or 'text'. If text it will display the 'banner.text' value else it will display the 'banner.image' value.
+                    image: '/site/public/images/landing/01.jpg',
+                    text: 'This is a very important announcement',
+                    color: '#ffffff',
+                    background: '#e08a00',
+                    padding: 20,
+                    margin: 0,
+                    fontSize: 18,
+                    textAlign: 'center',
+                },
+                footer: {
+                    active: true,
+                    text: '', // Leave empty to show the default WSO2 Text. Provide custom text to display your own thing.
+                    background: '#bdbdbd',
+                    color: '#222222',
+                },
             },
         },
     },

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/InfoBar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/InfoBar.jsx
@@ -21,7 +21,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import Icon from '@material-ui/core/Icon';
-import { Link } from 'react-router-dom';
+import { Link, withRouter } from 'react-router-dom';
 import Collapse from '@material-ui/core/Collapse';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -34,7 +34,7 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import API from 'AppData/api';
 import StarRatingBar from 'AppComponents/Apis/Listing/StarRatingBar';
 import VerticalDivider from '../../Shared/VerticalDivider';
-import ImageGenerator from '../Listing/ImageGenerator';
+import ApiThumb from '../Listing/ApiThumb';
 import ResourceNotFound from '../../Base/Errors/ResourceNotFound';
 import AuthManager from '../../../data/AuthManager';
 import { ApiContext } from 'AppComponents/Apis/Details/ApiContext';
@@ -159,7 +159,7 @@ const styles = (theme) => {
             marginRight: theme.spacing(1),
         },
         expandWrapper: {
-            cursor:'pointer',
+            cursor: 'pointer',
             display: 'block',
         },
     };
@@ -184,13 +184,31 @@ class InfoBar extends React.Component {
             tabValue: 'Social Sites',
             comment: '',
             commentList: null,
-            showOverview: false,
+            showOverview: true,
             checked: false,
             ratingUpdate: 0,
         };
         this.getSchema = this.getSchema.bind(this);
         this.getProvider = this.getProvider.bind(this);
         this.setRatingUpdate = this.setRatingUpdate.bind(this);
+    }
+    ditectCurrentMenu = (location) => {
+        const routeToCheck = 'overview';
+        const { pathname } = location;
+        const test1 = new RegExp('/' + routeToCheck + '$', 'g');
+        const test2 = new RegExp('/' + routeToCheck + '/', 'g');
+        if (pathname.match(test1) || pathname.match(test2)) {
+            this.setState({ showOverview: true });
+        } else {
+            this.setState({ showOverview: false });
+        }
+    };
+    componentDidMount() {
+        const { history } = this.props;
+        this.ditectCurrentMenu(history.location);
+        history.listen((location) => {
+            this.ditectCurrentMenu(location);
+        });
     }
 
     /**
@@ -260,8 +278,9 @@ class InfoBar extends React.Component {
         const {
             custom: {
                 leftMenu: { position },
-                infoBar: { showThumbnail, sliderPosition, sliderBackground },
+                infoBar: { showThumbnail },
                 tagWise: { key, active },
+                social: { showRating },
             },
         } = theme;
 
@@ -284,7 +303,7 @@ class InfoBar extends React.Component {
         }
 
         return (
-            <div className={classes.infoBarMain}>
+            <div className={classes.infoBarMain} id='infoBar'>
                 <div className={classes.root}>
                     <Link to='/apis' className={classes.backLink}>
                         <Icon className={classes.backIcon}>keyboard_arrow_left</Icon>
@@ -297,7 +316,7 @@ class InfoBar extends React.Component {
                     {showThumbnail && (
                         <React.Fragment>
                             <VerticalDivider height={70} />
-                            <ImageGenerator api={api} width='70' height='50' />
+                            <ApiThumb api={api} customWidth={70} customHeight={50} showInfo={false} />
                         </React.Fragment>
                     )}
                     <div style={{ marginLeft: theme.spacing.unit }}>
@@ -307,7 +326,7 @@ class InfoBar extends React.Component {
                         </Typography>
                     </div>
                     <VerticalDivider height={70} />
-                    {!api.advertiseInfo.advertised && user && (
+                    {!api.advertiseInfo.advertised && user && showRating && (
                         <StarRatingBar
                             apiId={api.id}
                             isEditable={false}
@@ -397,7 +416,7 @@ class InfoBar extends React.Component {
                                                     </TableCell>
                                                     <TableCell>21 May 2018</TableCell>
                                                 </TableRow> */}
-                                        {user && !api.advertiseInfo.advertised && (
+                                        {user && !api.advertiseInfo.advertised && showRating && (
                                             <TableRow>
                                                 <TableCell component='th' scope='row'>
                                                     <div className={classes.iconAligner}>
@@ -568,4 +587,4 @@ InfoBar.propTypes = {
 
 InfoBar.contextType = ApiContext;
 
-export default injectIntl(withStyles(styles, { withTheme: true })(InfoBar));
+export default injectIntl(withRouter(withStyles(styles, { withTheme: true })(InfoBar)));

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Overview.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Overview.jsx
@@ -52,7 +52,7 @@ const styles = theme => ({
     root: {
         padding: theme.spacing.unit * 3,
         color: theme.palette.getContrastText(theme.palette.background.paper),
-        margin: -1 * theme.spacing(0,2),
+        margin: -1 * theme.spacing(0, 2),
     },
     iconClass: {
         marginRight: 10,
@@ -175,6 +175,13 @@ ExpansionPanelSummary.muiName = 'ExpansionPanelSummary';
  */
 function Overview(props) {
     const { classes, theme } = props;
+    const {
+        custom: {
+            apiDetailPages: {
+                showCredentials, showComments, showTryout, showDocuments, showSdks,
+            },
+        },
+    } = theme;
     const { api, applicationsAvailable, subscribedApplications } = useContext(ApiContext);
     const [totalComments, setCount] = useState(0);
     const [totalDocuments, setDocsCount] = useState(0);
@@ -233,7 +240,7 @@ function Overview(props) {
     const user = AuthManager.getUser();
     return (
         <Grid container className={classes.root} spacing={2}>
-            {!api.advertiseInfo.advertised && (
+            {!api.advertiseInfo.advertised && showCredentials && (
                 <Grid item xs={12} lg={6}>
                     <ExpansionPanel defaultExpanded>
                         <ExpansionPanelSummary>
@@ -284,8 +291,8 @@ function Overview(props) {
                                             <FormattedMessage
                                                 id='Apis.Details.Overview.credential.wizard.info'
                                                 defaultMessage={
-                                                    'Use the Key Generation Wizard. Create a new application '
-                                                    + '-> Subscribe -> ' +
+                                                    'Use the Key Generation Wizard. Create a new application ' +
+                                                    '-> Subscribe -> ' +
                                                     ' Generate keys and Access Token to invoke this API.'
                                                 }
                                             />
@@ -318,8 +325,9 @@ function Overview(props) {
                                             <React.Fragment>
                                                 <Link
                                                     to={'/apis/' + api.id + '/credentials'}
-                                                    style={!api.isSubscriptionAvailable ?
-                                                        { pointerEvents: 'none' } : null}
+                                                    style={
+                                                        !api.isSubscriptionAvailable ? { pointerEvents: 'none' } : null
+                                                    }
                                                 >
                                                     <Button
                                                         variant='contained'
@@ -359,7 +367,7 @@ function Overview(props) {
                     </ExpansionPanel>
                 </Grid>
             )}
-            {api.type !== 'WS' && (
+            {api.type !== 'WS' && showTryout && (
                 <Grid item xs={12} lg={6}>
                     <ExpansionPanel defaultExpanded>
                         <ExpansionPanelSummary>
@@ -397,68 +405,70 @@ function Overview(props) {
             )}
             {!api.advertiseInfo.advertised && (
                 <React.Fragment>
-                    <Grid item xs={12} lg={6}>
-                        <ExpansionPanel defaultExpanded>
-                            <ExpansionPanelSummary>
-                                <CustomIcon
-                                    strokeColor={titleIconColor}
-                                    className={classes.iconClass}
-                                    width={titleIconSize}
-                                    height={titleIconSize}
-                                    icon='comments'
-                                />
-                                <Typography className={classes.heading} variant='h6'>
-                                    <FormattedMessage
-                                        id='Apis.Details.Overview.comments.title'
-                                        defaultMessage='Comments'
+                    {showComments && (
+                        <Grid item xs={12} lg={6}>
+                            <ExpansionPanel defaultExpanded>
+                                <ExpansionPanelSummary>
+                                    <CustomIcon
+                                        strokeColor={titleIconColor}
+                                        className={classes.iconClass}
+                                        width={titleIconSize}
+                                        height={titleIconSize}
+                                        icon='comments'
                                     />
-                                </Typography>
-                                <Typography className={classes.subheading}>
-                                    {' ' + (totalComments > 3 ? 3 : totalComments) + ' of ' + totalComments}
-                                </Typography>
-                            </ExpansionPanelSummary>
-                            <ExpansionPanelDetails
-                                classes={{
-                                    root: classNames(
-                                        { [classes.noCommentRoot]: totalComments === 0 },
-                                        { [classes.commentRoot]: totalComments !== 0 },
-                                    ),
-                                }}
-                            >
-                                <Grid container className={classes.root} spacing={2}>
-                                    {api &&
-                                        <Grid item xs={12}>
-                                            <Comments apiId={api.id} showLatest isOverview setCount={setCount} />
-                                        </Grid>
-                                    }
-                                    {totalComments === 0 &&
-                                        <Grid item xs={12}>
-                                            <div className={classes.emptyBox}>
-                                                <Typography variant='body2'>
-                                                    <FormattedMessage
-                                                        id='Apis.Details.Overview.comments.no.content'
-                                                        defaultMessage='No Comments Yet'
-                                                    />
-                                                </Typography>
-                                            </div>
-                                        </Grid>
-                                    }
-                                </Grid>
-                            </ExpansionPanelDetails>
-                            <Divider />
-                            <ExpansionPanelActions className={classes.actionPanel}>
-                                <Link to={'/apis/' + api.id + '/comments'} className={classes.button}>
-                                    <Button size='small' color='primary'>
+                                    <Typography className={classes.heading} variant='h6'>
                                         <FormattedMessage
-                                            id='Apis.Details.Overview.comments.show.more'
-                                            defaultMessage='Show More >>'
+                                            id='Apis.Details.Overview.comments.title'
+                                            defaultMessage='Comments'
                                         />
-                                    </Button>
-                                </Link>
-                            </ExpansionPanelActions>
-                        </ExpansionPanel>
-                    </Grid>
-                    {api.type !== 'WS' && (
+                                    </Typography>
+                                    <Typography className={classes.subheading}>
+                                        {' ' + (totalComments > 3 ? 3 : totalComments) + ' of ' + totalComments}
+                                    </Typography>
+                                </ExpansionPanelSummary>
+                                <ExpansionPanelDetails
+                                    classes={{
+                                        root: classNames(
+                                            { [classes.noCommentRoot]: totalComments === 0 },
+                                            { [classes.commentRoot]: totalComments !== 0 },
+                                        ),
+                                    }}
+                                >
+                                    <Grid container className={classes.root} spacing={2}>
+                                        {api && (
+                                            <Grid item xs={12}>
+                                                <Comments apiId={api.id} showLatest isOverview setCount={setCount} />
+                                            </Grid>
+                                        )}
+                                        {totalComments === 0 && (
+                                            <Grid item xs={12}>
+                                                <div className={classes.emptyBox}>
+                                                    <Typography variant='body2'>
+                                                        <FormattedMessage
+                                                            id='Apis.Details.Overview.comments.no.content'
+                                                            defaultMessage='No Comments Yet'
+                                                        />
+                                                    </Typography>
+                                                </div>
+                                            </Grid>
+                                        )}
+                                    </Grid>
+                                </ExpansionPanelDetails>
+                                <Divider />
+                                <ExpansionPanelActions className={classes.actionPanel}>
+                                    <Link to={'/apis/' + api.id + '/comments'} className={classes.button}>
+                                        <Button size='small' color='primary'>
+                                            <FormattedMessage
+                                                id='Apis.Details.Overview.comments.show.more'
+                                                defaultMessage='Show More >>'
+                                            />
+                                        </Button>
+                                    </Link>
+                                </ExpansionPanelActions>
+                            </ExpansionPanel>
+                        </Grid>
+                    )}
+                    {api.type !== 'WS' && showSdks && (
                         <Grid item xs={6}>
                             <ExpansionPanel defaultExpanded>
                                 <ExpansionPanelSummary>
@@ -508,41 +518,46 @@ function Overview(props) {
                     )}
                 </React.Fragment>
             )}
-            <Grid item xs={12} lg={6}>
-                <ExpansionPanel defaultExpanded>
-                    <ExpansionPanelSummary>
-                        <CustomIcon
-                            strokeColor={titleIconColor}
-                            className={classes.iconClass}
-                            width={titleIconSize}
-                            height={titleIconSize}
-                            icon='docs'
-                        />
+            {showDocuments && (
+                <Grid item xs={12} lg={6}>
+                    <ExpansionPanel defaultExpanded>
+                        <ExpansionPanelSummary>
+                            <CustomIcon
+                                strokeColor={titleIconColor}
+                                className={classes.iconClass}
+                                width={titleIconSize}
+                                height={titleIconSize}
+                                icon='docs'
+                            />
 
-                        <Typography className={classes.heading} variant='h6'>
-                            <FormattedMessage id='Apis.Details.Overview.documents.title' defaultMessage='Documents' />
-                        </Typography>
-                    </ExpansionPanelSummary>
-                    <ExpansionPanelDetails
-                        classes={{ root: classNames({ [classes.noDocumentRoot]: totalDocuments === 0 }) }}
-                    >
-                        <Grid container className={classes.root} spacing={2}>
-                            <OverviewDocuments apiId={api.id} setDocsCount={setDocsCount} />
-                        </Grid>
-                    </ExpansionPanelDetails>
-                    <Divider />
-                    <ExpansionPanelActions className={classes.actionPanel}>
-                        <Link to={'/apis/' + api.id + '/documents'} className={classes.button}>
-                            <Button size='small' color='primary'>
+                            <Typography className={classes.heading} variant='h6'>
                                 <FormattedMessage
-                                    id='Apis.Details.Overview.comments.show.more'
-                                    defaultMessage='Show More >>'
+                                    id='Apis.Details.Overview.documents.title'
+                                    defaultMessage='Documents'
                                 />
-                            </Button>
-                        </Link>
-                    </ExpansionPanelActions>
-                </ExpansionPanel>
-            </Grid>
+                            </Typography>
+                        </ExpansionPanelSummary>
+                        <ExpansionPanelDetails
+                            classes={{ root: classNames({ [classes.noDocumentRoot]: totalDocuments === 0 }) }}
+                        >
+                            <Grid container className={classes.root} spacing={2}>
+                                <OverviewDocuments apiId={api.id} setDocsCount={setDocsCount} />
+                            </Grid>
+                        </ExpansionPanelDetails>
+                        <Divider />
+                        <ExpansionPanelActions className={classes.actionPanel}>
+                            <Link to={'/apis/' + api.id + '/documents'} className={classes.button}>
+                                <Button size='small' color='primary'>
+                                    <FormattedMessage
+                                        id='Apis.Details.Overview.comments.show.more'
+                                        defaultMessage='Show More >>'
+                                    />
+                                </Button>
+                            </Link>
+                        </ExpansionPanelActions>
+                    </ExpansionPanel>
+                </Grid>
+            )}
         </Grid>
     );
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Sdk.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Sdk.jsx
@@ -29,7 +29,7 @@ import JSFileDownload from 'js-file-download';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, withTheme } from '@material-ui/core/styles';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import InlineMessage from 'AppComponents/Shared/InlineMessage';
 import AuthManager from 'AppData/AuthManager';
@@ -173,12 +173,24 @@ class Sdk extends React.Component {
      */
     render() {
         const languageList = this.state.items;
-        const { onlyIcons, intl, classes } = this.props;
+        const {
+            onlyIcons, intl, classes, theme,
+        } = this.props;
+        const {
+            custom: {
+                apiDetailPages: { onlyShowSdks },
+            },
+        } = theme;
+        const filteredLanguageList =
+        languageList && languageList.length > 0 && onlyShowSdks && onlyShowSdks.length > 0
+                ? languageList.filter(lang => onlyShowSdks.includes(lang.toLowerCase()))
+                : languageList;
         if (onlyIcons) {
             return (
-                languageList && (
+                filteredLanguageList && (
                     <React.Fragment>
-                        {languageList.map((language, index) => index < 3 && (
+                        {filteredLanguageList.map((language, index) =>
+                            index < 3 && (
                                 <Grid item xs={4}>
                                     <a
                                         onClick={event => this.handleClick(event, language)}
@@ -187,17 +199,20 @@ class Sdk extends React.Component {
                                         <img
                                             alt={language}
                                             src={
-                                                app.context + '/site/public/images/sdks/'
-                                                    + new String(language)
-                                                    + '.svg'
+                                                app.context +
+                                                    '/site/public/images/sdks/' +
+                                                    new String(language) +
+                                                    '.svg'
                                             }
                                             style={{
-                                                width: 80, height: 80, margin: 10,
+                                                width: 80,
+                                                height: 80,
+                                                margin: 10,
                                             }}
                                         />
                                     </a>
                                 </Grid>
-                            ),)}
+                            ))}
                     </React.Fragment>
                 )
             );
@@ -207,7 +222,7 @@ class Sdk extends React.Component {
                 <Typography variant='h4' className={classes.titleSub}>
                     <FormattedMessage id='Apis.Details.Sdk.title' defaultMessage='Software Development Kits (SDKs)' />
                 </Typography>
-                {languageList ? (
+                {filteredLanguageList ? (
                     <Grid container className='tab-grid' spacing={0}>
                         <Grid item xs={12} sm={6} md={9} lg={9} xl={10}>
                             {this.state.sdkLanguages.length >= this.filter_threshold && (
@@ -226,7 +241,7 @@ class Sdk extends React.Component {
                                 </Grid>
                             )}
                             <Grid container justify='flex-start' spacing={Number(24)}>
-                                {languageList.map((language, index) => (
+                                {filteredLanguageList.map((language, index) => (
                                     <Grid key={index} item>
                                         <div style={{ width: 'auto', textAlign: 'center', margin: '10px' }}>
                                             <Card>
@@ -234,15 +249,16 @@ class Sdk extends React.Component {
                                                 <Divider />
                                                 <CardMedia
                                                     title={language.toString().toUpperCase()}
-                                                    src={'/devportal/site/public/images/sdks/' + new String(language) +
-                                                    '.svg'}
+                                                    src={
+                                                        '/devportal/site/public/images/sdks/' +
+                                                        new String(language) +
+                                                        '.svg'
+                                                    }
                                                 >
                                                     <img
                                                         alt={language}
                                                         onError={this.addDefaultSrc}
-                                                        src={
-                                                            `/devportal/site/public/images/sdks/${language}.svg`
-                                                        }
+                                                        src={`/devportal/site/public/images/sdks/${language}.svg`}
                                                         style={{ width: '100px', height: '100px', margin: '30px' }}
                                                     />
                                                 </CardMedia>
@@ -268,10 +284,7 @@ class Sdk extends React.Component {
                     <div className={classes.genericMessageWrapper}>
                         <InlineMessage type='info' className={classes.dialogContainer}>
                             <Typography variant='h5' component='h3'>
-                                <FormattedMessage
-                                    id='Apis.Details.Sdk.no.sdks'
-                                    defaultMessage='No SDKs'
-                                />
+                                <FormattedMessage id='Apis.Details.Sdk.no.sdks' defaultMessage='No SDKs' />
                             </Typography>
                             <Typography component='p'>
                                 <FormattedMessage
@@ -291,4 +304,4 @@ Sdk.propTypes = {
     classes: PropTypes.instanceOf(Object).isRequired,
 };
 
-export default injectIntl(withStyles(styles)(Sdk));
+export default injectIntl(withStyles(styles, { withTheme: true })(Sdk));

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/index.jsx
@@ -38,37 +38,43 @@ import Wizard from './Credentials/Wizard/Wizard';
 const LoadableSwitch = withRouter(Loadable.Map({
     loader: {
         ApiConsole: () =>
-                import(// eslint-disable-line function-paren-newline
+                import(
+                    // eslint-disable-line function-paren-newline
                     /* webpackChunkName: "ApiConsole" */
                     /* webpackPrefetch: true */
                     // eslint-disable-next-line comma-dangle
                     './ApiConsole/ApiConsole'),
         Overview: () =>
-                import(// eslint-disable-line function-paren-newline
+                import(
+                    // eslint-disable-line function-paren-newline
                     /* webpackChunkName: "Overview" */
                     /* webpackPrefetch: true */
                     // eslint-disable-next-line comma-dangle
                     './Overview'),
         Documentation: () =>
-                import(// eslint-disable-line function-paren-newline
+                import(
+                    // eslint-disable-line function-paren-newline
                     /* webpackChunkName: "Documentation" */
                     /* webpackPrefetch: true */
                     // eslint-disable-next-line comma-dangle
                     './Documents/Documentation'),
         Credentials: () =>
-                import(// eslint-disable-line function-paren-newline
+                import(
+                    // eslint-disable-line function-paren-newline
                     /* webpackChunkName: "Credentials" */
                     /* webpackPrefetch: true */
                     // eslint-disable-next-line comma-dangle
                     './Credentials/Credentials'),
         Comments: () =>
-                import(// eslint-disable-line function-paren-newline
+                import(
+                    // eslint-disable-line function-paren-newline
                     /* webpackChunkName: "Comments" */
                     /* webpackPrefetch: true */
                     // eslint-disable-next-line comma-dangle
                     './Comments/Comments'),
         Sdk: () =>
-                import(// eslint-disable-line function-paren-newline
+                import(
+                    // eslint-disable-line function-paren-newline
                     /* webpackChunkName: "Sdk" */
                     /* webpackPrefetch: true */
                     // eslint-disable-next-line comma-dangle
@@ -92,11 +98,7 @@ const LoadableSwitch = withRouter(Loadable.Map({
                 <Redirect exact from={`/apis/${apiUuid}`} to={redirectURL} />
                 <Route path='/apis/:apiUuid/overview' render={() => <Overview {...props} />} />
                 <Route path='/apis/:apiUuid/documents' component={Documentation} />
-                <Route
-                    exact
-                    path='/apis/:apiUuid/credentials/wizard'
-                    component={Wizard}
-                />
+                <Route exact path='/apis/:apiUuid/credentials/wizard' component={Wizard} />
                 {!advertised && <Route path='/apis/:apiUuid/comments' component={Comments} />}
                 {!advertised && <Route path='/apis/:apiUuid/credentials' component={Credentials} />}
                 {!advertised && <Route path='/apis/:apiUuid/test' component={ApiConsole} />}
@@ -345,6 +347,9 @@ class Details extends React.Component {
                 leftMenu: {
                     rootIconSize, rootIconTextVisible, rootIconVisible, position,
                 },
+                apiDetailPages: {
+                    showCredentials, showComments, showTryout, showDocuments, showSdks,
+                },
             },
         } = theme;
         const globalStyle = 'body{ font-family: ' + theme.typography.fontFamily + '}';
@@ -382,42 +387,41 @@ class Details extends React.Component {
                         </Link>
                     )}
                     <LeftMenuItem
-                        text={
-                            <FormattedMessage id='Apis.Details.index.overview' defaultMessage='Overview' />
-                        }
+                        text={<FormattedMessage id='Apis.Details.index.overview' defaultMessage='Overview' />}
                         route='overview'
                         iconText='overview'
                         to={pathPrefix + 'overview'}
                     />
                     {!api.advertiseInfo.advertised && (
                         <React.Fragment>
-                            { user &&
-                            <React.Fragment>
+                            {user && showCredentials && (
+                                <React.Fragment>
+                                    <LeftMenuItem
+                                        text={
+                                            <FormattedMessage
+                                                id='Apis.Details.index.credentials'
+                                                defaultMessage='Credentials'
+                                            />
+                                        }
+                                        route='credentials'
+                                        iconText='credentials'
+                                        to={pathPrefix + 'credentials'}
+                                    />
+                                </React.Fragment>
+                            )}
+                            {showComments && (
                                 <LeftMenuItem
                                     text={
-                                        <FormattedMessage
-                                            id='Apis.Details.index.credentials'
-                                            defaultMessage='Credentials'
-                                        />
+                                        <FormattedMessage id='Apis.Details.index.comments' defaultMessage='Comments' />
                                     }
-                                    route='credentials'
-                                    iconText='credentials'
-                                    to={pathPrefix + 'credentials'}
+                                    route='comments'
+                                    iconText='comments'
+                                    to={pathPrefix + 'comments'}
                                 />
-                            </React.Fragment>}
-                            <LeftMenuItem
-                                text={
-                                    <FormattedMessage id='Apis.Details.index.comments' defaultMessage='Comments' />
-                                }
-                                route='comments'
-                                iconText='comments'
-                                to={pathPrefix + 'comments'}
-                             />
-                            {api.type !== 'WS' && (
+                            )}
+                            {api.type !== 'WS' && showSdks && (
                                 <LeftMenuItem
-                                    text={
-                                        <FormattedMessage id='Apis.Details.index.try.out' defaultMessage='Try out' />
-                                    }
+                                    text={<FormattedMessage id='Apis.Details.index.try.out' defaultMessage='Try out' />}
                                     route='test'
                                     iconText='test'
                                     to={pathPrefix + 'test'}
@@ -425,19 +429,15 @@ class Details extends React.Component {
                             )}
                         </React.Fragment>
                     )}
-                    <LeftMenuItem
-                        text={
-                            <FormattedMessage id='Apis.Details.index.documentation' defaultMessage='Documentation' />
-                        }
+                    {showDocuments && <LeftMenuItem
+                        text={<FormattedMessage id='Apis.Details.index.documentation' defaultMessage='Documentation' />}
                         route='documents'
                         iconText='docs'
                         to={pathPrefix + 'documents'}
-                    />
-                    {!api.advertiseInfo.advertised && api.type !== 'WS' && (
+                    />}
+                    {!api.advertiseInfo.advertised && api.type !== 'WS' && showSdks && (
                         <LeftMenuItem
-                            text={
-                                <FormattedMessage id='Apis.Details.index.sdk' defaultMessage='SDKs' />
-                            }
+                            text={<FormattedMessage id='Apis.Details.index.sdk' defaultMessage='SDKs' />}
                             route='sdk'
                             iconText='sdk'
                             to={pathPrefix + 'sdk'}
@@ -445,7 +445,7 @@ class Details extends React.Component {
                     )}
                 </div>
                 <div className={classes.content}>
-                    <InfoBar apiId={apiUuid} innerRef={node => (this.infoBar = node)} intl={intl} />
+                    <InfoBar apiId={apiUuid} innerRef={node => (this.infoBar = node)} intl={intl} {...this.props} />
                     <div
                         className={classNames(
                             { [classes.contentLoader]: position === 'horizontal' },

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/ApiThumb.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/ApiThumb.jsx
@@ -146,9 +146,9 @@ const windowURL = window.URL || window.webkitURL;
 class ApiThumb extends React.Component {
     /**
      *Creates an instance of APIThumb.
-    * @param {*} props
-    * @memberof APIThumb
-    */
+     * @param {*} props
+     * @memberof APIThumb
+     */
     constructor(props) {
         super(props);
         this.state = {
@@ -233,37 +233,37 @@ class ApiThumb extends React.Component {
         const path = this.getPathPrefix();
 
         const detailsLink = path + this.props.api.id;
-        const { api, classes, theme } = this.props;
-        const { thumbnail } = theme.custom;
         const {
-            name, version, context,
-        } = api;
+            api, classes, theme, customWidth, customHeight, showInfo,
+        } = this.props;
+        const { thumbnail } = theme.custom;
+        const { name, version, context } = api;
 
         let { provider } = api;
-        if (api.businessInformation && api.businessInformation.businessOwner
-            && api.businessInformation.businessOwner.trim() !== '') {
+        if (
+            api.businessInformation &&
+            api.businessInformation.businessOwner &&
+            api.businessInformation.businessOwner.trim() !== ''
+        ) {
             provider = api.businessInformation.businessOwner;
         }
         if (!api.lifeCycleStatus) {
             api.lifeCycleStatus = api.status;
         }
-        const imageWidth = thumbnail.width;
+        const imageWidth = customWidth || thumbnail.width;
+        const imageHeight = customHeight || 140;
         const defaultImage = thumbnail.defaultApiImage;
 
         let ImageView;
         if (imageObj) {
-            ImageView = (<img
-                height={140}
-                width={imageWidth}
-                src={imageObj}
-                alt='API Thumbnail'
-                className={classes.media}
-            />);
+            ImageView = (
+                <img height={imageHeight} width={imageWidth} src={imageObj} alt='API Thumbnail' className={classes.media} />
+            );
         } else {
             ImageView = (
                 <ImageGenerator
                     width={imageWidth}
-                    height={140}
+                    height={imageHeight}
                     api={api}
                     fixedIcon={{
                         key: selectedIcon,
@@ -284,82 +284,106 @@ class ApiThumb extends React.Component {
                 raised={isHover}
                 className={classes.card}
             >
-                <CardMedia >
+                <CardMedia>
                     <Link to={detailsLink} className={classes.suppressLinkStyles}>
                         {!defaultImage && ImageView}
                         {defaultImage && <img src={defaultImage} alt='img' />}
                     </Link>
                 </CardMedia>
-                <CardContent className={classes.apiDetails}>
-                    <Link to={detailsLink} className={classes.textWrapper}>
-                        <Typography
-                            className={classes.thumbHeader}
-                            variant='h5'
-                            gutterBottom
-                            onClick={this.handleRedirectToAPIOverview}
-                            title={name}
-                        >
-                            {name}
-                        </Typography>
-                    </Link>
-                    <div className={classes.row}>
-                        <Typography variant='caption' gutterBottom align='left' className={classes.thumbBy}>
-                            <FormattedMessage defaultMessage='By' id='Apis.Listing.ApiThumb.by' />
-                            <FormattedMessage defaultMessage=' : ' id='Apis.Listing.ApiThumb.by.colon' />
-                            {provider}
-                        </Typography>
-                    </div>
-                    <div className={classes.thumbInfo}>
+                {showInfo && (
+                    <CardContent className={classes.apiDetails}>
+                        <Link to={detailsLink} className={classes.textWrapper}>
+                            <Typography
+                                className={classes.thumbHeader}
+                                variant='h5'
+                                gutterBottom
+                                onClick={this.handleRedirectToAPIOverview}
+                                title={name}
+                            >
+                                {name}
+                            </Typography>
+                        </Link>
                         <div className={classes.row}>
+                            <Typography variant='caption' gutterBottom align='left' className={classes.thumbBy}>
+                                <FormattedMessage defaultMessage='By' id='Apis.Listing.ApiThumb.by' />
+                                <FormattedMessage defaultMessage=' : ' id='Apis.Listing.ApiThumb.by.colon' />
+                                {provider}
+                            </Typography>
+                        </div>
+                        <div className={classes.thumbInfo}>
+                            <div className={classes.row}>
+                                <div className={classes.thumbLeft}>
+                                    <Typography variant='subtitle1'>{version}</Typography>
+                                    <Typography variant='caption' gutterBottom align='left'>
+                                        <FormattedMessage defaultMessage='Version' id='Apis.Listing.ApiThumb.version' />
+                                    </Typography>
+                                </div>
+                            </div>
+                            <div className={classes.row}>
+                                <div className={classes.thumbRight}>
+                                    <Typography variant='subtitle1' align='right' className={classes.contextBox}>
+                                        {context}
+                                    </Typography>
+                                    <Typography
+                                        variant='caption'
+                                        gutterBottom
+                                        align='right'
+                                        className={classes.context}
+                                    >
+                                        <FormattedMessage defaultMessage='Context' id='Apis.Listing.ApiThumb.context' />
+                                    </Typography>
+                                </div>
+                            </div>
+                        </div>
+                        <div className={classes.thumbInfo}>
                             <div className={classes.thumbLeft}>
-                                <Typography variant='subtitle1'>{version}</Typography>
-                                <Typography variant='caption' gutterBottom align='left'>
-                                    <FormattedMessage defaultMessage='Version' id='Apis.Listing.ApiThumb.version' />
-                                </Typography>
-                            </div>
-                        </div>
-                        <div className={classes.row}>
-                            <div className={classes.thumbRight}>
-                                <Typography variant='subtitle1' align='right' className={classes.contextBox}>
-                                    {context}
-                                </Typography>
-                                <Typography variant='caption' gutterBottom align='right' className={classes.context}>
-                                    <FormattedMessage defaultMessage='Context' id='Apis.Listing.ApiThumb.context' />
-                                </Typography>
-                            </div>
-                        </div>
-                    </div>
-                    <div className={classes.thumbInfo}>
-                        <div className={classes.thumbLeft}>
-                            <Typography variant='subtitle1' gutterBottom align='left' className={classes.ratingWrapper}>
-                                <StarRatingBar
-                                    apiRating={api.avgRating}
-                                    apiId={api.id}
-                                    isEditable={false}
-                                    showSummary={false}
-                                />
-                            </Typography>
-                        </div>
-                        <div className={classes.thumbRight}>
-                            <Typography variant='subtitle1' gutterBottom align='right' className={classes.chipWrapper}>
-                                {(api.type === 'GRAPHQL' || api.transportType === 'GRAPHQL') && (
-                                    <Chip
-                                        label={api.transportType === undefined ? api.type : api.transportType}
-                                        color='primary'
+                                <Typography
+                                    variant='subtitle1'
+                                    gutterBottom
+                                    align='left'
+                                    className={classes.ratingWrapper}
+                                >
+                                    <StarRatingBar
+                                        apiRating={api.avgRating}
+                                        apiId={api.id}
+                                        isEditable={false}
+                                        showSummary={false}
                                     />
-                                )}
-                            </Typography>
+                                </Typography>
+                            </div>
+                            <div className={classes.thumbRight}>
+                                <Typography
+                                    variant='subtitle1'
+                                    gutterBottom
+                                    align='right'
+                                    className={classes.chipWrapper}
+                                >
+                                    {(api.type === 'GRAPHQL' || api.transportType === 'GRAPHQL') && (
+                                        <Chip
+                                            label={api.transportType === undefined ? api.type : api.transportType}
+                                            color='primary'
+                                        />
+                                    )}
+                                </Typography>
+                            </div>
                         </div>
-                    </div>
-                </CardContent>
+                    </CardContent>
+                )}
             </Card>
         );
     }
 }
-
+ApiThumb.defaultProps = {
+    customWidth: null,
+    customHeight: null,
+    showInfo: true,
+};
 ApiThumb.propTypes = {
     classes: PropTypes.shape({}).isRequired,
     theme: PropTypes.shape({}).isRequired,
+    customWidth: PropTypes.number,
+    customHeight: PropTypes.number,
+    showInfo: PropTypes.bool,
 };
 
 ApiThumb.contextType = ApiContext;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/CommonListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/CommonListing.jsx
@@ -264,17 +264,18 @@ class CommonListing extends React.Component {
                         { [classes.contentWithTagsHidden]: tagPaneVisible && !showLeftMenu },
                         { [classes.contentWithTags]: tagPaneVisible && showLeftMenu },
                     )}
+                    id='commonListing'
                 >
-                    <div className={classes.appBar}>
+                    <div className={classes.appBar} id='commonListingAppBar'>
                         <div className={classes.mainIconWrapper}>
                             <CustomIcon strokeColor={strokeColorMain} width={42} height={42} icon='api' />
                         </div>
-                        <div className={classes.mainTitleWrapper}>
+                        <div className={classes.mainTitleWrapper} id='mainTitleWrapper'>
                             <Typography variant='h4' className={classes.mainTitle}>
                                 <FormattedMessage defaultMessage='APIs' id='Apis.Listing.Listing.apis.main' />
                             </Typography>
                             {apis && (
-                                <Typography variant='caption' gutterBottom align='left'>
+                                <Typography variant='caption' gutterBottom align='left' id='apiCountDisplay'>
                                     <FormattedMessage
                                         defaultMessage='Displaying'
                                         id='Apis.Listing.Listing.displaying'
@@ -284,7 +285,7 @@ class CommonListing extends React.Component {
                                 </Typography>
                             )}
                         </div>
-                        <div className={classes.buttonRight}>
+                        <div className={classes.buttonRight} id='listGridWrapper'>
                             <IconButton className={classes.button} onClick={() => this.setListType('list')}>
                                 <Icon
                                     className={classNames(

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Base/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Base/index.jsx
@@ -85,7 +85,8 @@ const styles = (theme) => {
             height: 50,
         },
         footer: {
-            backgroundColor: theme.palette.grey.A100,
+            background: theme.custom.footer.background,
+            color: theme.custom.footer.color,
             paddingLeft: theme.spacing.unit * 3,
             height: 50,
             alignItems: 'center',
@@ -120,6 +121,16 @@ const styles = (theme) => {
         },
         icons: {
             marginRight: theme.spacing(),
+        },
+        banner: {
+            color: theme.custom.banner.color,
+            background: theme.custom.banner.background,
+            padding: theme.custom.banner.padding,
+            margin: theme.custom.banner.margin,
+            fontSize: theme.custom.banner.fontSize,
+            display: 'flex',
+            distributeContent: theme.custom.banner.textAlign,
+            justifyContent: theme.custom.banner.textAlign,
         },
     };
 };
@@ -235,6 +246,16 @@ class Layout extends React.Component {
      */
     render() {
         const { classes, theme } = this.props;
+        const {
+            custom: {
+                banner: {
+                    style, text, image, active,
+                },
+                footer: {
+                    active: footerActive, text: footerText,
+                }
+            },
+        } = theme;
         const { openNavBar } = this.state;
         const { tenantDomain, setTenantDomain } = this.context;
         const user = AuthManager.getUser();
@@ -249,173 +270,178 @@ class Layout extends React.Component {
             },
         };
         return (
-            <div className={classes.reactRoot}>
-                <div className={classes.wrapper}>
-                    <AppBar position='fixed' className={classes.appBar}>
-                        <Toolbar className={classes.toolbar}>
-                            <Hidden mdUp>
-                                <IconButton onClick={this.toggleGlobalNavBar} color='inherit'>
-                                    <Icon className={classes.menuIcon}>menu</Icon>
-                                </IconButton>
-                            </Hidden>
-                            <Link to='/'>
-                                <img
-                                    src={app.context + theme.custom.appBar.logo}
-                                    style={{
-                                        height: theme.custom.appBar.logoHeight,
-                                        width: theme.custom.appBar.logoWidth,
-                                    }}
-                                />
-                            </Link>
-                            <Hidden smDown>
-                                <VerticalDivider height={32} />
-                                <div className={classes.listInline}>
-                                    <GlobalNavBar smallView />
-                                </div>
-                            </Hidden>
-                            <Hidden mdUp>
-                                <Drawer
-                                    className={classes.drawerStyles}
-                                    PaperProps={paperStyles}
-                                    SlideProps={commonStyle}
-                                    ModalProps={commonStyle}
-                                    BackdropProps={commonStyle}
-                                    open={openNavBar}
-                                    onClose={this.toggleGlobalNavBar}
-                                >
-                                    <div
-                                        tabIndex={0}
-                                        role='button'
-                                        onClick={this.toggleGlobalNavBar}
-                                        onKeyDown={this.toggleGlobalNavBar}
-                                    >
-                                        <div className={classes.list}>
-                                            <GlobalNavBar smallView={false} />
-                                        </div>
-                                    </div>
-                                </Drawer>
-                            </Hidden>
-                            <VerticalDivider height={32} />
-                            <HeaderSearch />
-                            {(tenantDomain && tenantDomain !== 'INVALID') && (
-                                <Link
-                                    style={{
-                                        textDecoration: 'none',
-                                        color: '#ffffff',
-                                    }}
-                                    to='/'
-                                    onClick={() => setTenantDomain('INVALID')}
-                                >
-                                    <Button className={classes.publicStore}>
-                                        <Icon className={classes.icons}>public</Icon>
-                                        <FormattedMessage
-                                            id='Base.index.go.to.public.store'
-                                            defaultMessage='Go to public Dev Portal'
-                                        />
-                                    </Button>
+            <React.Fragment>
+                {active && <div className={classes.banner}>{style === 'text' ? text : <img src={`${app.context}/${image}`} />}</div>}
+                <div className={classes.reactRoot} id='pageRoot'>
+                    <div className={classes.wrapper}>
+                        <AppBar position='fixed' className={classes.appBar} id='appBar'>
+                            <Toolbar className={classes.toolbar} id='toolBar'>
+                                <Hidden mdUp>
+                                    <IconButton onClick={this.toggleGlobalNavBar} color='inherit'>
+                                        <Icon className={classes.menuIcon}>menu</Icon>
+                                    </IconButton>
+                                </Hidden>
+                                <Link to='/' id='logoLink'>
+                                    <img
+                                        src={app.context + theme.custom.appBar.logo}
+                                        style={{
+                                            height: theme.custom.appBar.logoHeight,
+                                            width: theme.custom.appBar.logoWidth,
+                                        }}
+                                    />
                                 </Link>
-                            )}
-                            <VerticalDivider height={72} />
-                            {/* Environment menu */}
-                            <EnvironmentMenu
-                                environments={this.state.environments}
-                                environmentLabel={Utils.getEnvironment().label}
-                                handleEnvironmentChange={this.handleEnvironmentChange}
-                            />
-                            {user ? (
-                                <React.Fragment>
-                                    <Link to='/settings'>
-                                        <Button className={classes.userLink}>
-                                            <Icon className={classes.icons}>settings</Icon>
+                                <Hidden smDown>
+                                    <VerticalDivider height={32} />
+                                    <div className={classes.listInline}>
+                                        <GlobalNavBar smallView />
+                                    </div>
+                                </Hidden>
+                                <Hidden mdUp>
+                                    <Drawer
+                                        className={classes.drawerStyles}
+                                        PaperProps={paperStyles}
+                                        SlideProps={commonStyle}
+                                        ModalProps={commonStyle}
+                                        BackdropProps={commonStyle}
+                                        open={openNavBar}
+                                        onClose={this.toggleGlobalNavBar}
+                                    >
+                                        <div
+                                            tabIndex={0}
+                                            role='button'
+                                            onClick={this.toggleGlobalNavBar}
+                                            onKeyDown={this.toggleGlobalNavBar}
+                                        >
+                                            <div className={classes.list}>
+                                                <GlobalNavBar smallView={false} />
+                                            </div>
+                                        </div>
+                                    </Drawer>
+                                </Hidden>
+                                <VerticalDivider height={32} />
+                                <HeaderSearch id='headerSearch' />
+                                {tenantDomain && tenantDomain !== 'INVALID' && (
+                                    <Link
+                                        style={{
+                                            textDecoration: 'none',
+                                            color: '#ffffff',
+                                        }}
+                                        to='/'
+                                        onClick={() => setTenantDomain('INVALID')}
+                                        id='gotoPubulicDevPortal'
+                                    >
+                                        <Button className={classes.publicStore}>
+                                            <Icon className={classes.icons}>public</Icon>
                                             <FormattedMessage
-                                                id='Base.index.settings.caption'
-                                                defaultMessage='Settings'
+                                                id='Base.index.go.to.public.store'
+                                                defaultMessage='Go to public Dev Portal'
                                             />
                                         </Button>
                                     </Link>
-                                    <Button
-                                        buttonRef={(node) => {
-                                            this.anchorEl = node;
-                                        }}
-                                        aria-owns={open ? 'menu-list-grow' : null}
-                                        aria-haspopup='true'
-                                        onClick={this.handleToggleUserMenu}
-                                        className={classes.userLink}
-                                    >
-                                        <Icon className={classes.icons}>person</Icon>
-                                        {user.name}
-                                    </Button>
-                                    <Popper
-                                        open={this.state.openUserMenu}
-                                        anchorEl={this.anchorEl}
-                                        transition
-                                        disablePortal
-                                        anchorOrigin={{
-                                            vertical: 'bottom',
-                                            horizontal: 'center',
-                                        }}
-                                        transformOrigin={{
-                                            vertical: 'top',
-                                            horizontal: 'center',
-                                        }}
-                                    >
-                                        {({ TransitionProps, placement }) => (
-                                            <Grow
-                                                {...TransitionProps}
-                                                id='menu-list-grow'
-                                                style={{
-                                                    transformOrigin:
-                                                        placement === 'bottom' ? 'center top' : 'center bottom',
-                                                }}
-                                            >
-                                                <Paper>
-                                                    <ClickAwayListener onClickAway={this.handleCloseUserMenu}>
-                                                        <MenuList>
-                                                            <MenuItem onClick={this.doOIDCLogout}>
-                                                                <FormattedMessage
-                                                                    id='Base.index.logout'
-                                                                    defaultMessage='Logout'
-                                                                />
-                                                            </MenuItem>
-                                                        </MenuList>
-                                                    </ClickAwayListener>
-                                                </Paper>
-                                            </Grow>
-                                        )}
-                                    </Popper>
-                                </React.Fragment>
-                            ) : (
-                                <React.Fragment>
-                                    {/* TODO: uncomment when the feature is working */}
-                                    {/* <Link to={'/sign-up'}>
+                                )}
+                                <VerticalDivider height={72} />
+                                {/* Environment menu */}
+                                <EnvironmentMenu
+                                    environments={this.state.environments}
+                                    environmentLabel={Utils.getEnvironment().label}
+                                    handleEnvironmentChange={this.handleEnvironmentChange}
+                                    id='environmentMenu'
+                                />
+                                {user ? (
+                                    <React.Fragment>
+                                        <Link to='/settings' id='settingsLink'>
+                                            <Button className={classes.userLink}>
+                                                <Icon className={classes.icons}>settings</Icon>
+                                                <FormattedMessage
+                                                    id='Base.index.settings.caption'
+                                                    defaultMessage='Settings'
+                                                />
+                                            </Button>
+                                        </Link>
+                                        <Button
+                                            buttonRef={(node) => {
+                                                this.anchorEl = node;
+                                            }}
+                                            aria-owns={open ? 'menu-list-grow' : null}
+                                            aria-haspopup='true'
+                                            onClick={this.handleToggleUserMenu}
+                                            className={classes.userLink}
+                                            id='userToggleButton'
+                                        >
+                                            <Icon className={classes.icons}>person</Icon>
+                                            {user.name}
+                                        </Button>
+                                        <Popper
+                                            id='userPopup'
+                                            open={this.state.openUserMenu}
+                                            anchorEl={this.anchorEl}
+                                            transition
+                                            disablePortal
+                                            anchorOrigin={{
+                                                vertical: 'bottom',
+                                                horizontal: 'center',
+                                            }}
+                                            transformOrigin={{
+                                                vertical: 'top',
+                                                horizontal: 'center',
+                                            }}
+                                        >
+                                            {({ TransitionProps, placement }) => (
+                                                <Grow
+                                                    {...TransitionProps}
+                                                    id='menu-list-grow'
+                                                    style={{
+                                                        transformOrigin:
+                                                            placement === 'bottom' ? 'center top' : 'center bottom',
+                                                    }}
+                                                >
+                                                    <Paper>
+                                                        <ClickAwayListener onClickAway={this.handleCloseUserMenu}>
+                                                            <MenuList>
+                                                                <MenuItem onClick={this.doOIDCLogout}>
+                                                                    <FormattedMessage
+                                                                        id='Base.index.logout'
+                                                                        defaultMessage='Logout'
+                                                                    />
+                                                                </MenuItem>
+                                                            </MenuList>
+                                                        </ClickAwayListener>
+                                                    </Paper>
+                                                </Grow>
+                                            )}
+                                        </Popper>
+                                    </React.Fragment>
+                                ) : (
+                                    <React.Fragment>
+                                        {/* TODO: uncomment when the feature is working */}
+                                        {/* <Link to={'/sign-up'}>
                                      <Button className={classes.userLink}>
                                      <HowToReg /> sign-up
                                      </Button>
                                      </Link> */}
-                                    <a href={app.context + '/services/configs'}>
-                                        <Button className={classes.userLink}>
-                                            <Icon>person</Icon>
-                                            <FormattedMessage id='Base.index.sign.in' defaultMessage=' Sign-in' />
-                                        </Button>
-                                    </a>
-                                </React.Fragment>
-                            )}
-                        </Toolbar>
-                    </AppBar>
-
-                    <div className={classes.contentWrapper}>{this.props.children}</div>
-
-                    <div className={classes.push} />
+                                        <a href={app.context + '/services/configs'}>
+                                            <Button className={classes.userLink}>
+                                                <Icon>person</Icon>
+                                                <FormattedMessage id='Base.index.sign.in' defaultMessage=' Sign-in' />
+                                            </Button>
+                                        </a>
+                                    </React.Fragment>
+                                )}
+                            </Toolbar>
+                        </AppBar>
+                        <div className={classes.contentWrapper}>{this.props.children}</div>
+                        {footerActive &&<div className={classes.push} />}
+                    </div>
+                    {footerActive && <footer className={classes.footer} id='footer'>
+                        <Typography noWrap>
+                            {footerText && footerText !== '' ? <span>{footerText}</span> :<FormattedMessage
+                                id='Base.index.copyright.text'
+                                defaultMessage='WSO2 APIM v3.0.0 | © 2019 WSO2 Inc'
+                            />}
+                        </Typography>
+                    </footer>}
                 </div>
-                <footer className={classes.footer}>
-                    <Typography noWrap>
-                        <FormattedMessage
-                            id='Base.index.copyright.text'
-                            defaultMessage='WSO2 APIM v3.0.0 | © 2019 WSO2 Inc'
-                        />
-                    </Typography>
-                </footer>
-            </div>
+            </React.Fragment>
         );
     }
 }


### PR DESCRIPTION
1- Making the overview info collapsable panel expanded by default.
Following are requirement for cloud users expecting via the theme.
2 - Added the ability to hide the sections of the api details page from theme except the overview page.
3 - Added the ability to add a banner to the devportal via the theme ( image/text )
4 - Added the ability to show hide the ratings via theme.
5 - The correct thumbnail is not coming when we go to the details of an api fixed.
6 - Added the ability to allow a given set of sdks to be displayed in the SDKs section
6 - Added id's to the UI components to make it possible to style via the main.css file ( just in case for edge cases. )
