### PR TITLE
Improvements to TryOut console

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -82,6 +82,8 @@ class ApiConsole extends React.Component {
             scopes: [],
             selectedKeyType: 'PRODUCTION',
             keys: [],
+            productionApiKey: '',
+            sandboxApiKey: '',
         };
         this.accessTokenProvider = this.accessTokenProvider.bind(this);
         this.updateSwagger = this.updateSwagger.bind(this);
@@ -94,6 +96,8 @@ class ApiConsole extends React.Component {
         this.setSelectedKeyType = this.setSelectedKeyType.bind(this);
         this.setKeys = this.setKeys.bind(this);
         this.updateAccessToken = this.updateAccessToken.bind(this);
+        this.setProductionApiKey = this.setProductionApiKey.bind(this);
+        this.setSandboxApiKey = this.setSandboxApiKey.bind(this);
     }
 
     /**
@@ -170,8 +174,12 @@ class ApiConsole extends React.Component {
      * Set Selected Environment
      * @memberof ApiConsole
      */
-    setSelectedEnvironment(selectedEnvironment) {
-        this.setState({ selectedEnvironment });
+    setSelectedEnvironment(selectedEnvironment, isUpdateSwagger) {
+        if (isUpdateSwagger) {
+            this.setState({ selectedEnvironment }, this.updateSwagger);
+        } else {
+            this.setState({ selectedEnvironment });
+        }
     }
 
     /**
@@ -188,6 +196,22 @@ class ApiConsole extends React.Component {
      */
     setSandboxAccessToken(sandboxAccessToken) {
         this.setState({ sandboxAccessToken });
+    }
+
+    /**
+     * Set Production API Key
+     * @memberof ApiConsole
+     */
+    setProductionApiKey(productionApiKey) {
+        this.setState({ productionApiKey });
+    }
+
+    /**
+     * Set Sandbox API Key
+     * @memberof ApiConsole
+     */
+    setSandboxApiKey(sandboxApiKey) {
+        this.setState({ sandboxApiKey });
     }
 
     /**
@@ -250,13 +274,19 @@ class ApiConsole extends React.Component {
     accessTokenProvider() {
         const {
             securitySchemeType, username, password, productionAccessToken,
-            sandboxAccessToken, selectedKeyType,
+            sandboxAccessToken, selectedKeyType, productionApiKey, sandboxApiKey,
         } = this.state;
         if (securitySchemeType === 'BASIC') {
             const credentials = username + ':' + password;
             return btoa(credentials);
         }
-        if (selectedKeyType === 'PRODUCTION') {
+        if (securitySchemeType === 'API-KEY') {
+            if (selectedKeyType === 'PRODUCTION') {
+                return productionApiKey;
+            } else {
+                return sandboxApiKey;
+            }
+        } else if (selectedKeyType === 'PRODUCTION') {
             return productionAccessToken;
         } else {
             return sandboxAccessToken;
@@ -295,7 +325,8 @@ class ApiConsole extends React.Component {
         const { classes } = this.props;
         const {
             api, notFound, swagger, securitySchemeType, selectedEnvironment, labels, environments, scopes,
-            username, password, productionAccessToken, sandboxAccessToken, selectedKeyType,
+            username, password, productionAccessToken, sandboxAccessToken, selectedKeyType, sandboxApiKey,
+            productionApiKey,
         } = this.state;
         const user = AuthManager.getUser();
         const downloadSwagger = JSON.stringify({ ...swagger });
@@ -367,6 +398,10 @@ class ApiConsole extends React.Component {
                         selectedKeyType={selectedKeyType}
                         updateSwagger={this.updateSwagger}
                         setKeys={this.setKeys}
+                        setProductionApiKey={this.setProductionApiKey}
+                        setSandboxApiKey={this.setSandboxApiKey}
+                        productionApiKey={productionApiKey}
+                        sandboxApiKey={sandboxApiKey}
                     />
 
                     <Grid container>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/TryOutController.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/TryOutController.jsx
@@ -99,8 +99,9 @@ function TryOutController(props) {
     const {
         securitySchemeType, selectedEnvironment, environments, labels,
         productionAccessToken, sandboxAccessToken, selectedKeyType, setKeys, setSelectedKeyType,
-        setSelectedEnvironment, setProductionAccessToken, setSandboxAccessToken, scopes, updateSwagger,
+        setSelectedEnvironment, setProductionAccessToken, setSandboxAccessToken, scopes,
         setSecurityScheme, setUsername, setPassword, username, password,
+        setProductionApiKey, setSandboxApiKey, productionApiKey, sandboxApiKey,
     } = props;
     const classes = styles();
 
@@ -143,7 +144,7 @@ function TryOutController(props) {
                             setSelectedApplication(selectedApplicationList);
                             setSubscriptions(subscriptionsList);
                             setKeys(appKeys);
-                            setSelectedEnvironment(selectedEnvironments);
+                            setSelectedEnvironment(selectedEnvironments, false);
                             setSelectedKeyType(selectedKeyTypes, false);
                             if (selectedKeyType === 'PRODUCTION') {
                                 setProductionAccessToken(accessToken);
@@ -155,7 +156,7 @@ function TryOutController(props) {
                     setSelectedApplication(selectedApplicationList);
                     setSubscriptions(subscriptionsList);
                     setKeys(keys);
-                    setSelectedEnvironment(selectedEnvironment);
+                    setSelectedEnvironment(selectedEnvironment, false);
                     if (selectedKeyType === 'PRODUCTION') {
                         setProductionAccessToken(accessToken);
                     } else {
@@ -167,7 +168,7 @@ function TryOutController(props) {
                 setSelectedApplication(selectedApplicationList);
                 setSubscriptions(subscriptionsList);
                 setKeys(keys);
-                setSelectedEnvironment(selectedEnvironment);
+                setSelectedEnvironment(selectedEnvironment, false);
                 if (selectedKeyType === 'PRODUCTION') {
                     setProductionAccessToken(accessToken);
                 } else {
@@ -230,9 +231,9 @@ function TryOutController(props) {
                 console.log('Non empty response received', response);
                 setShowToken(false);
                 if (selectedKeyType === 'PRODUCTION') {
-                    setProductionAccessToken(response.body.apikey);
+                    setProductionApiKey(response.body.apikey);
                 } else {
-                    setSandboxAccessToken(response.body.apikey);
+                    setSandboxApiKey(response.body.apikey);
                 }
                 setIsUpdating(false);
             })
@@ -302,12 +303,13 @@ function TryOutController(props) {
         const { name, value } = target;
         switch (name) {
             case 'selectedEnvironment':
-                setSelectedEnvironment(value);
-                updateSwagger();
+                setSelectedEnvironment(value, true);
                 break;
             case 'selectedApplication':
                 setProductionAccessToken('');
                 setSandboxAccessToken('');
+                setProductionApiKey('');
+                setSandboxApiKey('');
                 setSelectedApplication(value);
                 break;
             case 'selectedKeyType':
@@ -318,8 +320,6 @@ function TryOutController(props) {
                 }
                 break;
             case 'securityScheme':
-                setProductionAccessToken('');
-                setSandboxAccessToken('');
                 setSecurityScheme(value);
                 break;
             case 'username':
@@ -354,6 +354,13 @@ function TryOutController(props) {
         }
     }
     const isPrototypedAPI = api.lifeCycleStatus && api.lifeCycleStatus.toLowerCase() === 'prototyped';
+
+    let tokenValue = '';
+    if (securitySchemeType === 'API-KEY') {
+        tokenValue = selectedKeyType === 'PRODUCTION' ? productionApiKey : sandboxApiKey;
+    } else {
+        tokenValue = selectedKeyType === 'PRODUCTION' ? productionAccessToken : sandboxAccessToken;
+    }
 
     return (
         <>
@@ -492,8 +499,9 @@ function TryOutController(props) {
                                                 name='accessToken'
                                                 onChange={handleChanges}
                                                 type={showToken ? 'text' : 'password'}
-                                                value={selectedKeyType === 'PRODUCTION'
-                                                    ? productionAccessToken : sandboxAccessToken}
+                                                // value={selectedKeyType === 'PRODUCTION'
+                                                //     ? productionAccessToken : sandboxAccessToken}
+                                                value={tokenValue}
                                                 helperText={(
                                                     <FormattedMessage
                                                         id='enter.access.token'
@@ -539,7 +547,7 @@ function TryOutController(props) {
                                                     )}
                                                     <FormattedMessage
                                                         id='Apis.Details.ApiCOnsole.generate.test.key'
-                                                        defaultMessage='GEN. TEST KEY '
+                                                        defaultMessage='GET TEST KEY '
                                                     />
                                                 </Button>
                                                 <Tooltip
@@ -585,7 +593,7 @@ function TryOutController(props) {
                                                         id='Apis.Details.ApiConsole.environment'
                                                     />
                                                 )}
-                                                value={selectedEnvironment}
+                                                value={selectedEnvironment || (environments && environments[0])}
                                                 name='selectedEnvironment'
                                                 onChange={handleChanges}
                                                 helperText={(

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/TryOutController.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/TryOutController.jsx
@@ -499,8 +499,6 @@ function TryOutController(props) {
                                                 name='accessToken'
                                                 onChange={handleChanges}
                                                 type={showToken ? 'text' : 'password'}
-                                                // value={selectedKeyType === 'PRODUCTION'
-                                                //     ? productionAccessToken : sandboxAccessToken}
                                                 value={tokenValue}
                                                 helperText={(
                                                     <FormattedMessage


### PR DESCRIPTION
This PR includes the following changes:

- GEN.TEST KEY was changed to GET TEST KEY
- Both newly generated tokens for Api Key and Oauth are now persisted.
- Pre Selected Gateway environment displayed.

<img width="939" alt="Screen Shot 2020-04-02 at 1 58 36 PM" src="https://user-images.githubusercontent.com/19324135/78226907-14e5df80-74ea-11ea-8731-f8ca46d62017.png">
