### PR TITLE
Adding extension points to header menu

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/avatar/Avatar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/avatar/Avatar.jsx
@@ -11,6 +11,7 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import Configurations from 'Config';
+import AvatarMenu from './AvatarMenu';
 
 const styles = (theme) => ({
     profileMenu: {
@@ -124,14 +125,18 @@ class Avatar extends Component {
                     }}
                     className={classes.profileMenu}
                 >
-                    <Link to={{ pathname: '/services/logout' }}>
-                        <MenuItem onClick={this.doOIDCLogout} id='logout'>
-                            <FormattedMessage
-                                id='Base.Header.avatar.Avatar.logout'
-                                defaultMessage='Logout'
-                            />
-                        </MenuItem>
-                    </Link>
+                    {AvatarMenu
+                        ? (<AvatarMenu doOIDCLogout={this.doOIDCLogout} />)
+                        : (
+                            <Link to={{ pathname: '/services/logout' }}>
+                                <MenuItem onClick={this.doOIDCLogout} id='logout'>
+                                    <FormattedMessage
+                                        id='Base.Header.avatar.Avatar.logout'
+                                        defaultMessage='Logout'
+                                    />
+                                </MenuItem>
+                            </Link>
+                        )}
                 </Menu>
             </>
         );

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/avatar/AvatarMenu.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/avatar/AvatarMenu.jsx
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+export default false;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/index.jsx
@@ -24,7 +24,7 @@ import Hidden from '@material-ui/core/Hidden';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import VerticalDivider from 'AppComponents/Shared/VerticalDivider';
-import SettingsButton from 'AppComponents/Base/Header/settings/SettingsButton';
+import RightTopMenu from 'AppComponents/Base/Header/rightTopMenu/RightTopMenu';
 import Configurations from 'Config';
 import Avatar from './avatar/Avatar';
 import HeaderSearch from './headersearch/HeaderSearch';
@@ -145,7 +145,7 @@ class Header extends React.Component {
 }
 Header.defaultProps = {
     avatar: <Avatar />,
-    settings: <SettingsButton />,
+    settings: <RightTopMenu />,
 };
 
 Header.propTypes = {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/rightTopMenu/RightTopMenu.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/rightTopMenu/RightTopMenu.jsx
@@ -20,6 +20,7 @@ import { Icon, IconButton, withStyles } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
+import RightTopMenuLinks from './RightTopMenuLinks';
 
 const styles = (theme) => ({
     settingsIconbtn: {
@@ -35,6 +36,11 @@ const styles = (theme) => ({
 
 const SettingsButton = (props) => {
     const { classes } = props;
+    if (RightTopMenuLinks) {
+        return (
+            <RightTopMenuLinks />
+        );
+    }
     return (
         <>
             <Link to='/settings'>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/rightTopMenu/RightTopMenuLinks.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Base/Header/rightTopMenu/RightTopMenuLinks.jsx
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+export default false;


### PR DESCRIPTION
Added extension points to the top right-hand side menu. This is to let the cloud developers override the menu without maintaining our code at there side.