### PR TITLE
Support custom analytics data publishing

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -143,6 +143,9 @@ public class APIMgtGatewayConstants {
     public static final String CORS_REQUEST_HANDLER_ERROR = "Error in CORS_Request Handler";
     public static final String API_KEY_VALIDATOR_ERROR = "Error while accessing backend services for API key validation";
     public static final String GOOGLE_ANALYTICS_ERROR = "Error in Google Analytics Handler";
+    public static final String CUSTOM_ANALYTICS_REQUEST_PROPERTIES = "apim.analytics.request.properties";
+    public static final String CUSTOM_ANALYTICS_RESPONSE_PROPERTIES = "apim.analytics.response.properties";
+    public static final String CUSTOM_ANALYTICS_PROPERTY_SEPARATOR = ",";
 
     /**
      * Constants for swagger schema validator

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
@@ -62,6 +62,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -443,4 +445,36 @@ public class Utils {
         return false;
     }
 
+    /**
+     * Populate custom properties define in a mediation sequence
+     *
+     * @param messageContext MessageContext
+     * @return Map<String, String> with custom properties
+     */
+    public static Map<String, String> getCustomAnalyticsProperties(MessageContext messageContext) {
+        Map<String, String> requestProperties = getCustomAnalyticsProperties(messageContext,
+                APIMgtGatewayConstants.CUSTOM_ANALYTICS_REQUEST_PROPERTIES);
+        Map<String, String> responseProperties = getCustomAnalyticsProperties(messageContext,
+                APIMgtGatewayConstants.CUSTOM_ANALYTICS_RESPONSE_PROPERTIES);
+        Map<String, String> properties = new HashMap<>(requestProperties);
+        properties.putAll(responseProperties);
+        return properties;
+    }
+
+    private static Map<String, String> getCustomAnalyticsProperties(MessageContext messageContext,
+            String propertyPathKey) {
+        Set<String> keys = messageContext.getPropertyKeySet();
+        String properties = (String) messageContext.getProperty(propertyPathKey);
+        if (StringUtils.isBlank(properties)) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> propertyMap = new HashMap<>();
+        String[] propertyKeys = properties.split(APIMgtGatewayConstants.CUSTOM_ANALYTICS_PROPERTY_SEPARATOR);
+        for (String propertyKey : propertyKeys) {
+            if (keys.contains(propertyKey.trim())) {
+                propertyMap.put(propertyKey, (String) messageContext.getProperty(propertyKey.trim()));
+            }
+        }
+        return propertyMap;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtFaultHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtFaultHandler.java
@@ -21,6 +21,7 @@ import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.rest.RESTConstants;
 import org.json.simple.JSONObject;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.Utils;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityUtils;
 import org.wso2.carbon.apimgt.gateway.handlers.security.AuthenticationContext;
 import org.wso2.carbon.apimgt.gateway.mediators.APIMgtCommonExecutionPublisher;
@@ -32,6 +33,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Map;
 
 public class APIMgtFaultHandler extends APIMgtCommonExecutionPublisher {
 
@@ -114,6 +116,8 @@ public class APIMgtFaultHandler extends APIMgtCommonExecutionPublisher {
             faultPublisherDTO.setProtocol(protocol);
             faultPublisherDTO.setMetaClientType(metaClientType);
             faultPublisherDTO.setGatewaType(APIMgtGatewayConstants.SYNAPDE_GW_LABEL);
+            Map<String, String> properties = Utils.getCustomAnalyticsProperties(messageContext);
+            faultPublisherDTO.setProperties(properties);
             if (log.isDebugEnabled()) {
                 log.debug("Publishing fault event from gateway to analytics for: " + messageContext.getProperty(
                         APIMgtGatewayConstants.CONTEXT) + " with ID: " + messageContext.getMessageID() + " started"

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtResponseHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtResponseHandler.java
@@ -26,6 +26,7 @@ import org.apache.synapse.rest.RESTConstants;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
 import org.json.simple.JSONObject;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.Utils;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityUtils;
 import org.wso2.carbon.apimgt.gateway.handlers.security.AuthenticationContext;
 import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
@@ -242,7 +243,8 @@ public class APIMgtResponseHandler extends APIMgtCommonExecutionPublisher {
             stream.setCorrelationID(correlationID);
             stream.setGatewayType(APIMgtGatewayConstants.GATEWAY_TYPE);
             stream.setLabel(APIMgtGatewayConstants.SYNAPDE_GW_LABEL);
-            
+            Map<String, String> properties = Utils.getCustomAnalyticsProperties(mc);
+            stream.setProperties(properties);
             if (log.isDebugEnabled()) {
                 log.debug("Publishing success API invocation event from gateway to analytics for: "
                         + mc.getProperty(APIMgtGatewayConstants.CONTEXT) + " with ID: " +

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtThrottleUsageHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/APIMgtThrottleUsageHandler.java
@@ -18,6 +18,7 @@ package org.wso2.carbon.apimgt.gateway.handlers.analytics;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.rest.RESTConstants;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.Utils;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityUtils;
 import org.wso2.carbon.apimgt.gateway.handlers.security.AuthenticationContext;
 import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
@@ -28,6 +29,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Map;
 
 /*
 * This is the class mediator which will handle publishing events upon throttle out events
@@ -101,6 +103,8 @@ public class APIMgtThrottleUsageHandler extends APIMgtCommonExecutionPublisher {
                 throttlePublisherDTO.setCorrelationID(correlationID);
                 throttlePublisherDTO.setGatewayType(APIMgtGatewayConstants.GATEWAY_TYPE);
                 throttlePublisherDTO.setHostName(GatewayUtils.getHostName(messageContext));
+                Map<String, String> properties = Utils.getCustomAnalyticsProperties(messageContext);
+                throttlePublisherDTO.setProperties(properties);
                 
                 if (log.isDebugEnabled()) {
                     log.debug("Publishing throttling event from gateway to analytics for: "

--- a/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/DataPublisherUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/DataPublisherUtil.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.apimgt.usage.publisher;
 
+import com.google.gson.Gson;
 import org.apache.axis2.context.MessageContext;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -45,6 +46,8 @@ public class DataPublisherUtil {
     private static final String UNKNOWN_HOST = "UNKNOWN_HOST";
     private static boolean isEnabledMetering=false;
     private static final String HEADER_X_FORWARDED_FOR = "X-FORWARDED-FOR";
+    private static final Gson gson = new Gson();
+
     public static String getHostAddress() {
 
         if (hostAddress != null) {
@@ -131,5 +134,9 @@ public class DataPublisherUtil {
         } else {
             return null;
         }
+    }
+
+    public static String toJsonString(Map<String, String> properties) {
+        return gson.toJson(properties);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/dto/DataBridgeFaultPublisherDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/dto/DataBridgeFaultPublisherDTO.java
@@ -46,13 +46,15 @@ public class DataBridgeFaultPublisherDTO extends FaultPublisherDTO{
         setMetaClientType(faultPublisherDTO.getMetaClientType());
         setGatewaType(faultPublisherDTO.getGatewaType());
         setUserTenantDomain(faultPublisherDTO.getUserTenantDomain());
+        setProperties(faultPublisherDTO.getProperties());
     }
 
     public Object createPayload() {
         return new Object[] { getApplicationConsumerKey(), getApiName(), getApiVersion(),
                 getApiContext(), getApiResourcePath(), getApiMethod(), getApiCreator(), 
                 getUsername(), getApiCreatorTenantDomain(), getUserTenantDomain(), getHostname(), getApplicationId(), getApplicationName(),
-                getProtocol(), getErrorCode(), getErrorMessage(), getRequestTimestamp()};
+                getProtocol(), getErrorCode(), getErrorMessage(), getRequestTimestamp(),
+                DataPublisherUtil.toJsonString(getProperties()) };
     }
 
     public Object createMetaData() {

--- a/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/dto/DataBridgeRequestResponseStreamPublisherDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/dto/DataBridgeRequestResponseStreamPublisherDTO.java
@@ -58,6 +58,7 @@ public class DataBridgeRequestResponseStreamPublisherDTO extends RequestResponse
         setGatewayType(requestResponseStreamDTO.getGatewayType());
         setLabel(requestResponseStreamDTO.getLabel());
         setResponseTime(requestResponseStreamDTO.getResponseTime());
+        setProperties(requestResponseStreamDTO.getProperties());
     }
 
     public Object createPayload() {
@@ -70,7 +71,8 @@ public class DataBridgeRequestResponseStreamPublisherDTO extends RequestResponse
                 getResponseCode(), getDestination(), getExecutionTime().getSecurityLatency(),
                 getExecutionTime().getThrottlingLatency(), getExecutionTime().getRequestMediationLatency(),
                 getExecutionTime().getResponseMediationLatency(), getExecutionTime().getBackEndLatency(),
-                getExecutionTime().getOtherLatency(), getGatewayType(), getLabel() };
+                getExecutionTime().getOtherLatency(), getGatewayType(), getLabel(),
+                DataPublisherUtil.toJsonString(getProperties()) };
 
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/dto/DataBridgeThrottlePublisherDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/dto/DataBridgeThrottlePublisherDTO.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.apimgt.usage.publisher.dto;
 
 import org.json.simple.JSONObject;
+import org.wso2.carbon.apimgt.usage.publisher.DataPublisherUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,13 +45,14 @@ public class DataBridgeThrottlePublisherDTO extends ThrottlePublisherDTO {
         setGatewayType(throttlePublisherDTO.getGatewayType());
         setSubscriber(throttlePublisherDTO.getSubscriber());
         setHostName(throttlePublisherDTO.getHostName());
+        setProperties(throttlePublisherDTO.getProperties());
     }
 
     public Object createPayload() {
         return new Object[] { getUsername(), getTenantDomain(), getApiname(),
                 getVersion(), getContext(), getApiCreator(), getApiCreatorTenantDomain(), getApplicationId(),
                 getApplicationName(), getSubscriber(), getThrottledOutReason(), getGatewayType(), getThrottledTime(),
-                getHostName() };
+                getHostName(), DataPublisherUtil.toJsonString(getProperties()) };
     }
 
     public Object createMetaData() {

--- a/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/dto/FaultPublisherDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/dto/FaultPublisherDTO.java
@@ -1,22 +1,25 @@
 /*
-*  Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ *  Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.apimgt.usage.publisher.dto;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class FaultPublisherDTO {
     private String metaClientType;
@@ -32,127 +35,172 @@ public class FaultPublisherDTO {
     private String userTenantDomain;
     private String protocol;
     private String applicationName;
-    private String applicationId; 
+    private String applicationId;
     private String hostname;
     private String errorCode;
     private String errorMessage;
     private String gatewaType;
     private long requestTimestamp;
-    
-    
+    private Map<String, String> properties;
+
     public String getUserTenantDomain() {
         return userTenantDomain;
     }
+
     public void setUserTenantDomain(String userTenantDomain) {
         this.userTenantDomain = userTenantDomain;
     }
+
     public String getMetaClientType() {
         return metaClientType;
     }
+
     public void setMetaClientType(String metaClientType) {
         this.metaClientType = metaClientType;
     }
+
     public String getApplicationConsumerKey() {
         return applicationConsumerKey;
     }
+
     public void setApplicationConsumerKey(String applicationConsumerKey) {
         this.applicationConsumerKey = applicationConsumerKey;
     }
+
     public String getApiName() {
         return apiName;
     }
+
     public void setApiName(String apiName) {
         this.apiName = apiName;
     }
+
     public String getApiVersion() {
         return apiVersion;
     }
+
     public void setApiVersion(String apiVersion) {
         this.apiVersion = apiVersion;
     }
+
     public String getApiContext() {
         return apiContext;
     }
+
     public void setApiContext(String apiContext) {
         this.apiContext = apiContext;
     }
+
     public String getApiResourcePath() {
         return apiResourcePath;
     }
+
     public void setApiResourcePath(String apiResourcePath) {
         this.apiResourcePath = apiResourcePath;
     }
+
     public String getApiMethod() {
         return apiMethod;
     }
+
     public void setApiMethod(String apiMethod) {
         this.apiMethod = apiMethod;
     }
+
     public String getApiCreator() {
         return apiCreator;
     }
+
     public void setApiCreator(String apiProvider) {
         this.apiCreator = apiProvider;
     }
+
     public String getApiCreatorTenantDomain() {
         return apiCreatorTenantDomain;
     }
+
     public void setApiCreatorTenantDomain(String apiCreatorTenantDomain) {
         this.apiCreatorTenantDomain = apiCreatorTenantDomain;
     }
+
     public String getUsername() {
         return username;
     }
+
     public void setUsername(String username) {
         this.username = username;
     }
+
     public String getProtocol() {
         return protocol;
     }
+
     public void setProtocol(String protocol) {
         this.protocol = protocol;
     }
+
     public String getApplicationName() {
         return applicationName;
     }
+
     public void setApplicationName(String applicationName) {
         this.applicationName = applicationName;
     }
+
     public String getApplicationId() {
         return applicationId;
     }
+
     public void setApplicationId(String applicationId) {
         this.applicationId = applicationId;
     }
+
     public String getHostname() {
         return hostname;
     }
+
     public void setHostname(String hostname) {
         this.hostname = hostname;
     }
+
     public String getErrorCode() {
         return errorCode;
     }
+
     public void setErrorCode(String errorCode) {
         this.errorCode = errorCode;
     }
+
     public String getErrorMessage() {
         return errorMessage;
     }
+
     public void setErrorMessage(String errorMessage) {
         this.errorMessage = errorMessage;
     }
+
     public long getRequestTimestamp() {
         return requestTimestamp;
     }
+
     public void setRequestTimestamp(long requestTimestamp) {
         this.requestTimestamp = requestTimestamp;
     }
+
     public String getGatewaType() {
         return gatewaType;
     }
+
     public void setGatewaType(String gatewaType) {
         this.gatewaType = gatewaType;
     }
-    
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/dto/RequestResponseStreamDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/dto/RequestResponseStreamDTO.java
@@ -18,240 +18,316 @@
 
 package org.wso2.carbon.apimgt.usage.publisher.dto;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class RequestResponseStreamDTO {
 
-        private String applicationConsumerKey;
-        private String applicationName;
-        private String applicationId;
-        private String applicationOwner;
-        private String apiContext;
-        private String apiName;
-        private String apiVersion;
-        private String apiResourcePath;
-        private String apiResourceTemplate;
-        private String apiMethod;
-        private String apiCreator;
-        private String apiCreatorTenantDomain;
-        private String apiTier;
-        private String apiHostname;
-        private String username;
-        private String userTenantDomain;
-        private String userIp;
-        private String userAgent;
-        private long serviceTime;
-        private long requestTimestamp;
-        private boolean throttledOut;
-        private long backendTime; 
-        private boolean responseCacheHit;
-        private long responseSize;
-        private String protocol;
-        private int responseCode;
-        private String destination;
-        private String metaClientType;
-        private long responseTime;
-        private String gatewayType;
-        private String correlationID;
-        private String label;
-        private ExecutionTimeDTO executionTime;
-      
-        
-        public String getGatewayType() {
-            return gatewayType;
-        }
-        public void setGatewayType(String gatewayType) {
-            this.gatewayType = gatewayType;
-        }
-        public String getCorrelationID() {
-            return correlationID;
-        }
-        public void setCorrelationID(String correlationID) {
-            this.correlationID = correlationID;
-        }
-        public String getLabel() {
-            return label;
-        }
-        public void setLabel(String label) {
-            this.label = label;
-        }
-        public long getResponseTime() {
-            return responseTime;
-        }
-        public void setResponseTime(long responseTime) {
-            this.responseTime = responseTime;
-        }
-        public String getApplicationConsumerKey() {
-            return applicationConsumerKey;
-        }
-        public void setApplicationConsumerKey(String applicationConsumerKey) {
-            this.applicationConsumerKey = applicationConsumerKey;
-        }
-        public String getApplicationName() {
-            return applicationName;
-        }
-        public void setApplicationName(String applicationName) {
-            this.applicationName = applicationName;
-        }
-        public String getApplicationId() {
-            return applicationId;
-        }
-        public void setApplicationId(String applicationId) {
-            this.applicationId = applicationId;
-        }
-        public String getApplicationOwner() {
-            return applicationOwner;
-        }
-        public void setApplicationOwner(String applicationOwner) {
-            this.applicationOwner = applicationOwner;
-        }
-        public String getApiContext() {
-            return apiContext;
-        }
-        public void setApiContext(String apiContext) {
-            this.apiContext = apiContext;
-        }
-        public String getApiName() {
-            return apiName;
-        }
-        public void setApiName(String apiName) {
-            this.apiName = apiName;
-        }
-        public String getApiVersion() {
-            return apiVersion;
-        }
-        public void setApiVersion(String apiVersion) {
-            this.apiVersion = apiVersion;
-        }
-        public String getApiResourcePath() {
-            return apiResourcePath;
-        }
-        public void setApiResourcePath(String apiResourcePath) {
-            this.apiResourcePath = apiResourcePath;
-        }
-        public String getApiResourceTemplate() {
-            return apiResourceTemplate;
-        }
-        public void setApiResourceTemplate(String apiResourceTemplate) {
-            this.apiResourceTemplate = apiResourceTemplate;
-        }
-        public String getApiMethod() {
-            return apiMethod;
-        }
-        public void setApiMethod(String apiMethod) {
-            this.apiMethod = apiMethod;
-        }
-        public String getApiCreator() {
-            return apiCreator;
-        }
-        public void setApiCreator(String apiCreator) {
-            this.apiCreator = apiCreator;
-        }
-        public String getApiCreatorTenantDomain() {
-            return apiCreatorTenantDomain;
-        }
-        public void setApiCreatorTenantDomain(String apiCreatorTenantDomain) {
-            this.apiCreatorTenantDomain = apiCreatorTenantDomain;
-        }
-        public String getApiTier() {
-            return apiTier;
-        }
-        public void setApiTier(String apiTier) {
-            this.apiTier = apiTier;
-        }
-        public String getApiHostname() {
-            return apiHostname;
-        }
-        public void setApiHostname(String apiHostname) {
-            this.apiHostname = apiHostname;
-        }
-        public String getUsername() {
-            return username;
-        }
-        public void setUsername(String username) {
-            this.username = username;
-        }
-        public String getUserTenantDomain() {
-            return userTenantDomain;
-        }
-        public void setUserTenantDomain(String userTenantDomain) {
-            this.userTenantDomain = userTenantDomain;
-        }
-        public String getUserIp() {
-            return userIp;
-        }
-        public void setUserIp(String userIp) {
-            this.userIp = userIp;
-        }
-        public String getUserAgent() {
-            return userAgent;
-        }
-        public void setUserAgent(String userAgent) {
-            this.userAgent = userAgent;
-        }
-        public long getServiceTime() {
-            return serviceTime;
-        }
-        public void setServiceTime(long serviceTime) {
-            this.serviceTime = serviceTime;
-        }
-        public long getRequestTimestamp() {
-            return requestTimestamp;
-        }
-        public void setRequestTimestamp(long requestTimestamp) {
-            this.requestTimestamp = requestTimestamp;
-        }
-        public boolean isThrottledOut() {
-            return throttledOut;
-        }
-        public void setThrottledOut(boolean throttledOut) {
-            this.throttledOut = throttledOut;
-        }
-        public long getBackendTime() {
-            return backendTime;
-        }
-        public void setBackendTime(long backendTime) {
-            this.backendTime = backendTime;
-        }
-        public boolean isResponseCacheHit() {
-            return responseCacheHit;
-        }
-        public void setResponseCacheHit(boolean responseCacheHit) {
-            this.responseCacheHit = responseCacheHit;
-        }
-        public long getResponseSize() {
-            return responseSize;
-        }
-        public void setResponseSize(long responseSize) {
-            this.responseSize = responseSize;
-        }
-        public String getProtocol() {
-            return protocol;
-        }
-        public void setProtocol(String protocol) {
-            this.protocol = protocol;
-        }
-        public int getResponseCode() {
-            return responseCode;
-        }
-        public void setResponseCode(int responseCode) {
-            this.responseCode = responseCode;
-        }
-        public String getDestination() {
-            return destination;
-        }
-        public void setDestination(String destination) {
-            this.destination = destination;
-        }
-        public String getMetaClientType() {
-            return metaClientType;
-        }
-        public void setMetaClientType(String metaClientType) {
-            this.metaClientType = metaClientType;
-        }
-        public ExecutionTimeDTO getExecutionTime() {
-            return executionTime;
-        }
-        public void setExecutionTime(ExecutionTimeDTO executionTime) {
-            this.executionTime = executionTime;
-        }
+    private String applicationConsumerKey;
+    private String applicationName;
+    private String applicationId;
+    private String applicationOwner;
+    private String apiContext;
+    private String apiName;
+    private String apiVersion;
+    private String apiResourcePath;
+    private String apiResourceTemplate;
+    private String apiMethod;
+    private String apiCreator;
+    private String apiCreatorTenantDomain;
+    private String apiTier;
+    private String apiHostname;
+    private String username;
+    private String userTenantDomain;
+    private String userIp;
+    private String userAgent;
+    private long serviceTime;
+    private long requestTimestamp;
+    private boolean throttledOut;
+    private long backendTime;
+    private boolean responseCacheHit;
+    private long responseSize;
+    private String protocol;
+    private int responseCode;
+    private String destination;
+    private String metaClientType;
+    private long responseTime;
+    private String gatewayType;
+    private String correlationID;
+    private String label;
+    private ExecutionTimeDTO executionTime;
+    private Map<String, String> properties;
+
+    public String getGatewayType() {
+        return gatewayType;
+    }
+
+    public void setGatewayType(String gatewayType) {
+        this.gatewayType = gatewayType;
+    }
+
+    public String getCorrelationID() {
+        return correlationID;
+    }
+
+    public void setCorrelationID(String correlationID) {
+        this.correlationID = correlationID;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public long getResponseTime() {
+        return responseTime;
+    }
+
+    public void setResponseTime(long responseTime) {
+        this.responseTime = responseTime;
+    }
+
+    public String getApplicationConsumerKey() {
+        return applicationConsumerKey;
+    }
+
+    public void setApplicationConsumerKey(String applicationConsumerKey) {
+        this.applicationConsumerKey = applicationConsumerKey;
+    }
+
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    public void setApplicationName(String applicationName) {
+        this.applicationName = applicationName;
+    }
+
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public String getApplicationOwner() {
+        return applicationOwner;
+    }
+
+    public void setApplicationOwner(String applicationOwner) {
+        this.applicationOwner = applicationOwner;
+    }
+
+    public String getApiContext() {
+        return apiContext;
+    }
+
+    public void setApiContext(String apiContext) {
+        this.apiContext = apiContext;
+    }
+
+    public String getApiName() {
+        return apiName;
+    }
+
+    public void setApiName(String apiName) {
+        this.apiName = apiName;
+    }
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    public String getApiResourcePath() {
+        return apiResourcePath;
+    }
+
+    public void setApiResourcePath(String apiResourcePath) {
+        this.apiResourcePath = apiResourcePath;
+    }
+
+    public String getApiResourceTemplate() {
+        return apiResourceTemplate;
+    }
+
+    public void setApiResourceTemplate(String apiResourceTemplate) {
+        this.apiResourceTemplate = apiResourceTemplate;
+    }
+
+    public String getApiMethod() {
+        return apiMethod;
+    }
+
+    public void setApiMethod(String apiMethod) {
+        this.apiMethod = apiMethod;
+    }
+
+    public String getApiCreator() {
+        return apiCreator;
+    }
+
+    public void setApiCreator(String apiCreator) {
+        this.apiCreator = apiCreator;
+    }
+
+    public String getApiCreatorTenantDomain() {
+        return apiCreatorTenantDomain;
+    }
+
+    public void setApiCreatorTenantDomain(String apiCreatorTenantDomain) {
+        this.apiCreatorTenantDomain = apiCreatorTenantDomain;
+    }
+
+    public String getApiTier() {
+        return apiTier;
+    }
+
+    public void setApiTier(String apiTier) {
+        this.apiTier = apiTier;
+    }
+
+    public String getApiHostname() {
+        return apiHostname;
+    }
+
+    public void setApiHostname(String apiHostname) {
+        this.apiHostname = apiHostname;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getUserTenantDomain() {
+        return userTenantDomain;
+    }
+
+    public void setUserTenantDomain(String userTenantDomain) {
+        this.userTenantDomain = userTenantDomain;
+    }
+
+    public String getUserIp() {
+        return userIp;
+    }
+
+    public void setUserIp(String userIp) {
+        this.userIp = userIp;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+    public long getServiceTime() {
+        return serviceTime;
+    }
+
+    public void setServiceTime(long serviceTime) {
+        this.serviceTime = serviceTime;
+    }
+
+    public long getRequestTimestamp() {
+        return requestTimestamp;
+    }
+
+    public void setRequestTimestamp(long requestTimestamp) {
+        this.requestTimestamp = requestTimestamp;
+    }
+
+    public boolean isThrottledOut() {
+        return throttledOut;
+    }
+
+    public void setThrottledOut(boolean throttledOut) {
+        this.throttledOut = throttledOut;
+    }
+
+    public long getBackendTime() {
+        return backendTime;
+    }
+
+    public void setBackendTime(long backendTime) {
+        this.backendTime = backendTime;
+    }
+
+    public boolean isResponseCacheHit() {
+        return responseCacheHit;
+    }
+
+    public void setResponseCacheHit(boolean responseCacheHit) {
+        this.responseCacheHit = responseCacheHit;
+    }
+
+    public long getResponseSize() {
+        return responseSize;
+    }
+
+    public void setResponseSize(long responseSize) {
+        this.responseSize = responseSize;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public int getResponseCode() {
+        return responseCode;
+    }
+
+    public void setResponseCode(int responseCode) {
+        this.responseCode = responseCode;
+    }
+
+    public String getDestination() {
+        return destination;
+    }
+
+    public void setDestination(String destination) {
+        this.destination = destination;
+    }
+
+    public String getMetaClientType() {
+        return metaClientType;
+    }
+
+    public void setMetaClientType(String metaClientType) {
+        this.metaClientType = metaClientType;
+    }
+
+    public ExecutionTimeDTO getExecutionTime() {
+        return executionTime;
+    }
+
+    public void setExecutionTime(ExecutionTimeDTO executionTime) {
+        this.executionTime = executionTime;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/dto/ThrottlePublisherDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/dto/ThrottlePublisherDTO.java
@@ -1,21 +1,24 @@
 /*
-*  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.apimgt.usage.publisher.dto;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ThrottlePublisherDTO {
     private String accessToken;
@@ -35,6 +38,7 @@ public class ThrottlePublisherDTO {
     private String keyType;
     private String correlationID;
     private String hostName;
+    private Map<String, String> properties;
 
     public String getAccessToken() {
         return accessToken;
@@ -43,7 +47,6 @@ public class ThrottlePublisherDTO {
     public void setAccessToken(String accessToken) {
         this.accessToken = accessToken;
     }
-
 
     public String getUsername() {
         return username;
@@ -172,5 +175,13 @@ public class ThrottlePublisherDTO {
     public void setHostName(String hostName) {
         this.hostName = hostName;
     }
-    
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -280,15 +280,15 @@
         <Streams>
             <Request>
                 <Name>org.wso2.apimgt.statistics.request</Name>
-                <Version>3.0.0</Version>
+                <Version>3.1.0</Version>
             </Request>
             <Fault>
                 <Name>org.wso2.apimgt.statistics.fault</Name>
-                <Version>3.0.0</Version>
+                <Version>3.1.0</Version>
             </Fault>
             <Throttle>
                 <Name>org.wso2.apimgt.statistics.throttle</Name>
-                <Version>3.0.0</Version>
+                <Version>3.1.0</Version>
             </Throttle>
             <Workflow>
                 <Name>org.wso2.apimgt.statistics.workflow</Name>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
@@ -203,15 +203,15 @@
         <Streams>
             <Request>
                 <Name>org.wso2.apimgt.statistics.request</Name>
-                <Version>3.0.0</Version>
+                <Version>3.1.0</Version>
             </Request>
             <Fault>
                 <Name>org.wso2.apimgt.statistics.fault</Name>
-                <Version>3.0.0</Version>
+                <Version>3.1.0</Version>
             </Fault>
             <Throttle>
                 <Name>org.wso2.apimgt.statistics.throttle</Name>
-                <Version>3.0.0</Version>
+                <Version>3.1.0</Version>
             </Throttle>
             <Workflow>
                 <Name>org.wso2.apimgt.statistics.workflow</Name>


### PR DESCRIPTION
- Support custom analytics data publishing

Custom attributes can include the analytics event by adding a request/response mediation sequence. Custom attributes can be introduced in request and response path. so it support include request/response related information such as headers and query params.

The sample mediation sequence is as follows. 

* request path
```
<?xml version="1.0" encoding="UTF-8"?><sequence xmlns="http://ws.apache.org/ns/synapse" name="request">
    <propertyGroup description="A group of properties to include in the greeting.">
	    <property name="apim.analytics.request.properties" scope="default" type="STRING" value="name,age"/>

	    <property name="name" scope="default" type="STRING" expression="$trp:name" />
	    <property name="age" expression="$url:age" scope="default" type="STRING"/>

	</propertyGroup>
</sequence>

```

* response path
```
<?xml version="1.0" encoding="UTF-8"?><sequence xmlns="http://ws.apache.org/ns/synapse" name="response">
    <propertyGroup description="A group of properties to include in the greeting.">
	    <property name="apim.analytics.response.properties" scope="default" type="STRING" value="Server"/>
	    
	    <property name="Server" scope="default" type="STRING" expression="$trp:Server" />
	</propertyGroup>
</sequence>
```