### PR TITLE
Enable publishing capability when mutual SSL is selected as the only security scheme

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
@@ -186,7 +186,7 @@ function TransportLevel(props) {
                         </Typography>
                     </ExpansionPanelSummary>
                     <ExpansionPanelDetails className={classes.expansionPanelDetails}>
-                        <Transports api={api} configDispatcher={configDispatcher} />
+                        <Transports api={api} configDispatcher={configDispatcher} securityScheme={securityScheme} />
                         <FormControlLabel
                             control={(
                                 <Checkbox

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
@@ -30,6 +30,7 @@ import { FormattedMessage } from 'react-intl';
 import { makeStyles } from '@material-ui/core/styles';
 import { isRestricted } from 'AppData/AuthManager';
 import { useAPI } from 'AppComponents/Apis/Details/components/ApiContext';
+import { API_SECURITY_MUTUAL_SSL } from './APISecurity/components/apiSecurityConstants';
 
 const useStyles = makeStyles((theme) => ({
     error: {
@@ -44,15 +45,23 @@ const useStyles = makeStyles((theme) => ({
  * @returns
  */
 export default function Transports(props) {
-    const { api, configDispatcher } = props;
+    const { api, configDispatcher, securityScheme } = props;
     const [apiFromContext] = useAPI();
     const classes = useStyles();
+    const isMutualSSLEnabled = securityScheme.includes(API_SECURITY_MUTUAL_SSL);
     const Validate = () => {
         if (api.transport && api.transport.length === 0) {
             return (
                 <FormattedMessage
                     id='Apis.Details.Configuration.components.transport.empty'
                     defaultMessage='Please select at least one transport!'
+                />
+            );
+        } else if (isMutualSSLEnabled && !api.transport.includes('https')) {
+            return (
+                <FormattedMessage
+                    id='Apis.Details.Configuration.components.transport.sslHttps'
+                    defaultMessage='Please select Https as transport with mutual SSL!'
                 />
             );
         }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/CheckboxLabels.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/CheckboxLabels.jsx
@@ -71,10 +71,9 @@ const useStyles = makeStyles((theme) => ({
 export default function CheckboxLabels(props) {
     const classes = useStyles();
     const {
-        api, isMutualSSLEnabled, isCertAvailable, isAppLayerSecurityMandatory,
+        api, isMutualSSLEnabled, isCertAvailable, isAppLayerSecurityMandatory, isBusinessPlanAvailable,
     } = props;
     const isEndpointAvailable = api.endpointConfig !== null && !api.endpointConfig.implementation_status;
-    const isTierAvailable = api.policies.length !== 0;
     const isPrototypedAvailable = (api.endpointConfig !== null
         && api.endpointConfig.implementation_status === 'prototyped')
         || api.endpointImplementationType === 'INLINE';
@@ -126,7 +125,7 @@ export default function CheckboxLabels(props) {
                         <>
                             {isAppLayerSecurityMandatory && (
                                 <Grid xs={12} className={classes.grid}>
-                                    {isTierAvailable ? (
+                                    {isBusinessPlanAvailable ? (
                                         <CheckIcon className={classes.iconTrue} />
                                     ) : (
                                         <CloseIcon className={classes.iconFalse} />

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/CheckboxLabels.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/CheckboxLabels.jsx
@@ -121,7 +121,6 @@ export default function CheckboxLabels(props) {
                                 <LaunchIcon style={{ marginLeft: '2px' }} color='primary' fontSize='small' />
                             </Link>
                         </Grid>
-
                         <>
                             {isAppLayerSecurityMandatory && (
                                 <Grid xs={12} className={classes.grid}>
@@ -159,7 +158,6 @@ export default function CheckboxLabels(props) {
                                     </Link>
                                 </Grid>
                             ) }
-
                         </>
                     </Grid>
                     { api.type !== 'GRAPHQL' && (

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/CheckboxLabels.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/CheckboxLabels.jsx
@@ -70,7 +70,9 @@ const useStyles = makeStyles((theme) => ({
  */
 export default function CheckboxLabels(props) {
     const classes = useStyles();
-    const { api } = props;
+    const {
+        api, isMutualSSLEnabled, isCertAvailable, isAppLayerSecurityMandatory,
+    } = props;
     const isEndpointAvailable = api.endpointConfig !== null && !api.endpointConfig.implementation_status;
     const isTierAvailable = api.policies.length !== 0;
     const isPrototypedAvailable = (api.endpointConfig !== null
@@ -120,22 +122,46 @@ export default function CheckboxLabels(props) {
                                 <LaunchIcon style={{ marginLeft: '2px' }} color='primary' fontSize='small' />
                             </Link>
                         </Grid>
-                        <Grid xs={12} className={classes.grid}>
-                            {isTierAvailable ? (
-                                <CheckIcon className={classes.iconTrue} />
-                            ) : (
-                                <CloseIcon className={classes.iconFalse} />
+
+                        <>
+                            {isAppLayerSecurityMandatory && (
+                                <Grid xs={12} className={classes.grid}>
+                                    {isTierAvailable ? (
+                                        <CheckIcon className={classes.iconTrue} />
+                                    ) : (
+                                        <CloseIcon className={classes.iconFalse} />
+                                    )}
+                                    <Typography>
+                                        <FormattedMessage
+                                            id='Apis.Details.LifeCycle.CheckboxLabels.business.plans.selected'
+                                            defaultMessage='Business Plan(s) selected'
+                                        />
+                                    </Typography>
+                                    <Link to={'/apis/' + api.id + '/subscriptions'}>
+                                        <LaunchIcon style={{ marginLeft: '2px' }} color='primary' fontSize='small' />
+                                    </Link>
+                                </Grid>
                             )}
-                            <Typography>
-                                <FormattedMessage
-                                    id='Apis.Details.LifeCycle.CheckboxLabels.business.plans.selected'
-                                    defaultMessage='Business Plan(s) selected'
-                                />
-                            </Typography>
-                            <Link to={'/apis/' + api.id + '/subscriptions'}>
-                                <LaunchIcon style={{ marginLeft: '2px' }} color='primary' fontSize='small' />
-                            </Link>
-                        </Grid>
+                            {isMutualSSLEnabled && (
+                                <Grid xs={12} className={classes.grid}>
+                                    {isCertAvailable ? (
+                                        <CheckIcon className={classes.iconTrue} />
+                                    ) : (
+                                        <CloseIcon className={classes.iconFalse} />
+                                    )}
+                                    <Typography>
+                                        <FormattedMessage
+                                            id='Apis.Details.LifeCycle.CheckboxLabels.cert.provided'
+                                            defaultMessage='Certificate provided'
+                                        />
+                                    </Typography>
+                                    <Link to={'/apis/' + api.id + '/runtime-configuration'}>
+                                        <LaunchIcon style={{ marginLeft: '2px' }} color='primary' fontSize='small' />
+                                    </Link>
+                                </Grid>
+                            ) }
+
+                        </>
                     </Grid>
                     { api.type !== 'GRAPHQL' && (
                         <>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/LifeCycle.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/LifeCycle.jsx
@@ -30,7 +30,6 @@ import ApiContext from 'AppComponents/Apis/Details/components/ApiContext';
 import LifeCycleUpdate from './LifeCycleUpdate';
 import LifeCycleHistory from './LifeCycleHistory';
 
-
 const styles = (theme) => ({
     root: {
         flexGrow: 1,
@@ -86,7 +85,6 @@ class LifeCycle extends Component {
         this.setState({ checkList });
     };
 
-
     /**
      *
      *
@@ -95,13 +93,9 @@ class LifeCycle extends Component {
     updateData() {
         const { api: { id } } = this.props;
         const promisedAPI = Api.get(id);
-        // const promised_tiers = Api.policies('api');
         const promisedLcState = this.api.getLcState(id);
         const privateJetModeEnabled = false;
-
         const promisedLcHistory = this.api.getLcHistory(id);
-        // const promised_labels = this.api.labels();
-
         const promisedClientCerts = Api.getAllClientCertificates(id);
         Promise.all([promisedAPI, promisedLcState, promisedLcHistory, promisedClientCerts])
             .then((response) => {
@@ -138,7 +132,6 @@ class LifeCycle extends Component {
                     });
                     index++;
                 }
-
                 this.setState({
                     api,
                     lcState,
@@ -184,7 +177,6 @@ class LifeCycle extends Component {
                 </Grid>
             );
         }
-
         if (!lcState) {
             return <Progress />;
         }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/LifeCycle.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/LifeCycle.jsx
@@ -30,6 +30,7 @@ import ApiContext from 'AppComponents/Apis/Details/components/ApiContext';
 import LifeCycleUpdate from './LifeCycleUpdate';
 import LifeCycleHistory from './LifeCycleHistory';
 
+
 const styles = (theme) => ({
     root: {
         flexGrow: 1,
@@ -64,6 +65,7 @@ class LifeCycle extends Component {
         this.state = {
             lcHistory: null,
             checkList: [],
+            certList: [],
         };
         this.updateData = this.updateData.bind(this);
         this.handleChangeCheckList = this.handleChangeCheckList.bind(this);
@@ -84,6 +86,7 @@ class LifeCycle extends Component {
         this.setState({ checkList });
     };
 
+
     /**
      *
      *
@@ -98,11 +101,14 @@ class LifeCycle extends Component {
 
         const promisedLcHistory = this.api.getLcHistory(id);
         // const promised_labels = this.api.labels();
-        Promise.all([promisedAPI, promisedLcState, promisedLcHistory])
+
+        const promisedClientCerts = Api.getAllClientCertificates(id);
+        Promise.all([promisedAPI, promisedLcState, promisedLcHistory, promisedClientCerts])
             .then((response) => {
                 const api = response[0];
                 const lcState = response[1].body;
                 const lcHistory = response[2].body.list;
+                const clientCerts = response[3].body;
 
                 if (privateJetModeEnabled) {
                     if (!api.hasOwnGateway) {
@@ -132,12 +138,14 @@ class LifeCycle extends Component {
                     });
                     index++;
                 }
+
                 this.setState({
                     api,
                     lcState,
                     lcHistory,
                     privateJetModeEnabled,
                     checkList,
+                    certList: [...clientCerts.certificates],
                 });
             })
             .catch((error) => {
@@ -156,7 +164,7 @@ class LifeCycle extends Component {
     render() {
         const { classes } = this.props;
         const {
-            api, lcState, privateJetModeEnabled, checkList, lcHistory,
+            api, lcState, privateJetModeEnabled, checkList, lcHistory, certList,
         } = this.state;
         const apiFromContext = this.context.api;
         if (apiFromContext && isRestricted(['apim:api_publish'], apiFromContext)) {
@@ -195,6 +203,7 @@ class LifeCycle extends Component {
                                 handleChangeCheckList={this.handleChangeCheckList}
                                 api={api}
                                 privateJetModeEnabled={privateJetModeEnabled}
+                                certList={certList}
                             />
                         </Grid>
                         <Grid item xs={12}>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
@@ -194,7 +194,7 @@ class LifeCycleUpdate extends Component {
                     displayName,
                     disabled:
                         api.endpointConfig == null
-                        || api.policies.length === 0
+                        || (api.policies.length === 0 && !api.securityScheme.includes('mutualssl_mandatory'))
                         || api.endpointConfig.implementation_status === 'prototyped',
                 };
             }

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
@@ -154,7 +154,6 @@ class LifeCycleUpdate extends Component {
         this.updateLCStateOfAPI(apiUUID, action);
     }
 
-
     /**
      * @inheritdoc
      * @memberof LifeCycleUpdate

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
@@ -178,6 +178,8 @@ class LifeCycleUpdate extends Component {
         const isAppLayerSecurityMandatory = api.securityScheme.includes(
             API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY,
         );
+        const isCertAvailable = certList.length !== 0;
+        const isBusinessPlanAvailable = api.policies.length !== 0;
         const lifecycleButtons = lifecycleStates.map((item) => {
             const state = { ...item, displayName: item.event };
             if (state.event === 'Deploy as a Prototype') {
@@ -201,8 +203,8 @@ class LifeCycleUpdate extends Component {
                     displayName,
                     disabled:
                         api.endpointConfig === null
-                        || (isMutualSSLEnabled && certList.length === 0)
-                        || (isAppLayerSecurityMandatory && api.policies.length === 0)
+                        || (isMutualSSLEnabled && !isCertAvailable)
+                        || (isAppLayerSecurityMandatory && !isBusinessPlanAvailable)
                         || api.endpointConfig.implementation_status === 'prototyped',
                 };
             }
@@ -233,7 +235,8 @@ class LifeCycleUpdate extends Component {
                                             api={api}
                                             isMutualSSLEnabled={isMutualSSLEnabled}
                                             isAppLayerSecurityMandatory={isAppLayerSecurityMandatory}
-                                            isCertAvailable={certList.length !== 0}
+                                            isCertAvailable={isCertAvailable}
+                                            isBusinessPlanAvailable={isBusinessPlanAvailable}
                                         />
                                     </Grid>
                                 )}


### PR DESCRIPTION
In publisher portal, user can publish a created API which doesn't have any application layer security and only having mutual SSL as security scheme. 

Fixes https://github.com/wso2/product-apim/issues/7522
