### PR TITLE
Require re-subscription lifecycle checklist item displaying

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/APIMappingUtil.java
@@ -1103,7 +1103,8 @@ public class APIMappingUtil {
             List<LifecycleStateCheckItemsDTO> checkItemsDTOList = new ArrayList<>();
             for (Object checkListItemObj : checkListItems) {
                 CheckListItem checkListItem = (CheckListItem) checkListItemObj;
-                if (!apiOlderVersionExist && checkListItem.getName().equals(APIConstants.DEPRECATE_CHECK_LIST_ITEM)) {
+                if (!apiOlderVersionExist && (checkListItem.getName().equals(APIConstants.DEPRECATE_CHECK_LIST_ITEM)
+                        || checkListItem.getName().equals(APIConstants.RESUBSCRIBE_CHECK_LIST_ITEM))) {
                     continue;
                 }
 


### PR DESCRIPTION
According to [this](https://apim.docs.wso2.com/en/latest/learn/design-api/api-versioning/deprecate-the-old-version/#publish-the-new-version-and-deprecate-old-versions) documentation, only when older versions are available, `Requires re-subscription when publishing API` lifecycle checklist should be displayed.

Currently, when generating the lifecycle checklist, only `Depreciate older versions` item is filtered.

This PR will also filter by the `Requires re-subscription when publishing API` checklist item when generating checklist items.

Fixes: https://github.com/wso2/product-apim/issues/6530