### PR TITLE
Fix invalid jaggery log object construction

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/services/login/idp.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/services/login/idp.jag
@@ -17,7 +17,8 @@
  * under the License.
  */
 
-    var log = new Log("Services login DCR request");
+    var log = new Log();
+    log.debug("Services login DCR request");
     var app = require("/site/public/conf/settings.js").AppConfig.app;
     var appUtils = require("/services/utils.js");
     var utils = Packages.org.wso2.carbon.apimgt.impl.utils.APIUtil;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/services/login/introspect.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/services/login/introspect.jag
@@ -19,7 +19,8 @@
     include("/services/constants.jag");
     var appUtils = require("/services/utils.js");
 
-    var log = new Log("Jaggery service for token introspection");
+    var log = new Log();
+    log.debug("Jaggery service for token introspection");
     var utils = Packages.org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
     var userInfoEndpoint = appUtils.getLoopbackOrigin() + "/oauth2/userinfo";

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/services/login/login_callback.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/services/login/login_callback.jag
@@ -23,7 +23,8 @@
     include("/services/constants.jag");
     var app = require("/site/public/conf/settings.js").AppConfig.app;
     var utils = Packages.org.wso2.carbon.apimgt.impl.utils.APIUtil;
-    var log = new Log("Login Callback Endpoint: ");
+    var log = new Log();
+    log.debug("Login Callback Endpoint");
 
     var serverUrl = '';
     var forwarded_for = request.getHeader(app.customUrl.forwardedHeader);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/services/logout/logout.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/services/logout/logout.jag
@@ -17,7 +17,8 @@
  * under the License.
  */
 
-    var log = new Log("Logout Request Function");
+    var log = new Log();
+    log.debug("Logout Request Function");
     include("/services/constants.jag");
     var app = require("/site/public/conf/settings.js").AppConfig.app;
     var utils = Packages.org.wso2.carbon.apimgt.impl.utils.APIUtil;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/services/logout/logout_callback.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/services/logout/logout_callback.jag
@@ -17,7 +17,8 @@
  * under the License.
  */
 
-    var log = new Log("Logout Callback Function");
+    var log = new Log();
+    log.debug("Logout Callback Function");
     var app = require("/site/public/conf/settings.js").AppConfig.app;
     include("/services/constants.jag");
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/modules/la/log-analyzer-proxy.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/admin/modules/la/log-analyzer-proxy.jag
@@ -48,7 +48,7 @@
 
         var uri = request.getRequestURI();
         var uriMatcher = new URIMatcher(String(uri));
-        var log = new Log("log-analyzer-proxy.jag");
+        var log = new Log();
         var serviceInvokers = session.get("serviceInvokers");
 
         var MultitenantUtils = Packages.org.wso2.carbon.utils.multitenancy.MultitenantUtils;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/login/idp.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/login/idp.jag
@@ -17,7 +17,8 @@
  * under the License.
  */
 
-    var log = new Log("Services login DCR request");
+    var log = new Log();
+    log.debug("Services login DCR request");
     var app = require("/site/public/theme/settings.js").Settings.app;
     var appUtils = require("/services/utils.js");
     include("/services/constants.jag");

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/login/introspect.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/login/introspect.jag
@@ -20,7 +20,8 @@
     include("/services/constants.jag");
     var appUtils = require("/services/utils.js");
 
-    var log = new Log("Jaggery service for token introspection");
+    var log = new Log();
+    log.debug("Jaggery service for token introspection");
     var utils = Packages.org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
     var userInfoEndpoint = appUtils.getLoopbackOrigin() + "/oauth2/userinfo";

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/logout/logout.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/logout/logout.jag
@@ -17,7 +17,8 @@
  * under the License.
  */
 
-    var log = new Log("Logout Request Function");
+    var log = new Log();
+    log.debug("Logout Request Function");
     include("/services/constants.jag");
     var app = require("/site/public/theme/settings.js").Settings.app;
     var utils = Packages.org.wso2.carbon.apimgt.impl.utils.APIUtil;

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/logout/logout_callback.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/logout/logout_callback.jag
@@ -17,7 +17,8 @@
  * under the License.
  */
 
-    var log = new Log("Logout Callback Function");
+    var log = new Log();
+    log.debug("Logout Callback Function");
     var site = require("/site/public/theme/settings.js").Settings.app;
     include("/services/constants.jag");
     var appUtils = require("/services/utils.js");


### PR DESCRIPTION
Jaggery Log object have been created without using the default constructor which leads to log messages not been printed
at jaggery level. This fix rectifies that issue.