### PR TITLE
Provide the ability to configure gateway startup

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
@@ -99,7 +99,7 @@ public class GatewayStartupListener implements ServerStartupObserver, Runnable, 
         isAPIsDeployedInSyncMode = deployArtifactsAtStartup();
         if (!isAPIsDeployedInSyncMode) {
             log.error("Unable to deploy synapse artifacts at gateway");
-            deployAPIsInAsyncMode();
+            deployAPIsInSyncMode();
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
@@ -59,7 +59,7 @@ public class GatewayStartupListener implements ServerStartupObserver, Runnable, 
 
     @Override
     public void completingServerStartup() {
-        startListener();
+
     }
 
     private boolean deployArtifactsAtStartup() {
@@ -84,7 +84,9 @@ public class GatewayStartupListener implements ServerStartupObserver, Runnable, 
                 new APIMgtGatewayCacheMessageListener());
         jmsTransportHandlerForEventHub
                 .subscribeForJmsEvents(APIConstants.TopicNames.TOPIC_NOTIFICATION, new GatewayJMSMessageListener());
-
+        if (gatewayArtifactSynchronizerProperties.isRetrieveFromStorageEnabled()) {
+            startListener();
+        }
     }
 
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
@@ -101,14 +101,14 @@ public class GatewayStartupListener implements ServerStartupObserver, Runnable, 
         syncModeDeploymentCount ++;
         isAPIsDeployedInSyncMode = deployArtifactsAtStartup();
         if (!isAPIsDeployedInSyncMode) {
-            log.error("Unable to deploy synapse artifacts at gateway.");
+            log.error("Deployment attempt : " + syncModeDeploymentCount + " was unsuccessful") ;
             if (!(syncModeDeploymentCount > retryCount)) {
                 deployAPIsInSyncMode();
             } else {
                 log.error("Maximum retry limit exceeded. Server is starting without deploying all synapse artifacts");
             }
         } else {
-            log.info("Deployment successful in the attempt of  " + syncModeDeploymentCount);
+            log.info("Deployment attempt : " + syncModeDeploymentCount + " was successful");
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
@@ -25,7 +25,6 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dto.EventHubConfigurationDto;
 import org.wso2.carbon.apimgt.impl.dto.GatewayArtifactSynchronizerProperties;
 import org.wso2.carbon.apimgt.impl.dto.ThrottleProperties;
-import org.wso2.carbon.apimgt.impl.gatewayartifactsynchronizer.exception.ArtifactSynchronizerException;
 import org.wso2.carbon.apimgt.jms.listener.utils.JMSTransportHandler;
 import org.wso2.carbon.core.ServerShutdownHandler;
 import org.wso2.carbon.core.ServerStartupObserver;
@@ -79,8 +78,8 @@ public class GatewayStartupListener implements ServerStartupObserver, Runnable, 
     @Override
     public void completedServerStartup() {
         if (gatewayArtifactSynchronizerProperties.isRetrieveFromStorageEnabled()) {
-            if (gatewayArtifactSynchronizerProperties.getGatewayStartup()
-                    .equals(APIConstants.GatewayArtifactSynchronizer.GATEWAY_STARTUP_SYNC)) {
+            if (APIConstants.GatewayArtifactSynchronizer.GATEWAY_STARTUP_SYNC
+                    .equals(gatewayArtifactSynchronizerProperties.getGatewayStartup())) {
                 deployAPIsInSyncMode();
             } else {
                 deployAPIsInAsyncMode();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2315,7 +2315,7 @@ public final class APIConstants {
         public static final String SYNAPSE_ARTIFACTS = "/synapse-artifacts";
         public static final String GATEAY_SYNAPSE_ARTIFACTS = "/gateway-synapse-artifacts";
         public static final String DATA_SOURCE_NAME = "DataSourceName";
-        public static final String STARTUP_CONFIG = "GatewayStartupMode";
+        public static final String DATA_RETRIEVAL_MODE= "DataRetrievalMode";
         public static final String GATEWAY_STARTUP_SYNC = "sync";
         public static final String GATEWAY_STARTUP_ASYNC= "async";
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2315,7 +2315,9 @@ public final class APIConstants {
         public static final String SYNAPSE_ARTIFACTS = "/synapse-artifacts";
         public static final String GATEAY_SYNAPSE_ARTIFACTS = "/gateway-synapse-artifacts";
         public static final String DATA_SOURCE_NAME = "DataSourceName";
-
+        public static final String STARTUP_CONFIG = "GatewayStartupMode";
+        public static final String GATEWAY_STARTUP_SYNC = "sync";
+        public static final String GATEWAY_STARTUP_ASYNC= "async";
     }
 
     public static class ContainerMgtAttributes {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -1683,7 +1683,7 @@ public class APIManagerConfiguration {
             String serverStartup = startupConfigElement.getText();
             gatewayArtifactSynchronizerProperties.setGatewayStartup(serverStartup);
         } else {
-            log.debug("Retry Duration Element is not set. Set to default duaration");
+            log.debug("Gateway Startup mode is not set. Set to Sync Mode");
         }
 
         OMElement gatewayLabelElement = omElement

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -1677,6 +1677,15 @@ public class APIManagerConfiguration {
             log.debug("Retry Duration Element is not set. Set to default duaration");
         }
 
+        OMElement startupConfigElement = omElement.getFirstChildWithName(
+                new QName(APIConstants.GatewayArtifactSynchronizer.STARTUP_CONFIG));
+        if (startupConfigElement!= null) {
+            String serverStartup = startupConfigElement.getText();
+            gatewayArtifactSynchronizerProperties.setGatewayStartup(serverStartup);
+        } else {
+            log.debug("Retry Duration Element is not set. Set to default duaration");
+        }
+
         OMElement gatewayLabelElement = omElement
                 .getFirstChildWithName(new QName(APIConstants.GatewayArtifactSynchronizer.GATEWAY_LABELS_CONFIG));
         if (gatewayLabelElement != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -1677,11 +1677,11 @@ public class APIManagerConfiguration {
             log.debug("Retry Duration Element is not set. Set to default duaration");
         }
 
-        OMElement startupConfigElement = omElement.getFirstChildWithName(
-                new QName(APIConstants.GatewayArtifactSynchronizer.STARTUP_CONFIG));
-        if (startupConfigElement!= null) {
-            String serverStartup = startupConfigElement.getText();
-            gatewayArtifactSynchronizerProperties.setGatewayStartup(serverStartup);
+        OMElement dataRetrievalModeElement = omElement.getFirstChildWithName(
+                new QName(APIConstants.GatewayArtifactSynchronizer.DATA_RETRIEVAL_MODE));
+        if (dataRetrievalModeElement!= null) {
+            String dataRetrievalMode= dataRetrievalModeElement.getText();
+            gatewayArtifactSynchronizerProperties.setGatewayStartup(dataRetrievalMode);
         } else {
             log.debug("Gateway Startup mode is not set. Set to Sync Mode");
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/GatewayArtifactSynchronizerProperties.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/GatewayArtifactSynchronizerProperties.java
@@ -13,8 +13,10 @@ public class GatewayArtifactSynchronizerProperties {
     private String saverName = APIConstants.GatewayArtifactSynchronizer.DB_SAVER_NAME;
     private String retrieverName = APIConstants.GatewayArtifactSynchronizer.DB_RETRIEVER_NAME;
     private Set<String> gatewayLabels = new HashSet<>();
-    private String artifactSynchronizerDataSource = "jdbc/WSO2AM_DB" ;
+    private String artifactSynchronizerDataSource = "jdbc/WSO2AM_DB";
     private long retryDuartion = 15000 ;
+    private String gatewayStartup = "sync";
+
 
     public String getSaverName() {
 
@@ -94,5 +96,15 @@ public class GatewayArtifactSynchronizerProperties {
     public void  setRetryDuartion(long retryDuartion) {
 
         this.retryDuartion = retryDuartion;
+    }
+
+    public String getGatewayStartup() {
+
+        return gatewayStartup;
+    }
+
+    public void  setGatewayStartup(String gatewayStartup) {
+
+        this.gatewayStartup = gatewayStartup;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -357,7 +357,7 @@ public final class APIUtil {
 
     private static String hostAddress = null;
     private static final int timeoutInSeconds = 15;
-    private static final int retries = 15;
+    private static final int retries = 2;
 
     /**
      * To initialize the publisherRoleCache configurations, based on configurations.

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1247,6 +1247,9 @@
         {% if apim.sync_runtime_artifacts.gateway.deployment_retry_duartion is defined %}
         <RetryDuration>{{apim.sync_runtime_artifacts.gateway.deployment_retry_duartion}}</RetryDuration>
         {% endif %}
+        {% if apim.sync_runtime_artifacts.gateway.gateway_startup is defined %}
+        <GatewayStartupMode>{{apim.sync_runtime_artifacts.gateway.gateway_startup}}</GatewayStartupMode>
+        {% endif %}
     </SyncRuntimeArtifactsGateway>
     {% endif %}
 

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1247,8 +1247,8 @@
         {% if apim.sync_runtime_artifacts.gateway.deployment_retry_duartion is defined %}
         <RetryDuration>{{apim.sync_runtime_artifacts.gateway.deployment_retry_duartion}}</RetryDuration>
         {% endif %}
-        {% if apim.sync_runtime_artifacts.gateway.gateway_startup is defined %}
-        <GatewayStartupMode>{{apim.sync_runtime_artifacts.gateway.gateway_startup}}</GatewayStartupMode>
+        {% if apim.sync_runtime_artifacts.gateway.data_retrieval_mode is defined %}
+        <DataRetrievalMode>{{apim.sync_runtime_artifacts.data_retrieval_mode}}</DataRetrievalMode>
         {% endif %}
     </SyncRuntimeArtifactsGateway>
     {% endif %}


### PR DESCRIPTION
### Goal:

- Resolves https://github.com/wso2/product-apim/issues/8611

- Related to https://github.com/wso2/product-apim/issues/8246

- Adding a config of `gateway_startup`

### Approach:

- By default gateway Startup will be in a Synchronous manner. Here the server will wait until all the APIs been deployed. If there is any failure in the deployment, it will again be triggered for **n** times where **n** is the maximum retry count. If the APIs are not deployed even in **n** retries then the server will start with un deployed API artifacts.

- If the user wants to switch the startup mode to an Asynchronous mode then he needs to specify it in the configs as `gateway_startup= "async"`. Here the server will be up, independent of the deployment of synapse artifacts in gateway.
