### PR TITLE
[Admin REST API]- Role-Alias mapping

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SystemScopesApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SystemScopesApi.java
@@ -1,6 +1,7 @@
 package org.wso2.carbon.apimgt.rest.api.admin.v1;
 
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.RoleAliasListDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeListDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeSettingsDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.SystemScopesApiService;
@@ -52,6 +53,41 @@ SystemScopesApiService delegate = new SystemScopesApiServiceImpl();
         @ApiResponse(code = 500, message = "Internal Server Error. An internal server error occurred while retrieving the role scope mapping. ", response = ErrorDTO.class) })
     public Response systemScopesGet() throws APIManagementException{
         return delegate.systemScopesGet(securityContext);
+    }
+
+    @GET
+    @Path("/role-aliases")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Retreive role alias mappings", notes = "This operation can be used to retreive role alias mapping for system scope roles ", response = RoleAliasListDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:scope_manage", description = "Manage scope"),
+            @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations")
+        })
+    }, tags={ "System Scopes",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. The list of role mappings are returned. ", response = RoleAliasListDTO.class),
+        @ApiResponse(code = 404, message = "Not Found. Requested alias does not exist. ", response = ErrorDTO.class) })
+    public Response systemScopesRoleAliasesGet() throws APIManagementException{
+        return delegate.systemScopesRoleAliasesGet(securityContext);
+    }
+
+    @PUT
+    @Path("/role-aliases")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Add a new role alias", notes = "This operation can be used to add a new role alias mapping for system scope roles ", response = RoleAliasListDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:scope_manage", description = "Manage scope"),
+            @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations")
+        })
+    }, tags={ "System Scopes",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Role mapping alias returned ", response = RoleAliasListDTO.class),
+        @ApiResponse(code = 400, message = "Bad Request. Invalid Request or request validation failure. ", response = Void.class),
+        @ApiResponse(code = 500, message = "Internal Server Error An internal server error occurred while updating the roles. ", response = Void.class) })
+    public Response systemScopesRoleAliasesPut(@ApiParam(value = "role-alias mapping" ,required=true) RoleAliasListDTO body) throws APIManagementException{
+        return delegate.systemScopesRoleAliasesPut(body, securityContext);
     }
 
     @GET

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SystemScopesApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/SystemScopesApiService.java
@@ -10,6 +10,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.RoleAliasListDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeListDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeSettingsDTO;
 
