### PR TITLE
Fixing subscriptions are auto assigning issue to new versions

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/APIImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/APIImportExportConstants.java
@@ -57,6 +57,9 @@ public final class APIImportExportConstants {
     //location of the graphql schema definition file
     public static final String GRAPHQL_SCHEMA_DEFINITION_LOCATION = File.separator
             + APIImportExportConstants.META_INFO_DIRECTORY + File.separator + "schema.graphql";
+
+    public static final int REFER_REQUIRE_RE_SUBSCRIPTION_CHECK_ITEM = 1;
+
     //Image resource
     public static final String IMAGE_RESOURCE = "Image";
     //Sequences resource

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -434,7 +434,8 @@ public final class APIImportUtil {
             // Change API lifecycle if state transition is required
             if (StringUtils.isNotEmpty(lifecycleAction)) {
                 log.info("Changing lifecycle from " + currentStatus + " to " + targetStatus);
-                apiProvider.changeAPILCCheckListItems(importedApi.getId(), 1, true);
+                apiProvider.changeAPILCCheckListItems(importedApi.getId(),
+                        APIImportExportConstants.REFER_REQUIRE_RE_SUBSCRIPTION_CHECK_ITEM, true);
                 apiProvider.changeLifeCycleStatus(importedApi.getId(), lifecycleAction);
                 //Change the status of the imported API to targetStatus
                 importedApi.setStatus(targetStatus);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -434,6 +434,7 @@ public final class APIImportUtil {
             // Change API lifecycle if state transition is required
             if (StringUtils.isNotEmpty(lifecycleAction)) {
                 log.info("Changing lifecycle from " + currentStatus + " to " + targetStatus);
+                apiProvider.changeAPILCCheckListItems(importedApi.getId(), 1, true);
                 apiProvider.changeLifeCycleStatus(importedApi.getId(), lifecycleAction);
                 //Change the status of the imported API to targetStatus
                 importedApi.setStatus(targetStatus);


### PR DESCRIPTION
Description:
If the API is moving across the environments, it has no idea whether this is a new API or API that created from an existing version. In the next environment, it might not have the same applications and etc. Therefore, subscriptions shouldn't be migrated to next environments.
