### PR TITLE
[3.1.0] SOAP to REST fixes

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/SequenceGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/SequenceGenerator.java
@@ -344,6 +344,8 @@ public class SequenceGenerator {
                             isRootComplexType = false;
                         } else {
                             element = doc.createElementNS(null, parameterTreeNode);
+                            element.setAttribute(SOAPToRESTConstants.XMLNS,
+                                    SOAPToRESTConstants.X_WSO2_UNIQUE_NAMESPACE);
                         }
                         String xPathOfNode = StringUtils.EMPTY;
                         if (doc.getElementsByTagName(element.getTagName()).getLength() > 0) {
@@ -401,7 +403,7 @@ public class SequenceGenerator {
                     + stringWriter.toString());
         }
         Map<String, String> paramMap = new HashMap<>();
-        paramMap.put(operationId, stringWriter.toString());
+        paramMap.put(operationId, processPayloadFactXML(stringWriter.toString()));
         return paramMap;
     }
 
@@ -523,5 +525,13 @@ public class SequenceGenerator {
             handleException("Error occurred when transforming in sequence xml", e);
         }
         return property + SOAPToRESTConstants.SequenceGen.COMMA + argument;
+    }
+
+    private static String processPayloadFactXML(String xmlPayload) {
+        // When setting namespace as xmlns="", Xerces process it as empty namespace and removes it
+        // Hence following the string replace approach to add xmlns="".
+        // Refer https://issues.apache.org/jira/browse/XERCESJ-1720
+        String processedXMLPayload = xmlPayload.replaceAll(SOAPToRESTConstants.X_WSO2_UNIQUE_NAMESPACE, "");
+        return processedXMLPayload;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11SOAPOperationExtractor.java
@@ -753,6 +753,13 @@ public class WSDL11SOAPOperationExtractor extends WSDL11ProcessorImpl {
                                         .containsKey(part.getTypeName().getLocalPart())) {
                                     inputParameterModelList
                                             .add(parameterModelMap.get(part.getTypeName().getLocalPart()));
+                                } else if (part.getTypeName() != null && parameterModelMap
+                                        .containsKey(message.getQName().getLocalPart())) {
+                                    ModelImpl model = parameterModelMap.get(message.getQName().getLocalPart());
+                                    model.addProperty(part.getName(),
+                                            getPropertyFromDataType(part.getTypeName().getLocalPart()));
+                                    parameterModelMap.put(model.getName(), model);
+                                    inputParameterModelList.add(model);
                                 } else {
                                     ModelImpl model = new ModelImpl();
                                     model.setType(ObjectProperty.TYPE);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SOAPToRESTConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SOAPToRESTConstants.java
@@ -48,6 +48,8 @@ public class SOAPToRESTConstants {
     public static final String ELEMENT_FORM_DEFAULT= "elementFormDefault";
     public static final String QUALIFIED = "qualified";
     public static final String X_NAMESPACE_QUALIFIED = "x-namespace-qualified";
+    public static final String XMLNS = "xmlns";
+    public static final String X_WSO2_UNIQUE_NAMESPACE = "x-wso2-empty-namespace";
 
     public final class Swagger {
         public static final String DEFINITIONS = "definitions";


### PR DESCRIPTION
1. Fixes https://github.com/wso2/product-apim/issues/7132. Porting the fix done to 2.2.0

2. Fixes wso2/product-apim#7145. When there is no namespace set, payload mediator adds it's default namespace (http://ws.apache.org/ns/synapse) to request. It is fixed by adding an empty namespace as xmlns="" mentioned in [1].
[1] https://docs.wso2.com/display/EI650/PayloadFactory+Mediator#PayloadFactoryMediator-Example4:Suppressingthenamespace