### PR TITLE
Fix publisher restriction overriding visible to my domain accessibility

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -3578,7 +3578,8 @@ public final class APIUtil {
                     publisherAccessRoles = new StringBuilder(APIConstants.NULL_USER_ROLE_LIST);
                 }
 
-                if (visibility.equalsIgnoreCase(APIConstants.API_GLOBAL_VISIBILITY)) {
+                if (visibility.equalsIgnoreCase(APIConstants.API_GLOBAL_VISIBILITY)
+                        || visibility.equalsIgnoreCase(APIConstants.API_PRIVATE_VISIBILITY)) {
                     registryResource.setProperty(APIConstants.STORE_VIEW_ROLES, APIConstants.NULL_USER_ROLE_LIST);
                     publisherAccessRoles = new StringBuilder(APIConstants.NULL_USER_ROLE_LIST); // set publisher
                     // access roles null since store visibility is global. We do not need to add any roles to


### PR DESCRIPTION
Fixing wso2/product-apim#7106
If publisher access control is set to restrict to roles and store visibility to visible to my domain, store visibility is set only for the restricted roles of the publisher. With this PR, even though publisher access is restricted, store visibility to visible to my domain will set null as the role in registry.