### PR TITLE
Remove the default assignment of APILevel policy from REST API Layer | Fix error when exporting API without endpoints

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
@@ -716,13 +716,21 @@ public class APIExportUtil {
             throws APIImportExportException {
 
         JSONObject endpointConfig;
-        JSONTokener tokener = new JSONTokener(api.getEndpointConfig());
         List<String> productionEndpoints;
         List<String> sandboxEndpoints;
         Set<String> uniqueEndpointURLs = new HashSet<>();
         List<CertificateDetail> endpointCertificatesDetails = new ArrayList<>();
+        String endpointConfigString = api.getEndpointConfig();
 
+        if (StringUtils.isEmpty(endpointConfigString)) {
+            if(log.isDebugEnabled()) {
+                log.debug("Endpoint Details are empty for API: " + api.getId().getApiName() + StringUtils.SPACE
+                        + APIConstants.API_DATA_VERSION + ": " + api.getId().getVersion());
+            }
+            return;
+        }
         try {
+            JSONTokener tokener = new JSONTokener(endpointConfigString);
             endpointConfig = new JSONObject(tokener);
             productionEndpoints = getEndpointURLs(endpointConfig, APIConstants.API_DATA_PRODUCTION_ENDPOINTS,
                     api.getId().getApiName());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -472,22 +472,6 @@ public class ApisApiServiceImpl implements ApisApiService {
         //attach micro-geteway labels
         assignLabelsToDTO(body, apiToAdd);
 
-        // set default API Level Policy
-        if (apiToAdd.getApiLevelPolicy() != null) {
-            Policy[] apiPolicies = apiProvider.getPolicies(username, PolicyConstants.POLICY_LEVEL_API);
-            if (apiPolicies.length > 0) {
-                for (Policy policy : apiPolicies) {
-                    if (policy.getPolicyName().equals(APIConstants.UNLIMITED_TIER)) {
-                        apiToAdd.setApiLevelPolicy(APIConstants.UNLIMITED_TIER);
-                        break;
-                    }
-                }
-                if (StringUtils.isBlank(apiToAdd.getApiLevelPolicy())) {
-                    apiToAdd.setApiLevelPolicy(apiPolicies[0].getPolicyName());
-                }
-            }
-        }
-
         return apiToAdd;
     }
 


### PR DESCRIPTION
**Fix https://github.com/wso2/product-apim/issues/7210**

The validation was recently modified with https://github.com/wso2/carbon-apimgt/pull/7904/files to fix issue https://github.com/wso2/product-apim/issues/6859. But because of that modification, https://github.com/wso2/product-apim/issues/7210 has occurred. 

It makes sense to remove from the validation and default value assignment for apiLevelPolicy from REST API Level, as this scenario is handled in the DAO layer when adding URL Templates https://github.com/wso2/carbon-apimgt/blob/master/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java#L6185.

So when an API is created using POST /apis, if the apiLevelPolicy is given, the resource level policies will be neglected. If the apiLevelPolicy is null or empty (""), the resource level throttling will take precedence. 

**Fix https://github.com/wso2/product-apim/issues/7371**
Skip importing endpoint certificates when the endpoint is empty.