### PR TITLE
Removing the hardcoded system apps names in the logout handler and retrieve from system apps db table

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -3403,6 +3403,9 @@ public class SQLConstants {
                 "INSERT INTO AM_SYSTEM_APPS " + "(NAME,CONSUMER_KEY,CONSUMER_SECRET,TENANT_DOMAIN,CREATED_TIME) " +
                         "VALUES (?,?,?,?,?)";
 
+        public static final String GET_APPLICATIONS =
+                "SELECT * FROM " + "AM_SYSTEM_APPS WHERE TENANT_DOMAIN = ?";
+
         public static final String GET_CLIENT_CREDENTIALS_FOR_APPLICATION =
                 "SELECT CONSUMER_KEY,CONSUMER_SECRET FROM " + "AM_SYSTEM_APPS WHERE NAME = ? AND TENANT_DOMAIN = ?";
 


### PR DESCRIPTION
## Issue
Fixes https://github.com/wso2/product-apim/issues/7410

## Methodology

Getting the system apps from the database against the tenant and check against the apps authorized for the logout initiated user and revoke all the access token related to those apps. 