### PR TITLE
Fix issue when iteratively referring complex types definitions

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SequenceUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SequenceUtils.java
@@ -604,7 +604,11 @@ public class SequenceUtils {
 
         for (int i = 0; i < json.length(); i++) {
             Object data = json.get(i);
-            listObject(parent + ",array", data, parameterJsonPathMapping);
+            if (data instanceof org.json.JSONObject) {
+                listObject(parent, data, parameterJsonPathMapping);
+            } else {
+                listObject(parent + ",array", data, parameterJsonPathMapping);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes wso2/product-apim#7297. There is an issue in sequence generation when complex type definition refers another complex type definition in nested manner. In this case, Swagger generation is successful, but the generated sequence is not complete.