### PR TITLE
Include context in the event for a web socket API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
@@ -455,7 +455,7 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
             requestPublisherDTO.setUserIp(clientIp);
             requestPublisherDTO.setApplicationConsumerKey(infoDTO.getConsumerKey());
             //context will always be empty as this method will call only for WebSocketFrame and url is null
-            requestPublisherDTO.setApiContext("-");
+            requestPublisherDTO.setApiContext(apiContextUri);
             requestPublisherDTO.setThrottledOut(isThrottledOut);
             requestPublisherDTO.setApiHostname(DataPublisherUtil.getHostAddress());
             requestPublisherDTO.setApiMethod("-");


### PR DESCRIPTION
This PR fixes issue https://github.com/wso2/analytics-apim/issues/997. From APIM side, the event published when a web socket api was consumed, did not included the api context. Instead a dash character(-) was sent. So when siddhi aggregations are happening like in [here](https://github.com/wso2/analytics-apim/blob/v3.1.0-beta/features/org.wso2.analytics.apim.feature/src/main/resources/siddhi-files/APIM_ACCESS_SUMMARY.siddhi#L63) aggregations used the api context and since all the web sockets have the api context as "-" analytics shown in the dashboards were incorrect(Even the values stored in the aggregation tables were incorrect due to this).  

With this PR, api context is included in the published event from APIM side. 