### PR TITLE
Publish analytics events for throttling scenario

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
@@ -20,10 +20,17 @@ package org.wso2.carbon.apimgt.gateway.handlers;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.CombinedChannelDuplexHandler;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
 public class WebsocketHandler extends CombinedChannelDuplexHandler<WebsocketInboundHandler, WebsocketOutboundHandler> {
+
+    private static final Log log = LogFactory.getLog(WebsocketInboundHandler.class);
 
     public WebsocketHandler() {
         super(new WebsocketInboundHandler(), new WebsocketOutboundHandler());
@@ -32,16 +39,33 @@ public class WebsocketHandler extends CombinedChannelDuplexHandler<WebsocketInbo
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
 
-        if (msg instanceof WebSocketFrame) {
-            if (isThrottled(ctx, (WebSocketFrame) msg)) {
+        if ((msg instanceof CloseWebSocketFrame) || (msg instanceof PongWebSocketFrame)) {
+            //if the inbound frame is a closed frame, throttling, analytics will not be published.
+            outboundHandler().write(ctx, msg, promise);
+
+        } else if (msg instanceof WebSocketFrame) {
+            if (isAllowed(ctx, (WebSocketFrame) msg)) {
                 outboundHandler().write(ctx, msg, promise);
+                // publish analytics events if analytics is enabled
+                if (APIUtil.isAnalyticsEnabled()) {
+                    String clientIp = getClientIp(ctx);
+                    inboundHandler().publishRequestEvent(clientIp, true);
+                }
+            } else {
+                if (log.isDebugEnabled()){
+                    log.debug("Outbound Websocket frame is throttled. " + ctx.channel().toString());
+                }
             }
         } else {
             outboundHandler().write(ctx, msg, promise);
         }
     }
 
-    protected boolean isThrottled(ChannelHandlerContext ctx, WebSocketFrame msg) throws APIManagementException {
+    protected boolean isAllowed(ChannelHandlerContext ctx, WebSocketFrame msg) throws APIManagementException {
         return inboundHandler().doThrottle(ctx, msg);
+    }
+
+    protected String getClientIp(ChannelHandlerContext ctx) {
+        return inboundHandler().getRemoteIP(ctx);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
@@ -22,6 +22,8 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import org.apache.axiom.util.UIDGenerator;
@@ -49,6 +51,7 @@ import org.wso2.carbon.apimgt.usage.publisher.APIMgtUsageDataPublisher;
 import org.wso2.carbon.apimgt.usage.publisher.DataPublisherUtil;
 import org.wso2.carbon.apimgt.usage.publisher.dto.ExecutionTimeDTO;
 import org.wso2.carbon.apimgt.usage.publisher.dto.RequestResponseStreamDTO;
+import org.wso2.carbon.apimgt.usage.publisher.dto.ThrottlePublisherDTO;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.ganalytics.publisher.GoogleAnalyticsData;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -187,22 +190,31 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
                         headers.get(HttpHeaders.AUTHORIZATION));
             } else {
                 ctx.writeAndFlush(new TextWebSocketFrame(APISecurityConstants.API_AUTH_INVALID_CREDENTIALS_MESSAGE));
+                if (log.isDebugEnabled()) {
+                    log.debug("Authentication Failure for the websocket context: " + apiContextUri);
+                }
                 throw new APISecurityException(APISecurityConstants.API_AUTH_INVALID_CREDENTIALS,
                         APISecurityConstants.API_AUTH_INVALID_CREDENTIALS_MESSAGE);
             }
+        } else if ((msg instanceof CloseWebSocketFrame) || (msg instanceof PingWebSocketFrame)) {
+            //if the inbound frame is a closed frame, throttling, analytics will not be published.
+            ctx.fireChannelRead(msg);
         } else if (msg instanceof WebSocketFrame) {
-            boolean isThrottledOut = doThrottle(ctx, (WebSocketFrame) msg);
-            String clientIp = getRemoteIP(ctx);
 
-            if (isThrottledOut) {
+            boolean isAllowed = doThrottle(ctx, (WebSocketFrame) msg);
+
+            if (isAllowed) {
                 ctx.fireChannelRead(msg);
+                String clientIp = getRemoteIP(ctx);
+                // publish analytics events if analytics is enabled
+                if (APIUtil.isAnalyticsEnabled()) {
+                    publishRequestEvent(clientIp, true);
+                }
             } else {
                 ctx.writeAndFlush(new TextWebSocketFrame("Websocket frame throttled out"));
-            }
-
-            // publish analytics events if analytics is enabled
-            if (APIUtil.isAnalyticsEnabled()) {
-                publishRequestEvent(infoDTO, clientIp, isThrottledOut);
+                if (log.isDebugEnabled()) {
+                    log.debug("Inbound Websocket frame is throttled. " + ctx.channel().toString());
+                }
             }
         }
     }
@@ -405,6 +417,9 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
                     .isThrottled(resourceLevelThrottleKey, subscriptionLevelThrottleKey,
                             applicationLevelThrottleKey);
             if (isThrottled) {
+                if (APIUtil.isAnalyticsEnabled()) {
+                    publishThrottleEvent();
+                }
                 return false;
             }
         } finally {
@@ -431,11 +446,10 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
     /**
      * Publish reuqest event to analytics server
      *
-     * @param infoDTO        API and Application data
      * @param clientIp       client's IP Address
      * @param isThrottledOut request is throttled out or not
      */
-    private void publishRequestEvent(APIKeyValidationInfoDTO infoDTO, String clientIp, boolean isThrottledOut) {
+    public void publishRequestEvent(String clientIp, boolean isThrottledOut) {
         long requestTime = System.currentTimeMillis();
         String useragent = headers.get(HttpHeaders.USER_AGENT);
 
@@ -490,6 +504,40 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
             executionTime.setThrottlingLatency(0);
             requestPublisherDTO.setExecutionTime(executionTime);
             usageDataPublisher.publishEvent(requestPublisherDTO);
+        } catch (Exception e) {
+            // flow should not break if event publishing failed
+            log.error("Cannot publish event. " + e.getMessage(), e);
+        }
+
+    }
+
+    /*
+     * Publish throttle events.
+     */
+    private void publishThrottleEvent() {
+        long requestTime = System.currentTimeMillis();
+        String correlationID = UUID.randomUUID().toString();
+        try {
+            ThrottlePublisherDTO throttlePublisherDTO = new ThrottlePublisherDTO();
+            throttlePublisherDTO.setKeyType(infoDTO.getType());
+            throttlePublisherDTO.setTenantDomain(tenantDomain);
+            //throttlePublisherDTO.setApplicationConsumerKey(infoDTO.getConsumerKey());
+            throttlePublisherDTO.setApiname(infoDTO.getApiName());
+            throttlePublisherDTO.setVersion(infoDTO.getApiName() + ':' + version);
+            throttlePublisherDTO.setContext(apiContextUri);
+            throttlePublisherDTO.setApiCreator(infoDTO.getApiPublisher());
+            throttlePublisherDTO.setApiCreatorTenantDomain(MultitenantUtils.getTenantDomain(infoDTO.getApiPublisher()));
+            throttlePublisherDTO.setApplicationName(infoDTO.getApplicationName());
+            throttlePublisherDTO.setApplicationId(infoDTO.getApplicationId());
+            throttlePublisherDTO.setSubscriber(infoDTO.getSubscriber());
+            throttlePublisherDTO.setThrottledTime(requestTime);
+            throttlePublisherDTO.setGatewayType(APIMgtGatewayConstants.GATEWAY_TYPE);
+            throttlePublisherDTO.setThrottledOutReason("-");
+            throttlePublisherDTO.setUsername(infoDTO.getEndUserName());
+            throttlePublisherDTO.setCorrelationID(correlationID);
+            throttlePublisherDTO.setHostName(DataPublisherUtil.getHostAddress());
+            throttlePublisherDTO.setAccessToken("-");
+            usageDataPublisher.publishEvent(throttlePublisherDTO);
         } catch (Exception e) {
             // flow should not break if event publishing failed
             log.error("Cannot publish event. " + e.getMessage(), e);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandlerTestCase.java
@@ -88,8 +88,13 @@ public class WebsocketHandlerTestCase {
         Mockito.when(msg.content()).thenReturn(content);
         WebsocketHandler websocketHandler = new WebsocketHandler() {
             @Override
-            protected boolean isThrottled(ChannelHandlerContext ctx, WebSocketFrame msg) throws APIManagementException {
+            protected boolean isAllowed(ChannelHandlerContext ctx, WebSocketFrame msg) throws APIManagementException {
                 return true;
+            }
+
+            @Override
+            protected String getClientIp(ChannelHandlerContext ctx) {
+                return "192.168.0.100";
             }
         };
         WebsocketInboundHandler websocketInboundHandler = Mockito.mock(WebsocketInboundHandler.class);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandlerTestCase.java
@@ -180,7 +180,12 @@ public class WebsocketInboundHandlerTestCase {
         PowerMockito.when(DataPublisherUtil.getApiManagerAnalyticsConfiguration()).thenReturn(apiMngAnalyticsConfig);
         Mockito.when(apiMngAnalyticsConfig.getPublisherClass()).thenReturn(publisherClass);
         //test when the request is a handshake
-        WebsocketInboundHandler websocketInboundHandler = new WebsocketInboundHandler();
+        WebsocketInboundHandler websocketInboundHandler = new WebsocketInboundHandler() {
+            @Override
+            protected String getRemoteIP(ChannelHandlerContext ctx) {
+                return "192.168.0.100";
+            }
+        };
         ChannelHandlerContext channelHandlerContext = Mockito.mock(ChannelHandlerContext.class);
         FullHttpRequest fullHttpRequest = Mockito.mock(FullHttpRequest.class);
         try {
@@ -194,7 +199,12 @@ public class WebsocketInboundHandlerTestCase {
         Mockito.when(headers.get(org.apache.http.HttpHeaders.AUTHORIZATION)).thenReturn(AUTHORIZATION);
         Mockito.when(headers.get(org.apache.http.HttpHeaders.USER_AGENT)).thenReturn(USER_AGENT);
         Mockito.when(fullHttpRequest.headers()).thenReturn(headers);
-        WebsocketInboundHandler websocketInboundHandler1 = new WebsocketInboundHandler();
+        WebsocketInboundHandler websocketInboundHandler1 = new WebsocketInboundHandler() {
+            @Override
+            protected String getRemoteIP(ChannelHandlerContext ctx) {
+                return "192.168.0.100";
+            }
+        };
         CacheConfiguration.Duration duration = new CacheConfiguration.Duration(TimeUnit.SECONDS,
                 Long.parseLong(TOKEN_CACHE_EXPIRY));
         Mockito.when(gatewayCache.get(API_KEY)).thenReturn("fhgvjhhhjkghj");
@@ -316,7 +326,12 @@ public class WebsocketInboundHandlerTestCase {
         PowerMockito.when(DataPublisherUtil.getApiManagerAnalyticsConfiguration()).thenReturn(apiMngAnalyticsConfig);
         Mockito.when(apiMngAnalyticsConfig.getPublisherClass()).thenReturn(publisherClass);
         //test when the request is a handshake
-        WebsocketInboundHandler websocketInboundHandler = new WebsocketInboundHandler();
+        WebsocketInboundHandler websocketInboundHandler = new WebsocketInboundHandler() {
+            @Override
+            protected String getRemoteIP(ChannelHandlerContext ctx) {
+                return "192.168.0.100";
+            }
+        };
         PowerMockito.when(MultitenantUtils.getTenantDomainFromUrl(SUPER_TENANT_URL)).thenReturn(SUPER_TENANT_DOMAIN);
         try {
             websocketInboundHandler.channelRead(channelHandlerContext, fullHttpRequest);
@@ -325,7 +340,12 @@ public class WebsocketInboundHandlerTestCase {
 //            test for exception
         }
 
-        WebsocketInboundHandler websocketInboundHandler1 = new WebsocketInboundHandler();
+        WebsocketInboundHandler websocketInboundHandler1 = new WebsocketInboundHandler() {
+            @Override
+            protected String getRemoteIP(ChannelHandlerContext ctx) {
+                return "192.168.0.100";
+            }
+        };
         //test for Invalid Credentials error
         try {
             websocketInboundHandler1.channelRead(channelHandlerContext, fullHttpRequest);
@@ -409,6 +429,11 @@ public class WebsocketInboundHandlerTestCase {
                 info.setApiName("Phoneverify*1.0");
                 info.setType(APIConstants.API_KEY_TYPE_PRODUCTION);
                 return info;
+            }
+
+            @Override
+            protected String getRemoteIP(ChannelHandlerContext ctx) {
+                return "192.168.0.100";
             }
         };
         PowerMockito.mockStatic(org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder.class);


### PR DESCRIPTION
With the following PR,

- Throttle events would be published to the analytics.
- Bug Fix: Closed WebSocket frame will not increase the throttle counter. As well as it will not be published to the analytics under API Usage.
- Request events will be published to the analytics for both inbound and outbound frames (for the connection between client and the gateway)

public issue: wso2/product-apim#7879
