### PR TITLE
Bug-Fix:Get API details using REST API call returned null values

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -3418,7 +3418,6 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (api.isEndpointSecured() && StringUtils.isEmpty(api.getEndpointUTPassword())) {
             String errorMessage = "Empty password is given for endpointSecurity when creating API "
                     + api.getId().getApiName();
-            log.error(errorMessage);
             throw new APIManagementException(errorMessage);
         }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -487,12 +487,15 @@ public abstract class AbstractAPIManager implements APIManager {
      * @throws APIManagementException
      */
     public API getAPIbyUUID(String uuid, String requestedTenantDomain) throws APIManagementException {
+        boolean tenantFlowStarted = false;
         try {
             Registry registry;
             if (requestedTenantDomain != null && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals
                     (requestedTenantDomain)) {
                 int id = getTenantManager()
                         .getTenantId(requestedTenantDomain);
+                startTenantFlow(requestedTenantDomain);
+                tenantFlowStarted = true;
                 registry = getRegistryService().getGovernanceSystemRegistry(id);
             } else {
                 if (this.tenantDomain != null && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(this.tenantDomain)) {
@@ -530,6 +533,10 @@ public abstract class AbstractAPIManager implements APIManager {
             String msg = "Failed to get API";
             log.error(msg, e);
             throw new APIManagementException(msg, e);
+        }finally {
+            if (tenantFlowStarted) {
+                endTenantFlow();
+            }
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -533,7 +533,7 @@ public abstract class AbstractAPIManager implements APIManager {
             String msg = "Failed to get API";
             log.error(msg, e);
             throw new APIManagementException(msg, e);
-        }finally {
+        } finally {
             if (tenantFlowStarted) {
                 endTenantFlow();
             }


### PR DESCRIPTION
Get API Details using REST API returned null values for business information and the lifecycle state is displayed as "Created". 
(Backported fix from https://github.com/wso2-support/carbon-apimgt/pull/1883)
Fix https://github.com/wso2/product-apim/issues/7596