### PR TITLE
Fix issues related to custom policy creation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -204,6 +204,8 @@ ExceptionCodes implements ErrorHandler {
     INVALID_DATE_TIME_STAMP(900703, "Invalid timestamp value", 400, "Timestamp should be in ISO8601 format"),
     LENGTH_EXCEEDS(900704, "Character length exceeds the allowable limit", 400,
             "One of the provided input character length exceeds the allowable limit."),
+    BLANK_PROPERTY_VALUE(900705, "Blank value for required property", 400,
+            "%s property of payload value cannot be blank."),
 
     // Oauth related codes
     AUTH_GENERAL_ERROR(900900, "Authorization Error", 403, " Error in authorization"),

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -205,7 +205,7 @@ ExceptionCodes implements ErrorHandler {
     LENGTH_EXCEEDS(900704, "Character length exceeds the allowable limit", 400,
             "One of the provided input character length exceeds the allowable limit."),
     BLANK_PROPERTY_VALUE(900705, "Blank value for required property", 400,
-            "%s property of payload value cannot be blank."),
+            "%s property of payload value cannot be blank"),
 
     // Oauth related codes
     AUTH_GENERAL_ERROR(900900, "Authorization Error", 403, " Error in authorization"),

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/CustomRuleDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/CustomRuleDTO.java
@@ -28,8 +28,9 @@ public class CustomRuleDTO extends ThrottlePolicyDTO  {
   }
 
   
-  @ApiModelProperty(example = "FROM RequestStream\\nSELECT userId, ( userId == 'admin@carbon.super' ) AS isEligible , str:concat('admin@carbon.super','') as throttleKey\\nINSERT INTO EligibilityStream; \\n\\nFROM EligibilityStream[isEligible==true]#throttler:timeBatch(1 min) \\nSELECT throttleKey, (count(userId) >= 10) as isThrottled, expiryTimeStamp group by throttleKey \\nINSERT ALL EVENTS into ResultStream; ", value = "Siddhi query which represents the custom throttling policy")
+  @ApiModelProperty(example = "FROM RequestStream\\nSELECT userId, ( userId == 'admin@carbon.super' ) AS isEligible , str:concat('admin@carbon.super','') as throttleKey\\nINSERT INTO EligibilityStream; \\n\\nFROM EligibilityStream[isEligible==true]#throttler:timeBatch(1 min) \\nSELECT throttleKey, (count(userId) >= 10) as isThrottled, expiryTimeStamp group by throttleKey \\nINSERT ALL EVENTS into ResultStream; ", required = true, value = "Siddhi query which represents the custom throttling policy")
   @JsonProperty("siddhiQuery")
+  @NotNull
   public String getSiddhiQuery() {
     return siddhiQuery;
   }
@@ -46,8 +47,9 @@ public class CustomRuleDTO extends ThrottlePolicyDTO  {
   }
 
   
-  @ApiModelProperty(example = "$userId", value = "The specific combination of attributes that are checked in the policy.")
+  @ApiModelProperty(example = "$userId", required = true, value = "The specific combination of attributes that are checked in the policy.")
   @JsonProperty("keyTemplate")
+  @NotNull
   public String getKeyTemplate() {
     return keyTemplate;
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ThrottlingApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ThrottlingApiServiceImpl.java
@@ -707,8 +707,19 @@ public class ThrottlingApiServiceImpl implements ThrottlingApiService {
     public Response throttlingPoliciesCustomPost(CustomRuleDTO body, String contentType,
                                                  MessageContext messageContext) {
 
+        String errorMessage;
+
+        //Check if the required fields are blank
         if (StringUtils.isBlank(body.getPolicyName())) {
-            String errorMessage = "Policy name of custom rule cannot be blank";
+            errorMessage = "Policy name of custom rule cannot be blank";
+            RestApiUtil.handleBadRequest(errorMessage, log);
+        }
+        if (StringUtils.isBlank(body.getSiddhiQuery())) {
+            errorMessage = "Siddhi Query of custom rule cannot be blank";
+            RestApiUtil.handleBadRequest(errorMessage, log);
+        }
+        if (StringUtils.isBlank(body.getKeyTemplate())) {
+            errorMessage = "Key Template of custom rule cannot be blank";
             RestApiUtil.handleBadRequest(errorMessage, log);
         }
 
@@ -735,10 +746,10 @@ public class ThrottlingApiServiceImpl implements ThrottlingApiService {
             CustomRuleDTO policyDTO = GlobalThrottlePolicyMappingUtil.fromGlobalThrottlePolicyToDTO(newGlobalPolicy);
             return Response.created(new URI(RestApiConstants.RESOURCE_PATH_THROTTLING_POLICIES_GLOBAL + "/" + policyDTO.getPolicyId())).entity(policyDTO).build();
         } catch (APIManagementException e) {
-            String errorMessage = "Error while adding a custom rule: " + body.getPolicyName();
+            errorMessage = "Error while adding a custom rule: " + body.getPolicyName();
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
         } catch (URISyntaxException e) {
-            String errorMessage = "Error while retrieving Global Throttle policy location : " + body.getPolicyName();
+            errorMessage = "Error while retrieving Global Throttle policy location : " + body.getPolicyName();
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
         }
         return null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ThrottlingApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ThrottlingApiServiceImpl.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.jaxrs.ext.MessageContext;
+import org.apache.cxf.message.Message;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.ParseException;
 import org.wso2.carbon.apimgt.api.APIManagementException;
@@ -708,23 +709,8 @@ public class ThrottlingApiServiceImpl implements ThrottlingApiService {
     public Response throttlingPoliciesCustomPost(CustomRuleDTO body, String contentType,
                                                  MessageContext messageContext) throws APIManagementException {
 
-        String propertyName;
-        //Check if the required fields are blank
-        if (StringUtils.isBlank(body.getPolicyName())) {
-            propertyName = "policyName";
-            throw new APIManagementException(propertyName + " property value of payload cannot be blank",
-                    ExceptionCodes.from(ExceptionCodes.BLANK_PROPERTY_VALUE, propertyName));
-        }
-        if (StringUtils.isBlank(body.getSiddhiQuery())) {
-            propertyName = "siddhiQuery";
-            throw new APIManagementException(propertyName + " property value of payload cannot be blank",
-                    ExceptionCodes.from(ExceptionCodes.BLANK_PROPERTY_VALUE, propertyName));
-        }
-        if (StringUtils.isBlank(body.getKeyTemplate())) {
-            propertyName = "keyTemplate";
-            throw new APIManagementException(propertyName + " property value of payload cannot be blank",
-                    ExceptionCodes.from(ExceptionCodes.BLANK_PROPERTY_VALUE, propertyName));
-        }
+        RestApiAdminUtils
+                .validateCustomRuleRequiredProperties(body, (String) messageContext.get(Message.HTTP_REQUEST_METHOD));
 
         try {
             APIProvider apiProvider = RestApiUtil.getLoggedInUserProvider();
@@ -810,7 +796,11 @@ public class ThrottlingApiServiceImpl implements ThrottlingApiService {
     @Override
     public Response throttlingPoliciesCustomRuleIdPut(String ruleId, CustomRuleDTO body, String contentType,
                                                       String ifMatch, String ifUnmodifiedSince,
-                                                      MessageContext messageContext) {
+                                                      MessageContext messageContext) throws APIManagementException {
+
+        RestApiAdminUtils
+                .validateCustomRuleRequiredProperties(body, (String) messageContext.get(Message.HTTP_REQUEST_METHOD));
+
         try {
             APIProvider apiProvider = RestApiUtil.getLoggedInUserProvider();
             String username = RestApiUtil.getLoggedInUsername();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/RestApiAdminUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/RestApiAdminUtils.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.BlockConditionsDTO;
 import org.wso2.carbon.apimgt.api.model.policy.Policy;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.CustomRuleDTO;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -88,7 +89,7 @@ public class RestApiAdminUtils {
         String propertyName;
 
         //policyName property is validated only for POST request
-        if (httpMethod.equalsIgnoreCase("POST")) {
+        if (httpMethod.equalsIgnoreCase(APIConstants.HTTP_POST)) {
             if (StringUtils.isBlank(customRuleDTO.getPolicyName())) {
                 propertyName = "policyName";
                 throw new APIManagementException(propertyName + " property value of payload cannot be blank",

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/RestApiAdminUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/RestApiAdminUtils.java
@@ -22,9 +22,11 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.BlockConditionsDTO;
 import org.wso2.carbon.apimgt.api.model.policy.Policy;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.CustomRuleDTO;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.File;
@@ -72,6 +74,38 @@ public class RestApiAdminUtils {
         String userTenantDomain = MultitenantUtils.getTenantDomain(user);
         return !StringUtils.isBlank(blockCondition.getTenantDomain()) && blockCondition.getTenantDomain()
                 .equals(userTenantDomain);
+    }
+
+    /**
+     * Validate the required properties of Custom Rule Policy
+     *
+     * @param customRuleDTO custom rule object to check
+     * @param httpMethod    HTTP method of the request
+     */
+    public static void validateCustomRuleRequiredProperties(CustomRuleDTO customRuleDTO, String httpMethod)
+            throws APIManagementException {
+
+        String propertyName;
+
+        //policyName property is validated only for POST request
+        if (httpMethod.equalsIgnoreCase("POST")) {
+            if (StringUtils.isBlank(customRuleDTO.getPolicyName())) {
+                propertyName = "policyName";
+                throw new APIManagementException(propertyName + " property value of payload cannot be blank",
+                        ExceptionCodes.from(ExceptionCodes.BLANK_PROPERTY_VALUE, propertyName));
+            }
+        }
+
+        if (StringUtils.isBlank(customRuleDTO.getSiddhiQuery())) {
+            propertyName = "siddhiQuery";
+            throw new APIManagementException(propertyName + " property value of payload cannot be blank",
+                    ExceptionCodes.from(ExceptionCodes.BLANK_PROPERTY_VALUE, propertyName));
+        }
+        if (StringUtils.isBlank(customRuleDTO.getKeyTemplate())) {
+            propertyName = "keyTemplate";
+            throw new APIManagementException(propertyName + " property value of payload cannot be blank",
+                    ExceptionCodes.from(ExceptionCodes.BLANK_PROPERTY_VALUE, propertyName));
+        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/RestApiAdminUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/RestApiAdminUtils.java
@@ -82,12 +82,12 @@ public class RestApiAdminUtils {
      *
      * @param customRuleDTO custom rule object to check
      * @param httpMethod    HTTP method of the request
+     * @throws APIManagementException if a required property validation fails
      */
     public static void validateCustomRuleRequiredProperties(CustomRuleDTO customRuleDTO, String httpMethod)
             throws APIManagementException {
 
         String propertyName;
-
         //policyName property is validated only for POST request
         if (httpMethod.equalsIgnoreCase(APIConstants.HTTP_POST)) {
             if (StringUtils.isBlank(customRuleDTO.getPolicyName())) {
@@ -96,7 +96,6 @@ public class RestApiAdminUtils {
                         ExceptionCodes.from(ExceptionCodes.BLANK_PROPERTY_VALUE, propertyName));
             }
         }
-
         if (StringUtils.isBlank(customRuleDTO.getSiddhiQuery())) {
             propertyName = "siddhiQuery";
             throw new APIManagementException(propertyName + " property value of payload cannot be blank",

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -4193,12 +4193,12 @@ definitions:
 #-----------------------------------------------------
   CustomRule:
     title: Custom Rule
-    required:
-      - siddhiQuery
-      - keyTemplate
     allOf:
       - $ref: '#/definitions/ThrottlePolicy'
-      - properties:
+      - required:
+        - siddhiQuery
+        - keyTemplate
+        properties:
           siddhiQuery:
             type: string
             description: Siddhi query which represents the custom throttling policy


### PR DESCRIPTION
### Purpose
This PR contains functionality which validates the following when creating Custom Policies.
1. siddhiQuery field is required
2. siddhiQuery field cannot be blank
3. keyTemplate field is required
4. keyTemplate field cannot be blank
5. policyName field cannot be blank

Fixes: https://github.com/wso2/product-apim/issues/8198