### PR TITLE
Adding the functionality to retrieve API Product status and the version

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductSearchResultDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductSearchResultDTO.java
@@ -18,6 +18,7 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
   
     private String description = null;
     private String context = null;
+    private String version = null;
     private String provider = null;
     private String status = null;
     private String thumbnailUri = null;
@@ -56,6 +57,24 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
   }
   public void setContext(String context) {
     this.context = context;
+  }
+
+  /**
+   * The version of the API Product
+   **/
+  public APIProductSearchResultDTO version(String version) {
+    this.version = version;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "1.0.0", value = "The version of the API Product")
+  @JsonProperty("version")
+  public String getVersion() {
+    return version;
+  }
+  public void setVersion(String version) {
+    this.version = version;
   }
 
   /**
@@ -123,6 +142,7 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
     APIProductSearchResultDTO apIProductSearchResult = (APIProductSearchResultDTO) o;
     return Objects.equals(description, apIProductSearchResult.description) &&
         Objects.equals(context, apIProductSearchResult.context) &&
+        Objects.equals(version, apIProductSearchResult.version) &&
         Objects.equals(provider, apIProductSearchResult.provider) &&
         Objects.equals(status, apIProductSearchResult.status) &&
         Objects.equals(thumbnailUri, apIProductSearchResult.thumbnailUri);
@@ -130,7 +150,7 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, provider, status, thumbnailUri);
+    return Objects.hash(description, context, version, provider, status, thumbnailUri);
   }
 
   @Override
@@ -140,6 +160,7 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
     sb.append("    context: ").append(toIndentedString(context)).append("\n");
+    sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    thumbnailUri: ").append(toIndentedString(thumbnailUri)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/SearchResultMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/SearchResultMappingUtil.java
@@ -90,6 +90,7 @@ public class SearchResultMappingUtil {
         apiProductResultDTO.setContext(context);
         apiProductResultDTO.setType(SearchResultDTO.TypeEnum.APIPRODUCT);
         apiProductResultDTO.setDescription(apiProduct.getDescription());
+        apiProductResultDTO.setStatus(apiProduct.getState());
         apiProductResultDTO.setThumbnailUri(apiProduct.getThumbnailUrl());
         return apiProductResultDTO;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/SearchResultMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/mappings/SearchResultMappingUtil.java
@@ -81,6 +81,7 @@ public class SearchResultMappingUtil {
         apiProductResultDTO.setId(apiProduct.getUuid());
         APIProductIdentifier apiproductId = apiProduct.getId();
         apiProductResultDTO.setName(apiproductId.getName());
+        apiProductResultDTO.setVersion(apiproductId.getVersion());
         apiProductResultDTO.setProvider(APIUtil.replaceEmailDomainBack(apiproductId.getProviderName()));
         String context = apiProduct.getContextTemplate();
         if (context.endsWith("/" + RestApiConstants.API_VERSION_PARAM)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -9216,6 +9216,10 @@ definitions:
             type: string
             description: A string that represents the context of the user's request
             example: CalculatorAPI
+          version:
+            type: string
+            description: The version of the API Product
+            example: 1.0.0
           provider:
             description: |
               If the provider value is not given, the user invoking the API will be used as the provider.

--- a/docs/apidocs/publisher/v1/models/APIProductSearchResult.html
+++ b/docs/apidocs/publisher/v1/models/APIProductSearchResult.html
@@ -111,6 +111,21 @@
                     </tr>
                     <tr>
                         <td class="parameter">
+                            <p>version</p>
+                            <p class="param-required">
+                                
+                                optional
+                            </p>
+                        </td>
+                        <td class="parameter"><p class="marked">The version of the API Product</p></td>
+                        <td class="parameter">
+                                <a href="#!/models#string">string</a>
+                        </td>
+                        <td class="parameter"> <p class="marked">null</p></td>
+                        <td class="parameter"> <p class="marked">1.0.0</p></td>
+                    </tr>
+                    <tr>
+                        <td class="parameter">
                             <p>provider</p>
                             <p class="param-required">
                                 


### PR DESCRIPTION
## Purpose
Currently, the status and the version of an API Product cannot be retrieved. It will be fixed here.

## Goals
Provide the functionality to retrieve API Product version and the status through Publisher REST API as support for API Products listing in API Controller.

## Approach
- Set the status of an API Product in SearchResultMappingUtil.java 
- Defined the API Product version in publisher-api.yaml
- Set the version of an API Product in SearchResultMappingUtil.java  

## User stories
- When a user is using the Publisher REST API (or API Controller) to list API Product details, the version and the status can be retrieved through the REST call.

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/287

## Test environment
- JDK 1.8.0_241
- Ubuntu 18.04.4 LTS