### PR TITLE
Fix for #8760

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -1317,10 +1317,10 @@ public class OAS2Parser extends APIDefinition {
                     securityDefinitions.put(SWAGGER_SECURITY_SCHEMA_KEY, defaultTypeFlow);
                 }
             }
+            //update list of security schemes in the swagger object
+            swagger.setSecurityDefinitions(securityDefinitions);
         }
-        //update list of security schemes in the swagger object
         setOtherSchemes(otherSetOfSchemes);
-        swagger.setSecurityDefinitions(securityDefinitions);
         return swagger;
     }
 
@@ -1353,7 +1353,6 @@ public class OAS2Parser extends APIDefinition {
                         opScopesDefault.addAll(opScopesDefaultInstance);
                     }
                     updatedDefaultSecurityRequirement.put(SWAGGER_SECURITY_SCHEMA_KEY, opScopesDefault);
-                    securityRequirements.add(updatedDefaultSecurityRequirement);
                     for (Map<String, List<String>> input : securityRequirements) {
                         for (String scheme : schemes) {
                             if (!SWAGGER_SECURITY_SCHEMA_KEY.equals(scheme)) {
@@ -1368,10 +1367,8 @@ public class OAS2Parser extends APIDefinition {
                             }
                             updatedDefaultSecurityRequirement.put(SWAGGER_SECURITY_SCHEMA_KEY, opScopesDefault);
                         }
-                        if (input.containsKey(SWAGGER_SECURITY_SCHEMA_KEY)) {
-                            input = updatedDefaultSecurityRequirement;
-                        }
                     }
+                    securityRequirements.add(updatedDefaultSecurityRequirement);
                 }
                 operation.setSecurity(securityRequirements);
                 entry.setValue(operation);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1343,7 +1343,7 @@ public class OAS3Parser extends APIDefinition {
      * @throws APIManagementException
      */
     private OpenAPI injectOtherScopesToDefaultScheme(OpenAPI openAPI) throws APIManagementException {
-        Map<String, SecurityScheme> securitySchemes = null;
+        Map<String, SecurityScheme> securitySchemes ;
         Components component = openAPI.getComponents();
         List<String> otherSetOfSchemes = new ArrayList<>();
 
@@ -1395,9 +1395,9 @@ public class OAS3Parser extends APIDefinition {
                     defaultType.setFlows(defaultTypeFlows);
                 }
             }
+            component.setSecuritySchemes(securitySchemes);
+            openAPI.setComponents(component);
         }
-        component.setSecuritySchemes(securitySchemes);
-        openAPI.setComponents(component);
         setOtherSchemes(otherSetOfSchemes);
         return openAPI;
     }


### PR DESCRIPTION
### Purpose:
When importing an OAS definition using publisher portal or apictl, product throws a null pointer exception when the given OAS definition doesn't contain any scopes.

```
2020-06-16 11:51:10,835] ERROR - GlobalThrowableMapper An unknown exception has been captured by the global exception mapper.
java.lang.NullPointerException: null
	at org.wso2.carbon.apimgt.impl.definitions.OAS3Parser.injectOtherScopesToDefaultScheme_aroundBody88(OAS3Parser.java:1399) ~[org.wso2.carbon.apimgt.impl_6.7.10.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.definitions.OAS3Parser.injectOtherScopesToDefaultScheme(OAS3Parser.java:1345) ~[org.wso2.carbon.apimgt.impl_6.7.10.SNAPSHOT.jar:?]
```
 
This occurs due to lack of check conditions to check whether _Components_ and _securityDefinitions_ are null or not in the given definition.
This PR will resolve this issue.

## Goals
Fixes https://github.com/wso2/carbon-apimgt/issues/8760

## User stories
* Importing external swagger 2 definitions through API CTL.
* Importing external swagger 3 definitions through API CTL.
* Importing external swagger 2 definitions through API publisher UI or using curl commands.
* Importing external swagger 3 definitions through API  publisher UI or using curl commands.

## Test environment
macOS Catalina 10.15.5
Java 1.8_241

