### PR TITLE
Adding the capability to extend the scope issuer

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/ScopesIssuer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/ScopesIssuer.java
@@ -51,10 +51,10 @@ public class ScopesIssuer {
     }
 
     public static void loadInstance(List<String> whitelist) throws APIKeyMgtException{
-        APIManagerConfiguration configParser = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+        APIManagerConfiguration apiManagerConfiguration = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                 .getAPIManagerConfiguration();
-        if (configParser != null) {
-            String scopeIssuerClass = configParser.getFirstProperty(CONFIG_ELEM_SCOPE_ISSUER);
+        if (apiManagerConfiguration != null) {
+            String scopeIssuerClass = apiManagerConfiguration.getFirstProperty(CONFIG_ELEM_SCOPE_ISSUER);
             if (scopeIssuerClass != null) {
                 try {
                     scopesIssuer = (ScopesIssuer) APIUtil.getClassForName(scopeIssuerClass).newInstance();

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/ScopesIssuer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/ScopesIssuer.java
@@ -46,7 +46,7 @@ public class ScopesIssuer {
      */
     private static ScopesIssuer scopesIssuer;
 
-    private ScopesIssuer() {
+    public ScopesIssuer() {
 
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/ScopesIssuerTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/ScopesIssuerTest.java
@@ -7,6 +7,8 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.keymgt.issuers.AbstractScopesIssuer;
 import org.wso2.carbon.apimgt.keymgt.util.APIKeyMgtDataHolder;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
@@ -17,7 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest( {APIKeyMgtDataHolder.class})
+@PrepareForTest( {APIKeyMgtDataHolder.class, ServiceReferenceHolder.class})
 public class ScopesIssuerTest {
     @Test
     public void setScopes() throws Exception {
@@ -26,6 +28,14 @@ public class ScopesIssuerTest {
         Map<String, AbstractScopesIssuer> scopesIssuerMap = new HashMap<String, AbstractScopesIssuer>();
         scopesIssuerMap.put("wso2", mockIssuer);
         BDDMockito.given(APIKeyMgtDataHolder.getScopesIssuers()).willReturn(scopesIssuerMap);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfigurationService apiManagerConfigurationService = Mockito
+                .mock(APIManagerConfigurationService.class);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService())
+                .thenReturn(apiManagerConfigurationService);
+        Mockito.when(apiManagerConfigurationService.getAPIManagerConfiguration()).thenReturn(null);
         ScopesIssuer.loadInstance(Collections.<String>emptyList());
         ScopesIssuer scopesIssuer = ScopesIssuer.getInstance();
         OAuthTokenReqMessageContext tokReqMsgCtx = new OAuthTokenReqMessageContext(new OAuth2AccessTokenReqDTO());
@@ -39,6 +49,14 @@ public class ScopesIssuerTest {
         Map<String, AbstractScopesIssuer> scopesIssuerMap = new HashMap<String, AbstractScopesIssuer>();
         scopesIssuerMap.put("wso2", mockIssuer);
         BDDMockito.given(APIKeyMgtDataHolder.getScopesIssuers()).willReturn(scopesIssuerMap);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfigurationService apiManagerConfigurationService = Mockito
+                .mock(APIManagerConfigurationService.class);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService())
+                .thenReturn(apiManagerConfigurationService);
+        Mockito.when(apiManagerConfigurationService.getAPIManagerConfiguration()).thenReturn(null);
         ScopesIssuer.loadInstance(Collections.<String>emptyList());
         ScopesIssuer scopesIssuer = ScopesIssuer.getInstance();
         OAuthTokenReqMessageContext tokReqMsgCtx = new OAuthTokenReqMessageContext(new OAuth2AccessTokenReqDTO());
@@ -49,6 +67,14 @@ public class ScopesIssuerTest {
         PowerMockito.mockStatic(APIKeyMgtDataHolder.class);
         Map<String, AbstractScopesIssuer> scopesIssuerMap = new HashMap<String, AbstractScopesIssuer>();
         BDDMockito.given(APIKeyMgtDataHolder.getScopesIssuers()).willReturn(scopesIssuerMap);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfigurationService apiManagerConfigurationService = Mockito
+                .mock(APIManagerConfigurationService.class);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService())
+                .thenReturn(apiManagerConfigurationService);
+        Mockito.when(apiManagerConfigurationService.getAPIManagerConfiguration()).thenReturn(null);
         ScopesIssuer.loadInstance(Collections.<String>emptyList());
         ScopesIssuer scopesIssuer = ScopesIssuer.getInstance();
         OAuthTokenReqMessageContext tokReqMsgCtx = new OAuthTokenReqMessageContext(new OAuth2AccessTokenReqDTO());
@@ -61,6 +87,14 @@ public class ScopesIssuerTest {
         Map<String, AbstractScopesIssuer> scopesIssuerMap = new HashMap<String, AbstractScopesIssuer>();
         scopesIssuerMap.put("default", mockIssuer);
         BDDMockito.given(APIKeyMgtDataHolder.getScopesIssuers()).willReturn(scopesIssuerMap);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfigurationService apiManagerConfigurationService = Mockito
+                .mock(APIManagerConfigurationService.class);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService())
+                .thenReturn(apiManagerConfigurationService);
+        Mockito.when(apiManagerConfigurationService.getAPIManagerConfiguration()).thenReturn(null);
         ScopesIssuer.loadInstance(Collections.<String>emptyList());
         ScopesIssuer scopesIssuer = ScopesIssuer.getInstance();
         OAuthTokenReqMessageContext tokReqMsgCtx = new OAuthTokenReqMessageContext(new OAuth2AccessTokenReqDTO());

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/util/APIManagerOAuthCallbackHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/util/APIManagerOAuthCallbackHandlerTestCase.java
@@ -27,6 +27,8 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.keymgt.ScopesIssuer;
 import org.wso2.carbon.apimgt.keymgt.issuers.AbstractScopesIssuer;
 import org.wso2.carbon.apimgt.keymgt.issuers.RoleBasedScopesIssuer;
@@ -43,7 +45,7 @@ import java.util.List;
 import java.util.Map;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest( {APIKeyMgtDataHolder.class})
+@PrepareForTest( {APIKeyMgtDataHolder.class, ServiceReferenceHolder.class})
 public class APIManagerOAuthCallbackHandlerTestCase {
 
     @Test
@@ -88,6 +90,14 @@ public class APIManagerOAuthCallbackHandlerTestCase {
         Map<String, AbstractScopesIssuer> scopesIssuerMap = new HashMap<String, AbstractScopesIssuer>();
         scopesIssuerMap.put("wso2", mockIssuer);
         BDDMockito.given(APIKeyMgtDataHolder.getScopesIssuers()).willReturn(scopesIssuerMap);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfigurationService apiManagerConfigurationService = Mockito
+                .mock(APIManagerConfigurationService.class);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService())
+                .thenReturn(apiManagerConfigurationService);
+        Mockito.when(apiManagerConfigurationService.getAPIManagerConfiguration()).thenReturn(null);
         ScopesIssuer.loadInstance(Collections.<String>emptyList());
         handler.handle(callbacks);
 
@@ -112,6 +122,14 @@ public class APIManagerOAuthCallbackHandlerTestCase {
         Map<String, AbstractScopesIssuer> scopesIssuerMap = new HashMap<String, AbstractScopesIssuer>();
         scopesIssuerMap.put("wso2", mockIssuer);
         BDDMockito.given(APIKeyMgtDataHolder.getScopesIssuers()).willReturn(scopesIssuerMap);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfigurationService apiManagerConfigurationService = Mockito
+                .mock(APIManagerConfigurationService.class);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService())
+                .thenReturn(apiManagerConfigurationService);
+        Mockito.when(apiManagerConfigurationService.getAPIManagerConfiguration()).thenReturn(null);
         ScopesIssuer.loadInstance(whiteListScopes);
         Mockito.when(mockIssuer.getScopes(oAuthCallback,whiteListScopes)).thenReturn(authorizedScopes);
         handler.handle(callbacks);
@@ -172,8 +190,15 @@ public class APIManagerOAuthCallbackHandlerTestCase {
         Map<String, AbstractScopesIssuer> scopesIssuerMap = new HashMap<String, AbstractScopesIssuer>();
         scopesIssuerMap.put("wso2", mockIssuer);
         BDDMockito.given(APIKeyMgtDataHolder.getScopesIssuers()).willReturn(scopesIssuerMap);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfigurationService apiManagerConfigurationService = Mockito
+                .mock(APIManagerConfigurationService.class);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService())
+                .thenReturn(apiManagerConfigurationService);
+        Mockito.when(apiManagerConfigurationService.getAPIManagerConfiguration()).thenReturn(null);
         ScopesIssuer.loadInstance(Collections.<String>emptyList());
-
         handler.handle(callbacks);
         String[] scopes = oAuthCallback.getApprovedScope();
         Assert.assertEquals(1, scopes.length);

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -366,7 +366,9 @@
     <OAuthConfigurations>
         <!-- Remove OAuth headers from outgoing message. -->
         <RemoveOAuthHeadersFromOutMessage>{{not apim.oauth_config.enable_outbound_auth_header}}</RemoveOAuthHeadersFromOutMessage>
-
+        {% if apim.oauth_config.scope_issuer is defined %}
+        <ScopeIssuer>{{apim.oauth_config.scope_issuer}}</ScopeIssuer>
+        {% endif %}
         {% if apim.oauth_config.set_jwt_as_opaque_token is defined %}
         <!-- Consider incoming jwt token as an opaque token. -->
         <JWTAsOpaqueToken>{{apim.oauth_config.set_jwt_as_opaque_token}}</JWTAsOpaqueToken>


### PR DESCRIPTION
The PR will provide the capability to extend the scope issuer in the product through a config. In order to extend the scope issuer,  the following config should be given in deployment.toml

[apim.oauth_config]
scope_issuer="<fully qualified class name of the extension>"