### PR TITLE
Fix scope validation during Implicit grant flow 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/ScopesIssuer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/ScopesIssuer.java
@@ -41,19 +41,22 @@ public class ScopesIssuer {
      * Singleton of ScopeIssuer.*
      */
     private static ScopesIssuer scopesIssuer;
-    
+
     private ScopesIssuer() {
+
     }
 
     public static void loadInstance(List<String> whitelist) {
+
         scopesIssuer = new ScopesIssuer();
         if (whitelist != null && !whitelist.isEmpty()) {
             scopesIssuer.scopeSkipList.addAll(whitelist);
         }
         scopesIssuers = APIKeyMgtDataHolder.getScopesIssuers();
-    }  
+    }
 
     public static ScopesIssuer getInstance() {
+
         return scopesIssuer;
     }
 
@@ -77,7 +80,6 @@ public class ScopesIssuer {
 
         // if no issuers are defined
         if (scopesIssuers == null || scopesIssuers.isEmpty()) {
-
             if (log.isDebugEnabled()) {
                 log.debug("Scope Issuers are not loaded");
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/ScopesIssuer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/ScopesIssuer.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.keymgt.issuers.AbstractScopesIssuer;
 import org.wso2.carbon.apimgt.keymgt.util.APIKeyMgtDataHolder;
+import org.wso2.carbon.identity.oauth.callback.OAuthCallback;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 
 import java.util.*;
@@ -33,7 +34,7 @@ import java.util.*;
 public class ScopesIssuer {
 
     private static Log log = LogFactory.getLog(ScopesIssuer.class);
-    private List<String> scopeSkipList = new ArrayList<String>();
+    private List<String> scopeSkipList = new ArrayList<>();
     private static Map<String, AbstractScopesIssuer> scopesIssuers;
     private static final String DEFAULT_SCOPE_NAME = "default";
     /**
@@ -56,8 +57,73 @@ public class ScopesIssuer {
         return scopesIssuer;
     }
 
+    /**
+     * This method is used to validate the scopes in OAuthCallback and set the authorized scopes back to the
+     * callback object.
+     *
+     * @param scopeValidationCallback OAuthCallback
+     * @return true if the requested scopes are authorized, false if no scopes requested or scopes issuers are empty.
+     */
+    public boolean setScopes(OAuthCallback scopeValidationCallback) {
+
+        List<String> authorizedScopes;
+        List<String> sortedScopes;
+        Map<String, List<String>> scopeSets;
+        boolean isAllAuthorized = false;
+        Set<String> authorizedAllScopes = new HashSet<>();
+
+        String[] requestedScopes = scopeValidationCallback.getRequestedScope();
+        String[] defaultScope = new String[]{DEFAULT_SCOPE_NAME};
+
+        // if no issuers are defined
+        if (scopesIssuers == null || scopesIssuers.isEmpty()) {
+
+            if (log.isDebugEnabled()) {
+                log.debug("Scope Issuers are not loaded");
+            }
+            scopeValidationCallback.setApprovedScope(defaultScope);
+            return true;
+        }
+
+        //If no scopes were requested.
+        if (requestedScopes == null || requestedScopes.length == 0) {
+            scopeValidationCallback.setApprovedScope(defaultScope);
+            return true;
+        }
+
+        scopeSets = initializeScopeSets(requestedScopes);
+        for (Map.Entry<String, List<String>> entry : scopeSets.entrySet()) {
+            sortedScopes = entry.getValue();
+            if (!sortedScopes.isEmpty()) {
+                scopeValidationCallback.setRequestedScope(sortedScopes.toArray(new String[sortedScopes.size()]));
+                authorizedScopes = scopesIssuers.get(entry.getKey()).getScopes(scopeValidationCallback, scopeSkipList);
+                authorizedAllScopes.addAll(authorizedScopes);
+                isAllAuthorized = true;
+            }
+        }
+
+        if (isAllAuthorized) {
+            scopeValidationCallback
+                    .setApprovedScope(authorizedAllScopes.toArray(new String[authorizedAllScopes.size()]));
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * This method is used to validate the scopes in OAuthToken Request and set the authorized scopes back to the
+     * context.
+     *
+     * @param tokReqMsgCtx OAuthTokenReqMessageContext
+     * @return true if the requested scopes are authorized, false if no scopes requested or scopes issuers are empty.
+     */
     public boolean setScopes(OAuthTokenReqMessageContext tokReqMsgCtx) {
 
+        Map<String, List<String>> scopeSets;
+        List<String> authorizedScopes;
+        List<String> sortedScopes;
+        Set<String> authorizedAllScopes = new HashSet<>();
+        boolean isAllAuthorized = false;
         String[] requestedScopes = tokReqMsgCtx.getScope();
         String[] defaultScope = new String[]{DEFAULT_SCOPE_NAME};
 
@@ -77,13 +143,37 @@ public class ScopesIssuer {
             return true;
         }
 
-        Map<String, List<String>> scopeSets = new HashMap<String, List<String>>();
+        scopeSets = initializeScopeSets(requestedScopes);
+        for (Map.Entry<String, List<String>> entry : scopeSets.entrySet()) {
+            sortedScopes = entry.getValue();
+            if (!sortedScopes.isEmpty()) {
+                tokReqMsgCtx.setScope(sortedScopes.toArray(new String[sortedScopes.size()]));
+                authorizedScopes = scopesIssuers.get(entry.getKey()).getScopes(tokReqMsgCtx, scopeSkipList);
+                authorizedAllScopes.addAll(authorizedScopes);
+                isAllAuthorized = true;
+            }
+        }
 
+        if (isAllAuthorized) {
+            tokReqMsgCtx.setScope(authorizedAllScopes.toArray(new String[authorizedAllScopes.size()]));
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Initialize scope sets for the requested scopes with respect to scope issuer prefix
+     *
+     * @param requestedScopes requested scopes
+     * @return initialized scope sets
+     */
+    private Map<String, List<String>> initializeScopeSets(String[] requestedScopes) {
+
+        Map<String, List<String>> scopeSets = new HashMap<>();
         // initializing scope sets with respect to prefixes
         for (String prefix : scopesIssuers.keySet()) {
             scopeSets.put(prefix, new ArrayList<String>());
         }
-
         for (String scope : requestedScopes) {
             boolean scopeAssigned = false;
             for (String prefix : scopesIssuers.keySet()) {
@@ -97,26 +187,7 @@ public class ScopesIssuer {
                 scopeSets.get(DEFAULT_SCOPE_NAME).add(scope);
             }
         }
-
-        Set<String> authorizedAllScopes = new HashSet<String>();
-        List<String> authorizedScopes;
-        List<String> sortedScopes;
-        boolean isAllAuthorized = false;
-        for (String prefix : scopeSets.keySet()) {
-            sortedScopes = scopeSets.get(prefix);
-            if (sortedScopes.size() > 0) {
-                tokReqMsgCtx.setScope(sortedScopes.toArray(new String[sortedScopes.size()]));
-                authorizedScopes = scopesIssuers.get(prefix).getScopes(tokReqMsgCtx, scopeSkipList);
-                authorizedAllScopes.addAll(authorizedScopes);
-                isAllAuthorized = true;
-            }
-        }
-
-        if (isAllAuthorized) {
-            tokReqMsgCtx.setScope(authorizedAllScopes.toArray(new String[authorizedAllScopes.size()]));
-            return true;
-        }
-        return false;
+        return scopeSets;
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/issuers/RoleBasedScopesIssuer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/issuers/RoleBasedScopesIssuer.java
@@ -22,14 +22,12 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opensaml.saml.saml2.core.Assertion;
-import org.wso2.carbon.apimgt.api.APIManagementException;
-import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
-import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.keymgt.handlers.ResourceConstants;
 import org.wso2.carbon.apimgt.keymgt.util.APIKeyMgtUtil;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.oauth.callback.OAuthCallback;
 import org.wso2.carbon.identity.oauth.common.GrantType;
 import org.wso2.carbon.identity.oauth2.grant.jwt.JWTConstants;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
@@ -62,145 +60,183 @@ public class RoleBasedScopesIssuer extends AbstractScopesIssuer {
         return ISSUER_PREFIX;
     }
 
+    /**
+     * This method is used to retrieve authorized scopes with respect to an authorization callback.
+     *
+     * @param scopeValidationCallback Authorization callback to validate scopes
+     * @param whiteListedScopes       scopes to be white listed
+     * @return authorized scopes list
+     */
     @Override
-    public List<String> getScopes(OAuthTokenReqMessageContext tokReqMsgCtx, List<String> whiteListedScopes) {
-        String[] requestedScopes = tokReqMsgCtx.getScope();
-        List<String> defaultScope = new ArrayList<String>();
-        defaultScope.add(DEFAULT_SCOPE_NAME);
+    public List<String> getScopes(OAuthCallback scopeValidationCallback, List<String> whiteListedScopes) {
 
-        String consumerKey = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
-        String username = tokReqMsgCtx.getAuthorizedUser().getUserName();
-        String endUsernameWithDomain = addDomainToName(username, tokReqMsgCtx.getAuthorizedUser().getUserStoreDomain());
-        List<String> reqScopeList = Arrays.asList(requestedScopes);
-        Map<String, String> restAPIScopesOfCurrentTenant;
+        List<String> authorizedScopes = null;
+        String[] requestedScopes = scopeValidationCallback.getRequestedScope();
+        String clientId = scopeValidationCallback.getClient();
+        AuthenticatedUser authenticatedUser = scopeValidationCallback.getResourceOwner();
 
-        try {
-            Map<String, String> appScopes;
-            ApiMgtDAO apiMgtDAO = getApiMgtDAOInstance();
-            //Get all the scopes and roles against the scopes defined for the APIs subscribed to the application.
-            appScopes = apiMgtDAO.getScopeRolesOfApplication(consumerKey);
-            //Add API Manager rest API scopes set. This list should be loaded at server start up and keep
-            //in memory and add it to each and every request coming.
-            String tenantDomain = tokReqMsgCtx.getAuthorizedUser().getTenantDomain();
-            appScopes.putAll(APIUtil.getRESTAPIScopesForTenant(tenantDomain));
-
+        Map<String, String> appScopes = getAppScopes(clientId, authenticatedUser);
+        if (appScopes != null) {
             //If no scopes can be found in the context of the application
-            if (appScopes.isEmpty()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("No scopes defined for the Application " +
-                            tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId());
-                }
-
-                List<String> allowedScopes = getAllowedScopes(whiteListedScopes, reqScopeList);
-                return allowedScopes;
+            if (isAppScopesEmpty(appScopes, clientId)) {
+                return getAllowedScopes(whiteListedScopes, Arrays.asList(requestedScopes));
             }
-
-            int tenantId;
-            RealmService realmService = getRealmService();
-            UserStoreManager userStoreManager;
-            String[] userRoles;
-
-            try {
-                tenantId = realmService.getTenantManager().
-                        getTenantId(tenantDomain);
-
-                // If tenant Id is not set in the tokenReqContext, deriving it from username.
-                if (tenantId == 0 || tenantId == -1) {
-                    tenantId = getTenantIdOfUser(username);
-                }
-
-                String grantType = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType();
-                userStoreManager = realmService.getTenantUserRealm(tenantId).getUserStoreManager();
-
-                // If GrantType is SAML20_BEARER and CHECK_ROLES_FROM_SAML_ASSERTION is true,
-                // use user roles from assertion or from JWT otherwise use roles from userstore.
-                String isSAML2Enabled = System.getProperty(ResourceConstants.CHECK_ROLES_FROM_SAML_ASSERTION);
-                String isRetrieveRolesFromUserStoreForScopeValidation = System
-                        .getProperty(ResourceConstants.RETRIEVE_ROLES_FROM_USERSTORE_FOR_SCOPE_VALIDATION);
-                if (GrantType.SAML20_BEARER.toString().equals(grantType) && Boolean.parseBoolean(isSAML2Enabled)) {
-                    Assertion assertion = (Assertion) tokReqMsgCtx.getProperty(ResourceConstants.SAML2_ASSERTION);
-                    userRoles = getRolesFromAssertion(assertion);
-                } else if (JWTConstants.OAUTH_JWT_BEARER_GRANT_TYPE.equals(grantType) && !(Boolean
-                        .parseBoolean(isRetrieveRolesFromUserStoreForScopeValidation))) {
-                    AuthenticatedUser user = tokReqMsgCtx.getAuthorizedUser();
-                    Map<ClaimMapping, String> userAttributes = user.getUserAttributes();
-                    userRoles = getRolesFromUserAttribute(userAttributes,
-                            tokReqMsgCtx.getProperty(ResourceConstants.ROLE_CLAIM).toString());
-                } else {
-                    userRoles = userStoreManager.getRoleListOfUser(endUsernameWithDomain);
-                }
-
-            } catch (UserStoreException e) {
-                //Log and return since we do not want to stop issuing the token in case of scope validation failures.
-                log.error("Error when getting the tenant's UserStoreManager or when getting roles of user ", e);
-                return null;
-            }
-
-            if (userRoles == null || userRoles.length == 0) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Could not find roles of the user.");
-                }
-                return defaultScope;
-            }
-
-            List<String> authorizedScopes = new ArrayList<String>();
-            String preservedCaseSensitiveValue = System.getProperty(PRESERVED_CASE_SENSITIVE_VARIABLE);
-            boolean preservedCaseSensitive = JavaUtils.isTrueExplicitly(preservedCaseSensitiveValue);
-            List<String> userRoleList;
-            if (preservedCaseSensitive) {
-                userRoleList = Arrays.asList(userRoles);
-            } else {
-                userRoleList = new ArrayList<String>();
-                for (String aRole : userRoles) {
-                    userRoleList.add(aRole.toLowerCase());
-                }
-            }
-
-            //Iterate the requested scopes list.
-            for (String scope : requestedScopes) {
-                //Get the set of roles associated with the requested scope.
-                String roles = appScopes.get(scope);
-                //If the scope has been defined in the context of the App and if roles have been defined for the scope
-                if (roles != null && roles.length() != 0) {
-                    List<String> roleList = new ArrayList<String>();
-                    for (String aRole : roles.split(",")) {
-                        if (preservedCaseSensitive) {
-                            roleList.add(aRole.trim());
-                        } else {
-                            roleList.add(aRole.trim().toLowerCase());
-                        }
-                    }
-                    //Check if user has at least one of the roles associated with the scope
-                    roleList.retainAll(userRoleList);
-                    if (!roleList.isEmpty()) {
-                        authorizedScopes.add(scope);
-                    }
-                }
-                // The requested scope is defined for the context of the App but no roles have been associated with the
-                // scope
-                // OR
-                // The scope string starts with 'device_'.
-                else if (appScopes.containsKey(scope) || isWhiteListedScope(whiteListedScopes, scope)) {
-                    authorizedScopes.add(scope);
-                }
-            }
-            if (!authorizedScopes.isEmpty()) {
-                return authorizedScopes;
-            } else {
-                return defaultScope;
-            }
-        } catch (APIManagementException e) {
-            log.error("Error while getting scopes of application " + e.getMessage(), e);
-            return null;
+            String[] userRoles = getUserRoles(authenticatedUser);
+            authorizedScopes = getAuthorizedScopes(userRoles, requestedScopes, appScopes, whiteListedScopes);
         }
+        return authorizedScopes;
     }
 
     /**
-     * extract the roles from the user attributes
+     * This method is used to retrieve the authorized scopes with respect to a token.
+     *
+     * @param tokReqMsgCtx      token message context
+     * @param whiteListedScopes scopes to be white listed
+     * @return authorized scopes list
+     */
+    @Override
+    public List<String> getScopes(OAuthTokenReqMessageContext tokReqMsgCtx, List<String> whiteListedScopes) {
+
+        List<String> authorizedScopes = null;
+        String[] requestedScopes = tokReqMsgCtx.getScope();
+        String clientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
+        AuthenticatedUser authenticatedUser = tokReqMsgCtx.getAuthorizedUser();
+
+        Map<String, String> appScopes = getAppScopes(clientId, authenticatedUser);
+        if (appScopes != null) {
+            //If no scopes can be found in the context of the application
+            if (isAppScopesEmpty(appScopes, clientId)) {
+                return getAllowedScopes(whiteListedScopes, Arrays.asList(requestedScopes));
+            }
+
+            String grantType = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType();
+            String[] userRoles;
+
+            // If GrantType is SAML20_BEARER and CHECK_ROLES_FROM_SAML_ASSERTION is true, or if GrantType is
+            // JWT_BEARER and retrieveRolesFromUserStoreForScopeValidation system property is true,
+            // use user roles from assertion or jwt otherwise use roles from userstore.
+            String isSAML2Enabled = System.getProperty(ResourceConstants.CHECK_ROLES_FROM_SAML_ASSERTION);
+            String isRetrieveRolesFromUserStoreForScopeValidation = System
+                    .getProperty(ResourceConstants.RETRIEVE_ROLES_FROM_USERSTORE_FOR_SCOPE_VALIDATION);
+            if (GrantType.SAML20_BEARER.toString().equals(grantType) && Boolean.parseBoolean(isSAML2Enabled)) {
+                Assertion assertion = (Assertion) tokReqMsgCtx.getProperty(ResourceConstants.SAML2_ASSERTION);
+                userRoles = getRolesFromAssertion(assertion);
+            } else if (JWTConstants.OAUTH_JWT_BEARER_GRANT_TYPE.equals(grantType) && !(Boolean
+                    .parseBoolean(isRetrieveRolesFromUserStoreForScopeValidation))) {
+                AuthenticatedUser user = tokReqMsgCtx.getAuthorizedUser();
+                Map<ClaimMapping, String> userAttributes = user.getUserAttributes();
+                userRoles = getRolesFromUserAttribute(userAttributes,
+                        tokReqMsgCtx.getProperty(ResourceConstants.ROLE_CLAIM).toString());
+            } else {
+                userRoles = getUserRoles(authenticatedUser);
+            }
+            authorizedScopes = getAuthorizedScopes(userRoles, requestedScopes, appScopes, whiteListedScopes);
+        }
+        return authorizedScopes;
+    }
+
+    /**
+     * This method is used to get roles list of the user.
+     *
+     * @param authenticatedUser Authenticated user
+     * @return roles list
+     */
+    private String[] getUserRoles(AuthenticatedUser authenticatedUser) {
+
+        String[] userRoles = null;
+        String tenantDomain = authenticatedUser.getTenantDomain();
+        String username = authenticatedUser.getUserName();
+        String userStoreDomain = authenticatedUser.getUserStoreDomain();
+        RealmService realmService = getRealmService();
+        try {
+            int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
+            // If tenant Id is not set in the tokenReqContext, deriving it from username.
+            if (tenantId == 0 || tenantId == -1) {
+                tenantId = getTenantIdOfUser(username);
+            }
+            UserStoreManager userStoreManager = realmService.getTenantUserRealm(tenantId).getUserStoreManager();
+            String endUsernameWithDomain = addDomainToName(username, userStoreDomain);
+            userRoles = userStoreManager.getRoleListOfUser(endUsernameWithDomain);
+
+        } catch (UserStoreException e) {
+            //Log and return since we do not want to stop issuing the token in case of scope validation failures.
+            log.error("Error when getting the tenant's UserStoreManager or when getting roles of user ", e);
+        }
+        return userRoles;
+    }
+
+    /**
+     * This method is used to get authorized scopes for user from the requested scopes based on roles.
+     *
+     * @param userRoles         Roles list of user
+     * @param requestedScopes   Requested scopes
+     * @param appScopes         Scopes of the Application
+     * @param whiteListedScopes Scopes to be whitelisted
+     * @return authorized scopes list
+     */
+    private List<String> getAuthorizedScopes(String[] userRoles, String[] requestedScopes,
+                                             Map<String, String> appScopes, List<String> whiteListedScopes) {
+
+        List<String> defaultScope = new ArrayList<>();
+        defaultScope.add(DEFAULT_SCOPE_NAME);
+
+        if (userRoles == null || userRoles.length == 0) {
+            if (log.isDebugEnabled()) {
+                log.debug("Could not find roles of the user.");
+            }
+            return defaultScope;
+        }
+
+        List<String> authorizedScopes = new ArrayList<>();
+        String preservedCaseSensitiveValue = System.getProperty(PRESERVED_CASE_SENSITIVE_VARIABLE);
+        boolean preservedCaseSensitive = JavaUtils.isTrueExplicitly(preservedCaseSensitiveValue);
+        List<String> userRoleList;
+        if (preservedCaseSensitive) {
+            userRoleList = Arrays.asList(userRoles);
+        } else {
+            userRoleList = new ArrayList<>();
+            for (String aRole : userRoles) {
+                userRoleList.add(aRole.toLowerCase());
+            }
+        }
+
+        //Iterate the requested scopes list.
+        for (String scope : requestedScopes) {
+            //Get the set of roles associated with the requested scope.
+            String roles = appScopes.get(scope);
+            //If the scope has been defined in the context of the App and if roles have been defined for the scope
+            if (roles != null && roles.length() != 0) {
+                List<String> roleList = new ArrayList<>();
+                for (String aRole : roles.split(",")) {
+                    if (preservedCaseSensitive) {
+                        roleList.add(aRole.trim());
+                    } else {
+                        roleList.add(aRole.trim().toLowerCase());
+                    }
+                }
+                //Check if user has at least one of the roles associated with the scope
+                roleList.retainAll(userRoleList);
+                if (!roleList.isEmpty()) {
+                    authorizedScopes.add(scope);
+                }
+            }
+            //The requested scope is defined for the context of the App but no roles have been associated with the
+            //scope OR the scope string starts with 'device_'
+            else if (appScopes.containsKey(scope) || isWhiteListedScope(whiteListedScopes, scope)) {
+                authorizedScopes.add(scope);
+            }
+        }
+        return (!authorizedScopes.isEmpty()) ? authorizedScopes : defaultScope;
+    }
+
+    /**
+     * Extract the roles from the user attributes.
+     *
      * @param userAttributes retrieved from the token
      * @return roles
      */
     private String[] getRolesFromUserAttribute(Map<ClaimMapping, String> userAttributes, String roleClaim) {
+
         for (Iterator<Map.Entry<ClaimMapping, String>> iterator = userAttributes.entrySet().iterator(); iterator
                 .hasNext(); ) {
             Map.Entry<ClaimMapping, String> entry = iterator.next();

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/util/APIManagerOAuthCallbackHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/util/APIManagerOAuthCallbackHandler.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.keymgt.ScopesIssuer;
 import org.wso2.carbon.identity.oauth.callback.AbstractOAuthCallbackHandler;
 import org.wso2.carbon.identity.oauth.callback.OAuthCallback;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
@@ -50,14 +51,8 @@ public class APIManagerOAuthCallbackHandler extends AbstractOAuthCallbackHandler
             }
             if (OAuthCallback.OAuthCallbackType.SCOPE_VALIDATION_AUTHZ.equals(
                     oauthCallback.getCallbackType())){
-                String[] scopes = oauthCallback.getRequestedScope();
-                //If no scopes have been requested.
-                if(scopes == null || scopes.length == 0){
-                    //Issue a default scope. The default scope can only be used to access resources which are
-                    // not associated to a scope
-                    scopes = new String[]{APIConstants.OAUTH2_DEFAULT_SCOPE};
-                }
-                oauthCallback.setApprovedScope(scopes);
+                //Validate scopes in callback using scope issuers
+                ScopesIssuer.getInstance().setScopes(oauthCallback);
                 oauthCallback.setValidScope(true);
             }
             if (OAuthCallback.OAuthCallbackType.SCOPE_VALIDATION_TOKEN.equals(

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/issuers/PermissionBasedScopeIssuerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/issuers/PermissionBasedScopeIssuerTestCase.java
@@ -144,9 +144,14 @@ public class PermissionBasedScopeIssuerTestCase {
         PermissionBasedScopeIssuer permissionBasedScopeIssuer =
                 new PermissionBasedScopesIssuerWrapper(cacheManager, realmService, apiMgtDAO);
 
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setTenantDomain("carbon.super");
+        authenticatedUser.setUserName("admin");
+        authenticatedUser.setUserStoreDomain("admin.user.store.domain");
         OAuth2AccessTokenReqDTO tokenDTO = new OAuth2AccessTokenReqDTO();
         tokenDTO.setClientId("clientId");
         OAuthTokenReqMessageContext msgContext = new OAuthTokenReqMessageContext(tokenDTO);
+        msgContext.setAuthorizedUser(authenticatedUser);
         msgContext.setScope(new String[]{"scope 1", "scope 2"});
         ArrayList<String> whiteListedScopes = new ArrayList<String>();
         whiteListedScopes.add("scope 3");

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/issuers/RoleBasedScopesIssuerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/issuers/RoleBasedScopesIssuerTestCase.java
@@ -128,6 +128,9 @@ public class RoleBasedScopesIssuerTestCase {
         authenticatedUser.setUserStoreDomain("admin.user.store.domain");
         tokReqMsgCtx.setAuthorizedUser(authenticatedUser);
 
+        ApiMgtDAO apiMgtDAO = Mockito.mock(ApiMgtDAO.class);
+        Map<String, String> appScopes = new HashMap<String, String>();
+        Mockito.when(apiMgtDAO.getScopeRolesOfApplication("clientId")).thenReturn(appScopes);
         RoleBasedScopesIssuer roleBasedScopesIssuer = new RoleBasedScopesIssuerWrapper(cacheManager, realmService
                 , apiMgtDAO);
         ArrayList<String> whiteListedScopes = new ArrayList<String>();
@@ -387,7 +390,9 @@ public class RoleBasedScopesIssuerTestCase {
         whiteListedScopes.add("scope 3");
         whiteListedScopes.add("scope 4");
 
-        Assert.assertNull(roleBasedScopesIssuer.getScopes(tokReqMsgCtx, whiteListedScopes));
+        List<String> defaultScopes = roleBasedScopesIssuer.getScopes(tokReqMsgCtx, whiteListedScopes);
+        Assert.assertEquals(1, defaultScopes.size());
+        Assert.assertEquals("default", defaultScopes.get(0));
     }
 
     @Test

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/util/APIManagerOAuthCallbackHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/util/APIManagerOAuthCallbackHandlerTestCase.java
@@ -20,13 +20,30 @@ package org.wso2.carbon.apimgt.keymgt.util;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.keymgt.ScopesIssuer;
+import org.wso2.carbon.apimgt.keymgt.issuers.AbstractScopesIssuer;
+import org.wso2.carbon.apimgt.keymgt.issuers.RoleBasedScopesIssuer;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.oauth.callback.OAuthCallback;
 
 import javax.security.auth.callback.Callback;
-import java.util.Arrays;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest( {APIKeyMgtDataHolder.class})
 public class APIManagerOAuthCallbackHandlerTestCase {
 
     @Test
@@ -66,6 +83,12 @@ public class APIManagerOAuthCallbackHandlerTestCase {
                 OAuthCallbackType.SCOPE_VALIDATION_AUTHZ);
         Callback[] callbacks = {oAuthCallback};
         APIManagerOAuthCallbackHandler handler = new APIManagerOAuthCallbackHandler();
+        PowerMockito.mockStatic(APIKeyMgtDataHolder.class);
+        AbstractScopesIssuer mockIssuer = Mockito.mock(AbstractScopesIssuer.class);
+        Map<String, AbstractScopesIssuer> scopesIssuerMap = new HashMap<String, AbstractScopesIssuer>();
+        scopesIssuerMap.put("wso2", mockIssuer);
+        BDDMockito.given(APIKeyMgtDataHolder.getScopesIssuers()).willReturn(scopesIssuerMap);
+        ScopesIssuer.loadInstance(Collections.<String>emptyList());
         handler.handle(callbacks);
 
         String[] scopes = oAuthCallback.getApprovedScope();
@@ -79,10 +102,18 @@ public class APIManagerOAuthCallbackHandlerTestCase {
 
         OAuthCallback oAuthCallback = new OAuthCallback(new AuthenticatedUser(), "client", OAuthCallback.
                 OAuthCallbackType.SCOPE_VALIDATION_AUTHZ);
-        String[] scopesList = {"default", "test"};
-        oAuthCallback.setRequestedScope(scopesList);
+        String[] scopesList = {"wso2:default", "wso2:test"};
+        List<String> authorizedScopes = Arrays.asList(scopesList);
+        List<String> whiteListScopes = new ArrayList<>();        oAuthCallback.setRequestedScope(scopesList);
         Callback[] callbacks = {oAuthCallback};
         APIManagerOAuthCallbackHandler handler = new APIManagerOAuthCallbackHandler();
+        PowerMockito.mockStatic(APIKeyMgtDataHolder.class);
+        RoleBasedScopesIssuer mockIssuer = Mockito.mock(RoleBasedScopesIssuer.class);
+        Map<String, AbstractScopesIssuer> scopesIssuerMap = new HashMap<String, AbstractScopesIssuer>();
+        scopesIssuerMap.put("wso2", mockIssuer);
+        BDDMockito.given(APIKeyMgtDataHolder.getScopesIssuers()).willReturn(scopesIssuerMap);
+        ScopesIssuer.loadInstance(whiteListScopes);
+        Mockito.when(mockIssuer.getScopes(oAuthCallback,whiteListScopes)).thenReturn(authorizedScopes);
         handler.handle(callbacks);
 
         String[] scopes = oAuthCallback.getApprovedScope();
@@ -136,8 +167,14 @@ public class APIManagerOAuthCallbackHandlerTestCase {
         oAuthCallback.setRequestedScope(scopesList);
         Callback[] callbacks = {oAuthCallback};
         APIManagerOAuthCallbackHandler handler = new APIManagerOAuthCallbackHandler();
-        handler.handle(callbacks);
+        PowerMockito.mockStatic(APIKeyMgtDataHolder.class);
+        AbstractScopesIssuer mockIssuer = Mockito.mock(AbstractScopesIssuer.class);
+        Map<String, AbstractScopesIssuer> scopesIssuerMap = new HashMap<String, AbstractScopesIssuer>();
+        scopesIssuerMap.put("wso2", mockIssuer);
+        BDDMockito.given(APIKeyMgtDataHolder.getScopesIssuers()).willReturn(scopesIssuerMap);
+        ScopesIssuer.loadInstance(Collections.<String>emptyList());
 
+        handler.handle(callbacks);
         String[] scopes = oAuthCallback.getApprovedScope();
         Assert.assertEquals(1, scopes.length);
         Assert.assertEquals(APIConstants.OAUTH2_DEFAULT_SCOPE, scopes[0]);


### PR DESCRIPTION
As of now, we only validate scopes in the grant handler when issuing tokens, we do not perform scope validation in the authcallback during /authorize flow. This PR fixes https://github.com/wso2/product-apim/issues/7331