### PR TITLE
Fix issues in tenant theme upload

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/pom.xml
@@ -234,7 +234,7 @@
                             org.wso2.carbon.user.mgt.*;version="${carbon.identity.imp.pkg.version}",
                             org.osgi.framework.*;version="${imp.package.version.osgi.framework}",
                             org.osgi.service.*;version="${imp.package.version.osgi.service}",
-                            org.apache.commons.*,
+                            org.apache.commons.io.*,
                             *;resolution:=optional
                         </Import-Package>
                         <Embed-Dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/pom.xml
@@ -234,7 +234,7 @@
                             org.wso2.carbon.user.mgt.*;version="${carbon.identity.imp.pkg.version}",
                             org.osgi.framework.*;version="${imp.package.version.osgi.framework}",
                             org.osgi.service.*;version="${imp.package.version.osgi.service}",
-                            org.apache.commons.io.*,
+                            org.apache.commons.io.*;version="${import.package.version.commons.io}",
                             *;resolution:=optional
                         </Import-Package>
                         <Embed-Dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/pom.xml
@@ -125,10 +125,6 @@
             <artifactId>org.wso2.carbon.apimgt.keymgt.client</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-io.wso2</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.user.registration.stub</artifactId>
         </dependency>
@@ -238,6 +234,7 @@
                             org.wso2.carbon.user.mgt.*;version="${carbon.identity.imp.pkg.version}",
                             org.osgi.framework.*;version="${imp.package.version.osgi.framework}",
                             org.osgi.service.*;version="${imp.package.version.osgi.service}",
+                            org.apache.commons.*,
                             *;resolution:=optional
                         </Import-Package>
                         <Embed-Dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/TenantManagerHostObject.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.hostobjects/src/main/java/org/wso2/carbon/apimgt/hostobjects/TenantManagerHostObject.java
@@ -45,7 +45,7 @@ public class TenantManagerHostObject extends ScriptableObject {
 
     //using a set for file extensions white list since it will be faster to search
     private static final Set<String> EXTENTION_WHITELIST = new HashSet<String>(Arrays.asList(
-            new String[]{"css", "jpg", "png", "gif", "svg", "ttf", "html", "js", "json"}
+            new String[]{"css", "jpg", "png", "gif", "svg", "ttf", "html", "js", "json", "ico"}
     ));
 
     public static String getStoreTenantThemesPath() {

--- a/pom.xml
+++ b/pom.xml
@@ -994,6 +994,12 @@
                 <groupId>commons-io.wso2</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1847,6 +1847,7 @@
         <org.json.version.range>[3.0.0,4.0.0)</org.json.version.range>
         <pax.logging.api.version>1.11.2</pax.logging.api.version>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
+        <import.package.version.commons.io>[2.4.0,2.5.0)</import.package.version.commons.io>
 
         <com.amazonaws.version>1.11.253</com.amazonaws.version>
         <software.amazon.ion.version>1.0.2</software.amazon.ion.version>


### PR DESCRIPTION
This PR,
Fixes a classDefNotFound error for commons-io FilenameUtils while uploading tenant theme.
Whitelists .ico extension as we are supporting favicon uploads with tenant login themes feature.