### PR TITLE
Moving Blacklist policies to a new page

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/site/public/locales/en.json
@@ -14,6 +14,8 @@
   "Admin.Throttling.Custom.Throttling.policy.table.header.description": "Description",
   "Admin.Throttling.Custom.Throttling.policy.table.header.key.template": "Key Template",
   "Admin.Throttling.Custom.Throttling.policy.table.header.name": "Name",
+  "Admin.Throttling.Custom.policy.add.policy.description": "Description of Throttling Policy",
+  "Admin.Throttling.Custom.policy.add.policy.name": "Name of Throttling Policy",
   "Admin.Throttling.Custom.policy.add.siddhi.query": "Siddhi Query:",
   "Admin.Throttling.Custom.policy.add.siddhi.query.description": "The following query will allow 5 requests per minute for an Admin user.",
   "Admin.Throttling.Custom.policy.add.siddhi.query.key.template": "Key Template : $userId",
@@ -181,6 +183,11 @@
   "Throttling.Blacklist.Policy.policy.dialog.delete.error": "Blacklist Policy will be deleted.",
   "Throttling.Blacklist.Policy.policy.update.success": "Condition status has been updated successfully.",
   "Throttling.Blacklist.Policy.search.default": "Blacklist Policies",
+  "Throttling.Custom.AddEdit.form.add": "Add",
+  "Throttling.Custom.AddEdit.form.cancel": "Cancel",
+  "Throttling.Custom.AddEdit.title.add": "Custom Rate Limiting Policy - Define Policy",
+  "Throttling.Custom.AddEdit.title.edit": "Custom Rate Limiting Policy - Edit",
+  "Throttling.Custom.List.add.new.polcy": "Define Policy",
   "Throttling.Custom.Policy.List.addButtonProps.title": "Define Custom Policy",
   "Throttling.Custom.Policy.List.addButtonProps.triggerButtonText": "Define Policy",
   "Throttling.Custom.Policy.List.empty.content.custom.policies and abuse by": "Custom throttling allows system administrators to define dynamic rules for specific use cases, which are applied globally across all tenants.",
@@ -194,5 +201,6 @@
   "UnexpectedError.logout": "Logout",
   "UnexpectedError.message": "Error occured due to invalid request",
   "UnexpectedError.title": "Internal Server Error",
-  "app.components.Shared.Banner.back": "Back"
+  "app.components.Shared.Banner.back": "Back",
+  "dsdds": "The specific combination of attributes being checked in the policy need to be defined as the key template"
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/site/public/locales/fr.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/site/public/locales/fr.json
@@ -14,6 +14,8 @@
   "Admin.Throttling.Custom.Throttling.policy.table.header.description": "",
   "Admin.Throttling.Custom.Throttling.policy.table.header.key.template": "",
   "Admin.Throttling.Custom.Throttling.policy.table.header.name": "",
+  "Admin.Throttling.Custom.policy.add.policy.description": "",
+  "Admin.Throttling.Custom.policy.add.policy.name": "",
   "Admin.Throttling.Custom.policy.add.siddhi.query": "",
   "Admin.Throttling.Custom.policy.add.siddhi.query.description": "",
   "Admin.Throttling.Custom.policy.add.siddhi.query.key.template": "",
@@ -181,6 +183,11 @@
   "Throttling.Blacklist.Policy.policy.dialog.delete.error": "",
   "Throttling.Blacklist.Policy.policy.update.success": "",
   "Throttling.Blacklist.Policy.search.default": "",
+  "Throttling.Custom.AddEdit.form.add": "",
+  "Throttling.Custom.AddEdit.form.cancel": "",
+  "Throttling.Custom.AddEdit.title.add": "",
+  "Throttling.Custom.AddEdit.title.edit": "",
+  "Throttling.Custom.List.add.new.polcy": "",
   "Throttling.Custom.Policy.List.addButtonProps.title": "",
   "Throttling.Custom.Policy.List.addButtonProps.triggerButtonText": "",
   "Throttling.Custom.Policy.List.empty.content.custom.policies and abuse by": "",
@@ -194,5 +201,6 @@
   "UnexpectedError.logout": "",
   "UnexpectedError.message": "",
   "UnexpectedError.title": "",
-  "app.components.Shared.Banner.back": ""
+  "app.components.Shared.Banner.back": "",
+  "dsdds": ""
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Base/RouteMenuMapping.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Base/RouteMenuMapping.jsx
@@ -31,7 +31,6 @@ import DemoTable from 'AppComponents/AdminPages/Microgateways/List';
 import ApplicationThrottlingPolicies from 'AppComponents/Throttling/Application/List';
 import APICategories from 'AppComponents/APICategories/ListApiCategories';
 import BlacklistThrottlingPolicies from 'AppComponents/Throttling/Blacklist/List';
