### PR TITLE
Checking removed resources that have already been used in API Products when updating an API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.apimgt.api;
 
 import org.json.simple.JSONObject;
+import org.wso2.carbon.apimgt.api.doc.model.APIResource;
 import org.wso2.carbon.apimgt.api.dto.CertificateInformationDTO;
 import org.wso2.carbon.apimgt.api.dto.CertificateMetadataDTO;
 import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
@@ -1305,4 +1306,26 @@ public interface APIProvider extends APIManager {
      * @throws APIManagementException
      */
     JSONObject getSecurityAuditAttributesFromConfig(String userId) throws APIManagementException;
+
+    /**
+     * Find the resources that should be removed from API Products,
+     * because those have been already removed from the swagger definition of the updating API.
+     *
+     * @param apiId API Identifier
+     * @param apiDefinition swagger definition
+     * @return  List of resources to be removed that are reused among API Products
+     * @throws APIManagementException when error updating resources
+     */
+    List<APIResource> getResourcesToBeRemovedFromAPIProducts(APIIdentifier apiId, String apiDefinition)
+            throws APIManagementException;
+
+    /**
+     * Finds resources that have been removed in the updated API URITemplates,
+     * that are currently reused by API Products.
+     *
+     * @param updatedUriTemplates Updated URITemplates
+     * @param existingAPI         Existing API
+     * @return List of removed resources that are reused among API Products
+     */
+    List<APIResource> getRemovedProductResources(Set<URITemplate> updatedUriTemplates, API existingAPI);
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/doc/model/APIResource.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/doc/model/APIResource.java
@@ -1,6 +1,7 @@
 package org.wso2.carbon.apimgt.api.doc.model;
 
 import java.util.List;
+import java.util.Objects;
 
 public class APIResource {
 	
@@ -9,6 +10,8 @@ public class APIResource {
 	private String description;
 	
 	private List<Operation> operations;
+
+	private String verb;
 	
 	public APIResource(String path, String description, List<Operation> ops) {
 		this.path = path;
@@ -16,6 +19,36 @@ public class APIResource {
 		this.operations = ops;
 	}
 
+	public APIResource(String verb, String path) {
+		this.verb = verb;
+		this.path = path;
+	}
+
+	@Override
+	public String toString() {
+		return "{" +
+				"verb='" + verb + '\'' +
+				", path='" + path + '\'' +
+				'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+
+		if (!(o instanceof APIResource)) {
+			return false;
+		}
+
+		APIResource that = (APIResource) o;
+		return verb.equals(that.verb) &&
+				path.equals(that.path);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(verb, path);
+	}
 }
 
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -40,6 +40,8 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.apimgt.api.APIDefinition;
+import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIMgtResourceNotFoundException;
 import org.wso2.carbon.apimgt.api.APIProvider;
@@ -50,6 +52,7 @@ import org.wso2.carbon.apimgt.api.MonetizationException;
 import org.wso2.carbon.apimgt.api.PolicyDeploymentFailureException;
 import org.wso2.carbon.apimgt.api.UnsupportedPolicyTypeException;
 import org.wso2.carbon.apimgt.api.WorkflowResponse;
+import org.wso2.carbon.apimgt.api.doc.model.APIResource;
 import org.wso2.carbon.apimgt.api.dto.CertificateInformationDTO;
 import org.wso2.carbon.apimgt.api.dto.CertificateMetadataDTO;
 import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
@@ -8016,5 +8019,63 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             }
         }
         return null;
+    }
+
+    @Override
+    public List<APIResource> getResourcesToBeRemovedFromAPIProducts(APIIdentifier apiId, String swaggerContent)
+            throws APIManagementException {
+        API existingAPI = getAPI(apiId);
+        APIDefinitionValidationResponse response = OASParserUtil
+                .validateAPIDefinition(swaggerContent, true);
+        APIDefinition oasParser = response.getParser();
+        String apiDefinition = response.getJsonContent();
+        Set<URITemplate> uriTemplates = null;
+        try {
+            uriTemplates = oasParser.getURITemplates(apiDefinition);
+        } catch (APIManagementException e) {
+            // catch APIManagementException inside again to capture validation error
+            log.error("Swagger validation error");
+        }
+        if(uriTemplates == null || uriTemplates.isEmpty()) {
+            log.error("No resources found");
+        }
+
+        List<APIResource> removedProductResources = getRemovedProductResources(uriTemplates, existingAPI);
+        return removedProductResources;
+    }
+
+    @Override
+    public List<APIResource> getRemovedProductResources(Set<URITemplate> updatedUriTemplates, API existingAPI) {
+        Set<URITemplate> existingUriTemplates = existingAPI.getUriTemplates();
+        List<APIResource> removedReusedResources = new ArrayList<>();
+
+        for (URITemplate existingUriTemplate : existingUriTemplates) {
+
+            // If existing URITemplate is used by any API Products
+            if (!existingUriTemplate.retrieveUsedByProducts().isEmpty()) {
+                String existingVerb = existingUriTemplate.getHTTPVerb();
+                String existingPath = existingUriTemplate.getUriTemplate();
+                boolean isReusedResourceRemoved = true;
+
+                for (URITemplate updatedUriTemplate : updatedUriTemplates) {
+                    String updatedVerb = updatedUriTemplate.getHTTPVerb();
+                    String updatedPath = updatedUriTemplate.getUriTemplate();
+
+                    //Check if existing reused resource is among updated resources
+                    if (existingVerb.equalsIgnoreCase(updatedVerb) &&
+                            existingPath.equalsIgnoreCase(updatedPath)) {
+                        isReusedResourceRemoved = false;
+                        break;
+                    }
+                }
+
+                // Existing reused resource is not among updated resources
+                if (isReusedResourceRemoved) {
+                    APIResource removedResource = new APIResource(existingVerb, existingPath);
+                    removedReusedResources.add(removedResource);
+                }
+            }
+        }
+        return removedReusedResources;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.apimgt.api.APIMgtResourceAlreadyExistsException;
 import org.wso2.carbon.apimgt.api.APIMgtResourceNotFoundException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.FaultGatewaysException;
+import org.wso2.carbon.apimgt.api.doc.model.APIResource;
 import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
@@ -390,6 +391,17 @@ public final class APIImportUtil {
             //Swagger definition will only be available of API type HTTP. Web socket API does not have it.
             if (!APIConstants.APITransportType.WS.toString().equalsIgnoreCase(importedApi.getType())) {
                 String swaggerContent = loadSwaggerFile(pathToArchive);
+
+                // Check whether any of the resources should be removed from the API when updating,
+                // that has already been used in API Products
+                List<APIResource> resourcesToRemove = apiProvider.getResourcesToBeRemovedFromAPIProducts(importedApi.getId(),
+                        swaggerContent);
+                // Do not allow to remove resources from API Products, hence throw an exception
+                if (!resourcesToRemove.isEmpty()) {
+                    throw new APIImportExportException("Cannot remove following resource paths " +
+                            resourcesToRemove.toString() + " because they are used by one or more API Products");
+                }
+
                 addSwaggerDefinition(importedApi.getId(), swaggerContent, apiProvider);
                 //If graphQL API, import graphQL schema definition to registry
                 if (StringUtils.equals(importedApi.getType(), APIConstants.APITransportType.GRAPHQL.toString())) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -68,6 +68,7 @@ import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.FaultGatewaysException;
 import org.wso2.carbon.apimgt.api.MonetizationException;
+import org.wso2.carbon.apimgt.api.doc.model.APIResource;
 import org.wso2.carbon.apimgt.api.dto.CertificateInformationDTO;
 import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
 import org.wso2.carbon.apimgt.api.model.*;
@@ -159,42 +160,6 @@ public class ApisApiServiceImpl implements ApisApiService {
 
     private static final Log log = LogFactory.getLog(ApisApiServiceImpl.class);
     private static final String API_PRODUCT_TYPE = "APIPRODUCT";
-
-    class APIResource {
-        String verb;
-        String path;
-
-        APIResource(String verb, String path) {
-            this.verb = verb;
-            this.path = path;
-        }
-
-        @Override
-        public String toString() {
-            return "{" +
-                    "verb='" + verb + '\'' +
-                    ", path='" + path + '\'' +
-                    '}';
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-
-            if (!(o instanceof APIResource)) {
-                return false;
-            }
-
-            APIResource that = (APIResource) o;
-            return verb.equals(that.verb) &&
-                    path.equals(that.path);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(verb, path);
-        }
-    }
 
     @Override
     public Response apisGet(Integer limit, Integer offset, String xWSO2Tenant, String query,
@@ -1004,49 +969,6 @@ public class ApisApiServiceImpl implements ApisApiService {
                             httpConn.getResponseCode() + " - " + httpConn.getResponseMessage());
         }
         return auditUuid;
-    }
-
-    /**
-     * Finds resources that have been removed in the updated API URITemplates,
-     * that are currently reused by API Products.
-     *
-     * @param updatedUriTemplates Updated URITemplates
-     * @param existingAPI         Existing API
-     * @return List of removed resources that are reused among API Products
-     */
-    private List<APIResource> getRemovedProductResources(Set<URITemplate> updatedUriTemplates, API existingAPI) {
-        Set<URITemplate> existingUriTemplates = existingAPI.getUriTemplates();
-        List<APIResource> removedReusedResources = new ArrayList<>();
-
-        for (URITemplate existingUriTemplate : existingUriTemplates) {
-
-            // If existing URITemplate is used by any API Products
-            if (!existingUriTemplate.retrieveUsedByProducts().isEmpty()) {
-                String existingVerb = existingUriTemplate.getHTTPVerb();
-                String existingPath = existingUriTemplate.getUriTemplate();
-                boolean isReusedResourceRemoved = true;
-
-                for (URITemplate updatedUriTemplate : updatedUriTemplates) {
-                    String updatedVerb = updatedUriTemplate.getHTTPVerb();
-                    String updatedPath = updatedUriTemplate.getUriTemplate();
-
-                    //Check if existing reused resource is among updated resources
-                    if (existingVerb.equalsIgnoreCase(updatedVerb) &&
-                            existingPath.equalsIgnoreCase(updatedPath)) {
-                        isReusedResourceRemoved = false;
-                        break;
-                    }
-                }
-
-                // Existing reused resource is not among updated resources
-                if (isReusedResourceRemoved) {
-                    APIResource removedResource = new APIResource(existingVerb, existingPath);
-                    removedReusedResources.add(removedResource);
-                }
-            }
-        }
-
-        return removedReusedResources;
     }
 
     /**
@@ -2969,7 +2891,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             }
         }
 
-        List<APIResource> removedProductResources = getRemovedProductResources(uriTemplates, existingAPI);
+        List<APIResource> removedProductResources = apiProvider.getRemovedProductResources(uriTemplates, existingAPI);
 
         if (!removedProductResources.isEmpty()) {
             RestApiUtil.handleConflict("Cannot remove following resource paths " +


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/277

## Goals
When updating an API using **_apictl import-api_** with **--update** flag, enforce a condition to check whether any resources that have been used by any API Product has been removed from the swagger definition of the corresponding API.

## Approach
1. Moved the function named **getRemovedProductResources** (which was in [carbon-apimgt/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java](url)) to impl level (APIProviderImpl.java). 
2. Wrote a new function named **getResourcesToBeRemovedFromAPIProducts** in APIProviderImpl.java to use that moved function.
3. That function was used to check whether any of the resources should be removed from the API when updating, that has already been used in API Products, before adding the swagger definition to the registry.
4. If there are any resources that already have been removed from the swagger definition of the updating API, but are used in API Products, throw an exception and stop the updating process.

## User stories
Users will not be allowed to update APIs using **apictl import-api** with **--update** flag **if the swagger definition does not contain any resource that already has been used in one or more API Products**.

## Test environment
-  JDK 1.8.0_241
- Ubuntu 18.04.4 LTS
