### PR TITLE
Fixing pagination issue in publisher

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/TableView/TableView.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/TableView/TableView.jsx
@@ -176,7 +176,10 @@ class TableView extends React.Component {
             // We check if the response in the rest api callls have 0 items.
             // We remove the local storage and redo the api call
             if (this.count > 0 && total === 0) {
+                this.page = 0;
                 this.removeLocalStorage();
+                this.getData();
+                return;
             }
             this.count = total;
             this.setState({ apisAndApiProducts: list, notFound: false, displayCount: count });
@@ -187,8 +190,6 @@ class TableView extends React.Component {
         const { isAPIProduct } = this.props;
         const paginationSufix = isAPIProduct ? 'products' : 'apis';
         window.localStorage.removeItem('pagination-' + paginationSufix);
-        this.page = 0;
-        this.getData();
     }
 
     getLocalStorage = () => {
@@ -391,7 +392,9 @@ class TableView extends React.Component {
             rowsPerPage,
             onChangeRowsPerPage: (numberOfRows) => {
                 this.rowsPerPage = numberOfRows;
-                if (count - 1 === rowsPerPage * page && page !== 0) {
+                if (page * numberOfRows > count) {
+                    this.page = 0;
+                } else if (count - 1 === rowsPerPage * page && page !== 0) {
                     this.page = page - 1;
                 }
                 this.getData();

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/TableView/TableView.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/TableView/TableView.jsx
@@ -172,10 +172,24 @@ class TableView extends React.Component {
             const { body } = data;
             const { list, pagination, count } = body;
             const { total } = pagination;
+            if (this.count > 0 && total === 0) {
+                this.removeLocalStorage();
+            }
             this.count = total;
             this.setState({ apisAndApiProducts: list, notFound: false, displayCount: count });
         });
     };
+
+    removeLocalStorage = () => {
+        // When there is a count stored in the localstorage and it's greater than 0
+        // We check if the response in the rest api callls have 0 items.
+        // We remove the local storage and rerun the api call
+        const { isAPIProduct } = this.props;
+        const paginationSufix = isAPIProduct ? 'products' : 'apis';
+        window.localStorage.removeItem('pagination-' + paginationSufix);
+        this.page = 0;
+        this.getData();
+    }
 
     getLocalStorage = () => {
         const { isAPIProduct } = this.props;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/TableView/TableView.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/TableView/TableView.jsx
@@ -172,6 +172,9 @@ class TableView extends React.Component {
             const { body } = data;
             const { list, pagination, count } = body;
             const { total } = pagination;
+            // When there is a count stored in the localstorage and it's greater than 0
+            // We check if the response in the rest api callls have 0 items.
+            // We remove the local storage and redo the api call
             if (this.count > 0 && total === 0) {
                 this.removeLocalStorage();
             }
@@ -181,9 +184,6 @@ class TableView extends React.Component {
     };
 
     removeLocalStorage = () => {
-        // When there is a count stored in the localstorage and it's greater than 0
-        // We check if the response in the rest api callls have 0 items.
-        // We remove the local storage and rerun the api call
         const { isAPIProduct } = this.props;
         const paginationSufix = isAPIProduct ? 'products' : 'apis';
         window.localStorage.removeItem('pagination-' + paginationSufix);


### PR DESCRIPTION
This fix is fixing the issue in a more general way. 

Checked the following cases.

Add 120 apis.
Navigate to a page > 2 when the number of rows per page is 10.
Now change the number of rows per page to 100.
The page number drops to 0.

Add 120 apis.
Navigate to a page > 1
Now delete all the APIs leaving only leaving one API using Rest API. Or deploy another instance where it has only one API.
The page number drops to 0 and local storage is cleared.