### PR TITLE
Modify exceptions when importing/exporting API thumbnail icon from UI

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -19,7 +19,12 @@
 package org.wso2.carbon.apimgt.impl.importexport.utils;
 
 import com.google.common.collect.Sets;
-import com.google.gson.*;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.io.FileUtils;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -19,11 +19,7 @@
 package org.wso2.carbon.apimgt.impl.importexport.utils;
 
 import com.google.common.collect.Sets;
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.io.FileUtils;
@@ -531,8 +527,13 @@ public final class APIImportUtil {
                 // Check whether the icon is in .json format (UI icons are stored as .json)
                 new JsonParser().parse(new FileReader(imageFile));
                 mimeType = APIConstants.APPLICATION_JSON_MEDIA_TYPE;
-            } catch (Exception e) {
-                log.error("Failed to read the file. ", e);
+            } catch (JsonParseException e) {
+                // Here the exceptions were handled and logged that may arise when parsing the .json file,
+                // and this will not break the flow of importing the API.
+                // If the .json is wrong or cannot be found the API import process will still be carried out.
+                log.error("Failed to read the thumbnail file. ", e);
+            } catch (FileNotFoundException e) {
+                log.error("Failed to find the thumbnail file. ", e);
             }
         }
         try (FileInputStream inputStream = new FileInputStream(imageFile.getAbsolutePath())) {


### PR DESCRIPTION
## Purpose
Change the exception handling when importing/exporting API thumbnail icon from UI. 
Fixes: https://github.com/wso2/product-apim-tooling/issues/216

## Goals
- Change the generic exception to specific ones.
- Justify the need more using comments

## Approach
- String mimeType = URLConnection.guessContentTypeFromName(fileName) decides the mimetype for image extensions such as .jpg, .jpeg, .png, .gif, .bmp. But if the file type is .json URLConnection returns null. 
- So, used JsonParser which will identify whether it is a valid .json file or not.
- If it is not an image or not a JSON file then the exception should be handled without breaking the flow. (In here the thumbnail will not get imported, but the API will get successfully imported without the thumbnail) 

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/8384
- https://github.com/wso2-support/carbon-apimgt/pull/1929

## Test environment
-  JDK 1.8.0_241
- Ubuntu 18.04.4 LTS

