### PR TITLE
Fixing tag cloud link text rotation and adding missing style classes

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/InfoBar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/InfoBar.jsx
@@ -278,7 +278,7 @@ class InfoBar extends React.Component {
         const {
             custom: {
                 leftMenu: { position },
-                infoBar: { showThumbnail },
+                infoBar: { showThumbnail, height },
                 tagWise: { key, active },
                 social: { showRating },
             },
@@ -315,7 +315,7 @@ class InfoBar extends React.Component {
                     </Link>
                     {showThumbnail && (
                         <React.Fragment>
-                            <VerticalDivider height={70} />
+                            <VerticalDivider height={height} />
                             <ApiThumb api={api} customWidth={70} customHeight={50} showInfo={false} />
                         </React.Fragment>
                     )}

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/ApiThumb.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/ApiThumb.jsx
@@ -31,6 +31,7 @@ import StarRatingBar from 'AppComponents/Apis/Listing/StarRatingBar';
 import ImageGenerator from './ImageGenerator';
 import Api from '../../../data/api';
 import { ApiContext } from '../Details/ApiContext';
+import classNames from 'classnames';
 
 /**
  *
@@ -43,7 +44,15 @@ const styles = theme => ({
         maxWidth: theme.custom.thumbnail.width,
         transition: 'box-shadow 0.3s ease-in-out',
     },
-    apiDetails: { padding: theme.spacing.unit },
+    apiDetails: {
+        padding: theme.spacing.unit,
+        background: theme.custom.thumbnail.contentBackgroundColor,
+        padding: theme.spacing.unit,
+        color: theme.palette.getContrastText(theme.custom.thumbnail.contentBackgroundColor),
+        '& a': {
+            color: theme.palette.getContrastText(theme.custom.thumbnail.contentBackgroundColor),
+        },
+    },
     suppressLinkStyles: {
         textDecoration: 'none',
         color: theme.palette.text.disabled,
@@ -60,12 +69,6 @@ const styles = theme => ({
     },
     thumbContent: {
         width: theme.custom.thumbnail.width - theme.spacing(2),
-        backgroundColor: theme.palette.background.paper,
-        padding: theme.spacing.unit,
-        color: theme.palette.getContrastText(theme.palette.background.paper),
-        '& a': {
-            color: theme.palette.getContrastText(theme.palette.background.paper),
-        },
     },
     thumbLeft: {
         alignSelf: 'flex-start',
@@ -83,7 +86,6 @@ const styles = theme => ({
     thumbHeader: {
         width: theme.custom.thumbnail.width - theme.spacing.unit,
         whiteSpace: 'nowrap',
-        color: theme.palette.text.secondary,
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         cursor: 'pointer',
@@ -257,7 +259,13 @@ class ApiThumb extends React.Component {
         let ImageView;
         if (imageObj) {
             ImageView = (
-                <img height={imageHeight} width={imageWidth} src={imageObj} alt='API Thumbnail' className={classes.media} />
+                <img
+                    height={imageHeight}
+                    width={imageWidth}
+                    src={imageObj}
+                    alt='API Thumbnail'
+                    className={classes.media}
+                />
             );
         } else {
             ImageView = (
@@ -282,7 +290,7 @@ class ApiThumb extends React.Component {
                 onMouseOut={this.toggleMouseOver}
                 onBlur={this.toggleMouseOver}
                 raised={isHover}
-                className={classes.card}
+                className={classNames('image-thumbnail', classes.card)}
             >
                 <CardMedia>
                     <Link to={detailsLink} className={classes.suppressLinkStyles}>
@@ -291,7 +299,7 @@ class ApiThumb extends React.Component {
                     </Link>
                 </CardMedia>
                 {showInfo && (
-                    <CardContent className={classes.apiDetails}>
+                    <CardContent classes={{ root: classes.apiDetails }}>
                         <Link to={detailsLink} className={classes.textWrapper}>
                             <Typography
                                 className={classes.thumbHeader}
@@ -341,7 +349,7 @@ class ApiThumb extends React.Component {
                                     variant='subtitle1'
                                     gutterBottom
                                     align='left'
-                                    className={classes.ratingWrapper}
+                                    className={classNames('api-thumb-rating', classes.ratingWrapper)}
                                 >
                                     <StarRatingBar
                                         apiRating={api.avgRating}

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/CommonListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/CommonListing.jsx
@@ -133,14 +133,14 @@ const styles = theme => ({
         cursor: 'pointer',
     },
     rotatedText: {
-        transform: 'rotate(90deg)',
+        transform: 'rotate(270deg)',
         transformOrigin: 'left bottom 0',
         position: 'absolute',
         whiteSpace: 'nowrap',
-        top: theme.custom.infoBar.height,
-        marginLeft: 4,
+        top: theme.custom.infoBar.height * 2,
+        marginLeft: 23,
         cursor: 'pointer',
-    }
+    },
 });
 
 /**
@@ -213,7 +213,7 @@ class CommonListing extends React.Component {
             },
         } = theme;
         const { listType, allTags, showLeftMenu } = this.state;
-        const strokeColorMain = theme.custom.tagCloud.leftMenu.background;
+        const strokeColorMain = theme.palette.getContrastText(theme.custom.infoBar.background);
         const searchParam = new URLSearchParams(search);
         const searchQuery = searchParam.get('query');
         let selectedTag = null;
@@ -249,11 +249,8 @@ class CommonListing extends React.Component {
                             <Icon>keyboard_arrow_right</Icon>
                         </div>
                         <div className={classes.rotatedText} onClick={this.toggleLeftMenu}>
-                                <FormattedMessage
-                                    defaultMessage='Tag Cloud'
-                                    id='Apis.Listing.Listing.ApiTagCloud.title'
-                                />
-                            </div>
+                            <FormattedMessage defaultMessage='Tag Cloud' id='Apis.Listing.Listing.ApiTagCloud.title' />
+                        </div>
                     </div>
                 )}
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Details/InfoBar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Details/InfoBar.jsx
@@ -24,6 +24,7 @@ import Button from '@material-ui/core/Button';
 import { Link } from 'react-router-dom';
 import Collapse from '@material-ui/core/Collapse';
 import Icon from '@material-ui/core/Icon';
+import Hidden from '@material-ui/core/Hidden';
 import { FormattedMessage } from 'react-intl';
 import Loading from 'AppComponents/Base/Loading/Loading';
 import ResourceNotFound from 'AppComponents/Base/Errors/ResourceNotFound';
@@ -34,32 +35,35 @@ import API from 'AppData/api';
  * @param {*} theme theme details
  * @returns {Object}
  */
-const styles = theme => ({
-    root: {
-        height: 70,
-        background: theme.palette.background.paper,
-        borderBottom: 'solid 1px ' + theme.palette.grey.A200,
-        display: 'flex',
-        alignItems: 'center',
-    },
-    backIcon: {
-        color: theme.palette.primary.main,
-        fontSize: 56,
-        cursor: 'pointer',
-    },
-    backText: {
-        color: theme.palette.primary.main,
-        cursor: 'pointer',
-        fontFamily: theme.typography.fontFamily,
-    },
-    apiIcon: {
-        height: 45,
-        marginTop: 10,
-        marginRight: 10,
-    },
+const styles = (theme) => {
+    const mainBack = theme.custom.infoBar.background || '#ffffff';
+    const infoBarHeight = theme.custom.infoBar.height || 70;
+    const backIconDisplay = theme.custom.infoBar.showBackIcon ? 'flex' : 'none';
+    const starColor = theme.custom.infoBar.starColor || theme.palette.getContrastText(mainBack);
+
+    return {
+        root: {
+            height: infoBarHeight,
+            background: mainBack,
+            color: theme.palette.getContrastText(mainBack),
+            borderBottom: 'solid 1px ' + theme.palette.grey.A200,
+            display: 'flex',
+            alignItems: 'center',
+            paddingLeft: theme.spacing.unit * 2,
+        },
+        backIcon: {
+            color: theme.palette.primary.main,
+            fontSize: 56,
+            cursor: 'pointer',
+        },
+        backText: {
+            color: theme.palette.primary.main,
+            cursor: 'pointer',
+            fontFamily: theme.typography.fontFamily,
+        },
     starRate: {
-        fontSize: 70,
-        color: theme.custom.starColor,
+        fontSize: 40,
+        color: starColor,
     },
     starRateMy: {
         fontSize: 70,
@@ -75,13 +79,17 @@ const styles = theme => ({
         paddingBottom: theme.spacing.unit * 2,
     },
     infoContent: {
-        background: theme.palette.background.paper,
+        color: theme.palette.getContrastText(mainBack),
+        background: mainBack,
         padding: theme.spacing.unit * 3,
+        '& td, & th': {
+            color: theme.palette.getContrastText(mainBack),
+        },
     },
     infoContentBottom: {
-        background: theme.palette.grey['200'],
+        background: theme.custom.infoBar.sliderBackground,
+        color: theme.palette.getContrastText(theme.custom.infoBar.sliderBackground),
         borderBottom: 'solid 1px ' + theme.palette.grey.A200,
-        color: theme.palette.grey['600'],
     },
     infoItem: {
         marginRight: theme.spacing.unit * 4,
@@ -99,8 +107,18 @@ const styles = theme => ({
         padding: '5px 12px',
         width: 350,
         transition: theme.transitions.create(['border-color', 'box-shadow']),
-        fontFamily: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial',
-            'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"'].join(','),
+        fontFamily: [
+            '-apple-system',
+            'BlinkMacSystemFont',
+            '"Segoe UI"',
+            'Roboto',
+            '"Helvetica Neue"',
+            'Arial',
+            'sans-serif',
+            '"Apple Color Emoji"',
+            '"Segoe UI Emoji"',
+            '"Segoe UI Symbol"',
+        ].join(','),
         '&:focus': {
             borderColor: '#80bdff',
             boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
@@ -174,14 +192,36 @@ const styles = theme => ({
     button: {
         textDecoration: 'none',
     },
-    appName: {
+    appNameXSmall: {
         whiteSpace: 'nowrap',
         textOverflow: 'ellipsis',
-        overflow: 'auto',
-        maxWidth: 600,
+        overflowX: 'auto',
+        maxWidth: 200,
         lineHeight: 1.3,
     },
-});
+    appNameSmall: {
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+        overflowX: 'auto',
+        maxWidth: 310,
+        lineHeight: 1.3,
+    },
+    appNameMid: {
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+        overflowX: 'auto',
+        maxWidth: 640,
+        lineHeight: 1.3,
+    },
+    appNameBig: {
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+        overflowX: 'auto',
+        maxWidth: 980,
+        lineHeight: 1.3,
+    },
+};
+};
 /**
  *
  *
@@ -190,8 +230,8 @@ const styles = theme => ({
  */
 class InfoBar extends React.Component {
     /**
-    * @param {Object} props props passed from above
-    */
+     * @param {Object} props props passed from above
+     */
     constructor(props) {
         super(props);
         this.state = {
@@ -254,6 +294,11 @@ class InfoBar extends React.Component {
         const {
             application, tierDescription, showOverview, notFound,
         } = this.state;
+        const {
+            custom: {
+                leftMenu: { position },
+            },
+        } = theme;
 
         if (notFound) {
             return <ResourceNotFound message={resourceNotFountMessage} />;
@@ -269,25 +314,36 @@ class InfoBar extends React.Component {
                     <Link to='/applications' className={classes.backLink}>
                         <Icon className={classes.backIcon}>keyboard_arrow_left</Icon>
                         <div className={classes.backText}>
-                            <FormattedMessage
-                                id='Applications.Details.InfoBar.new.back.to'
-                                defaultMessage='BACK TO'
-                            />
-                            {' '}
+                            <FormattedMessage id='Applications.Details.InfoBar.new.back.to' defaultMessage='BACK TO' />{' '}
                             <br />
-                            <FormattedMessage
-                                id='Applications.Details.InfoBar.listing'
-                                defaultMessage='LISTING'
-                            />
+                            <FormattedMessage id='Applications.Details.InfoBar.listing' defaultMessage='LISTING' />
                         </div>
                     </Link>
                     <VerticalDivider height={70} />
                     <div style={{ marginLeft: theme.spacing.unit }}>
-                        <Typography className={classes.appName} variant='h4'>{application.name}</Typography>
-                        <Typography variant='caption' gutterBottom align='left'>
-                            { application.subscriptionCount }
-                            {' '}
+                        <Hidden smUp>
+                            <Typography className={classes.appNameXSmall} variant='h4'>
+                                {application.name}
+                            </Typography>
+                        </Hidden>
 
+                        <Hidden xsDown mdUp>
+                            <Typography className={classes.appNameSmall} variant='h4'>
+                                {application.name}
+                            </Typography>
+                        </Hidden>
+                        <Hidden smDown lgUp>
+                            <Typography className={classes.appNameMid} variant='h4'>
+                                {application.name}
+                            </Typography>
+                        </Hidden>
+                        <Hidden mdDown xlUp>
+                            <Typography className={classes.appNameBig} variant='h4'>
+                                {application.name}
+                            </Typography>
+                        </Hidden>
+                        <Typography variant='caption' gutterBottom align='left'>
+                            {application.subscriptionCount}{' '}
                             <FormattedMessage
                                 id='Applications.Details.InfoBar.subscriptions'
                                 defaultMessage='Subscriptions'
@@ -295,7 +351,7 @@ class InfoBar extends React.Component {
                         </Typography>
                     </div>
                 </div>
-
+                {position === 'horizontal' && <div style={{ height: 60 }} />}
                 {showOverview && (
                     <Collapse in={showOverview} timeout='auto' unmountOnExit>
                         <div className={classes.infoContent}>
@@ -303,14 +359,8 @@ class InfoBar extends React.Component {
                                 <div className={classes.topBar}>
                                     <div className={classes.infoItem}>
                                         <Typography variant='subtitle1' gutterBottom>
-                                            {application.throttlingPolicy}
-                                            {' '}
-                                            <Typography variant='caption'>
-                                                (
-                                                {tierDescription}
-                                                {' '}
-                                                )
-                                            </Typography>
+                                            {application.throttlingPolicy}{' '}
+                                            <Typography variant='caption'>({tierDescription} )</Typography>
                                         </Typography>
                                         <Typography variant='caption' gutterBottom align='left'>
                                             <FormattedMessage
@@ -319,28 +369,19 @@ class InfoBar extends React.Component {
                                             />
                                         </Typography>
                                     </div>
-                                    {Object.entries(application.attributes).map(([key, value]) => (
-                                        value !== '' ? (
+                                    {Object.entries(application.attributes).map(([key, value]) =>
+                                        (value !== '' ? (
                                             <div className={classes.infoItem} key={key}>
                                                 <Typography variant='subtitle1' gutterBottom>
-                                                    { key }
+                                                    {key}
                                                     {' : '}
-                                                    <Typography variant='caption'>
-                                                        { value }
-                                                    </Typography>
+                                                    <Typography variant='caption'>{value}</Typography>
                                                 </Typography>
                                             </div>
-                                        ) : (null)
-                                    ))}
+                                        ) : null))}
                                     <div className={classes.infoItem}>
-                                        <Link
-                                            to={`/applications/${applicationId}/edit/`}
-                                            className={classes.button}
-                                        >
-                                            <Button
-                                                variant='contained'
-                                                color='default'
-                                            >
+                                        <Link to={`/applications/${applicationId}/edit/`} className={classes.button}>
+                                            <Button variant='contained' color='default'>
                                                 <FormattedMessage
                                                     id='Applications.Details.InfoBar.edit'
                                                     defaultMessage='Edit'
@@ -361,25 +402,15 @@ class InfoBar extends React.Component {
                         onKeyDown={this.toggleOverview}
                     >
                         <div className={classes.buttonView}>
-                            {showOverview
-                                ? (
-                                    <Typography className={classes.buttonOverviewText}>
-
-                                        <FormattedMessage
-                                            id='Applications.Details.InfoBar.less'
-                                            defaultMessage='LESS'
-                                        />
-                                    </Typography>
-                                )
-                                : (
-                                    <Typography className={classes.buttonOverviewText}>
-
-                                        <FormattedMessage
-                                            id='Applications.Details.InfoBar.more'
-                                            defaultMessage='MORE'
-                                        />
-                                    </Typography>
-                                )}
+                            {showOverview ? (
+                                <Typography className={classes.buttonOverviewText}>
+                                    <FormattedMessage id='Applications.Details.InfoBar.less' defaultMessage='LESS' />
+                                </Typography>
+                            ) : (
+                                <Typography className={classes.buttonOverviewText}>
+                                    <FormattedMessage id='Applications.Details.InfoBar.more' defaultMessage='MORE' />
+                                </Typography>
+                            )}
                             {showOverview ? <Icon>arrow_drop_up_circle</Icon> : <Icon>arrow_drop_down_circle</Icon>}
                         </div>
                     </div>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Details/index.jsx
@@ -241,6 +241,7 @@ class Details extends Component {
                 },
             },
         } = theme;
+        const strokeColorMain = theme.palette.getContrastText(theme.custom.infoBar.background);
         if (notFound) {
             return <ResourceNotFound />;
         } else if (!application) {
@@ -268,7 +269,7 @@ class Details extends Component {
                             <CustomIcon width={rootIconSize} height={rootIconSize} icon='applications' />
                             {rootIconTextVisible && (
                                 <Typography className={classes.leftLInkMainText}>
-                                    <FormattedMessage id='Apis.Details.index.all.apis' defaultMessage='ALL APPs' />
+                                    <FormattedMessage id='Applications.Details.applications.all' defaultMessage='ALL APPs' />
                                 </Typography>
                             )}
                         </Link>
@@ -279,7 +280,12 @@ class Details extends Component {
                 </div>
                 <div className={classes.content}>
                     <InfoBar applicationId={match.params.application_uuid} innerRef={node => (this.infoBar = node)} />
-                    <div className={classes.contentDown}>
+                    <div
+                        className={classNames(
+                            { [classes.contentLoader]: position === 'horizontal' },
+                            { [classes.contentLoaderRightMenu]: position === 'vertical-right' },
+                        )}
+                    >
                         <Switch>
                             <Redirect exact from='/applications/:applicationId' to={redirectUrl} />
                             <Route

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Listing/Listing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Listing/Listing.jsx
@@ -83,7 +83,8 @@ const styles = theme => ({
     },
     root: {
         height: 80,
-        background: theme.palette.background.paper,
+        background: theme.custom.infoBar.background,
+        color: theme.palette.getContrastText(theme.custom.infoBar.background),
         borderBottom: `solid 1px ${theme.palette.grey.A200}`,
         display: 'block',
     },
@@ -295,7 +296,7 @@ class Listing extends Component {
             return <Loading />;
         }
         const { classes, theme, intl } = this.props;
-        const strokeColorMain = theme.palette.getContrastText(theme.palette.background.paper);
+        const strokeColorMain = theme.palette.getContrastText(theme.custom.infoBar.background);
         return (
             <main className={classes.content}>
                 <div className={classes.root}>


### PR DESCRIPTION
Rotate the tagCloud text 180 and fixed some theme parameters missing in the application page.
<img width="204" alt="Screen Shot 2019-10-24 at 4 45 04 PM" src="https://user-images.githubusercontent.com/3424539/67480506-ade01700-f67d-11e9-85d5-a92d0284bf8a.png">

Note that the following screens are snapshots from the test theming attempt. NOT THE ONE IN THE DEFAULT PACK.
![screencapture-localhost-9443-devportal-apis-1087aa3f-0951-4bd9-a787-9fdaf1776587-overview-2019-10-24-16_41_58](https://user-images.githubusercontent.com/3424539/67480411-75403d80-f67d-11e9-93ab-3a2d99469fb4.png)
![screencapture-localhost-9443-devportal-applications-b53c596d-5723-48bd-8aea-62a2da9765c3-productionkeys-2019-10-24-16_43_06](https://user-images.githubusercontent.com/3424539/67480414-75403d80-f67d-11e9-8d8c-6e492bb89f0f.png)
