### PR TITLE
Restrict admin settings API content for anonymous user

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SettingsApiServiceImpl.java
@@ -44,11 +44,11 @@ public class SettingsApiServiceImpl implements SettingsApiService {
      *
      * @param messageContext
      * @return settings list
+     * @throws APIManagementException
      */
     @Override
-    public Response settingsGet(MessageContext messageContext) {
+    public Response settingsGet(MessageContext messageContext) throws APIManagementException {
 
-        try {
             String username = RestApiUtil.getLoggedInUsername();
             boolean isUserAvailable = false;
             if (!APIConstants.WSO2_ANONYMOUS_USER.equalsIgnoreCase(username)) {
@@ -57,11 +57,6 @@ public class SettingsApiServiceImpl implements SettingsApiService {
             SettingsMappingUtil settingsMappingUtil = new SettingsMappingUtil();
             SettingsDTO settingsDTO = settingsMappingUtil.fromSettingsToDTO(isUserAvailable);
             return Response.ok().entity(settingsDTO).build();
-        } catch (APIManagementException e) {
-            String errorMessage = "Error while retrieving Admin Settings";
-            RestApiUtil.handleInternalServerError(errorMessage, e, log);
-        }
-        return null;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SettingsApiServiceImpl.java
@@ -39,8 +39,15 @@ public class SettingsApiServiceImpl implements SettingsApiService {
 
     private static final Log log = LogFactory.getLog(SettingsApiServiceImpl.class);
 
+    /**
+     * Retrieves admin portal related server settings
+     *
+     * @param messageContext
+     * @return settings list
+     */
     @Override
     public Response settingsGet(MessageContext messageContext) {
+
         try {
             String username = RestApiUtil.getLoggedInUsername();
             boolean isUserAvailable = false;
@@ -48,7 +55,7 @@ public class SettingsApiServiceImpl implements SettingsApiService {
                 isUserAvailable = true;
             }
             SettingsMappingUtil settingsMappingUtil = new SettingsMappingUtil();
-            SettingsDTO settingsDTO = settingsMappingUtil.fromSettingstoDTO(isUserAvailable);
+            SettingsDTO settingsDTO = settingsMappingUtil.fromSettingsToDTO(isUserAvailable);
             return Response.ok().entity(settingsDTO).build();
         } catch (APIManagementException e) {
             String errorMessage = "Error while retrieving Admin Settings";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
@@ -54,11 +54,14 @@ public class SettingsMappingUtil {
      * @return SettingsDTO
      * @throws APIManagementException
      */
-    public SettingsDTO fromSettingstoDTO(Boolean isUserAvailable) throws APIManagementException {
+    public SettingsDTO fromSettingsToDTO(Boolean isUserAvailable) throws APIManagementException {
+
         SettingsDTO settingsDTO = new SettingsDTO();
-        settingsDTO.setScopes(GetScopeList());
-        settingsDTO.setAnalyticsEnabled(APIUtil.isAnalyticsEnabled());
-        settingsDTO.setKeyManagerConfiguration(getSettingsKeyManagerConfigurationDTOList());
+        if (isUserAvailable) {
+            settingsDTO.setAnalyticsEnabled(APIUtil.isAnalyticsEnabled());
+            settingsDTO.setKeyManagerConfiguration(getSettingsKeyManagerConfigurationDTOList());
+        }
+        settingsDTO.setScopes(getScopeList());
         return settingsDTO;
     }
 
@@ -74,7 +77,7 @@ public class SettingsMappingUtil {
         return list;
     }
 
-    private List<String> GetScopeList() throws APIManagementException {
+    private List<String> getScopeList() throws APIManagementException {
         String definition = null;
         try {
             definition = IOUtils


### PR DESCRIPTION
### Purpose
The admin Settings REST API is a white-listed API which means that an access token is not required to invoke the API. Hence anonymous users also can invoke the admin settings API. This PR restricts the settings API to return only the scopes when an anonymous user invokes the API.