### PR TITLE
[Admin Portal Revamp]Use App context in bot data detection feature

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/BotDetection/DetectedBotData/ListDetectedBotData.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/BotDetection/DetectedBotData/ListDetectedBotData.jsx
@@ -16,7 +16,8 @@
  * under the License.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
+import { useAppContext } from 'AppComponents/Shared/AppContext';
 import API from 'AppData/api';
 import { useIntl, FormattedMessage } from 'react-intl';
 import List from '@material-ui/core/List';
@@ -39,14 +40,11 @@ import InlineProgress from 'AppComponents/AdminPages/Addons/InlineProgress';
  * Render a list
  * @returns {JSX} Header AppBar components.
  */
-export default function ListMGLabels() {
+export default function ListDetectedBotData() {
+    const { settings } = useAppContext();
     const intl = useIntl();
-    const [isAnalyticsEnabled, setIsAnalyticsEnabled] = useState();
+    const isAnalyticsEnabled = settings.analyticsEnabled;
     const restApi = new API();
-
-    restApi.getAnalyticsEnabled().then((result) => {
-        setIsAnalyticsEnabled(result.body.analyticsEnabled);
-    });
 
     /**
      * API call to get Detected Data

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/BotDetection/EmailConfig/ListEmails.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/components/BotDetection/EmailConfig/ListEmails.jsx
@@ -17,6 +17,7 @@
  */
 
 import React, { useState } from 'react';
+import { useAppContext } from 'AppComponents/Shared/AppContext';
 import API from 'AppData/api';
 import { useIntl, FormattedMessage } from 'react-intl';
 import List from '@material-ui/core/List';
@@ -41,14 +42,11 @@ import InlineProgress from 'AppComponents/AdminPages/Addons/InlineProgress';
  * @returns {JSX} Header AppBar components.
  */
 export default function ListEmails() {
+    const { settings } = useAppContext();
     const intl = useIntl();
     const [emailList, setEmailList] = useState([]);
-    const [isAnalyticsEnabled, setIsAnalyticsEnabled] = useState();
+    const isAnalyticsEnabled = settings.analyticsEnabled;
     const restApi = new API();
-
-    restApi.getAnalyticsEnabled().then((result) => {
-        setIsAnalyticsEnabled(result.body.analyticsEnabled);
-    });
 
     /**
      * API call to get all emails

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/data/api.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin_new/source/src/app/data/api.js
@@ -556,17 +556,6 @@ class API extends Resource {
         });
     }
 
-    /**
-     * Get Analytics Enabled setting
-     */
-    getAnalyticsEnabled(){ 
-        return this.client.then((client) => {
-            return client.apis['Settings'].get_settings(
-                this._requestMetaData(),
-            );
-        });
-    }
-
      /**
      * Retrieve tenant information of the given username
      */


### PR DESCRIPTION
### Description
- Use App context to retrieve `isAnalyticsEnabled` variable.
- Remove duplicate api method.