### PR TITLE
Support WSDL file/archive upload in SOAP2REST

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -170,6 +170,7 @@ public enum ExceptionCodes implements ErrorHandler {
     URL_NOT_RECOGNIZED_AS_WSDL(900683, "Invalid WSDL URL", 400, "Provided URL is not recognized as a WSDL"),
     NO_WSDL_AVAILABLE_FOR_API(900684, "WSDL Not Found", 404, "No WSDL Available for the API %s:%s"),
     CORRUPTED_STORED_WSDL(900685, "Corrupted Stored WSDL", 500, "The WSDL of the API %s is corrupted."),
+    UNSUPPORTED_WSDL_FILE_EXTENSION(900686, "Unsupported WSDL File Extension", 400, "Unsupported extension. Only supported extensions are .wsdl and .zip"),
 
 
     //OpenAPI/Swagger related codes [900750 900???)

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIMWSDLReader.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIMWSDLReader.java
@@ -303,6 +303,34 @@ public class APIMWSDLReader {
     }
 
     /**
+     * Returns a WSDL11SOAPOperationExtractor for the WSDL byte content {@code content}. Only WSDL 1.1 is supported.
+     *
+     * @param content WSDL byte[] content
+     * @return WSDL11SOAPOperationExtractor for the provided URL
+     * @throws APIManagementException If an error occurs while determining the processor
+     */
+    public static WSDL11SOAPOperationExtractor getWSDLSOAPOperationExtractor(byte[] content)
+            throws APIManagementException {
+        WSDL11SOAPOperationExtractor processor = new WSDL11SOAPOperationExtractor();
+        processor.init(content);
+        return processor;
+    }
+
+    /**
+     * Returns a WSDL11SOAPOperationExtractor for the url {@code url}. Only WSDL 1.1 is supported.
+     *
+     * @param wsdlPath File path containing WSDL files and dependant files
+     * @return WSDL11SOAPOperationExtractor for the provided URL
+     * @throws APIManagementException If an error occurs while determining the processor
+     */
+    public static WSDL11SOAPOperationExtractor getWSDLSOAPOperationExtractor(String wsdlPath)
+            throws APIManagementException {
+        WSDL11SOAPOperationExtractor processor = new WSDL11SOAPOperationExtractor();
+        processor.initPath(wsdlPath);
+        return processor;
+    }
+
+    /**
 	 * Read the wsdl and clean the actual service endpoint instead of that set
 	 * the gateway endpoint.
 	 *

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/AbstractWSDLProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/AbstractWSDLProcessor.java
@@ -51,6 +51,7 @@ import javax.xml.parsers.ParserConfigurationException;
 abstract class AbstractWSDLProcessor implements WSDLProcessor {
 
     protected static final int MAX_URL_READ_LINES = 100;
+    private Mode mode;
 
     /**
      * Returns an "XXE safe" built DOM XML object by reading the content from the provided URL.
@@ -184,5 +185,13 @@ abstract class AbstractWSDLProcessor implements WSDLProcessor {
             throw new APIMgtWSDLException("General error occurred while creating WSDL archive", e,
                     ExceptionCodes.ERROR_WHILE_CREATING_WSDL_ARCHIVE);
         }
+    }
+
+    void setMode(Mode mode) {
+        this.mode = mode;
+    }
+
+    public Mode getMode() {
+        return this.mode;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractor.java
@@ -123,6 +123,12 @@ public class WSDL11SOAPOperationExtractor extends WSDL11ProcessorImpl {
         return initModels();
     }
 
+    @Override
+    public boolean initPath(String pathToExtractedZip) throws APIMgtWSDLException {
+        super.initPath(pathToExtractedZip);
+        return initModels();
+    }
+
     /**
      * Initiallize SOAP to REST Operations
      *

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20ProcessorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20ProcessorImpl.java
@@ -93,6 +93,7 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
 
     @Override
     public boolean init(URL url) throws APIMgtWSDLException {
+        setMode(Mode.SINGLE);
         WSDLReader reader;
         try {
             reader = WSDLFactory.newInstance().newWSDLReader();
@@ -117,6 +118,7 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
 
     @Override
     public boolean init(byte[] wsdlContent) throws APIMgtWSDLException {
+        setMode(Mode.SINGLE);
         WSDLReader reader;
         try {
             reader = getWsdlFactoryInstance().newWSDLReader();
@@ -145,6 +147,7 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
 
     @Override
     public boolean initPath(String path) throws APIMgtWSDLException {
+        setMode(Mode.ARCHIVE);
         pathToDescriptionMap = new HashMap<>();
         wsdlArchiveExtractedPath = path;
         WSDLReader reader;
@@ -199,7 +202,7 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
 
     @Override
     public ByteArrayInputStream getWSDL() throws APIMgtWSDLException {
-        if (wsdlDescription != null) {
+        if (Mode.SINGLE.equals(getMode())) {
             return getSingleWSDL();
         } else {
             return getWSDLArchive(wsdlArchiveExtractedPath);
@@ -253,7 +256,7 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
 
     @Override
     public void updateEndpoints(API api, String environmentName, String environmentType) throws APIMgtWSDLException {
-        if (wsdlDescription != null) {
+        if (Mode.SINGLE.equals(getMode())) {
             updateEndpointsOfSingleWSDL(api, environmentName, environmentType);
         } else {
             updateEndpointsOfWSDLArchive(api, environmentName, environmentType);
@@ -341,7 +344,7 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
      * @throws APIMgtWSDLException if error occurs while reading endpoints
      */
     private Map<String, String> getEndpoints() throws APIMgtWSDLException {
-        if (wsdlDescription != null) {
+        if (Mode.SINGLE.equals(getMode())) {
             return getEndpoints(wsdlDescription);
         } else {
             Map<String, String> allEndpointsOfAllWSDLs = new HashMap<>();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDLProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDLProcessor.java
@@ -37,6 +37,10 @@ public interface WSDLProcessor {
     int ENTITY_EXPANSION_LIMIT = 0;
     Logger log = LoggerFactory.getLogger(WSDLProcessor.class);
 
+    enum Mode {
+        SINGLE, ARCHIVE;
+    }
+
     boolean init(URL url) throws APIMgtWSDLException;
 
     /**
@@ -100,4 +104,6 @@ public interface WSDLProcessor {
     boolean canProcess(URL url);
 
     ErrorHandler getError();
+
+    Mode getMode();
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/SOAPOperationBindingTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/SOAPOperationBindingTestCase.java
@@ -37,7 +37,7 @@ public class SOAPOperationBindingTestCase {
 
     @Test
     public void testGetSoapOperationMapping() throws Exception {
-        String mapping = SOAPOperationBindingUtils.getSoapOperationMapping(Thread.currentThread().getContextClassLoader()
+        String mapping = SOAPOperationBindingUtils.getSoapOperationMappingForUrl(Thread.currentThread().getContextClassLoader()
                 .getResource("wsdls/phoneverify.wsdl").toExternalForm());
         Assert.assertTrue("Failed getting soap operation mapping from the WSDL", !mapping.isEmpty());
     }
@@ -54,7 +54,7 @@ public class SOAPOperationBindingTestCase {
 
     @Test
     public void testGetSwaggerFromWSDL() throws Exception {
-        String swaggerStr = SOAPOperationBindingUtils.getSoapOperationMapping(Thread.currentThread().getContextClassLoader()
+        String swaggerStr = SOAPOperationBindingUtils.getSoapOperationMappingForUrl(Thread.currentThread().getContextClassLoader()
                 .getResource("wsdls/phoneverify.wsdl").toExternalForm());
 
         Swagger swagger = new SwaggerParser().parse(swaggerStr);
@@ -77,7 +77,7 @@ public class SOAPOperationBindingTestCase {
                 + "  },\n" + "  \"info\": {\n" + "    \"title\": \"\",\n" + "    \"version\": \"\"\n" + "  },\n"
                 + "  \"definitions\": {\n" + "    \"getCustomerOutput\": {\n" + "      \"type\": \"object\"\n"
                 + "    }\n" + "  }\n" + "}";
-        String generatedSwagger = SOAPOperationBindingUtils.getSoapOperationMapping(
+        String generatedSwagger = SOAPOperationBindingUtils.getSoapOperationMappingForUrl(
                 Thread.currentThread().getContextClassLoader().getResource("wsdls/simpleCustomerService.wsdl")
                         .toExternalForm());
         Swagger swagger = new SwaggerParser().parse(generatedSwagger);
@@ -88,7 +88,7 @@ public class SOAPOperationBindingTestCase {
 
     @Test
     public void testVendorExtensions() throws Exception {
-        String swaggerStr = SOAPOperationBindingUtils.getSoapOperationMapping(
+        String swaggerStr = SOAPOperationBindingUtils.getSoapOperationMappingForUrl(
                 Thread.currentThread().getContextClassLoader().getResource("wsdls/simpleCustomerService.wsdl")
                         .toExternalForm());
         Swagger swagger = new SwaggerParser().parse(swaggerStr);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -75,7 +75,6 @@ import org.wso2.carbon.apimgt.api.model.policy.APIPolicy;
 import org.wso2.carbon.apimgt.api.model.policy.Policy;
 import org.wso2.carbon.apimgt.api.model.policy.PolicyConstants;
 import org.wso2.carbon.apimgt.impl.APIConstants;
-import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.GZIPUtils;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.certificatemgt.ResponseCode;
@@ -84,7 +83,6 @@ import org.wso2.carbon.apimgt.impl.definitions.OAS2Parser;
 import org.wso2.carbon.apimgt.impl.definitions.OAS3Parser;
 import org.wso2.carbon.apimgt.impl.definitions.OASParserUtil;
 import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
-import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.CertificateMgtUtils;
 import org.wso2.carbon.apimgt.impl.wsdl.SequenceGenerator;
 import org.wso2.carbon.apimgt.impl.wsdl.model.WSDLValidationResponse;
@@ -3345,7 +3343,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             String additionalProperties, String implementationType, MessageContext messageContext)
             throws APIManagementException {
         try {
-            validateWSDLAndReset(fileInputStream, fileDetail, url);
+            WSDLValidationResponse validationResponse = validateWSDLAndReset(fileInputStream, fileDetail, url);
 
             if (StringUtils.isEmpty(implementationType)) {
                 implementationType = APIDTO.TypeEnum.SOAP.toString();
@@ -3354,7 +3352,6 @@ public class ApisApiServiceImpl implements ApisApiService {
             boolean isSoapToRestConvertedAPI = APIDTO.TypeEnum.SOAPTOREST.toString().equals(implementationType);
             boolean isSoapAPI = APIDTO.TypeEnum.SOAP.toString().equals(implementationType);
 
-            APIProvider apiProvider = RestApiUtil.getLoggedInUserProvider();
             APIDTO additionalPropertiesAPI = null;
             APIDTO createdApiDTO;
             URI createdApiUri;
@@ -3369,7 +3366,12 @@ public class ApisApiServiceImpl implements ApisApiService {
             if (isSoapAPI) {
                 createdApi = importSOAPAPI(fileInputStream, fileDetail, url, apiToAdd);
             } else if (isSoapToRestConvertedAPI) {
-                createdApi = importSOAPToRESTAPI(fileInputStream, fileDetail, url, apiToAdd);
+                String wsdlArchiveExtractedPath = null;
+                if (validationResponse.getWsdlArchiveInfo() != null) {
+                    wsdlArchiveExtractedPath = validationResponse.getWsdlArchiveInfo().getLocation()
+                            + File.separator + APIConstants.API_WSDL_EXTRACTED_DIRECTORY;
+                }
+                createdApi = importSOAPToRESTAPI(fileInputStream, fileDetail, url, wsdlArchiveExtractedPath, apiToAdd);
             } else {
                 RestApiUtil.handleBadRequest("Invalid implementationType parameter", log);
             }
@@ -3391,7 +3393,7 @@ public class ApisApiServiceImpl implements ApisApiService {
      * @param url WSDL url
      * @throws APIManagementException when error occurred during the operation
      */
-    private void validateWSDLAndReset(InputStream fileInputStream, Attachment fileDetail, String url)
+    private WSDLValidationResponse validateWSDLAndReset(InputStream fileInputStream, Attachment fileDetail, String url)
             throws APIManagementException {
         Map validationResponseMap = validateWSDL(url, fileInputStream, fileDetail);
         WSDLValidationResponse validationResponse =
@@ -3417,6 +3419,7 @@ public class ApisApiServiceImpl implements ApisApiService {
                         "input stream.");
             }
         }
+        return validationResponse;
     }
 
     /**
@@ -3487,7 +3490,8 @@ public class ApisApiServiceImpl implements ApisApiService {
      * @param apiToAdd API object to be added to the system (which is not added yet)
      * @return API added api
      */
-    private API importSOAPToRESTAPI(InputStream fileInputStream, Attachment fileDetail, String url, API apiToAdd) {
+    private API importSOAPToRESTAPI(InputStream fileInputStream, Attachment fileDetail, String url,
+            String wsdlArchiveExtractedPath, API apiToAdd) throws APIManagementException {
         try {
             APIProvider apiProvider = RestApiUtil.getLoggedInUserProvider();
             //adding the api
@@ -3496,19 +3500,26 @@ public class ApisApiServiceImpl implements ApisApiService {
             APIIdentifier createdApiId = apiToAdd.getId();
             //Retrieve the newly added API to send in the response payload
             API createdApi = apiProvider.getAPI(createdApiId);
-
-
-            String swaggerStr = SOAPOperationBindingUtils.getSoapOperationMapping(url);
-
+            String swaggerStr = "";
+            if (StringUtils.isNotBlank(url)) {
+                swaggerStr = SOAPOperationBindingUtils.getSoapOperationMappingForUrl(url);
+            } else if (fileInputStream != null) {
+                String filename = fileDetail.getContentDisposition().getFilename();
+                if (filename.endsWith(".zip")) {
+                    swaggerStr = SOAPOperationBindingUtils.getSoapOperationMapping(wsdlArchiveExtractedPath);;
+                } else if (filename.endsWith(".wsdl")) {
+                    byte[] wsdlContent = APIUtil.toByteArray(fileInputStream);
+                    swaggerStr = SOAPOperationBindingUtils.getSoapOperationMapping(wsdlContent);
+                } else {
+                    throw new APIManagementException(ExceptionCodes.UNSUPPORTED_WSDL_FILE_EXTENSION);
+                }
+            }
             String updatedSwagger = updateSwagger(createdApi.getUUID(), swaggerStr);
             SequenceGenerator.generateSequencesFromSwagger(updatedSwagger, apiToAdd.getId());
-
             return createdApi;
-        } catch (APIManagementException | FaultGatewaysException e) {
-            RestApiUtil.handleInternalServerError("Error while importing WSDL to create a SOAP-to-REST API",
-                    e, log);
+        } catch (FaultGatewaysException | IOException e) {
+            throw new APIManagementException("Error while importing WSDL to create a SOAP-to-REST API", e);
         }
-        return null;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
@@ -326,7 +326,7 @@ public class ApisApiServiceImpl extends ApisApiService {
                         "Specified policy " + body.getApiLevelPolicy() + " is invalid", log);
             }
             if (isSoapToRestConvertedApi && StringUtils.isNotBlank(body.getWsdlUri())) {
-                String swaggerStr = SOAPOperationBindingUtils.getSoapOperationMapping(body.getWsdlUri());
+                String swaggerStr = SOAPOperationBindingUtils.getSoapOperationMappingForUrl(body.getWsdlUri());
                 body.setApiDefinition(swaggerStr);
             }
             API apiToAdd = APIMappingUtil.fromDTOtoAPI(body, provider);
@@ -346,7 +346,7 @@ public class ApisApiServiceImpl extends ApisApiService {
             apiProvider.addAPI(apiToAdd);
             if (isSoapToRestConvertedApi) {
                 if (StringUtils.isNotBlank(apiToAdd.getWsdlUrl())) {
-                    String swaggerStr = SOAPOperationBindingUtils.getSoapOperationMapping(body.getWsdlUri());
+                    String swaggerStr = SOAPOperationBindingUtils.getSoapOperationMappingForUrl(body.getWsdlUri());
                     apiProvider.saveSwagger20Definition(apiToAdd.getId(), swaggerStr);
                     SequenceGenerator.generateSequencesFromSwagger(swaggerStr, apiToAdd.getId());
                 } else {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/WSDL/Steps/ProvideWSDL.jsx
@@ -63,7 +63,6 @@ const useStyles = makeStyles((theme) => ({
 export default function ProvideWSDL(props) {
     const { apiInputs, inputsDispatcher, onValidate } = props;
     const isFileInput = apiInputs.inputType === 'file';
-    const isArchiveInput = apiInputs.inputType === 'archive';
     const isGenerateRESTAPI = apiInputs.type === 'SOAPTOREST';
     const classes = useStyles();
     const [isError, setValidity] = useState(); // If valid value is `null` else an error object will be there
@@ -227,7 +226,7 @@ export default function ProvideWSDL(props) {
                 error={isError && isError.file}
                 onDrop={onDrop}
                 files={apiInputs.inputValue}
-                accept={isArchiveInput ? '.bz,.bz2,.gz,.rar,.tar,.zip,.7z,.wsdl' : '.wsdl'}
+                accept='.bz,.bz2,.gz,.rar,.tar,.zip,.7z,.wsdl'
             >
                 {isValidating ? (<CircularProgress />)
                     : (
@@ -268,18 +267,6 @@ export default function ProvideWSDL(props) {
             </InputAdornment>
         );
     }
-
-    const fileControlLabel = isGenerateRESTAPI ? (
-        <FormattedMessage
-            id='Apis.Create.WSDL.Steps.ProvideWSDL.file.label.wsdl.file'
-            defaultMessage='WSDL File'
-        />
-    ) : (
-        <FormattedMessage
-            id='Apis.Create.WSDL.Steps.ProvideWSDL.file.label.wsdl.file.archive'
-            defaultMessage='WSDL File/Archive'
-        />
-    );
 
     return (
         <>
@@ -365,10 +352,14 @@ option is only available for WSDL URL input type
                                 )}
                             />
                             <FormControlLabel
-                                value={isGenerateRESTAPI ? 'file' : 'archive'}
-                                disabled={isGenerateRESTAPI}
+                                value='file'
                                 control={<Radio color='primary' />}
-                                label={fileControlLabel}
+                                label={(
+                                    <FormattedMessage
+                                        id='Apis.Create.WSDL.Steps.ProvideWSDL.file.label.wsdl.file.archive'
+                                        defaultMessage='WSDL File/Archive'
+                                    />
+                                )}
                             />
                         </RadioGroup>
                     </FormControl>
@@ -387,7 +378,7 @@ option is only available for WSDL URL input type
                         </Grid>
                     )}
                 <Grid item md={11}>
-                    {(isFileInput || isArchiveInput) ? renderFileUpload()
+                    {isFileInput ? renderFileUpload()
                         : (
                             <TextField
                                 autoFocus


### PR DESCRIPTION
Currently, only creating a SOAP to REST API by WSDL URL is supported. 
This PR adds support to import a WSDL file or zip and create a SOAP to REST API.

Fixes: https://github.com/wso2/product-apim/issues/7182

