### PR TITLE
Add missing properties of generated SOAP resource definition

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -344,6 +344,7 @@ public class RestApiPublisherUtils {
             + "\"name\":\"SOAP Request\",\"required\":true,\"in\":\"body\"},"
                 + "{\"description\":\"SOAPAction header for soap 1.1\",\"name\":\"SOAPAction\",\"type\":\"string\","
                 + "\"required\":false,\"in\":\"header\"}],\"responses\":{\"200\":{\"description\":\"OK\"}}," +
-                "\"security\":[{\"default\":[]}],\"consumes\":[\"text/xml\",\"application/soap+xml\"]}}}";
+                "\"security\":[{\"default\":[]}],\"consumes\":[\"text/xml\",\"application/soap+xml\"]," +
+                "\"x-auth-type\":\"Application & Application User\",\"x-throttling-tier\":\"Unlimited\"}}}";
     }
 }


### PR DESCRIPTION
## Purpose
- Fixes: https://github.com/wso2/product-apim/issues/8228
- The issue occurs because x-auth-type is not added to the path property of the SOAP API resource definition

## Approach
- Added the x-auth-type and x-throttling-tier properties when generating the SOAP Operation for the path property of the SOAP API resource definition.

## Test Environment
JDK 1.8.0_241
Ubuntu 18.04.4 LTS