### PR TITLE
Fixing Application import issue when there are APIs with similar names

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/ApplicationImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/ApplicationImportExportManager.java
@@ -118,15 +118,16 @@ public class ApplicationImportExportManager {
             if (!StringUtils.isEmpty(tenantDomain) && APIUtil.isTenantAvailable(tenantDomain)) {
                 String name = apiIdentifier.getApiName();
                 String version = apiIdentifier.getVersion();
-                //creating a solr compatible search query
+                //creating a solr compatible search query, here we will execute a search query without wildcard *s
                 StringBuilder searchQuery = new StringBuilder();
                 String[] searchCriteria = {name, "version:" + version};
                 for (int i = 0; i < searchCriteria.length; i++) {
                     if (i == 0) {
-                        searchQuery = new StringBuilder(APIUtil.getSingleSearchCriteria(searchCriteria[i]));
+                        searchQuery = new StringBuilder(
+                                APIUtil.getSingleSearchCriteria(searchCriteria[i]).replace("*", ""));
                     } else {
                         searchQuery.append(APIConstants.SEARCH_AND_TAG)
-                                .append(APIUtil.getSingleSearchCriteria(searchCriteria[i]));
+                                .append(APIUtil.getSingleSearchCriteria(searchCriteria[i]).replace("*", ""));
                     }
                 }
                 Map matchedAPIs;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/ApplicationImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/utils/ApplicationImportExportManager.java
@@ -128,15 +128,16 @@ public class ApplicationImportExportManager {
             if (!StringUtils.isEmpty(tenantDomain) && APIUtil.isTenantAvailable(tenantDomain)) {
                 String name = apiIdentifier.getApiName();
                 String version = apiIdentifier.getVersion();
-                //creating a solr compatible search query
+                //creating a solr compatible search query, here we will execute a search query without wildcards
                 StringBuilder searchQuery = new StringBuilder();
                 String[] searchCriteria = {name, "version:" + version};
                 for (int i = 0; i < searchCriteria.length; i++) {
                     if (i == 0) {
-                        searchQuery = new StringBuilder(APIUtil.getSingleSearchCriteria(searchCriteria[i]));
+                        searchQuery = new StringBuilder(
+                                APIUtil.getSingleSearchCriteria(searchCriteria[i]).replace("*", ""));
                     } else {
                         searchQuery.append(APIConstants.SEARCH_AND_TAG)
-                                .append(APIUtil.getSingleSearchCriteria(searchCriteria[i]));
+                                .append(APIUtil.getSingleSearchCriteria(searchCriteria[i]).replace("*", ""));
                     }
                 }
                 Map matchedAPIs;


### PR DESCRIPTION
Fixes https://github.com/wso2/product-apim/issues/7840

When there are APIs with similar names in the requested tenant domain, the wildcard search query,
```name=*apiName*&version=*apiVersion*``` will return all matching APIs in the search result leading to issues. But in fact we need only the exact match for the name and version. Hence removing the wildcard from the search query.