### PR TITLE
Add mTLS client certificate import/export capability to tool

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/APIImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/APIImportExportConstants.java
@@ -97,7 +97,13 @@ public final class APIImportExportConstants {
 
     public static final String JSON_ENDPOINTS_CERTIFICATE_FILE = File.separator
             + APIImportExportConstants.META_INFO_DIRECTORY + File.separator + "endpoint_certificates.json";
+    
+    public static final String YAML_CLIENT_CERTIFICATE_FILE = File.separator
+            + APIImportExportConstants.META_INFO_DIRECTORY + File.separator + "client_certificates.yaml";
 
+    public static final String JSON_CLIENT_CERTIFICATE_FILE = File.separator
+            + APIImportExportConstants.META_INFO_DIRECTORY + File.separator + "client_certificates.json";
+    
     public static final String HOSTNAME_JSON_KEY = "hostName";
 
     public static final String ALIAS_JSON_KEY = "alias";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
@@ -36,6 +36,7 @@ import org.json.JSONTokener;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.dto.CertificateMetadataDTO;
+import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.Documentation;
@@ -143,6 +144,14 @@ public class APIExportUtil {
 
             //export meta information
             exportMetaInformation(archivePath, apiToReturn, registry, exportFormat, provider);
+            
+            //export mTLS authentication related certificates
+            if(provider.isClientCertificateBasedAuthenticationConfigured()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Mutual SSL enabled. Exporting client certificates.");
+                }
+                exportClientCertificates(archivePath, apiToReturn, tenantId, provider, exportFormat);
+            }
         } catch (APIManagementException e) {
             String errorMessage = "Unable to retrieve API Documentation for API: " + apiIDToReturn.getApiName()
                     + StringUtils.SPACE + APIConstants.API_DATA_VERSION + " : " + apiIDToReturn.getVersion();
@@ -685,6 +694,52 @@ public class APIExportUtil {
                     + api.getId().getApiName() + " as YAML";
             log.error(errorMessage, e);
             throw new APIImportExportException(errorMessage, e);
+        }
+    }
+    
+    /**
+     * Export Mutual SSL related certificates
+     * 
+     * @param api          API to be exported
+     * @param tenantId     tenant id of the user
+     * @param apiProvider  api Provider
+     * @param exportFormat Export format of file
+     * @throws APIImportExportException
+     */
+
+    private static void exportClientCertificates(String archivePath, API api, int tenantId, APIProvider provider,
+            ExportFormat exportFormat) throws APIImportExportException {
+
+        List<ClientCertificateDTO> certificateMetadataDTOS;
+        try {
+            certificateMetadataDTOS = provider.searchClientCertificates(tenantId, null, api.getId());
+            if (!certificateMetadataDTOS.isEmpty()) {
+                CommonUtil.createDirectory(archivePath + File.separator + APIImportExportConstants.META_INFO_DIRECTORY);
+
+                Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                String element = gson.toJson(certificateMetadataDTOS,
+                        new TypeToken<ArrayList<ClientCertificateDTO>>() {
+                        }.getType());
+
+                switch (exportFormat) {
+                    case YAML:
+                        String yaml = CommonUtil.jsonToYaml(element);
+                        CommonUtil.writeFile(archivePath + APIImportExportConstants.YAML_CLIENT_CERTIFICATE_FILE,
+                                yaml);
+                        break;
+                    case JSON:
+                        CommonUtil.writeFile(archivePath + APIImportExportConstants.JSON_CLIENT_CERTIFICATE_FILE,
+                                element);
+                }
+            }
+        } catch (IOException e) {
+            String errorMessage = "Error while retrieving saving as YAML";
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (APIManagementException e) {
+            String errorMsg = "Error retrieving certificate meta data. tenantId [" + tenantId + "] api ["
+                    + tenantId + "]";
+            throw new APIImportExportException(errorMsg, e);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -24,6 +24,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -41,6 +43,7 @@ import org.wso2.carbon.apimgt.api.APIMgtResourceAlreadyExistsException;
 import org.wso2.carbon.apimgt.api.APIMgtResourceNotFoundException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.FaultGatewaysException;
+import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIStatus;
@@ -79,6 +82,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -398,6 +403,13 @@ public final class APIImportUtil {
             addAPISpecificSequences(pathToArchive, importedApi, registry);
             addAPIWsdl(pathToArchive, importedApi, apiProvider, registry);
             addEndpointCertificates(pathToArchive, importedApi, apiProvider, tenantId);
+            
+            if(apiProvider.isClientCertificateBasedAuthenticationConfigured()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Mutual SSL enabled. Importing client certificates.");
+                }
+                addClientCertificates(pathToArchive, apiProvider);
+            }
 
             // Change API lifecycle if state transition is required
             if (StringUtils.isNotEmpty(lifecycleAction)) {
@@ -838,7 +850,54 @@ public final class APIImportUtil {
             throw new APIImportExportException(errorMessage, e);
         }
     }
+    
+    /**
+     * Import client certificates for Mutual SSL related configuration
+     * 
+     * @param pathToArchive location of the extracted folder of the API
+     * @throws APIImportExportException
+     */
+    private static void addClientCertificates(String pathToArchive, APIProvider apiProvider)
+            throws APIImportExportException {
+        String jsonContent = null;
+        String pathToYamlFile = pathToArchive + APIImportExportConstants.YAML_CLIENT_CERTIFICATE_FILE;
+        String pathToJsonFile = pathToArchive + APIImportExportConstants.JSON_CLIENT_CERTIFICATE_FILE;
 
+        try {
+            // try loading file as YAML
+            if (CommonUtil.checkFileExistence(pathToYamlFile)) {
+                log.debug("Found client certificate file " + pathToYamlFile);
+                String yamlContent = FileUtils.readFileToString(new File(pathToYamlFile));
+                jsonContent = CommonUtil.yamlToJson(yamlContent);
+            } else if (CommonUtil.checkFileExistence(pathToJsonFile)) {
+                // load as a json fallback
+                log.debug("Found client certificate file " + pathToJsonFile);
+                jsonContent = FileUtils.readFileToString(new File(pathToJsonFile));
+            }
+            if (jsonContent == null) {
+                log.debug("No client certificate file found to be added, skipping");
+                return;
+            }
+            Gson gson = new Gson();
+            List<ClientCertificateDTO> certificateMetadataDTOS = gson.fromJson(jsonContent, 
+                    new TypeToken<ArrayList<ClientCertificateDTO>>(){}.getType());
+            for (ClientCertificateDTO certDTO : certificateMetadataDTOS) {
+                apiProvider.addClientCertificate(
+                        APIUtil.replaceEmailDomainBack(certDTO.getApiIdentifier().getProviderName()),
+                        certDTO.getApiIdentifier(), certDTO.getCertificate(), certDTO.getAlias(),
+                        certDTO.getTierName());
+            }
+        } catch (IOException e) {
+            String errorMessage = "Error in reading " + APIImportExportConstants.YAML_ENDPOINTS_CERTIFICATE_FILE
+                    + " file";
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        } catch (APIManagementException e) {
+            String errorMessage = "Error while importing client certificate";
+            log.error(errorMessage, e);
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
     /**
      * Update API with the certificate.
      * If certificate alias already exists for tenant in database, certificate content will be


### PR DESCRIPTION
This provides the capability to import and export client certificates added for mutual ssl enabled APIs.

These certificates are saved in a file in client_certificates.yaml under Meta-information section of the Zip file

See the below structure of the exported zip file

    .
    └── PizzaShackAPI-1.0.0
        ├── Docs
        │   ├── FileContents
        │   │   └── PizzaShackAPIDoc.pdf
        │   └── docs.yaml
        ├── Image
        │   └── icon.jpeg
        └── Meta-information
            ├── api.yaml
            ├── client_certificates.yaml
            └── swagger.yaml


Following is the sample content of the client_certificates.yaml file.

	 -
	  alias: cert1
	  certificate: LS0tLS1CRUdJ.,.....
	  tierName: Gold
	  apiIdentifier:
	    providerName: admin
	    apiName: PizzaShackAPI
	    version: 1.0.0
	 -
	  alias: cert2
	  certificate: LS0tLS1CRUdJ.......
	  tierName: Silver
	  apiIdentifier:
	    providerName: admin
	    apiName: PizzaShackAPI
	    version: 1.0.0


Fixes https://github.com/wso2/product-apim/issues/6763