### PR TITLE
Fix issue with expanded category left pane overlapping api listing content

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/CommonListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/CommonListing.jsx
@@ -308,9 +308,9 @@ class CommonListing extends React.Component {
                 <main
                     className={classNames(
                         classes.content,
-                        { [classes.contentWithoutTags]: !tagPaneVisible || !showLeftMenu },
-                        { [classes.contentWithTagsHidden]: tagPaneVisible && !showLeftMenu },
-                        { [classes.contentWithTags]: tagPaneVisible && showLeftMenu },
+                        { [classes.contentWithoutTags]: !(tagPaneVisible || categoryPaneVisible) || !showLeftMenu },
+                        { [classes.contentWithTagsHidden]: (tagPaneVisible || categoryPaneVisible) && !showLeftMenu },
+                        { [classes.contentWithTags]: (tagPaneVisible || categoryPaneVisible) && showLeftMenu },
                     )}
                     id='commonListing'
                 >


### PR DESCRIPTION
Fixes https://github.com/wso2/product-apim/issues/7483


![test](https://user-images.githubusercontent.com/28379317/74714268-406d7d00-5250-11ea-8c17-124db17c4986.png)
