### PR TITLE
Handle OIDC Error log when ClientId is null

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/ProtectedApp.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/ProtectedApp.jsx
@@ -252,13 +252,13 @@ class ProtectedApp extends Component {
         if(isWidget) {
             return (
                 <>
-                    <iframe
+                    {clientId && <iframe
                         title='iframeOP'
                         id='iframeOP'
                         src={checkSessionURL}
                         width='0px'
                         height='0px'
-                    />
+                    />}
                     <AppRouts isAuthenticated={isAuthenticated} isUserFound={isUserFound} />  
                 </>
             );  
@@ -271,13 +271,13 @@ class ProtectedApp extends Component {
          */
         return (
             <Base>
-                <iframe
+                {clientId && <iframe
                     title='iframeOP'
                     id='iframeOP'
                     src={checkSessionURL}
                     width='0px'
                     height='0px'
-                />
+                />}
                 <AppRouts isAuthenticated={isAuthenticated} isUserFound={isUserFound} />
             </Base>
         );


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/7874

## Approach
Render the session checking iframe only when clientId is not null.


## Test environment
JDK 1.8.0_241
Ubuntu 18.04.4 LTS