### PR TITLE
Fix document link in search result listing

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/DocThumb.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/DocThumb.jsx
@@ -145,7 +145,7 @@ class DocThumb extends React.Component {
         const { doc: {
  name, sourceType, apiName, apiVersion, id, apiUUID 
 } } = this.props;
-        const details_link = '/apis/' + apiUUID + '/docs';
+        const details_link = '/apis/' + apiUUID + '/documents/' + id + '/details';
         const { thumbnail } = theme.custom;
         const imageWidth = thumbnail.width;
         const defaultImage = thumbnail.defaultApiImage;


### PR DESCRIPTION
When we click on a document that is in the search results listing, the user is being redirected to an incorrect URL.
This PR fixes that issue.