### PR TITLE
Add x-wso2-mutual-ssl extension and change transport extension

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1226,8 +1226,6 @@ public final class APIConstants {
     public static final String SWAGGER_X_THROTTLING_TIER = "x-throttling-tier";
     public static final String SWAGGER_X_MEDIATION_SCRIPT = "x-mediation-script";
     public static final String SWAGGER_X_WSO2_SECURITY = "x-wso2-security";
-    public static final String SWAGGER_X_WSO2_APP_SECURITY = "x-wso2-application-security";
-    public static final String SWAGGER_X_WSO2_RESPONSE_CACHE = "x-wso2-response-cache";
     public static final String WSO2_APP_SECURITY_TYPES = "security-types";
     public static final String OPTIONAL = "optional";
     public static final String MANDATORY = "mandatory";
@@ -1299,6 +1297,9 @@ public final class APIConstants {
     public static final String X_WSO2_SANDBOX_ENDPOINTS = "x-wso2-sandbox-endpoints";
     public static final String X_WSO2_BASEPATH = "x-wso2-basePath";
     public static final String X_WSO2_TRANSPORTS = "x-wso2-transports";
+    public static final String X_WSO2_MUTUAL_SSL = "x-wso2-mutual-ssl";
+    public static final String X_WSO2_APP_SECURITY = "x-wso2-application-security";
+    public static final String X_WSO2_RESPONSE_CACHE = "x-wso2-response-cache";
     public static final String X_WSO2_ENDPOINT_TYPE = "type";
 
     //API Constants

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -658,11 +658,21 @@ public class OAS2Parser extends APIDefinition {
             swagger.setVendorExtension(APIConstants.X_WSO2_SANDBOX_ENDPOINTS, sandEndpointObj);
         }
         swagger.setVendorExtension(APIConstants.X_WSO2_BASEPATH, api.getContext());
-        swagger.setVendorExtension(APIConstants.X_WSO2_TRANSPORTS,
-                OASParserUtil.getTransportSecurity(api.getApiSecurity(), api.getTransports()));
-        swagger.setVendorExtension(APIConstants.SWAGGER_X_WSO2_APP_SECURITY,
-                OASParserUtil.getAppSecurity(api.getApiSecurity()));
-        swagger.setVendorExtension(APIConstants.SWAGGER_X_WSO2_RESPONSE_CACHE,
+        if (api.getTransports() != null) {
+            swagger.setVendorExtension(APIConstants.X_WSO2_TRANSPORTS, api.getTransports().split(","));
+        }
+        String apiSecurity = api.getApiSecurity();
+        // set mutual ssl extension if enabled
+        if (apiSecurity != null) {
+            List<String> securityList = Arrays.asList(apiSecurity.split(","));
+            if (securityList.contains(APIConstants.API_SECURITY_MUTUAL_SSL)) {
+                String mutualSSLOptional = !securityList.contains(APIConstants.API_SECURITY_MUTUAL_SSL_MANDATORY) ?
+                        APIConstants.OPTIONAL : APIConstants.MANDATORY;
+                swagger.setVendorExtension(APIConstants.X_WSO2_MUTUAL_SSL, mutualSSLOptional);
+            }
+        }
+        swagger.setVendorExtension(APIConstants.X_WSO2_APP_SECURITY, OASParserUtil.getAppSecurity(apiSecurity));
+        swagger.setVendorExtension(APIConstants.X_WSO2_RESPONSE_CACHE,
                 OASParserUtil.getResponseCacheConfig(api.getResponseCache(), api.getCacheTimeout()));
 
         return getSwaggerJsonString(swagger);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -655,11 +655,21 @@ public class OAS3Parser extends APIDefinition {
             openAPI.addExtension(APIConstants.X_WSO2_SANDBOX_ENDPOINTS, sandEndpointObj);
         }
         openAPI.addExtension(APIConstants.X_WSO2_BASEPATH, api.getContext());
-        openAPI.addExtension(APIConstants.X_WSO2_TRANSPORTS,
-                OASParserUtil.getTransportSecurity(api.getApiSecurity(), api.getTransports()));
-        openAPI.addExtension(APIConstants.SWAGGER_X_WSO2_APP_SECURITY,
-                OASParserUtil.getAppSecurity(api.getApiSecurity()));
-        openAPI.addExtension(APIConstants.SWAGGER_X_WSO2_RESPONSE_CACHE,
+        if (api.getTransports() != null) {
+            openAPI.addExtension(APIConstants.X_WSO2_TRANSPORTS, api.getTransports().split(","));
+        }
+        String apiSecurity = api.getApiSecurity();
+        // set mutual ssl extension if enabled
+        if (apiSecurity != null) {
+            List<String> securityList = Arrays.asList(apiSecurity.split(","));
+            if (securityList.contains(APIConstants.API_SECURITY_MUTUAL_SSL)) {
+                String mutualSSLOptional = !securityList.contains(APIConstants.API_SECURITY_MUTUAL_SSL_MANDATORY) ?
+                        APIConstants.OPTIONAL : APIConstants.MANDATORY;
+                openAPI.addExtension(APIConstants.X_WSO2_MUTUAL_SSL, mutualSSLOptional);
+            }
+        }
+        openAPI.addExtension(APIConstants.X_WSO2_APP_SECURITY, OASParserUtil.getAppSecurity(apiSecurity));
+        openAPI.addExtension(APIConstants.X_WSO2_RESPONSE_CACHE,
                 OASParserUtil.getResponseCacheConfig(api.getResponseCache(), api.getCacheTimeout()));
         return Json.pretty(openAPI);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1096,27 +1096,16 @@ public class OASParserUtil {
         if (extensions == null) {
             return;
         }
-        if (extensions.containsKey(APIConstants.X_WSO2_AUTH_HEADER)) {
-            extensions.remove(APIConstants.X_WSO2_AUTH_HEADER);
-        }
-        if (extensions.containsKey(APIConstants.X_THROTTLING_TIER)) {
-            extensions.remove(APIConstants.X_THROTTLING_TIER);
-        }
-        if (extensions.containsKey(APIConstants.X_WSO2_CORS)) {
-            extensions.remove(APIConstants.X_WSO2_CORS);
-        }
-        if (extensions.containsKey(APIConstants.X_WSO2_PRODUCTION_ENDPOINTS)) {
-            extensions.remove(APIConstants.X_WSO2_PRODUCTION_ENDPOINTS);
-        }
-        if (extensions.containsKey(APIConstants.X_WSO2_SANDBOX_ENDPOINTS)) {
-            extensions.remove(APIConstants.X_WSO2_SANDBOX_ENDPOINTS);
-        }
-        if (extensions.containsKey(APIConstants.X_WSO2_BASEPATH)) {
-            extensions.remove(APIConstants.X_WSO2_BASEPATH);
-        }
-        if (extensions.containsKey(APIConstants.X_WSO2_TRANSPORTS)) {
-            extensions.remove(APIConstants.X_WSO2_TRANSPORTS);
-        }
+        extensions.remove(APIConstants.X_WSO2_AUTH_HEADER);
+        extensions.remove(APIConstants.X_THROTTLING_TIER);
+        extensions.remove(APIConstants.X_WSO2_CORS);
+        extensions.remove(APIConstants.X_WSO2_PRODUCTION_ENDPOINTS);
+        extensions.remove(APIConstants.X_WSO2_SANDBOX_ENDPOINTS);
+        extensions.remove(APIConstants.X_WSO2_BASEPATH);
+        extensions.remove(APIConstants.X_WSO2_TRANSPORTS);
+        extensions.remove(APIConstants.X_WSO2_APP_SECURITY);
+        extensions.remove(APIConstants.X_WSO2_RESPONSE_CACHE);
+        extensions.remove(APIConstants.X_WSO2_MUTUAL_SSL);
     }
 
     /**
@@ -1168,30 +1157,5 @@ public class OASParserUtil {
          responseCacheConfig.put(APIConstants.RESPONSE_CACHING_ENABLED, enabled);
          responseCacheConfig.put(APIConstants.RESPONSE_CACHING_TIMEOUT, cacheTimeout);
          return responseCacheConfig;
-    }
-
-    /**
-     * generate app security information for OAS definition
-     *
-     * @param security          application security
-     * @param transport          transport security
-     * @return JsonNode
-     */
-     static JsonNode getTransportSecurity(String security, String transport) {
-         ObjectNode endpointResult = objectMapper.createObjectNode();
-         if (transport != null) {
-             List<String> transportTypes = Arrays.asList(transport.split(","));
-             endpointResult.put(Constants.TRANSPORT_HTTP, transportTypes.contains(Constants.TRANSPORT_HTTP));
-             endpointResult.put(Constants.TRANSPORT_HTTPS, transportTypes.contains(Constants.TRANSPORT_HTTPS));
-         }
-         if (security != null) {
-             List<String> securityList = Arrays.asList(security.split(","));
-             if (securityList.contains(APIConstants.API_SECURITY_MUTUAL_SSL)) {
-                 String mutualSSLOptional = !securityList.contains(APIConstants.API_SECURITY_MUTUAL_SSL_MANDATORY) ?
-                         APIConstants.OPTIONAL : APIConstants.MANDATORY;
-                 endpointResult.put(APIConstants.API_SECURITY_MUTUAL_SSL, mutualSSLOptional);
-             }
-         }
-        return endpointResult;
     }
 }


### PR DESCRIPTION
The following format[1] of x-wso2-transport extension was later changed to [2] to support mutual ssl. But after this change, format [1] gives parsing issues.

```
[1]x-wso2-transports:
  - "http"
  - "https"
[2]x-wso2-transports:
  http: true
  https: true
  mutualssl: "mandatory"
```
This causes backword compatibility issues. Hence the extension was changed to below

```
x-wso2-transports:
- "http"
- "https"
x-wso2-mutual-ssl: "mandatory"
```

Fixing https://github.com/wso2/product-microgateway/issues/1083
Related to https://github.com/wso2/carbon-apimgt/pull/8153