### PR TITLE
Update APIUtilTest.java to make it work anywhere on earth

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilTest.java
@@ -105,6 +105,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -406,7 +407,7 @@ public class APIUtilTest {
         Mockito.when(registry.get(artifactPath)).thenReturn(resource);
         Mockito.when(resource.getLastModified()).thenReturn(expectedAPI.getLastUpdated());
 
-        DateFormat df = new SimpleDateFormat("E MMM dd HH:mm:ss zzz yyyy");
+        DateFormat df = new SimpleDateFormat("E MMM dd HH:mm:ss zzz yyyy", Locale.US);
         Date createdTime = df.parse(expectedAPI.getCreatedTime());
         Mockito.when(resource.getCreatedTime()).thenReturn(createdTime);
 


### PR DESCRIPTION
The test initialization code uses new Date().toString(). Parsing this string with a SimpleDateFormat instance that is initialized with a non US locale does not work.

This change stabilizes the test results for people who run their laptop in another default language than us englisch. It makes the `man clean install` result more reliable.