### PR TITLE
Provide 409 status code instead of 500 when application is already exists in devportal.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ImportApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ImportApiServiceImpl.java
@@ -25,6 +25,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.phase.PhaseInterceptorChain;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.APIMgtResourceAlreadyExistsException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIKey;
@@ -308,6 +309,8 @@ public class ImportApiServiceImpl implements ImportApiService {
                 APIInfoListDTO skippedAPIListDTO = APIInfoMappingUtil.fromAPIInfoListToDTO(skippedAPIs);
                 return Response.created(location).status(207).entity(skippedAPIListDTO).build();
             }
+        } catch (APIMgtResourceAlreadyExistsException e) {
+            RestApiUtil.handleResourceAlreadyExistsError("Error while importing Application", e, log);
         } catch (APIManagementException | URISyntaxException | UserStoreException e) {
             RestApiUtil.handleInternalServerError("Error while importing Application", e, log);
         } catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
## Purpose
When importing an application using APICTL, if the user import an existing application again without --update flag, it gives as Internal Server Error with 500 status code instead of Resource already exists Error with 409 status code. This PR will solve this issue and provide a 409 status error code as it supposed to do initially.

## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/409

## Approach
1. Currently, when a user tries to import an existing application without --update flag, the output will be shown as follows.

`./apictl import-app -f /home/chamindu/.wso2apictl/exported/apps/dev/admin_default-apictl-app -e dev `

```
Error importing Application.
Status: 500 
Response: {"code":500,"message":"Internal server error","description":"Error while importing Application","moreInfo":"","error":[]}
apictl: Error importing Application Reason: 500 
Exit status 1
```


2. After the fix, the output will be changed as follows.

`./apictl import-app -f /home/chamindu/.wso2apictl/exported/apps/dev/admin_default-apictl-app.zip -e dev 
`

```
Error importing Application.
Status: 409 
Response: {"code":409,"message":"Resource Already Exists","description":"Error while importing Application","moreInfo":"","error":[]}
apictl: Error importing Application Reason: 409 
Exit status 1

```
## User stories
Importing an Application using the API Controller tool.


## Test environment
OS - Ubuntu 20.04 LTS
Java - JDK 1.8_252
APIM - 3.2.0
APICTL- 3.2.0 Beta
