### PR TITLE
Fix empty namespace undeclaration issue when deploying sequence in on premise gateway(cloud)

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/pom.xml
@@ -197,6 +197,7 @@
                             org.apache.commons.io.*,
                             com.fasterxml.jackson.databind.*; version="${fasterxml.jackson.version}",
                             com.fasterxml.jackson.annotation.*; version="${fasterxml.jackson.version}",
+                            org.apache.axiom.om.*;
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer.internal,

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/pom.xml
@@ -35,6 +35,20 @@
             <groupId>org.wso2.carbon.multitenancy</groupId>
             <artifactId>org.wso2.carbon.tenant.mgt</artifactId>
             <version>${carbon.multitenancy.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jdk14</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>
@@ -148,6 +162,16 @@
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.databridge.agent</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>slf4j.wso2</groupId>
+                    <artifactId>slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/APISynchronizer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/APISynchronizer.java
@@ -678,7 +678,7 @@ public class APISynchronizer implements OnPremiseGatewayInitListener {
             APISynchronizationException {
         String seqFileName = APISynchronizationConstants.EMPTY_STRING;
         String tenantDomain = APISynchronizationConstants.EMPTY_STRING;
-        String name = APISynchronizationConstants.NAME;
+        String sequenceName = APISynchronizationConstants.SEQUENCE_NAME;
         try {
             String type = sequenceInfo.getType().name();
             String xmlStr = sequenceInfo.getConfig();
@@ -706,7 +706,7 @@ public class APISynchronizer implements OnPremiseGatewayInitListener {
             }
             OMElement element = AXIOMUtil.stringToOM(xmlStr);
 
-            String originalSeqName = element.getAttributeValue(new QName(name));
+            String originalSeqName = element.getAttributeValue(new QName(sequenceName));
             String newXML = xmlStr.replace(originalSeqName, seqElementName);
 
             APIManagerConfiguration apimConfig = ServiceDataHolder.getInstance().

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/APISynchronizer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/APISynchronizer.java
@@ -33,6 +33,10 @@ import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
 import org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer.dto.APIDTO;
 import org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer.dto.APIInfoDTO;
 import org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer.dto.APIListDTO;
@@ -699,16 +703,11 @@ public class APISynchronizer implements OnPremiseGatewayInitListener {
             if (log.isDebugEnabled()) {
                 log.debug("Starting to deploy sequence: " + seqName);
             }
+            OMElement element = AXIOMUtil.stringToOM(xmlStr);
 
-            Document doc = convertStringToDocument(xmlStr);
-            Node seqNode = doc.getElementsByTagName(APISynchronizationConstants.API_SEQUENCE).item(0);
-            NamedNodeMap attr = seqNode.getAttributes();
-            Node nodeAttr = attr.getNamedItem(APISynchronizationConstants.API_NAME);
-            nodeAttr.setTextContent(seqElementName);
-            String str = convertDocumentToString(doc);
+            String originalSeqName =  element.getAttributeValue(new QName("name"));
+            String newXML = xmlStr.replace(originalSeqName,seqElementName);
 
-            // ToDo Generalise the fix for automatic xmlns="" namespace (un)declaration
-            str = str.replaceAll("xmlns=\"\"", APISynchronizationConstants.EMPTY_STRING);
             APIManagerConfiguration apimConfig = ServiceDataHolder.getInstance().
                     getAPIManagerConfigurationService().getAPIManagerConfiguration();
             String username = apimConfig.getFirstProperty(APIConstants.API_KEY_VALIDATOR_USERNAME);
@@ -720,14 +719,17 @@ public class APISynchronizer implements OnPremiseGatewayInitListener {
 
             File dir = new File(path);
             File file = new File(dir, seqFileName);
-            FileUtils.writeStringToFile(file, str);
+            FileUtils.writeStringToFile(file, newXML);
             if (log.isDebugEnabled()) {
                 log.debug("Successfully deployed sequence: " + seqName);
             }
         } catch (UserStoreException e) {
             throw new APISynchronizationException("An error occurred while obtaining tenant identifier of " +
                     "tenant domain " + tenantDomain, e);
-        } catch (FileNotFoundException e) {
+        }  catch (XMLStreamException e) {
+            throw new APISynchronizationException("There was an error in reading XML Stream of the file " +seqFileName,
+                    e);
+        }catch (FileNotFoundException e) {
             throw new APISynchronizationException("The file " + seqFileName + " could not be located.", e);
         } catch (IOException e) {
             throw new APISynchronizationException("An error occurred while reading the file " + seqFileName);

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/APISynchronizer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/APISynchronizer.java
@@ -35,8 +35,6 @@ import org.w3c.dom.Node;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLStreamException;
 import org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer.dto.APIDTO;
 import org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer.dto.APIInfoDTO;
 import org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer.dto.APIListDTO;
@@ -86,6 +84,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -678,6 +678,7 @@ public class APISynchronizer implements OnPremiseGatewayInitListener {
             APISynchronizationException {
         String seqFileName = APISynchronizationConstants.EMPTY_STRING;
         String tenantDomain = APISynchronizationConstants.EMPTY_STRING;
+        String name = APISynchronizationConstants.NAME;
         try {
             String type = sequenceInfo.getType().name();
             String xmlStr = sequenceInfo.getConfig();
@@ -705,8 +706,8 @@ public class APISynchronizer implements OnPremiseGatewayInitListener {
             }
             OMElement element = AXIOMUtil.stringToOM(xmlStr);
 
-            String originalSeqName =  element.getAttributeValue(new QName("name"));
-            String newXML = xmlStr.replace(originalSeqName,seqElementName);
+            String originalSeqName = element.getAttributeValue(new QName(name));
+            String newXML = xmlStr.replace(originalSeqName, seqElementName);
 
             APIManagerConfiguration apimConfig = ServiceDataHolder.getInstance().
                     getAPIManagerConfigurationService().getAPIManagerConfiguration();
@@ -726,8 +727,8 @@ public class APISynchronizer implements OnPremiseGatewayInitListener {
         } catch (UserStoreException e) {
             throw new APISynchronizationException("An error occurred while obtaining tenant identifier of " +
                     "tenant domain " + tenantDomain, e);
-        }  catch (XMLStreamException e) {
-            throw new APISynchronizationException("There was an error in reading XML Stream of the file " +seqFileName,
+        } catch (XMLStreamException e) {
+            throw new APISynchronizationException("There was an error in reading XML Stream of the file " + seqFileName,
                     e);
         }catch (FileNotFoundException e) {
             throw new APISynchronizationException("The file " + seqFileName + " could not be located.", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/APISynchronizer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/APISynchronizer.java
@@ -730,7 +730,7 @@ public class APISynchronizer implements OnPremiseGatewayInitListener {
         } catch (XMLStreamException e) {
             throw new APISynchronizationException("There was an error in reading XML Stream of the file " + seqFileName,
                     e);
-        }catch (FileNotFoundException e) {
+        } catch (FileNotFoundException e) {
             throw new APISynchronizationException("The file " + seqFileName + " could not be located.", e);
         } catch (IOException e) {
             throw new APISynchronizationException("An error occurred while reading the file " + seqFileName);

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/util/APISynchronizationConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/util/APISynchronizationConstants.java
@@ -45,4 +45,5 @@ public class APISynchronizationConstants {
     public static final String PAGINATION_LIMIT_PREFIX = "limit=";
     public static final String PAGINATION_LIMIT = "500";
     public static final String CHARSET_UTF8 = "UTF-8";
+    public static final String NAME = "name";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/util/APISynchronizationConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.api.synchronizer/src/main/java/org/wso2/carbon/apimgt/hybrid/gateway/api/synchronizer/util/APISynchronizationConstants.java
@@ -45,5 +45,5 @@ public class APISynchronizationConstants {
     public static final String PAGINATION_LIMIT_PREFIX = "limit=";
     public static final String PAGINATION_LIMIT = "500";
     public static final String CHARSET_UTF8 = "UTF-8";
-    public static final String NAME = "name";
+    public static final String SEQUENCE_NAME = "name";
 }


### PR DESCRIPTION
If a sequence contains empty namespace as xmlns="", when deploying that sequence in the  on premise gateway in cloud  it undeclares the empty namespace. This caused to not to work payload factory mediators properly when deploying in the onpremise gateway.
This fix will fix the aforementioned issue.