### PR TITLE
Enable Authenticator access when extending handler

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIAuthenticationHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIAuthenticationHandler.java
@@ -85,7 +85,7 @@ import java.util.regex.Pattern;
 public class APIAuthenticationHandler extends AbstractHandler implements ManagedLifecycle {
     private static final Log log = LogFactory.getLog(APIAuthenticationHandler.class);
 
-    private ArrayList<Authenticator> authenticators = new ArrayList<>();
+    protected ArrayList<Authenticator> authenticators = new ArrayList<>();
     private SynapseEnvironment synapseEnvironment;
 
     private String authorizationHeader;


### PR DESCRIPTION
Currently the Authenticator data structure is private. Making this protected allows users to register a customized authenticator.
We have attempted to provide thsi flexibility by making the initializeAuthenticators() method protected, but we do not get a real
benifit from this if the Authenticator data structure remains private.