### PR TITLE
Assigning the API Identifier of the imported API with the targeted API Identifier when updating

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
@@ -366,6 +366,10 @@ public class API implements Serializable {
         return id;
     }
 
+    public void setId(APIIdentifier id) {
+        this.id = id;
+    }
+
     public String getTransports() {
         return transports;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -337,6 +337,9 @@ public final class APIImportUtil {
                 targetApi = apiProvider.getAPI(apiIdentifier);
                 // Store target API status
                 currentStatus = targetApi.getStatus();
+
+                // Since the overwrite should be done, the imported API Identifier should be equal to the target API Identifier
+                importedApi.setId(targetApi.getId());
             } else {
                 if (apiProvider.isAPIAvailable(importedApi.getId())
                         || apiProvider.isApiNameWithDifferentCaseExist(apiName)) {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/311

## Goals
When there is an overwrite to be done, the imported API Identifier should be assigned by the value of the target API Identifier.

## Approach
- Wrote setId() function in the API.java file.
- Retrieved the API Identifier of the target API, if exists, and assigned it as the API Identifier of the imported API.

## User stories
- User stories related to https://github.com/wso2/product-apim-tooling/issues/311 will be covered.

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/312

## Test environment
- JDK 1.8.0_241
- Ubuntu 18.04.4 LTS