### PR TITLE
Convert scope list to string array

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/interceptors/auth/BasicAuthenticationInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/interceptors/auth/BasicAuthenticationInterceptor.java
@@ -276,8 +276,12 @@ public class BasicAuthenticationInterceptor extends AbstractPhaseInterceptor {
                 }
             }
         }
-        //Add the validated user scope list to the cxf message
-        inMessage.getExchange().put(RestApiConstants.USER_REST_API_SCOPES, validatedUserScopes.toArray());
+
+        List<String> scopes = new ArrayList<>();
+        validatedUserScopes.forEach(scope -> scopes.add(scope.getKey()));
+
+        // Add the validated user scope list to the cxf message
+        inMessage.getExchange().put(RestApiConstants.USER_REST_API_SCOPES, scopes.toArray(new String[0]));
 
         if (!validatedUserScopes.isEmpty()) {
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
Fixes: wso2/product-apim#8074

Having object type scope list causes issues later in other places. Scope list in OAuth flow is an string array and that type is expected when scope property is used later in the code.