### PR TITLE
Added REST API to validate a given user has a particular scope.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SettingsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SettingsApi.java
@@ -1,6 +1,7 @@
 package org.wso2.carbon.apimgt.rest.api.admin.v1;
 
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeSettingsDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.SettingsDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.SettingsApiService;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.SettingsApiServiceImpl;
@@ -13,6 +14,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.inject.Inject;
 
 import io.swagger.annotations.*;
+
 import java.io.InputStream;
 
 import org.apache.cxf.jaxrs.ext.MessageContext;
@@ -22,50 +24,52 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.util.Map;
 import java.util.List;
 import javax.validation.constraints.*;
+
 @Path("/settings")
 
 @Api(description = "the settings API")
-@Consumes({ "application/json" })
-@Produces({ "application/json" })
+@Consumes({"application/json"})
+@Produces({"application/json"})
 
 
-public class SettingsApi  {
+public class SettingsApi {
 
-  @Context MessageContext securityContext;
+    @Context
+    MessageContext securityContext;
 
-SettingsApiService delegate = new SettingsApiServiceImpl();
+    SettingsApiService delegate = new SettingsApiServiceImpl();
 
 
     @GET
-    
-    @Consumes({ "application/json" })
-    @Produces({ "application/json" })
+
+    @Consumes({"application/json"})
+    @Produces({"application/json"})
     @ApiOperation(value = "Retreive admin settings", notes = "Retreive admin settings ", response = SettingsDTO.class, authorizations = {
-        @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:admin_settings", description = "Retrieve admin settings")
-        })
-    }, tags={ "Settings",  })
-    @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "OK. Settings returned ", response = SettingsDTO.class),
-        @ApiResponse(code = 404, message = "Not Found. Requested Settings does not exist. ", response = ErrorDTO.class) })
-    public Response settingsGet() throws APIManagementException{
+            @Authorization(value = "OAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "apim:admin_settings", description = "Retrieve admin settings")
+            })
+    }, tags = {"Settings",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "OK. Settings returned ", response = SettingsDTO.class),
+            @ApiResponse(code = 404, message = "Not Found. Requested Settings does not exist. ", response = ErrorDTO.class)})
+    public Response settingsGet() throws APIManagementException {
         return delegate.settingsGet(securityContext);
     }
 
     @GET
