### PR TITLE
Fixing issue [UX] [Devportal] When clicking an API shows the overview page but "try-it" menu is selected

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/index.jsx
@@ -383,7 +383,7 @@ class Details extends React.Component {
                                     to={pathPrefix + 'comments'}
                                 />
                             )}
-                            {api.type !== 'WS' && showSdks && (
+                            {api.type !== 'WS' && showTryout && (
                                 <LeftMenuItem
                                     text={<FormattedMessage id='Apis.Details.index.try.out' defaultMessage='Try out' />}
                                     route='test'

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/LeftMenuItem.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/LeftMenuItem.jsx
@@ -93,8 +93,12 @@ function LeftMenuItem(props) {
     const { leftMenu } = theme.custom;
     const strokeColor = theme.palette.getContrastText(leftMenu.background);
     const { iconSize } = leftMenu;
-    const ditectCurrentMenu = (location) => {
+    const ditectCurrentMenu = (location = null) => {
+        if(!location) {
+            location = window.location;
+        }
         const { pathname } = location;
+        
         const test1 = new RegExp('/' + routeToCheck + '$', 'g');
         const test2 = new RegExp('/' + routeToCheck + '/', 'g');
         if (pathname.match(test1) || pathname.match(test2)) {
@@ -102,10 +106,11 @@ function LeftMenuItem(props) {
         } else {
             setSelected(false);
         }
+        
+        
     };
     useEffect(() => {
-        const { location } = history;
-        ditectCurrentMenu(location);
+        ditectCurrentMenu();
     }, []);
     history.listen((location) => {
         ditectCurrentMenu(location);


### PR DESCRIPTION
Fixed Issue
https://github.com/wso2/product-apim/issues/7535
[UX] [Devportal] When clicking an API shows the overview page but "try-it" menu is selected