### PR TITLE
Changed recommendations and Tenant config Cache

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/TenantServiceCreator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/TenantServiceCreator.java
@@ -153,6 +153,8 @@ public class TenantServiceCreator extends AbstractAxis2ConfigurationContextObser
         CacheProvider.createRESTAPIInvalidTokenCache();
         CacheProvider.createGatewayJWTTokenCache();
         CacheProvider.createGatewayJWKSCache();
+        CacheProvider.createTenantConfigCache();
+        CacheProvider.createRecommendationsCache();
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -110,8 +110,6 @@ public final class APIConstants {
 
     public static final String API_TENANT_CONF_MEDIA_TYPE = "tenant-config";
     public static final String TENANT_CONFIG_CACHE_NAME = "tenantConfigCache";
-    public static final long TENANT_CONFIG_CACHE_MODIFIED_EXPIRY = 900; // cache set to 15 minutes
-    public static final long TENANT_CONFIG_CACHE_ACCESS_EXPIRY = 900;
 
     public static final String RESOURCE_FOLDER_LOCATION = "repository" + File.separator + "resources";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -74,6 +74,7 @@ import org.wso2.carbon.apimgt.api.model.Tag;
 import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.api.model.TierPermission;
 import org.wso2.carbon.apimgt.impl.caching.CacheInvalidator;
+import org.wso2.carbon.apimgt.impl.caching.CacheProvider;
 import org.wso2.carbon.apimgt.impl.definitions.OASParserUtil;
 import org.wso2.carbon.apimgt.impl.dto.ApplicationDTO;
 import org.wso2.carbon.apimgt.impl.dto.ApplicationRegistrationWorkflowDTO;
@@ -5777,12 +5778,8 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 return true;
             } else {
                 try {
-                    org.json.JSONObject tenantConfig = null;
-                    Cache tenantConfigCache = APIUtil.getCache(
-                            APIConstants.API_MANAGER_CACHE_MANAGER,
-                            APIConstants.TENANT_CONFIG_CACHE_NAME,
-                            APIConstants.TENANT_CONFIG_CACHE_MODIFIED_EXPIRY,
-                            APIConstants.TENANT_CONFIG_CACHE_ACCESS_EXPIRY);
+                    org.json.JSONObject tenantConfig;
+                    Cache tenantConfigCache = CacheProvider.getTenantConfigCache();
                     String cacheName = tenantDomain + "_" + APIConstants.TENANT_CONFIG_CACHE_NAME;
                     if (tenantConfigCache.containsKey(cacheName)) {
                         tenantConfig = (org.json.JSONObject) tenantConfigCache.get(cacheName);
@@ -5796,7 +5793,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                         Object value = tenantConfig.get(APIConstants.API_TENANT_CONF_ENABLE_RECOMMENDATION_KEY);
                         return Boolean.parseBoolean(value.toString());
                     }
-                } catch (UserStoreException | RegistryException | NullPointerException e) {
+                } catch (UserStoreException | RegistryException e) {
                     log.error("Error occurred when getting API tenant config from registry", e);
                 }
             }