-// import CustomThrottlingPolicies from 'AppComponents/Throttling/Custom/List';
 import ListApplications from 'AppComponents/ApplicationSettings/ListApplications';
 import MicrogatewayLabels from 'AppComponents/MicrogatewayLabels/ListMGLabels';
 import AdvancedThrottlePolicies from 'AppComponents/Throttling/Advanced';

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Base/RouteMenuMapping.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Base/RouteMenuMapping.jsx
@@ -31,10 +31,11 @@ import DemoTable from 'AppComponents/AdminPages/Microgateways/List';
 import ApplicationThrottlingPolicies from 'AppComponents/Throttling/Application/List';
 import APICategories from 'AppComponents/APICategories/ListApiCategories';
 import BlacklistThrottlingPolicies from 'AppComponents/Throttling/Blacklist/List';
-import CustomThrottlingPolicies from 'AppComponents/Throttling/Custom/List';
+// import CustomThrottlingPolicies from 'AppComponents/Throttling/Custom/List';
 import ListApplications from 'AppComponents/ApplicationSettings/ListApplications';
 import MicrogatewayLabels from 'AppComponents/MicrogatewayLabels/ListMGLabels';
 import AdvancedThrottlePolicies from 'AppComponents/Throttling/Advanced';
+import CustomThrottlingPolicies from 'AppComponents/Throttling/Custom';
 import TenantTheme from 'AppComponents/TenantTheme/UploadTheme';
 import ListDetectedBotData from 'AppComponents/BotDetection/DetectedBotData/ListDetectedBotData';
 

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Throttling/Application/AddEdit.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Throttling/Application/AddEdit.jsx
@@ -58,8 +58,7 @@ const useStyles = makeStyles((theme) => ({
  * @param {JSON} state The second number.
  * @returns {Promise}
  */
-function reducer(state, newValue) {
-    const { field, value } = newValue;
+function reducer(state, { field, value }) {
     switch (field) {
         case 'policyName':
             return { ...state, [field]: value };
@@ -95,8 +94,10 @@ function reducer(state, newValue) {
                 ...state,
                 defaultLimit: { ...state.defaultLimit, [field]: value },
             };
+        case 'editDetails':
+            return value;
         default:
-            return newValue;
+            return state;
     }
 }
 
@@ -318,7 +319,7 @@ function AddEdit(props) {
                         },
                     };
                 }
-                dispatch(editState);
+                dispatch({ field: 'editDetails', value: editState });
             });
         }
     };

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Throttling/Custom/AddEdit.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Throttling/Custom/AddEdit.jsx
@@ -81,8 +81,7 @@ const formattedSampleSiddhiQuery = sqlFormatter.format(sampleSiddhiQuery);
  * @param {JSON} state The second number.
  * @returns {Promise}
  */
