### PR TITLE
Disabling logout consent page

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -483,6 +483,9 @@ public final class APIConstants {
     public static final String APP_SKIP_CONSENT_DISPLAY = "Skip Consent";
     public static final String APP_SKIP_CONSENT_NAME = "skipConsent";
     public static final String APP_SKIP_CONSENT_VALUE = "true";
+    public static final String APP_SKIP_LOGOUT_CONSENT_DISPLAY = "Skip Logout Consent";
+    public static final String APP_SKIP_LOGOUT_CONSENT_NAME = "skipLogoutConsent";
+    public static final String APP_SKIP_LOGOUT_CONSENT_VALUE = "true";
     public static final String RECEIVER_URL = "receiverURL";
     public static final String AUTHENTICATOR_URL = "authenticatorURL";
     public static final String USERNAME = "username";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/java/org/wso2/carbon/apimgt/rest/api/dcr/web/impl/RegistrationServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/java/org/wso2/carbon/apimgt/rest/api/dcr/web/impl/RegistrationServiceImpl.java
@@ -334,7 +334,7 @@ public class RegistrationServiceImpl implements RegistrationService {
             serviceProvider.setApplicationName(applicationName);
             serviceProvider.setDescription("Service Provider for application " + appName);
             serviceProvider.setSaasApp(applicationInfo.getIsSaasApplication());
-            ServiceProviderProperty[] serviceProviderProperties = new ServiceProviderProperty[3];
+            ServiceProviderProperty[] serviceProviderProperties = new ServiceProviderProperty[4];
             ServiceProviderProperty serviceProviderProperty = new ServiceProviderProperty();
             serviceProviderProperty.setName(APP_DISPLAY_NAME);
             serviceProviderProperty.setValue(applicationName);
@@ -348,6 +348,11 @@ public class RegistrationServiceImpl implements RegistrationService {
             consentProperty.setName(APIConstants.APP_SKIP_CONSENT_NAME);
             consentProperty.setValue(APIConstants.APP_SKIP_CONSENT_VALUE);
             serviceProviderProperties[2] = consentProperty;
+            ServiceProviderProperty logoutConsentProperty = new ServiceProviderProperty();
+            logoutConsentProperty.setDisplayName(APIConstants.APP_SKIP_LOGOUT_CONSENT_DISPLAY);
+            logoutConsentProperty.setName(APIConstants.APP_SKIP_LOGOUT_CONSENT_NAME);
+            logoutConsentProperty.setValue(APIConstants.APP_SKIP_LOGOUT_CONSENT_VALUE);
+            serviceProviderProperties[3] = logoutConsentProperty;
             serviceProvider.setSpProperties(serviceProviderProperties);
             ApplicationManagementService appMgtService = ApplicationManagementService.getInstance();
             appMgtService.createApplication(serviceProvider, tenantDomain, userName);


### PR DESCRIPTION
## Issues

product-apim: https://github.com/wso2/product-apim/issues/6735

## Methodology

Adding SP property to disable logout consent page when creating the SP using DCR request by default. Users can re-enable by editing the SP App from carbon console if needed.