### PR TITLE
Fix service-catalog/entry displayName update issue and Refractor RegistriesApiServiceImpl

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/endpoint/registry/impl/EndpointRegistryImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/endpoint/registry/impl/EndpointRegistryImpl.java
@@ -66,6 +66,12 @@ public class EndpointRegistryImpl implements EndpointRegistry {
         try {
             tenantId = ServiceReferenceHolder.getInstance().getRealmService().getTenantManager()
                     .getTenantId(tenantDomain);
+
+            // If the displayName is empty, set the registryName as the displayName
+            if (StringUtils.isEmpty(endpointRegistry.getDisplayName())) {
+                endpointRegistry.setDisplayName(endpointRegistry.getName());
+            }
+
             // if another registry with the given name or type already exists, fail the operation.
             if (registryDAO.isEndpointRegistryTypeExists(endpointRegistry.getType(), tenantId)) {
                 EndpointRegistryUtil.raiseResourceAlreadyExistsException("Endpoint Registry of type '"
@@ -92,7 +98,7 @@ public class EndpointRegistryImpl implements EndpointRegistry {
      * Returns details of an Endpoint Registry
      *
      * @param registryId   Registry Identifier
-     * @param tenantDomain
+     * @param tenantDomain Tenant domain
      * @return An EndpointRegistryInfo object related to the given identifier or null
      * @throws EndpointRegistryException if failed to get details of an Endpoint Registry
      */
@@ -126,7 +132,7 @@ public class EndpointRegistryImpl implements EndpointRegistry {
     /**
      * Returns details of all Endpoint Registries belong to a given tenant
      *
-     * @param tenantDomain
+     * @param tenantDomain Tenant domain
      * @return A list of EndpointRegistryInfo objects
      * @throws EndpointRegistryException if failed to get details of an Endpoint Registries
      */
@@ -190,6 +196,11 @@ public class EndpointRegistryImpl implements EndpointRegistry {
      */
     public String addEndpointRegistryEntry(EndpointRegistryEntry registryEntry) throws EndpointRegistryException {
 
+        // If the displayName is empty, set the entryName as the displayName
+        if (StringUtils.isEmpty(registryEntry.getDisplayName())) {
+            registryEntry.setDisplayName(registryEntry.getEntryName());
+        }
+
         if (registryDAO.isRegistryEntryNameExists(registryEntry, false)) {
             EndpointRegistryUtil.raiseResourceAlreadyExistsException("Endpoint Registry Entry with name '"
                     + registryEntry.getEntryName() + "' already exists");
@@ -209,6 +220,11 @@ public class EndpointRegistryImpl implements EndpointRegistry {
      */
     public void updateEndpointRegistryEntry(String displayName, EndpointRegistryEntry registryEntry)
             throws EndpointRegistryException {
+
+        // If the displayName is empty, set the old displayName
+        if (StringUtils.isEmpty(registryEntry.getDisplayName())) {
+            registryEntry.setDisplayName(displayName);
+        }
 
         if (!displayName.equals(registryEntry.getDisplayName()) &&
                 registryDAO.isRegistryEntryNameExists(registryEntry, true)) {
@@ -241,6 +257,12 @@ public class EndpointRegistryImpl implements EndpointRegistry {
         try {
             tenantId = ServiceReferenceHolder.getInstance().getRealmService().getTenantManager()
                     .getTenantId(tenantDomain);
+
+            // If the displayName is empty, set the old displayName
+            if (StringUtils.isEmpty(endpointRegistryInfo.getDisplayName())) {
+                endpointRegistryInfo.setDisplayName(registryDisplayName);
+            }
+
             // if another registry with the updated name or type already exists, fail the operation.
             if (!registryType.equals(endpointRegistryInfo.getType()) &&
                     registryDAO.isEndpointRegistryTypeExists(endpointRegistryInfo.getType(), tenantId)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/endpoint/registry/impl/EndpointRegistryImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/endpoint/registry/impl/EndpointRegistryImpl.java
@@ -67,11 +67,6 @@ public class EndpointRegistryImpl implements EndpointRegistry {
             tenantId = ServiceReferenceHolder.getInstance().getRealmService().getTenantManager()
                     .getTenantId(tenantDomain);
 
-            // If the displayName is empty, set the registryName as the displayName
-            if (StringUtils.isEmpty(endpointRegistry.getDisplayName())) {
-                endpointRegistry.setDisplayName(endpointRegistry.getName());
-            }
-
             // if another registry with the given name or type already exists, fail the operation.
             if (registryDAO.isEndpointRegistryTypeExists(endpointRegistry.getType(), tenantId)) {
                 EndpointRegistryUtil.raiseResourceAlreadyExistsException("Endpoint Registry of type '"
@@ -196,11 +191,6 @@ public class EndpointRegistryImpl implements EndpointRegistry {
      */
     public String addEndpointRegistryEntry(EndpointRegistryEntry registryEntry) throws EndpointRegistryException {
 
-        // If the displayName is empty, set the entryName as the displayName
-        if (StringUtils.isEmpty(registryEntry.getDisplayName())) {
-            registryEntry.setDisplayName(registryEntry.getEntryName());
-        }
-
         if (registryDAO.isRegistryEntryNameExists(registryEntry, false)) {
             EndpointRegistryUtil.raiseResourceAlreadyExistsException("Endpoint Registry Entry with name '"
                     + registryEntry.getEntryName() + "' already exists");
@@ -220,11 +210,6 @@ public class EndpointRegistryImpl implements EndpointRegistry {
      */
     public void updateEndpointRegistryEntry(String displayName, EndpointRegistryEntry registryEntry)
             throws EndpointRegistryException {
-
-        // If the displayName is empty, set the old displayName
-        if (StringUtils.isEmpty(registryEntry.getDisplayName())) {
-            registryEntry.setDisplayName(displayName);
-        }
 
         if (!displayName.equals(registryEntry.getDisplayName()) &&
                 registryDAO.isRegistryEntryNameExists(registryEntry, true)) {
@@ -257,11 +242,6 @@ public class EndpointRegistryImpl implements EndpointRegistry {
         try {
             tenantId = ServiceReferenceHolder.getInstance().getRealmService().getTenantManager()
                     .getTenantId(tenantDomain);
-
-            // If the displayName is empty, set the old displayName
-            if (StringUtils.isEmpty(endpointRegistryInfo.getDisplayName())) {
-                endpointRegistryInfo.setDisplayName(registryDisplayName);
-            }
 
             // if another registry with the updated name or type already exists, fail the operation.
             if (!registryType.equals(endpointRegistryInfo.getType()) &&

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/EndpointRegistryImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/EndpointRegistryImplTest.java
@@ -319,6 +319,7 @@ public class EndpointRegistryImplTest {
         endpointRegistryInfo.setUuid("abc1");
         endpointRegistryInfo.setRegistryId(1);
         endpointRegistryInfo.setName("Endpoint Registry 1");
+        endpointRegistryInfo.setDisplayName("Endpoint Registry 1");
         endpointRegistryInfo.setType("wso2");
         endpointRegistryInfo.setOwner(ADMIN_USERNAME);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.endpoint.registry/src/main/java/org/wso2/carbon/apimgt/rest/api/endpoint/registry/impl/RegistriesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.endpoint.registry/src/main/java/org/wso2/carbon/apimgt/rest/api/endpoint/registry/impl/RegistriesApiServiceImpl.java
@@ -142,6 +142,7 @@ public class RegistriesApiServiceImpl implements RegistriesApiService {
         EndpointRegistryInfo registry = EndpointRegistryMappingUtils.fromDTOtoEndpointRegistry(body, user);
         try {
             EndpointRegistry registryProvider = new EndpointRegistryImpl(user);
+            EndpointRegistryMappingUtils.updateDisplayName(registry, null);
             String registryId = registryProvider.addEndpointRegistry(registry);
             EndpointRegistryInfo createdRegistry = registryProvider.getEndpointRegistryByUUID(registryId, tenantDomain);
 
@@ -170,6 +171,7 @@ public class RegistriesApiServiceImpl implements RegistriesApiService {
             InputStream definitionFile = validateAndRetrieveDefinition(definitionFileInputStream, registryEntry);
             EndpointRegistryEntry entryToAdd = EndpointRegistryMappingUtils.fromDTOToRegistryEntry(registryEntry,
                     null, definitionFile, endpointRegistry.getRegistryId());
+            EndpointRegistryMappingUtils.updateDisplayName(entryToAdd, null);
             String entryId = registryProvider.addEndpointRegistryEntry(entryToAdd);
             EndpointRegistryEntry createdEntry = registryProvider.getEndpointRegistryEntryByUUID(registryId, entryId);
             audit.info("Successfully created endpoint registry entry with id :" + createdEntry.getEntryId() +
@@ -197,6 +199,7 @@ public class RegistriesApiServiceImpl implements RegistriesApiService {
         EndpointRegistryInfo registryToUpdate = EndpointRegistryMappingUtils.fromDTOtoEndpointRegistry(body, user);
         try {
             EndpointRegistryInfo endpointRegistry = getEndpointRegistry(registryId, tenantDomain, registryProvider);
+            EndpointRegistryMappingUtils.updateDisplayName(registryToUpdate, endpointRegistry.getDisplayName());
             registryProvider.updateEndpointRegistry(registryId, endpointRegistry.getDisplayName(),
                     endpointRegistry.getType(), registryToUpdate);
             EndpointRegistryInfo updatedEndpointRegistry
@@ -265,7 +268,7 @@ public class RegistriesApiServiceImpl implements RegistriesApiService {
             InputStream definitionFile = validateAndRetrieveDefinition(definitionFileInputStream, registryEntry);
             EndpointRegistryEntry entryToUpdate = EndpointRegistryMappingUtils.fromDTOToRegistryEntry(registryEntry,
                     entryId, definitionFile, endpointRegistry.getRegistryId());
-
+            EndpointRegistryMappingUtils.updateDisplayName(entryToUpdate, endpointRegistryEntry.getDisplayName());
             registryProvider.updateEndpointRegistryEntry(endpointRegistryEntry.getDisplayName(), entryToUpdate);
 
             EndpointRegistryEntry updatedEntry = registryProvider.getEndpointRegistryEntryByUUID(registryId, entryId);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.endpoint.registry/src/main/java/org/wso2/carbon/apimgt/rest/api/endpoint/registry/util/EndpointRegistryMappingUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.endpoint.registry/src/main/java/org/wso2/carbon/apimgt/rest/api/endpoint/registry/util/EndpointRegistryMappingUtils.java
@@ -189,4 +189,39 @@ public class EndpointRegistryMappingUtils {
         return filterParams;
     }
 
+    /**
+     * Updates the displayName in a given EndpointRegistryInfo
+     *
+     * @param endpointRegistryInfo EndpointRegistryInfo object
+     * @param oldDisplayName       Old display name
+     */
+    public static void updateDisplayName(EndpointRegistryInfo endpointRegistryInfo, String oldDisplayName) {
+        if (StringUtils.isEmpty(endpointRegistryInfo.getDisplayName())) {
+            if (StringUtils.isNotEmpty(oldDisplayName)) {
+                // If the displayName is empty, set the old displayName
+                endpointRegistryInfo.setDisplayName(oldDisplayName);
+            } else {
+                // If the displayName is empty, set the registryName as the displayName
+                endpointRegistryInfo.setDisplayName(endpointRegistryInfo.getName());
+            }
+        }
+    }
+
+    /**
+     * Updates the displayName in a given EndpointRegistryEntry
+     *
+     * @param registryEntry  EndpointRegistryEntry object
+     * @param oldDisplayName Old display name
+     */
+    public static void updateDisplayName(EndpointRegistryEntry registryEntry, String oldDisplayName) {
+        if (StringUtils.isEmpty(registryEntry.getDisplayName())) {
+            if (StringUtils.isNotEmpty(oldDisplayName)) {
+                // If the displayName is empty, set the old displayName
+                registryEntry.setDisplayName(oldDisplayName);
+            } else {
+                // If the displayName is empty, set the entryName as the displayName
+                registryEntry.setDisplayName(registryEntry.getEntryName());
+            }
+        }
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.endpoint.registry/src/main/java/org/wso2/carbon/apimgt/rest/api/endpoint/registry/util/EndpointRegistryMappingUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.endpoint.registry/src/main/java/org/wso2/carbon/apimgt/rest/api/endpoint/registry/util/EndpointRegistryMappingUtils.java
@@ -63,11 +63,7 @@ public class EndpointRegistryMappingUtils {
         RegistryDTO registryDTO = new RegistryDTO();
         registryDTO.setId(registry.getUuid());
         registryDTO.setName(registry.getName());
-        if (StringUtils.isEmpty(registry.getDisplayName())) {
-            registryDTO.setDisplayName(registry.getName());
-        } else {
-            registryDTO.setDisplayName(registry.getDisplayName());
-        }
+        registryDTO.setDisplayName(registry.getDisplayName());
         registryDTO.setType(RegistryDTO.TypeEnum.fromValue(registry.getType()));
         registryDTO.setOwner(registry.getOwner());
         return registryDTO;
@@ -109,11 +105,7 @@ public class EndpointRegistryMappingUtils {
         EndpointRegistryEntry registryEntry = new EndpointRegistryEntry();
         registryEntry.setEntryId(entryUUID);
         registryEntry.setEntryName(registryEntryDTO.getEntryName());
-        if (StringUtils.isEmpty(registryEntryDTO.getDisplayName())) {
-            registryEntry.setDisplayName(registryEntryDTO.getEntryName());
-        } else {
-            registryEntry.setDisplayName(registryEntryDTO.getDisplayName());
-        }
+        registryEntry.setDisplayName(registryEntryDTO.getDisplayName());
         registryEntry.setVersion(registryEntryDTO.getVersion());
         registryEntry.setDescription(registryEntryDTO.getDescription());
         if (registryEntryDTO.getDefinitionType() != null) {


### PR DESCRIPTION
- Refractor **RegistriesApiServiceImpl** class
  - Introduced private methods to check the existence of Registry/Entry
  - Moved endpoint definition retrieving and validation to a new method

- Fix service-catalog/entry **displayName** update issue
  - With new implementation, if a user does not send displayName in the payload(during an update resource call), the current displayName will not be updated