### PR TITLE
GQL Operation sorting fixed from the UI side

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Operations/Operations.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Operations/Operations.jsx
@@ -20,7 +20,6 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
-import cloneDeep from 'lodash.clonedeep';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import Box from '@material-ui/core/Box';
@@ -124,7 +123,7 @@ class Operations extends React.Component {
         super(props);
         const { api } = props;
         const { operations } = api;
-        const operationCopy = cloneDeep(operations);
+        const operationCopy = [...operations];
         operationCopy.sort((a, b) => ((a.target + a.verb > b.target + b.verb) ? 1 : -1));
         this.state = {
             notFound: false,

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Operations/Operations.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Operations/Operations.jsx
@@ -20,6 +20,7 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
+import cloneDeep from 'lodash.clonedeep';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import Box from '@material-ui/core/Box';
@@ -122,10 +123,13 @@ class Operations extends React.Component {
     constructor(props) {
         super(props);
         const { api } = props;
+        const { operations } = api;
+        const operationCopy = cloneDeep(operations);
+        operationCopy.sort((a, b) => ((a.target + a.verb > b.target + b.verb) ? 1 : -1));
         this.state = {
             notFound: false,
             apiPolicies: [],
-            operations: api.operations,
+            operations: operationCopy,
             apiThrottlingPolicy: api.apiThrottlingPolicy,
             filterKeyWord: '',
             isSaving: false,


### PR DESCRIPTION
This PR is fixing the random sorting with the GQL operations list when an operation is performed on one of the rows making the location of the row changed.

The fix is at the UI side but the Rest API side also has to be fixed.

https://github.com/wso2/product-apim/issues/8478