### PR TITLE
Fix issue in redirection to document listing page

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/OverviewDocuments.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/OverviewDocuments.jsx
@@ -132,7 +132,7 @@ function OverviewDocuments(props) {
             <Grid item xs={12}>
                 <div className={classes.subscriptionTop}>
                     <div className={classes.boxBadge}>{docs.length}</div>
-                    <Link to={'/apis/' + apiId + '/docs'} className={classes.linkStyle}>
+                    <Link to={'/apis/' + apiId + '/documents'} className={classes.linkStyle}>
                         <FormattedMessage id='Apis.Details.Overview.documents.count.sufix' defaultMessage='Documents' />
                     </Link>
                 </div>
@@ -143,7 +143,7 @@ function OverviewDocuments(props) {
                 </Typography>
                 {docs.length > 0 && (
                     <div className={classes.subscriptionBox}>
-                        <Link to={'/apis/' + apiId + '/docs'} className={classes.linkStyle}>
+                        <Link to={'/apis/' + apiId + '/documents'} className={classes.linkStyle}>
                             {docs[0].name}
                         </Link>
                         {/* <Typography variant='caption'>


### PR DESCRIPTION
Fix issue in redirection in following section of overview page:
![image](https://user-images.githubusercontent.com/19728269/67380461-fdecaa00-f5a7-11e9-8cfe-e1fef8da9954.png)

Currently it redirects to '/docs' endpoint, hence it renders page not found:
![image](https://user-images.githubusercontent.com/19728269/67380934-b581bc00-f5a8-11e9-81b2-7ccee61e9107.png)
