### PR TITLE
Sync JWT grant version with product-apim

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/issuers/RoleBasedScopesIssuer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/issuers/RoleBasedScopesIssuer.java
@@ -30,7 +30,6 @@ import org.wso2.carbon.apimgt.keymgt.util.APIKeyMgtUtil;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth.common.GrantType;
 import org.wso2.carbon.identity.oauth2.grant.jwt.JWTConstants;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;

--- a/pom.xml
+++ b/pom.xml
@@ -1628,7 +1628,7 @@
         <carbon.identity.version>5.15.0</carbon.identity.version>
         <carbon.identity.governance.version>1.3.21</carbon.identity.governance.version>
         <carbon.identity-inbound-auth-oauth.version>6.2.55</carbon.identity-inbound-auth-oauth.version>
-        <carbon.identity-oauth2-grant-jwt.version>1.0.15</carbon.identity-oauth2-grant-jwt.version>
+        <carbon.identity-oauth2-grant-jwt.version>1.0.23</carbon.identity-oauth2-grant-jwt.version>
         <carbon.identity-user-ws.version>5.3.3</carbon.identity-user-ws.version>
         <carbon.identity-inbound-auth-saml2.version>5.4.5</carbon.identity-inbound-auth-saml2.version>
         <carbon.identity-inbound-auth-openid.version>5.4.3</carbon.identity-inbound-auth-openid.version>


### PR DESCRIPTION
This PR removes unused imports and sync the carbon.identity-oauth2-grant-jwt.version with that in product apim.