### PR TITLE
Remove production and sandbox endpoints in Overview and Run-time Configurations UI if API is prototyped.

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
@@ -417,17 +417,13 @@ export default function RuntimeConfiguration() {
                             />
                         </Typography>
                         <Paper className={classes.paper} style={{ height: 'calc(100% - 75px)' }} elevation={0}>
-                            {!api.isAPIProduct() && !isPrototypedAvailable && (
+                            {!api.isAPIProduct() && (
                                 <>
                                     <MaxBackendTps api={apiConfig} configDispatcher={configDispatcher} />
                                     <Endpoints api={api} />
                                 </>
                             )}
-                            {!api.isAPIProduct() && isPrototypedAvailable && (
-                                <>
-                                    <MaxBackendTps api={apiConfig} configDispatcher={configDispatcher} />
-                                </>
-                            )}
+
                             {api.isAPIProduct() && (
                                 <Box alignItems='center' justifyContent='center' className={classes.info}>
                                     <Typography variant='body1'>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
@@ -270,6 +270,8 @@ export default function RuntimeConfiguration() {
         }
     }
     const { api, updateAPI } = useContext(APIContext);
+    const isPrototypedAvailable = api.endpointConfig !== null
+        && api.endpointConfig.implementation_status === 'prototyped';
     const [isUpdating, setIsUpdating] = useState(false);
     const [apiConfig, configDispatcher] = useReducer(configReducer, copyAPIConfig(api));
     const classes = useStyles();
@@ -415,10 +417,15 @@ export default function RuntimeConfiguration() {
                             />
                         </Typography>
                         <Paper className={classes.paper} style={{ height: 'calc(100% - 75px)' }} elevation={0}>
-                            {!api.isAPIProduct() && (
+                            {!api.isAPIProduct() && !isPrototypedAvailable && (
                                 <>
                                     <MaxBackendTps api={apiConfig} configDispatcher={configDispatcher} />
                                     <Endpoints api={api} />
+                                </>
+                            )}
+                            {!api.isAPIProduct() && isPrototypedAvailable && (
+                                <>
+                                    <MaxBackendTps api={apiConfig} configDispatcher={configDispatcher} />
                                 </>
                             )}
                             {api.isAPIProduct() && (

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
@@ -270,8 +270,6 @@ export default function RuntimeConfiguration() {
         }
     }
     const { api, updateAPI } = useContext(APIContext);
-    const isPrototypedAvailable = api.endpointConfig !== null
-        && api.endpointConfig.implementation_status === 'prototyped';
     const [isUpdating, setIsUpdating] = useState(false);
     const [apiConfig, configDispatcher] = useReducer(configReducer, copyAPIConfig(api));
     const classes = useStyles();

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Endpoints.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Endpoints.jsx
@@ -30,7 +30,6 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Box from '@material-ui/core/Box';
 import { withAPI } from 'AppComponents/Apis/Details/components/ApiContext';
 import { makeStyles } from '@material-ui/core/styles';
-import Grid from "@material-ui/core/Grid";
 
 const showEndpoint = function (api, type) {
     if (api.endpointConfig) {
@@ -128,13 +127,13 @@ function Endpoints(props) {
                                                     info when it's available with the api object */}
 
                                     { !isPrototypedAvailable ? (
-                                    <Typography component='p' variant='subtitle2' className={classes.subtitle}>
-                                        <FormattedMessage
-                                            id='Apis.Details.Configuration.components.Endpoints.production'
-                                            defaultMessage='Production'
-                                        />
-                                    </Typography>
-                                        ):(
+                                        <Typography component='p' variant='subtitle2' className={classes.subtitle}>
+                                            <FormattedMessage
+                                                id='Apis.Details.Configuration.components.Endpoints.production'
+                                                defaultMessage='Production'
+                                            />
+                                        </Typography>
+                                    ) : (
                                         <Typography component='p' variant='subtitle2' className={classes.subtitle}>
                                             <FormattedMessage
                                                 id='Apis.Details.Configuration.components.Endpoints.prototype'
@@ -169,38 +168,39 @@ function Endpoints(props) {
                                 </Box>
                                 {!isPrototypedAvailable && (
                                     <Box pb={2}>
-                                    {/* Sandbox Endpoint (TODO) fix the endpoint info when
+                                        {/* Sandbox Endpoint (TODO) fix the endpoint info when
                                                 it's available with the api object */}
-                                    <Typography component='p' variant='subtitle2' className={classes.subtitle}>
-                                        <FormattedMessage
-                                            id='Apis.Details.Configuration.components.Endpoints.sandbox'
-                                            defaultMessage='Sandbox'
-                                        />
-                                    </Typography>
-                                    {showEndpoint(api, 'sand')
-                                && (
-                                    <Tooltip
-                                        title={showEndpoint(api, 'sand')}
-                                        interactive
-                                    >
-                                        <Typography component='p' variant='body1' className={classes.textTrim}>
-                                            <>
-                                                {showEndpoint(api, 'sand')}
-                                            </>
+                                        <Typography component='p' variant='subtitle2' className={classes.subtitle}>
+                                            <FormattedMessage
+                                                id='Apis.Details.Configuration.components.Endpoints.sandbox'
+                                                defaultMessage='Sandbox'
+                                            />
                                         </Typography>
-                                    </Tooltip>
-                                )}
-                                    <Typography component='p' variant='body1' className={classes.notConfigured}>
-                                        {!showEndpoint(api, 'sand') && (
-                                            <>
-                                                <FormattedMessage
-                                                    id='Apis.Details.Configuration.components.Endpoints.sandbox.not.set'
-                                                    defaultMessage='-'
-                                                />
-                                            </>
-                                        )}
-                                    </Typography>
-                                </Box>
+                                        {showEndpoint(api, 'sand')
+                                    && (
+                                        <Tooltip
+                                            title={showEndpoint(api, 'sand')}
+                                            interactive
+                                        >
+                                            <Typography component='p' variant='body1' className={classes.textTrim}>
+                                                <>
+                                                    {showEndpoint(api, 'sand')}
+                                                </>
+                                            </Typography>
+                                        </Tooltip>
+                                    )}
+                                        <Typography component='p' variant='body1' className={classes.notConfigured}>
+                                            {!showEndpoint(api, 'sand') && (
+                                                <>
+                                                    <FormattedMessage
+                                                        id='Apis.Details.Configuration.components.Endpoints.sandbox.
+                                                        not.set'
+                                                        defaultMessage='-'
+                                                    />
+                                                </>
+                                            )}
+                                        </Typography>
+                                    </Box>
                                 )}
                             </>
                         )}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Endpoints.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Endpoints.jsx
@@ -30,6 +30,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Box from '@material-ui/core/Box';
 import { withAPI } from 'AppComponents/Apis/Details/components/ApiContext';
 import { makeStyles } from '@material-ui/core/styles';
+import Grid from "@material-ui/core/Grid";
 
 const showEndpoint = function (api, type) {
     if (api.endpointConfig) {
@@ -78,6 +79,8 @@ const useStyles = makeStyles((theme) => ({
 function Endpoints(props) {
     const { api } = props;
     const classes = useStyles();
+    const isPrototypedAvailable = api.endpointConfig !== null
+        && api.endpointConfig.implementation_status === 'prototyped';
 
     /**
      * Check whether the endpoint configuration is dynamic
@@ -124,12 +127,21 @@ function Endpoints(props) {
                                     {/* Production Endpoint (TODO) fix the endpoint
                                                     info when it's available with the api object */}
 
+                                    { !isPrototypedAvailable ? (
                                     <Typography component='p' variant='subtitle2' className={classes.subtitle}>
                                         <FormattedMessage
                                             id='Apis.Details.Configuration.components.Endpoints.production'
                                             defaultMessage='Production'
                                         />
                                     </Typography>
+                                        ):(
+                                        <Typography component='p' variant='subtitle2' className={classes.subtitle}>
+                                            <FormattedMessage
+                                                id='Apis.Details.Configuration.components.Endpoints.prototype'
+                                                defaultMessage='Prototype'
+                                            />
+                                        </Typography>
+                                    )}
                                     {showEndpoint(api, 'prod')
                                 && (
                                     <Tooltip
@@ -148,14 +160,15 @@ function Endpoints(props) {
                                             <>
                                                 <FormattedMessage
                                                     id={'Apis.Details.Configuration.'
-                                                    + 'components.Endpoints.production.not.set'}
+                                                    + 'components.Endpoints.not.set'}
                                                     defaultMessage='-'
                                                 />
                                             </>
                                         )}
                                     </Typography>
                                 </Box>
-                                <Box pb={2}>
+                                {!isPrototypedAvailable && (
+                                    <Box pb={2}>
                                     {/* Sandbox Endpoint (TODO) fix the endpoint info when
                                                 it's available with the api object */}
                                     <Typography component='p' variant='subtitle2' className={classes.subtitle}>
@@ -188,6 +201,7 @@ function Endpoints(props) {
                                         )}
                                     </Typography>
                                 </Box>
+                                )}
                             </>
                         )}
                     <Box width='100%' textAlign='right' m={1}>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/Endpoints.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/Endpoints.jsx
@@ -46,123 +46,127 @@ const showEndpoint = (api, type) => {
  */
 function Endpoints(props) {
     const { parentClasses, api } = props;
-
-    return (
-        <>
-            <div>
-                <Typography variant='h5' component='h3' className={parentClasses.title}>
-                    <FormattedMessage
-                        id='Apis.Details.NewOverview.Endpoints.endpoints'
-                        defaultMessage='Endpoints'
-                    />
-                </Typography>
-            </div>
-            <Box p={1}>
-                <Grid container spacing={2}>
-                    <Grid item xs={12} md={6} lg={4}>
-                        {/* Production Endpoint (TODO) fix the endpoint
+    const isPrototypedAvailable = api.endpointConfig !== null
+        && api.endpointConfig.implementation_status === 'prototyped';
+    if(!isPrototypedAvailable) {
+        return (
+            <>
+                <div>
+                    <Typography variant='h5' component='h3' className={parentClasses.title}>
+                        <FormattedMessage
+                            id='Apis.Details.NewOverview.Endpoints.endpoints'
+                            defaultMessage='Endpoints'
+                        />
+                    </Typography>
+                </div>
+                <Box p={1}>
+                    <Grid container spacing={2}>
+                        <Grid item xs={12} md={6} lg={4}>
+                            {/* Production Endpoint (TODO) fix the endpoint
                                                 info when it's available with the api object */}
-                        <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
-                            <FormattedMessage
-                                id='Apis.Details.NewOverview.Endpoints.production.endpoint'
-                                defaultMessage='Production Endpoint'
-                            />
-                        </Typography>
-                    </Grid>
-                    <Grid item xs={12} md={6} lg={8}>
-                        <Tooltip
-                            placement='top'
-                            classes={{
-                                tooltip: parentClasses.htmlTooltip,
-                            }}
-                            title={
-                                showEndpoint(api, 'prod')
-                                && <>{showEndpoint(api, 'prod')}</>
-                            }
-                        >
-                            <Typography component='p' variant='body1' className={parentClasses.url}>
-                                {showEndpoint(api, 'prod')
+                            <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
+                                <FormattedMessage
+                                    id='Apis.Details.NewOverview.Endpoints.production.endpoint'
+                                    defaultMessage='Production Endpoint'
+                                />
+                            </Typography>
+                        </Grid>
+                        <Grid item xs={12} md={6} lg={8}>
+                            <Tooltip
+                                placement='top'
+                                classes={{
+                                    tooltip: parentClasses.htmlTooltip,
+                                }}
+                                title={
+                                    showEndpoint(api, 'prod')
+                                    && <>{showEndpoint(api, 'prod')}</>
+                                }
+                            >
+                                <Typography component='p' variant='body1' className={parentClasses.url}>
+                                    {showEndpoint(api, 'prod')
                                     && <>{showEndpoint(api, 'prod')}</>}
+                                </Typography>
+                            </Tooltip>
+                            <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
+                                {!showEndpoint(api, 'prod') && (
+                                    <>
+                                        <FormattedMessage
+                                            id='Apis.Details.NewOverview.Endpoints.production.not.set'
+                                            defaultMessage='-'
+                                        />
+                                    </>
+                                )}
                             </Typography>
-                        </Tooltip>
-                        <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
-                            {!showEndpoint(api, 'prod') && (
-                                <>
-                                    <FormattedMessage
-                                        id='Apis.Details.NewOverview.Endpoints.production.not.set'
-                                        defaultMessage='-'
-                                    />
-                                </>
-                            )}
-                        </Typography>
-                    </Grid>
-                    <Grid item xs={12} md={6} lg={4}>
-                        {/* Sandbox Endpoint (TODO) fix the endpoint info when
+                        </Grid>
+                        <Grid item xs={12} md={6} lg={4}>
+                            {/* Sandbox Endpoint (TODO) fix the endpoint info when
                                                 it's available with the api object */}
-                        <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
-                            <FormattedMessage
-                                id='Apis.Details.NewOverview.Endpoints.sandbox.endpoint'
-                                defaultMessage='Sandbox Endpoint'
-                            />
-                        </Typography>
-                    </Grid>
-                    <Grid item xs={12} md={6} lg={8}>
-                        <Tooltip
-                            placement='top'
-                            classes={{
-                                tooltip: parentClasses.htmlTooltip,
-                            }}
-                            title={
-                                showEndpoint(api, 'sand')
-                                && <>{showEndpoint(api, 'sand')}</>
-                            }
-                        >
-                            <Typography component='p' variant='body1' className={parentClasses.url}>
-                                {showEndpoint(api, 'sand')
+                            <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
+                                <FormattedMessage
+                                    id='Apis.Details.NewOverview.Endpoints.sandbox.endpoint'
+                                    defaultMessage='Sandbox Endpoint'
+                                />
+                            </Typography>
+                        </Grid>
+                        <Grid item xs={12} md={6} lg={8}>
+                            <Tooltip
+                                placement='top'
+                                classes={{
+                                    tooltip: parentClasses.htmlTooltip,
+                                }}
+                                title={
+                                    showEndpoint(api, 'sand')
+                                    && <>{showEndpoint(api, 'sand')}</>
+                                }
+                            >
+                                <Typography component='p' variant='body1' className={parentClasses.url}>
+                                    {showEndpoint(api, 'sand')
                                     && <>{showEndpoint(api, 'sand')}</>}
+                                </Typography>
+                            </Tooltip>
+                            <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
+                                {!showEndpoint(api, 'sand') && (
+                                    <>
+                                        <FormattedMessage
+                                            id='Apis.Details.NewOverview.Endpoints.sandbox.not.set'
+                                            defaultMessage='-'
+                                        />
+                                    </>
+                                )}
                             </Typography>
-                        </Tooltip>
-                        <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
-                            {!showEndpoint(api, 'sand') && (
-                                <>
-                                    <FormattedMessage
-                                        id='Apis.Details.NewOverview.Endpoints.sandbox.not.set'
-                                        defaultMessage='-'
-                                    />
-                                </>
-                            )}
-                        </Typography>
-                    </Grid>
-                    <Grid item xs={12} md={6} lg={4}>
-                        {/* Sandbox Endpoint (TODO) fix the endpoint info when
+                        </Grid>
+                        <Grid item xs={12} md={6} lg={4}>
+                            {/* Sandbox Endpoint (TODO) fix the endpoint info when
                                                 it's available with the api object */}
-                        <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
-                            <FormattedMessage
-                                id='Apis.Details.NewOverview.Endpoints.endpoint.security'
-                                defaultMessage='Endpoint Security'
-                            />
-                        </Typography>
+                            <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
+                                <FormattedMessage
+                                    id='Apis.Details.NewOverview.Endpoints.endpoint.security'
+                                    defaultMessage='Endpoint Security'
+                                />
+                            </Typography>
+                        </Grid>
+                        <Grid item xs={12} md={6} lg={8}>
+                            <Typography component='p' variant='body1'>
+                                {api.endpointSecurity && <>{api.endpointSecurity.type}</>}
+                            </Typography>
+                            <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
+                                {!api.endpointSecurity
+                                && (
+                                    <>
+                                        <FormattedMessage
+                                            id='Apis.Details.NewOverview.Endpoints.security.not.set'
+                                            defaultMessage='-'
+                                        />
+                                    </>
+                                )}
+                            </Typography>
+                        </Grid>
                     </Grid>
-                    <Grid item xs={12} md={6} lg={8}>
-                        <Typography component='p' variant='body1'>
-                            {api.endpointSecurity && <>{api.endpointSecurity.type}</>}
-                        </Typography>
-                        <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
-                            {!api.endpointSecurity
-                            && (
-                                <>
-                                    <FormattedMessage
-                                        id='Apis.Details.NewOverview.Endpoints.security.not.set'
-                                        defaultMessage='-'
-                                    />
-                                </>
-                            )}
-                        </Typography>
-                    </Grid>
-                </Grid>
-            </Box>
-        </>
-    );
+                </Box>
+            </>
+        );
+    }
+    return null ;
 }
 
 Endpoints.propTypes = {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/Endpoints.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/Endpoints.jsx
@@ -49,39 +49,79 @@ function Endpoints(props) {
     const isPrototypedAvailable = api.endpointConfig !== null
         && api.endpointConfig.implementation_status === 'prototyped';
 
-    {
-        return (
-            <>
-                <div>
-                    <Typography variant='h5' component='h3' className={parentClasses.title}>
-                        <FormattedMessage
-                            id='Apis.Details.NewOverview.Endpoints.endpoints'
-                            defaultMessage='Endpoints'
-                        />
-                    </Typography>
-                </div>
-                <Box p={1}>
-                    <Grid container spacing={2}>
-                        <Grid item xs={12} md={6} lg={4}>
-                            {/* Production Endpoint (TODO) fix the endpoint
-                                                info when it's available with the api object */}
-                            { !isPrototypedAvailable ? (
+    return (
+        <>
+            <div>
+                <Typography variant='h5' component='h3' className={parentClasses.title}>
+                    <FormattedMessage
+                        id='Apis.Details.NewOverview.Endpoints.endpoints'
+                        defaultMessage='Endpoints'
+                    />
+                </Typography>
+            </div>
+            <Box p={1}>
+                <Grid container spacing={2}>
+                    <Grid item xs={12} md={6} lg={4}>
+                        {/* Production Endpoint (TODO) fix the endpoint
+                                            info when it's available with the api object */}
+                        { !isPrototypedAvailable ? (
+                            <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
+                                <FormattedMessage
+                                    id='Apis.Details.NewOverview.Endpoints.production.endpoint'
+                                    defaultMessage='Production Endpoint'
+                                />
+                            </Typography>
+                        )
+                            : (
                                 <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
-                                    <FormattedMessage
-                                        id='Apis.Details.NewOverview.Endpoints.production.endpoint'
-                                        defaultMessage='Production Endpoint'
-                                    />
-                                </Typography>
-                            )
-                                :(
-                                    <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
                                     <FormattedMessage
                                         id='Apis.Details.NewOverview.Endpoints.prototype.endpoint'
                                         defaultMessage='Prototype Endpoint'
                                     />
-                                    </Typography>
-                                )}
+                                </Typography>
+                            )}
+                    </Grid>
+                    <Grid item xs={12} md={6} lg={8}>
+                        <Tooltip
+                            placement='top'
+                            classes={{
+                                tooltip: parentClasses.htmlTooltip,
+                            }}
+                            title={
+                                showEndpoint(api, 'prod')
+                                && <>{showEndpoint(api, 'prod')}</>
+                            }
+                        >
+                            <Typography component='p' variant='body1' className={parentClasses.url}>
+                                {showEndpoint(api, 'prod')
+                                && <>{showEndpoint(api, 'prod')}</>}
+                            </Typography>
+                        </Tooltip>
+                        <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
+                            {!showEndpoint(api, 'prod') && (
+                                <>
+                                    <FormattedMessage
+                                        id='Apis.Details.NewOverview.Endpoints.not.set'
+                                        defaultMessage='-'
+                                    />
+                                </>
+                            )}
+                        </Typography>
+                    </Grid>
+                    {!isPrototypedAvailable && (
+                        <Grid item xs={12} md={6} lg={4}>
+                            {/* Sandbox Endpoint (TODO) fix the endpoint info when
+                                                it's available with the api object */}
+                            <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
+                                <FormattedMessage
+                                    id='Apis.Details.NewOverview.Endpoints.sandbox.endpoint'
+                                    defaultMessage='Sandbox Endpoint'
+                                />
+                            </Typography>
                         </Grid>
+                    )}
+
+                    {!isPrototypedAvailable && (
                         <Grid item xs={12} md={6} lg={8}>
                             <Tooltip
                                 placement='top'
@@ -89,100 +129,57 @@ function Endpoints(props) {
                                     tooltip: parentClasses.htmlTooltip,
                                 }}
                                 title={
-                                    showEndpoint(api, 'prod')
-                                    && <>{showEndpoint(api, 'prod')}</>
+                                    showEndpoint(api, 'sand')
+                                    && <>{showEndpoint(api, 'sand')}</>
                                 }
                             >
                                 <Typography component='p' variant='body1' className={parentClasses.url}>
-                                    {showEndpoint(api, 'prod')
-                                    && <>{showEndpoint(api, 'prod')}</>}
+                                    {showEndpoint(api, 'sand')
+                                    && <>{showEndpoint(api, 'sand')}</>}
                                 </Typography>
                             </Tooltip>
                             <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
-                                {!showEndpoint(api, 'prod') && (
+                                {!showEndpoint(api, 'sand') && (
                                     <>
                                         <FormattedMessage
-                                            id='Apis.Details.NewOverview.Endpoints.not.set'
+                                            id='Apis.Details.NewOverview.Endpoints.sandbox.not.set'
                                             defaultMessage='-'
                                         />
                                     </>
                                 )}
                             </Typography>
                         </Grid>
-                        {!isPrototypedAvailable && (
-                            <Grid item xs={12} md={6} lg={4}>
-                                {/* Sandbox Endpoint (TODO) fix the endpoint info when
-                                                    it's available with the api object */}
-                                <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
-                                    <FormattedMessage
-                                        id='Apis.Details.NewOverview.Endpoints.sandbox.endpoint'
-                                        defaultMessage='Sandbox Endpoint'
-                                    />
-                                </Typography>
-                            </Grid>
-                        )}
-
-                        {!isPrototypedAvailable && (
-                            <Grid item xs={12} md={6} lg={8}>
-                                <Tooltip
-                                    placement='top'
-                                    classes={{
-                                        tooltip: parentClasses.htmlTooltip,
-                                    }}
-                                    title={
-                                        showEndpoint(api, 'sand')
-                                        && <>{showEndpoint(api, 'sand')}</>
-                                    }
-                                >
-                                    <Typography component='p' variant='body1' className={parentClasses.url}>
-                                        {showEndpoint(api, 'sand')
-                                        && <>{showEndpoint(api, 'sand')}</>}
-                                    </Typography>
-                                </Tooltip>
-                                <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
-                                    {!showEndpoint(api, 'sand') && (
-                                        <>
-                                            <FormattedMessage
-                                                id='Apis.Details.NewOverview.Endpoints.sandbox.not.set'
-                                                defaultMessage='-'
-                                            />
-                                        </>
-                                    )}
-                                </Typography>
-                            </Grid>
-                        )}
-                        <Grid item xs={12} md={6} lg={4}>
-                            {/* Sandbox Endpoint (TODO) fix the endpoint info when
-                                                it's available with the api object */}
-                            <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
-                                <FormattedMessage
-                                    id='Apis.Details.NewOverview.Endpoints.endpoint.security'
-                                    defaultMessage='Endpoint Security'
-                                />
-                            </Typography>
-                        </Grid>
-                        <Grid item xs={12} md={6} lg={8}>
-                            <Typography component='p' variant='body1'>
-                                {api.endpointSecurity && <>{api.endpointSecurity.type}</>}
-                            </Typography>
-                            <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
-                                {!api.endpointSecurity
-                                && (
-                                    <>
-                                        <FormattedMessage
-                                            id='Apis.Details.NewOverview.Endpoints.security.not.set'
-                                            defaultMessage='-'
-                                        />
-                                    </>
-                                )}
-                            </Typography>
-                        </Grid>
+                    )}
+                    <Grid item xs={12} md={6} lg={4}>
+                        {/* Sandbox Endpoint (TODO) fix the endpoint info when
+                                            it's available with the api object */}
+                        <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
+                            <FormattedMessage
+                                id='Apis.Details.NewOverview.Endpoints.endpoint.security'
+                                defaultMessage='Endpoint Security'
+                            />
+                        </Typography>
                     </Grid>
-                </Box>
-            </>
-        );
-    }
-
+                    <Grid item xs={12} md={6} lg={8}>
+                        <Typography component='p' variant='body1'>
+                            {api.endpointSecurity && <>{api.endpointSecurity.type}</>}
+                        </Typography>
+                        <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
+                            {!api.endpointSecurity
+                            && (
+                                <>
+                                    <FormattedMessage
+                                        id='Apis.Details.NewOverview.Endpoints.security.not.set'
+                                        defaultMessage='-'
+                                    />
+                                </>
+                            )}
+                        </Typography>
+                    </Grid>
+                </Grid>
+            </Box>
+        </>
+    );
 }
 
 Endpoints.propTypes = {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/Endpoints.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/Endpoints.jsx
@@ -48,7 +48,8 @@ function Endpoints(props) {
     const { parentClasses, api } = props;
     const isPrototypedAvailable = api.endpointConfig !== null
         && api.endpointConfig.implementation_status === 'prototyped';
-    if(!isPrototypedAvailable) {
+
+    {
         return (
             <>
                 <div>
@@ -64,12 +65,22 @@ function Endpoints(props) {
                         <Grid item xs={12} md={6} lg={4}>
                             {/* Production Endpoint (TODO) fix the endpoint
                                                 info when it's available with the api object */}
-                            <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
-                                <FormattedMessage
-                                    id='Apis.Details.NewOverview.Endpoints.production.endpoint'
-                                    defaultMessage='Production Endpoint'
-                                />
-                            </Typography>
+                            { !isPrototypedAvailable ? (
+                                <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
+                                    <FormattedMessage
+                                        id='Apis.Details.NewOverview.Endpoints.production.endpoint'
+                                        defaultMessage='Production Endpoint'
+                                    />
+                                </Typography>
+                            )
+                                :(
+                                    <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
+                                    <FormattedMessage
+                                        id='Apis.Details.NewOverview.Endpoints.prototype.endpoint'
+                                        defaultMessage='Prototype Endpoint'
+                                    />
+                                    </Typography>
+                                )}
                         </Grid>
                         <Grid item xs={12} md={6} lg={8}>
                             <Tooltip
@@ -91,50 +102,55 @@ function Endpoints(props) {
                                 {!showEndpoint(api, 'prod') && (
                                     <>
                                         <FormattedMessage
-                                            id='Apis.Details.NewOverview.Endpoints.production.not.set'
+                                            id='Apis.Details.NewOverview.Endpoints.not.set'
                                             defaultMessage='-'
                                         />
                                     </>
                                 )}
                             </Typography>
                         </Grid>
-                        <Grid item xs={12} md={6} lg={4}>
-                            {/* Sandbox Endpoint (TODO) fix the endpoint info when
-                                                it's available with the api object */}
-                            <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
-                                <FormattedMessage
-                                    id='Apis.Details.NewOverview.Endpoints.sandbox.endpoint'
-                                    defaultMessage='Sandbox Endpoint'
-                                />
-                            </Typography>
-                        </Grid>
-                        <Grid item xs={12} md={6} lg={8}>
-                            <Tooltip
-                                placement='top'
-                                classes={{
-                                    tooltip: parentClasses.htmlTooltip,
-                                }}
-                                title={
-                                    showEndpoint(api, 'sand')
-                                    && <>{showEndpoint(api, 'sand')}</>
-                                }
-                            >
-                                <Typography component='p' variant='body1' className={parentClasses.url}>
-                                    {showEndpoint(api, 'sand')
-                                    && <>{showEndpoint(api, 'sand')}</>}
+                        {!isPrototypedAvailable && (
+                            <Grid item xs={12} md={6} lg={4}>
+                                {/* Sandbox Endpoint (TODO) fix the endpoint info when
+                                                    it's available with the api object */}
+                                <Typography component='p' variant='subtitle2' className={parentClasses.subtitle}>
+                                    <FormattedMessage
+                                        id='Apis.Details.NewOverview.Endpoints.sandbox.endpoint'
+                                        defaultMessage='Sandbox Endpoint'
+                                    />
                                 </Typography>
-                            </Tooltip>
-                            <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
-                                {!showEndpoint(api, 'sand') && (
-                                    <>
-                                        <FormattedMessage
-                                            id='Apis.Details.NewOverview.Endpoints.sandbox.not.set'
-                                            defaultMessage='-'
-                                        />
-                                    </>
-                                )}
-                            </Typography>
-                        </Grid>
+                            </Grid>
+                        )}
+
+                        {!isPrototypedAvailable && (
+                            <Grid item xs={12} md={6} lg={8}>
+                                <Tooltip
+                                    placement='top'
+                                    classes={{
+                                        tooltip: parentClasses.htmlTooltip,
+                                    }}
+                                    title={
+                                        showEndpoint(api, 'sand')
+                                        && <>{showEndpoint(api, 'sand')}</>
+                                    }
+                                >
+                                    <Typography component='p' variant='body1' className={parentClasses.url}>
+                                        {showEndpoint(api, 'sand')
+                                        && <>{showEndpoint(api, 'sand')}</>}
+                                    </Typography>
+                                </Tooltip>
+                                <Typography component='p' variant='body1' className={parentClasses.notConfigured}>
+                                    {!showEndpoint(api, 'sand') && (
+                                        <>
+                                            <FormattedMessage
+                                                id='Apis.Details.NewOverview.Endpoints.sandbox.not.set'
+                                                defaultMessage='-'
+                                            />
+                                        </>
+                                    )}
+                                </Typography>
+                            </Grid>
+                        )}
                         <Grid item xs={12} md={6} lg={4}>
                             {/* Sandbox Endpoint (TODO) fix the endpoint info when
                                                 it's available with the api object */}
@@ -166,7 +182,7 @@ function Endpoints(props) {
             </>
         );
     }
-    return null ;
+
 }
 
 Endpoints.propTypes = {


### PR DESCRIPTION
Remove production and sandbox endpoints in Overview and Run-time Configurations  if API is prototyped.

![Screenshot from 2020-02-19 11-09-10](https://user-images.githubusercontent.com/60866295/74805502-41aeb080-5309-11ea-9ff1-c45e44716897.png)

Fixes https://github.com/wso2/product-apim/issues/6906