### PR TITLE
Modifying listing all the applications for a tenant

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -4873,7 +4873,6 @@ public class ApiMgtDAO {
         Connection connection = null;
         PreparedStatement prepStmt = null;
         ResultSet rs = null;
-        Application applications = null;
         String sqlQuery = null;
         List<Application> applicationList = new ArrayList<>();
         sqlQuery = SQLConstantManagerFactory.getSQlString("GET_APPLICATIONS_BY_TENANT_ID");
@@ -4900,6 +4899,7 @@ public class ApiMgtDAO {
                 application.setGroupId(rs.getString("GROUP_ID"));
                 subscriber.setTenantId(rs.getInt("TENANT_ID"));
                 subscriber.setId(rs.getInt("SUBSCRIBER_ID"));
+                application.setStatus(rs.getString("APPLICATION_STATUS"));
                 application.setOwner(subscriberName);
                 applicationList.add(application);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantOracle.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantOracle.java
@@ -227,7 +227,8 @@ public class SQLConstantOracle extends SQLConstants{
                     "   SUB.TENANT_ID AS TENANT_ID, " +
                     "   SUB.SUBSCRIBER_ID AS SUBSCRIBER_ID, " +
                     "   APP.UUID AS UUID," +
-                    "   APP.NAME AS NAME" +
+                    "   APP.NAME AS NAME," +
+                    "   APP.APPLICATION_STATUS as APPLICATION_STATUS" +
                     " FROM" +
                     "   AM_APPLICATION APP, " +
                     "   AM_SUBSCRIBER SUB  " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantPostgreSQL.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantPostgreSQL.java
@@ -210,7 +210,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   SUB.TENANT_ID AS TENANT_ID, " +
                     "   SUB.SUBSCRIBER_ID AS SUBSCRIBER_ID, " +
                     "   APP.UUID AS UUID," +
-                    "   APP.NAME AS NAME   " +
+                    "   APP.NAME AS NAME," +
+                    "   APP.APPLICATION_STATUS as APPLICATION_STATUS  " +
                     " FROM" +
                     "   AM_APPLICATION APP, " +
                     "   AM_SUBSCRIBER SUB  " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsDB2.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsDB2.java
@@ -191,7 +191,8 @@ public class SQLConstantsDB2 extends SQLConstants{
                     "   SUB.TENANT_ID AS TENANT_ID, " +
                     "   SUB.SUBSCRIBER_ID AS SUBSCRIBER_ID, " +
                     "   APP.UUID AS UUID," +
-                    "   APP.NAME AS NAME  " +
+                    "   APP.NAME AS NAME," +
+                    "   APP.APPLICATION_STATUS as APPLICATION_STATUS  " +
                     " FROM" +
                     "   AM_APPLICATION APP, " +
                     "   AM_SUBSCRIBER SUB  " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsH2MySQL.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsH2MySQL.java
@@ -213,7 +213,8 @@ public class SQLConstantsH2MySQL extends SQLConstants{
                     "   SUB.TENANT_ID AS TENANT_ID, " +
                     "   SUB.SUBSCRIBER_ID AS SUBSCRIBER_ID, " +
                     "   APP.UUID AS UUID," +
-                    "   APP.NAME AS NAME  " +
+                    "   APP.NAME AS NAME," +
+                    "   APP.APPLICATION_STATUS as APPLICATION_STATUS  " +
                     " FROM" +
                     "   AM_APPLICATION APP, " +
                     "   AM_SUBSCRIBER SUB  " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsMSSQL.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsMSSQL.java
@@ -231,7 +231,8 @@ public class SQLConstantsMSSQL extends SQLConstants{
                     "   SUB.TENANT_ID AS TENANT_ID, " +
                     "   SUB.SUBSCRIBER_ID AS SUBSCRIBER_ID, " +
                     "   APP.UUID AS UUID," +
-                    "   cast(APP.NAME as varchar(100)) collate SQL_Latin1_General_CP1_CI_AS as NAME" +
+                    "   cast(APP.NAME as varchar(100)) collate SQL_Latin1_General_CP1_CI_AS as NAME, " +
+                    "   APP.APPLICATION_STATUS as APPLICATION_STATUS" +
                     " FROM" +
                     "   AM_APPLICATION APP, " +
                     "   AM_SUBSCRIBER SUB  " +

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ApplicationsApiServiceImpl.java
@@ -9,6 +9,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.impl.APIAdminImpl;
 import org.wso2.carbon.apimgt.impl.APIManagerFactory;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.admin.ApplicationsApiService;
 import org.wso2.carbon.apimgt.rest.api.admin.dto.ApplicationListDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.utils.mappings.ApplicationMappingUtil;
@@ -17,7 +18,6 @@ import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import javax.ws.rs.core.Response;
-
 public class ApplicationsApiServiceImpl extends ApplicationsApiService {
 
     private static final Log log = LogFactory.getLog(ApplicationsApiServiceImpl.class);
@@ -46,8 +46,12 @@ public class ApplicationsApiServiceImpl extends ApplicationsApiService {
     @Override
     public Response applicationsGet(String user, Integer limit, Integer offset, String accept, String ifNoneMatch,
                                     String appTenantDomain) {
+
+        // To store the initial value of the user (specially if it is null or empty)
+        String givenUser = user;
+
         // if no username provided user associated with access token will be used
-        if (user == null || user.isEmpty()) {
+        if (user == null || StringUtils.isEmpty(user)) {
             user = RestApiUtil.getLoggedInUsername();
         }
 
@@ -65,8 +69,18 @@ public class ApplicationsApiServiceImpl extends ApplicationsApiService {
                     return Response.status(Response.Status.FORBIDDEN).entity(errorMsg).build();
                 }
                 APIConsumer apiConsumer = APIManagerFactory.getInstance().getAPIConsumer(user);
-                allMatchedApps = apiConsumer.getApplicationsByOwner(user);
 
+                // If no user is passed, get the applications for the tenant (not only for the user)
+                if (givenUser == null || StringUtils.isEmpty(givenUser)) {
+                    APIAdmin apiAdmin = new APIAdminImpl();
+                    int tenantId = APIUtil.getTenantId(user);
+                    allMatchedApps = apiAdmin.getApplicationsByTenantIdWithPagination(tenantId, 0, limit,
+                            "", "", ApplicationMappingUtil.getApplicationSortByField("name"),
+                            RestApiConstants.DEFAULT_SORT_ORDER).toArray(new Application[0]);
+                }
+                else {
+                    allMatchedApps = apiConsumer.getApplicationsByOwner(user);
+                }
             } else { // flow at migration process
                 if (StringUtils.isEmpty(appTenantDomain)) {
                     appTenantDomain = MultitenantUtils.getTenantDomain(user);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/impl/ApplicationsApiServiceImpl.java
@@ -8,6 +8,7 @@ import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.impl.APIAdminImpl;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerFactory;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.admin.ApplicationsApiService;
@@ -75,10 +76,9 @@ public class ApplicationsApiServiceImpl extends ApplicationsApiService {
                     APIAdmin apiAdmin = new APIAdminImpl();
                     int tenantId = APIUtil.getTenantId(user);
                     allMatchedApps = apiAdmin.getApplicationsByTenantIdWithPagination(tenantId, 0, limit,
-                            "", "", ApplicationMappingUtil.getApplicationSortByField("name"),
+                            "", "", APIConstants.APPLICATION_NAME,
                             RestApiConstants.DEFAULT_SORT_ORDER).toArray(new Application[0]);
-                }
-                else {
+                } else {
                     allMatchedApps = apiConsumer.getApplicationsByOwner(user);
                 }
             } else { // flow at migration process

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/mappings/ApplicationMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/mappings/ApplicationMappingUtil.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.rest.api.admin.utils.mappings;
 import org.wso2.carbon.apimgt.api.model.APIKey;
 import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.Subscriber;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.rest.api.admin.dto.ApplicationInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.dto.ApplicationListDTO;
 import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
@@ -31,6 +32,24 @@ import java.util.Map;
 
 public class ApplicationMappingUtil {
 
+    /***
+     * Converts the sort by object according to the input
+     *
+     * @param sortBy
+     * @return Updated sort by field
+     */
+    public static String getApplicationSortByField (String sortBy) {
+        String updatedSortBy = "";
+        if (RestApiConstants.SORT_BY_NAME.equals(sortBy)) {
+            updatedSortBy = APIConstants.APPLICATION_NAME;
+        } else if (RestApiConstants.SORT_BY_THROTTLING_TIER.equals(sortBy)) {
+            updatedSortBy = APIConstants.APPLICATION_TIER;
+        } else if (RestApiConstants.SORT_BY_STATUS.equals(sortBy)) {
+            updatedSortBy = APIConstants.APPLICATION_STATUS;
+        }
+
+        return updatedSortBy;
+    }
 
     public static ApplicationListDTO fromApplicationsToDTO(Application[] applications, int limit, int offset) {
         ApplicationListDTO applicationListDTO = new ApplicationListDTO();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/mappings/ApplicationMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/mappings/ApplicationMappingUtil.java
@@ -32,25 +32,6 @@ import java.util.Map;
 
 public class ApplicationMappingUtil {
 
-    /***
-     * Converts the sort by object according to the input
-     *
-     * @param sortBy
-     * @return Updated sort by field
-     */
-    public static String getApplicationSortByField (String sortBy) {
-        String updatedSortBy = "";
-        if (RestApiConstants.SORT_BY_NAME.equals(sortBy)) {
-            updatedSortBy = APIConstants.APPLICATION_NAME;
-        } else if (RestApiConstants.SORT_BY_THROTTLING_TIER.equals(sortBy)) {
-            updatedSortBy = APIConstants.APPLICATION_TIER;
-        } else if (RestApiConstants.SORT_BY_STATUS.equals(sortBy)) {
-            updatedSortBy = APIConstants.APPLICATION_STATUS;
-        }
-
-        return updatedSortBy;
-    }
-
     public static ApplicationListDTO fromApplicationsToDTO(Application[] applications, int limit, int offset) {
         ApplicationListDTO applicationListDTO = new ApplicationListDTO();
         List<ApplicationInfoDTO> applicationInfoDTOs = applicationListDTO.getList();


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/205

## Goals
- Perform the changes to list applications in an environment without specifying the owner or by specifying the owner
- Change the database queries to retrieve APPLICATION_STATUS as well.

## Approach
If the owner is not specified based on the tenant ID all the application for that particular tenant was retrieved using getApplicationsByTenantIdWithPagination. The database queries associated with this function were changed since earlier it does not retrieve "APPLICATION_STATUS".

## User stories
Assume there is an environment named "test".
- When someone has invoked the below command to list applications for an environment **without specifying the owner**, it should list all the applications belongs to the tenant (which the currently logged in user belongs) in that environment.
  <code>apictl list apps -e test -k</code>
- When someone has invoked the below command to list applications for an environment **by specifying the owner**, it should list all the applications belongs to that particular owner in that environment.
  <code>apictl list apps -e test -o sampleUser -k</code>

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/209

## Test environment
-  JDK 1.8.0_241
- Ubuntu 18.04.4 LTS
