### PR TITLE
[UI] Admin portal Initial validation error fix

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/APICategories/AddEditAPICategory.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/APICategories/AddEditAPICategory.jsx
@@ -56,7 +56,6 @@ function AddEdit(props) {
 
     let id = null;
     let initialState = {
-        name: undefined,
         description: '',
     };
 

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/APICategories/AddEditAPICategory.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/APICategories/AddEditAPICategory.jsx
@@ -56,7 +56,7 @@ function AddEdit(props) {
 
     let id = null;
     let initialState = {
-        name: '',
+        name: undefined,
         description: '',
     };
 
@@ -81,6 +81,10 @@ function AddEdit(props) {
         let error;
         switch (fieldName) {
             case 'name':
+                if (value === undefined) {
+                    error = false;
+                    break;
+                }
                 if (value === '') {
                     error = 'Name is Empty';
                 } else if (/\s/.test(value)) {
@@ -98,7 +102,13 @@ function AddEdit(props) {
     };
     const getAllFormErrors = () => {
         let errorText = '';
-        const NameErrors = hasErrors('name', name);
+        let NameErrors;
+        if (name === undefined) {
+            dispatch({ field: 'name', value: '' });
+            NameErrors = hasErrors('name', '');
+        } else {
+            NameErrors = hasErrors('name', name);
+        }
         if (NameErrors) {
             errorText += NameErrors + '\n';
         }

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/AdminPages/Addons/InputListBase.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/AdminPages/Addons/InputListBase.jsx
@@ -56,13 +56,13 @@ const InputList = (props) => {
             setId(i);
         } else {
             setId(id + 1);
-            setUserInputItems([{ key: '' + id, value: '', error: onValidation('') }]);
+            setUserInputItems([{ key: '' + id, value: '', error: onValidation(undefined) }]);
         }
     }, []);
 
     const onAddInputField = () => {
         setId(id + 1);
-        const newUserItemList = [...userInputItems, { key: '' + id, value: '', error: onValidation('') }];
+        const newUserItemList = [...userInputItems, { key: '' + id, value: '', error: onValidation(undefined) }];
         setUserInputItems(newUserItemList);
     };
 

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/AdminPages/Addons/InputListBase.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/AdminPages/Addons/InputListBase.jsx
@@ -56,13 +56,13 @@ const InputList = (props) => {
             setId(i);
         } else {
             setId(id + 1);
-            setUserInputItems([{ key: '' + id, value: '', error: onValidation(undefined) }]);
+            setUserInputItems([{ key: '' + id, value: '' }]);
         }
     }, []);
 
     const onAddInputField = () => {
         setId(id + 1);
-        const newUserItemList = [...userInputItems, { key: '' + id, value: '', error: onValidation(undefined) }];
+        const newUserItemList = [...userInputItems, { key: '' + id, value: '' }];
         setUserInputItems(newUserItemList);
     };
 

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/BotDetection/EmailConfig/AddEmail.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/BotDetection/EmailConfig/AddEmail.jsx
@@ -75,6 +75,10 @@ function AddEmail(props) {
     };
 
     const formSaveCallback = () => {
+        if (email === undefined) {
+            setEmail('');
+            return false;
+        }
         const validationErrors = validateEmail(email);
         if (validationErrors) {
             Alert.error(validationErrors);

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/BotDetection/EmailConfig/AddEmail.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/BotDetection/EmailConfig/AddEmail.jsx
@@ -43,16 +43,18 @@ function AddEmail(props) {
         updateList, icon, triggerButtonText, title, emailList,
     } = props;
     const classes = useStyles();
-    const [email, setEmail] = useState('');
+    const [email, setEmail] = useState();
 
     const onChange = (e) => {
         setEmail(e.target.value);
     };
 
-    const validateEmail = (value) => {
+    const validateEmail = () => {
+        if (email === undefined) {
+            return false;
+        }
         const schema = Joi.string().email().empty();
-        const validationError = schema.validate(value).error;
-
+        const validationError = schema.validate(email).error;
         if (validationError) {
             const errorType = validationError.details[0].type;
             if (errorType === 'any.empty') {
@@ -127,8 +129,8 @@ function AddEmail(props) {
                     </span>
                 )}
                 fullWidth
-                error={validateEmail(email)}
-                helperText={validateEmail(email) || 'Enter Email address'}
+                error={validateEmail()}
+                helperText={validateEmail() || 'Enter Email address'}
                 variant='outlined'
             />
         </FormDialogBase>

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/MicrogatewayLabels/AddEditMGLabel.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/MicrogatewayLabels/AddEditMGLabel.jsx
@@ -64,7 +64,6 @@ function AddEditMGLabel(props) {
 
     let id = null;
     let initialState = {
-        name: undefined,
         description: '',
         hosts: [],
     };

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/MicrogatewayLabels/AddEditMGLabel.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/MicrogatewayLabels/AddEditMGLabel.jsx
@@ -64,7 +64,7 @@ function AddEditMGLabel(props) {
 
     let id = null;
     let initialState = {
-        name: '',
+        name: undefined,
         description: '',
         hosts: [],
     };
@@ -89,6 +89,9 @@ function AddEditMGLabel(props) {
     };
 
     const handleHostValidation = (hostName) => {
+        if (hostName === undefined) {
+            return false;
+        }
         const schema = Joi.string().uri().empty();
         const validationError = schema.validate(hostName).error;
 
@@ -107,6 +110,10 @@ function AddEditMGLabel(props) {
         let error;
         switch (fieldName) {
             case 'name':
+                if (name === undefined) {
+                    error = false;
+                    break;
+                }
                 if (value === '') {
                     error = 'Name is Empty';
                 } else if (/\s/.test(value)) {
@@ -118,6 +125,10 @@ function AddEditMGLabel(props) {
                 }
                 break;
             case 'hosts':
+                if (hosts === undefined) {
+                    error = false;
+                    break;
+                }
                 if (value.length === 0) {
                     error = 'Host is empty';
                     break;
@@ -136,6 +147,9 @@ function AddEditMGLabel(props) {
     };
     const getAllFormErrors = () => {
         let errorText = '';
+        if (name === undefined) {
+            dispatch({ field: 'name', value: '' });
+        }
         const NameErrors = hasErrors('name', name);
         const hostErrors = hasErrors('hosts', hosts);
         if (NameErrors) {

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/MicrogatewayLabels/AddEditMGLabel.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/MicrogatewayLabels/AddEditMGLabel.jsx
@@ -110,7 +110,7 @@ function AddEditMGLabel(props) {
         let error;
         switch (fieldName) {
             case 'name':
-                if (name === undefined) {
+                if (value === undefined) {
                     error = false;
                     break;
                 }


### PR DESCRIPTION
### Description

On the Admin Portal, when a Add popup is displayed, errors will be shown on mandatory fields (Field is empty).
**Expected behavior:** Validation should start after the user has started entering values.

This PR fixes the mentioned behavior.