### PR TITLE
Add passwordChangeEnabled resource to store settings API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
@@ -28,6 +28,7 @@ public class SettingsDTO   {
     private Boolean isUnlimitedTierPaid = false;
     private SettingsIdentityProviderDTO identityProvider = null;
     private Boolean isAnonymousModeEnabled = true;
+    private Boolean isPasswordChangeEnabled = true;
 
   /**
    **/
@@ -199,6 +200,23 @@ public class SettingsDTO   {
     this.isAnonymousModeEnabled = isAnonymousModeEnabled;
   }
 
+  /**
+   * Get store Password Change Enabled
+   **/
+  public SettingsDTO isPasswordChangeEnabled(Boolean isPasswordChangeEnabled) {
+    this.isPasswordChangeEnabled = isPasswordChangeEnabled;
+    return this;
+  }
+
+  @ApiModelProperty(value = "")
+  @JsonProperty("IsPasswordChangeEnabled")
+  public Boolean isIsPasswordChangeEnabled() {
+    return isPasswordChangeEnabled;
+  }
+  public void setIsPasswordChangeEnabled(Boolean isPasswordChangeEnabled) {
+    this.isPasswordChangeEnabled = isPasswordChangeEnabled;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -218,12 +236,13 @@ public class SettingsDTO   {
         Objects.equals(recommendationEnabled, settings.recommendationEnabled) &&
         Objects.equals(isUnlimitedTierPaid, settings.isUnlimitedTierPaid) &&
         Objects.equals(identityProvider, settings.identityProvider) &&
-        Objects.equals(isAnonymousModeEnabled, settings.isAnonymousModeEnabled);
+        Objects.equals(isAnonymousModeEnabled, settings.isAnonymousModeEnabled) &&
+        Objects.equals(isPasswordChangeEnabled, settings.isPasswordChangeEnabled);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(grantTypes, scopes, applicationSharingEnabled, mapExistingAuthApps, apiGatewayEndpoint, monetizationEnabled, recommendationEnabled, isUnlimitedTierPaid, identityProvider, isAnonymousModeEnabled);
+    return Objects.hash(grantTypes, scopes, applicationSharingEnabled, mapExistingAuthApps, apiGatewayEndpoint, monetizationEnabled, recommendationEnabled, isUnlimitedTierPaid, identityProvider, isAnonymousModeEnabled, isPasswordChangeEnabled);
   }
 
   @Override
@@ -241,6 +260,7 @@ public class SettingsDTO   {
     sb.append("    isUnlimitedTierPaid: ").append(toIndentedString(isUnlimitedTierPaid)).append("\n");
     sb.append("    identityProvider: ").append(toIndentedString(identityProvider)).append("\n");
     sb.append("    isAnonymousModeEnabled: ").append(toIndentedString(isAnonymousModeEnabled)).append("\n");
+    sb.append("    isPasswordChangeEnabled: ").append(toIndentedString(isPasswordChangeEnabled)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SettingsMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SettingsMappingUtil.java
@@ -24,8 +24,11 @@ import org.apache.commons.io.IOUtils;
 import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.Scope;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.definitions.OASParserUtil;
 import org.wso2.carbon.apimgt.impl.dto.Environment;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SettingsDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SettingsIdentityProviderDTO;
@@ -53,6 +56,11 @@ public class SettingsMappingUtil {
         identityProviderDTO.setExternal(APIUtil.getIdentityProviderConfig() != null);
         settingsDTO.setIdentityProvider(identityProviderDTO);
         settingsDTO.setIsAnonymousModeEnabled(anonymousEnabled);
+        APIManagerConfiguration config = ServiceReferenceHolder.getInstance().
+                getAPIManagerConfigurationService().getAPIManagerConfiguration();
+        boolean enableChangePassword =
+                Boolean.parseBoolean(config.getFirstProperty(APIConstants.ENABLE_CHANGE_PASSWORD));
+        settingsDTO.setIsPasswordChangeEnabled(enableChangePassword);
         if (isUserAvailable) {
             settingsDTO.setGrantTypes(APIUtil.getGrantTypes());
             Map<String, Environment> environments = APIUtil.getEnvironments();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
@@ -5472,6 +5472,9 @@ definitions:
       IsAnonymousModeEnabled:
         type: boolean
         default: true
+      IsPasswordChangeEnabled:
+        type: boolean
+        default: true
   #-----------------------------------------------------
   # The Application Attribute resource
   #-----------------------------------------------------


### PR DESCRIPTION
### Description:
The store password change enabled configuration is added to the store settings api.

### Example response:
When password change is disabled.
```
{"grantTypes":[],"scopes":
["apim:api_key","apim:app_import_export","apim:app_manage","apim:store_settings","apim:sub_alert_manage",
"apim:sub_manage","apim:subscribe","openid"],"applicationSharingEnabled":false,"mapExistingAuthApps":false,
"apiGatewayEndpoint":null,"monetizationEnabled":false,"recommendationEnabled":false,"IsUnlimitedTierPaid":false,
"identityProvider":{"external":false},"IsAnonymousModeEnabled":true,"IsPasswordChangeEnabled":false}
```