-    @Path("/scopes")
-    @Consumes({ "application/json" })
-    @Produces({ "application/json" })
-    @ApiOperation(value = "Retrieve scopes for a particular user", notes = "This operation will return the scope list of particular user In order to get it, we need to pass the userId as a query parameter ", response = SettingsDTO.class, authorizations = {
-        @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:admin_settings", description = "Retrieve admin settings")
-        })
-    }, tags={ "Settings", })
-    @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "OK. Scopes for a particular user retrieved successfully. ", response = SettingsDTO.class),
-        @ApiResponse(code = 400, message = "Bad Request. Invalid request or validation error ", response = ErrorDTO.class),
-        @ApiResponse(code = 404, message = "Not Found. Requested user does not exist. ", response = ErrorDTO.class) })
-    public Response settingsScopesGet( @NotNull @ApiParam(value = "",required=true)  @QueryParam("username") String username,  @NotNull @ApiParam(value = "",required=true)  @QueryParam("scope") String scope) throws APIManagementException{
-        return delegate.settingsScopesGet(username, scope, securityContext);
+    @Path("/scopes/{scope}")
+    @Consumes({"application/json"})
+    @Produces({"application/json"})
+    @ApiOperation(value = "Retrieve scopes for a particular user", notes = "This operation will return the scope list of particular user In order to get it, we need to pass the userId as a query parameter ", response = ScopeSettingsDTO.class, authorizations = {
+            @Authorization(value = "OAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "apim:admin_settings", description = "Retrieve admin settings")
+            })
+    }, tags = {"Settings"})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "OK. Particular scope exists for the given user. ", response = ScopeSettingsDTO.class),
+            @ApiResponse(code = 400, message = "Bad Request. Invalid request or validation error ", response = ErrorDTO.class),
+            @ApiResponse(code = 404, message = "Not Found. Requested user does not exist. ", response = ErrorDTO.class)})
+    public Response settingsScopesScopeGet(@NotNull @ApiParam(value = "", required = true) @QueryParam("username") String username, @ApiParam(value = "scope name to be validated ", required = true) @PathParam("scope") String scope) throws APIManagementException {
+        return delegate.settingsScopesScopeGet(username, scope, securityContext);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SettingsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SettingsApi.java
@@ -14,7 +14,6 @@ import javax.ws.rs.core.SecurityContext;
 import javax.inject.Inject;
 
 import io.swagger.annotations.*;
-
 import java.io.InputStream;
 
 import org.apache.cxf.jaxrs.ext.MessageContext;
@@ -24,52 +23,50 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.util.Map;
 import java.util.List;
 import javax.validation.constraints.*;
-
 @Path("/settings")
 
 @Api(description = "the settings API")
-@Consumes({"application/json"})
-@Produces({"application/json"})
+@Consumes({ "application/json" })
+@Produces({ "application/json" })
 
 
-public class SettingsApi {
+public class SettingsApi  {
 
-    @Context
-    MessageContext securityContext;
+  @Context MessageContext securityContext;
 
-    SettingsApiService delegate = new SettingsApiServiceImpl();
+SettingsApiService delegate = new SettingsApiServiceImpl();
 
 
     @GET
-
-    @Consumes({"application/json"})
-    @Produces({"application/json"})
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
     @ApiOperation(value = "Retreive admin settings", notes = "Retreive admin settings ", response = SettingsDTO.class, authorizations = {
-            @Authorization(value = "OAuth2Security", scopes = {
-                    @AuthorizationScope(scope = "apim:admin_settings", description = "Retrieve admin settings")
-            })
-    }, tags = {"Settings",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK. Settings returned ", response = SettingsDTO.class),
-            @ApiResponse(code = 404, message = "Not Found. Requested Settings does not exist. ", response = ErrorDTO.class)})
-    public Response settingsGet() throws APIManagementException {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:admin_settings", description = "Retrieve admin settings")
+        })
+    }, tags={ "Settings",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Settings returned ", response = SettingsDTO.class),
+        @ApiResponse(code = 404, message = "Not Found. Requested Settings does not exist. ", response = ErrorDTO.class) })
+    public Response settingsGet() throws APIManagementException{
         return delegate.settingsGet(securityContext);
     }
 
     @GET
     @Path("/scopes/{scope}")
-    @Consumes({"application/json"})
-    @Produces({"application/json"})
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
     @ApiOperation(value = "Retrieve scopes for a particular user", notes = "This operation will return the scope list of particular user In order to get it, we need to pass the userId as a query parameter ", response = ScopeSettingsDTO.class, authorizations = {
-            @Authorization(value = "OAuth2Security", scopes = {
-                    @AuthorizationScope(scope = "apim:admin_settings", description = "Retrieve admin settings")
-            })
-    }, tags = {"Settings"})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK. Particular scope exists for the given user. ", response = ScopeSettingsDTO.class),
-            @ApiResponse(code = 400, message = "Bad Request. Invalid request or validation error ", response = ErrorDTO.class),
-            @ApiResponse(code = 404, message = "Not Found. Requested user does not exist. ", response = ErrorDTO.class)})
-    public Response settingsScopesScopeGet(@NotNull @ApiParam(value = "", required = true) @QueryParam("username") String username, @ApiParam(value = "scope name to be validated ", required = true) @PathParam("scope") String scope) throws APIManagementException {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:admin_settings", description = "Retrieve admin settings")
+        })
+    }, tags={ "Settings" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Particular scope exists for the given user. ", response = ScopeSettingsDTO.class),
+        @ApiResponse(code = 400, message = "Bad Request. Invalid request or validation error ", response = ErrorDTO.class),
+        @ApiResponse(code = 404, message = "Not Found. Requested user does not exist. ", response = ErrorDTO.class) })
+    public Response settingsScopesScopeGet( @NotNull @ApiParam(value = "",required=true)  @QueryParam("username") String username, @ApiParam(value = "scope name to be validated ",required=true) @PathParam("scope") String scope) throws APIManagementException{
         return delegate.settingsScopesScopeGet(username, scope, securityContext);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SettingsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SettingsApi.java
@@ -44,11 +44,28 @@ SettingsApiService delegate = new SettingsApiServiceImpl();
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin_settings", description = "Retrieve admin settings")
         })
