### PR TITLE
Fix schema validation when property "json-eval($.)" is used

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/TestSchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/TestSchemaValidator.java
@@ -16,87 +16,194 @@
 
 package org.wso2.carbon.apimgt.gateway.handlers.security;
 
+import com.google.gson.GsonBuilder;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.GsonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.soap.SOAPFactory;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.config.Entry;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.rest.Handler;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 
+import javax.xml.stream.XMLStreamException;
 import java.io.File;
+import java.io.IOException;
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.Set;
 
 public class TestSchemaValidator {
     private static final Log log = LogFactory.getLog(TestSchemaValidator.class);
     private MessageContext messageContext;
     private org.apache.axis2.context.MessageContext axis2MsgContext;
-    private SchemaValidator schemaValidator;
+    private Handler schemaValidator = new SchemaValidator();
     private String uuid;
     SynapseConfiguration synapseConfiguration = Mockito.mock(SynapseConfiguration.class);
     Map map = Mockito.mock(Map.class);
     Entry entry = Mockito.mock(Entry.class);
 
+    @BeforeClass
+    public static void init() {
+        // Set GsonJsonProvider as the default Jayway JSON path default configuration
+        // Which is set by synapse-core at runtime of the server
+        Configuration.setDefaults(new Configuration.Defaults() {
+            private final JsonProvider jsonProvider = new GsonJsonProvider(new GsonBuilder().serializeNulls().create());
+            private final MappingProvider mappingProvider = new GsonMappingProvider();
+
+            public JsonProvider jsonProvider() {
+                return jsonProvider;
+            }
+
+            public MappingProvider mappingProvider() {
+                return mappingProvider;
+            }
+
+            public Set<Option> options() {
+                return EnumSet.noneOf(Option.class);
+            }
+        });
+    }
+
+
     @Before
-    public void init() {
+    public void before() {
         messageContext = Mockito.mock(Axis2MessageContext.class);
-        axis2MsgContext = Mockito.mock(org.apache.axis2.context.MessageContext
-                .class);
+        axis2MsgContext = Mockito.mock(org.apache.axis2.context.MessageContext.class);
     }
 
     @Test
-    public void testValidRequest() throws Exception {
-        SOAPFactory fac = OMAbstractFactory.getSOAP12Factory();
-        SOAPEnvelope env = fac.createSOAPEnvelope();
-        fac.createSOAPBody(env);
-        OMElement messageStore = AXIOMUtil.stringToOM(
-                "<jsonObject><id>0</id><category><id>0</id><name>string</name></category>" +
-                        "<name>doggie</name><photoUrls>string</photoUrls><tags><id>0</id><name>string</name>" +
-                        "</tags><status>available</status></jsonObject>" );
-        env.getBody().addChild(messageStore);
-        log.info(" Running the test case to validate the request content against the defined schemas.");
-        String contentType = "application/json";
-        File swaggerJsonFile = new File(Thread.currentThread().getContextClassLoader().
-                getResource("swaggerEntry/swagger.json").getFile());
-        String swaggerValue = FileUtils.readFileToString(swaggerJsonFile);
-        Mockito.doReturn(env).when(messageContext).getEnvelope();
-        // Mockito.when()
-
-        Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgContext);
-        Mockito.when((String) axis2MsgContext.getProperty(APIMgtGatewayConstants.REST_CONTENT_TYPE))
-                .thenReturn(contentType);
-        Mockito.when((String) axis2MsgContext.getProperty(APIMgtGatewayConstants.HTTP_REQUEST_METHOD)).
-                thenReturn("POST");
-        Mockito.when((String)messageContext.getProperty((APIMgtGatewayConstants.API_ELECTED_RESOURCE))).
-                thenReturn("/pet");
-        Mockito.when((String)messageContext.getProperty(APIMgtGatewayConstants.ELECTED_REQUEST_METHOD)).
-                thenReturn("POST");
-        Mockito.when((String) axis2MsgContext.getProperty(APIMgtGatewayConstants.HTTP_REQUEST_METHOD)).
-                thenReturn("POST");
-
-        Mockito.when(messageContext.getConfiguration()).thenReturn(synapseConfiguration);
-        Mockito.when(synapseConfiguration.getLocalRegistry()).thenReturn(map);
-        Mockito.when(map.get(uuid)).thenReturn(entry);
-        Mockito.when((String)messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_STRING)).thenReturn(swaggerValue);
+    public void testValidRequestPostPet() throws IOException, XMLStreamException {
+        // Happy Path: Valid Pet
+        setMockedRequest("POST", "/pet", "<jsonObject>" +
+                "<id>123</id><name>Doggie</name>" +
+                "<photoUrls>https://mydog_1.jpg</photoUrls><photoUrls>https://mydog_2.jpg</photoUrls>" +
+                "<category><id>2</id><name>dog</name></category>" +
+                "<tags><id>12</id><name>Black</name></tags><tags><id>43</id><name>German Shepherd</name></tags>" +
+                "<status>available</status>" +
+                "</jsonObject>");
+        assertValidRequest();
     }
 
     @Test
-    public void testBadRequest() throws Exception {
+    public void testValidRequestPostStoreOrder() throws IOException, XMLStreamException {
+        // Happy Path: Valid Store Order: Valid date
+        setMockedRequest("POST", "/store/order", "<jsonObject>" +
+                "<id>123</id><petId>22</petId><quantity>8</quantity><shipDate>2020-05-14T10:29:24.160Z</shipDate>" +
+                "<status>placed</status><complete>false</complete>" +
+                "</jsonObject>");
+        assertValidRequest();
+    }
+
+    @Test
+    public void testValidRequestPostArrayOfUsers() throws IOException, XMLStreamException {
+        // Happy Path: Valid Array of Users
+        setMockedRequest("POST", "/user/createWithArray", "<jsonArray><jsonElement>" +
+                "<id>1234</id><username>andy</username><firstName>Andy</firstName>" +
+                "<lastName>Fernando</lastName><email>andy@abc.com</email><password>pw1234</password>" +
+                "<phone>01234567890</phone><userStatus>3</userStatus></jsonElement>" +
+                "<jsonElement><id>2345</id><username>ann</username><firstName>Ann</firstName>" +
+                "<lastName>Fernando</lastName><email>ann@abc.com</email><password>pw2233</password>" +
+                "<phone>01234567890</phone><userStatus>5</userStatus>" +
+                "</jsonElement></jsonArray>");
+        assertValidRequest();
+    }
+
+    @Test
+    public void testBadRequestInvalidEnum() throws IOException, XMLStreamException {
+        // Invalid Enum
+        setMockedRequest("POST", "/pet", "<jsonObject>" +
+                "<id>123</id><name>Doggie</name>" +
+                "<photoUrls>https://mydog_1.jpg</photoUrls><photoUrls>https://mydog_2.jpg</photoUrls>" +
+                "<category><id>2</id><name>dog</name></category>" +
+                "<tags><id>12</id><name>Black</name></tags><tags><id>43</id><name>German Shepherd</name></tags>" +
+                "<status>INVALID-ENUM</status>" +
+                "</jsonObject>");
+        assertBadRequest();
+    }
+
+    @Test
+    public void testBadRequestInvalidInt() throws IOException, XMLStreamException {
+        // Invalid Int
+        setMockedRequest("POST", "/pet", "<jsonObject>" +
+                "<id>INVALID-INT</id><name>Doggie</name>" +
+                "<photoUrls>https://mydog_1.jpg</photoUrls><photoUrls>https://mydog_2.jpg</photoUrls>" +
+                "<category><id>2</id><name>dog</name></category>" +
+                "<tags><id>12</id><name>Black</name></tags><tags><id>43</id><name>German Shepherd</name></tags>" +
+                "<status>available</status>" +
+                "</jsonObject>");
+        assertBadRequest();
+    }
+
+    @Test
+    public void testBadRequestInvalidString() throws IOException, XMLStreamException {
+        // Invalid String: name of pet
+        setMockedRequest("POST", "/pet", "<jsonObject>" +
+                "<id>123</id><name>1234</name>" +
+                "<photoUrls>https://mydog_1.jpg</photoUrls><photoUrls>https://mydog_2.jpg</photoUrls>" +
+                "<category><id>2</id><name>dog</name></category>" +
+                "<tags><id>12</id><name>Black</name></tags><tags><id>43</id><name>German Shepherd</name></tags>" +
+                "<status>available</status>" +
+                "</jsonObject>");
+        assertBadRequest();
+    }
+
+    @Test
+    public void testBadRequestInvalidDate() throws IOException, XMLStreamException {
+        // Invalid date
+        setMockedRequest("POST", "/store/order", "<jsonObject>" +
+                "<id>123</id><petId>22</petId><quantity>8</quantity><shipDate>2020-05-14</shipDate>" +
+                "<status>placed</status><complete>false</complete>" +
+                "</jsonObject>");
+        assertBadRequest();
+    }
+
+    @Test
+    public void testBadRequestMissRequiredField() throws IOException, XMLStreamException {
+        // Missing required field - Name of Pet
+        setMockedRequest("POST", "/pet", "<jsonObject>" +
+                "<id>123</id>" +
+                "<photoUrls>https://mydog_1.jpg</photoUrls><photoUrls>https://mydog_2.jpg</photoUrls>" +
+                "<category><id>2</id><name>dog</name></category>" +
+                "<tags><id>12</id><name>Black</name></tags><tags><id>43</id><name>German Shepherd</name></tags>" +
+                "<status>available</status>" +
+                "</jsonObject>");
+        assertBadRequest();
+    }
+
+    private void assertValidRequest() {
+        Assert.assertTrue(schemaValidator.handleRequest(messageContext));
+        Mockito.verify(messageContext, Mockito.times(0))
+                .setProperty(APIMgtGatewayConstants.THREAT_FOUND, true);
+    }
+
+    private void assertBadRequest() {
+        schemaValidator.handleRequest(messageContext);
+        Mockito.verify(messageContext).setProperty(APIMgtGatewayConstants.THREAT_FOUND, true);
+    }
+
+    private void setMockedRequest(String httpMethod, String resourcePath, String xmlMessage) throws XMLStreamException, IOException {
         SOAPFactory fac = OMAbstractFactory.getSOAP12Factory();
         SOAPEnvelope env = fac.createSOAPEnvelope();
         fac.createSOAPBody(env);
-        OMElement messageStore = AXIOMUtil.stringToOM("<jsonObject><id>0</id><category>" +
-                "<id>dededededededed</id><name>string</name></category><name>doggie</name><photoUrls>" +
-                "string</photoUrls><tags><id>0</id><name>string</name></tags><status>available</status></jsonObject>");
+        OMElement messageStore = AXIOMUtil.stringToOM(xmlMessage);
         env.getBody().addChild(messageStore);
         log.info(" Running the test case to validate the request content against the defined schemas.");
         String contentType = "application/json";
@@ -105,7 +212,6 @@ public class TestSchemaValidator {
                 getResource("swaggerEntry/swagger.json").getFile());
         String swaggerValue = FileUtils.readFileToString(swaggerJsonFile);
 
-
         Mockito.doReturn(env).when(messageContext).getEnvelope();
         // Mockito.when()
 
@@ -113,22 +219,22 @@ public class TestSchemaValidator {
         Mockito.when((String) axis2MsgContext.getProperty(APIMgtGatewayConstants.REST_CONTENT_TYPE))
                 .thenReturn(contentType);
         Mockito.when((String) axis2MsgContext.getProperty(APIMgtGatewayConstants.HTTP_REQUEST_METHOD)).
-                thenReturn("POST");
+                thenReturn(httpMethod);
         Mockito.when(messageContext.getConfiguration()).thenReturn(synapseConfiguration);
         Mockito.when(synapseConfiguration.getLocalRegistry()).thenReturn(map);
         Mockito.when(map.get(uuid)).thenReturn(entry);
 
         Mockito.when(messageContext.getConfiguration()).thenReturn(synapseConfiguration);
         Mockito.when((String) messageContext.getProperty((APIMgtGatewayConstants.API_ELECTED_RESOURCE))).
-                thenReturn("/pet");
+                thenReturn(resourcePath);
         Mockito.when(synapseConfiguration.getLocalRegistry()).thenReturn(map);
         Mockito.when(map.get(ApiId)).thenReturn(entry);
         Mockito.when((String) entry.getValue()).thenReturn(swaggerValue);
         Mockito.when((String) messageContext.getProperty(APIMgtGatewayConstants.ELECTED_REQUEST_METHOD)).
-                thenReturn("POST");
+                thenReturn(httpMethod);
         Mockito.when((String) axis2MsgContext.getProperty(APIMgtGatewayConstants.HTTP_REQUEST_METHOD)).
-                thenReturn("POST");
-        Mockito.when((String)messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_STRING)).thenReturn(swaggerValue);
+                thenReturn(httpMethod);
+        Mockito.when((String) messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_STRING))
+                .thenReturn(swaggerValue);
     }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1751,7 +1751,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-	    <synapse.version>v2.1.7-wso2v165</synapse.version>
+	    <synapse.version>2.1.7-wso2v165</synapse.version>
 
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1751,7 +1751,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-	<synapse.version>2.1.7-wso2v147</synapse.version>
+	    <synapse.version>v2.1.7-wso2v165</synapse.version>
 
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 


### PR DESCRIPTION
#### Purpose
Replace Jackson with GSON without changing the logic of SchemaValidator.

#### Related Changes (updated synapse)
https://github.com/wso2-support/wso2-synapse/pull/787: Set GsonJsonProvider as the default config for Jayway JsonPath when init the server.


fix wso2/product-apim#7949
fix https://github.com/wso2/product-apim/issues/8056