### PR TITLE
Adding support to disable one of the Grid or List view

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/conf/defaultTheme.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/conf/defaultTheme.js
@@ -56,7 +56,8 @@ const AppThemes = {
             logo: '/site/public/images/logo.svg',
             logoHeight: 40,
             logoWidth: 222,
-            defaultApiView: 'grid', // Sets the default view for the api listing page ( Other values available = 'list' )
+            defaultApiView: 'grid', /* Sets the default view for the api listing page ( Other values available = 'list' )
+                                        To disable one option for an example if you want to disable grid completely and get rid of the toggle buttons use ['list']. */
             showApiHelp: false, // API detials page has a right hand side panel showing it's related help. Set this to false if you want to hide it.
             leftMenu: 'icon left', //  other values ('icon top', 'icon left', 'no icon', 'no text')
             leftMenuIconSize: 24,

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/TableView/TableView.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/TableView/TableView.jsx
@@ -62,11 +62,19 @@ const styles = (theme) => ({
 class TableView extends React.Component {
     constructor(props) {
         super(props);
+        let { defaultApiView } = props.theme.custom;
+        this.showToggle = true;
+        if (typeof defaultApiView === 'object' && defaultApiView.length > 0) {
+            if (defaultApiView.length === 1) { // We will disable toggle buttons
+                this.showToggle = false;
+            }
+            defaultApiView = defaultApiView[defaultApiView.length - 1];
+        }
         this.state = {
             apisAndApiProducts: null,
             notFound: true,
             displayCount: 0,
-            listType: props.theme.custom.defaultApiView,
+            listType: defaultApiView,
         };
         this.page = 0;
         this.count = 100;
@@ -448,6 +456,7 @@ class TableView extends React.Component {
                         setListType={this.setListType}
                         isAPIProduct={isAPIProduct}
                         listType={listType}
+                        showToggle={this.showToggle}
                     />
                     <div className={classes.contentInside}>
                         {isAPIProduct ? (
@@ -468,6 +477,7 @@ class TableView extends React.Component {
                     setListType={this.setListType}
                     isAPIProduct={isAPIProduct}
                     listType={listType}
+                    showToggle={this.showToggle}
                     query={query}
                 />
                 <div className={classes.contentInside}>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/components/TopMenu.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/components/TopMenu.jsx
@@ -110,7 +110,7 @@ function getTitleForArtifactType(props) {
  */
 function TopMenu(props) {
     const {
-        classes, data, setListType, theme, count, isAPIProduct, listType,
+        classes, data, setListType, theme, count, isAPIProduct, listType, showToggle,
     } = props;
     const strokeColorMain = theme.palette.getContrastText(theme.palette.background.paper);
 
@@ -173,22 +173,24 @@ function TopMenu(props) {
                         </APICreateMenu>
                     )}
                 </div>
-                <div className={classes.buttonRight}>
-                    <IconButton
-                        className={classes.button}
-                        disabled={data.length === 0}
-                        onClick={() => setListType('list')}
-                    >
-                        <List color={listType === 'list' ? 'primary' : 'default'} />
-                    </IconButton>
-                    <IconButton
-                        className={classes.button}
-                        disabled={data.length === 0}
-                        onClick={() => setListType('grid')}
-                    >
-                        <GridOn color={listType === 'grid' ? 'primary' : 'default'} />
-                    </IconButton>
-                </div>
+                {showToggle && (
+                    <div className={classes.buttonRight}>
+                        <IconButton
+                            className={classes.button}
+                            disabled={data.length === 0}
+                            onClick={() => setListType('list')}
+                        >
+                            <List color={listType === 'list' ? 'primary' : 'default'} />
+                        </IconButton>
+                        <IconButton
+                            className={classes.button}
+                            disabled={data.length === 0}
+                            onClick={() => setListType('grid')}
+                        >
+                            <GridOn color={listType === 'grid' ? 'primary' : 'default'} />
+                        </IconButton>
+                    </div>
+                )}
             </div>
         );
     } else {
@@ -206,6 +208,7 @@ TopMenu.propTypes = {
         custom: PropTypes.string,
     }).isRequired,
     isAPIProduct: PropTypes.bool.isRequired,
+    showToggle: PropTypes.bool.isRequired,
 };
 
 export default withStyles(styles, { withTheme: true })(TopMenu);

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/CommonListing.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/CommonListing.jsx
@@ -172,8 +172,16 @@ class CommonListing extends React.Component {
      */
     constructor(props) {
         super(props);
+        let { defaultApiView } = props.theme.custom;
+        this.showToggle = true;
+        if(typeof defaultApiView === 'object' && defaultApiView.length > 0) {
+            if(defaultApiView.length === 1) { // We will disable the other
+                this.showToggle = false;
+            }
+            defaultApiView = defaultApiView[0];
+        }
         this.state = {
-            listType: props.theme.custom.defaultApiView,
+            listType: defaultApiView,
             allTags: null,
             showLeftMenu: false,
             isMonetizationEnabled: false,
@@ -323,7 +331,7 @@ class CommonListing extends React.Component {
                                 <FormattedMessage defaultMessage='APIs' id='Apis.Listing.Listing.apis.main' />
                             </Typography>
                         </div>
-                        <div className={classes.buttonRight} id='listGridWrapper'>
+                        {this.showToggle && (<div className={classes.buttonRight} id='listGridWrapper'>
                             <IconButton className={classes.button} onClick={() => this.setListType('list')}>
                                 <Icon
                                     className={classNames(
@@ -344,7 +352,7 @@ class CommonListing extends React.Component {
                                     grid_on
                                 </Icon>
                             </IconButton>
-                        </div>
+                        </div>)}
                     </div>
                     {active && allTags && allTags.length > 0 && <ApiBreadcrumbs selectedTag={selectedTag} />}
                     <div className={classes.listContentWrapper}>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/defaultTheme.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/defaultTheme.js
@@ -32,7 +32,8 @@ const DefaultConfigurations = {
     custom: {
         contentAreaWidth: 1240,
         backgroundImage: '', // Add a watermark background to the content area of the page. Example ( '/devportal/site/public/images/back-light.png')
-        defaultApiView: 'grid', // Sets the default view for the api listing page ( Other values available = 'list' )
+        defaultApiView: 'grid',   // Sets the default view for the api listing page ( Other values available = 'list' ). 
+                                    // To disable one option for an example if you want to disable grid completely and get rid of the toggle buttons use ['list'].
         page: {
             style: 'fluid', // Set the page style ( Other values available 'fixed', 'fluid')
             width: 1240, // This value is effected only when the page.style = 'fixed'


### PR DESCRIPTION
Adding support to disable one of the Grid or List view from the API Listing pages.

Old config will work as expected
```
custom: {
  defaultApiView: 'grid',
}
```

The following will disable the grid view and set the list view. And it will hide the toggle buttons.
```
custom: {
  defaultApiView: ['list'],
}
```

Setting the following will be the same as the old-style config.
```
custom: {
  defaultApiView: ['list','grid'],
}
```
For both publisher and devportal the same config will work.


