### PR TITLE
Make API provider name optional when exporting an API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ExportApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ExportApi.java
@@ -40,11 +40,11 @@ public class ExportApi  {
 
     public Response exportApiGet(@ApiParam(value = "API Name\n",required=true) @QueryParam("name")  String name,
     @ApiParam(value = "Version of the API\n",required=true) @QueryParam("version")  String version,
-    @ApiParam(value = "Provider name of the API\n",required=true) @QueryParam("providerName")  String providerName,
     @ApiParam(value = "Format of output documents. Can be YAML or JSON.\n",required=true, allowableValues="{values=[JSON, YAML]}") @QueryParam("format")  String format,
+    @ApiParam(value = "Provider name of the API\n") @QueryParam("providerName")  String providerName,
     @ApiParam(value = "Preserve API Status on export\n") @QueryParam("preserveStatus")  Boolean preserveStatus)
     {
-    return delegate.exportApiGet(name,version,providerName,format,preserveStatus);
+    return delegate.exportApiGet(name,version,format,providerName,preserveStatus);
     }
     @GET
     @Path("/applications")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ExportApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/ExportApiService.java
@@ -14,7 +14,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import javax.ws.rs.core.Response;
 
 public abstract class ExportApiService {
-    public abstract Response exportApiGet(String name,String version,String providerName,String format,Boolean preserveStatus);
+    public abstract Response exportApiGet(String name,String version,String format,String providerName,Boolean preserveStatus);
     public abstract Response exportApplicationsGet(String appName,String appOwner,Boolean withKeys);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ExportApiServiceImpl.java
@@ -61,7 +61,7 @@ public class ExportApiServiceImpl extends ExportApiService {
      * @return Zipped file containing exported API
      */
     @Override
-    public Response exportApiGet(String name, String version, String providerName, String format,
+    public Response exportApiGet(String name, String version, String format, String providerName,
                                  Boolean preserveStatus) {
         ExportApiUtil exportApi = new ExportApiUtil();
         return exportApi.exportApiByParams(name, version, providerName, format, preserveStatus);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/resources/admin-api.yaml
@@ -2153,7 +2153,7 @@ paths:
           in: query
           description: |
             Provider name of the API
-          required: true
+          required: false
           type: string
         - name: format
           in: query

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/ExportApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/ExportApiUtil.java
@@ -60,6 +60,9 @@ public class ExportApiUtil {
         //If not specified status is preserved by default
         boolean isStatusPreserved = preserveStatus == null || preserveStatus;
 
+        // Print context information (name and version of the API) in the log
+        log.info("API name: "+ name + ", version: "+ version);
+
         if (name == null || version == null) {
             RestApiUtil.handleBadRequest("'name' or 'version' should not be null", log);
         }
@@ -74,13 +77,13 @@ public class ExportApiUtil {
             apiRequesterDomain = RestApiUtil.getLoggedInUserTenantDomain();
 
             // If provider name is not given
-            if (providerName.isEmpty()){
+            if (StringUtils.isBlank(providerName)) {
                 // Retrieve the provider who is in same tenant domain and who owns the same API (by comparing
                 // API name and the version)
                 providerName = APIUtil.getAPIProviderFromAPINameVersionTenant(name, version, apiRequesterDomain);
 
                 // If there is no provider in current domain, the API cannot be exported
-                if (providerName == null){
+                if (providerName == null) {
                     String errorMessage = "Error occurred while exporting. API: " + name + " version: " + version
                             + " not found";
                     RestApiUtil.handleResourceNotFoundError(errorMessage, log);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/ExportApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/ExportApiUtil.java
@@ -60,8 +60,8 @@ public class ExportApiUtil {
         //If not specified status is preserved by default
         boolean isStatusPreserved = preserveStatus == null || preserveStatus;
 
-        if (name == null || version == null || providerName == null) {
-            RestApiUtil.handleBadRequest("'name', 'version' or 'provider' should not be null", log);
+        if (name == null || version == null) {
+            RestApiUtil.handleBadRequest("'name' or 'version' should not be null", log);
         }
 
         try {
@@ -69,10 +69,26 @@ public class ExportApiUtil {
             exportFormat = StringUtils.isNotEmpty(format) ? ExportFormat.valueOf(format.toUpperCase()) :
                     ExportFormat.YAML;
 
+            // Get currently logged in user's username and the domain
             userName = RestApiUtil.getLoggedInUsername();
+            apiRequesterDomain = RestApiUtil.getLoggedInUserTenantDomain();
+
+            // If provider name is not given
+            if (providerName.isEmpty()){
+                // Retrieve the provider who is in same tenant domain and who owns the same API (by comparing
+                // API name and the version)
+                providerName = APIUtil.getAPIProviderFromAPINameVersionTenant(name, version, apiRequesterDomain);
+
+                // If there is no provider in current domain, the API cannot be exported
+                if (providerName == null){
+                    String errorMessage = "Error occurred while exporting. API: " + name + " version: " + version
+                            + " not found";
+                    RestApiUtil.handleResourceNotFoundError(errorMessage, log);
+                }
+            }
+
             //provider names with @ signs are only accepted
             apiDomain = MultitenantUtils.getTenantDomain(providerName);
-            apiRequesterDomain = RestApiUtil.getLoggedInUserTenantDomain();
 
             if (!StringUtils.equals(apiDomain, apiRequesterDomain)) {
                 //not authorized to export requested API

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/ExportApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/ExportApiUtil.java
@@ -60,11 +60,9 @@ public class ExportApiUtil {
         //If not specified status is preserved by default
         boolean isStatusPreserved = preserveStatus == null || preserveStatus;
 
-        // Print context information (name and version of the API) in the log
-        log.info("API name: "+ name + ", version: "+ version);
-
         if (name == null || version == null) {
-            RestApiUtil.handleBadRequest("'name' or 'version' should not be null", log);
+            RestApiUtil.handleBadRequest("'name' (" + name + ") or 'version' (" + version
+                    + ") should not be null.", log);
         }
 
         try {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/admin-api.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/admin-api.json
@@ -2197,7 +2197,7 @@
             "name": "providerName",
             "in": "query",
             "description": "Provider name of the API\n",
-            "required": true,
+            "required": false,
             "type": "string"
           },
           {
@@ -3546,9 +3546,9 @@
           "example": "IP"
         },
         "conditionValue": {
-          "type": "string",
+          "type": "object",
           "description": "Value of the blocking condition",
-          "example": "192.168.7.77"
+          "example": "{\"fixedIp\":\"192.168.1.1\":\"invert\":false}"
         }
       }
     },


### PR DESCRIPTION
## Purpose
During the API export process, the API Provider is a mandatory value. But when having more API providers, it is hard to define the correct API provider for each export request. 
Resolves issue https://github.com/wso2/product-apim-tooling/issues/173

## Goals
This fix makes API Provider optional by considering the logged-in user's tenant domain and checking it with the API provider's tenant.

## Approach
- Get currently logged in user name. 
- Get currently logged in user’s tenant domain (API requester domain).
- If the command was executed without the provider name (since it was made optional), get the API provider name using the API name, version which matches with the API requester domain. If such API provider was not found, display an error message.
 - If the command was executed with the provider name, steps should be carried out which were done before implementing this fix.


## User stories
Four user stories will be covered. (Assume two tenants as test1.com and test2.com were created, and an API was imported by user admin1@test1.com)
<ol>
<li>Export an API using a tenant user (by specifying the provider name) - API is in the same tenant
<code>apictl export-api -n SwaggerPetstore -r admin1@test1.com -v 1.0.3 -e production -k</code>
This works when a user who belongs to the same tenant executes the above command.
</li><br>

<li>Export an API using a tenant user (without specifying the provider name) - API is in the same tenant
<code>apictl export-api -n SwaggerPetstore -v 1.0.3 -e production -k</code>
This works when a user who belongs to the same tenant executes the above command.
</li><br>

<li>Export an API using a tenant user (by specifying the provider name) - API is in a different tenant
<code>apictl export-api -n SwaggerPetstore -r admin1@test1.com -v 1.0.3 -e production -k</code>
This does not work when a user who belongs to another tenant executes the above command.</li><br>

<li>Export an API using a tenant user (without specifying the provider name) - API is in a different tenant
<code>apictl export-api -n SwaggerPetstore -v 1.0.3 -e production -k</code>
This does not work when a user who belongs to another tenant executes the above command.
</li><br>
</ol>

## Release note
When exporting an API using API Controller (apictl), --provider (-r) flag is optional

## Documentation
Docs should change here: https://github.com/wso2/docs-apim/blob/master/en/docs/learn/api-controller/migrating-apis-to-different-environments.md#export-an-api

!!! info **Flags:** section should change like below by adding --provider as an optional flag 
    
            -    Required :  
                `--name` or `-n` : Name of the API to be exported  
                `--version` or `-v` : Version of the API to be exported   
                `--environment` or `-e` : Environment to which the API should be exported  
            -   Optional :  
                `--provider` or `-r` : Provider of the API        
                `--preserveStatus` : Preserve API status when exporting. Otherwise, the API will be exported in the `CREATED` status. The default value is `true`.  
                `--format` : File format of exported archive (JSON or YAML). The default value is YAML.
            
!!! example section should change like below (remove "-r admin" in the first example)
            ```go
            apictl export-api -n PhoneVerification -v 1.0.0 -e dev -k
            ```
            ```go
            apictl export-api -n PizzaShackAPI -v 1.0.0 -r Alice -e dev --preserveStatus=true --format JSON -k
            ```            
## Test environment
-  JDK 1.8.0_241
- Ubuntu 18.04.4 LTS