### PR TITLE
Fixes issue apikey not working in try-out console

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/CORSConfiguration.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/CORSConfiguration.jsx
@@ -74,6 +74,9 @@ export default function CORSConfiguration(props) {
     const isAllowAllOrigins = corsConfiguration.accessControlAllowOrigins[0] === '*'
         && corsConfiguration.accessControlAllowOrigins.length === 1;
     const classes = useStyles();
+    if (!corsConfiguration.accessControlAllowHeaders.includes('apikey')) {
+        corsConfiguration.accessControlAllowHeaders.push('apikey');
+    }
 
     return (
         <ExpansionPanel className={classes.expansionPanel}>


### PR DESCRIPTION
Fixes https://github.com/wso2/product-apim/issues/7600

**Need to add in the doc that user needs to enable CORS in order to user apikey in the try-out console.**