### PR TITLE
Add REST API to retrieve subscriber-info

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -177,6 +177,24 @@ public interface APIProvider extends APIManager {
      */
     long getAPISubscriptionCountByAPI(APIIdentifier identifier) throws APIManagementException;
 
+    /**
+     * Returns the subscriber name for the given subscription id.
+     *
+     * @param subscriptionId The subscription id of the subscriber to be returned
+     * @return The subscriber or null if the requested subscriber does not exist
+     * @throws APIManagementException if failed to get Subscriber
+     */
+    String getSubscriber(String subscriptionId) throws APIManagementException;
+
+    /**
+     * Returns the claims of subscriber for the given subscriber.
+     *
+     * @param subscriber The name of the subscriber to be returned
+     * @return The looked up claims of the subscriber or null if the requested subscriber does not exist
+     * @throws APIManagementException if failed to get Subscriber
+     */
+    List getSubscriberClaims(String subscriber) throws APIManagementException;
+
     void addTier(Tier tier) throws APIManagementException;
 
     void addPolicy(Policy policy) throws APIManagementException;

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -193,7 +193,7 @@ public interface APIProvider extends APIManager {
      * @return The looked up claims of the subscriber or null if the requested subscriber does not exist
      * @throws APIManagementException if failed to get Subscriber
      */
-    List getSubscriberClaims(String subscriber) throws APIManagementException;
+    Map getSubscriberClaims(String subscriber) throws APIManagementException;
 
     void addTier(Tier tier) throws APIManagementException;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -699,6 +699,7 @@ public final class APIConstants {
     public static final String API_PUBLISHER_ENABLE_ACCESS_CONTROL_LEVELS = API_PUBLISHER
             + "EnableAccessControl";
     public static final String API_PUBLISHER_APIS_PER_PAGE = API_PUBLISHER + "APIsPerPage";
+    public static final String API_PUBLISHER_SUBSCRIBER_CLAIMS = API_PUBLISHER + "SubscriberClaims";
     public static final String WSO2_API_STORE_TYPE = "wso2";
 
     public static final String EXTERNAL_API_STORES = "ExternalAPIStores";
@@ -947,6 +948,7 @@ public final class APIConstants {
     public static final String API_USER_ROLE_CACHE = "appPublisherUserRoleCache";
     public static final String API_PUBLISHER_ADMIN_PERMISSION_CACHE = "apimAdminPermissionCache";
     public static final String API_SUBSCRIBER_CACHE = "subscriberCache";
+    public static final String EMAIL_CLAIM = "http://wso2.org/claims/emailaddress";
 
     //URI Authentication Schemes
     public static final Set<String> SUPPORTED_METHODS =

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -2028,10 +2028,10 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
      * @throws APIManagementException if failed to get Subscriber
      */
     @Override
-    public List getSubscriberClaims(String subscriber) throws APIManagementException {
+    public Map<String, String> getSubscriberClaims(String subscriber) throws APIManagementException {
         String tenantDomain = MultitenantUtils.getTenantDomain(subscriber);
         int tenantId = 0;
-        List claimList = new ArrayList();
+        Map<String, String> claimMap = new HashMap<>();
         try {
             tenantId = getTenantId(tenantDomain);
         SortedMap<String, String> subscriberClaims =
@@ -2041,16 +2041,14 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 .getFirstProperty(APIConstants.API_PUBLISHER_SUBSCRIBER_CLAIMS);
         if (subscriberClaims != null) {
             for (String claimURI : configuredClaims.split(",")) {
-                Map<String, String> claimMap = new HashMap<>();
                 claimMap.put(claimURI, subscriberClaims.get(claimURI));
-                claimList.add(claimMap);
             }
         }
         } catch (UserStoreException e) {
             throw new APIManagementException("Error while retrieving tenant id for tenant domain "
                     + tenantDomain, e);
         }
-        return claimList;
+        return claimMap;
     }
 
     private Map<String, String> publishToGateway(API api) throws APIManagementException {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -117,7 +117,6 @@ import org.wso2.carbon.apimgt.impl.template.APITemplateBuilderImpl;
 import org.wso2.carbon.apimgt.impl.template.APITemplateException;
 import org.wso2.carbon.apimgt.impl.template.ThrottlePolicyTemplateBuilder;
 import org.wso2.carbon.apimgt.impl.token.ClaimsRetriever;
-import org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetriever;
 import org.wso2.carbon.apimgt.impl.utils.APIAuthenticationAdminClient;
 import org.wso2.carbon.apimgt.impl.utils.APINameComparator;
 import org.wso2.carbon.apimgt.impl.utils.APIStoreNameComparator;
@@ -8019,37 +8018,5 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             }
         }
         return null;
-    }
-
-    /**
-     * This methods loads the claim retriever implementation class
-     *
-     * @return claim retriever implementation
-     * @throws APIManagementException if failed to load claim retriever implementation class
-     */
-    private ClaimsRetriever getClaimRetrieverImplClass(String claimsRetrieverImpl) throws APIManagementException {
-
-        APIManagerConfiguration configuration = org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder.
-                getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration();
-        ClaimsRetriever claimsRetriever = null;
-        if (configuration == null) {
-            log.error("API Manager configuration is not initialized.");
-        } else {
-            String claimRetrieverClass = configuration.getFirstProperty("ppublis");
-            if (StringUtils.isEmpty(claimRetrieverClass)) {
-                claimsRetriever = new DefaultClaimsRetriever();
-            } else {
-                try {
-                    claimsRetriever = (ClaimsRetriever) APIUtil.getClassForName(claimRetrieverClass).newInstance();
-                } catch (ClassNotFoundException e) {
-                    APIUtil.handleException("Class not found " + claimRetrieverClass, e);
-                } catch (InstantiationException e) {
-                    APIUtil.handleException("Error when instantiating " + claimRetrieverClass, e);
-                } catch (IllegalAccessException e) {
-                    APIUtil.handleException("Illegal access to " + claimRetrieverClass, e);
-                }
-            }
-        }
-        return claimsRetriever;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -74,6 +74,7 @@ import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
 import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
 import org.wso2.carbon.apimgt.impl.indexing.indexer.DocumentIndexer;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.token.ClaimsRetriever;
 import org.wso2.carbon.apimgt.impl.utils.APIAPIProductNameComparator;
 import org.wso2.carbon.apimgt.impl.utils.APINameComparator;
 import org.wso2.carbon.apimgt.impl.utils.APIProductNameComparator;
@@ -125,6 +126,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.xml.namespace.QName;
@@ -1629,15 +1631,21 @@ public abstract class AbstractAPIManager implements APIManager {
 
         Subscriber subscriber = new Subscriber(username);
         subscriber.setSubscribedDate(new Date());
-        //TODO : need to set the proper email
-        subscriber.setEmail("");
         try {
             int tenantId = getTenantManager()
                     .getTenantId(getTenantDomain(username));
+            SortedMap<String, String> claims = APIUtil.getClaims(username, tenantId, ClaimsRetriever
+                    .DEFAULT_DIALECT_URI);
+            String email = claims.get(APIConstants.EMAIL_CLAIM);
+            if (email != null && !email.isEmpty()) {
+                subscriber.setEmail(email);
+            } else {
+                subscriber.setEmail(StringUtils.EMPTY);
+            }
             subscriber.setTenantId(tenantId);
             apiMgtDAO.addSubscriber(subscriber, groupingId);
             //Add a default application once subscriber is added
-            if (!APIUtil.isDefaultApplicationCreationDisabledForTenant(tenantId)){
+            if (!APIUtil.isDefaultApplicationCreationDisabledForTenant(tenantId)) {
                 addDefaultApplicationForSubscriber(subscriber);
             }
         } catch (APIManagementException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -1637,7 +1637,7 @@ public abstract class AbstractAPIManager implements APIManager {
             SortedMap<String, String> claims = APIUtil.getClaims(username, tenantId, ClaimsRetriever
                     .DEFAULT_DIALECT_URI);
             String email = claims.get(APIConstants.EMAIL_CLAIM);
-            if (email != null && !email.isEmpty()) {
+            if (StringUtils.isNotEmpty(email)) {
                 subscriber.setEmail(email);
             } else {
                 subscriber.setEmail(StringUtils.EMPTY);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -591,6 +591,53 @@ public class ApiMgtDAO {
     }
 
     /**
+     * Get subscriber name using subscription ID
+     *
+     * @param subscriptionId
+     * @return subscriber name
+     * @throws APIManagementException
+     */
+    public String getSubscriberName(String subscriptionId) throws APIManagementException {
+
+        int subscriberId = getSubscriberIdBySubscriptionUUID(subscriptionId);
+        Subscriber subscriber = getSubscriber(subscriberId);
+        if (subscriber != null) {
+            return subscriber.getName();
+        }
+        return StringUtils.EMPTY;
+    }
+
+    /**
+     * Get subscriber ID using subscription ID
+     *
+     * @param subscriptionId
+     * @return subscriber ID
+     * @throws APIManagementException
+     */
+    private int getSubscriberIdBySubscriptionUUID(String subscriptionId) throws APIManagementException {
+
+        Connection connection = null;
+        ResultSet rs = null;
+        PreparedStatement ps = null;
+        int subscirberId = 0;
+        try {
+            connection = APIMgtDBUtil.getConnection();
+            String query = SQLConstants.GET_SUBSCRIBER_ID_BY_SUBSCRIPTION_UUID_SQL;
+            ps = connection.prepareStatement(query);
+            ps.setString(1, subscriptionId);
+            rs = ps.executeQuery();
+            if (rs.next()) {
+                subscirberId = rs.getInt("SUBSCRIBER_ID");
+            }
+        } catch (SQLException e) {
+            handleException("Error while retrieving Subscriber ID: ", e);
+        } finally {
+            APIMgtDBUtil.closeAllConnections(ps, connection, rs);
+        }
+        return subscirberId;
+    }
+
+    /**
      * Derives info about monetization usage publish job
      *
      * @return ifno about the monetization usage publish job

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -614,23 +614,18 @@ public class ApiMgtDAO {
      * @throws APIManagementException
      */
     private int getSubscriberIdBySubscriptionUUID(String subscriptionId) throws APIManagementException {
-        Connection connection = null;
-        ResultSet rs = null;
-        PreparedStatement ps = null;
         int subscirberId = 0;
-        try {
-            connection = APIMgtDBUtil.getConnection();
-            String query = SQLConstants.GET_SUBSCRIBER_ID_BY_SUBSCRIPTION_UUID_SQL;
-            ps = connection.prepareStatement(query);
+        String query = SQLConstants.GET_SUBSCRIBER_ID_BY_SUBSCRIPTION_UUID_SQL;
+        try (Connection connection = APIMgtDBUtil.getConnection();
+            PreparedStatement ps = connection.prepareStatement(query)) {
             ps.setString(1, subscriptionId);
-            rs = ps.executeQuery();
-            if (rs.next()) {
-                subscirberId = rs.getInt(APIConstants.APPLICATION_SUBSCRIBER_ID);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    subscirberId = rs.getInt(APIConstants.APPLICATION_SUBSCRIBER_ID);
+                }
             }
         } catch (SQLException e) {
             handleException("Error while retrieving Subscriber ID: ", e);
-        } finally {
-            APIMgtDBUtil.closeAllConnections(ps, connection, rs);
         }
         return subscirberId;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -598,7 +598,6 @@ public class ApiMgtDAO {
      * @throws APIManagementException
      */
     public String getSubscriberName(String subscriptionId) throws APIManagementException {
-
         int subscriberId = getSubscriberIdBySubscriptionUUID(subscriptionId);
         Subscriber subscriber = getSubscriber(subscriberId);
         if (subscriber != null) {
@@ -615,7 +614,6 @@ public class ApiMgtDAO {
      * @throws APIManagementException
      */
     private int getSubscriberIdBySubscriptionUUID(String subscriptionId) throws APIManagementException {
-
         Connection connection = null;
         ResultSet rs = null;
         PreparedStatement ps = null;
@@ -627,7 +625,7 @@ public class ApiMgtDAO {
             ps.setString(1, subscriptionId);
             rs = ps.executeQuery();
             if (rs.next()) {
-                subscirberId = rs.getInt("SUBSCRIBER_ID");
+                subscirberId = rs.getInt(APIConstants.APPLICATION_SUBSCRIBER_ID);
             }
         } catch (SQLException e) {
             handleException("Error while retrieving Subscriber ID: ", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -478,6 +478,15 @@ public class SQLConstants {
             " WHERE " +
             "   API_ID = ? " +
             "   AND APPLICATION_ID = ?";
+
+    public static final String GET_SUBSCRIBER_ID_BY_SUBSCRIPTION_UUID_SQL =
+            " SELECT APPS.SUBSCRIBER_ID  AS SUBSCRIBER_ID " +
+            " FROM " +
+            " AM_APPLICATION APPS, " +
+            " AM_SUBSCRIPTION SUBS" +
+            " WHERE " +
+            " SUBS.APPLICATION_ID = APPS.APPLICATION_ID " +
+            " AND SUBS.UUID = ?";
     
     public static final String GET_SUBSCRIPTION_STATUS_BY_UUID_SQL =
             " SELECT SUB_STATUS " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/DefaultClaimsRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/DefaultClaimsRetriever.java
@@ -87,39 +87,26 @@ public class DefaultClaimsRetriever implements ClaimsRetriever {
             enabledJWTClaimCache = Boolean.valueOf(strEnabledJWTClaimCache);
         }
         SortedMap<String, String> claimValues;
-        try {
-            if (endUserName != null) {
-                int tenantId = APIUtil.getTenantId(endUserName);
-                String tenantAwareUserName = MultitenantUtils.getTenantAwareUsername(endUserName);
-                //check in local cache
-                String key = endUserName + ':' + tenantId;
-                ClaimCacheKey cacheKey = new ClaimCacheKey(key);
-                Object result = null;
-                if (enabledJWTClaimCache) {
-                    result = getClaimsLocalCache().get(cacheKey);
-                }
-                if (result != null) {
-                    return ((UserClaims) result).getClaimValues();
-                } else {
-                    ClaimManager claimManager = ServiceReferenceHolder.getInstance().getRealmService().
-                            getTenantUserRealm(tenantId).getClaimManager();
-                    //Claim[] claims = claimManager.getAllClaims(dialectURI);
-                    ClaimMapping[] claims = claimManager.getAllClaimMappings(dialectURI);
-                    String[] claimURIs = claimMappingtoClaimURIString(claims);
-                    UserStoreManager userStoreManager = ServiceReferenceHolder.getInstance().getRealmService().
-                            getTenantUserRealm(tenantId).getUserStoreManager();
-
-                    claimValues = new TreeMap(userStoreManager.getUserClaimValues(tenantAwareUserName, claimURIs,null));
-                    UserClaims userClaims = new UserClaims(claimValues);
-                    //add to cache
-                    if (enabledJWTClaimCache) {
-                        getClaimsLocalCache().put(cacheKey, userClaims);
-                    }
-                    return claimValues;
-                }
+        if (endUserName != null) {
+            int tenantId = APIUtil.getTenantId(endUserName);
+            //check in local cache
+            String key = endUserName + ':' + tenantId;
+            ClaimCacheKey cacheKey = new ClaimCacheKey(key);
+            Object result = null;
+            if (enabledJWTClaimCache) {
+                result = getClaimsLocalCache().get(cacheKey);
             }
-        } catch (UserStoreException e) {
-            throw new APIManagementException("Error while retrieving user claim values from " + "user store", e);
+            if (result != null) {
+                return ((UserClaims) result).getClaimValues();
+            } else {
+                claimValues = APIUtil.getClaims(endUserName, tenantId, dialectURI);
+                UserClaims userClaims = new UserClaims(claimValues);
+                //add to cache
+                if (enabledJWTClaimCache) {
+                    getClaimsLocalCache().put(cacheKey, userClaims);
+                }
+                return claimValues;
+            }
         }
         return null;
     }
@@ -129,18 +116,5 @@ public class DefaultClaimsRetriever implements ClaimsRetriever {
      */
     public String getDialectURI(String endUserName) {
         return dialectURI;
-    }
-
-    /**
-     * Helper method to convert array of <code>Claim</code> object to
-     * array of <code>String</code> objects corresponding to the ClaimURI values.
-     */
-    private String[] claimMappingtoClaimURIString(ClaimMapping[] claims) {
-        String[] temp = new String[claims.length];
-        for (int i = 0; i < claims.length; i++) {
-            temp[i] = claims[i].getClaim().getClaimUri();
-       
-        }
-        return temp;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/DefaultClaimsRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/DefaultClaimsRetriever.java
@@ -89,6 +89,7 @@ public class DefaultClaimsRetriever implements ClaimsRetriever {
         SortedMap<String, String> claimValues;
         if (endUserName != null) {
             int tenantId = APIUtil.getTenantId(endUserName);
+            String tenantAwareUserName = MultitenantUtils.getTenantAwareUsername(endUserName);
             //check in local cache
             String key = endUserName + ':' + tenantId;
             ClaimCacheKey cacheKey = new ClaimCacheKey(key);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10465,6 +10465,9 @@ public final class APIUtil {
     /**
      * Helper method to convert array of <code>Claim</code> object to
      * array of <code>String</code> objects corresponding to the ClaimURI values.
+     *
+     * @param claims claims object
+     * @return String array of claims
      */
     private static String[] claimMappingtoClaimURIString(ClaimMapping[] claims) {
         String[] temp = new String[claims.length];

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
@@ -128,6 +128,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.cache.Caching;
@@ -142,6 +143,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.wso2.carbon.apimgt.impl.token.ClaimsRetriever.DEFAULT_DIALECT_URI;
 
 @RunWith(PowerMockRunner.class)
 @SuppressStaticInitializationFor("org.wso2.carbon.context.PrivilegedCarbonContext")
@@ -847,6 +849,39 @@ public class APIProviderImplTest {
         assertFalse(apiProvider.deleteBlockConditionByUUID("testId"));
         //deleteState true
         assertTrue(apiProvider.deleteBlockConditionByUUID("testId"));
+    }
+
+    @Test
+    public void testGetSubscriberClaims() throws APIManagementException, UserStoreException {
+        String configuredClaims = "http://wso2.org/claim1,http://wso2.org/claim2";
+        APIProviderImplWrapper apiProvider = new APIProviderImplWrapper(apimgtDAO, null, null);
+        // Mock retrieving the tenant domain
+        PowerMockito.mockStatic(MultitenantUtils.class);
+        PowerMockito.mockStatic(APIUtil.class);
+        Mockito.when(MultitenantUtils.getTenantDomain("admin")).thenReturn("carbon.super");
+        ServiceReferenceHolder serviceReferenceHolder = TestUtils.getServiceReferenceHolder();
+        RealmService realmService = Mockito.mock(RealmService.class);
+        TenantManager tenantManager = Mockito.mock(TenantManager.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        Mockito.when(serviceReferenceHolder.getRealmService()).thenReturn(realmService);
+        Mockito.when(realmService.getTenantManager()).thenReturn(tenantManager);
+        PowerMockito.when(tenantManager.getTenantId(Matchers.anyString())).thenReturn(-1234);
+
+        SortedMap<String, String> claimValues = new TreeMap<String, String>();
+        claimValues.put("claim1", "http://wso2.org/claim1");
+        claimValues.put("claim2", "http://wso2.org/claim2");
+        claimValues.put("claim3", "http://wso2.org/claim3");
+        PowerMockito.when(APIUtil.getClaims("admin", -1234, DEFAULT_DIALECT_URI))
+                .thenReturn(claimValues);
+        APIManagerConfiguration configuration = Mockito.mock(APIManagerConfiguration.class);
+        APIManagerConfigurationService configurationService = Mockito.mock(APIManagerConfigurationService.class);
+        PowerMockito.when(serviceReferenceHolder.getAPIManagerConfigurationService()).thenReturn(configurationService);
+        PowerMockito.when(configurationService.getAPIManagerConfiguration()).thenReturn(configuration);
+        Mockito.when(configuration.getFirstProperty(APIConstants.API_PUBLISHER_SUBSCRIBER_CLAIMS)).
+                thenReturn(configuredClaims);
+        List subscriberClaims = apiProvider.getSubscriberClaims("admin");
+        assertNotNull(subscriberClaims);
+        assertEquals(configuredClaims.split(",").length, subscriberClaims.size());
     }
 
     @Test

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
@@ -879,7 +879,7 @@ public class APIProviderImplTest {
         PowerMockito.when(configurationService.getAPIManagerConfiguration()).thenReturn(configuration);
         Mockito.when(configuration.getFirstProperty(APIConstants.API_PUBLISHER_SUBSCRIBER_CLAIMS)).
                 thenReturn(configuredClaims);
-        List subscriberClaims = apiProvider.getSubscriberClaims("admin");
+        Map subscriberClaims = apiProvider.getSubscriberClaims("admin");
         assertNotNull(subscriberClaims);
         assertEquals(configuredClaims.split(",").length, subscriberClaims.size());
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AbstractAPIManagerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AbstractAPIManagerTestCase.java
@@ -99,12 +99,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.UUID;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 
 import static org.wso2.carbon.apimgt.impl.TestUtils.mockRegistryAndUserRealm;
+import static org.wso2.carbon.apimgt.impl.token.ClaimsRetriever.DEFAULT_DIALECT_URI;
 import static org.wso2.carbon.utils.ServerConstants.CARBON_HOME;
 
 @RunWith (PowerMockRunner.class)
@@ -1129,6 +1132,10 @@ public class AbstractAPIManagerTestCase {
                 apiMgtDAO);
         Mockito.when(tenantManager.getTenantId(Mockito.anyString())).thenThrow(UserStoreException.class)
                 .thenReturn(tenantId);
+        PowerMockito.mockStatic(APIUtil.class);
+        SortedMap<String, String> claimValues = new TreeMap<String, String>();
+        claimValues.put("admin@wso2.om", APIConstants.EMAIL_CLAIM);
+        PowerMockito.when(APIUtil.getClaims(API_PROVIDER, tenantId, DEFAULT_DIALECT_URI)).thenReturn(claimValues);
         try {
             abstractAPIManager.addSubscriber(API_PROVIDER, SAMPLE_RESOURCE_ID);
             Assert.fail("User store exception not thrown for error scenario");

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/token/DefaultClaimsRetrieverTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/token/DefaultClaimsRetrieverTestCase.java
@@ -117,15 +117,10 @@ public class DefaultClaimsRetrieverTestCase {
         Claim claim2 = new Claim();
         claim2.setClaimUri("http://wso2.com/claim2");
 
-        ClaimMapping[] cliams = new ClaimMapping[] { new ClaimMapping(claim1, "claim1"),
-                new ClaimMapping(claim2, "claim2") };
-        Mockito.when(claimManager.getAllClaimMappings(DEFAULT_DIALECT_URI)).thenReturn(cliams);
-
         SortedMap<String, String> claimValues = new TreeMap<String, String>();
         claimValues.put("claim1", "http://wso2.org/claim1");
         claimValues.put("claim2", "http://wso2.org/claim2");
-        Mockito.when(userStoreManager.getUserClaimValues(Matchers.any(String.class), Matchers.any(String[].class),
-                Matchers.any(String.class))).thenReturn(claimValues);
+        PowerMockito.when(APIUtil.getClaims(USER_NAME, TENANT_ID, DEFAULT_DIALECT_URI)).thenReturn(claimValues);
         SortedMap<String, String> claims = defaultClaimsRetriever.getClaims(USER_NAME);
 
         Assert.assertNotNull(claims);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/SubscriptionsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/SubscriptionsApi.java
@@ -2,6 +2,7 @@ package org.wso2.carbon.apimgt.rest.api.publisher.v1;
 
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIMonetizationUsageDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubscriberInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubscriptionListDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.SubscriptionsApiService;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.impl.SubscriptionsApiServiceImpl;
@@ -70,6 +71,22 @@ SubscriptionsApiService delegate = new SubscriptionsApiServiceImpl();
         @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported ", response = ErrorDTO.class) })
     public Response subscriptionsGet( @NotNull @ApiParam(value = "**API ID** consisting of the **UUID** of the API. The combination of the provider of the API, name of the API and the version is also accepted as a valid API I. Should be formatted as **provider-name-version**. ",required=true)  @QueryParam("apiId") String apiId,  @ApiParam(value = "Maximum size of resource array to return. ", defaultValue="25") @DefaultValue("25") @QueryParam("limit") Integer limit,  @ApiParam(value = "Starting point within the complete list of items qualified. ", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset, @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved variant of the resource. " )@HeaderParam("If-None-Match") String ifNoneMatch,  @ApiParam(value = "Keywords to filter subscriptions ")  @QueryParam("query") String query) throws APIManagementException{
         return delegate.subscriptionsGet(apiId, limit, offset, ifNoneMatch, query, securityContext);
+    }
+
+    @GET
+    @Path("/{subscriptionId}/subscriber-info")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get details of a user who subscribed an API", notes = "This operation can be used to get details of a user who subscribed to the API. ", response = SubscriberInfoDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:subscription_view", description = "View Subscription")
+        })
+    }, tags={ "Subscriber",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Details of a pending invoice returned. ", response = SubscriberInfoDTO.class),
+        @ApiResponse(code = 404, message = "Not Found. Requested Subscription does not exist. ", response = ErrorDTO.class) })
+    public Response subscriptionsSubscriptionIdSubscriberInfoGet(@ApiParam(value = "Subscription Id ",required=true) @PathParam("subscriptionId") String subscriptionId) throws APIManagementException{
+        return delegate.subscriptionsSubscriptionIdSubscriberInfoGet(subscriptionId, securityContext);
     }
 
     @GET

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/SubscriptionsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/SubscriptionsApi.java
@@ -83,7 +83,7 @@ SubscriptionsApiService delegate = new SubscriptionsApiServiceImpl();
         })
     }, tags={ "Subscriber",  })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "OK. Details of a pending invoice returned. ", response = SubscriberInfoDTO.class),
+        @ApiResponse(code = 200, message = "OK.  Details of the subscriber are returned. ", response = SubscriberInfoDTO.class),
         @ApiResponse(code = 404, message = "Not Found. Requested Subscription does not exist. ", response = ErrorDTO.class) })
     public Response subscriptionsSubscriptionIdSubscriberInfoGet(@ApiParam(value = "Subscription Id ",required=true) @PathParam("subscriptionId") String subscriptionId) throws APIManagementException{
         return delegate.subscriptionsSubscriptionIdSubscriberInfoGet(subscriptionId, securityContext);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/SubscriptionsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/SubscriptionsApiService.java
@@ -11,6 +11,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIMonetizationUsageDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubscriberInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubscriptionListDTO;
 
 import java.util.List;
@@ -24,6 +25,7 @@ import javax.ws.rs.core.SecurityContext;
 public interface SubscriptionsApiService {
       public Response subscriptionsBlockSubscriptionPost(String subscriptionId, String blockState, String ifMatch, MessageContext messageContext) throws APIManagementException;
       public Response subscriptionsGet(String apiId, Integer limit, Integer offset, String ifNoneMatch, String query, MessageContext messageContext) throws APIManagementException;
+      public Response subscriptionsSubscriptionIdSubscriberInfoGet(String subscriptionId, MessageContext messageContext) throws APIManagementException;
       public Response subscriptionsSubscriptionIdUsageGet(String subscriptionId, MessageContext messageContext) throws APIManagementException;
       public Response subscriptionsUnblockSubscriptionPost(String subscriptionId, String ifMatch, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/ClaimDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/ClaimDTO.java
@@ -1,0 +1,116 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.util.annotations.Scope;
+
+
+
+public class ClaimDTO   {
+  
+    private String name = null;
+    private String URI = null;
+    private String value = null;
+
+  /**
+   **/
+  public ClaimDTO name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "email", value = "")
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   **/
+  public ClaimDTO URI(String URI) {
+    this.URI = URI;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "http://wso2.org/claims/emailaddress", value = "")
+  @JsonProperty("URI")
+  public String getURI() {
+    return URI;
+  }
+  public void setURI(String URI) {
+    this.URI = URI;
+  }
+
+  /**
+   **/
+  public ClaimDTO value(String value) {
+    this.value = value;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "admin@wso2.com", value = "")
+  @JsonProperty("value")
+  public String getValue() {
+    return value;
+  }
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ClaimDTO claim = (ClaimDTO) o;
+    return Objects.equals(name, claim.name) &&
+        Objects.equals(URI, claim.URI) &&
+        Objects.equals(value, claim.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, URI, value);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ClaimDTO {\n");
+    
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    URI: ").append(toIndentedString(URI)).append("\n");
+    sb.append("    value: ").append(toIndentedString(value)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/SubscriberInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/SubscriberInfoDTO.java
@@ -1,0 +1,99 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ClaimDTO;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.util.annotations.Scope;
+
+
+
+public class SubscriberInfoDTO   {
+  
+    private String name = null;
+    private List<ClaimDTO> claims = new ArrayList<>();
+
+  /**
+   **/
+  public SubscriberInfoDTO name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "admin", value = "")
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   **/
+  public SubscriberInfoDTO claims(List<ClaimDTO> claims) {
+    this.claims = claims;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("claims")
+  public List<ClaimDTO> getClaims() {
+    return claims;
+  }
+  public void setClaims(List<ClaimDTO> claims) {
+    this.claims = claims;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SubscriberInfoDTO subscriberInfo = (SubscriberInfoDTO) o;
+    return Objects.equals(name, subscriberInfo.name) &&
+        Objects.equals(claims, subscriberInfo.claims);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, claims);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SubscriberInfoDTO {\n");
+    
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    claims: ").append(toIndentedString(claims)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SubscriptionsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SubscriptionsApiServiceImpl.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.SubscriptionsApiService;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIMonetizationUsageDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubscriberInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubscriptionDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubscriptionListDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.utils.mappings.APIMappingUtil;
@@ -212,5 +213,21 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
         }
 
         return null;
+    }
+
+    @Override
+    public Response subscriptionsSubscriptionIdSubscriberInfoGet(String subscriptionId, MessageContext messageContext)
+            throws APIManagementException {
+        if (StringUtils.isBlank(subscriptionId)) {
+            String errorMessage = "Subscription ID cannot be empty or null when getting subscriber info.";
+            RestApiUtil.handleBadRequest(errorMessage, log);
+        }
+        String username = RestApiUtil.getLoggedInUsername();
+        APIProvider apiProvider = RestApiUtil.getProvider(username);
+        String subscriberName = apiProvider.getSubscriber(subscriptionId);
+        List subscriberClaims = apiProvider.getSubscriberClaims(subscriberName);
+        SubscriberInfoDTO subscriberInfoDTO = SubscriptionMappingUtil
+                .fromSubscriberClaimsToDTO(subscriberClaims, subscriberName);
+        return Response.ok().entity(subscriberInfoDTO).build();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SubscriptionsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SubscriptionsApiServiceImpl.java
@@ -226,8 +226,8 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
         APIProvider apiProvider = RestApiUtil.getProvider(username);
         String subscriberName = apiProvider.getSubscriber(subscriptionId);
         List subscriberClaims = apiProvider.getSubscriberClaims(subscriberName);
-        SubscriberInfoDTO subscriberInfoDTO = SubscriptionMappingUtil
-                .fromSubscriberClaimsToDTO(subscriberClaims, subscriberName);
+        SubscriberInfoDTO subscriberInfoDTO = SubscriptionMappingUtil.fromSubscriberClaimsToDTO(subscriberClaims,
+                subscriberName);
         return Response.ok().entity(subscriberInfoDTO).build();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SubscriptionsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SubscriptionsApiServiceImpl.java
@@ -225,7 +225,7 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
         String username = RestApiUtil.getLoggedInUsername();
         APIProvider apiProvider = RestApiUtil.getProvider(username);
         String subscriberName = apiProvider.getSubscriber(subscriptionId);
-        List subscriberClaims = apiProvider.getSubscriberClaims(subscriberName);
+        Map subscriberClaims = apiProvider.getSubscriberClaims(subscriberName);
         SubscriberInfoDTO subscriberInfoDTO = SubscriptionMappingUtil.fromSubscriberClaimsToDTO(subscriberClaims,
                 subscriberName);
         return Response.ok().entity(subscriberInfoDTO).build();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/ApplicationMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/ApplicationMappingUtil.java
@@ -17,6 +17,7 @@
 package org.wso2.carbon.apimgt.rest.api.publisher.v1.utils.mappings;
 
 import org.wso2.carbon.apimgt.api.model.Application;
+import org.wso2.carbon.apimgt.api.model.Subscriber;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ApplicationInfoDTO;
 
 /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/SubscriptionMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/SubscriptionMappingUtil.java
@@ -21,8 +21,11 @@ import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.dto.UserApplicationAPIUsage;
 import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ApplicationInfoDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ClaimDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.PaginationDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubscriberInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubscriptionDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubscriptionListDTO;
 import org.wso2.carbon.apimgt.rest.api.util.RestApiConstants;
@@ -215,5 +218,31 @@ public class SubscriptionMappingUtil {
 
         application = apiProvider.getLightweightApplicationByUUID(application.getUUID());
         return ApplicationMappingUtil.fromApplicationToInfoDTO(application);
+    }
+
+    /**
+     * Convert Subscriber claims information into SubscriberInfoDTO
+     *
+     * @param subscriberClaims list of subscriber claims
+     * @param subscriberName   subscriber name
+     * @return SubscriberInfoDTO
+     * @throws APIManagementException If an error occurs when getting display name of claim
+     */
+    public static SubscriberInfoDTO fromSubscriberClaimsToDTO(List<Map> subscriberClaims, String subscriberName)
+            throws APIManagementException {
+        SubscriberInfoDTO subscriberInfoDTO = new SubscriberInfoDTO();
+        subscriberInfoDTO.setName(subscriberName);
+        List<ClaimDTO> claimDTOList = new ArrayList<>();
+        for (Map<String, String> claimMap : subscriberClaims) {
+            for (String key : claimMap.keySet()) {
+                ClaimDTO claimDTO = new ClaimDTO();
+                claimDTO.setName(APIUtil.getClaimDisplayName(key, subscriberName));
+                claimDTO.setURI(key);
+                claimDTO.setValue(claimMap.get(key));
+                claimDTOList.add(claimDTO);
+            }
+        }
+        subscriberInfoDTO.setClaims(claimDTOList);
+        return subscriberInfoDTO;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/SubscriptionMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/SubscriptionMappingUtil.java
@@ -228,19 +228,17 @@ public class SubscriptionMappingUtil {
      * @return SubscriberInfoDTO
      * @throws APIManagementException If an error occurs when getting display name of claim
      */
-    public static SubscriberInfoDTO fromSubscriberClaimsToDTO(List<Map> subscriberClaims, String subscriberName)
-            throws APIManagementException {
+    public static SubscriberInfoDTO fromSubscriberClaimsToDTO(Map<String, String> subscriberClaims,
+                                                              String subscriberName) throws APIManagementException {
         SubscriberInfoDTO subscriberInfoDTO = new SubscriberInfoDTO();
         subscriberInfoDTO.setName(subscriberName);
         List<ClaimDTO> claimDTOList = new ArrayList<>();
-        for (Map<String, String> claimMap : subscriberClaims) {
-            for (String key : claimMap.keySet()) {
-                ClaimDTO claimDTO = new ClaimDTO();
-                claimDTO.setName(APIUtil.getClaimDisplayName(key, subscriberName));
-                claimDTO.setURI(key);
-                claimDTO.setValue(claimMap.get(key));
-                claimDTOList.add(claimDTO);
-            }
+        for (String key : subscriberClaims.keySet()) {
+            ClaimDTO claimDTO = new ClaimDTO();
+            claimDTO.setName(APIUtil.getClaimDisplayName(key, subscriberName));
+            claimDTO.setURI(key);
+            claimDTO.setValue(subscriberClaims.get(key));
+            claimDTOList.add(claimDTO);
         }
         subscriberInfoDTO.setClaims(claimDTOList);
         return subscriberInfoDTO;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -3893,6 +3893,35 @@ paths:
             $ref: '#/definitions/Error'
 
   ######################################################
+  # The get subscriber information
+  ######################################################
+  '/subscriptions/{subscriptionId}/subscriber-info':
+    get:
+      security:
+        - OAuth2Security:
+            - apim:subscription_view
+      summary: Get details of a user who subscribed an API
+      description: |
+        This operation can be used to get details of a user who subscribed to the API.
+      parameters:
+        - $ref: '#/parameters/subscriptionId'
+      tags:
+        - Subscriber
+      responses:
+        200:
+          description: |
+            OK.
+            Details of a pending invoice returned.
+          schema:
+            $ref: '#/definitions/SubscriberInfo'
+        404:
+          description: |
+            Not Found.
+            Requested Subscription does not exist.
+          schema:
+            $ref: '#/definitions/Error'
+
+  ######################################################
   # The "Block Subscription" Processing Function resource API
   ######################################################
   /subscriptions/block-subscription:
@@ -7806,6 +7835,36 @@ definitions:
       technicalOwnerEmail:
         type: string
         example: technicalowner@wso2.com
+
+  #-----------------------------------------------------
+  # The Claim resource
+  #-----------------------------------------------------
+  Claim:
+    title: Claim
+    properties:
+      name:
+        type: string
+        example: email
+      URI:
+        type: string
+        example: http://wso2.org/claims/emailaddress
+      value:
+        type: string
+        example: admin@wso2.com
+
+  #-----------------------------------------------------
+  # The Subscriber resource
+  #-----------------------------------------------------
+  SubscriberInfo:
+    title: SubscriberInfo
+    properties:
+      name:
+        type: string
+        example: admin
+      claims:
+        type: array
+        items:
+          $ref: '#/definitions/Claim'
 
   #-----------------------------------------------------
   # The Application resource

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -3911,7 +3911,7 @@ paths:
         200:
           description: |
             OK.
-            Details of a pending invoice returned.
+             Details of the subscriber are returned.
           schema:
             $ref: '#/definitions/SubscriberInfo'
         404:

--- a/docs/apidocs/publisher/v1/index.html
+++ b/docs/apidocs/publisher/v1/index.html
@@ -346,6 +346,13 @@
                             </ul>
                         </li>
                         <hr/>
+                        <span class="class-name">Subscriber</span>
+                        <li class="section-box">
+                            <ul class="nav nav-stacked">
+                                        <li id="op-subscriptionsSubscriptionIdSubscriberInfoGet"><a href="#!/operations#Subscriber#subscriptionsSubscriptionIdSubscriberInfoGet">Get details of a user who subscribed an API</a></li>
+                            </ul>
+                        </li>
+                        <hr/>
                         <span class="class-name">Subscriptions</span>
                         <li class="section-box">
                             <ul class="nav nav-stacked">
@@ -586,6 +593,11 @@
                         <li class="section-box">
                             <ul class="nav nav-stacked">
                                 <li id="def-Certificates"><a href="#!/models#Certificates">Certificates</a></li>
+                            </ul>
+                        </li>
+                        <li class="section-box">
+                            <ul class="nav nav-stacked">
+                                <li id="def-Claim"><a href="#!/models#Claim">Claim</a></li>
                             </ul>
                         </li>
                         <li class="section-box">
@@ -841,6 +853,11 @@
                         <li class="section-box">
                             <ul class="nav nav-stacked">
                                 <li id="def-Settings"><a href="#!/models#Settings">Settings</a></li>
+                            </ul>
+                        </li>
+                        <li class="section-box">
+                            <ul class="nav nav-stacked">
+                                <li id="def-SubscriberInfo"><a href="#!/models#SubscriberInfo">SubscriberInfo</a></li>
                             </ul>
                         </li>
                         <li class="section-box">

--- a/docs/apidocs/publisher/v1/models/Claim.html
+++ b/docs/apidocs/publisher/v1/models/Claim.html
@@ -1,0 +1,69 @@
+<div class="main-content">
+
+        <h2>Claim</h2>
+            <table class="table table-hover">
+                <colgroup>
+                    <col style="width: 10%;"/>
+                    <col style="width: 30%;"/>
+                    <col style="width: 10%;"/>
+                    <col style="width: 20%;"/>
+                    <col style="width: 30%;"/>
+                </colgroup>
+                <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Schema</th>
+                    <th>Default</th>
+                    <th>Example</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="parameter">
+                            <p>name</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked"></p></td>
+                        <td class="parameter">
+                                <a href="#!/models#string">string</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked">email</p></td>
+                    </tr>
+                    <tr>
+                        <td class="parameter">
+                            <p>URI</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked"></p></td>
+                        <td class="parameter">
+                                <a href="#!/models#string">string</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked">http://wso2.org/claims/emailaddress</p></td>
+                    </tr>
+                    <tr>
+                        <td class="parameter">
+                            <p>value</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked"></p></td>
+                        <td class="parameter">
+                                <a href="#!/models#string">string</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked">admin@wso2.com</p></td>
+                    </tr>
+                </tbody>
+            </table>
+</div>

--- a/docs/apidocs/publisher/v1/models/SubscriberInfo.html
+++ b/docs/apidocs/publisher/v1/models/SubscriberInfo.html
@@ -1,0 +1,54 @@
+<div class="main-content">
+
+        <h2>SubscriberInfo</h2>
+            <table class="table table-hover">
+                <colgroup>
+                    <col style="width: 10%;"/>
+                    <col style="width: 30%;"/>
+                    <col style="width: 10%;"/>
+                    <col style="width: 20%;"/>
+                    <col style="width: 30%;"/>
+                </colgroup>
+                <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Schema</th>
+                    <th>Default</th>
+                    <th>Example</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="parameter">
+                            <p>name</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked"></p></td>
+                        <td class="parameter">
+                                <a href="#!/models#string">string</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked">admin</p></td>
+                    </tr>
+                    <tr>
+                        <td class="parameter">
+                            <p>claims</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked"></p></td>
+                        <td class="parameter">
+                                <a href="#!/models#array">array</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked"></p></td>
+                    </tr>
+                </tbody>
+            </table>
+</div>

--- a/docs/apidocs/publisher/v1/operations/Subscriber.html
+++ b/docs/apidocs/publisher/v1/operations/Subscriber.html
@@ -1,0 +1,102 @@
+<div class="main-content">
+    <h1><a name="Subscriber"></a>Subscriber</h1>
+
+            <hr/>
+            <h4 class="operation-heading"><a name="subscriptionsSubscriptionIdSubscriberInfoGet"></a>Get details of a user who subscribed an API</h4> <code>GET https://apis.wso2.com/api/am/publisher/v1/subscriptions/{subscriptionId}/subscriber-info</code>
+            <p class="marked"></p>
+
+            <p class="marked">This operation can be used to get details of a user who subscribed to the API.
+</p>
+
+            <h4 class="section-heading">OAuth 2.0 Scope</h4>
+                <code>apim:subscription_view</code>
+
+            <h4 class="section-heading">
+                Examples
+            </h4>
+
+            <h4 class="section-heading" id="scroll-to">Parameters</h4>
+            <table class="table table-hover">
+                <colgroup>
+                    <col style="width: 10%;"/>
+                    <col style="width: 20%;"/>
+                    <col style="width: 40%;"/>
+                    <col style="width: 10%;"/>
+                    <col style="width: 20%;"/>
+                </colgroup>
+                <thead>
+                <tr class="active">
+                    <th>Type</th>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Schema</th>
+                    <th>Default</th>
+                </tr>
+                </thead>
+                    <tr>
+                        <td class="parameter">
+                            
+                            
+                            <span class="param-in">Path </span>
+                            
+                            
+                        </td>
+                        <td class="param-name">
+                            <p>subscriptionId</p>
+                            <p class="param-required">
+                                required
+                                
+                            </p>
+                        </td>
+                        <td>
+                            <p class="param-description marked">Subscription Id
+</p>
+                        </td>
+                        <td>
+                            <span class="param-type">
+                                String
+                            </span>
+                        </td>
+                        <td>
+                            <p class="marked"></p>
+                        </td>
+                    </tr>
+            </table>
+
+            <h4 class="section-heading">Responses</h4>
+
+            <table class="table table-hover">
+                <colgroup>
+                    <col style="width: 15%;"/>
+                    <col style="width: 70%;"/>
+                    <col style="width: 15%;"/>
+                </colgroup>
+                <thead>
+                <tr class="active">
+                    <th>HTTP Code</th>
+                    <th>Description</th>
+                    <th>Schema</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="parameter"><p class="marked">200</p></td>
+                        <td class="parameter"><p class="marked">OK. Details of a pending invoice returned. </p></td>
+                        <td class="parameter">
+                            <span class="parameter">
+                                    <a href="#!/models#SubscriberInfo">SubscriberInfo</a>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="parameter"><p class="marked">404</p></td>
+                        <td class="parameter"><p class="marked">Not Found. Requested Subscription does not exist. </p></td>
+                        <td class="parameter">
+                            <span class="parameter">
+                                    <a href="#!/models#Error">Error</a>
+                            </span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+</div>

--- a/docs/apidocs/publisher/v1/operations/Subscriber.html
+++ b/docs/apidocs/publisher/v1/operations/Subscriber.html
@@ -81,7 +81,7 @@
                 <tbody>
                     <tr>
                         <td class="parameter"><p class="marked">200</p></td>
-                        <td class="parameter"><p class="marked">OK. Details of a pending invoice returned. </p></td>
+                        <td class="parameter"><p class="marked">OK.  Details of the subscriber are returned. </p></td>
                         <td class="parameter">
                             <span class="parameter">
                                     <a href="#!/models#SubscriberInfo">SubscriberInfo</a>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -518,6 +518,8 @@
         <!--APIsPerPage>30</APIsPerPage-->
         <!-- This property need to be enabled to enable the publisher access control support -->
         <EnableAccessControl>true</EnableAccessControl>
+        <!-- This property is to add the claims that needs to be displayed in Publisher -->
+        <SubscriberClaims>{{apim.publisher.subscriber_claims}}</SubscriberClaims>
     </APIPublisher>
 
     <!-- Status observers can be registered against the API Publisher to listen for


### PR DESCRIPTION
This PR adds new Publisher REST API to retrieve subscriber-info. REST API path is : `/subscriptions/{subscription-id}/subscriber-info`

Request format:
`curl -X GET "https://localhost:9443/api/am/publisher/v1/subscriptions/{subscriptionId}/subscriber-info" -H  "Authorization: Bearer xxxxxxx"`

Sample request:
`curl -X GET "https://localhost:9443/api/am/publisher/v1/subscriptions/04b306b6-49da-49fc-88ae-feb6dc87150b/subscriber-info" -H  "Authorization: Bearer 33f03b51-6f97-3076-9eb0-0045b04e1706" `

Sample response:
```
{
  "name": "user1@test.com",
  "claims": [
    {
      "name": "First Name",
      "value": "user1",
      "URI": "http://wso2.org/claims/givenname"
    },
    {
      "name": "Last Name",
      "value": "user1",
      "URI": "http://wso2.org/claims/lastname"
    },
    {
      "name": "Email",
      "value": "user1@wso2.com",
      "URI": "http://wso2.org/claims/emailaddress"
    },
    {
      "name": "Organization",
      "value": "wso2",
      "URI": "http://wso2.org/claims/organization"
    }
  ]
}
```

Related PR - https://github.com/wso2/product-apim/pull/7906
Related Issue - https://github.com/wso2/product-apim/issues/7873