### PR TITLE
Avoid appending the version twice to the context when updating an exported-imported API using APICTL (Fix for product-apim-tooling/issues/404) 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
@@ -200,10 +200,9 @@ public abstract class APIDefinition {
      *
      * @param swaggerContent String
      * @param api            API
-     * @param isBasepathExtractedFromSwagger boolean
      * @return API
      */
-    public abstract API setExtensionsToAPI(String swaggerContent, API api, boolean isBasepathExtractedFromSwagger)
+    public abstract API setExtensionsToAPI(String swaggerContent, API api)
             throws APIManagementException;
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -1402,13 +1402,12 @@ public class OAS2Parser extends APIDefinition {
     /**
      * This method returns api that is attached with api extensions related to micro-gw
      *
-     * @param apiDefinition                  String
-     * @param api                            API
-     * @param isBasepathExtractedFromSwagger boolean
+     * @param apiDefinition String
+     * @param api           API
      * @return API
      */
     @Override
-    public API setExtensionsToAPI(String apiDefinition, API api, boolean isBasepathExtractedFromSwagger) throws APIManagementException {
+    public API setExtensionsToAPI(String apiDefinition, API api) throws APIManagementException {
         Swagger swagger = getSwagger(apiDefinition);
         Map<String, Object> extensions = swagger.getVendorExtensions();
         if (extensions == null) {
@@ -1459,13 +1458,7 @@ public class OAS2Parser extends APIDefinition {
         if (StringUtils.isNotBlank(throttleTier)) {
             api.setApiLevelPolicy(throttleTier);
         }
-        //Setup Basepath
-        String basePath = OASParserUtil.getBasePathFromSwagger(extensions);
-        if (StringUtils.isNotBlank(basePath) && isBasepathExtractedFromSwagger) {
-            basePath = basePath.replace("{version}", api.getId().getVersion());
-            api.setContextTemplate(basePath);
-            api.setContext(basePath);
-        }
+
         return api;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1518,13 +1518,12 @@ public class OAS3Parser extends APIDefinition {
     /**
      * This method returns api that is attached with api extensions related to micro-gw
      *
-     * @param apiDefinition                  String
-     * @param api                            API
-     * @param isBasepathExtractedFromSwagger boolean
+     * @param apiDefinition String
+     * @param api           API
      * @return API
      */
     @Override
-    public API setExtensionsToAPI(String apiDefinition, API api, boolean isBasepathExtractedFromSwagger) throws APIManagementException {
+    public API setExtensionsToAPI(String apiDefinition, API api) throws APIManagementException {
         OpenAPI openAPI = getOpenAPI(apiDefinition);
         Map<String, Object> extensions = openAPI.getExtensions();
         if (extensions == null) {
@@ -1574,13 +1573,6 @@ public class OAS3Parser extends APIDefinition {
         String throttleTier = OASParserUtil.getThrottleTierFromSwagger(extensions);
         if (StringUtils.isNotBlank(throttleTier)) {
             api.setApiLevelPolicy(throttleTier);
-        }
-        //Setup Basepath
-        String basePath = OASParserUtil.getBasePathFromSwagger(extensions);
-        if (StringUtils.isNotBlank(basePath) && isBasepathExtractedFromSwagger) {
-            basePath = basePath.replace("{version}", api.getId().getVersion());
-            api.setContextTemplate(basePath);
-            api.setContext(basePath);
         }
         return api;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1323,24 +1323,11 @@ public class OASParserUtil {
      *
      * @param swaggerContent String
      * @param api            API
-     * @param isBasepathExtractedFromSwagger boolean
      * @return API
      */
-    public static API setExtensionsToAPI(String swaggerContent, API api, boolean isBasepathExtractedFromSwagger) throws APIManagementException {
+    public static API setExtensionsToAPI(String swaggerContent, API api) throws APIManagementException {
         APIDefinition apiDefinition = getOASParser(swaggerContent);
-        return apiDefinition.setExtensionsToAPI(swaggerContent, api, isBasepathExtractedFromSwagger);
-    }
-
-    /**
-     * This method returns extension of basepath related to micro-gw
-     *
-     * @param extensions Map<String, Object>
-     * @return String
-     * @throws APIManagementException throws if an error occurred
-     */
-    public static String getBasePathFromSwagger(Map<String, Object> extensions) throws APIManagementException {
-        Object basepath = extensions.get(APIConstants.X_WSO2_BASEPATH);
-        return basepath == null ? null : basepath.toString();
+        return apiDefinition.setExtensionsToAPI(swaggerContent, api);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -296,9 +296,8 @@ public final class APIImportUtil {
                     importedApi.setUriTemplates(uriTemplates);
                     Set<Scope> scopes = apiDefinition.getScopes(swaggerContent);
                     importedApi.setScopes(scopes);
-                    boolean isBasepathExtractedFromSwagger = true;
-                    //Setup vendor extensions to API when importing through CTL tool
-                    importedApi = OASParserUtil.setExtensionsToAPI(swaggerContent, importedApi, isBasepathExtractedFromSwagger);
+                    //Set extensions from API definition to API object
+                    importedApi = OASParserUtil.setExtensionsToAPI(swaggerContent, importedApi);
                 }
             }
             // This is required to make url templates and scopes get effected

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3532,9 +3532,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             Set<Scope> scopes = apiDefinition.getScopes(definitionToAdd);
             apiToAdd.setUriTemplates(uriTemplates);
             apiToAdd.setScopes(scopes);
-            //Set x-wso2-extensions to API when importing through API publisher
-            boolean isBasepathExtractedFromSwagger = false;
-            apiToAdd = OASParserUtil.setExtensionsToAPI(definitionToAdd, apiToAdd, isBasepathExtractedFromSwagger);
+            //Set extensions from API definition to API object
+            apiToAdd = OASParserUtil.setExtensionsToAPI(definitionToAdd, apiToAdd);
             if (!syncOperations) {
                 validateScopes(apiToAdd);
                 swaggerData = new SwaggerData(apiToAdd);


### PR DESCRIPTION
## Purpose
After exporting an API using the APICTL, when we reimport the API to APIM and edit it in publisher the store will display the context by appending the version twice. This PR will solve this issue.

## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/404

## Approach

Removing process of extracting up x-wso2-basepath extension from a swagger or open API definition and set that value as the context of API when importing an API through the API Controller tool. 

## User stories
Importing an API using the API Controller tool.


## Test environment
OS - Ubuntu 20.04 LTS
Java - JDK 1.8_252
APIM - 3.2.0
GO - 1.14
APICTL- 3.2.0 Beta