### PR TITLE
Fixing customURL tenant domain coming as null issue

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/site/public/pages/index.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/site/public/pages/index.jag
@@ -45,13 +45,13 @@
   </div>
   <script type="text/javascript" src="<%= settings.Settings.app.context %>/site/public/theme/defaultTheme.js"></script>
   <script type="text/javascript" src="<%= settings.Settings.app.context %>/services/settings/settings.js"></script>
+  <script type="text/javascript">
+    Settings.app.customUrl.tenantDomain = '<%=appUtils.getCustomUrlEnabledDomain()%>';
+  </script>
   <script src="<%= settings.Settings.app.context %>/site/public/fonts/iconfont/MaterialIcons.js"></script>
   <script src="<%= settings.Settings.app.context %>/site/public/dist/<%= indexBundle %>"></script>
   <link rel="stylesheet" href="<%= settings.Settings.app.context %>/site/public/fonts/iconfont/material-icons.css">
   <link rel="stylesheet" href="<%= settings.Settings.app.context %>/site/public/css/overrides.css">
-  <script type="text/javascript">
-    Settings.app.customUrl.tenantDomain = '<%=appUtils.getCustomUrlEnabledDomain()%>';
-  </script>
 </body>
 
 </html>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/DevPortal.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/DevPortal.jsx
@@ -75,6 +75,14 @@ class DevPortal extends React.Component {
      *  Mounting the components
      */
     componentDidMount() {
+        const { app: { customUrl: { tenantDomain: customUrlEnabledDomain } } } = Settings;
+        let tenant = null;
+        const urlParams = new URLSearchParams(window.location.search);
+        if (customUrlEnabledDomain !== 'null') {
+            tenant = customUrlEnabledDomain;
+        } else {
+            tenant = urlParams.get('tenant')
+        }
         const api = new API();
         const promisedSettings = api.getSettings();
         promisedSettings
@@ -94,8 +102,7 @@ class DevPortal extends React.Component {
                     error,
                 );
             });
-        const urlParams = new URLSearchParams(window.location.search);
-        if (urlParams.get('tenant') === null || urlParams.get('tenant') === 'carbon.super') {
+        if (tenant === null || tenant === 'carbon.super') {
             const { custom: { publicTenantStore } } = this.systemTheme;
             if(publicTenantStore) {
                 const { active: publicTenantStoreActive, redirectToIfInactive } = publicTenantStore;
@@ -111,7 +118,7 @@ class DevPortal extends React.Component {
                 this.setState({ theme: this.systemTheme, redirecting: false });
             }
         } else {
-            this.setTenantTheme(urlParams.get('tenant'));
+            this.setTenantTheme(tenant);
         }
     }
     /**


### PR DESCRIPTION
Redirection to a given URL is not supposed to work when custom URLs enabled and the following config is set.

```java
 publicTenantStore: {
            active: false,
            redirectToIfInactive: 'https://wso2.com/api-management/cloud/',
  },
```