### PR TITLE
Handling error messages when corrupted swagger is provided with APICTL [Fix for https://github.com/wso2/product-apim-tooling/issues/396]

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ImportApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ImportApiServiceImpl.java
@@ -112,6 +112,9 @@ public class ImportApiServiceImpl implements ImportApiService {
             } else if (RestApiUtil.isDueToResourceNotFound(e)) {
                 RestApiUtil.handleResourceNotFoundError("Requested " + RestApiConstants.RESOURCE_API + " not found",
                         e, log);
+            } else if (RestApiUtil.isDueToMetaInfoIsCorrupted(e)) {
+                RestApiUtil.handleMetaInformationFailureError("Error while reading API meta information from path.",
+                        e, log);
             }
             RestApiUtil.handleInternalServerError("Error while importing API", e, log);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
@@ -612,6 +612,17 @@ public class RestApiUtil {
     }
 
     /**
+     * Check if the specified throwable e is happened as the provided meta information related to api is corrupted
+     *
+     * @param e throwable to check
+     * @return true if the specified throwable e is happened as the provided meta information is corrupted, false otherwise
+     */
+    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+    public static boolean isDueToMetaInfoIsCorrupted(Throwable e) {
+        return detailedMessageMatches(e, "Error while reading API meta information from path");
+    }
+
+    /**
      * Check if the specified throwable e is happened as the updated/new resource conflicting with an already existing
      * resource
      *
@@ -663,6 +674,18 @@ public class RestApiUtil {
     public static boolean rootCauseMessageMatches (Throwable e, String message) {
         Throwable rootCause = getPossibleErrorCause(e);
         return rootCause.getMessage().contains(message);
+    }
+
+    /**
+     * Check if the message of the detailed message of 'e' matches with the specified message
+     *
+     * @param e       throwable to check
+     * @param message error message
+     * @return true if the message of the root cause of 'e' matches with 'message'
+     */
+    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+    public static boolean detailedMessageMatches(Throwable e, String message) {
+        return e.getMessage().contains(message);
     }
 
     /**
@@ -877,6 +900,21 @@ public class RestApiUtil {
         NotFoundException notFoundException = buildNotFoundException(description);
         log.error(description, t);
         throw notFoundException;
+    }
+
+    /**
+     * Logs the error, builds a BadRequestException with specified details and throws it
+     *
+     * @param description description of the error
+     * @param t           Throwable instance
+     * @param log         Log instance
+     * @throws BadRequestException
+     */
+    public static void handleMetaInformationFailureError(String description, Throwable t, Log log)
+            throws BadRequestException {
+        BadRequestException badRequestException = buildBadRequestException(description);
+        log.error(description, t);
+        throw badRequestException;
     }
 
     /**


### PR DESCRIPTION
## Purpose
Providing a detailed error message when a user imports an API using apictl with a corrupted swagger or OpenApi Definition.

Currently, When importing an API with invalid swagger definition, Tool returns a 500 internal server error message instead of providing correct error information to the developer.

This PR will solve that issue and provide a 400 Bad Request error as it supposed to and message will say that something is wrong with the metadata of importing Project.

## Goals
> Fixes https://github.com/wso2/product-apim-tooling/issues/396

## Approach
Current output when a wrong swagger is provided.
```
API ID: 0974174c-372a-4ac0-8049-e68793a3692b
Error importing API.
Status: 500 
Response: {"code":500,"message":"Internal server error","description":"Error while importing API","moreInfo":"","error":[]}
apictl: Error importing API Reason: 500 
Exit status 1

```

Output After the fix 
![Screenshot from 2020-07-09 18-57-43](https://user-images.githubusercontent.com/42435576/87122110-d78bad80-c2a1-11ea-830c-4825f629a008.png)

## User stories
Importing a new API project or updating an API using APICTL.

## Documentation
No doc changes Required


## Test environment
OS - Ubuntu 20.04 LTS
Java - JDK 1.8_252
APIM - 3.2.0
