### PR TITLE
Reading urls from additionalProperties

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
@@ -62,27 +62,29 @@ const styles = (theme) => ({
         }
     },
     tableMain: {
-        width: '100%',
-        borderCollapse: 'collapse',
-        marginTop: theme.spacing(3),
-        marginLeft: theme.spacing(2),
-        marginRight: theme.spacing(1),
-        '& tr td':{
+        '& > table': {
+            width: '100%',
+            borderCollapse: 'collapse',
+            marginTop: theme.spacing(3),
+            marginLeft: theme.spacing(2),
+            marginRight: theme.spacing(1),
+        },
+        '& table > tr td':{
             paddingLeft: theme.spacing(1),
         },
-        '& tr:nth-child(even)': {
+        '&  table > tr:nth-child(even)': {
             backgroundColor: theme.custom.listView.tableBodyEvenBackgrund,
             '& td, & a, & .material-icons': {
                 color: theme.palette.getContrastText(theme.custom.listView.tableBodyEvenBackgrund),
             },
         },
-        '& tr:nth-child(odd)': {
+        '&  table > tr:nth-child(odd)': {
             backgroundColor: theme.custom.listView.tableBodyOddBackgrund,
             '& td, & a, & .material-icons': {
                 color: theme.palette.getContrastText(theme.custom.listView.tableBodyOddBackgrund),
             },
         },
-        '& th': {
+        '&  table > tr > th': {
             backgroundColor: theme.custom.listView.tableHeadBackground,
             color: theme.palette.getContrastText(theme.custom.listView.tableHeadBackground),
             paddingLeft: theme.spacing(1),
@@ -485,46 +487,48 @@ class Credentials extends React.Component {
                                         defaultMessage='( Applications Subscribed to this Api )'
                                     />
                                 </Typography>
-                                <table className={classes.tableMain}>
-                                    <tr>
-                                        <th className={classes.th}>
-                                            <FormattedMessage
-                                                id={'Apis.Details.Credentials.Credentials.'
-                                                + 'api.credentials.subscribed.apps.name'}
-                                                defaultMessage='Application Name'
+                                <div className={classes.tableMain}>
+                                    <table>
+                                        <tr>
+                                            <th className={classes.th}>
+                                                <FormattedMessage
+                                                    id={'Apis.Details.Credentials.Credentials.'
+                                                    + 'api.credentials.subscribed.apps.name'}
+                                                    defaultMessage='Application Name'
+                                                />
+                                            </th>
+                                            <th className={classes.th}>
+                                                <FormattedMessage
+                                                    id={'Apis.Details.Credentials.Credentials.api.'
+                                                    + 'credentials.subscribed.apps.tier'}
+                                                    defaultMessage='Throttling Tier'
+                                                />
+                                            </th>
+                                            <th className={classes.th}>
+                                                <FormattedMessage
+                                                    id={'Apis.Details.Credentials.Credentials.'
+                                                    + 'api.credentials.subscribed.apps.status'}
+                                                    defaultMessage='Application Status'
+                                                />
+                                            </th>
+                                            <th className={classes.th} />
+                                        </tr>
+                                        {subscribedApplications.map((app, index) => (
+                                            <SubscriptionTableRow
+                                                key={index}
+                                                loadInfo={this.loadInfo}
+                                                handleSubscriptionDelete={this.handleSubscriptionDelete}
+                                                selectedAppId={selectedAppId}
+                                                updateSubscriptionData={updateSubscriptionData}
+                                                selectedKeyType={selectedKeyType}
+                                                app={app}
+                                                index={index}
+                                                applicationOwner={applicationOwner}
+                                                hashEnabled={hashEnabled}
                                             />
-                                        </th>
-                                        <th className={classes.th}>
-                                            <FormattedMessage
-                                                id={'Apis.Details.Credentials.Credentials.api.'
-                                                + 'credentials.subscribed.apps.tier'}
-                                                defaultMessage='Throttling Tier'
-                                            />
-                                        </th>
-                                        <th className={classes.th}>
-                                            <FormattedMessage
-                                                id={'Apis.Details.Credentials.Credentials.'
-                                                + 'api.credentials.subscribed.apps.status'}
-                                                defaultMessage='Application Status'
-                                            />
-                                        </th>
-                                        <th className={classes.th} />
-                                    </tr>
-                                    {subscribedApplications.map((app, index) => (
-                                        <SubscriptionTableRow
-                                            key={index}
-                                            loadInfo={this.loadInfo}
-                                            handleSubscriptionDelete={this.handleSubscriptionDelete}
-                                            selectedAppId={selectedAppId}
-                                            updateSubscriptionData={updateSubscriptionData}
-                                            selectedKeyType={selectedKeyType}
-                                            app={app}
-                                            index={index}
-                                            applicationOwner={applicationOwner}
-                                            hashEnabled={hashEnabled}
-                                        />
-                                    ))}
-                                </table>
+                                        ))}
+                                    </table>
+                                </div>
                             </>
                         )}
                     </>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/AppConfiguration.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/AppConfiguration.jsx
@@ -17,17 +17,23 @@
  */
 
 import React, { useState } from 'react';
-import Box from '@material-ui/core/Box';
+import InputLabel from '@material-ui/core/InputLabel';
+import FormControl from '@material-ui/core/FormControl';
+import ListItemText from '@material-ui/core/ListItemText';
+import Checkbox from '@material-ui/core/Checkbox';
 import Chip from '@material-ui/core/Chip';
 import MenuItem from '@material-ui/core/MenuItem';
-import Grid from '@material-ui/core/Grid';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
 import { withStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import Select from '@material-ui/core/Select';
 import Input from '@material-ui/core/Input';
+import Box from '@material-ui/core/Box';
+
 
 const styles = theme => ({
     FormControl: {
@@ -63,18 +69,6 @@ const styles = theme => ({
     },
 });
 
-const MenuProps = {
-    PaperProps: {
-        style: {
-            paddingTop: 2,
-            paddingBottom: 2,
-            paddingLeft: 0,
-            maxHeight: 224,
-            width: 500,
-        },
-    },
-};
-
 /**
  *
  *
@@ -89,7 +83,7 @@ const AppConfiguration = (props) => {
 
     const [selectedValue, setSelectedValue] = useState(defaultValue);
     const [multipleSelectedValue, setMultipleSelectedValue] = useState([]);
-    
+
     /**
      * This method is used to handle the updating of key generation
      * request object.
@@ -98,127 +92,137 @@ const AppConfiguration = (props) => {
      */
     const handleAppRequestChange = (event) => {
         const { target: currentTarget } = event;
-        if(config.multiple){
+        if (config.multiple) {
             setMultipleSelectedValue(currentTarget.value);
-        }else {
+        } else {
             setSelectedValue(currentTarget.value);
         }
-        
+
         handleChange('additionalProperties', event);
     }
 
-    return ( 
-        <Box display='flex'>
-        <Grid item xs={10} md={5}>
-        {config.type === 'select'  && config.multiple === false ? (
-            <TextField
-                classes={{
-                    root: classes.removeHelperPadding,
-                }}
-                fullWidth
-                id={config.name}
-                select
-                label={config.label}
-                value={selectedValue}
-                name={config.name}
-                onChange={e => handleAppRequestChange(e)}
-                helperText={
-                    <Typography variant='caption'>
-                        {config.tooltip}                 
-                    </Typography>
-                }
-                margin='normal'
-                variant='outlined'
-                disabled={!isUserOwner}
-            >
-            {config.values.map( key => (
-                <MenuItem key={key} value={key}>
-                    {key}
-                </MenuItem>
-            ))}
-            </TextField>
-        ) : (config.type === 'select'  && config.multiple === true) ? (
-            <React.Fragment>
-                <Typography variant='caption'>
-                    {config.label}                 
-                </Typography>
-                <br/>
-                <Select
-                    displayEmpty
-                    name={config.name}
-                    multiple
-                    value={multipleSelectedValue}
-                    onChange={e => handleAppRequestChange(e)}
-                    input={<Input id='select-multiple-chip' />}
-                    renderValue={selected => (
-                        <div className={classes.chips}>
-                            {selected.map(value => (
-                                <Chip key={value} label={value} className={classes.chip} />
+    return (
+        <>
+            <TableRow>
+                <TableCell component='th' scope='row' className={classes.leftCol}>
+                    {config.label}
+                </TableCell>
+                <TableCell>
+                    <Box maxWidth={600}>
+                    {config.type === 'select' && config.multiple === false ? (
+                        <TextField
+                            classes={{
+                                root: classes.removeHelperPadding,
+                            }}
+                            fullWidth
+                            id={config.name}
+                            select
+                            label={config.label}
+                            value={selectedValue}
+                            name={config.name}
+                            onChange={e => handleAppRequestChange(e)}
+                            helperText={
+                                <Typography variant='caption'>
+                                    {config.tooltip}
+                                </Typography>
+                            }
+                            margin='dense'
+                            variant='outlined'
+                            disabled={!isUserOwner}
+                        >
+                            {config.values.map(key => (
+                                <MenuItem key={key} value={key}>
+                                    {key}
+                                </MenuItem>
                             ))}
-                        </div>
-                    )}
-                    MenuProps={MenuProps}
-                    helperText={
-                        <Typography variant='caption'>
-                            {config.tooltip}                 
-                        </Typography>
-                    }
-                    label={config.label}
-                >
-                {config.values.map( key => (
-                    <MenuItem key={key} value={key}>
-                        {key}
-                    </MenuItem>
-                ))}
-                </Select>
-                <br/>
-                <Typography variant='caption'>
-                        {config.tooltip}                 
-                </Typography>
-            </React.Fragment>
-        ) : (config.type === 'input') ? (
-            <TextField
-                classes={{
-                    root: classes.removeHelperPadding,
-                }}
-                fullWidth
-                id={config.name}
-                label={config.label}
-                value={selectedValue}
-                name={config.name}
-                onChange={e => handleAppRequestChange(e)}
-                helperText={
-                        <Typography variant='caption'>
-                            {config.tooltip}                 
-                        </Typography>
-                }
-                margin='normal'
-                variant='outlined'
-                disabled={!isUserOwner}
-            />
-        ) : (
-            <TextField
-                classes={{
-                    root: classes.removeHelperPadding,
-                }}
-                fullWidth
-                id={config.name}
-                label={config.label}
-                value={selectedValue}
-                name={config.name}
-                onChange={e => handleAppRequestChange(e)}
-                helperText={
-                        <Typography variant='caption'>                          
+                        </TextField>
+                    ) : (config.type === 'select' && config.multiple === true) ? (
+                        <>
+                            <FormControl variant="outlined" className={classes.formControl} fullWidth>
+                                <InputLabel id="multi-select-label">{config.label}</InputLabel>
+                                <Select
+                                    labelId="multi-select-label"
+                                    id="multi-select-outlined"
+                                    margin='dense'
+                                    displayEmpty
+                                    name={config.name}
+                                    multiple
+                                    value={multipleSelectedValue}
+                                    onChange={e => handleAppRequestChange(e)}
+                                    input={<Input id='multi-select-outlined' />}
+                                    renderValue={selected => (
+                                        <div className={classes.chips}>
+                                            {selected.map(value => (
+                                                <Chip key={value} label={value} className={classes.chip} />
+                                            ))}
+                                        </div>
+                                    )}
+                                    helperText={
+                                        <Typography variant='caption'>
+                                            {config.tooltip}
+                                        </Typography>
+                                    }
+                                    label={config.label}
+                                >
+                                    {config.values.map(key => (
+                                        <MenuItem key={key} value={key}>
+                                            <Checkbox checked={multipleSelectedValue.indexOf(key) > -1} />
+                                            <ListItemText primary={key} />
+                                        </MenuItem>
+                                    ))}
+                                </Select>
+                            </FormControl>
+
+
+                            <Typography variant='caption'>
                                 {config.tooltip}
-                        </Typography>
-                }
-                margin='normal'
-                variant='outlined'
-                disabled={!isUserOwner}
-            />
-        )}
-        </Grid>
-    </Box>
+                            </Typography>
+                        </>
+                    ) : (config.type === 'input') ? (
+                        <TextField
+                            classes={{
+                                root: classes.removeHelperPadding,
+                            }}
+                            fullWidth
+                            id={config.name}
+                            label={config.label}
+                            value={selectedValue}
+                            name={config.name}
+                            onChange={e => handleAppRequestChange(e)}
+                            helperText={
+                                <Typography variant='caption'>
+                                    {config.tooltip}
+                                </Typography>
+                            }
+                            margin='dense'
+                            variant='outlined'
+                            disabled={!isUserOwner}
+                        />
+                    ) : (
+                                    <TextField
+                                        classes={{
+                                            root: classes.removeHelperPadding,
+                                        }}
+                                        fullWidth
+                                        id={config.name}
+                                        label={config.label}
+                                        value={selectedValue}
+                                        name={config.name}
+                                        onChange={e => handleAppRequestChange(e)}
+                                        helperText={
+                                            <Typography variant='caption'>
+                                                {config.tooltip}
+                                            </Typography>
+                                        }
+                                        margin='dense'
+                                        variant='outlined'
+                                        disabled={!isUserOwner}
+                                    />
+                                )}
+                            </Box>
+                </TableCell>
+            </TableRow>
+        </>
     );
 };
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/KeyConfiguration.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/KeyConfiguration.jsx
@@ -18,11 +18,8 @@
 import React, { useState } from 'react';
 import Box from '@material-ui/core/Box';
 import cloneDeep from 'lodash.clonedeep';
-import Grid from '@material-ui/core/Grid';
 import { withStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
-import InputLabel from '@material-ui/core/InputLabel';
-import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -114,10 +111,10 @@ const KeyConfiguration = (props) => {
         classes, notFound, isUserOwner, keyManagerConfig, validating, updateKeyRequest, keyRequest,
     } = props;
     const {
-        selectedGrantTypes, callbackUrl, additionalProperties
+        selectedGrantTypes, callbackUrl,
     } = keyRequest;
     let {
-        applicationConfiguration, availableGrantTypes, description,
+        applicationConfiguration, availableGrantTypes, description, additionalProperties,
         enableMapOAuthConsumerApps, enableOAuthAppCreation, enableTokenEncryption, enableTokenGeneration,
         id, name, revokeEndpoint, tokenEndpoint, type, userInfoEndpoint,
     } = keyManagerConfig;
@@ -214,6 +211,11 @@ const KeyConfiguration = (props) => {
         availableGrantTypes,
         Settings.grantTypes,
     );
+
+    // Check for additional properties for token endpoint and revoke endpoints.
+    const propPrefix = keyRequest.keyType.toLowerCase();
+    tokenEndpoint = additionalProperties[`${propPrefix}_token_endpoint`] || tokenEndpoint;
+    revokeEndpoint = additionalProperties[`${propPrefix}_revoke_endpoint`] || revokeEndpoint;
 
     return (
         <>
@@ -366,6 +368,7 @@ const KeyConfiguration = (props) => {
                                         id='Shared.AppsAndKeys.KeyConfiguration.the.application.can'
                                     />
                                 </FormHelperText>
+                                        
                             </TableCell>
                         </TableRow>
                         <TableRow>
@@ -377,48 +380,48 @@ const KeyConfiguration = (props) => {
 
                             </TableCell>
                             <TableCell>
-                                <TextField
-                                    margin='dense'
-                                    id='callbackURL'
-                                    label={<FormattedMessage
-                                        defaultMessage='Callback URL'
-                                        id='Shared.AppsAndKeys.KeyConfiguration.callback.url.label'
-                                    />}
-                                    value={callbackUrl}
-                                    name='callbackURL'
-                                    onChange={e => handleChange('callbackUrl', e)}
-                                    helperText={callBackHasErrors() || <FormattedMessage
-                                        defaultMessage={`Callback URL is a redirection URI in the client
-                        application which is used by the authorization server to send the
-                        client's user-agent (usually web browser) back after granting access.`}
-                                        id='Shared.AppsAndKeys.KeyConfCiguration.callback.url.helper.text'
-                                    />}
-                                    variant='outlined'
-                                    disabled={!isUserOwner ||
-                                        (selectedGrantTypes && !selectedGrantTypes.includes('authorization_code')
-                                            && !selectedGrantTypes.includes('implicit'))
-                                    }
-                                    error={callBackHasErrors()}
-                                    placeholder={intl.formatMessage({
-                                        defaultMessage: 'http://url-to-webapp',
-                                        id: 'Shared.AppsAndKeys.KeyConfiguration.url.to.webapp',
-                                    })}
-                                />
+                                <Box maxWidth={600}>
+                                    <TextField
+                                        margin='dense'
+                                        id='callbackURL'
+                                        label={<FormattedMessage
+                                            defaultMessage='Callback URL'
+                                            id='Shared.AppsAndKeys.KeyConfiguration.callback.url.label'
+                                        />}
+                                        value={callbackUrl}
+                                        name='callbackURL'
+                                        onChange={e => handleChange('callbackUrl', e)}
+                                        helperText={callBackHasErrors() || <FormattedMessage
+                                            defaultMessage={`Callback URL is a redirection URI in the client
+                            application which is used by the authorization server to send the
+                            client's user-agent (usually web browser) back after granting access.`}
+                                            id='Shared.AppsAndKeys.KeyConfCiguration.callback.url.helper.text'
+                                        />}
+                                        variant='outlined'
+                                        disabled={!isUserOwner ||
+                                            (selectedGrantTypes && !selectedGrantTypes.includes('authorization_code')
+                                                && !selectedGrantTypes.includes('implicit'))
+                                        }
+                                        error={callBackHasErrors()}
+                                        placeholder={intl.formatMessage({
+                                            defaultMessage: 'http://url-to-webapp',
+                                            id: 'Shared.AppsAndKeys.KeyConfiguration.url.to.webapp',
+                                        })}
+                                    />
+                                </Box>
                             </TableCell>
                         </TableRow>
+                        {applicationConfiguration.length > 0 && applicationConfiguration.map(config => (
+                            <AppConfiguration
+                                config={config}
+                                defaultValue={config.default}
+                                isUserOwner={isUserOwner}
+                                handleChange={handleChange}
+                            />
+                        ))}
                     </TableBody>
                 </Table>
             </Box>
-
-
-            {applicationConfiguration.length > 0 && applicationConfiguration.map(config => (
-                <AppConfiguration
-                    config={config}
-                    defaultValue={config.default}
-                    isUserOwner={isUserOwner}
-                    handleChange={handleChange}
-                />
-            ))}
         </>
     );
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/ViewCurl.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/ViewCurl.jsx
@@ -23,7 +23,6 @@ import CopyToClipboard from 'react-copy-to-clipboard';
 import FileCopy from '@material-ui/icons/FileCopy';
 import Tooltip from '@material-ui/core/Tooltip';
 import { FormattedMessage, injectIntl } from 'react-intl';
-import Settings from 'AppComponents/Shared/SettingsContext';
 
 const useStyles = makeStyles(theme => ({
     code: {
@@ -55,9 +54,10 @@ function ViewCurl(props) {
     const {
         keys: { consumerKey, consumerSecret },
         intl,
+        keyType,
+        keyManagerConfig,
     } = props;
     const bas64Encoded = window.btoa(consumerKey + ':' + consumerSecret);
-    const { settings: { apiGatewayEndpoint } } = useContext(Settings);
     const [showReal, setShowReal] = useState(false);
     const [tokenCopied, setTokenCopied] = useState(false);
     const onCopy = () => {
@@ -72,8 +72,12 @@ function ViewCurl(props) {
         setShowReal(!showReal);
     };
 
-    const gatewayUrl = apiGatewayEndpoint ? apiGatewayEndpoint.split(',')[0] : 'https://localhost:8243';
-    const tokenURL = `${gatewayUrl}/token`;
+
+    // Check for additional properties for token endpoint and revoke endpoints.
+    const { additionalProperties } = keyManagerConfig;
+    let { tokenEndpoint } = keyManagerConfig;
+    const propPrefix = keyType.toLowerCase();
+    tokenEndpoint = additionalProperties[`${propPrefix}_token_endpoint`] || tokenEndpoint;
 
     return (
         <React.Fragment>
@@ -88,7 +92,7 @@ function ViewCurl(props) {
             <div className={classes.contentWrapper}>
                 <div className={classes.code}>
                     <div>
-                        <span className={classes.command}>curl -k -X POST </span> {tokenURL}
+                        <span className={classes.command}>curl -k -X POST </span> {tokenEndpoint}
                         <span className={classes.command}> -d </span>{' '}
                         {'"grant_type=password&username=Username&password=Password"'}
                     </div>
@@ -117,9 +121,9 @@ function ViewCurl(props) {
                         placement='right'
                     >
                         <CopyToClipboard
-                            text={`curl -k -X POST ${tokenURL} -d ` +
-                            '"grant_type=password&username=Username&password=Password" -H ' +
-                            `"Authorization: Basic ${bas64Encoded}"`}
+                            text={`curl -k -X POST ${tokenEndpoint} -d ` +
+                                '"grant_type=password&username=Username&password=Password" -H ' +
+                                `"Authorization: Basic ${bas64Encoded}"`}
                             onCopy={onCopy}
                         >
                             <FileCopy color='secondary' />
@@ -137,7 +141,7 @@ function ViewCurl(props) {
             <div className={classes.contentWrapper}>
                 <div className={classes.code}>
                     <div>
-                        <span className={classes.command}>curl -k -X POST </span> {tokenURL}
+                        <span className={classes.command}>curl -k -X POST </span> {tokenEndpoint}
                         <span className={classes.command}> -d </span>{' '}
                         {'"grant_type=client_credentials"'}
                     </div>
@@ -153,9 +157,9 @@ function ViewCurl(props) {
                 <div>
                     <Tooltip title={tokenCopied ? 'Copied' : 'Copy to clipboard'} placement='right'>
                         <CopyToClipboard
-                            text={`curl -k -X POST ${tokenURL} -d ` +
-                            '"grant_type=client_credentials" -H' +
-                            `"Authorization: Basic ${bas64Encoded}"`}
+                            text={`curl -k -X POST ${tokenEndpoint} -d ` +
+                                '"grant_type=client_credentials" -H' +
+                                `"Authorization: Basic ${bas64Encoded}"`}
                             onCopy={onCopy}
                         >
                             <FileCopy color='secondary' />

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/ViewKeys.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/ViewKeys.jsx
@@ -575,7 +575,11 @@ class ViewKeys extends React.Component {
                                 )}
                                 {showCurl && (
                                     <DialogContentText>
-                                        <ViewCurl keys={{ consumerKey, consumerSecret }} />
+                                        <ViewCurl 
+                                            keys={{ consumerKey, consumerSecret }} 
+                                            keyType={keyType} 
+                                            keyManagerConfig={keyManagerConfig} 
+                                        />
                                     </DialogContentText>
                                 )}
                                 {showSecretGen && (


### PR DESCRIPTION
Key manager config read the additionalProperties attribute to populate the token/revoke endpoints.

Key manager config ex.

```java
{
      "id": "a5bc256f-c893-4d4f-9a1c-18420c496377",
      "name": "Default",
      "type": "default",
      "displayName": null,
      "description": "This is Key Manager",
      "enabled": true,
      "availableGrantTypes": [
        "refresh_token",
        "urn:ietf:params:oauth:grant-type:saml2-bearer",
        "password",
        "client_credentials",
        "iwa:ntlm",
        "urn:ietf:params:oauth:grant-type:device_code",
        "authorization_code",
        "urn:ietf:params:oauth:grant-type:jwt-bearer"
      ],
      "tokenEndpoint": "https://localhost:9443/oauth2/token",
      "revokeEndpoint": "https://localhost:9443/oauth2/revoke",
      "userInfoEndpoint": null,
      "enableTokenGeneration": true,
      "enableTokenEncryption": false,
      "enableTokenHashing": false,
      "enableOAuthAppCreation": false,
      "enableMapOAuthConsumerApps": false,
      "applicationConfiguration": [],
      "additionalProperties": {
        "sandbox_token_endpoint": "https://localhost:8243/token",
        "production_revoke_endpoint": "https://localhost:8243/revoke",
        "sandbox_revoke_endpoint": "https://localhost:8243/revoke",
        "production_token_endpoint": "https://localhost:8243/token"
      }
    }
```

additionalProperties.sandbox_token_endpoint is taking priority over tokenEndpoint.


Update the view curl link to have the correct URL from the km configs.

Fixed styling issues with keygen UI @ the subscriptions page.