### PR TITLE
Modify SubscriptionThrottlePolicyDTO to support GraphQL Query Analysis

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/GraphQLQueryDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/GraphQLQueryDTO.java
@@ -1,0 +1,98 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.util.annotations.Scope;
+
+
+
+public class GraphQLQueryDTO   {
+  
+    private Integer graphQLMaxComplexity = null;
+    private Integer graphQLMaxDepth = null;
+
+  /**
+   * Maximum Complexity of the GraphQL query
+   **/
+  public GraphQLQueryDTO graphQLMaxComplexity(Integer graphQLMaxComplexity) {
+    this.graphQLMaxComplexity = graphQLMaxComplexity;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "400", value = "Maximum Complexity of the GraphQL query")
+  @JsonProperty("graphQLMaxComplexity")
+  public Integer getGraphQLMaxComplexity() {
+    return graphQLMaxComplexity;
+  }
+  public void setGraphQLMaxComplexity(Integer graphQLMaxComplexity) {
+    this.graphQLMaxComplexity = graphQLMaxComplexity;
+  }
+
+  /**
+   * Maximum Depth of the GraphQL query
+   **/
+  public GraphQLQueryDTO graphQLMaxDepth(Integer graphQLMaxDepth) {
+    this.graphQLMaxDepth = graphQLMaxDepth;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "10", value = "Maximum Depth of the GraphQL query")
+  @JsonProperty("graphQLMaxDepth")
+  public Integer getGraphQLMaxDepth() {
+    return graphQLMaxDepth;
+  }
+  public void setGraphQLMaxDepth(Integer graphQLMaxDepth) {
+    this.graphQLMaxDepth = graphQLMaxDepth;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    GraphQLQueryDTO graphQLQuery = (GraphQLQueryDTO) o;
+    return Objects.equals(graphQLMaxComplexity, graphQLQuery.graphQLMaxComplexity) &&
+        Objects.equals(graphQLMaxDepth, graphQLQuery.graphQLMaxDepth);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(graphQLMaxComplexity, graphQLMaxDepth);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class GraphQLQueryDTO {\n");
+    
+    sb.append("    graphQLMaxComplexity: ").append(toIndentedString(graphQLMaxComplexity)).append("\n");
+    sb.append("    graphQLMaxDepth: ").append(toIndentedString(graphQLMaxDepth)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SubscriptionThrottlePolicyDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SubscriptionThrottlePolicyDTO.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.CustomAttributeDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.GraphQLQueryDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.MonetizationInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ThrottleLimitTypeDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ThrottlePolicyDTO;
@@ -21,6 +22,8 @@ import org.wso2.carbon.apimgt.rest.api.util.annotations.Scope;
 
 public class SubscriptionThrottlePolicyDTO extends ThrottlePolicyDTO  {
   
+    private Integer graphQLMaxComplexity = null;
+    private Integer graphQLMaxDepth = null;
     private ThrottleLimitTypeDTO defaultLimit = null;
     private MonetizationInfoDTO monetization = null;
     private Integer rateLimitCount = null;
@@ -28,6 +31,42 @@ public class SubscriptionThrottlePolicyDTO extends ThrottlePolicyDTO  {
     private List<CustomAttributeDTO> customAttributes = new ArrayList<>();
     private Boolean stopOnQuotaReach = false;
     private String billingPlan = null;
+
+  /**
+   * Maximum Complexity of the GraphQL query
+   **/
+  public SubscriptionThrottlePolicyDTO graphQLMaxComplexity(Integer graphQLMaxComplexity) {
+    this.graphQLMaxComplexity = graphQLMaxComplexity;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "400", value = "Maximum Complexity of the GraphQL query")
+  @JsonProperty("graphQLMaxComplexity")
+  public Integer getGraphQLMaxComplexity() {
+    return graphQLMaxComplexity;
+  }
+  public void setGraphQLMaxComplexity(Integer graphQLMaxComplexity) {
+    this.graphQLMaxComplexity = graphQLMaxComplexity;
+  }
+
+  /**
+   * Maximum Depth of the GraphQL query
+   **/
+  public SubscriptionThrottlePolicyDTO graphQLMaxDepth(Integer graphQLMaxDepth) {
+    this.graphQLMaxDepth = graphQLMaxDepth;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "10", value = "Maximum Depth of the GraphQL query")
+  @JsonProperty("graphQLMaxDepth")
+  public Integer getGraphQLMaxDepth() {
+    return graphQLMaxDepth;
+  }
+  public void setGraphQLMaxDepth(Integer graphQLMaxDepth) {
+    this.graphQLMaxDepth = graphQLMaxDepth;
+  }
 
   /**
    **/
@@ -163,7 +202,9 @@ public class SubscriptionThrottlePolicyDTO extends ThrottlePolicyDTO  {
       return false;
     }
     SubscriptionThrottlePolicyDTO subscriptionThrottlePolicy = (SubscriptionThrottlePolicyDTO) o;
-    return Objects.equals(defaultLimit, subscriptionThrottlePolicy.defaultLimit) &&
+    return Objects.equals(graphQLMaxComplexity, subscriptionThrottlePolicy.graphQLMaxComplexity) &&
+        Objects.equals(graphQLMaxDepth, subscriptionThrottlePolicy.graphQLMaxDepth) &&
+        Objects.equals(defaultLimit, subscriptionThrottlePolicy.defaultLimit) &&
         Objects.equals(monetization, subscriptionThrottlePolicy.monetization) &&
         Objects.equals(rateLimitCount, subscriptionThrottlePolicy.rateLimitCount) &&
         Objects.equals(rateLimitTimeUnit, subscriptionThrottlePolicy.rateLimitTimeUnit) &&
@@ -174,7 +215,7 @@ public class SubscriptionThrottlePolicyDTO extends ThrottlePolicyDTO  {
 
   @Override
   public int hashCode() {
-    return Objects.hash(defaultLimit, monetization, rateLimitCount, rateLimitTimeUnit, customAttributes, stopOnQuotaReach, billingPlan);
+    return Objects.hash(graphQLMaxComplexity, graphQLMaxDepth, defaultLimit, monetization, rateLimitCount, rateLimitTimeUnit, customAttributes, stopOnQuotaReach, billingPlan);
   }
 
   @Override
@@ -182,6 +223,8 @@ public class SubscriptionThrottlePolicyDTO extends ThrottlePolicyDTO  {
     StringBuilder sb = new StringBuilder();
     sb.append("class SubscriptionThrottlePolicyDTO {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    sb.append("    graphQLMaxComplexity: ").append(toIndentedString(graphQLMaxComplexity)).append("\n");
+    sb.append("    graphQLMaxDepth: ").append(toIndentedString(graphQLMaxDepth)).append("\n");
     sb.append("    defaultLimit: ").append(toIndentedString(defaultLimit)).append("\n");
     sb.append("    monetization: ").append(toIndentedString(monetization)).append("\n");
     sb.append("    rateLimitCount: ").append(toIndentedString(rateLimitCount)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -3316,6 +3316,7 @@ definitions:
       - defaultLimit
     allOf:
       - $ref: '#/definitions/ThrottlePolicy'
+      - $ref: '#/definitions/GraphQLQuery'
       - properties:
           defaultLimit:
             $ref: '#/definitions/ThrottleLimitType'
@@ -3347,6 +3348,21 @@ definitions:
             type: string
             description: |
               define whether this is Paid or a Free plan. Allowed values are FREE or COMMERCIAL.
+
+#-----------------------------------------------------
+# The GraphQL Query resource
+#-----------------------------------------------------
+  GraphQLQuery:
+    title: GraphQL Query
+    properties:
+      graphQLMaxComplexity:
+        type: integer
+        description: Maximum Complexity of the GraphQL query
+        example: 400
+      graphQLMaxDepth:
+        type: integer
+        description: Maximum Depth of the GraphQL query
+        example: 10
 #-----------------------------------------------------
 # The Subscription Throttling Policy List resource
 #-----------------------------------------------------


### PR DESCRIPTION
### Purpose
This PR will add the following two optional fields to the SubscriptionThrottlePolicyDTO to support GraphQL Query Analysis.
1. graphQLMaxComplexity
2. graphQLMaxDepth