@@ -5819,11 +5816,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
     public String getApiRecommendations(String userName, String tenantDomain) {
 
         if (tenantDomain != null && userName != null) {
-            Cache recommendationsCache = APIUtil.getCache(
-                    APIConstants.API_MANAGER_CACHE_MANAGER,
-                    APIConstants.RECOMMENDATIONS_CACHE_NAME,
-                    APIConstants.TENANT_CONFIG_CACHE_MODIFIED_EXPIRY,
-                    APIConstants.TENANT_CONFIG_CACHE_ACCESS_EXPIRY);
+            Cache recommendationsCache = CacheProvider.getRecommendationsCache();
             String cacheName = userName + "_" + tenantDomain;
             if (recommendationsCache.containsKey(cacheName)) {
                 org.json.JSONObject cachedObject = (org.json.JSONObject) recommendationsCache.get(cacheName);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5772,33 +5772,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
      */
 
     public boolean isRecommendationEnabled(String tenantDomain) {
-
-        if (recommendationEnvironment != null) {
-            if (recommendationEnvironment.isApplyForAllTenants()) {
-                return true;
-            } else {
-                try {
-                    org.json.JSONObject tenantConfig;
-                    Cache tenantConfigCache = CacheProvider.getTenantConfigCache();
-                    String cacheName = tenantDomain + "_" + APIConstants.TENANT_CONFIG_CACHE_NAME;
-                    if (tenantConfigCache.containsKey(cacheName)) {
-                        tenantConfig = (org.json.JSONObject) tenantConfigCache.get(cacheName);
-                    } else {
-                        String content = apimRegistryService
-                                .getConfigRegistryResourceContent(tenantDomain, APIConstants.API_TENANT_CONF_LOCATION);
-                        tenantConfig = new org.json.JSONObject(content);
-                        tenantConfigCache.put(cacheName, tenantConfig);
-                    }
-                    if (tenantConfig.has(APIConstants.API_TENANT_CONF_ENABLE_RECOMMENDATION_KEY)) {
-                        Object value = tenantConfig.get(APIConstants.API_TENANT_CONF_ENABLE_RECOMMENDATION_KEY);
-                        return Boolean.parseBoolean(value.toString());
-                    }
-                } catch (UserStoreException | RegistryException e) {
-                    log.error("Error occurred when getting API tenant config from registry", e);
-                }
-            }
-        }
-        return false;
+        return APIUtil.isRecommendationEnabled(tenantDomain);
     }
 
     public String getRequestedTenant() {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/caching/CacheProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/caching/CacheProvider.java
@@ -123,6 +123,20 @@ public class CacheProvider {
     }
 
     /**
+     * @return Tenant Config cache
+     */
+    public static Cache getTenantConfigCache() {
+        return getCache(APIConstants.TENANT_CONFIG_CACHE_NAME);
+    }
+
+    /**
+     * @return Recommendations cache
+     */
+    public static Cache getRecommendationsCache() {
+        return getCache(APIConstants.RECOMMENDATIONS_CACHE_NAME);
+    }
+
+    /**
      * @return APIManagerConfiguration
      */
     private static APIManagerConfiguration getApiManagerConfiguration() {
@@ -372,6 +386,38 @@ public class CacheProvider {
     }
 
     /**
+     * Create and return the Tenant Config Cache
+     */
+    public static Cache createTenantConfigCache() {
+
+        String apimGWCacheExpiry = getApiManagerConfiguration().getFirstProperty(APIConstants.TOKEN_CACHE_EXPIRY);
+        if (apimGWCacheExpiry != null) {
+            return getCache(APIConstants.API_MANAGER_CACHE_MANAGER, APIConstants.TENANT_CONFIG_CACHE_NAME,
+                    Long.parseLong(apimGWCacheExpiry), Long.parseLong(apimGWCacheExpiry));
+        } else {
+            long defaultCacheTimeout = getDefaultCacheTimeout();
+            return getCache(APIConstants.API_MANAGER_CACHE_MANAGER, APIConstants.TENANT_CONFIG_CACHE_NAME,
+                    defaultCacheTimeout, defaultCacheTimeout);
+        }
+    }
+
+    /**
+     * Create and return the Recommendations Cache
+     */
+    public static Cache createRecommendationsCache() {
+
+        String apimGWCacheExpiry = getApiManagerConfiguration().getFirstProperty(APIConstants.TOKEN_CACHE_EXPIRY);
+        if (apimGWCacheExpiry != null) {
+            return getCache(APIConstants.API_MANAGER_CACHE_MANAGER, APIConstants.RECOMMENDATIONS_CACHE_NAME,
+                    Long.parseLong(apimGWCacheExpiry), Long.parseLong(apimGWCacheExpiry));
+        } else {
+            long defaultCacheTimeout = getDefaultCacheTimeout();
+            return getCache(APIConstants.API_MANAGER_CACHE_MANAGER, APIConstants.RECOMMENDATIONS_CACHE_NAME,
+                    defaultCacheTimeout, defaultCacheTimeout);
+        }
+    }
+
+    /**
      * remove caches
      */
     public static void removeAllCaches() {
@@ -401,6 +447,10 @@ public class CacheProvider {
                 getGatewayApiKeyDataCache().getName());
         Caching.getCacheManager(APIConstants.API_MANAGER_CACHE_MANAGER).removeCache(CacheProvider.
                 getInvalidGatewayApiKeyCache().getName());
+        Caching.getCacheManager(APIConstants.API_MANAGER_CACHE_MANAGER).removeCache(CacheProvider.
+                getTenantConfigCache().getName());
+        Caching.getCacheManager(APIConstants.API_MANAGER_CACHE_MANAGER).removeCache(CacheProvider.
+                getRecommendationsCache().getName());
         Caching.getCacheManager(APIConstants.API_MANAGER_CACHE_MANAGER)
                 .removeCache(CacheProvider.getJWKSCache().getName());
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/handlers/TenantConfigMediaTypeHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/handlers/TenantConfigMediaTypeHandler.java
@@ -18,7 +18,7 @@
 package org.wso2.carbon.apimgt.impl.handlers;
 
 import org.wso2.carbon.apimgt.impl.APIConstants;
-import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.impl.caching.CacheProvider;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.registry.core.jdbc.handlers.Handler;
 import org.wso2.carbon.registry.core.jdbc.handlers.RequestContext;
@@ -36,11 +36,7 @@ public class TenantConfigMediaTypeHandler extends Handler {
     }
 
     private void clearConfigCache() {
-        Cache tenantConfigCache = APIUtil.getCache(
-                APIConstants.API_MANAGER_CACHE_MANAGER,
-                APIConstants.TENANT_CONFIG_CACHE_NAME,
-                APIConstants.TENANT_CONFIG_CACHE_MODIFIED_EXPIRY,
-                APIConstants.TENANT_CONFIG_CACHE_ACCESS_EXPIRY);
+        Cache tenantConfigCache = CacheProvider.getTenantConfigCache();
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         String cacheName = tenantDomain + "_" + APIConstants.TENANT_CONFIG_CACHE_NAME;
         if (tenantConfigCache.containsKey(cacheName)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/handlers/TenantConfigMediaTypeHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/handlers/TenantConfigMediaTypeHandler.java
@@ -37,8 +37,8 @@ public class TenantConfigMediaTypeHandler extends Handler {
 
     private void clearConfigCache() {
         Cache tenantConfigCache = CacheProvider.getTenantConfigCache();
-        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        String cacheName = tenantDomain + "_" + APIConstants.TENANT_CONFIG_CACHE_NAME;
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        String cacheName = tenantId + "_" + APIConstants.TENANT_CONFIG_CACHE_NAME;
         if (tenantConfigCache.containsKey(cacheName)) {
             tenantConfigCache.remove(cacheName);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
@@ -259,6 +259,8 @@ public class APIManagerComponent {
             CacheProvider.createRESTAPITokenCache();
             CacheProvider.createRESTAPIInvalidTokenCache();
             CacheProvider.createGatewayJWTTokenCache();
+            CacheProvider.createTenantConfigCache();
+            CacheProvider.createRecommendationsCache();
             //Initialize Recommendation wso2event output publisher
             configureRecommendationEventPublisherProperties();
             setupAccessTokenGenerator();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/recommendationmgt/RecommenderDetailsExtractor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/recommendationmgt/RecommenderDetailsExtractor.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
 import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.caching.CacheProvider;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
@@ -351,11 +352,7 @@ public class RecommenderDetailsExtractor implements RecommenderEventPublisher {
             } else {
                 try {
                     JSONObject tenantConfig = null;
-                    Cache tenantConfigCache = APIUtil.getCache(
-                            APIConstants.API_MANAGER_CACHE_MANAGER,
-                            APIConstants.TENANT_CONFIG_CACHE_NAME,
-                            APIConstants.TENANT_CONFIG_CACHE_MODIFIED_EXPIRY,
-                            APIConstants.TENANT_CONFIG_CACHE_ACCESS_EXPIRY);
+                    Cache tenantConfigCache = CacheProvider.getTenantConfigCache();
                     String cacheName = tenantDomain + "_" + APIConstants.TENANT_CONFIG_CACHE_NAME;
                     if (tenantConfigCache.containsKey(cacheName)) {
                         tenantConfig = (JSONObject) tenantConfigCache.get(cacheName);
@@ -379,7 +376,7 @@ public class RecommenderDetailsExtractor implements RecommenderEventPublisher {
                         Object value = tenantConfig.get(APIConstants.API_TENANT_CONF_ENABLE_RECOMMENDATION_KEY);
                         return Boolean.parseBoolean(value.toString());
                     }
-                } catch (RegistryException | UserStoreException | NullPointerException | APIManagementException e) {
+                } catch (RegistryException | UserStoreException | APIManagementException e) {
                     log.error("Error while retrieving Recommendation config from registry", e);
                 }
             }
@@ -399,11 +396,7 @@ public class RecommenderDetailsExtractor implements RecommenderEventPublisher {
         long currentTime = System.currentTimeMillis();
         long lastUpdatedTime = 0;
         long waitDuration = recommendationEnvironment.getWaitDuration() * 60 * 1000;
-        Cache recommendationsCache = APIUtil.getCache(
-                APIConstants.API_MANAGER_CACHE_MANAGER,
-                APIConstants.RECOMMENDATIONS_CACHE_NAME,
-                APIConstants.TENANT_CONFIG_CACHE_MODIFIED_EXPIRY,
-                APIConstants.TENANT_CONFIG_CACHE_ACCESS_EXPIRY);
+        Cache recommendationsCache = CacheProvider.getRecommendationsCache();
         String cacheName = userName + "_" + tenantDomain;
         JSONObject cachedObject = (JSONObject) recommendationsCache.get(cacheName);
         if (cachedObject != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10381,7 +10381,7 @@ public final class APIUtil {
                 return true;
             } else {
                 try {
-                    org.json.simple.JSONObject tenantConfig = APIUtil.getTenantConfig(tenantDomain);
+                    org.json.simple.JSONObject tenantConfig = getTenantConfig(tenantDomain);
                     Object value = tenantConfig.get(APIConstants.API_TENANT_CONF_ENABLE_RECOMMENDATION_KEY);
                     return Boolean.parseBoolean(value.toString());
                 } catch (APIManagementException e) {


### PR DESCRIPTION
Changed the recommendations cache and tenant config cache get methods. Previously, APIUtil.getCache(cacheManagerName,  cacheName, modifiedExp,accessExp) was used to get cache and this might give errors in expiry times. 
Changed the two configs to standard approach with two different methods to create and get the cache in CacheProvider.