### PR TITLE
Fix for #7696

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/CacheInvalidationServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/service/CacheInvalidationServiceImpl.java
@@ -75,15 +75,11 @@ public class CacheInvalidationServiceImpl implements CacheInvalidationService {
                 cache.removeAll();
             } else {
                 String apiCacheKey = APIUtil.getAPIInfoDTOCacheKey(apiContext, apiVersion);
-                if (cache.containsKey(apiCacheKey)) {
-                    cache.remove(apiCacheKey);
-                }
+                cache.remove(apiCacheKey);
                 for (ResourceCacheInvalidationDto uriTemplate : uriTemplates) {
                     String resourceVerbCacheKey = APIUtil.getResourceInfoDTOCacheKey(apiContext, apiVersion,
                             uriTemplate.getResourceURLContext(), uriTemplate.getHttpVerb());
-                    if (cache.containsKey(resourceVerbCacheKey)) {
-                        cache.remove(resourceVerbCacheKey);
-                    }
+                    cache.remove(resourceVerbCacheKey);
                 }
             }
 


### PR DESCRIPTION
This PR resolves the issue of resource cache invalidation cluster message not being sent to the worker nodes when updating an API resource.