### PR TITLE
Devportal Password change - validation on UI

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/site/public/locales/en.json
@@ -356,6 +356,8 @@
   "Change.Password.password.change.disabled": "Password change disabled",
   "Change.Password.password.changed.success": "Successfuly changed the password",
   "Change.Password.password.empty": "Password is empty",
+  "Change.Password.password.length.long": "Password is too long!",
+  "Change.Password.password.length.short": "Password is too short!",
   "Change.Password.password.mismatch": "Password doesn't match",
   "Change.Password.password.pattern.invalid": "Invalid password pattern",
   "Change.Password.password.policy": "Password policy:",


### PR DESCRIPTION
### Description

With this PR the following user password policies are validated on the UI.
 - The `PasswordJavaRegEx` cofigured in the UserStoreManager
 - The regex configured in deployment.toml file under `passwordPolicy.properties.pattern`
 - Min and Max password legths defined under `passwordPolicy.properties.'min.length'` and `passwordPolicy.properties.'max.length'` in deployment.toml file.

> Note: When the password policy is overridden by the management console per tenant, those policies will also be followed.

### Screenshot
When the password doesn't match with the provided password regex
![password validation wrong pattern](https://user-images.githubusercontent.com/25490163/87120179-7eba1600-c29d-11ea-9660-f48cf69a0385.png)

