### PR TITLE
Add mutual SSL to the API definition.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1211,7 +1211,10 @@ public final class APIConstants {
     public static final String SWAGGER_X_THROTTLING_TIER = "x-throttling-tier";
     public static final String SWAGGER_X_MEDIATION_SCRIPT = "x-mediation-script";
     public static final String SWAGGER_X_WSO2_SECURITY = "x-wso2-security";
-    public static final String SWAGGER_X_WSO2_API_SECURITY = "x-wso2-api-security";
+    public static final String SWAGGER_X_WSO2_APP_SECURITY = "x-wso2-application-security";
+    public static final String WSO2_APP_SECURITY_TYPES = "security-types";
+    public static final String OPTIONAL = "optional";
+    public static final String MANDATORY = "mandatory";
     public static final String SWAGGER_X_WSO2_SCOPES = "x-wso2-scopes";
     public static final String SWAGGER_X_EXAMPLES = "x-examples";
     public static final String SWAGGER_SCOPE_KEY = "key";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -523,12 +523,11 @@ public class OAS2Parser extends APIDefinition {
         if (sandEndpointObj != null) {
             swagger.setVendorExtension(APIConstants.X_WSO2_SANDBOX_ENDPOINTS, sandEndpointObj);
         }
-        swagger.setVendorExtension(APIConstants.X_WSO2_BASEPATH, api.getContext());
-        if (api.getTransports() != null) {
-            swagger.setVendorExtension(APIConstants.X_WSO2_TRANSPORTS, api.getTransports().split(","));
-        }
-        swagger.setVendorExtension(APIConstants.SWAGGER_X_WSO2_API_SECURITY,
-                OASParserUtil.getAPISecurity(api.getApiSecurity()));
+        swagger.setVendorExtension(APIConstants.X_WSO2_TRANSPORTS,
+                OASParserUtil.getTransportSecurity(api.getApiSecurity(), api.getTransports()));
+        swagger.setVendorExtension(APIConstants.SWAGGER_X_WSO2_APP_SECURITY,
+                OASParserUtil.getAppSecurity(api.getApiSecurity()));
+
         return getSwaggerJsonString(swagger);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -513,11 +513,10 @@ public class OAS3Parser extends APIDefinition {
             openAPI.addExtension(APIConstants.X_WSO2_SANDBOX_ENDPOINTS, sandEndpointObj);
         }
         openAPI.addExtension(APIConstants.X_WSO2_BASEPATH, api.getContext());
-        if (api.getTransports() != null) {
-            openAPI.addExtension(APIConstants.X_WSO2_TRANSPORTS, api.getTransports().split(","));
-        }
-        openAPI.addExtension(APIConstants.SWAGGER_X_WSO2_API_SECURITY,
-                OASParserUtil.getAPISecurity(api.getApiSecurity()));
+        openAPI.addExtension(APIConstants.X_WSO2_TRANSPORTS,
+                OASParserUtil.getTransportSecurity(api.getApiSecurity(), api.getTransports()));
+        openAPI.addExtension(APIConstants.SWAGGER_X_WSO2_APP_SECURITY,
+                OASParserUtil.getAppSecurity(api.getApiSecurity()));
         return Json.pretty(openAPI);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -55,6 +55,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.parser.ObjectMapperFactory;
 import io.swagger.v3.parser.converter.SwaggerConverter;
+import org.apache.axis2.Constants;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -90,6 +91,7 @@ import org.wso2.carbon.registry.core.session.UserRegistry;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -1105,20 +1107,63 @@ public class OASParserUtil {
     }
 
     /**
-     * Get Application level security
-     * @param security string
+     * Get Application level security types
+     * @param security list of security types
      * @return List of api security
      */
-    public static List<String> getAPISecurity(String security) {
+    private static List<String> getAPISecurity(List<String> security) {
         List<String> apiSecurityList = new ArrayList<>();
-        if (security != null) {
-            String[] securityList = security.split(",");
-            for (String securityType : securityList) {
-                if (APIConstants.APPLICATION_LEVEL_SECURITY.contains(securityType)) {
-                    apiSecurityList.add(securityType);
-                }
+        for (String securityType : security) {
+            if (APIConstants.APPLICATION_LEVEL_SECURITY.contains(securityType)) {
+                apiSecurityList.add(securityType);
             }
         }
         return apiSecurityList;
+    }
+
+    /**
+     * generate app security information for OAS definition
+     *
+     * @param security          application security
+     * @return JsonNode
+     */
+     static JsonNode getAppSecurity(String security) {
+         List<String> appSecurityList = new ArrayList<>();
+         ObjectNode endpointResult = objectMapper.createObjectNode();
+         boolean appSecurityOptional = false;
+         if (security != null) {
+             List<String> securityList = Arrays.asList(security.split(","));
+             appSecurityList = getAPISecurity(securityList);
+             appSecurityOptional = !securityList.contains(APIConstants.API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY);
+         }
+        ArrayNode appSecurityTypes = objectMapper.valueToTree(appSecurityList);
+        endpointResult.set(APIConstants.WSO2_APP_SECURITY_TYPES, appSecurityTypes);
+        endpointResult.put(APIConstants.OPTIONAL, appSecurityOptional);
+        return endpointResult;
+    }
+
+    /**
+     * generate app security information for OAS definition
+     *
+     * @param security          application security
+     * @param transport          transport security
+     * @return JsonNode
+     */
+     static JsonNode getTransportSecurity(String security, String transport) {
+         ObjectNode endpointResult = objectMapper.createObjectNode();
+         if (transport != null) {
+             List<String> transportTypes = Arrays.asList(transport.split(","));
+             endpointResult.put(Constants.TRANSPORT_HTTP, transportTypes.contains(Constants.TRANSPORT_HTTP));
+             endpointResult.put(Constants.TRANSPORT_HTTPS, transportTypes.contains(Constants.TRANSPORT_HTTPS));
+         }
+         if (security != null) {
+             List<String> securityList = Arrays.asList(security.split(","));
+             if (securityList.contains(APIConstants.API_SECURITY_MUTUAL_SSL)) {
+                 String mutualSSLOptional = !securityList.contains(APIConstants.API_SECURITY_MUTUAL_SSL_MANDATORY) ?
+                         APIConstants.OPTIONAL : APIConstants.MANDATORY;
+                 endpointResult.put(APIConstants.API_SECURITY_MUTUAL_SSL, mutualSSLOptional);
+             }
+         }
+        return endpointResult;
     }
 }


### PR DESCRIPTION
Add mutual SSL to the API definition.
Renamed the x-wso2-api-security to x-wso2-application-security.

Fix https://github.com/wso2/product-apim/issues/7388
Related to https://github.com/wso2/product-apim/issues/7205

e.g.
x-wso2-transports: 
    http: true
    https: false
    mutualssl: "mandatory"
  x-wso2-application-security: 
    security-types: 
      - "oauth2"
      - "api_key"
    optional: false