### PR TITLE
Directing custom URL enabled tenant to appropriate authentication endpoint

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/login/idp.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/login/idp.jag
@@ -29,7 +29,10 @@
     if (app.customUrl.enabled && forwarded_for) {
         serverUrl = MGT_TRANSPORT + forwarded_for;
     } else {
-        serverUrl = utils.getServerURL();
+        serverUrl = appUtils.getTenantBasedCustomUrl();
+        if (serverUrl == null) {
+            serverUrl = utils.getServerURL();
+        }
     }
     var authorizeEndpoint = serverUrl + AUTHORIZE_ENDPOINT_SUFFIX;
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/login/login_callback.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/login/login_callback.jag
@@ -29,7 +29,10 @@
     if (app.customUrl.enabled && forwarded_for) {
         serverUrl = MGT_TRANSPORT + forwarded_for;
     } else {
-        serverUrl = utils.getServerURL();
+        serverUrl = appUtils.getTenantBasedCustomUrl();
+        if (serverUrl == null) {
+            serverUrl = utils.getServerURL();
+        }
     }
     if(request.getParameter("error") === "login_required"){
        response.sendRedirect(serverUrl + app.context + "/services/configs");

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/logout/logout.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/logout/logout.jag
@@ -32,7 +32,10 @@
     if (app.customUrl.enabled && forwarded_for) {
         serverUrl = MGT_TRANSPORT + forwarded_for;
     } else {
-        serverUrl = utils.getServerURL();
+        serverUrl = appUtils.getTenantBasedCustomUrl();
+        if (serverUrl == null) {
+            serverUrl = utils.getServerURL();
+        }
     }
     var logoutEndpoint = serverUrl + OIDC_LOGOUT_ENDPOINT_SUFFIX;
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/services/utils.js
@@ -88,6 +88,16 @@ var getCustomUrlEnabledDomain = function() {
     return tenantDomain;
 };
 
+var getTenantBasedCustomUrl = function() {
+    var tenantDomain = getTenantDomain();
+    var storeDomainMapping = utils.getTenantBasedStoreDomainMapping(tenantDomain);
+    if (storeDomainMapping != null) {
+        return "https://" + storeDomainMapping.get('customUrl');
+    } else {
+        return null;
+    }
+};
+
 var getServiceProviderTenantDomain = function(){
     var tenantDomain = getTenantDomain();
     if (isPerTenantServiceProviderEnabled()) {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/7809

## Goals
When custom URL is enabled, direct the user to the authentication endpoint containing the custom URL.

## Approach
If customURL is enabled, assign customURL value to serverURL.

## Test environment
JDK 1.8.0_241
Ubuntu 18.04.4 LTS