### PR TITLE
Update tenant-conf migration to handle missing roles to handle migration

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1312,6 +1312,7 @@ public final class APIConstants {
     public static final String REST_API_SCOPE_NAME = "Name";
     public static final String REST_API_SCOPE_ROLE = "Roles";
     public static final String REST_API_SCOPES_CONFIG = "RESTAPIScopes";
+    public static final String APIM_SUBSCRIBE_SCOPE = "apim:subscribe";
 
     public static final String HTTPS_PROTOCOL = "https";
     public static final String HTTPS_PROTOCOL_URL_PREFIX = "https://";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -4129,6 +4129,7 @@ public final class APIUtil {
                     throw new APIManagementException("Error while formatting tenant-conf.json of tenant " + tenantId);
                 }
             } else {
+                log.debug("Scopes in tenant-conf.json in tenant " + tenantId + " are already migrated.");
                 return Optional.empty();
             }
         } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -194,6 +194,11 @@
       }
     ]
   },
+  "Meta" : {
+    "Migration": {
+      "3.0.0": true
+    }
+  },
   "NotificationsEnabled":"false",
   "Notifications":[{
     "Type":"new_api_version",

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json
@@ -194,6 +194,11 @@
       }
     ]
   },
+  "Meta" : {
+    "Migration": {
+      "3.0.0": true
+    }
+  },
   "NotificationsEnabled":"false",
   "Notifications":[{
     "Type":"new_api_version",

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/tenant/tenant-conf.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/tenant/tenant-conf.json
@@ -194,6 +194,11 @@
       }
     ]
   },
+  "Meta" : {
+    "Migration": {
+      "3.0.0": true
+    }
+  },
   "NotificationsEnabled":"false",
   "Notifications":[{
     "Type":"new_api_version",


### PR DESCRIPTION
This PR contains the following changes:

In 2.0.0, admin role is not added as a role for apim:subscribe scope, if any user migrates from 2.0.0 to 3.0.0, admin of migrated tenant will not be able to login to dev portal due to forbidden error.

In order to fix this issue, this PR contains changes to add admin role to apim:subscribe scope on the fly. Once, this role is added, there will be a meta entry added to tenant-conf.json as in the format given below, in order to make sure that it is not getting overwritten again.

"Meta": {
   "Migration": {
     "3.0.0": true
   }
 }
Related git issue - wso2/product-apim#7188