-function reducer(state, newValue) {
-    const { field, value } = newValue;
+function reducer(state, { field, value }) {
     switch (field) {
         case 'policyName':
             return { ...state, [field]: value };
@@ -92,8 +91,10 @@ function reducer(state, newValue) {
             return { ...state, [field]: value };
         case 'siddhiQuery':
             return { ...state, [field]: value };
+        case 'editDetails':
+            return value;
         default:
-            return newValue;
+            return state;
     }
 }
 
@@ -132,7 +133,7 @@ function AddEdit(props) {
                     keyTemplate: result.body.keyTemplate,
                     siddhiQuery: formattedSiddhiQuery,
                 };
-                dispatch(editState);
+                dispatch({ field: 'editDetails', value: editState });
             });
         }
         setInitialState({

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Throttling/Custom/AddEdit.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Throttling/Custom/AddEdit.jsx
@@ -118,13 +118,12 @@ function AddEdit(props) {
         policyName, description, keyTemplate, siddhiQuery,
     } = state;
     const [validationError, setValidationError] = useState([]);
-    const [editMode, setIsEditMode] = useState(false);
     const restApi = new API();
     const { policyId } = props.match.params;
+    const editMode = policyId !== 'create';
 
     useEffect(() => {
-        if (policyId !== 'create') {
-            setIsEditMode(true);
+        if (editMode) {
             restApi.customPolicyGet(policyId).then((result) => {
                 const formattedSiddhiQuery = sqlFormatter.format(result.body.siddhiQuery);
                 const editState = {
@@ -221,7 +220,7 @@ function AddEdit(props) {
         }
         const customPolicy = state;
 
-        if (policyId !== 'create') {
+        if (editMode) {
             promisedAddCustomPolicy = restApi.updateCustomPolicy(policyId,
                 customPolicy);
             return promisedAddCustomPolicy

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Throttling/Custom/List.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Throttling/Custom/List.jsx
@@ -19,6 +19,7 @@
 import React from 'react';
 import { useIntl, FormattedMessage } from 'react-intl';
 import List from '@material-ui/core/List';
+import Button from '@material-ui/core/Button';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -28,12 +29,10 @@ import ListBase from 'AppComponents/AdminPages/Addons/ListBase';
 import DescriptionIcon from '@material-ui/icons/Description';
 import Link from '@material-ui/core/Link';
 import Configurations from 'Config';
-import AddEdit from 'AppComponents/Throttling/Custom/AddEditOld';
 import Delete from 'AppComponents/Throttling/Custom/Delete';
 import API from 'AppData/api';
 import EditIcon from '@material-ui/icons/Edit';
 import { Link as RouterLink } from 'react-router-dom';
-import IconButton from '@material-ui/core/IconButton';
 
 /**
  * Render a list
@@ -127,6 +126,12 @@ export default function ListCustomThrottlingPolicies() {
                 sort: false,
             },
         },
+        { // Id column has to be always the last.
+            name: 'policyId',
+            options: {
+                display: false,
+            },
+        },
     ];
 
     const emptyBoxProps = {
@@ -172,6 +177,17 @@ export default function ListCustomThrottlingPolicies() {
         });
     }
 
+    const addButtonOverride = (
+        <RouterLink to='/throttling/custom/create'>
+            <Button variant='contained' color='primary' size='small'>
+                <FormattedMessage
+                    id='Throttling.Custom.List.add.new.polcy'
+                    defaultMessage='Define Policy'
+                />
+            </Button>
+        </RouterLink>
+    );
+
     return (
         <ListBase
             columProps={columProps}
@@ -181,18 +197,12 @@ export default function ListCustomThrottlingPolicies() {
             emptyBoxProps={emptyBoxProps}
             apiCall={apiCall}
             DeleteComponent={Delete}
-            // EditComponent={AddEdit}
-            EditComponent={() => (
-                <RouterLink to='/throttling/custom/policyid'>
-                    <IconButton color='primary' component='span'>
-                        <EditIcon />
-                    </IconButton>
-                </RouterLink>
-            )}
             editComponentProps={{
                 icon: <EditIcon />,
-                title: 'Edit Custom Policy',
+                title: 'Edit Policy',
+                routeTo: '/throttling/custom/',
             }}
+            addButtonOverride={addButtonOverride}
         />
     );
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Throttling/Custom/List.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Throttling/Custom/List.jsx
@@ -28,10 +28,12 @@ import ListBase from 'AppComponents/AdminPages/Addons/ListBase';
 import DescriptionIcon from '@material-ui/icons/Description';
 import Link from '@material-ui/core/Link';
 import Configurations from 'Config';
-import AddEdit from 'AppComponents/Throttling/Custom/AddEdit';
+import AddEdit from 'AppComponents/Throttling/Custom/AddEditOld';
 import Delete from 'AppComponents/Throttling/Custom/Delete';
 import API from 'AppData/api';
 import EditIcon from '@material-ui/icons/Edit';
+import { Link as RouterLink } from 'react-router-dom';
+import IconButton from '@material-ui/core/IconButton';
 
 /**
  * Render a list
@@ -179,7 +181,14 @@ export default function ListCustomThrottlingPolicies() {
             emptyBoxProps={emptyBoxProps}
             apiCall={apiCall}
             DeleteComponent={Delete}
-            EditComponent={AddEdit}
+            // EditComponent={AddEdit}
+            EditComponent={() => (
+                <RouterLink to='/throttling/custom/policyid'>
+                    <IconButton color='primary' component='span'>
+                        <EditIcon />
+                    </IconButton>
+                </RouterLink>
+            )}
             editComponentProps={{
                 icon: <EditIcon />,
                 title: 'Edit Custom Policy',

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Throttling/Custom/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/Throttling/Custom/index.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { withRouter, Switch, Route } from 'react-router-dom';
+import List from 'AppComponents/Throttling/Custom/List';
+import AddEdit from 'AppComponents/Throttling/Custom/AddEdit';
+import ResourceNotFound from 'AppComponents/Base/Errors/ResourceNotFound';
+
+/**
+ * Render a list
+ * @returns {JSX} Header AppBar components.
+ */
+function CustomThrottlePolicies() {
+    return (
+        <Switch>
+            <Route exact path='/throttling/custom' component={List} />
+            <Route path='/throttling/custom/:policyId' component={AddEdit} />
+            <Route path='/throttling/custom/create' component={AddEdit} />
+            <Route component={ResourceNotFound} />
+        </Switch>
+    );
+}
+
+export default withRouter(CustomThrottlePolicies);


### PR DESCRIPTION
This PR includes the following changes

- Moving Blacklist policies to a new page
- Put the "The following sample siddhi query ..." text into an infobox
- Add key template helper text
- Validate Key Templates from UI

**Define policy:**
<img width="1433" alt="Screen Shot 2020-06-01 at 2 33 58 PM" src="https://user-images.githubusercontent.com/19324135/83396202-3fd0af00-a419-11ea-9aec-f4581cfab2d3.png">

**Edit policy:**
<img width="1362" alt="Screen Shot 2020-06-01 at 2 34 24 PM" src="https://user-images.githubusercontent.com/19324135/83396229-47905380-a419-11ea-89e4-9bb2a0e3f251.png">