-    }, tags={ "Settings" })
+    }, tags={ "Settings",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "OK. Settings returned ", response = SettingsDTO.class),
         @ApiResponse(code = 404, message = "Not Found. Requested Settings does not exist. ", response = ErrorDTO.class) })
     public Response settingsGet() throws APIManagementException{
         return delegate.settingsGet(securityContext);
+    }
+
+    @GET
+    @Path("/scopes")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Retrieve scopes for a particular user", notes = "This operation will return the scope list of particular user In order to get it, we need to pass the userId as a query parameter ", response = SettingsDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:admin_settings", description = "Retrieve admin settings")
+        })
+    }, tags={ "Settings", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Scopes for a particular user retrieved successfully. ", response = SettingsDTO.class),
+        @ApiResponse(code = 400, message = "Bad Request. Invalid request or validation error ", response = ErrorDTO.class),
+        @ApiResponse(code = 404, message = "Not Found. Requested user does not exist. ", response = ErrorDTO.class) })
+    public Response settingsScopesGet( @NotNull @ApiParam(value = "",required=true)  @QueryParam("username") String username,  @NotNull @ApiParam(value = "",required=true)  @QueryParam("scope") String scope) throws APIManagementException{
+        return delegate.settingsScopesGet(username, scope, securityContext);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SettingsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SettingsApiService.java
@@ -22,4 +22,5 @@ import javax.ws.rs.core.SecurityContext;
 
 public interface SettingsApiService {
       public Response settingsGet(MessageContext messageContext) throws APIManagementException;
+      public Response settingsScopesGet(String username, String scope, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SettingsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SettingsApiService.java
@@ -10,6 +10,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeSettingsDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.SettingsDTO;
 
 import java.util.List;
@@ -21,6 +22,6 @@ import javax.ws.rs.core.SecurityContext;
 
 
 public interface SettingsApiService {
-      public Response settingsGet(MessageContext messageContext) throws APIManagementException;
-      public Response settingsScopesGet(String username, String scope, MessageContext messageContext) throws APIManagementException;
+    public Response settingsGet(MessageContext messageContext) throws APIManagementException;
+    public Response settingsScopesScopeGet(String username, String scope, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SettingsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SettingsApiService.java
@@ -22,6 +22,6 @@ import javax.ws.rs.core.SecurityContext;
 
 
 public interface SettingsApiService {
-    public Response settingsGet(MessageContext messageContext) throws APIManagementException;
-    public Response settingsScopesScopeGet(String username, String scope, MessageContext messageContext) throws APIManagementException;
+      public Response settingsGet(MessageContext messageContext) throws APIManagementException;
+      public Response settingsScopesScopeGet(String username, String scope, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/ScopeSettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/ScopeSettingsDTO.java
@@ -2,79 +2,75 @@ package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
-
 import javax.validation.constraints.*;
 
 
 import io.swagger.annotations.*;
-
 import java.util.Objects;
 
 import javax.xml.bind.annotation.*;
-
 import org.wso2.carbon.apimgt.rest.api.util.annotations.Scope;
 
 
-public class ScopeSettingsDTO {
 
+public class ScopeSettingsDTO   {
+  
     private String name = null;
 
-    /**
-     *
-     **/
-    public ScopeSettingsDTO name(String name) {
-        this.name = name;
-        return this;
+  /**
+   **/
+  public ScopeSettingsDTO name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
     }
-
-
-    @ApiModelProperty(value = "")
-    @JsonProperty("name")
-    public String getName() {
-        return name;
+    if (o == null || getClass() != o.getClass()) {
+      return false;
     }
+    ScopeSettingsDTO scopeSettings = (ScopeSettingsDTO) o;
+    return Objects.equals(name, scopeSettings.name);
+  }
 
-    public void setName(String name) {
-        this.name = name;
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ScopeSettingsDTO {\n");
+    
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
     }
-
-
-    @Override
-    public boolean equals(java.lang.Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ScopeSettingsDTO scopeSettings = (ScopeSettingsDTO) o;
-        return Objects.equals(name, scopeSettings.name);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name);
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class ScopeSettingsDTO {\n");
-
-        sb.append("    name: ").append(toIndentedString(name)).append("\n");
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
+    return o.toString().replace("\n", "\n    ");
+  }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/ScopeSettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/ScopeSettingsDTO.java
@@ -1,0 +1,80 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+
+import org.wso2.carbon.apimgt.rest.api.util.annotations.Scope;
+
+
+public class ScopeSettingsDTO {
+
+    private String name = null;
+
+    /**
+     *
+     **/
+    public ScopeSettingsDTO name(String name) {
+        this.name = name;
+        return this;
+    }
+
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ScopeSettingsDTO scopeSettings = (ScopeSettingsDTO) o;
+        return Objects.equals(name, scopeSettings.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ScopeSettingsDTO {\n");
+
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SettingsApiServiceImpl.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import javax.ws.rs.core.Response;
+import java.util.Map;
 
 public class SettingsApiServiceImpl implements SettingsApiService {
 
@@ -67,24 +68,26 @@ public class SettingsApiServiceImpl implements SettingsApiService {
         String[] userRoles;
         ScopeSettingsDTO scopeSettingsDTO = new ScopeSettingsDTO();
         ErrorDTO errorDTO = new ErrorDTO();
-
+        Map<String, String> scopeRoleMapping = APIUtil.getRESTAPIScopesForTenant(MultitenantUtils
+                .getTenantDomain(username));
         try {
-            if (APIUtil.isUserExist(username) && APIUtil.getRESTAPIScopesForTenant(MultitenantUtils
-                    .getTenantDomain(username)).containsKey(scopeName)) {
+            if (APIUtil.isUserExist(username) && scopeRoleMapping.containsKey(scopeName)) {
                 userRoles = APIUtil.getListOfRoles(username);
                 SettingsMappingUtil settingsMappingUtil = new SettingsMappingUtil();
 
-                if (settingsMappingUtil.GetRoleScopeList(userRoles, username).contains(scopeName)) {
+                if (settingsMappingUtil.GetRoleScopeList(userRoles, scopeRoleMapping).contains(scopeName)) {
                     scopeSettingsDTO.setName(scopeName);
                 }
             } else {
                 errorDTO.setCode(404l);
-                errorDTO.description("Username or Scope does not exist");
+                errorDTO.description("Username or Scope does not exist. Username: "
+                        + username + ", " + "Scope: " + scopeName);
                 errorDTO.setMessage("Not Found");
                 return Response.ok().entity(errorDTO).build();
             }
         } catch (APIManagementException e) {
-            String errorMessage = "Error when getting the list of scopes";
+            String errorMessage = "Error when getting the list of scopes. Username: " + username + " , "
+                    + "Scope: " + scopeName;
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
         }
         return Response.ok().entity(scopeSettingsDTO).build();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
@@ -72,7 +72,7 @@ public class SettingsMappingUtil {
         return scopeList;
     }
 
-    public List<String> GetRoleScopeList(String[] userRoles, String username) {
+    public List<String> GetRoleScopeList(String[] userRoles, Map<String, String> scopeRoleMapping) {
         List<String> userRoleList;
         List<String> authorizedScopes = new ArrayList<>();
 
@@ -81,8 +81,6 @@ public class SettingsMappingUtil {
         }
 
         userRoleList = Arrays.asList(userRoles);
-        Map<String, String> scopeRoleMapping =
-                APIUtil.getRESTAPIScopesForTenant(MultitenantUtils.getTenantDomain(username));
         Iterator<Map.Entry<String, String>> iterator = scopeRoleMapping.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<String, String> entry = iterator.next();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
@@ -27,10 +27,14 @@ import org.wso2.carbon.apimgt.impl.definitions.OASParserUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.SettingsDTO;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class SettingsMappingUtil {
@@ -66,5 +70,28 @@ public class SettingsMappingUtil {
             scopeList.add(entry.getKey());
         }
         return scopeList;
+    }
+
+    public List<String> GetRoleScopeList(String[] userRoles, String username) {
+        List<String> userRoleList;
+        List<String> authorizedScopes = new ArrayList<>();
+
+        if (userRoles == null || userRoles.length == 0) {
+            userRoles = new String[0];
+        }
+
+        userRoleList = Arrays.asList(userRoles);
+        Map<String, String> scopeRoleMapping =
+                APIUtil.getRESTAPIScopesForTenant(MultitenantUtils.getTenantDomain(username));
+        Iterator<Map.Entry<String, String>> iterator = scopeRoleMapping.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, String> entry = iterator.next();
+            for (String aRole : entry.getValue().split(",")) {
+                if (userRoleList.contains(aRole)) {
+                    authorizedScopes.add(entry.getKey());
+                }
+            }
+        }
+        return authorizedScopes;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -2965,10 +2965,74 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /settings/scopes:
+    #-----------------------------------------------------
+    # Retrieve scope settings
+    #-----------------------------------------------------
+    get:
+      security:
+        - OAuth2Security:
+            - apim:admin_settings
+      x-wso2-curl: "curl -k -X GET \"https://localhost:9443/api/am/admin/v1/settings/scopes?username=john&scope=apim:subscribe\" -H \"accept: application/json\" -H \"Authorization: Bearer 8e8edc50-4a70-3fec-af00-ce08097012ab"
+      x-wso2-request: "GET https://localhost:9443/api/am/admin/v1/settings/scopes?username=john&scope=apim:subscribe Authorization: Bearer 8e8edc50-4a70-3fec-af00-ce08097012ab"
+      x-wso2-response: "{\n  \"scopes\":[\"apim:subscribe\" \n] \n}\n"
+      summary: Retrieve scopes for a particular user
+      description: |
+        This operation will return the scope list of particular user
+        In order to get it, we need to pass the userId as a query parameter
+      parameters:
+        - name: username
+          in: query
+          type: string
+          required: true
+        - name: scope
+          in: query
+          type: string
+          required: true
+      tags:
+        - Settings
+      responses:
+        200:
+          description: |
+            OK.
+            Particular scope exists for the given user.
+          schema:
+            $ref: '#/definitions/Settings'
+        400:
+          description: |
+            Bad Request.
+            Invalid request or validation error
+          schema:
+            $ref: '#/definitions/Error'
+        404:
+          description: |
+            Not Found.
+            Requested user does not exist.
+          schema:
+            $ref: '#/definitions/Error'
+
 ######################################################
 # Parameters - required by some of the APIs above
 ######################################################
 parameters:
+
+# Group Identifier of the application
+  username:
+    name: username
+    in: query
+    description: |
+      username of the new application owner
+    required: true
+    type: string
+
+# Group Identifier of the application
+  scope:
+    name: scope
+    in: query
+    description: |
+      scope name to be validated
+    required: true
+    type: string
 
 # Label Id
 # Specified as part of the path expression

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -2965,7 +2965,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /settings/scopes:
+  /settings/scopes/{scope}:
     #-----------------------------------------------------
     # Retrieve scope settings
     #-----------------------------------------------------
@@ -2985,10 +2985,7 @@ paths:
           in: query
           type: string
           required: true
-        - name: scope
-          in: query
-          type: string
-          required: true
+        - $ref : '#/parameters/scope'
       tags:
         - Settings
       responses:
@@ -2997,7 +2994,7 @@ paths:
             OK.
             Particular scope exists for the given user.
           schema:
-            $ref: '#/definitions/Settings'
+            $ref: '#/definitions/ScopeSettings'
         400:
           description: |
             Bad Request.
@@ -3025,10 +3022,10 @@ parameters:
     required: true
     type: string
 
-# Group Identifier of the application
+# Scope Name
   scope:
     name: scope
-    in: query
+    in: path
     description: |
       scope name to be validated
     required: true
@@ -4183,6 +4180,18 @@ definitions:
         type: boolean
         description: To determine whether analytics is enabled or not
         example: false
+
+  #-----------------------------------------------------
+  # The Scope Settings resource
+  #-----------------------------------------------------
+  ScopeSettings:
+    title: Settings
+    properties:
+      name:
+        type: string
+        items:
+          type: string
+
 
 #-----------------------------------------------------
 # END-OF-FILE

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -2973,9 +2973,9 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin_settings
-      x-wso2-curl: "curl -k -X GET \"https://localhost:9443/api/am/admin/v1/settings/scopes?username=john&scope=apim:subscribe\" -H \"accept: application/json\" -H \"Authorization: Bearer 8e8edc50-4a70-3fec-af00-ce08097012ab"
-      x-wso2-request: "GET https://localhost:9443/api/am/admin/v1/settings/scopes?username=john&scope=apim:subscribe Authorization: Bearer 8e8edc50-4a70-3fec-af00-ce08097012ab"
-      x-wso2-response: "{\n  \"scopes\":[\"apim:subscribe\" \n] \n}\n"
+      x-wso2-curl: "curl -k -X GET \"https://localhost:9443/api/am/admin/v1/settings/scopes/apim:subscribe?username=john\" -H \"accept: application/json\" -H \"Authorization: Bearer 8e8edc50-4a70-3fec-af00-ce08097012ab"
+      x-wso2-request: "GET https://localhost:9443/api/am/admin/v1/settings/scopes/apim:subscribe?username=john Authorization: Bearer 8e8edc50-4a70-3fec-af00-ce08097012ab"
+      x-wso2-response: "{\n  \"name\":\"apim:subscribe\"  \n}\n"
       summary: Retrieve scopes for a particular user
       description: |
         This operation will return the scope list of particular user


### PR DESCRIPTION
Fix https://github.com/wso2/product-apim/issues/7975 (https://github.com/wso2/product-apim/issues/7954)
Scenario: When transferring ownership of an application to a user, that user should hold the role Internal/subscriber

There are two required parameters used to validate the existence of scope.

- username(query)

- scope(path)

The scope will be returned if the user has the particular scope else empty list will be returned.
And 404 will be thrown if the user name or scope name does not exist.

Sample cURL request and response:

Request: curl -k -X GET "https://localhost:9443/api/am/admin/v1/settings/scopes/apim:subscribe?username=john" -H "accept: application/json" -H "Authorization: Bearer e2fd27f7-cdf4-36ae-9b32-db4a47dcb14a"
Response: {"name":"apim:subscribe"}

Request: curl -k -X GET "https://localhost:9443/api/am/admin/v1/settings/scopes/apim:api_view?username=john" -H "accept: application/json" -H "Authorization: Bearer e2fd27f7-cdf4-36ae-9b32-db4a47dcb14a"
Response: {"name":null}

Tested Scenarios :
![image](https://user-images.githubusercontent.com/28688743/83297065-894dae00-a20f-11ea-9857-75a6714d1f04.png)
