### PR TITLE
Fix regex pattern find issue for sub string values in JWTClaims and QueryParam Conditional Throttling

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleConditionEvaluator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleConditionEvaluator.java
@@ -207,16 +207,18 @@ public class ThrottleConditionEvaluator {
     private boolean isJWTClaimPresent(AuthenticationContext authenticationContext, ConditionDTO condition) {
 
         Map assertions = GatewayUtils.getJWTClaims(authenticationContext);
-
-        Object value = assertions.get(condition.getConditionName());
-        if (value == null) {
-            return false;
-        } else if (value instanceof String) {
-            String valueString = (String) value;
-            return valueString.matches(condition.getConditionValue());
-        } else {
-            return false;
+        if (assertions != null) {
+            Object value = assertions.get(condition.getConditionName());
+            if (value == null) {
+                return false;
+            } else if (value instanceof String) {
+                String valueString = (String) value;
+                Pattern pattern = Pattern.compile(condition.getConditionValue());
+                Matcher matcher = pattern.matcher(valueString);
+                return matcher.find();
+            }
         }
+        return false;
     }
 
     private boolean isJWTClaimPresent(AuthenticationContext authenticationContext, ConditionDto.JWTClaimConditions
@@ -232,7 +234,9 @@ public class ThrottleConditionEvaluator {
                 break;
             } else if (value instanceof String) {
                 String valueString = (String) value;
-                status = status && valueString.matches(jwtClaim.getValue());
+                Pattern pattern = Pattern.compile(jwtClaim.getValue());
+                Matcher matcher = pattern.matcher(valueString);
+                status = status && matcher.find();
             } else {
                 status = false;
             }
@@ -255,7 +259,9 @@ public class ThrottleConditionEvaluator {
                 status = false;
                 break;
             } else {
-                status = status && value.matches(queryParam.getValue());
+                Pattern pattern = Pattern.compile(queryParam.getValue());
+                Matcher matcher = pattern.matcher(value);
+                status = status && matcher.find();
             }
         }
         if (condition.isInvert()) {
@@ -269,12 +275,16 @@ public class ThrottleConditionEvaluator {
 
         Map<String, String> queryParamMap = GatewayUtils.getQueryParams(messageContext);
 
-        String value = queryParamMap.get(condition.getConditionName());
-
-        if (value == null) {
-            return false;
+        if (queryParamMap != null) {
+            String value = queryParamMap.get(condition.getConditionName());
+            if (value == null) {
+                return false;
+            }
+            Pattern pattern = Pattern.compile(condition.getConditionValue());
+            Matcher matcher = pattern.matcher(value);
+            return matcher.find();
         }
-        return value.matches(condition.getConditionValue());
+        return false;
     }
 
     private boolean isMatchingIP(MessageContext messageContext, ConditionDTO condition) {


### PR DESCRIPTION
Fix https://github.com/wso2/product-apim/issues/7737 applies for both JWTClaims and QueryParam Throttling. 

For example, a JWTClaim thorttling execution plan will look like this
`...SELECT messageID, (apiTenant == 'abc.com' and resourceTier == 'JWTClaom' AND (regex:find('1.0',cast(map:get(propertiesMap,'http://wso2.org/claims/version'),'string')))) AS isEligible, str:concat(resourceKey,'_condition_232') AS throttleKey, ...` 

Note the **regex:find**

The problem is that in GW, we do a match for the entire string instead of finding for any substring.