### PR TITLE
Added tags to API artifact in registry.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -8111,6 +8111,13 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             // Make the LC status of the API Product published by default
             saveAPIStatus(artifactPath, APIConstants.PUBLISHED);
 
+            Set<String> tagSet = apiProduct.getTags();
+            if (tagSet != null) {
+                for (String tag : tagSet) {
+                    registry.applyTag(artifactPath, tag);
+                }
+            }
+
             String visibleRolesList = apiProduct.getVisibleRoles();
             String[] visibleRoles = new String[0];
             if (visibleRolesList != null) {


### PR DESCRIPTION
Fix wso2/product-apim/issues/8210

Created an API product via "POST /api/am/publisher/v1/api-products" by providing sample tags in the payload.
"tags": [ "product", "test" ]
The response contains the tags that we give in the payload, and it is visible in dev portal.