### PR TITLE
Publisher API implementation changes to create API from Registry Entry

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -362,9 +362,6 @@ public final class APIConstants {
     //This constant is used in Json schema validator
     public static final String API_OVERVIEW_ENABLE_JSON_SCHEMA = "overview_enableSchemaValidation";
 
-    // This constant used in Endpoint Registry Entries
-    public static final String API_OVERVIEW_ENPOINT_REGISTRY_ENTRY = "overview_endpointRegistryEntry";
-
     //Those constance are used in Provider artifact.
     public static final String PROVIDER_OVERVIEW_NAME = "overview_name";
     public static final String PROVIDER_OVERVIEW_EMAIL = "overview_email";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -1219,24 +1219,6 @@ public final class APIUtil {
             artifact.setAttribute(APIConstants.API_OVERVIEW_ENABLE_JSON_SCHEMA,
                     Boolean.toString(api.isEnabledSchemaValidation()));
 
-            JSONParser parser = new JSONParser();
-            String endpointConfig = api.getEndpointConfig();
-            if (StringUtils.isNotEmpty(endpointConfig)) {
-                try {
-                    JSONObject endpoint_config = (JSONObject) parser.parse(endpointConfig);
-                    if (APIConstants.ENDPOINT_REGISTRY_TYPE.equals(endpoint_config
-                            .get(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE))) {
-                        String registryEntryId = (String) endpoint_config.get(APIConstants.ENDPOINT_REGISTRY_ENTRY_ID);
-                        artifact.setAttribute(APIConstants.API_OVERVIEW_ENPOINT_REGISTRY_ENTRY, registryEntryId);
-                    } else {
-                        artifact.setAttribute(APIConstants.API_OVERVIEW_ENPOINT_REGISTRY_ENTRY, StringUtils.EMPTY);
-                    }
-                } catch (ParseException e) {
-                    throw new APIManagementException("Error while parsing the endpoint config of API : "
-                            + api.getId().getApiName());
-                }
-            }
-
             //Validate if the API has an unsupported context before setting it in the artifact
             String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
             if (APIConstants.SUPER_TENANT_DOMAIN.equals(tenantDomain)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3210,6 +3210,16 @@ public class ApisApiServiceImpl implements ApisApiService {
             throw RestApiUtil.buildBadRequestException("Error while parsing 'additionalProperties'", e);
         }
 
+        if (apiDTOFromProperties.getEndpointConfig() != null) {
+            LinkedHashMap endpointConfig = (LinkedHashMap) apiDTOFromProperties.getEndpointConfig();
+            if (APIConstants.ENDPOINT_REGISTRY_TYPE.equals(endpointConfig
+                    .get(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE)) &&
+                    !endpointConfig.containsKey(APIConstants.ENDPOINT_REGISTRY_ENTRY_ID)) {
+                RestApiUtil.handleBadRequest("Parameter endpoint_id should be provided to create API from " +
+                        "Registry Entry", log);
+            }
+        }
+
         // Only HTTP type APIs should be allowed
         if (!APIDTO.TypeEnum.HTTP.equals(apiDTOFromProperties.getType())) {
             throw RestApiUtil.buildBadRequestException("The API's type should only be HTTP when " +
@@ -3370,6 +3380,15 @@ public class ApisApiServiceImpl implements ApisApiService {
 
             // Minimum requirement name, version, context and endpointConfig.
             additionalPropertiesAPI = new ObjectMapper().readValue(additionalProperties, APIDTO.class);
+            if (additionalPropertiesAPI.getEndpointConfig() != null) {
+                LinkedHashMap endpointConfig = (LinkedHashMap) additionalPropertiesAPI.getEndpointConfig();
+                if (APIConstants.ENDPOINT_REGISTRY_TYPE.equals(endpointConfig
+                        .get(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE)) &&
+                        !endpointConfig.containsKey(APIConstants.ENDPOINT_REGISTRY_ENTRY_ID)) {
+                    RestApiUtil.handleBadRequest("Parameter endpoint_id should be provided to create API from " +
+                            "Registry Entry", log);
+                }
+            }
             additionalPropertiesAPI.setProvider(RestApiUtil.getLoggedInUsername());
             additionalPropertiesAPI.setType(APIDTO.TypeEnum.fromValue(implementationType));
             API apiToAdd = prepareToCreateAPIByDTO(additionalPropertiesAPI);
@@ -3772,6 +3791,15 @@ public class ApisApiServiceImpl implements ApisApiService {
             }
 
             additionalPropertiesAPI = new ObjectMapper().readValue(additionalProperties, APIDTO.class);
+            if (additionalPropertiesAPI.getEndpointConfig() != null) {
+                LinkedHashMap endpointConfig = (LinkedHashMap) additionalPropertiesAPI.getEndpointConfig();
+                if (APIConstants.ENDPOINT_REGISTRY_TYPE.equals(endpointConfig
+                        .get(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE)) &&
+                        !endpointConfig.containsKey(APIConstants.ENDPOINT_REGISTRY_ENTRY_ID)) {
+                    RestApiUtil.handleBadRequest("Parameter endpoint_id should be provided to create API from " +
+                            "Endpoint Registry", log);
+                }
+            }
             additionalPropertiesAPI.setType(APIDTO.TypeEnum.GRAPHQL);
             APIProvider apiProvider = RestApiUtil.getLoggedInUserProvider();
             API apiToAdd = prepareToCreateAPIByDTO(additionalPropertiesAPI);

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/rxts/api.rxt
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/rxts/api.rxt
@@ -78,9 +78,6 @@
 		<field type="text" url="true">
             <name>Endpoint Password</name>
         </field>
-        <field type="text">
-            <name>Endpoint Registry Entry</name>
-        </field>
 	<field type="text">
             <name>InSequence</name>
         </field>


### PR DESCRIPTION
When creating API from Registry Entry (Import from definition file or from definition URL) and revert the new field added to API RXT file. 
When creating API from Endpoint Registry Entry, endpointConfig should be specified as mentioned below:
```
  "endpointConfig": {
    "endpoint_type": "Registry",
    "endpoint_id": "{registry-name}:{entry-name}:{entry-version}"
  }
```