### PR TITLE
Flexibility to specify any scope scheme apart from "default" scheme when importing an OpenAPI definition

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
@@ -197,4 +197,13 @@ public abstract class APIDefinition {
     public abstract String getOASDefinitionWithTierContentAwareProperty(String oasDefinition,
             List<String> contentAwareTiersList, String apiLevelTier) throws APIManagementException;
 
+    /**
+     * This method changes the URI templates from the API definition as it support different schemes
+     * @param resourceConfigsJSON json String of oasDefinition
+     * @throws APIManagementException throws if an error occurred
+     * @return URI templates
+     */
+    public abstract String processOtherSchemeScopes(String resourceConfigsJSON)
+            throws APIManagementException;
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -87,6 +87,15 @@ import static org.wso2.carbon.apimgt.impl.APIConstants.APPLICATION_XML_MEDIA_TYP
 public class OAS3Parser extends APIDefinition {
     private static final Log log = LogFactory.getLog(OAS3Parser.class);
     static final String OPENAPI_SECURITY_SCHEMA_KEY = "default";
+    private List<String> otherSchemes;
+
+    private List<String> getOtherSchemes() {
+        return otherSchemes;
+    }
+
+    private void setOtherSchemes(List<String> otherSchemes) {
+        this.otherSchemes = otherSchemes;
+    }
 
     /**
      * This method  generates Sample/Mock payloads for Open API Specification (3.0) definitions
@@ -1234,4 +1243,211 @@ public class OAS3Parser extends APIDefinition {
             return Json.pretty(swagger);
         }
     }
+
+    /**
+     * This method returns the boolean value which checks whether the swagger is included default security scheme or not
+     *
+     * @param swaggerContent resource json
+     * @return is default is given already
+     * @throws APIManagementException
+     */
+    private boolean isDefaultGiven(String swaggerContent) throws APIManagementException {
+        OpenAPI openAPI = getOpenAPI(swaggerContent);
+        boolean isDefaultIsGiven = true;
+        SecurityScheme checkDefault = openAPI.getComponents().getSecuritySchemes().get(OPENAPI_SECURITY_SCHEMA_KEY);
+        if (checkDefault == null) {
+            isDefaultIsGiven = false;
+        }
+        return isDefaultIsGiven;
+    }
+
+    /**
+     * This method will inject scopes of other schemes to the swagger definition
+     *
+     * @param swaggerContent resource json
+     * @return updated json string
+     * @throws APIManagementException
+     */
+    @Override
+    public String processOtherSchemeScopes(String swaggerContent) throws APIManagementException {
+        OpenAPI openAPI = getOpenAPI(swaggerContent);
+        boolean isDefaultAvailable = isDefaultGiven(swaggerContent);
+        openAPI = injectOtherScopesToDefaultScheme(openAPI, isDefaultAvailable);
+        openAPI = injectOtherResourceScopesToDefaultScheme(openAPI, isDefaultAvailable);
+        return Json.pretty(openAPI);
+    }
+
+    /**
+     * This method returns the oauth scopes according to the given swagger(version 3)
+     *
+     * @param openAPI            - OpenApi object
+     * @param isDefaultAvailable - boolean
+     * @return scope set as all defaults
+     * @throws APIManagementException
+     */
+    private OpenAPI injectOtherScopesToDefaultScheme(OpenAPI openAPI, boolean isDefaultAvailable) throws APIManagementException {
+        Map<String, SecurityScheme> securitySchemes = null;
+        Components component = openAPI.getComponents();
+        List<String> otherSetOfSchemes = new ArrayList<>();
+
+        if (openAPI.getComponents() != null && (securitySchemes = openAPI.getComponents().getSecuritySchemes()) != null
+                && !isDefaultAvailable) {
+            //If there is no default type schemes set a one
+            SecurityScheme newDefault = new SecurityScheme();
+            securitySchemes.put(OPENAPI_SECURITY_SCHEMA_KEY, newDefault);
+            for (Map.Entry<String, SecurityScheme> entry : securitySchemes.entrySet()) {
+                if (!OPENAPI_SECURITY_SCHEMA_KEY.equals(entry.getKey()) && "oauth2".equals(entry.getValue().getType().toString())) {
+                    otherSetOfSchemes.add(entry.getKey());
+                    //Check for default one
+                    SecurityScheme defaultType = securitySchemes.get(OPENAPI_SECURITY_SCHEMA_KEY);
+                    OAuthFlows defaultTypeFlows = defaultType.getFlows();
+                    if (defaultTypeFlows == null) {
+                        defaultTypeFlows = new OAuthFlows();
+                    }
+                    OAuthFlow defaultTypeFlow = defaultTypeFlows.getImplicit();
+                    if (defaultTypeFlow == null) {
+                        defaultTypeFlow = new OAuthFlow();
+                    }
+
+                    SecurityScheme noneDefaultType = entry.getValue();
+                    OAuthFlows noneDefaultTypeFlows = noneDefaultType.getFlows();
+                    //Get Implicit Flows
+                    OAuthFlow noneDefaultTypeFlowImplicit = noneDefaultTypeFlows.getImplicit();
+                    if (noneDefaultTypeFlowImplicit != null) {
+                        defaultTypeFlow = extractAndInjectScopesFromFlow(noneDefaultTypeFlowImplicit, defaultTypeFlow);
+                        defaultTypeFlows.setImplicit(defaultTypeFlow);
+                    }
+                    //Get AuthorizationCode Flow
+                    OAuthFlow noneDefaultTypeFlowAuthorizationCode = noneDefaultTypeFlows.getAuthorizationCode();
+                    if (noneDefaultTypeFlowAuthorizationCode != null) {
+                        defaultTypeFlow = extractAndInjectScopesFromFlow(noneDefaultTypeFlowAuthorizationCode, defaultTypeFlow);
+                        defaultTypeFlows.setImplicit(defaultTypeFlow);
+                    }
+                    //Get ClientCredentials Flow
+                    OAuthFlow noneDefaultTypeFlowClientCredentials = noneDefaultTypeFlows.getClientCredentials();
+                    if (noneDefaultTypeFlowClientCredentials != null) {
+                        defaultTypeFlow = extractAndInjectScopesFromFlow(noneDefaultTypeFlowClientCredentials, defaultTypeFlow);
+                        defaultTypeFlows.setImplicit(defaultTypeFlow);
+                    }
+                    //Get Password Flow
+                    OAuthFlow noneDefaultTypeFlowPassword = noneDefaultTypeFlows.getPassword();
+                    if (noneDefaultTypeFlowPassword != null) {
+                        defaultTypeFlow = extractAndInjectScopesFromFlow(noneDefaultTypeFlowPassword, defaultTypeFlow);
+                        defaultTypeFlows.setImplicit(defaultTypeFlow);
+                    }
+
+                    defaultType.setFlows(defaultTypeFlows);
+                }
+            }
+        }
+        component.setSecuritySchemes(securitySchemes);
+        openAPI.setComponents(component);
+        setOtherSchemes(otherSetOfSchemes);
+        return openAPI;
+    }
+
+    /**
+     * This method returns the oauth scopes of Oauthflows according to the given swagger(version 3)
+     *
+     * @param noneDefaultTypeFlow , OAuthflow
+     * @param defaultTypeFlow,    OAuthflow
+     * @return scopes of given flow
+     */
+    private OAuthFlow extractAndInjectScopesFromFlow(OAuthFlow noneDefaultTypeFlow, OAuthFlow defaultTypeFlow) {
+        Scopes noneDefaultFlowScopes = noneDefaultTypeFlow.getScopes();
+        Scopes defaultFlowScopes = defaultTypeFlow.getScopes();
+        Map<String, String> defaultScopeBindings = null;
+        if (defaultFlowScopes == null) {
+            defaultFlowScopes = new Scopes();
+        }
+
+        for (Map.Entry<String, String> input : noneDefaultFlowScopes.entrySet()) {
+            String name = input.getKey();
+            String description = input.getValue();
+            //Inject scopes set into default scheme
+            defaultFlowScopes.addString(name, description);
+            defaultTypeFlow.setScopes(defaultFlowScopes);
+        }
+        //Check X-Scope Bindings
+        Map<String, String> noneDefaultScopeBindings = null;
+        Map<String, Object> defaultTypeExtension = defaultTypeFlow.getExtensions();
+        if (defaultTypeExtension == null) {
+            defaultTypeExtension = new HashMap<>();
+        }
+        if (noneDefaultTypeFlow.getExtensions() != null && (noneDefaultScopeBindings =
+                (Map<String, String>) noneDefaultTypeFlow.getExtensions().get(APIConstants.SWAGGER_X_SCOPES_BINDINGS))
+                != null) {
+            defaultScopeBindings = (Map<String, String>) defaultTypeExtension.get(APIConstants.SWAGGER_X_SCOPES_BINDINGS);
+            if (defaultScopeBindings == null) {
+                defaultScopeBindings = new HashMap<>();
+            }
+            for (Map.Entry<String, String> roleInUse : noneDefaultScopeBindings.entrySet()) {
+                String noneDefaultTypeScope = roleInUse.getKey();
+                String noneDefaultTypeRole = roleInUse.getValue();
+                defaultScopeBindings.put(noneDefaultTypeScope, noneDefaultTypeRole);
+            }
+        }
+        defaultTypeExtension.put(APIConstants.SWAGGER_X_SCOPES_BINDINGS, defaultScopeBindings);
+        defaultTypeFlow.setExtensions(defaultTypeExtension);
+        return defaultTypeFlow;
+    }
+
+    /**
+     * This method returns URI templates according to the given swagger file(Swagger version 3)
+     *
+     * @param openAPI OpenAPI,isDefaultAvailable boolean
+     * @return URI Templates
+     * @throws APIManagementException
+     */
+    private OpenAPI injectOtherResourceScopesToDefaultScheme(OpenAPI openAPI, boolean isDefaultAvailable) throws APIManagementException {
+        List<String> schemes = getOtherSchemes();
+
+        Paths paths = openAPI.getPaths();
+        if (!isDefaultAvailable) {
+            for (String pathKey : paths.keySet()) {
+                PathItem pathItem = paths.get(pathKey);
+                Map<PathItem.HttpMethod, Operation> operationsMap = pathItem.readOperationsMap();
+                SecurityRequirement updatedDefaultSecurityRequirement = new SecurityRequirement();
+                for (Map.Entry<PathItem.HttpMethod, Operation> entry : operationsMap.entrySet()) {
+                    PathItem.HttpMethod httpMethod = entry.getKey();
+                    Operation operation = entry.getValue();
+                    List<SecurityRequirement> securityRequirements = operation.getSecurity();
+                    if (securityRequirements == null) {
+                        securityRequirements = new ArrayList<>();
+                    }
+                    if (APIConstants.SUPPORTED_METHODS.contains(httpMethod.name().toLowerCase())) {
+                        List<String> opScopesDefault = new ArrayList<>();
+                        List<String> opScopesDefaultInstance = getScopeOfOperations(OPENAPI_SECURITY_SCHEMA_KEY, operation);
+                        if (opScopesDefaultInstance != null) {
+                            opScopesDefault.addAll(opScopesDefaultInstance);
+                        }
+                        updatedDefaultSecurityRequirement.put(OPENAPI_SECURITY_SCHEMA_KEY, opScopesDefault);
+                        for (Map<String, List<String>> input : securityRequirements) {
+                            for (String scheme : schemes) {
+                                if (!OPENAPI_SECURITY_SCHEMA_KEY.equals(scheme)) {
+                                    List<String> opScopesOthers = getScopeOfOperations(scheme, operation);
+                                    if (opScopesOthers != null) {
+                                        for (String scope : opScopesOthers) {
+                                            if (!opScopesDefault.contains(scope)) {
+                                                opScopesDefault.add(scope);
+                                            }
+                                        }
+                                    }
+                                }
+                                updatedDefaultSecurityRequirement.put(OPENAPI_SECURITY_SCHEMA_KEY, opScopesDefault);
+                            }
+                        }
+                        securityRequirements.add(updatedDefaultSecurityRequirement);
+                    }
+                    operation.setSecurity(securityRequirements);
+                    entry.setValue(operation);
+                    operationsMap.put(httpMethod, operation);
+                }
+                paths.put(pathKey, pathItem);
+            }
+            openAPI.setPaths(paths);
+        }
+        return openAPI;
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1211,4 +1211,18 @@ public class OASParserUtil {
         scopesSortedlist.sort(Comparator.comparing(Scope::getName));
         return new LinkedHashSet<>(scopesSortedlist);
     }
+
+    /**
+     * Preprocessing of scopes schemes to support multiple schemes other than 'default' type
+     * This method will change the given definition
+     *
+     * @param swaggerContent
+     * @return processedSwaggerContent
+     */
+    public static String preProcess(String swaggerContent) throws APIManagementException {
+        //Load required properties from swagger to the API
+        APIDefinition apiDefinition = getOASParser(swaggerContent);
+        String swaggerContentUpdated = apiDefinition.processOtherSchemeScopes(swaggerContent);
+        return swaggerContentUpdated;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -401,6 +401,8 @@ public final class APIImportUtil {
                     throw new APIImportExportException("Cannot remove following resource paths " +
                             resourcesToRemove.toString() + " because they are used by one or more API Products");
                 }
+                //preProcess swagger definition
+                swaggerContent = OASParserUtil.preProcess(swaggerContent);
 
                 addSwaggerDefinition(importedApi.getId(), swaggerContent, apiProvider);
                 //If graphQL API, import graphQL schema definition to registry

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -2866,6 +2866,7 @@ public class ApisApiServiceImpl implements ApisApiService {
         API existingAPI = apiProvider.getAPIbyUUID(apiId, tenantDomain);
         APIDefinition oasParser = response.getParser();
         String apiDefinition = response.getJsonContent();
+        apiDefinition = OASParserUtil.preProcess(apiDefinition);
         Set<URITemplate> uriTemplates = null;
         try {
             uriTemplates = oasParser.getURITemplates(apiDefinition);
@@ -3221,6 +3222,7 @@ public class ApisApiServiceImpl implements ApisApiService {
                 swaggerData = new SwaggerData(apiToAdd);
                 definitionToAdd = apiDefinition.populateCustomManagementInfo(definitionToAdd, swaggerData);
             }
+            definitionToAdd = OASParserUtil.preProcess(definitionToAdd);
             Set<URITemplate> uriTemplates = apiDefinition.getURITemplates(definitionToAdd);
             Set<Scope> scopes = apiDefinition.getScopes(definitionToAdd);
             apiToAdd.setUriTemplates(uriTemplates);


### PR DESCRIPTION
## Purpose
Providing Flexibility to specify any scope scheme apart from "default" scheme when importing an OpenAPI definition through API publisher or through API Controller and assign those scopes into resources correctly.

## Goals
Currently, the API publisher does not support multiple OAuth2 scope schemes and support only 'default' scope schemes. But when a customer brings their own API definition as a swagger file there can be OAuth2 scope schemes that are not written in the 'default' scope scheme. In that case, currently, those scopes do not get exposed or used in API publisher to generate tokens or perform any other operations. Since Microgateway supports these types of different OAuth2 scope schemes the APIM product should provide support for this particular scenario. 
Fixes https://github.com/wso2/product-apim-tooling/issues/124 and https://github.com/wso2/product-apim/issues/7648

## Approach
Change the swagger file when importing into APIM publisher - 

In this approach what we are going to do is copy or replace the Oauth2 scope definitions that are not default scheme into default schemes. In this approach, the swagger definition can be replaced or merged with the changes. And that changed swagger definition will be the subject to OAS3 parser or OAS2 parser. Then the API exposing process will go on as in the current procedure. 

 

_Disadvantage_ -  In this approach since we make a change to the swagger file when the support of multiple scope schemes implemented properly this fix will be troublesome.
_Advantage_ - For the moment this approach will provide a fix to the use-case that we discussed above without breaking or interrupting the existing chain of processes. 


> _Eg: External Swagger Scheme_

![7QXViHC9_73xS3OCtF-X1pbP3l19eFTWEyBUsmFToa43Q8yO1OSVcRTlr4uAs368dz35aMvQDQWxPLjFYVGxIt9Xww2uPvxfneUfedBa7Av_vRXlbaGdx5zBKyXdvimqkOTAhkRB](https://user-images.githubusercontent.com/42435576/80142409-b5e72800-85c8-11ea-8403-0a46570dc6e2.png)

> _The way resources use these security schemes originally._

![9O0GVP37C-bTfx2hPdncy7WK7ICqgq5DB-d0NBRPoqufklclhXLMNcZK3K8BYzRODf4OpDeuNbpBjXJVDIRpesap1h-fvIj5R2ZgwEWaChSiw2yIiYAeIc5gC2GNq7OsT7X6jzG2](https://user-images.githubusercontent.com/42435576/80142569-fc3c8700-85c8-11ea-947d-398cae43f4c1.png)

>  _After the change._

![mLHyIozkBiIjO2dvuuEvr9hh_E8_R_2YC0mHMmjw5l8XRb1Tf2EZ6Pcm8NIXdetaoeT54qAubusCKKJYCmFsLoEKcyLYhVxqEdSogTwusRR_crss7equnZm1gF8EwvN4QYsRIc8I](https://user-images.githubusercontent.com/42435576/80142589-0bbbd000-85c9-11ea-8282-24dbb621b8e9.png)


> _The way resources use these security schemes after the fix of the issue._

![image](https://user-images.githubusercontent.com/42435576/80142594-0d859380-85c9-11ea-9d68-430b4a2e99d2.png)

## User stories
* Importing external swagger 2 definitions through API CTL.
* Importing external swagger 3 definitions through API CTL.
* Importing external swagger 2 definitions through API publisher UI or using curl commands.
* Importing external swagger 3 definitions through API  publisher UI or using curl commands.
* Importing Swagger definitions with additional properties.

## Documentation
Doc has Impact
https://github.com/wso2/docs-apim/pull/1075
https://github.com/wso2/docs-apim/pull/1074
