### PR TITLE
Remove port value from IP address in X-Forwarded-For header

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/throttling/publisher/DataProcessAndPublishingAgent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/throttling/publisher/DataProcessAndPublishingAgent.java
@@ -200,6 +200,10 @@ public class DataProcessAndPublishingAgent implements Runnable {
         }
 
         if (remoteIP != null && remoteIP.length() > 0) {
+            if (remoteIP.contains(":")) {
+                log.warn("Client port will be ignored and only the IP address will concern from " + remoteIP);
+                remoteIP = remoteIP.split(":")[0];
+            }
             try {
                 InetAddress address = APIUtil.getAddress(remoteIP);
                 if (address instanceof Inet4Address) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/publisher/DataProcessAndPublishingAgentTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/publisher/DataProcessAndPublishingAgentTest.java
@@ -339,5 +339,32 @@ public class DataProcessAndPublishingAgentTest {
                 apiTenant, appId, messageContext, authenticationContext);
         dataProcessAndPublishingAgent.run();
     }
+    @Test
+    public void testIgnoreClientPortFromXForwardedForHeader() throws Exception {
+        ThrottleProperties throttleProperties = new ThrottleProperties();
+        throttleProperties.setEnabled(true);
+        DataProcessAndPublishingAgent dataProcessAndPublishingAgent = new DataProcessAndPublishingAgentWrapper
+                (throttleProperties);
+        AuthenticationContext authenticationContext = new AuthenticationContext();
+        MessageContext messageContext = Mockito.mock(Axis2MessageContext.class);
+        org.apache.axis2.context.MessageContext axis2MsgCntxt = Mockito.mock(org.apache.axis2.context.MessageContext
+                .class);
+        Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+        Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API)).thenReturn("admin--PizzaShackAPI");
+        TreeMap headers = new TreeMap();
+        headers.put(APIMgtGatewayConstants.X_FORWARDED_FOR, "192.168.1.1:80");
+        Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
+                .thenReturn(headers);
+        VerbInfoDTO verbInfoDTO = new VerbInfoDTO();
+        verbInfoDTO.setContentAware(false);
+        ArrayList<VerbInfoDTO> list = new ArrayList<VerbInfoDTO>();
+        list.add(verbInfoDTO);
+        Mockito.when(messageContext.getProperty(APIConstants.VERB_INFO_DTO)).thenReturn(list);
+        dataProcessAndPublishingAgent.setDataReference(applicationLevelThrottleKey, applicationLevelTier,
+                apiLevelThrottleKey, null, subscriptionLevelThrottleKey, subscriptionLevelTier,
+                resourceLevelThrottleKey, resourceLevelTier, authorizedUser, apiContext, apiVersion, appTenant,
+                apiTenant, appId, messageContext, authenticationContext);
+        dataProcessAndPublishingAgent.run();
+    }
 
 }


### PR DESCRIPTION
Fix the issue related to X-Forwarded-For header containing a IP address with a port value.