### PR TITLE
Add analyticsEnabled property to admin v1 settings API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsDTO.java
@@ -18,6 +18,7 @@ import org.wso2.carbon.apimgt.rest.api.util.annotations.Scope;
 public class SettingsDTO   {
   
     private List<String> scopes = new ArrayList<>();
+    private Boolean analyticsEnabled = null;
 
   /**
    **/
@@ -36,6 +37,24 @@ public class SettingsDTO   {
     this.scopes = scopes;
   }
 
+  /**
+   * To determine whether analytics is enabled or not
+   **/
+  public SettingsDTO analyticsEnabled(Boolean analyticsEnabled) {
+    this.analyticsEnabled = analyticsEnabled;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "false", value = "To determine whether analytics is enabled or not")
+  @JsonProperty("analyticsEnabled")
+  public Boolean isAnalyticsEnabled() {
+    return analyticsEnabled;
+  }
+  public void setAnalyticsEnabled(Boolean analyticsEnabled) {
+    this.analyticsEnabled = analyticsEnabled;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -46,12 +65,13 @@ public class SettingsDTO   {
       return false;
     }
     SettingsDTO settings = (SettingsDTO) o;
-    return Objects.equals(scopes, settings.scopes);
+    return Objects.equals(scopes, settings.scopes) &&
+        Objects.equals(analyticsEnabled, settings.analyticsEnabled);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(scopes);
+    return Objects.hash(scopes, analyticsEnabled);
   }
 
   @Override
@@ -60,6 +80,7 @@ public class SettingsDTO   {
     sb.append("class SettingsDTO {\n");
     
     sb.append("    scopes: ").append(toIndentedString(scopes)).append("\n");
+    sb.append("    analyticsEnabled: ").append(toIndentedString(analyticsEnabled)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SettingsApiServiceImpl.java
@@ -46,7 +46,7 @@ public class SettingsApiServiceImpl implements SettingsApiService {
             SettingsDTO settingsDTO = settingsMappingUtil.fromSettingstoDTO(isUserAvailable);
             return Response.ok().entity(settingsDTO).build();
         } catch (APIManagementException e) {
-            String errorMessage = "Error while retrieving Publisher Settings";
+            String errorMessage = "Error while retrieving Admin Settings";
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
         }
         return null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.impl.definitions.OASParserUtil;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.SettingsDTO;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
@@ -44,10 +45,9 @@ public class SettingsMappingUtil {
      * @throws APIManagementException
      */
     public SettingsDTO fromSettingstoDTO(Boolean isUserAvailable) throws APIManagementException {
-        //TODO: Complete the function once the full requirement is obtained
-        //Currently returns only list of scopes
         SettingsDTO settingsDTO = new SettingsDTO();
         settingsDTO.setScopes(GetScopeList());
+        settingsDTO.setAnalyticsEnabled(APIUtil.isAnalyticsEnabled());
         return settingsDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -2940,7 +2940,7 @@ paths:
 ######################################################
   /settings:
 #-----------------------------------------------------
-# Retrieve store settings
+# Retrieve admin settings
 #-----------------------------------------------------
     get:
       summary: Retreive admin settings
@@ -4099,6 +4099,10 @@ definitions:
         type: array
         items:
           type: string
+      analyticsEnabled:
+        type: boolean
+        description: To determine whether analytics is enabled or not
+        example: false
 
 #-----------------------------------------------------
 # END-OF-FILE


### PR DESCRIPTION
### Purpose

Add analyticsEnabled property to admin v1 settings API to determine whether analytics is enabled or not.

Invoking settings API would provide the following repsonse.
![settingsnew](https://user-images.githubusercontent.com/30455603/82776556-f60c2580-9e68-11ea-96c9-3a54dfdc78d0.png)

Fixes: https://github.com/wso2/product-apim/issues/8116
