### PR TITLE
Fix for https://github.com/wso2/product-apim-tooling/issues/418

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/ApplicationImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/ApplicationImportExportManager.java
@@ -99,7 +99,7 @@ public class ApplicationImportExportManager {
     }
 
     /**
-     * Import and add subscriptions of a particular application for the available APIs
+     * Import and add subscriptions of a particular application for the available APIs and API products
      *
      * @param appDetails details of the imported application
      * @param userId     username of the subscriber
@@ -137,8 +137,9 @@ public class ApplicationImportExportManager {
                 Set<Object> apiSet = (Set<Object>) matchedAPIs.get("apis");
                 if (apiSet != null && !apiSet.isEmpty()) {
                     Object type = apiSet.iterator().next();
-
+                    //Check whether the object is an ApiProduct
                     if (isApiProduct(type)) {
+                        //Handle Api Product subscriptions
                         APIProduct apiProduct = (APIProduct) apiSet.iterator().next();
                         //tier of the imported subscription
                         Tier tier = subscribedAPI.getTier();
@@ -161,6 +162,7 @@ public class ApplicationImportExportManager {
                             skippedAPIList.add(subscribedAPI.getApiId());
                         }
                     } else {
+                        //Handle API subscriptions
                         API api = (API) apiSet.iterator().next();
                         //tier of the imported subscription
                         Tier tier = subscribedAPI.getTier();
@@ -214,19 +216,18 @@ public class ApplicationImportExportManager {
         }
     }
 
-//    /**
-//     * Check whether a target Tier is available to subscribe
-//     *
-//     * @param targetTier Target Tier
-//     * @param api        - {@link API}
-//     * @return true, if the target tier is available
-//     */
+    /**
+     * Check whether the object is a type of ApiProduct
+     *
+     * @param object        - {@link Object}
+     * @return true, if the object is an ApiProduct, otherwise false
+     */
     private boolean isApiProduct(Object object) {
-
-        try{
+        try {
+            //Cast object to ApiProduct
             APIProduct apiProduct = (APIProduct) object;
-            return  (apiProduct != null) ?  true:  false;
-        } catch (Exception e){
+            return (apiProduct != null) ? true : false;
+        } catch (Exception e) {
             return false;
         }
     }
@@ -239,13 +240,13 @@ public class ApplicationImportExportManager {
      * @return true, if the target tier is available
      */
     private boolean isTierAvailableForProduct(Tier targetTier, APIProduct apiProduct) {
-        APIProductIdentifier apiId = apiProduct.getId();
+        APIProductIdentifier apiProductId = apiProduct.getId();
         Set<Tier> availableTiers = apiProduct.getAvailableTiers();
         if (availableTiers.contains(targetTier)) {
             return true;
         } else {
-            log.error("Tier:" + targetTier.getName() + " is not available for API " + apiId.getName() + "-" +
-                    apiId.getVersion());
+            log.error("Tier:" + targetTier.getName() + " is not available for API Product " + apiProductId.getName() + "-" +
+                    apiProductId.getVersion());
             return false;
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/ApplicationImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/ApplicationImportExportManager.java
@@ -216,13 +216,8 @@ public class ApplicationImportExportManager {
      * @return true, if the object is an ApiProduct, otherwise false
      */
     private boolean isApiProduct(Object object) {
-        try {
-            //Cast object to ApiProduct
-            APIProduct apiProduct = (APIProduct) object;
-            return (apiProduct != null) ? true : false;
-        } catch (Exception e) {
-            return false;
-        }
+        //Check whether the object is an instance of ApiProduct
+        return (object) instanceof APIProduct;
     }
 
     /**


### PR DESCRIPTION
## Purpose
When importing An Application using API Controller it gives an error when that importing application has an active subscription with an API Product. This PR will solve this issue and remove the above mentioned blocker

## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/418

## Approach

When search query executed on REST API, it will return a map of objects which are equal to the given search query. But the latest new feature support of API products from APICTL tool this map will return both API and API Product objects. Currently this import application method only assert the subscriptions of API objects only.
So this PR will provide the ability to detect the type of the returning object (API or APIProduct) and assert that object. Then necessary steps will be executed the import Application based on type of subscriptions that has with Applications.
 
## User stories
Importing an Application using the API Controller tool which has active subscriptions with APIs and APIProducts.


## Test environment
OS - Ubuntu 20.04 LTS
Java - JDK 1.8_252
APIM - 3.2.0
GO - 1.14
APICTL- 3.1.3 