### PR TITLE
Retrieving provider name correctly with @ symbol in Publisher REST API Unified Search

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/SearchResultMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/SearchResultMappingUtil.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.apimgt.api.model.APIProduct;
 import org.wso2.carbon.apimgt.api.model.APIProductIdentifier;
 import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIProductSearchResultDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DocumentSearchResultDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.PaginationDTO;
@@ -54,7 +55,7 @@ public class SearchResultMappingUtil {
         APIIdentifier apiId = api.getId();
         apiResultDTO.setName(apiId.getApiName());
         apiResultDTO.setVersion(apiId.getVersion());
-        apiResultDTO.setProvider(apiId.getProviderName());
+        apiResultDTO.setProvider(APIUtil.replaceEmailDomainBack(apiId.getProviderName()));
         String context = api.getContextTemplate();
         if (context.endsWith("/" + RestApiConstants.API_VERSION_PARAM)) {
             context = context.replace("/" + RestApiConstants.API_VERSION_PARAM, "");
@@ -80,7 +81,7 @@ public class SearchResultMappingUtil {
         apiProductResultDTO.setId(apiProduct.getUuid());
         APIProductIdentifier apiproductId = apiProduct.getId();
         apiProductResultDTO.setName(apiproductId.getName());
-        apiProductResultDTO.setProvider(apiproductId.getProviderName());
+        apiProductResultDTO.setProvider(APIUtil.replaceEmailDomainBack(apiproductId.getProviderName()));
         String context = apiProduct.getContextTemplate();
         if (context.endsWith("/" + RestApiConstants.API_VERSION_PARAM)) {
             context = context.replace("/" + RestApiConstants.API_VERSION_PARAM, "");
@@ -112,7 +113,7 @@ public class SearchResultMappingUtil {
         APIIdentifier apiId = api.getId();
         docResultDTO.setApiName(apiId.getApiName());
         docResultDTO.setApiVersion(apiId.getVersion());
-        docResultDTO.setApiProvider(apiId.getProviderName());
+        docResultDTO.setApiProvider(APIUtil.replaceEmailDomainBack(apiId.getProviderName()));
         docResultDTO.setApiUUID(api.getUUID());
         return docResultDTO;
     }
@@ -133,7 +134,7 @@ public class SearchResultMappingUtil {
         APIProductIdentifier apiId = apiProduct.getId();
         docResultDTO.setApiName(apiId.getName());
         docResultDTO.setApiVersion(apiId.getVersion());
-        docResultDTO.setApiProvider(apiId.getProviderName());
+        docResultDTO.setApiProvider(APIUtil.replaceEmailDomainBack(apiId.getProviderName()));
         docResultDTO.setApiUUID(apiProduct.getUuid());
         return docResultDTO;
     }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/7959

## Goals
Retrieving provider name correctly with @ symbol instead of -AT- in Publisher REST API Unified Search.

## Approach
In [carbon-apimgt/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/SearchResultMappingUtil.java](url) file, when setting the provider name replaced the -AT- with @ using the function **replaceEmailDomainBack(**).

## User stories
- When a user retrieves details on APIs or API Products using the REST API [here](https://apim.docs.wso2.com/en/next/develop/product-apis/publisher-v1/#/Unified%20Search), the API provider name will be retrieved correctly with @ sign, if it contains an @ sign actually.
- When a user searches for API or API Product details by logging into the Publisher portal, he/she will retrieve the API provider name correctly with @ sign, if it contains an @ sign actually.

## Test environment
-  JDK 1.8.0_241
- Ubuntu 18.04.4 LTS