### PR TITLE
Importing/exporting API thumbnail icon from UI

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/APIImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/APIImportExportConstants.java
@@ -128,5 +128,7 @@ public final class APIImportExportConstants {
         fileExtensionMapping.put("image/jpg", "jpg");
         fileExtensionMapping.put("image/bmp", "bmp");
         fileExtensionMapping.put("image/gif", "gif");
+        // To identify thumbnail icons
+        fileExtensionMapping.put("application/json", "json");
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -76,6 +76,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -523,7 +524,17 @@ public final class APIImportUtil {
     private static void updateAPIWithThumbnail(File imageFile, API importedApi, APIProvider apiProvider) {
 
         APIIdentifier apiIdentifier = importedApi.getId();
-        String mimeType = URLConnection.guessContentTypeFromName(imageFile.getName());
+        String fileName = imageFile.getName();
+        String mimeType = URLConnection.guessContentTypeFromName(fileName);
+        if (StringUtils.isBlank(mimeType)) {
+            try {
+                // Check whether the icon is in .json format (UI icons are stored as .json)
+                new JsonParser().parse(new FileReader(imageFile));
+                mimeType = APIConstants.APPLICATION_JSON_MEDIA_TYPE;
+            } catch (Exception e) {
+                log.error("Failed to read the file. ", e);
+            }
+        }
         try (FileInputStream inputStream = new FileInputStream(imageFile.getAbsolutePath())) {
             ResourceFile apiImage = new ResourceFile(inputStream, mimeType);
             String thumbPath = APIUtil.getIconPath(apiIdentifier);


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/216

## Goals
- If an API is exported with a UI thumbnail icon (which is not an image but in .json format), include it in the exported archive.
- If an API is imported with a UI thumbnail icon (which is not an image but in .json format) included in an archive or directory, import it successfully. (Need to work when updating an API as well)

## Approach
- When exporting an API, earlier if the thumbnail is in .json format it was skipped. But now if the thumbnail is in .json format the particular file will be exported in the archive as a .json file.
- When importing an API, earlier if the thumbnail is in .json format it was skipped. But now if the thumbnail is in .json format the particular file will be imported and will be stored in the registry as a .json file.

## User stories
- Export
  - A user exports an API with a thumbnail icon using apictl.
  - A user downloads an API with a thumbnail icon using the UI.
- Import
  - A user imports an API with a thumbnail icon using apictl.
  - A user updates an API with a thumbnail icon by importing it using apictl.

## Test environment
-  JDK 1.8.0_241
- Ubuntu 18.04.4 LTS