### PR TITLE
Add app-security extension at resource level

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1109,6 +1109,18 @@ public class OASParserUtil {
     }
 
     /**
+     * remove publisher/MG related extension from OAS
+     *
+     * @param extensions extensions
+     */
+    public static void removePublisherSpecificInfofromOperation(Map<String, Object> extensions) {
+        if (extensions == null) {
+            return;
+        }
+        extensions.remove(APIConstants.X_WSO2_APP_SECURITY);
+    }
+
+    /**
      * Get Application level security types
      * @param security list of security types
      * @return List of api security


### PR DESCRIPTION
App security extension should be given in the resource level. Otherwise, the default oauth2 scheme defined at each resource level will override application securities.