### PR TITLE
Mandated HTTPS transport if mutual SSL is in use.

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
@@ -186,7 +186,7 @@ function TransportLevel(props) {
                         </Typography>
                     </ExpansionPanelSummary>
                     <ExpansionPanelDetails className={classes.expansionPanelDetails}>
-                        <Transports api={api} configDispatcher={configDispatcher} />
+                        <Transports api={api} configDispatcher={configDispatcher} securityScheme={securityScheme}/>
                         <FormControlLabel
                             control={(
                                 <Checkbox

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
@@ -186,7 +186,7 @@ function TransportLevel(props) {
                         </Typography>
                     </ExpansionPanelSummary>
                     <ExpansionPanelDetails className={classes.expansionPanelDetails}>
-                        <Transports api={api} configDispatcher={configDispatcher} securityScheme={securityScheme}/>
+                        <Transports api={api} configDispatcher={configDispatcher} securityScheme={securityScheme} />
                         <FormControlLabel
                             control={(
                                 <Checkbox

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
@@ -31,6 +31,10 @@ import { makeStyles } from '@material-ui/core/styles';
 import { isRestricted } from 'AppData/AuthManager';
 import { useAPI } from 'AppComponents/Apis/Details/components/ApiContext';
 
+import {
+    API_SECURITY_MUTUAL_SSL,
+} from './APISecurity/components/apiSecurityConstants';
+
 const useStyles = makeStyles((theme) => ({
     error: {
         color: theme.palette.error.main,
@@ -44,15 +48,24 @@ const useStyles = makeStyles((theme) => ({
  * @returns
  */
 export default function Transports(props) {
-    const { api, configDispatcher } = props;
+    const { api, configDispatcher, securityScheme } = props;
     const [apiFromContext] = useAPI();
     const classes = useStyles();
+    const isMutualSSLEnabled = securityScheme.includes(API_SECURITY_MUTUAL_SSL);
     const Validate = () => {
         if (api.transport && api.transport.length === 0) {
             return (
                 <FormattedMessage
                     id='Apis.Details.Configuration.components.transport.empty'
                     defaultMessage='Please select at least one transport!'
+                />
+            );
+        }
+        else if (isMutualSSLEnabled && !api.transport.includes('https')) {
+            return (
+                <FormattedMessage
+                    id='Apis.Details.Configuration.components.transport.sslHttps'
+                    defaultMessage='Please select Https as transport with mutual ssl!'
                 />
             );
         }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
@@ -60,12 +60,11 @@ export default function Transports(props) {
                     defaultMessage='Please select at least one transport!'
                 />
             );
-        }
-        else if (isMutualSSLEnabled && !api.transport.includes('https')) {
+        } else if (isMutualSSLEnabled && !api.transport.includes('https')) {
             return (
                 <FormattedMessage
                     id='Apis.Details.Configuration.components.transport.sslHttps'
-                    defaultMessage='Please select Https as transport with mutual ssl!'
+                    defaultMessage='Please select Https as transport with mutual SSL!'
                 />
             );
         }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
@@ -30,10 +30,7 @@ import { FormattedMessage } from 'react-intl';
 import { makeStyles } from '@material-ui/core/styles';
 import { isRestricted } from 'AppData/AuthManager';
 import { useAPI } from 'AppComponents/Apis/Details/components/ApiContext';
-
-import {
-    API_SECURITY_MUTUAL_SSL,
-} from './APISecurity/components/apiSecurityConstants';
+import { API_SECURITY_MUTUAL_SSL } from './APISecurity/components/apiSecurityConstants';
 
 const useStyles = makeStyles((theme) => ({
     error: {


### PR DESCRIPTION
Added an info message which appears when disabling HTTPS with mutual SSL enabled. 

Fixes wso2/product-apim#7398 