### PR TITLE
[Front Port] Fix UI tryout issue when gateway environment name is renamed

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5843,14 +5843,11 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 hostsWithSchemes.put(APIConstants.HTTPS_PROTOCOL, customUrl);
             }
         } else {
-            APIManagerConfiguration config = ServiceReferenceHolder.getInstance()
-                    .getAPIManagerConfigurationService().getAPIManagerConfiguration();
-            Map<String, Environment> allEnvironments = config.getApiGatewayEnvironments();
+            Map<String, Environment> allEnvironments = APIUtil.getEnvironments();
             Environment environment = allEnvironments.get(environmentName);
 
             if (environment == null) {
-                handleException(
-                        "Could not find provided environment '" + environmentName);
+                handleResourceNotFoundException("Could not find provided environment '" + environmentName + "'");
             }
 
             assert environment != null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApisApiServiceImpl.java
@@ -575,14 +575,25 @@ public class ApisApiServiceImpl implements ApisApiService {
 
             // gets the first available environment if neither label nor environment is not provided
             if (StringUtils.isEmpty(labelName) && StringUtils.isEmpty(environmentName)) {
-                if (!api.getEnvironments().isEmpty()) {
-                    environmentName = api.getEnvironments().iterator().next();
-                } else {
+                Map<String, Environment> existingEnvironments = APIUtil.getEnvironments();
+
+                // find a valid environment name from API
+                // gateway environment may be invalid due to inconsistent state of the API
+                // example: publish an API and later rename gateway environment from configurations
+                //          then the old gateway environment name becomes invalid
+                for (String environmentNameOfApi : api.getEnvironments()) {
+                    if (existingEnvironments.get(environmentNameOfApi) != null) {
+                        environmentName = environmentNameOfApi;
+                        break;
+                    }
+                }
+
+                // if all environment of API are invalid or there are no environments (i.e. empty)
+                if (StringUtils.isEmpty(environmentName)) {
                     // if there are no environments in the API, take a random environment from the existing ones.
                     // This is to make sure the swagger doesn't have invalid endpoints
-                    Map<String, Environment> environments = APIUtil.getEnvironments();
-                    if (!environments.keySet().isEmpty()) {
-                        environmentName = environments.keySet().iterator().next();
+                    if (!existingEnvironments.keySet().isEmpty()) {
+                        environmentName = existingEnvironments.keySet().iterator().next();
                     }
                 }
             }
@@ -594,7 +605,17 @@ public class ApisApiServiceImpl implements ApisApiService {
 
             String apiSwagger = null;
             if (StringUtils.isNotEmpty(environmentName)) {
-                apiSwagger = apiConsumer.getOpenAPIDefinitionForEnvironment(api.getId(), environmentName);
+                try {
+                    apiSwagger = apiConsumer.getOpenAPIDefinitionForEnvironment(api.getId(), environmentName);
+                } catch (APIManagementException e) {
+                    // handle gateway not found exception otherwise pass it
+                    if (RestApiUtil.isDueToResourceNotFound(e)) {
+                        RestApiUtil.handleResourceNotFoundError(
+                                "Gateway environment '" + environmentName + "' not found", e, log);
+                        return null;
+                    }
+                    throw e;
+                }
             } else if (StringUtils.isNotEmpty(labelName)) {
                 apiSwagger = apiConsumer.getOpenAPIDefinitionForLabel(api.getId(), labelName);
             } else {
@@ -609,7 +630,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             } else if (RestApiUtil.isDueToResourceNotFound(e)) {
                 RestApiUtil.handleResourceNotFoundError(RestApiConstants.RESOURCE_API, apiId, e, log);
             } else {
-                String errorMessage = "Error while retrieving API : " + apiId;
+                String errorMessage = "Error while retrieving swagger of API : " + apiId;
                 RestApiUtil.handleInternalServerError(errorMessage, e, log);
             }
         } catch (UserStoreException e) {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/GraphQL/ApiCreateGraphQL.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/GraphQL/ApiCreateGraphQL.jsx
@@ -31,6 +31,7 @@ import Alert from 'AppComponents/Shared/Alert';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import DefaultAPIForm from 'AppComponents/Apis/Create/Components/DefaultAPIForm';
 import APICreateBase from 'AppComponents/Apis/Create/Components/APICreateBase';
+import { useAppContext } from 'AppComponents/Shared/AppContext';
 
 import ProvideGraphQL from './Steps/ProvideGraphQL';
 
@@ -44,7 +45,7 @@ import ProvideGraphQL from './Steps/ProvideGraphQL';
 export default function ApiCreateGraphQL(props) {
     const [wizardStep, setWizardStep] = useState(0);
     const { history } = props;
-
+    const { settings } = useAppContext();
     /**
      *
      * Reduce the events triggered from API input fields to current state
@@ -147,7 +148,8 @@ export default function ApiCreateGraphQL(props) {
                 },
             };
         }
-        additionalProperties.gatewayEnvironments = ['Production and Sandbox'];
+        additionalProperties.gatewayEnvironments = Array.isArray(settings.environment)
+            && settings.environment.length > 0 ? settings.environment[0] : [];
         const newApi = new API(additionalProperties);
         const apiData = {
             additionalProperties: JSON.stringify(additionalProperties),

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/OpenAPI/ApiCreateOpenAPI.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/OpenAPI/ApiCreateOpenAPI.jsx
@@ -31,6 +31,7 @@ import Alert from 'AppComponents/Shared/Alert';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import DefaultAPIForm from 'AppComponents/Apis/Create/Components/DefaultAPIForm';
 import APICreateBase from 'AppComponents/Apis/Create/Components/APICreateBase';
+import { useAppContext } from 'AppComponents/Shared/AppContext';
 
 import ProvideOpenAPI from './Steps/ProvideOpenAPI';
 
@@ -44,6 +45,7 @@ import ProvideOpenAPI from './Steps/ProvideOpenAPI';
 export default function ApiCreateOpenAPI(props) {
     const [wizardStep, setWizardStep] = useState(0);
     const { history } = props;
+    const { settings } = useAppContext();
 
     /**
      *
@@ -137,7 +139,8 @@ export default function ApiCreateOpenAPI(props) {
                 },
             };
         }
-        additionalProperties.gatewayEnvironments = ['Production and Sandbox'];
+        additionalProperties.gatewayEnvironments = Array.isArray(settings.environment)
+            && settings.environment.length > 0 ? settings.environment[0] : [];
         const newAPI = new API(additionalProperties);
         const promisedResponse = inputType === 'file'
             ? newAPI.importOpenAPIByFile(inputValue) : newAPI.importOpenAPIByUrl(inputValue);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/SampleAPI/SampleAPI.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/SampleAPI/SampleAPI.jsx
@@ -28,6 +28,7 @@ import Create from '@material-ui/icons/Create';
 import GetApp from '@material-ui/icons/GetApp';
 import { PropTypes } from 'prop-types';
 import { FormattedMessage, injectIntl } from 'react-intl';
+import { useAppContext } from 'AppComponents/Shared/AppContext';
 
 import API from 'AppData/api';
 import Alert from 'AppComponents/Shared/Alert';
@@ -133,6 +134,7 @@ class SampleAPI extends Component {
      * @memberof SampleAPI
      */
     createSampleAPI() {
+        const { settings } = useAppContext();
         const data = {
             name: 'PizzaShackAPI',
             description: 'This is a simple API for Pizza Shack online pizza delivery store.',
@@ -143,7 +145,8 @@ class SampleAPI extends Component {
             policies: ['Unlimited'],
             securityScheme: ['oauth2'],
             visibility: 'PUBLIC',
-            gatewayEnvironments: ['Production and Sandbox'],
+            gatewayEnvironments: Array.isArray(settings.environment)
+                && settings.environment.length > 0 ? settings.environment[0] : [],
             businessInformation: {
                 businessOwner: 'Jane Roe',
                 businessOwnerEmail: 'marketing@pizzashack.com',

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -165,10 +165,7 @@ class ApiConsole extends React.Component {
                 if (process.env.NODE_ENV !== 'production') {
                     console.error(error);
                 }
-                const { status } = error;
-                if (status === 404) {
-                    this.setState({ notFound: true });
-                }
+                this.setState({ serverError: `${error.statusCode} - ${error.response.body.description}` });
             });
     }
 
@@ -308,7 +305,7 @@ class ApiConsole extends React.Component {
     render() {
         const { classes } = this.props;
         const {
-            api, notFound, swagger, securitySchemeType, selectedEnvironment, labels, environments, scopes,
+            api, serverError, swagger, securitySchemeType, selectedEnvironment, labels, environments, scopes,
             username, password, productionAccessToken, sandboxAccessToken, selectedKeyType,
         } = this.state;
         const user = AuthManager.getUser();
@@ -316,12 +313,18 @@ class ApiConsole extends React.Component {
         const downloadLink = 'data:text/json;charset=utf-8, ' + encodeURIComponent(downloadSwagger);
         const fileName = 'swagger.json';
 
+        if (serverError) {
+            return (
+                <Typography variant='h4' className={classes.titleSub}>
+                    <FormattedMessage id='Apis.Details.ApiConsole.ApiConsole.error' defaultMessage={serverError} />
+                </Typography>
+            );
+        }
+
         if (api == null || swagger == null) {
             return <Progress />;
         }
-        if (notFound) {
-            return 'API Not found !';
-        }
+
         let isApiKeyEnabled = false;
         let authorizationHeader = api.authorizationHeader ? api.authorizationHeader : 'Authorization';
         if (api && api.securityScheme) {


### PR DESCRIPTION
fix wso2/product-apim#8094
Front port: https://github.com/wso2-support/carbon-apimgt/pull/2069

#### Purpose
- Correct gateway environment not found exception in store REST API
- Handle invalid state of API's gateway environment
- Handle server error in dev-portal UI
- Select a valid gateway environment when creating an API from OpenAPI, GraphQL and Sample

#### Samples
- GET | {{storeHost}}/api/am/store/v1/apis/{{api-id}}/swagger?environmentName=staging
```json
{
    "code": 404,
    "message": "Not Found",
    "description": "Gateway environment 'staging' not found",
    "moreInfo": "",
    "error": []
}
```

- GET | {{storeHost}}/api/am/store/v1/apis/{{api-id}}/swagger
```log
200 OK
```

- GET | {{storeHost}}/api/am/store/v1/apis/{{api-id}}/swagger?environmentName=dev
```log
200 OK
```