### PR TITLE
Errorous cast of APIs & APIProducts into Set<API>

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
@@ -157,7 +157,7 @@ public class ApisApiServiceImpl extends ApisApiService {
 
             Map<String, Object> result = apiProvider.searchPaginatedAPIs(newSearchQuery, tenantDomain,
                                         offset, limit, false);
-            Set<API> apis = (Set<API>) result.get("apis");
+            Set<API> apis = (Set)((Set)result.get("apis")).stream().filter(p->p instanceof API).collect(Collectors.toSet());
             allMatchedApis.addAll(apis);
 
             apiListDTO = APIMappingUtil.fromAPIListToDTO(allMatchedApis, expand);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/impl/ApisApiServiceImpl.java
@@ -96,6 +96,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.xml.namespace.QName;


### PR DESCRIPTION
apiProvider.searchPaginatedAPIs returns APIs and APIProducts in single Set. Casting this set to Set of API cause error in org.wso2.carbon.apimgt.rest.api.publisher.utils.mappings.APIMappingUtil.fromAPIListToDTO method because APIProduct is not extended on API class. 
Exception than occurs: java.lang.ClassCastException: org.wso2.carbon.apimgt.api.model.APIProduct cannot be cast to org.wso2.carbon.apimgt.api.model.API