### PR TITLE
Fix copying custom assets for login customization

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/listeners/ServerStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/listeners/ServerStartupListener.java
@@ -64,6 +64,7 @@ public class ServerStartupListener implements ServerStartupObserver {
         String repositoryDir = "repository";
         String resourcesDir = "resources";
         String extensionsDir = "extensions";
+        String customAssetsDir = "customAssets";
         String webappDir = "webapps";
         String authenticationEndpointDir = "authenticationendpoint";
         String accountRecoveryEndpointDir = "accountrecoveryendpoint";
@@ -76,6 +77,9 @@ public class ServerStartupListener implements ServerStartupObserver {
             String resourceExtDirectoryPath =
                     CarbonUtils.getCarbonHome() + File.separator + repositoryDir + File.separator + resourcesDir
                             + File.separator + extensionsDir;
+            String customAssetsExtDirectoryPath =
+                    CarbonUtils.getCarbonHome() + File.separator + repositoryDir + File.separator + resourcesDir
+                    + File.separator + extensionsDir + File.separator + customAssetsDir;
             String authenticationEndpointWebAppPath =
                     CarbonUtils.getCarbonRepository() + webappDir + File.separator + authenticationEndpointDir;
             String authenticationEndpointWebAppExtPath =
@@ -84,6 +88,9 @@ public class ServerStartupListener implements ServerStartupObserver {
                     CarbonUtils.getCarbonRepository() + webappDir + File.separator + accountRecoveryEndpointDir;
             String accountRecoveryWebAppExtPath = accountRecoveryWebAppPath + File.separator + extensionsDir;
             if (new File(resourceExtDirectoryPath).exists()) {
+                // delete extensions directory from the webapp folders if they exist
+                FileUtils.deleteDirectory(new File(authenticationEndpointWebAppExtPath));
+                FileUtils.deleteDirectory(new File(accountRecoveryWebAppExtPath));
                 log.info("Starting to copy identity page extensions...");
                 String headerJsp = resourceExtDirectoryPath + File.separator + headerJspFile;
                 String footerJsp = resourceExtDirectoryPath + File.separator + footerJspFile;
@@ -113,6 +120,13 @@ public class ServerStartupListener implements ServerStartupObserver {
                 if (new File(privacyPolicyContentJsp).exists()) {
                     copyFileToDirectory(privacyPolicyContentJsp, authenticationEndpointWebAppExtPath,
                             authenticationEndpointWebAppPath);
+                }
+                // copy custom asset files to the webapp directories
+                if (new File(customAssetsExtDirectoryPath).exists()) {
+                    FileUtils.copyDirectory(new File(customAssetsExtDirectoryPath),
+                            new File(authenticationEndpointWebAppExtPath + File.separator + customAssetsDir));
+                    FileUtils.copyDirectory(new File(customAssetsExtDirectoryPath),
+                            new File(accountRecoveryWebAppExtPath + File.separator + customAssetsDir));
                 }
                 log.info("Successfully completed copying identity page extensions");
             }


### PR DESCRIPTION
This PR fixes https://github.com/wso2/product-apim/issues/8730

With this fix, all the custom assets like logos, etc should be added to 
```<APIM_HOME>/repository/resources/extensions/customAssets``` folder for login customization steps in document [1].

[1] https://apim.docs.wso2.com/en/latest/develop/customizations/customizing-login-pages-for-dev-portal-and-publisher/#customizing-different-sections-of-identity-server-related-jsp-pages