### PR TITLE
Fix devportal application page issues

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Listing/Listing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Listing/Listing.jsx
@@ -225,7 +225,7 @@ class Listing extends Component {
         const nextRowsPerPage = event.target.value;
         const { rowsPerPage, page } = this.state;
         const rowsPerPageRatio = rowsPerPage / nextRowsPerPage;
-        const nextPage =  Math.floor( page * rowsPerPageRatio );
+        const nextPage =  Math.floor(page * rowsPerPageRatio);
         this.setState({ rowsPerPage: nextRowsPerPage, page: nextPage }, this.updateApps);
     };
 
@@ -249,12 +249,11 @@ class Listing extends Component {
      * @memberof Listing
      */
     handleAppDelete() {
-        const { data, deletingId } = this.state;
+        const { data, deletingId, page } = this.state;
         const { intl } = this.props;
         const newData = new Map([...data]);
         const app = newData.get(deletingId);
         app.deleting = true;
-        this.setState({ data: newData });
 
         let message = intl.formatMessage({
             defaultMessage: 'Application {name} deleted successfully!',
@@ -266,7 +265,11 @@ class Listing extends Component {
                 newData.delete(deletingId);
                 Alert.info(message);
                 this.toggleDeleteConfirmation();
-                this.setState({ data: newData });
+                // Page is reduced by 1, when there is only one application in a particular page and it is deleted (except when in first page)
+                if (newData.size === 0 && page !== 0) {
+                    this.setState((state) => ({ page: state.page - 1 }));
+                }
+                this.updateApps();
             }
         }).catch((error) => {
             console.log(error);

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Listing/Listing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Listing/Listing.jsx
@@ -222,7 +222,11 @@ class Listing extends Component {
      * @memberof Listing
      */
     handleChangeRowsPerPage = (event) => {
-        this.setState({ rowsPerPage: event.target.value }, this.updateApps);
+        const nextRowsPerPage = event.target.value;
+        const { rowsPerPage, page } = this.state;
+        const rowsPerPageRatio = rowsPerPage / nextRowsPerPage;
+        const nextPage =  Math.floor( page * rowsPerPageRatio );
+        this.setState({ rowsPerPage: nextRowsPerPage, page: nextPage }, this.updateApps);
     };
 
     /**

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Listing/Listing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Listing/Listing.jsx
@@ -123,6 +123,7 @@ const styles = theme => ({
  */
 class Listing extends Component {
     static contextType = Settings;
+    static rowsPerPage = 10;
 
     /**
      *
@@ -135,7 +136,7 @@ class Listing extends Component {
             orderBy: 'name',
             data: null,
             page: 0,
-            rowsPerPage: 10,
+            rowsPerPage: Listing.rowsPerPage,
             open: false,
             isApplicationSharingEnabled: true,
             isDeleteOpen: false,
@@ -294,7 +295,7 @@ class Listing extends Component {
         }
         const { classes, theme, intl } = this.props;
         const strokeColorMain = theme.palette.getContrastText(theme.custom.infoBar.background);
-        const paginationEnabled = totalApps > rowsPerPage;
+        const paginationEnabled = totalApps > Listing.rowsPerPage;
         return (
             <main className={classes.content}>
                 <div className={classes.root}>


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/7898

## Approach
* When an application is deleted from a page, if there are applications in the next page, one of those applications will move in to the current page. This is done by fetching relevant applications again when an application is deleted. This will also update the application count when an application is deleted. (Fix for Issue 1 and Issue 2)

* When only one application is present in the last page and that application is deleted, the page number is decreased by 1 to move to the previous page. But if only one application is present (which would be in the first page), then the page will show that no applications are present. (Fix for Issue 3)

* A static variable is introduced to handle the pagination enabling behavior. (Fix for Issue 4)
 
* When the rows per page is changed, the correct page number on which the currently displaying applications should be in, is calculated and the page number is updated. (Fix for Issue 5)
Eg:- Total Applications - 15. Rows Per Page - 5. Current Page - 1 (Displaying applications 6-10)
When Rows Per Page is changed to 10, the Page Number should be 0. (Displaying applications 1-10)

## Test environment
JDK 1.8.0_241
Ubuntu 18.04.4 LTS