### PR TITLE
Add apim:bot_data scope to tenant-conf.json

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -240,6 +240,10 @@
       {
         "Name": "apim:admin_alert_manage",
         "Roles": "admin"
+      },
+      {
+        "Name": "apim:bot_data",
+        "Roles": "admin"
       }
     ]
   },

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json
@@ -232,6 +232,10 @@
       {
         "Name": "apim:admin_alert_manage",
         "Roles": "admin"
+      },
+      {
+        "Name": "apim:bot_data",
+        "Roles": "admin"
       }
     ]
   },


### PR DESCRIPTION
### Purpose
Add apim:bot_data scope and associated role to tenant-conf.json

### Approach
```
{
    "Name": "apim:bot_data", 
    "Roles": "admin"
}
```
Added the above mentioned scope to role mapping to the following files.
1. components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
2. components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json