### PR TITLE
Adding null check for API Product Username and Password

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/template/SecurityConfigContext.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/template/SecurityConfigContext.java
@@ -173,8 +173,8 @@ public class SecurityConfigContext extends ConfigContextDecorator {
                         endpointSecurityModel.setType(endpointSecurityEntry.getValue().getType());
                         endpointSecurityModel
                                 .setAdditionalProperties(endpointSecurityEntry.getValue().getAdditionalProperties());
-                        if (endpointSecurityModel.getUsername() != null &&
-                        endpointSecurityModel.getPassword() != null) {
+                        if (!StringUtils.isEmpty(endpointSecurityModel.getUsername()) &&
+                        !StringUtils.isEmpty(endpointSecurityModel.getPassword())) {
                             endpointSecurityModel.setBase64EncodedPassword(new String(Base64.encodeBase64(
                                     endpointSecurityModel.getUsername().concat(":")
                                             .concat(endpointSecurityModel.getPassword())

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/template/SecurityConfigContext.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/template/SecurityConfigContext.java
@@ -173,10 +173,13 @@ public class SecurityConfigContext extends ConfigContextDecorator {
                         endpointSecurityModel.setType(endpointSecurityEntry.getValue().getType());
                         endpointSecurityModel
                                 .setAdditionalProperties(endpointSecurityEntry.getValue().getAdditionalProperties());
-                        endpointSecurityModel.setBase64EncodedPassword(new String(Base64.encodeBase64(
-                                endpointSecurityModel.getUsername().concat(":")
-                                        .concat(endpointSecurityModel.getPassword())
-                                        .getBytes())));
+                        if (endpointSecurityModel.getUsername() != null &&
+                        endpointSecurityModel.getPassword() != null) {
+                            endpointSecurityModel.setBase64EncodedPassword(new String(Base64.encodeBase64(
+                                    endpointSecurityModel.getUsername().concat(":")
+                                            .concat(endpointSecurityModel.getPassword())
+                                            .getBytes())));
+                        }
                         endpointSecurityModel.setAlias(alias.concat("--").concat(endpointSecurityEntry.getKey()));
 
                         if (endpointSecurityEntry.getValue().getType()


### PR DESCRIPTION
Adding null check for API Product Username and Password. Will potentially fix API Product Creation Test failures.