### PR TITLE
Add elementFormDefault support to SOAP to REST APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractor.java
@@ -330,6 +330,18 @@ public class WSDL11SOAPOperationExtractor extends WSDL11ProcessorImpl {
                         } else {
                             model.setType(ObjectProperty.TYPE);
                         }
+                        String elementFormDefault = null;
+                        if (current.getParentNode().getAttributes() != null && current.getParentNode().getAttributes()
+                                .getNamedItem(SOAPToRESTConstants.ELEMENT_FORM_DEFAULT) != null) {
+                            elementFormDefault = current.getParentNode().getAttributes()
+                                    .getNamedItem(SOAPToRESTConstants.ELEMENT_FORM_DEFAULT).getNodeValue();
+                        }
+                        if (StringUtils.isNotEmpty(elementFormDefault) &&
+                                SOAPToRESTConstants.QUALIFIED.equals(elementFormDefault)) {
+                            model.setVendorExtension(SOAPToRESTConstants.X_NAMESPACE_QUALIFIED, true);
+                        } else {
+                            model.setVendorExtension(SOAPToRESTConstants.X_NAMESPACE_QUALIFIED, false);
+                        }
                     }
                 } else if (model.getProperties() == null) {
                     if (SOAPToRESTConstants.RESTRICTION_ATTR.equals(type)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SOAPToRESTConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SOAPToRESTConstants.java
@@ -44,6 +44,9 @@ public class SOAPToRESTConstants {
     public static final String SOAP11_NAMESPACE = "http://schemas.xmlsoap.org/soap/envelope/";
     public static final String SOAP12_NAMSPACE = "http://www.w3.org/2003/05/soap-envelope";
     public static final String TEXT_XML = "text/xml";
+    public static final String ELEMENT_FORM_DEFAULT= "elementFormDefault";
+    public static final String QUALIFIED = "qualified";
+    public static final String X_NAMESPACE_QUALIFIED = "x-namespace-qualified";
 
     public final class Swagger {
         public static final String DEFINITIONS = "definitions";


### PR DESCRIPTION
This PR fixes wso2/product-apim#6973. Currently, elementFormDefault attribute is not considered when adding namespace prefix for complex types. This PR adds it. When generating swagger definition from the provided wsdl, an attribute named as **x-namespace-qualified** is added to complex type definitions in swagger and it is used to check whether the namespace prefix needs to be added or not.