### PR TITLE
Fix Swagger UI to show corresponding hostname for transport schemes

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
@@ -154,11 +154,11 @@ public abstract class APIDefinition {
      *
      * @param api            API
      * @param oasDefinition  OAS definition
-     * @param hostWithScheme host address with protocol
+     * @param hostsWithSchemes host addresses with protocol mapping
      * @return updated OAS definition
      * @throws APIManagementException throws if an error occurred
      */
-    public abstract String getOASDefinitionForStore(API api, String oasDefinition, String hostWithScheme)
+    public abstract String getOASDefinitionForStore(API api, String oasDefinition, Map<String, String> hostsWithSchemes)
             throws APIManagementException;
 
     /**
@@ -166,12 +166,12 @@ public abstract class APIDefinition {
      *
      * @param product        APIProduct
      * @param oasDefinition  OAS definition
-     * @param hostWithScheme host address with protocol
+     * @param hostsWithSchemes host addresses with protocol mapping
      * @return updated OAS definition
      * @throws APIManagementException throws if an error occurred
      */
-    public abstract String getOASDefinitionForStore(APIProduct product, String oasDefinition, String hostWithScheme)
-            throws APIManagementException;
+    public abstract String getOASDefinitionForStore(APIProduct product, String oasDefinition,
+                                                    Map<String, String> hostsWithSchemes) throws APIManagementException;
 
     /**
      * Update OAS definition for API Publisher

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5425,7 +5425,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             throws APIManagementException {
         String apiTenantDomain;
         String updatedDefinition = null;
-        String hostWithScheme;
+        Map<String,String> hostsWithSchemes;
         String definition = super.getOpenAPIDefinition(apiId);
         APIDefinition oasParser = OASParserUtil.getOASParser(definition);
         if (apiId instanceof APIIdentifier) {
@@ -5434,15 +5434,15 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             api.setScopes(oasParser.getScopes(definition));
             api.setUriTemplates(oasParser.getURITemplates(definition));
             apiTenantDomain = MultitenantUtils.getTenantDomain(api.getId().getProviderName());
-            hostWithScheme = getHostWithSchemeForEnvironment(apiTenantDomain, environmentName);
+            hostsWithSchemes = getHostWithSchemeMappingForEnvironment(apiTenantDomain, environmentName);
             api.setContext(getBasePath(apiTenantDomain, api.getContext()));
-            updatedDefinition = oasParser.getOASDefinitionForStore(api, definition, hostWithScheme);
+            updatedDefinition = oasParser.getOASDefinitionForStore(api, definition, hostsWithSchemes);
         } else if (apiId instanceof APIProductIdentifier) {
             APIProduct apiProduct = getAPIProduct((APIProductIdentifier) apiId);
             apiTenantDomain = MultitenantUtils.getTenantDomain(apiProduct.getId().getProviderName());
-            hostWithScheme = getHostWithSchemeForEnvironment(apiTenantDomain, environmentName);
+            hostsWithSchemes = getHostWithSchemeMappingForEnvironment(apiTenantDomain, environmentName);
             apiProduct.setContext(getBasePath(apiTenantDomain, apiProduct.getContext()));
-            updatedDefinition = oasParser.getOASDefinitionForStore(apiProduct, definition, hostWithScheme);
+            updatedDefinition = oasParser.getOASDefinitionForStore(apiProduct, definition, hostsWithSchemes);
         }
         return updatedDefinition;
     }
@@ -5451,19 +5451,19 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
     public String getOpenAPIDefinitionForLabel(Identifier apiId, String labelName) throws APIManagementException {
         List<Label> gatewayLabels;
         String updatedDefinition = null;
-        String hostWithScheme;
+        Map<String,String> hostsWithSchemes;
         String definition = super.getOpenAPIDefinition(apiId);
         APIDefinition oasParser = OASParserUtil.getOASParser(definition);
         if (apiId instanceof APIIdentifier) {
             API api = getLightweightAPI((APIIdentifier) apiId);
             gatewayLabels = api.getGatewayLabels();
-            hostWithScheme = getHostWithSchemeForLabel(gatewayLabels, labelName);
-            updatedDefinition = oasParser.getOASDefinitionForStore(api, definition, hostWithScheme);
+            hostsWithSchemes = getHostWithSchemeMappingForLabel(gatewayLabels, labelName);
+            updatedDefinition = oasParser.getOASDefinitionForStore(api, definition, hostsWithSchemes);
         } else if (apiId instanceof APIProductIdentifier) {
             APIProduct apiProduct = getAPIProduct((APIProductIdentifier) apiId);
             gatewayLabels = apiProduct.getGatewayLabels();
-            hostWithScheme = getHostWithSchemeForLabel(gatewayLabels, labelName);
-            updatedDefinition = oasParser.getOASDefinitionForStore(apiProduct, definition, hostWithScheme);
+            hostsWithSchemes = getHostWithSchemeMappingForLabel(gatewayLabels, labelName);
+            updatedDefinition = oasParser.getOASDefinitionForStore(apiProduct, definition, hostsWithSchemes);
         }
         return updatedDefinition;
     }
@@ -5619,11 +5619,27 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         return applicationAttributes;
     }
 
-    private String getHostWithSchemeForEnvironment(String apiTenantDomain, String environmentName) throws APIManagementException {
+    /**
+     * Get host names with transport scheme mapping from Gateway Environments in api-manager.xml or from the tenant
+     * custom url config in registry.
+     *
+     * @param apiTenantDomain Tenant domain
+     * @param environmentName Environment name
+     * @return Host name to transport scheme mapping
+     * @throws APIManagementException if an error occurs when getting host names with schemes
+     */
+    private Map<String, String> getHostWithSchemeMappingForEnvironment(String apiTenantDomain, String environmentName)
+            throws APIManagementException {
+
         Map<String, String> domains = getTenantDomainMappings(apiTenantDomain, APIConstants.API_DOMAIN_MAPPINGS_GATEWAY);
-        String hostWithScheme = null;
+        Map<String, String> hostsWithSchemes = new HashMap<>();
         if (!domains.isEmpty()) {
-            hostWithScheme = domains.get(APIConstants.CUSTOM_URL);
+            String customUrl = domains.get(APIConstants.CUSTOM_URL);
+            if (customUrl.startsWith(APIConstants.HTTP_PROTOCOL_URL_PREFIX)) {
+                hostsWithSchemes.put(APIConstants.HTTP_PROTOCOL, customUrl);
+            } else {
+                hostsWithSchemes.put(APIConstants.HTTPS_PROTOCOL, customUrl);
+            }
         } else {
             APIManagerConfiguration config = ServiceReferenceHolder.getInstance()
                     .getAPIManagerConfigurationService().getAPIManagerConfiguration();
@@ -5639,19 +5655,28 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             String[] hostsWithScheme = environment.getApiGatewayEndpoint().split(",");
             for (String url : hostsWithScheme) {
                 if (url.startsWith(APIConstants.HTTPS_PROTOCOL_URL_PREFIX)) {
-                    hostWithScheme = url;
-                    break;
+                    hostsWithSchemes.put(APIConstants.HTTPS_PROTOCOL, url);
+                }
+                if (url.startsWith(APIConstants.HTTP_PROTOCOL_URL_PREFIX)) {
+                    hostsWithSchemes.put(APIConstants.HTTP_PROTOCOL, url);
                 }
             }
-
-            if (hostWithScheme == null) {
-                hostWithScheme = hostsWithScheme[0];
-            }
         }
-        return hostWithScheme;
+        return hostsWithSchemes;
     }
 
-    private String getHostWithSchemeForLabel(List<Label> gatewayLabels, String labelName) throws APIManagementException {
+    /**
+     * Get gateway host names with transport scheme mapping.
+     *
+     * @param gatewayLabels gateway label list
+     * @param labelName     Label name
+     * @return Hostname with transport schemes
+     * @throws APIManagementException If an error occurs when getting gateway host names.
+     */
+    private Map<String, String> getHostWithSchemeMappingForLabel(List<Label> gatewayLabels, String labelName)
+            throws APIManagementException {
+
+        Map<String, String> hostsWithSchemes = new HashMap<>();
         Label labelObj = null;
         for (Label label : gatewayLabels) {
             if (label.getName().equals(labelName)) {
@@ -5664,18 +5689,17 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                     "Could not find provided label '" + labelName);
             return null;
         }
-        String hostWithScheme = null;
+
         List<String> accessUrls = labelObj.getAccessUrls();
         for (String url : accessUrls) {
             if (url.startsWith(APIConstants.HTTPS_PROTOCOL_URL_PREFIX)) {
-                hostWithScheme = url;
-                break;
+                hostsWithSchemes.put(APIConstants.HTTPS_PROTOCOL, url);
+            }
+            if (url.startsWith(APIConstants.HTTP_PROTOCOL_URL_PREFIX)) {
+                hostsWithSchemes.put(APIConstants.HTTP_PROTOCOL, url);
             }
         }
-        if (hostWithScheme == null) {
-            hostWithScheme = accessUrls.get(0);
-        }
-        return hostWithScheme;
+        return hostsWithSchemes;
     }
 
     private String getBasePath(String apiTenantDomain, String basePath) throws APIManagementException {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -852,7 +852,6 @@ public class OAS2Parser extends APIDefinition {
      * @param product        APIProduct
      * @param hostsWithSchemes  GW hosts with protocol mapping
      * @param swagger        Swagger
-     * @throws APIManagementException
      */
     private void updateEndpoints(APIProduct product, Map<String,String> hostsWithSchemes, Swagger swagger) {
         String basePath = product.getContext();
@@ -866,7 +865,6 @@ public class OAS2Parser extends APIDefinition {
      * @param api            API
      * @param hostsWithSchemes  GW hosts with protocol mapping
      * @param swagger        Swagger
-     * @throws APIManagementException
      */
     private void updateEndpoints(API api, Map<String,String> hostsWithSchemes, Swagger swagger) {
         String basePath = api.getContext();
@@ -885,15 +883,22 @@ public class OAS2Parser extends APIDefinition {
     private void updateEndpoints(Swagger swagger, String basePath, String transports,
                                  Map<String, String> hostsWithSchemes) {
 
-        String host = hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL).trim()
-                .replace(APIConstants.HTTPS_PROTOCOL_URL_PREFIX, "");
+        String host = StringUtils.EMPTY;
         String[] apiTransports = transports.split(",");
         List<Scheme> schemes = new ArrayList<>();
-        if (ArrayUtils.contains(apiTransports, APIConstants.HTTPS_PROTOCOL)) {
+        if (ArrayUtils.contains(apiTransports, APIConstants.HTTPS_PROTOCOL)
+                && hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL) != null) {
             schemes.add(Scheme.HTTPS);
+            host = hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL).trim()
+                    .replace(APIConstants.HTTPS_PROTOCOL_URL_PREFIX, "");
         }
-        if (ArrayUtils.contains(apiTransports, APIConstants.HTTP_PROTOCOL)) {
+        if (ArrayUtils.contains(apiTransports, APIConstants.HTTP_PROTOCOL)
+                && hostsWithSchemes.get(APIConstants.HTTP_PROTOCOL) != null) {
             schemes.add(Scheme.HTTP);
+            if (StringUtils.isEmpty(host)) {
+                host = hostsWithSchemes.get(APIConstants.HTTP_PROTOCOL).trim()
+                        .replace(APIConstants.HTTP_PROTOCOL_URL_PREFIX, "");
+            }
         }
         swagger.setSchemes(schemes);
         swagger.setBasePath(basePath);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -464,18 +464,18 @@ public class OAS2Parser extends APIDefinition {
      *
      * @param api            API
      * @param oasDefinition  OAS definition
-     * @param hostWithScheme host address with protocol
+     * @param hostsWithSchemes host addresses with protocol mapping
      * @return OAS definition
      * @throws APIManagementException throws if an error occurred
      */
     @Override
-    public String getOASDefinitionForStore(API api, String oasDefinition, String hostWithScheme)
+    public String getOASDefinitionForStore(API api, String oasDefinition, Map<String, String> hostsWithSchemes)
             throws APIManagementException {
 
         Swagger swagger = getSwagger(oasDefinition);
         updateOperations(swagger);
-        updateEndpoints(api, hostWithScheme, swagger);
-        return updateSwaggerSecurityDefinitionForStore(swagger, new SwaggerData(api), hostWithScheme);
+        updateEndpoints(api, hostsWithSchemes, swagger);
+        return updateSwaggerSecurityDefinitionForStore(swagger, new SwaggerData(api), hostsWithSchemes);
     }
 
     /**
@@ -483,17 +483,18 @@ public class OAS2Parser extends APIDefinition {
      *
      * @param product        APIProduct
      * @param oasDefinition  OAS definition
-     * @param hostWithScheme host address with protocol
+     * @param hostsWithSchemes host addresses with protocol mapping
      * @return OAS definition
      * @throws APIManagementException throws if an error occurred
      */
     @Override
-    public String getOASDefinitionForStore(APIProduct product, String oasDefinition, String hostWithScheme)
-            throws APIManagementException {
+    public String getOASDefinitionForStore(APIProduct product, String oasDefinition,
+                                           Map<String, String> hostsWithSchemes) throws APIManagementException {
+
         Swagger swagger = getSwagger(oasDefinition);
         updateOperations(swagger);
-        updateEndpoints(product, hostWithScheme, swagger);
-        return updateSwaggerSecurityDefinitionForStore(swagger, new SwaggerData(product), hostWithScheme);
+        updateEndpoints(product, hostsWithSchemes, swagger);
+        return updateSwaggerSecurityDefinitionForStore(swagger, new SwaggerData(product), hostsWithSchemes);
     }
 
     /**
@@ -849,28 +850,28 @@ public class OAS2Parser extends APIDefinition {
      * Update OAS definition with GW endpoints
      *
      * @param product        APIProduct
-     * @param hostWithScheme GW host with protocol
+     * @param hostsWithSchemes  GW hosts with protocol mapping
      * @param swagger        Swagger
      * @throws APIManagementException
      */
-    private void updateEndpoints(APIProduct product, String hostWithScheme, Swagger swagger) {
+    private void updateEndpoints(APIProduct product, Map<String,String> hostsWithSchemes, Swagger swagger) {
         String basePath = product.getContext();
         String transports = product.getTransports();
-        updateEndpoints(swagger, basePath, transports, hostWithScheme);
+        updateEndpoints(swagger, basePath, transports, hostsWithSchemes);
     }
 
     /**
      * Update OAS definition with GW endpoints
      *
      * @param api            API
-     * @param hostWithScheme GW host with protocol
+     * @param hostsWithSchemes  GW hosts with protocol mapping
      * @param swagger        Swagger
      * @throws APIManagementException
      */
-    private void updateEndpoints(API api, String hostWithScheme, Swagger swagger) {
+    private void updateEndpoints(API api, Map<String,String> hostsWithSchemes, Swagger swagger) {
         String basePath = api.getContext();
         String transports = api.getTransports();
-        updateEndpoints(swagger, basePath, transports, hostWithScheme);
+        updateEndpoints(swagger, basePath, transports, hostsWithSchemes);
     }
 
     /**
@@ -879,10 +880,12 @@ public class OAS2Parser extends APIDefinition {
      * @param swagger        Swagger
      * @param basePath       API context
      * @param transports     transports types
-     * @param hostWithScheme GW host with protocol
+     * @param hostsWithSchemes GW hosts with protocol mapping
      */
-    private void updateEndpoints(Swagger swagger, String basePath, String transports, String hostWithScheme) {
-        String host = hostWithScheme.trim().replace(APIConstants.HTTP_PROTOCOL_URL_PREFIX, "")
+    private void updateEndpoints(Swagger swagger, String basePath, String transports,
+                                 Map<String, String> hostsWithSchemes) {
+
+        String host = hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL).trim()
                 .replace(APIConstants.HTTPS_PROTOCOL_URL_PREFIX, "");
         String[] apiTransports = transports.split(",");
         List<Scheme> schemes = new ArrayList<>();
@@ -900,14 +903,22 @@ public class OAS2Parser extends APIDefinition {
     /**
      * Update OAS definition with authorization endpoints
      *
-     * @param swagger        Swagger
-     * @param swaggerData    SwaggerData
-     * @param hostWithScheme GW host with protocol
+     * @param swagger           Swagger
+     * @param swaggerData       SwaggerData
+     * @param hostsWithSchemes  GW hosts with protocols
      * @return updated OAS definition
      */
     private String updateSwaggerSecurityDefinitionForStore(Swagger swagger, SwaggerData swaggerData,
-            String hostWithScheme) throws APIManagementException {
-        String authUrl = hostWithScheme + "/authorize";
+                                                           Map<String,String> hostsWithSchemes)
+            throws APIManagementException {
+
+        String authUrl;
+        // By Default, add the GW host with HTTPS protocol if present.
+        if (hostsWithSchemes.containsKey(APIConstants.HTTPS_PROTOCOL)) {
+            authUrl = (hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL)).concat("/authorize");
+        } else {
+            authUrl = (hostsWithSchemes.get(APIConstants.HTTP_PROTOCOL)).concat("/authorize");
+        }
         updateSwaggerSecurityDefinition(swagger, swaggerData, authUrl);
         return getSwaggerJsonString(swagger);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -425,11 +425,10 @@ public class OAS3Parser extends APIDefinition {
      * @param oasDefinition  OAS definition
      * @param hostsWithSchemes host addresses with protocol mapping
      * @return OAS definition
-     * @throws APIManagementException throws if an error occurred
      */
     @Override
-    public String getOASDefinitionForStore(API api, String oasDefinition, Map<String, String> hostsWithSchemes)
-            throws APIManagementException {
+    public String getOASDefinitionForStore(API api, String oasDefinition, Map<String, String> hostsWithSchemes) {
+
         OpenAPI openAPI = getOpenAPI(oasDefinition);
         updateOperations(openAPI);
         updateEndpoints(api, hostsWithSchemes, openAPI);
@@ -443,7 +442,6 @@ public class OAS3Parser extends APIDefinition {
      * @param oasDefinition  OAS definition
      * @param hostsWithSchemes host addresses with protocol mapping
      * @return OAS definition
-     * @throws APIManagementException throws if an error occurred
      */
     @Override
     public String getOASDefinitionForStore(APIProduct product, String oasDefinition,
@@ -818,7 +816,6 @@ public class OAS3Parser extends APIDefinition {
      * @param product           APIProduct
      * @param hostsWithSchemes  GW hosts with protocol mapping
      * @param openAPI           OpenAPI
-     * @throws APIManagementException
      */
     private void updateEndpoints(APIProduct product, Map<String, String> hostsWithSchemes, OpenAPI openAPI) {
 
@@ -833,7 +830,6 @@ public class OAS3Parser extends APIDefinition {
      * @param api               API
      * @param hostsWithSchemes  GW hosts with protocol mapping
      * @param openAPI           OpenAPI
-     * @throws APIManagementException
      */
     private void updateEndpoints(API api, Map<String, String> hostsWithSchemes, OpenAPI openAPI) {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -423,17 +423,17 @@ public class OAS3Parser extends APIDefinition {
      *
      * @param api            API
      * @param oasDefinition  OAS definition
-     * @param hostWithScheme host address with protocol
+     * @param hostsWithSchemes host addresses with protocol mapping
      * @return OAS definition
      * @throws APIManagementException throws if an error occurred
      */
     @Override
-    public String getOASDefinitionForStore(API api, String oasDefinition, String hostWithScheme)
+    public String getOASDefinitionForStore(API api, String oasDefinition, Map<String, String> hostsWithSchemes)
             throws APIManagementException {
         OpenAPI openAPI = getOpenAPI(oasDefinition);
         updateOperations(openAPI);
-        updateEndpoints(api, hostWithScheme, openAPI);
-        return updateSwaggerSecurityDefinitionForStore(openAPI, new SwaggerData(api), hostWithScheme);
+        updateEndpoints(api, hostsWithSchemes, openAPI);
+        return updateSwaggerSecurityDefinitionForStore(openAPI, new SwaggerData(api), hostsWithSchemes);
     }
 
     /**
@@ -441,17 +441,18 @@ public class OAS3Parser extends APIDefinition {
      *
      * @param product        APIProduct
      * @param oasDefinition  OAS definition
-     * @param hostWithScheme host address with protocol
+     * @param hostsWithSchemes host addresses with protocol mapping
      * @return OAS definition
      * @throws APIManagementException throws if an error occurred
      */
     @Override
-    public String getOASDefinitionForStore(APIProduct product, String oasDefinition, String hostWithScheme)
-            throws APIManagementException {
+    public String getOASDefinitionForStore(APIProduct product, String oasDefinition,
+                                           Map<String, String> hostsWithSchemes) {
+
         OpenAPI openAPI = getOpenAPI(oasDefinition);
         updateOperations(openAPI);
-        updateEndpoints(product, hostWithScheme, openAPI);
-        return updateSwaggerSecurityDefinitionForStore(openAPI, new SwaggerData(product), hostWithScheme);
+        updateEndpoints(product, hostsWithSchemes, openAPI);
+        return updateSwaggerSecurityDefinitionForStore(openAPI, new SwaggerData(product), hostsWithSchemes);
     }
 
     /**
@@ -790,80 +791,81 @@ public class OAS3Parser extends APIDefinition {
     }
 
     /**
-     * Update OAS definition with authorization endpoints
+     * Update OAS definition with authorization endpoints.
      *
      * @param openAPI        OpenAPI
      * @param swaggerData    SwaggerData
-     * @param hostWithScheme GW host with protocol
+     * @param hostsWithSchemes GW hosts with protocols
      * @return updated OAS definition
      */
     private String updateSwaggerSecurityDefinitionForStore(OpenAPI openAPI, SwaggerData swaggerData,
-            String hostWithScheme) {
-        String authUrl = hostWithScheme + "/authorize";
-        updateSwaggerSecurityDefinition(openAPI, swaggerData, authUrl);
+            Map<String,String> hostsWithSchemes) {
 
+        String authUrl;
+        // By Default, add the GW host with HTTPS protocol if present.
+        if (hostsWithSchemes.containsKey(APIConstants.HTTPS_PROTOCOL)) {
+            authUrl = (hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL)).concat("/authorize");
+        } else {
+            authUrl = (hostsWithSchemes.get(APIConstants.HTTP_PROTOCOL)).concat("/authorize");
+        }
+        updateSwaggerSecurityDefinition(openAPI, swaggerData, authUrl);
         return Json.pretty(openAPI);
     }
 
     /**
      * Update OAS definition with GW endpoints
      *
-     * @param product        APIProduct
-     * @param hostWithScheme GW host with protocol
-     * @param openAPI        OpenAPI
+     * @param product           APIProduct
+     * @param hostsWithSchemes  GW hosts with protocol mapping
+     * @param openAPI           OpenAPI
      * @throws APIManagementException
      */
-    private void updateEndpoints(APIProduct product, String hostWithScheme, OpenAPI openAPI)
-            throws APIManagementException {
+    private void updateEndpoints(APIProduct product, Map<String, String> hostsWithSchemes, OpenAPI openAPI) {
+
         String basePath = product.getContext();
         String transports = product.getTransports();
-        try {
-            updateEndpoints(openAPI, basePath, transports, hostWithScheme);
-        } catch (MalformedURLException e) {
-            throw new APIManagementException("Error occurred while setting server endpoints.", e);
-        }
+        updateEndpoints(openAPI, basePath, transports, hostsWithSchemes);
     }
 
     /**
      * Update OAS definition with GW endpoints
      *
-     * @param api            API
-     * @param hostWithScheme GW host with protocol
-     * @param openAPI        OpenAPI
+     * @param api               API
+     * @param hostsWithSchemes  GW hosts with protocol mapping
+     * @param openAPI           OpenAPI
      * @throws APIManagementException
      */
-    private void updateEndpoints(API api, String hostWithScheme, OpenAPI openAPI) throws APIManagementException {
+    private void updateEndpoints(API api, Map<String, String> hostsWithSchemes, OpenAPI openAPI) {
+
         String basePath = api.getContext();
         String transports = api.getTransports();
-        try {
-            updateEndpoints(openAPI, basePath, transports, hostWithScheme);
-        } catch (MalformedURLException e) {
-            throw new APIManagementException("Error occurred while setting server endpoints.", e);
-        }
+        updateEndpoints(openAPI, basePath, transports, hostsWithSchemes);
     }
 
     /**
      * Update OAS definition with GW endpoints and API information
      *
-     * @param openAPI        OpenAPI
-     * @param basePath       API context
-     * @param transports     transports types
-     * @param hostWithScheme GW host with protocol
-     * @throws MalformedURLException
+     * @param openAPI          OpenAPI
+     * @param basePath         API context
+     * @param transports       transports types
+     * @param hostsWithSchemes GW hosts with protocol mapping
      */
-    private void updateEndpoints(OpenAPI openAPI, String basePath, String transports, String hostWithScheme)
-            throws MalformedURLException {
-        String host = hostWithScheme.trim().replace(APIConstants.HTTP_PROTOCOL_URL_PREFIX, "")
-                .replace(APIConstants.HTTPS_PROTOCOL_URL_PREFIX, "");
+    private void updateEndpoints(OpenAPI openAPI, String basePath, String transports,
+                                 Map<String, String> hostsWithSchemes) {
+
         String[] apiTransports = transports.split(",");
         List<Server> servers = new ArrayList<>();
         if (ArrayUtils.contains(apiTransports, APIConstants.HTTPS_PROTOCOL)) {
+            String host = hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL).trim()
+                    .replace(APIConstants.HTTPS_PROTOCOL_URL_PREFIX, "");
             String httpsURL = APIConstants.HTTPS_PROTOCOL + "://" + host + basePath;
             Server httpsServer = new Server();
             httpsServer.setUrl(httpsURL);
             servers.add(httpsServer);
         }
         if (ArrayUtils.contains(apiTransports, APIConstants.HTTP_PROTOCOL)) {
+            String host = hostsWithSchemes.get(APIConstants.HTTP_PROTOCOL).trim()
+                    .replace(APIConstants.HTTP_PROTOCOL_URL_PREFIX, "");
             String httpURL = APIConstants.HTTP_PROTOCOL + "://" + host + basePath;
             Server httpsServer = new Server();
             httpsServer.setUrl(httpURL);


### PR DESCRIPTION
Fix https://github.com/wso2/product-apim/issues/6878

This fix will only fix the issue for OpenAPI 3.0. 
For OpenAPI 2, we would need to find a way to customize the hosts in the swagger UI, because of OpenAPI2 only supports one host. 