### PR TITLE
adding monetization lables to API image

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIInfoDTO.java
@@ -33,6 +33,7 @@ public class APIInfoDTO   {
     private AdvertiseInfoDTO advertiseInfo = null;
     private APIBusinessInformationDTO businessInformation = null;
     private Boolean isSubscriptionAvailable = null;
+    private String monetizationLabel = null;
 
   /**
    **/
@@ -276,6 +277,23 @@ public class APIInfoDTO   {
     this.isSubscriptionAvailable = isSubscriptionAvailable;
   }
 
+  /**
+   **/
+  public APIInfoDTO monetizationLabel(String monetizationLabel) {
+    this.monetizationLabel = monetizationLabel;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Free", value = "")
+  @JsonProperty("monetizationLabel")
+  public String getMonetizationLabel() {
+    return monetizationLabel;
+  }
+  public void setMonetizationLabel(String monetizationLabel) {
+    this.monetizationLabel = monetizationLabel;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -299,12 +317,13 @@ public class APIInfoDTO   {
         Objects.equals(throttlingPolicies, apIInfo.throttlingPolicies) &&
         Objects.equals(advertiseInfo, apIInfo.advertiseInfo) &&
         Objects.equals(businessInformation, apIInfo.businessInformation) &&
-        Objects.equals(isSubscriptionAvailable, apIInfo.isSubscriptionAvailable);
+        Objects.equals(isSubscriptionAvailable, apIInfo.isSubscriptionAvailable) &&
+        Objects.equals(monetizationLabel, apIInfo.monetizationLabel);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, context, version, type, provider, lifeCycleStatus, thumbnailUri, avgRating, throttlingPolicies, advertiseInfo, businessInformation, isSubscriptionAvailable);
+    return Objects.hash(id, name, description, context, version, type, provider, lifeCycleStatus, thumbnailUri, avgRating, throttlingPolicies, advertiseInfo, businessInformation, isSubscriptionAvailable, monetizationLabel);
   }
 
   @Override
@@ -326,6 +345,7 @@ public class APIInfoDTO   {
     sb.append("    advertiseInfo: ").append(toIndentedString(advertiseInfo)).append("\n");
     sb.append("    businessInformation: ").append(toIndentedString(businessInformation)).append("\n");
     sb.append("    isSubscriptionAvailable: ").append(toIndentedString(isSubscriptionAvailable)).append("\n");
+    sb.append("    monetizationLabel: ").append(toIndentedString(monetizationLabel)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
@@ -22,6 +22,8 @@ public class SettingsDTO   {
     private Boolean applicationSharingEnabled = false;
     private Boolean mapExistingAuthApps = false;
     private String apiGatewayEndpoint = null;
+    private Boolean monetizationEnabled = false;
+    private Boolean isUnlimitedTierPaid = false;
 
   /**
    **/
@@ -108,6 +110,40 @@ public class SettingsDTO   {
     this.apiGatewayEndpoint = apiGatewayEndpoint;
   }
 
+  /**
+   **/
+  public SettingsDTO monetizationEnabled(Boolean monetizationEnabled) {
+    this.monetizationEnabled = monetizationEnabled;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("monetizationEnabled")
+  public Boolean isMonetizationEnabled() {
+    return monetizationEnabled;
+  }
+  public void setMonetizationEnabled(Boolean monetizationEnabled) {
+    this.monetizationEnabled = monetizationEnabled;
+  }
+
+  /**
+   **/
+  public SettingsDTO isUnlimitedTierPaid(Boolean isUnlimitedTierPaid) {
+    this.isUnlimitedTierPaid = isUnlimitedTierPaid;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("IsUnlimitedTierPaid")
+  public Boolean isIsUnlimitedTierPaid() {
+    return isUnlimitedTierPaid;
+  }
+  public void setIsUnlimitedTierPaid(Boolean isUnlimitedTierPaid) {
+    this.isUnlimitedTierPaid = isUnlimitedTierPaid;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -122,12 +158,14 @@ public class SettingsDTO   {
         Objects.equals(scopes, settings.scopes) &&
         Objects.equals(applicationSharingEnabled, settings.applicationSharingEnabled) &&
         Objects.equals(mapExistingAuthApps, settings.mapExistingAuthApps) &&
-        Objects.equals(apiGatewayEndpoint, settings.apiGatewayEndpoint);
+        Objects.equals(apiGatewayEndpoint, settings.apiGatewayEndpoint) &&
+        Objects.equals(monetizationEnabled, settings.monetizationEnabled) &&
+        Objects.equals(isUnlimitedTierPaid, settings.isUnlimitedTierPaid);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(grantTypes, scopes, applicationSharingEnabled, mapExistingAuthApps, apiGatewayEndpoint);
+    return Objects.hash(grantTypes, scopes, applicationSharingEnabled, mapExistingAuthApps, apiGatewayEndpoint, monetizationEnabled, isUnlimitedTierPaid);
   }
 
   @Override
@@ -140,6 +178,8 @@ public class SettingsDTO   {
     sb.append("    applicationSharingEnabled: ").append(toIndentedString(applicationSharingEnabled)).append("\n");
     sb.append("    mapExistingAuthApps: ").append(toIndentedString(mapExistingAuthApps)).append("\n");
     sb.append("    apiGatewayEndpoint: ").append(toIndentedString(apiGatewayEndpoint)).append("\n");
+    sb.append("    monetizationEnabled: ").append(toIndentedString(monetizationEnabled)).append("\n");
+    sb.append("    isUnlimitedTierPaid: ").append(toIndentedString(isUnlimitedTierPaid)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SettingsApiServiceImpl.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIConsumerImpl;
 import org.wso2.carbon.apimgt.impl.APIManagerFactory;
 import org.wso2.carbon.apimgt.rest.api.store.v1.SettingsApiService;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationAttributeDTO;
@@ -36,6 +37,7 @@ import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SettingsDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.mappings.ApplicationMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.mappings.SettingsMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
@@ -49,12 +51,15 @@ public class SettingsApiServiceImpl implements SettingsApiService {
     public Response settingsGet(MessageContext messageContext) {
         try {
             String username = RestApiUtil.getLoggedInUsername();
+            String tenantDomain = MultitenantUtils.getTenantDomain(username);
+            APIConsumer apiConsumer = RestApiUtil.getConsumer(username);
+            boolean monetizationEnabled = apiConsumer.isMonetizationEnabled(tenantDomain);
             boolean isUserAvailable = false;
             if (!APIConstants.WSO2_ANONYMOUS_USER.equalsIgnoreCase(username)) {
                 isUserAvailable = true;
             }
             SettingsMappingUtil settingsMappingUtil = new SettingsMappingUtil();
-            SettingsDTO settingsDTO = settingsMappingUtil.fromSettingstoDTO(isUserAvailable);
+            SettingsDTO settingsDTO = settingsMappingUtil.fromSettingstoDTO( isUserAvailable, monetizationEnabled );
             return Response.ok().entity(settingsDTO).build();
         } catch (APIManagementException e) {
             String errorMessage = "Error while retrieving Store Settings";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -620,18 +620,18 @@ public class APIMappingUtil {
                 subscriptionAllowedTenants));
         int free = 0, commercial = 0;
         for (Tier tier : throttlingPolicies) {
-            if(tier.getTierPlan().equalsIgnoreCase("FREE")) {
+            if(tier.getTierPlan().equalsIgnoreCase(RestApiConstants.FREE)) {
                 free = free + 1;
-            } else if (tier.getTierPlan().equalsIgnoreCase("COMMERCIAL")) {
+            } else if (tier.getTierPlan().equalsIgnoreCase(RestApiConstants.COMMERCIAL)) {
                 commercial = commercial + 1;
             }
         }
         if (free > 0 && commercial == 0){
-            apiInfoDTO.setMonetizationLabel("FREE");
+            apiInfoDTO.setMonetizationLabel(RestApiConstants.FREE);
         } else if (free == 0 && commercial > 0) {
-            apiInfoDTO.setMonetizationLabel("PAID");
+            apiInfoDTO.setMonetizationLabel(RestApiConstants.PAID);
         } else if (free > 0 && commercial > 0) {
-            apiInfoDTO.setMonetizationLabel("FREEMIUM");
+            apiInfoDTO.setMonetizationLabel(RestApiConstants.FREEMIUM);
         }
         return apiInfoDTO;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -618,6 +618,21 @@ public class APIMappingUtil {
         String subscriptionAllowedTenants = api.getSubscriptionAvailableTenants();
         apiInfoDTO.setIsSubscriptionAvailable(isSubscriptionAvailable(apiTenant, subscriptionAvailability,
                 subscriptionAllowedTenants));
+        int free = 0, commercial = 0;
+        for (Tier tier : throttlingPolicies) {
+            if(tier.getTierPlan().equalsIgnoreCase("FREE")) {
+                free = free + 1;
+            } else if (tier.getTierPlan().equalsIgnoreCase("COMMERCIAL")) {
+                commercial = commercial + 1;
+            }
+        }
+        if (free > 0 && commercial == 0){
+            apiInfoDTO.setMonetizationLabel("FREE");
+        } else if (free == 0 && commercial > 0) {
+            apiInfoDTO.setMonetizationLabel("PAID");
+        } else if (free > 0 && commercial > 0) {
+            apiInfoDTO.setMonetizationLabel("FREEMIUM");
+        }
         return apiInfoDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SettingsMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SettingsMappingUtil.java
@@ -24,7 +24,6 @@ import org.apache.commons.io.IOUtils;
 import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.Scope;
-import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.definitions.OASParserUtil;
 import org.wso2.carbon.apimgt.impl.dto.Environment;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
@@ -42,7 +41,7 @@ public class SettingsMappingUtil {
 
     private static final Log log = LogFactory.getLog(SettingsMappingUtil.class);
 
-    public SettingsDTO fromSettingstoDTO(Boolean isUserAvailable) throws APIManagementException {
+    public SettingsDTO fromSettingstoDTO(Boolean isUserAvailable, Boolean moneatizationEnabled) throws APIManagementException {
         SettingsDTO settingsDTO = new SettingsDTO();
         if (isUserAvailable) {
             settingsDTO.setGrantTypes(APIUtil.getGrantTypes());
@@ -56,6 +55,7 @@ public class SettingsMappingUtil {
             settingsDTO.setScopes(GetScopeList());
             settingsDTO.setApplicationSharingEnabled(APIUtil.isMultiGroupAppSharingEnabled());
             settingsDTO.setMapExistingAuthApps(APIUtil.isMapExistingAuthAppsEnabled());
+            settingsDTO.setMonetizationEnabled(moneatizationEnabled);
         }
         return settingsDTO;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
@@ -3755,6 +3755,9 @@ definitions:
       isSubscriptionAvailable:
         type: boolean
         example: false
+      monetizationLabel:
+        type: string
+        example: Free
 
 #-----------------------------------------------------
 # The Standard API resource
@@ -5062,6 +5065,12 @@ definitions:
         default: false
       apiGatewayEndpoint:
         type: string
+      monetizationEnabled:
+        type: boolean
+        default: false
+      IsUnlimitedTierPaid:
+        type: boolean
+        default: false
 #-----------------------------------------------------
 # The Application Attribute resource
 #-----------------------------------------------------

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
@@ -217,6 +217,11 @@ public final class RestApiConstants {
     public static final String PUT = "PUT";
     public static final String DELETE = "DELETE";
 
+    public static final String FREE = "FREE";
+    public static final String COMMERCIAL = "COMMERCIAL";
+    public static final String PAID = "PAID";
+    public static final String FREEMIUM = "FREEMIUM";
+
     //System property set at server startup
     public static final String MIGRATION_MODE = "migrationMode";
 

--- a/docs/apidocs/store/v1/models/APIInfo.html
+++ b/docs/apidocs/store/v1/models/APIInfo.html
@@ -229,6 +229,21 @@
                         <td class="parameter"> <p class="marked">null</p></td>
                         <td class="parameter"> <p class="marked">false</p></td>
                     </tr>
+                    <tr>
+                        <td class="parameter">
+                            <p>monetizationLabel</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked"></p></td>
+                        <td class="parameter">
+                                <a href="#!/models#string">string</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked">Free</p></td>
+                    </tr>
                 </tbody>
             </table>
 </div>

--- a/docs/apidocs/store/v1/models/Settings.html
+++ b/docs/apidocs/store/v1/models/Settings.html
@@ -94,6 +94,36 @@
                         <td class="parameter"> <p class="marked">null</p></td>
                         <td class="parameter"> <p class="marked"></p></td>
                     </tr>
+                    <tr>
+                        <td class="parameter">
+                            <p>monetizationEnabled</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked"></p></td>
+                        <td class="parameter">
+                                <a href="#!/models#boolean">boolean</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked"></p></td>
+                    </tr>
+                    <tr>
+                        <td class="parameter">
+                            <p>IsUnlimitedTierPaid</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked"></p></td>
+                        <td class="parameter">
+                                <a href="#!/models#boolean">boolean</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked"></p></td>
+                    </tr>
                 </tbody>
             </table>
 </div>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/package-lock.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/package-lock.json
@@ -983,6 +983,46 @@
             "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.3.tgz",
             "integrity": "sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw=="
         },
+        "@hapi/address": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+            "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+        },
+        "@hapi/formula": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+            "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+        },
+        "@hapi/hoek": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+            "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+        },
+        "@hapi/joi": {
+            "version": "16.1.7",
+            "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+            "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+            "requires": {
+                "@hapi/address": "^2.1.2",
+                "@hapi/formula": "^1.2.0",
+                "@hapi/hoek": "^8.2.4",
+                "@hapi/pinpoint": "^1.0.2",
+                "@hapi/topo": "^3.1.3"
+            }
+        },
+        "@hapi/pinpoint": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+            "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
+        },
+        "@hapi/topo": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+            "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+            "requires": {
+                "@hapi/hoek": "^8.3.0"
+            }
+        },
         "@jest/console": {
             "version": "24.9.0",
             "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -2512,6 +2552,7 @@
             "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "hoek": "2.x.x"
             }
@@ -6051,7 +6092,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -6072,12 +6114,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -6092,17 +6136,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -6219,7 +6266,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -6231,6 +6279,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -6245,6 +6294,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -6252,12 +6302,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -6276,6 +6328,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -6356,7 +6409,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -6368,6 +6422,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -6453,7 +6508,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -6489,6 +6545,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -6508,6 +6565,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -6551,12 +6609,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -6921,7 +6981,8 @@
             "version": "2.16.3",
             "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
             "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "hoist-non-react-statics": {
             "version": "3.3.0",

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/package.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/package.json
@@ -20,6 +20,7 @@
     "author": "WSO2 Org",
     "license": "Apache-2.0",
     "dependencies": {
+        "@hapi/joi": "^16.1.7",
         "@material-ui/core": "^4.4.3",
         "@material-ui/icons": "^4.4.3",
         "async-mutex": "^0.1.3",

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/ApiThumb.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/ApiThumb.jsx
@@ -43,6 +43,7 @@ const styles = theme => ({
         margin: theme.spacing.unit * (3 / 2),
         maxWidth: theme.custom.thumbnail.width,
         transition: 'box-shadow 0.3s ease-in-out',
+        position: 'relative',
     },
     apiDetails: {
         padding: theme.spacing.unit,
@@ -134,6 +135,15 @@ const styles = theme => ({
     },
     ratingWrapper: {
         marginTop: '20px',
+    },
+    textblock: {
+        color: theme.palette.text.secondary,
+        position: 'absolute',
+        bottom: '35px',
+        right: '10px',
+        background: theme.custom.thumbnail.contentBackgroundColor,
+        'padding-left': '10px',
+        'padding-right': '10px',
     },
 });
 
@@ -292,6 +302,9 @@ class ApiThumb extends React.Component {
                 raised={isHover}
                 className={classNames('image-thumbnail', classes.card)}
             >
+                {this.context.isMonetizationEnabled && (
+                    <div className={classes.textblock}>{api.monetizationLabel}</div>
+                )}
                 <CardMedia>
                     <Link to={detailsLink} className={classes.suppressLinkStyles}>
                         {!defaultImage && ImageView}

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/ApiThumb.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/ApiThumb.jsx
@@ -243,6 +243,7 @@ class ApiThumb extends React.Component {
             imageObj, selectedIcon, color, backgroundIndex, category, isHover,
         } = this.state;
         const path = this.getPathPrefix();
+        const { isMonetizationEnabled } = this.context;
 
         const detailsLink = path + this.props.api.id;
         const {
@@ -302,7 +303,7 @@ class ApiThumb extends React.Component {
                 raised={isHover}
                 className={classNames('image-thumbnail', classes.card)}
             >
-                {this.context.isMonetizationEnabled && (
+                {isMonetizationEnabled && (
                     <div className={classes.textblock}>{api.monetizationLabel}</div>
                 )}
                 <CardMedia>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/CommonListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/CommonListing.jsx
@@ -24,6 +24,7 @@ import Icon from '@material-ui/core/Icon';
 import { withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 import CustomIcon from 'AppComponents/Shared/CustomIcon';
+import Settings from 'AppComponents/Shared/SettingsContext';
 import API from 'AppData/api';
 import ApiBreadcrumbs from './ApiBreadcrumbs';
 import ApiTableView from './ApiTableView';
@@ -150,6 +151,8 @@ const styles = theme => ({
  * @extends {Component}
  */
 class CommonListing extends React.Component {
+    static contextType = Settings;
+
     /**
      * Constructor
      *
@@ -161,6 +164,7 @@ class CommonListing extends React.Component {
             listType: props.theme.custom.defaultApiView,
             allTags: null,
             showLeftMenu: false,
+            isMonetizationEnabled: false,
         };
     }
 
@@ -188,10 +192,21 @@ class CommonListing extends React.Component {
             .catch((error) => {
                 console.log(error);
             });
+        this.isMonetizationEnabled();
     }
     toggleLeftMenu = () => {
         this.setState(prevState => ({ showLeftMenu: !prevState.showLeftMenu }));
     };
+
+    /**
+     * retrieve Settings from the context and check the monetization enabled
+     */
+    isMonetizationEnabled = () => {
+        const settingsContext = this.context;
+        const enabled = settingsContext.settings.monetizationEnabled;
+        this.setState({ isMonetizationEnabled: enabled });
+    }
+
     /**
      *
      * @inheritdoctheme
@@ -212,7 +227,7 @@ class CommonListing extends React.Component {
                 tagCloud: { active: tagCloudActive },
             },
         } = theme;
-        const { listType, allTags, showLeftMenu } = this.state;
+        const { listType, allTags, showLeftMenu, isMonetizationEnabled } = this.state;
         const strokeColorMain = theme.palette.getContrastText(theme.custom.infoBar.background);
         const searchParam = new URLSearchParams(search);
         const searchQuery = searchParam.get('query');
@@ -308,12 +323,12 @@ class CommonListing extends React.Component {
                     {active && allTags && allTags.length > 0 && <ApiBreadcrumbs selectedTag={selectedTag} />}
                     <div className={classes.listContentWrapper}>
                         {listType === 'grid' && (
-                            <ApiContext.Provider value={{ apiType }}>
+                            <ApiContext.Provider value={{ apiType, isMonetizationEnabled }}>
                                 <ApiTableView gridView query={search} />
                             </ApiContext.Provider>
                         )}
                         {listType === 'list' && (
-                            <ApiContext.Provider value={{ apiType }}>
+                            <ApiContext.Provider value={{ apiType, isMonetizationEnabled }}>
                                 <ApiTableView gridView={false} query={search} />
                             </ApiContext.Provider>
                         )}

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/ApiKey.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/ApiKey.jsx
@@ -23,6 +23,7 @@ import TextField from '@material-ui/core/TextField';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
+import Validation from 'AppData/Validation';
 
 // Styles for Grid and Paper elements
 const styles = theme => ({
@@ -38,6 +39,7 @@ const styles = theme => ({
  */
 const tokens = (props) => {
     const [infiniteValidity, setInfiniteValidity] = useState(true);
+    const [invalidTimeout, setInvaildTimeout] = useState(false);
 
     /**
     * This method is used to handle the updating of create api key
@@ -46,7 +48,7 @@ const tokens = (props) => {
     * @param {*} event event fired
     */
     const handleChange = (field, event) => {
-        const { accessTokenRequest, updateAccessTokenRequest } = props;
+        const { accessTokenRequest, updateAccessTokenRequest} = props;
         const newRequest = { ...accessTokenRequest };
 
         const { target: currentTarget } = event;
@@ -61,10 +63,12 @@ const tokens = (props) => {
                 }
                 break;
             case 'timeout':
-                if (!isNaN(currentTarget.value)) {
+                if (Validation.timeout.validate(currentTarget.value).error === undefined) {
                     newRequest.timeout = currentTarget.value;
+                    setInvaildTimeout(false);
                 } else {
                     newRequest.timeout = null;
+                    setInvaildTimeout(true);
                 }
                 break;
             default:
@@ -95,12 +99,21 @@ const tokens = (props) => {
                     InputLabelProps={{
                         shrink: true,
                     }}
-                    helperText={intl.formatMessage({
-                        defaultMessage: 'You can set an expiration period to determine the validity period of '
+                    helperText={
+                        invalidTimeout ? (
+                            intl.formatMessage({
+                                defaultMessage: 'Please use a valid number for API Key expiry time',
+                                id: 'Shared.AppsAndKeys.Tokens.apikey.set.validity',
+                            })
+                        ) : (
+                            intl.formatMessage({
+                                defaultMessage: 'You can set an expiration period to determine the validity period of '
                                 + 'the token after generation. Set this as -1 to ensure that the '
                                 + 'apikey never expires.',
-                        id: 'Shared.AppsAndKeys.Tokens.apikey.set.validity',
-                    })}
+                                id: 'Shared.AppsAndKeys.Tokens.apikey.set.validity',
+                            })
+                        )
+                    }
                     fullWidth
                     name='timeout'
                     onChange={e => handleChange('timeout', e)}
@@ -111,6 +124,7 @@ const tokens = (props) => {
                     value={accessTokenRequest.timeout}
                     autoFocus
                     className={classes.inputText}
+                    error={invalidTimeout}
                 />
                 }
             </FormControl>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/ApiKey.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/ApiKey.jsx
@@ -61,7 +61,11 @@ const tokens = (props) => {
                 }
                 break;
             case 'timeout':
-                newRequest.timeout = currentTarget.value;
+                if (!isNaN(currentTarget.value)) {
+                    newRequest.timeout = currentTarget.value;
+                } else {
+                    newRequest.timeout = null;
+                }
                 break;
             default:
                 break;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/data/Validation.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/data/Validation.jsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Joi from '@hapi/joi';
+
+const definition = {
+    timeout: Joi.number().integer(),
+};
+
+export default definition;


### PR DESCRIPTION
## Issue
product-apim: https://github.com/wso2/product-apim/issues/6760
product-apim: https://github.com/wso2/product-apim/issues/6699

## Methodology

- Changing the APIInfo REST API to send "monetizationLabel" which can be "FREE", "PAID" ,"FREEMIUM" and the logic to check which label for the API.
- Changing the settings rest api to get the monetization enabled value from tenant.conf.
- Retrieving the settings response using settings context in store and passing the enableMonetization attribute to API Context.
- Checking if the monetization enabled and adding the label to the API Image Card.

- Adding number validation for API Key timeout field using joi validation library. Now the generate button is active only when numbers are provided and error msg is displayed as helper text.

## Labels
APIM 3.0.1 UI REST WUM

## Images 

<img width="723" alt="Screen Shot 2019-11-07 at 11 35 40 AM" src="https://user-images.githubusercontent.com/23296184/68366048-4b484a00-0158-11ea-846a-e96635a0ed4a.png">

<img width="1075" alt="Screen Shot 2019-11-08 at 3 05 49 PM" src="https://user-images.githubusercontent.com/23296184/68466600-b8341080-023a-11ea-811b-d5c9c5c03981.png">
