### PR TITLE
[Admin Portal Revamp] Fix API Categories Listing

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/APICategories/ListApiCategories.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/APICategories/ListApiCategories.jsx
@@ -80,7 +80,7 @@ export default function ListApiCategories() {
             },
         },
         {
-            name: 'noOfApis',
+            name: 'numberOfAPIs',
             label: intl.formatMessage({
                 id: 'AdminPages.ApiCategories.table.header.category.number.of.apis',
                 defaultMessage: 'Number of APIs',


### PR DESCRIPTION
### Description
Fix API Category listing to be compatible with REST API v1.
Now the `Number of APIs` is displayed