@@ -23,6 +24,8 @@ import javax.ws.rs.core.SecurityContext;
 
 public interface SystemScopesApiService {
       public Response systemScopesGet(MessageContext messageContext) throws APIManagementException;
+      public Response systemScopesRoleAliasesGet(MessageContext messageContext) throws APIManagementException;
+      public Response systemScopesRoleAliasesPut(RoleAliasListDTO body, MessageContext messageContext) throws APIManagementException;
       public Response systemScopesScopeNameGet(String scopeName, String username, MessageContext messageContext) throws APIManagementException;
       public Response updateRolesForScope(ScopeListDTO body, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/RoleAliasDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/RoleAliasDTO.java
@@ -1,0 +1,98 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.util.annotations.Scope;
+
+
+
+public class RoleAliasDTO   {
+  
+    private String role = null;
+    private Object aliases = null;
+
+  /**
+   * The original role
+   **/
+  public RoleAliasDTO role(String role) {
+    this.role = role;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Internal/subscriber", value = "The original role")
+  @JsonProperty("role")
+  public String getRole() {
+    return role;
+  }
+  public void setRole(String role) {
+    this.role = role;
+  }
+
+  /**
+   * The role mapping for role alias
+   **/
+  public RoleAliasDTO aliases(Object aliases) {
+    this.aliases = aliases;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "", value = "The role mapping for role alias")
+  @JsonProperty("aliases")
+  public Object getAliases() {
+    return aliases;
+  }
+  public void setAliases(Object aliases) {
+    this.aliases = aliases;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RoleAliasDTO roleAlias = (RoleAliasDTO) o;
+    return Objects.equals(role, roleAlias.role) &&
+        Objects.equals(aliases, roleAlias.aliases);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(role, aliases);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class RoleAliasDTO {\n");
+    
+    sb.append("    role: ").append(toIndentedString(role)).append("\n");
+    sb.append("    aliases: ").append(toIndentedString(aliases)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/RoleAliasListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/RoleAliasListDTO.java
@@ -1,0 +1,100 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.RoleAliasDTO;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.util.annotations.Scope;
+
+
+
+public class RoleAliasListDTO   {
+  
+    private Integer count = null;
+    private List<RoleAliasDTO> list = new ArrayList<>();
+
+  /**
+   * The number of role aliases
+   **/
+  public RoleAliasListDTO count(Integer count) {
+    this.count = count;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "3", value = "The number of role aliases")
+  @JsonProperty("count")
+  public Integer getCount() {
+    return count;
+  }
+  public void setCount(Integer count) {
+    this.count = count;
+  }
+
+  /**
+   **/
+  public RoleAliasListDTO list(List<RoleAliasDTO> list) {
+    this.list = list;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("list")
+  public List<RoleAliasDTO> getList() {
+    return list;
+  }
+  public void setList(List<RoleAliasDTO> list) {
+    this.list = list;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RoleAliasListDTO roleAliasList = (RoleAliasListDTO) o;
+    return Objects.equals(count, roleAliasList.count) &&
+        Objects.equals(list, roleAliasList.list);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(count, list);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class RoleAliasListDTO {\n");
+    
+    sb.append("    count: ").append(toIndentedString(count)).append("\n");
+    sb.append("    list: ").append(toIndentedString(list)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SystemScopesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SystemScopesApiServiceImpl.java
@@ -55,7 +55,7 @@ public class SystemScopesApiServiceImpl implements SystemScopesApiService {
             if (existence) {
                 scopeSettingsDTO.setName(decodedScope);
             } else {
-                throw new APIManagementException("Scope Not Found. Scope : " + decodedScope +
+                throw new APIManagementException("Scope Not Found. Scope : " + decodedScope,
                         ExceptionCodes.SCOPE_NOT_FOUND);
             }
         } else {
@@ -113,7 +113,6 @@ public class SystemScopesApiServiceImpl implements SystemScopesApiService {
         RoleAliasListDTO roleAliasListDTO = new RoleAliasListDTO();
         //read from tenant-conf.json
         JsonObject existingTenantConfObject = new JsonObject();
-
         try {
             APIMRegistryService apimRegistryService = new APIMRegistryServiceImpl();
             String existingTenantConf = apimRegistryService.getConfigRegistryResourceContent(tenantDomain,

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SystemScopesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SystemScopesApiServiceImpl.java
@@ -1,23 +1,35 @@
 package org.wso2.carbon.apimgt.rest.api.admin.v1.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.json.simple.JSONObject;
 
 import org.wso2.carbon.apimgt.api.APIAdmin;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.impl.APIAdminImpl;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIMRegistryService;
+import org.wso2.carbon.apimgt.impl.APIMRegistryServiceImpl;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.*;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.*;
 
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ErrorDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeSettingsDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.utils.mappings.SystemScopesMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.Base64;
@@ -31,33 +43,34 @@ public class SystemScopesApiServiceImpl implements SystemScopesApiService {
 
     private static final Log log = LogFactory.getLog(SystemScopesApiServiceImpl.class);
 
-    public Response systemScopesScopeNameGet(String scope, String username, MessageContext messageContext) throws APIManagementException{
+    public Response systemScopesScopeNameGet(String scope, String username, MessageContext messageContext)
+            throws APIManagementException {
         ScopeSettingsDTO scopeSettingsDTO = new ScopeSettingsDTO();
         APIAdmin apiAdmin = new APIAdminImpl();
         String decodedScope = new String(Base64.getDecoder().decode(scope));
-        boolean existence ;
+        boolean existence;
 
-            if (username == null) {
-                existence = apiAdmin.isScopeExists(RestApiUtil.getLoggedInUsername(), decodedScope);
-                if (existence) {
-                    scopeSettingsDTO.setName(decodedScope);
-                } else {
-                    throw new APIManagementException("Scope Not Found.  Scope : " + decodedScope +
-                            ExceptionCodes.SCOPE_NOT_FOUND);
-                }
+        if (username == null) {
+            existence = apiAdmin.isScopeExists(RestApiUtil.getLoggedInUsername(), decodedScope);
+            if (existence) {
+                scopeSettingsDTO.setName(decodedScope);
             } else {
-                existence = apiAdmin.isScopeExistsForUser(username, decodedScope);
-                if (existence) {
-                    scopeSettingsDTO.setName(decodedScope);
-                } else {
-                    throw new APIManagementException("User does not have  scope. Username :" + username + " Scope : "
-                            + decodedScope + ExceptionCodes.SCOPE_NOT_FOUND_FOR_USER);
-                }
+                throw new APIManagementException("Scope Not Found. Scope : " + decodedScope +
+                        ExceptionCodes.SCOPE_NOT_FOUND);
             }
+        } else {
+            existence = apiAdmin.isScopeExistsForUser(username, decodedScope);
+            if (existence) {
+                scopeSettingsDTO.setName(decodedScope);
+            } else {
+                throw new APIManagementException("User does not have scope. Username : " + username + " Scope : "
+                        + decodedScope, ExceptionCodes.SCOPE_NOT_FOUND_FOR_USER);
+            }
+        }
         return Response.ok().entity(scopeSettingsDTO).build();
     }
 
-    public Response systemScopesGet(MessageContext messageContext) throws APIManagementException {
+    public Response systemScopesGet(MessageContext messageContext) {
         try {
             Map<String, String> scopeRoleMapping = APIUtil.getRESTAPIScopesForTenant(MultitenantUtils
                     .getTenantDomain(RestApiUtil.getLoggedInUsername()));
@@ -78,5 +91,60 @@ public class SystemScopesApiServiceImpl implements SystemScopesApiService {
                 .getTenantDomain(RestApiUtil.getLoggedInUsername()));
         ScopeListDTO scopeListDTO = SystemScopesMappingUtil.fromScopeListToScopeListDTO(scopeRoleMapping);
         return Response.ok().entity(scopeListDTO).build();
+    }
+
+    @Override
+    public Response systemScopesRoleAliasesGet(MessageContext messageContext) throws APIManagementException {
+        String tenantDomain = MultitenantUtils.getTenantDomain(RestApiUtil.getLoggedInUsername());
+        JSONObject tenantConfig = APIUtil.getTenantConfig(tenantDomain);
+        JSONObject roleMapping = (JSONObject) tenantConfig.get(APIConstants.REST_API_ROLE_MAPPINGS_CONFIG);
+        RoleAliasListDTO roleAliasListDTO = new RoleAliasListDTO();
+        if (roleMapping != null) {
+            roleAliasListDTO = SystemScopesMappingUtil.fromRoleAliasListToRoleAliasListDTO(
+                    SystemScopesMappingUtil.createMapOfRoleMapping((roleMapping)));
+        }
+        return Response.ok().entity(roleAliasListDTO).build();
+    }
+
+    @Override
+    public Response systemScopesRoleAliasesPut(RoleAliasListDTO body, MessageContext messageContext)
+            throws APIManagementException {
+        String tenantDomain = MultitenantUtils.getTenantDomain(RestApiUtil.getLoggedInUsername());
+        RoleAliasListDTO roleAliasListDTO = new RoleAliasListDTO();
+        //read from tenant-conf.json
+        JsonObject existingTenantConfObject = new JsonObject();
+
+        try {
+            APIMRegistryService apimRegistryService = new APIMRegistryServiceImpl();
+            String existingTenantConf = apimRegistryService.getConfigRegistryResourceContent(tenantDomain,
+                    APIConstants.API_TENANT_CONF_LOCATION);
+            existingTenantConfObject = new JsonParser().parse(existingTenantConf).getAsJsonObject();
+        } catch (RegistryException e) {
+            APIUtil.handleException("Couldn't read tenant configuration from tenant registry", e);
+        } catch (UserStoreException e) {
+            APIUtil.handleException("Couldn't read tenant configuration from User Store", e);
+        }
+        JSONObject responseJson = SystemScopesMappingUtil.createJsonObjectOfRoleMapping(body);
+        existingTenantConfObject.remove(APIConstants.REST_API_ROLE_MAPPINGS_CONFIG);
+        JsonElement jsonElement = new JsonParser().parse(String.valueOf(responseJson));
+        existingTenantConfObject.add(APIConstants.REST_API_ROLE_MAPPINGS_CONFIG, jsonElement);
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            String formattedTenantConf = mapper.writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(existingTenantConfObject.toString());
+            APIUtil.updateTenantConf(existingTenantConfObject.toString(), tenantDomain);
+            if (log.isDebugEnabled()) {
+                log.debug("Finalized tenant-conf.json: " + formattedTenantConf);
+            }
+        } catch (JsonProcessingException e) {
+            throw new APIManagementException("Error while formatting tenant-conf.json of tenant: " + tenantDomain, e);
+        }
+        JSONObject tenantConfig = APIUtil.getTenantConfig(tenantDomain);
+        JSONObject roleMapping = (JSONObject) tenantConfig.get(APIConstants.REST_API_ROLE_MAPPINGS_CONFIG);
+        if (roleMapping != null) {
+            roleAliasListDTO = SystemScopesMappingUtil.fromRoleAliasListToRoleAliasListDTO(
+                    SystemScopesMappingUtil.createMapOfRoleMapping((roleMapping)));
+        }
+        return Response.ok().entity(roleAliasListDTO).build();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SystemScopesMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SystemScopesMappingUtil.java
@@ -140,7 +140,7 @@ public class SystemScopesMappingUtil {
     /**
      * Extract roles and aliases and create JSONObject
      *
-     * @param body
+     * @param body          RoleAliasListDTO as request body
      * @return JSONObject   role-alias data
      */
     public static JSONObject createJsonObjectOfRoleMapping(RoleAliasListDTO body) {
@@ -154,7 +154,7 @@ public class SystemScopesMappingUtil {
     /**
      * Extract roles and aliases and create MAP from JSONObject
      *
-     * @param roleMapping JSONObject
+     * @param roleMapping from tenant-conf in JSONObject format
      * @return Converted MAP of role alias list
      */
     public static Map<String, List<String>> createMapOfRoleMapping(JSONObject roleMapping) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SystemScopesMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SystemScopesMappingUtil.java
@@ -19,10 +19,7 @@ package org.wso2.carbon.apimgt.rest.api.admin.v1.utils.mappings;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-<<<<<<< HEAD
 import org.json.JSONArray;
-=======
->>>>>>> Removed unnecessary imports.
 import org.json.simple.JSONObject;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.RoleAliasDTO;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SystemScopesMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SystemScopesMappingUtil.java
@@ -22,12 +22,15 @@ import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
 import org.json.simple.JSONObject;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.RoleAliasDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.RoleAliasListDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeListDTO;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +38,7 @@ public class SystemScopesMappingUtil {
 
     private static final Log log = LogFactory.getLog(SystemScopesMappingUtil.class);
     private static final Object lock = new Object();
-    private static volatile Map<String, List<String>>  portalScopeList = new HashMap<>();
+    private static volatile Map<String, List<String>> portalScopeList = new HashMap<>();
 
     /**
      * Convert list of API Scope to ScopeListDTO
@@ -43,8 +46,8 @@ public class SystemScopesMappingUtil {
      * @param scopeRoleMapping Map of a Role Scope  Mapping
      * @return ScopeListDTO list containing role scope mapping data
      */
-    public static ScopeListDTO fromScopeListToScopeListDTO(Map<String, String>  scopeRoleMapping)
-            throws APIManagementException{
+    public static ScopeListDTO fromScopeListToScopeListDTO(Map<String, String> scopeRoleMapping)
+            throws APIManagementException {
         ScopeListDTO scopeListDTO = new ScopeListDTO();
         scopeListDTO.setCount(scopeRoleMapping.size());
         scopeListDTO.setList(fromRoleScopeMapToRoleScopeDTOList(scopeRoleMapping));
@@ -57,7 +60,7 @@ public class SystemScopesMappingUtil {
      * @param scopeRoleMapping Map of a Role Scope  Mapping
      * @return RoleScopeDTO list
      */
-    private static List<ScopeDTO> fromRoleScopeMapToRoleScopeDTOList(Map<String, String>  scopeRoleMapping)
+    private static List<ScopeDTO> fromRoleScopeMapToRoleScopeDTOList(Map<String, String> scopeRoleMapping)
             throws APIManagementException {
         List<ScopeDTO> scopeDTOs = new ArrayList<>(scopeRoleMapping.size());
 
@@ -69,7 +72,7 @@ public class SystemScopesMappingUtil {
             }
         }
 
-        for (Map.Entry<String, List<String>>  mapping : portalScopeList.entrySet()) {
+        for (Map.Entry<String, List<String>> mapping : portalScopeList.entrySet()) {
             if (scopeRoleMapping.containsKey(mapping.getKey())) {
                 ScopeDTO roleScopeDTO = new ScopeDTO();
                 roleScopeDTO.setName(mapping.getKey());
@@ -78,7 +81,7 @@ public class SystemScopesMappingUtil {
                 roleScopeDTO.setTag(mapping.getValue().get(1));
                 scopeDTOs.add(roleScopeDTO);
             } else {
-                log.warn("The scope "+ mapping.getKey() +" does not exist in tenant.conf");
+                log.warn("The scope " + mapping.getKey() + " does not exist in tenant.conf");
             }
         }
         return scopeDTOs;
@@ -101,5 +104,65 @@ public class SystemScopesMappingUtil {
         }
         responseJson.put("Scope", scopeJson);
         return responseJson;
+    }
+    /**
+     * Convert list of role alias mapping to RoleAliasListDTO
+     *
+     * @param roleMapping Map of a Role Alias Mapping
+     * @return RoleAliasListDTO list containing role scope mapping data
+     */
+    public static RoleAliasListDTO fromRoleAliasListToRoleAliasListDTO(Map<String, List<String>> roleMapping) {
+        RoleAliasListDTO roleAliasListDTO = new RoleAliasListDTO();
+        roleAliasListDTO.setCount(roleMapping.size());
+        roleAliasListDTO.setList(fromRoleAliasObjectToRoleAliasDTOList(roleMapping));
+        return roleAliasListDTO;
+    }
+
+    /**
+     * Converts api scope-role mapping to RoleScopeDTO List.
+     *
+     * @param roleMapping Map of a Role Scope  Mapping
+     * @return RoleScopeDTO list
+     */
+    private static List<RoleAliasDTO> fromRoleAliasObjectToRoleAliasDTOList(Map<String, List<String>> roleMapping) {
+        List<RoleAliasDTO> roleAliasDTOS = new ArrayList<>(roleMapping.size());
+        for (Map.Entry<String, List<String>> mapping : roleMapping.entrySet()) {
+            RoleAliasDTO roleAliasDTO = new RoleAliasDTO();
+            roleAliasDTO.setRole(mapping.getKey());
+            roleAliasDTO.setAliases(mapping.getValue());
+            roleAliasDTOS.add(roleAliasDTO);
+        }
+        return roleAliasDTOS;
+    }
+
+    /**
+     * Extract roles and aliases and create JSONObject
+     *
+     * @param body
+     * @return JSONObject   role-alias data
+     */
+    public static JSONObject createJsonObjectOfRoleMapping(RoleAliasListDTO body) {
+        JSONObject roleJson = new JSONObject();
+        for (RoleAliasDTO roleAlias : body.getList()) {
+            roleJson.put(roleAlias.getRole(), roleAlias.getAliases());
+        }
+        return roleJson;
+    }
+
+    /**
+     * Extract roles and aliases and create MAP from JSONObject
+     *
+     * @param roleMapping JSONObject
+     * @return Converted MAP of role alias list
+     */
+    public static Map<String, List<String>> createMapOfRoleMapping(JSONObject roleMapping) {
+        Map<String, List<String>> map = new HashMap<>();
+        for (Object role : roleMapping.keySet()) {
+            List<String> result = new ArrayList<>();
+            String key = (String) role;
+            result.add((String) roleMapping.get(key));
+            map.put(key, result);
+        }
+        return map;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SystemScopesMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SystemScopesMappingUtil.java
@@ -19,7 +19,10 @@ package org.wso2.carbon.apimgt.rest.api.admin.v1.utils.mappings;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+<<<<<<< HEAD
 import org.json.JSONArray;
+=======
+>>>>>>> Removed unnecessary imports.
 import org.json.simple.JSONObject;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.RoleAliasDTO;
@@ -30,7 +33,6 @@ import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -73,22 +73,22 @@ securityDefinitions:
     scopes:
       openid: Authorize access to user details
       apim:admin: Manage all admin operations
-      apim:tier_view: View throttling policies
-      apim:tier_manage: Update and delete throttling policies
-      apim:bl_view: View deny policies
-      apim:bl_manage: Update and delete deny policies
+      apim:tier_view: View tiers
+      apim:tier_manage: Update and delete tiers
+      apim:bl_view: View blocking conditions
+      apim:bl_manage: Update and delete blocking conditions
       apim:mediation_policy_view: View mediation policies
-      apim:mediation_policy_create: Create and update mediation policies
-      apim:app_owner_change: Retrieve and manage applications
+      apim:mediation_policy_create: Create mediation policies
+      apim:app_owner_change: Retrieve and manage applications #TODO: Verify Description
       apim:app_import_export: Import and export applications related operations
       apim:api_import_export: Import and export APIs related operations
       apim:api_product_import_export: Import and export API Products related operations
-      apim:label_manage: Manage microgateway labels
-      apim:label_read: Retrieve microgateway labels
-      apim:monetization_usage_publish: Retrieve and publish Monetization related usage records
-      apim:api_workflow_approve: Manage workflows
-      apim:bot_data: Retrieve bot detection data
-      apim:tenantInfo: Retrieve tenant related information
+      apim:label_manage: Manage labels
+      apim:label_read: Retrieve labels
+      apim:monetization_usage_publish: Retrieve and publish Monetization related usage records #TODO: Verify Description
+      apim:api_workflow_approve: Manage workflows #TODO: Verify Description
+      apim:bot_data: Manage emails  #TODO: Verify Description
+      apim:tenantInfo: Retrieve tenant related information  #TODO: Verify Description
       apim:tenant_theme_manage: Manage tenant themes
       apim:admin_operations: Manage API categories
       apim:admin_settings: Retrieve admin settings
@@ -3535,114 +3535,24 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-    #--------------------------------------------------
-    # Update the roles for scopes
-    #--------------------------------------------------
-    put:
-      security:
-        - OAuth2Security:
-            - apim:admin
-            - apim:scope_manage
-      summary: |
-        Update Roles For Scope
-      operationId: updateRolesForScope
-      description: |
-        This operation is used to update the roles for all scopes
-      parameters:
-        - in: body
-          name: body
-          description: |
-            Key Manager object with updated information
-          required: true
-          schema:
-            $ref: '#/definitions/ScopeList'
-      tags:
-        - System Scopes
-      responses:
-        200:
-          description: |
-            OK.
-            Successful response with the newly added roles.
-          headers:
-            Content-Type:
-              description: |
-                The content type of the body.
-              type: string
-          schema:
-            $ref: '#/definitions/ScopeList'
-        400:
-          description: |
-            Bad Request.
-            Invalid Request or request validation failure.
-        500:
-          description: |
-            Internal Server Error
-            An internal server error occurred while updating the roles.
-          schema:
-            $ref: '#/definitions/Error'
-
 ######################################################
 # The Tenant Theme resource APIs
 ######################################################
-  /tenant-theme:
-    #-----------------------------------------------------
-    # Export Tenant Theme
-    #-----------------------------------------------------
-    get:
-      security:
-        - OAuth2Security:
-            - apim:admin
-            - apim:tenant_theme_manage
-      operationId: exportTenantTheme
-      produces:
-        - application/zip
-      summary: Export a DevPortal Tenant Theme
-      description: |
-        This operation can be used to export a DevPortal tenant theme as a zip file.
-      tags:
-        - Tenant Theme
-      responses:
-        200:
-          description: |
-            OK.
-            Tenant Theme Exported Successfully.
-          headers:
-            Content-Type:
-              description: |
-                The content type of the body.
-              type: string
-          schema:
-            type: file
-        403:
-          description: |
-            Forbidden.
-            Not Authorized to export.
-          schema:
-            $ref: '#/definitions/Error'
-        404:
-          description: |
-            Not Found.
-            Requested tenant theme does not exist.
-          schema:
-            $ref: '#/definitions/Error'
-        500:
-          description: |
-            Internal Server Error.
-            Error in exporting tenant theme.
-          schema:
-            $ref: '#/definitions/Error'
+  /tenant-theme/import:
 
-    #-----------------------------------------------------
-    # Import Tenant Theme
-    #-----------------------------------------------------
-    put:
+    post:
       security:
         - OAuth2Security:
             - apim:admin
             - apim:tenant_theme_manage
-      operationId: importTenantTheme
       consumes:
         - multipart/form-data
+      x-wso2-curl: "curl -k -F \"file=@exported.zip\" -X POST -H \"Authorization: Bearer
+      ae4eae22-3f65-387b-a171-d37eaa366fa8\" https://localhost:9443/api/am/admin/v1/tenant-theme/import"
+      x-wso2-request: |
+        POST https://localhost:9443/api/am/admin/v1/tenant-theme/import
+        Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8
+      x-wso2-response: "HTTP/1.1 200 OK\nTenant Theme imported successfully."
       summary: Import a DevPortal Tenant Theme
       description: |
         This operation can be used to import a DevPortal tenant theme.
@@ -3653,30 +3563,23 @@ paths:
             Zip archive consisting of tenant theme configuration
           required: true
           type: file
-      tags:
-        - Tenant Theme
       responses:
         200:
           description: |
             Ok.
-            Tenant Theme Imported Successfully.
+            Theme Imported Successfully.
         403:
           description: |
             Forbidden.
             Not Authorized to import.
           schema:
             $ref: '#/definitions/Error'
-        413:
-          description: |
-            Payload Too Large.
-            Tenant Theme file size exceeds the allowed limit.
         500:
           description: |
             Internal Server Error.
             Error in importing Theme.
           schema:
             $ref: '#/definitions/Error'
-
   ######################################################
   # The "Key Manager Collection" resource API
   ######################################################
@@ -5522,23 +5425,23 @@ definitions:
       messageID:
         type: string
         description: The message ID
-        example: 'urn:uuid:1ed6d2de-29df-4fed-a96a-46d2329dce65'
+        example: urn:uuid:1ed6d2de-29df-4fed-a96a-46d2329dce65
       apiMethod:
         type: string
         description: The api method
-        example: 'GET'
+        example: GET
       headerSet:
         type: string
         description: The header set
-        example: '[Accept=*/*, Host=localhost:8243, User-Agent=curl/7.58.0]'
+        example: [Accept=*/*, Host=localhost:8243, User-Agent=curl/7.58.0]
       messageBody:
         type: string
         description: The content of the message body
-        example: '<soapenv:Body xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"/>'
+        example: <soapenv:Body xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\"/>
       clientIp:
         type: string
         description: The IP of the client
-        example: '127.0.0.1'
+        example: 127.0.0.1
 
 #-----------------------------------------------------
 # END-OF-FILE


### PR DESCRIPTION
This PR contains GET and PUT operations for role-alias mapping. The original role can be mapped with a different name when customizing. 
GET :
Request : curl  -k -X GET 'https://localhost:9443/api/am/admin/v1/system-scopes/role-aliases' -H "Authorization: Bearer eb435e9d-f067-38b3-901a-c1104ca0095d" 
Response : `{
    "count": 2,
    "list": [
        {
            "role": "Internal/subscriber",
            "aliases": [
                "testing,test"
            ]
        },
        {
            "role": "Internal/creator",
            "aliases": [
                "alias"
            ]
        }
    ]
}`

PUT :
Request  : curl -k -X PUT 'https://localhost:9443/api/am/admin/v1/system-scopes/role-aliases' -H 'Authorization: Bearer 2992c6bc-08e7-3051-ace9-be2ce3111392'  -H 'Content-Type: application/json' 
-d  '{"count":1,"list":[{ "role":"Internal/subscriber","aliases":"testing,test"}, {"role": "Internal/creator","aliases": "alias"}]}'
Response: `{
    "count": 2,
    "list": [
        {
            "role": "Internal/subscriber",
            "aliases": [
                "testing,test"
            ]
        },
        {
            "role": "Internal/creator",
            "aliases": [
                "alias"
            ]
        }
    ]
}`

Related to https://github.com/wso2/product-apim/issues/7954