### PR TITLE
Add config to consider jwt token as an opaque token

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
@@ -75,6 +75,7 @@ public class OAuthAuthenticator implements Authenticator {
     private String securityContextHeader;
     private boolean removeOAuthHeadersFromOutMessage=true;
     private boolean removeDefaultAPIHeaderFromOutMessage=true;
+    private boolean isJWTAnOpaqueToken = false;
     private String clientDomainHeader = "referer";
     private String requestOrigin;
     private String remainingAuthHeader;
@@ -186,7 +187,7 @@ public class OAuthAuthenticator implements Authenticator {
         String authenticationScheme;
         try {
             //Initial guess of a JWT token using the presence of a DOT.
-            if (StringUtils.isNotEmpty(apiKey) && apiKey.contains(APIConstants.DOT)) {
+            if (!isJWTAnOpaqueToken && StringUtils.isNotEmpty(apiKey) && apiKey.contains(APIConstants.DOT)) {
                 try {
                     // Check if the header part is decoded
                     Base64.getUrlDecoder().decode(apiKey.split("\\.")[0]);
@@ -487,6 +488,10 @@ public class OAuthAuthenticator implements Authenticator {
         String value = config.getFirstProperty(APIConstants.REMOVE_OAUTH_HEADERS_FROM_MESSAGE);
         if (value != null) {
             removeOAuthHeadersFromOutMessage = Boolean.parseBoolean(value);
+        }
+        value = config.getFirstProperty(APIConstants.JWT_AS_OPAQUE_TOKEN);
+        if (value != null) {
+            isJWTAnOpaqueToken = Boolean.parseBoolean(value);
         }
         JWTConfigurationDto jwtConfigurationDto = config.getJwtConfigurationDto();
         value = jwtConfigurationDto.getJwtHeader();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -421,6 +421,7 @@ public final class APIConstants {
     public static final String REMOVE_OAUTH_HEADER_FROM_OUT_MESSAGE = "RemoveOAuthHeadersFromOutMessage";
     public static final String REMOVE_OAUTH_HEADER_FROM_OUT_MESSAGE_DEFAULT = "true";
     public static final String REMOVE_OAUTH_HEADERS_FROM_MESSAGE = OAUTH_CONFIGS + "RemoveOAuthHeadersFromOutMessage";
+    public static final String JWT_AS_OPAQUE_TOKEN = OAUTH_CONFIGS + "JWTAsOpaqueToken";
     public static final String APPLICATION_TOKEN_SCOPE = OAUTH_CONFIGS + "ApplicationTokenScope";
     public static final String WHITELISTED_SCOPES = OAUTH_CONFIGS + "ScopeWhitelist.Scope";
     public static final String TOKEN_ENDPOINT_NAME = OAUTH_CONFIGS + "TokenEndPointName";

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -367,6 +367,8 @@
         <!-- Remove OAuth headers from outgoing message. -->
         <RemoveOAuthHeadersFromOutMessage>{{not apim.oauth_config.enable_outbound_auth_header}}</RemoveOAuthHeadersFromOutMessage>
         {% if apim.oauth_config.auth_header is defined %}
+        <!-- Consider incoming jwt token as an opaque token. -->
+        <JWTAsOpaqueToken>{{apim.oauth_config.set_jwt_as_opaque_token}}</JWTAsOpaqueToken>
         <!--Authorization header-->
         <AuthorizationHeader>{{apim.oauth_config.auth_header}}</AuthorizationHeader>
         {% endif %}


### PR DESCRIPTION
Add config to consider jwt token as an opaque token. This will pass the jwt token to the keymanager interface to validate instead of validating it from the gateway. 

To enable this add following. (default behavior is to validate the jwt token from the gateway. )

```
[apim.oauth_config]
set_jwt_as_opaque_token = true
```