### PR TITLE
Change scope scheme mapping in swagger parsers after migration changes

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -1332,7 +1332,9 @@ public class OAS2Parser extends APIDefinition {
         Map<String, String> defaultScopeBindings = null;
         if (securityDefinitions != null) {
             //If there is no default type schemes set a one
-            OAuth2Definition newDefault = new OAuth2Definition();
+            OAuth2Definition newDefault = new OAuth2Definition().implicit("https://test.com");
+            newDefault.setType("oauth2");
+            newDefault.setDescription("");
             securityDefinitions.put(SWAGGER_SECURITY_SCHEMA_KEY, newDefault);
             //Check all the security definitions
             for (Map.Entry<String, SecuritySchemeDefinition> definition : securityDefinitions.entrySet()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1456,6 +1456,7 @@ public class OAS3Parser extends APIDefinition {
             SecurityScheme defaultScheme = securitySchemes.get(OPENAPI_SECURITY_SCHEMA_KEY);
             if (defaultScheme == null) {
                 SecurityScheme newDefault = new SecurityScheme();
+                newDefault.setType(SecurityScheme.Type.OAUTH2);
                 securitySchemes.put(OPENAPI_SECURITY_SCHEMA_KEY, newDefault);
             }
             for (Map.Entry<String, SecurityScheme> entry : securitySchemes.entrySet()) {


### PR DESCRIPTION
## Purpose
Change scope scheme mapping in OAS2Parser and OAS3Parser after migration changes
