### PR TITLE
Add config to disable workflow listing

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.apimgt.api.model.botDataAPI.BotDetectionData;
 import org.wso2.carbon.apimgt.impl.alertmgt.AlertMgtConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dao.constants.SQLConstants;
+import org.wso2.carbon.apimgt.impl.dto.WorkflowProperties;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.keymgt.KeyMgtNotificationSender;
 import org.wso2.carbon.apimgt.impl.monetization.DefaultMonetizationImpl;
@@ -770,7 +771,13 @@ public class APIAdminImpl implements APIAdmin {
      */
     public Workflow[] getworkflows(String workflowType, String status, String tenantDomain)
             throws APIManagementException {
-        return apiMgtDAO.getworkflows(workflowType, status, tenantDomain);
+        WorkflowProperties workflowConfig = org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder.
+                getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration().getWorkflowProperties();
+        if (workflowConfig.isListTasks()) {
+            return apiMgtDAO.getworkflows(workflowType, status, tenantDomain);
+        } else {
+            return new Workflow[0];
+        }
     }
 
     /**
@@ -784,9 +791,14 @@ public class APIAdminImpl implements APIAdmin {
      */
     public Workflow getworkflowReferenceByExternalWorkflowReferenceID(String externelWorkflowRef, String status,
                                                                       String tenantDomain) throws APIManagementException {
-        Workflow workflow = apiMgtDAO.getworkflowReferenceByExternalWorkflowReferenceID(externelWorkflowRef,
-                status, tenantDomain);
-
+        Workflow workflow = null;
+        WorkflowProperties workflowConfig = org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder.
+                getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration().getWorkflowProperties();
+        if (workflowConfig.isListTasks()) {
+            workflow = apiMgtDAO.getworkflowReferenceByExternalWorkflowReferenceID(externelWorkflowRef,
+                    status, tenantDomain);
+        } 
+        
         if (workflow == null) {
             String msg = "External workflow Reference: " + externelWorkflowRef + " was not found.";
             throw new APIMgtResourceNotFoundException(msg);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1833,6 +1833,7 @@ public final class APIConstants {
         public static final String WORKFLOW_DCR_EP = "DCREndPoint";
         public static final String WORKFLOW_DCR_EP_USER = "DCREndPointUser";
         public static final String WORKFLOW_DCR_EP_PASSWORD = "DCREndPointPassword";
+        public static final String LIST_PENDING_TASKS = "ListPendingTasks";
 
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -798,6 +798,12 @@ public class APIManagerConfiguration {
             String dcrEPPassword = MiscellaneousUtil.resolve(dcrEPPasswordOmElement, secretResolver);
             dcrEPPassword = APIUtil.replaceSystemProperty(dcrEPPassword);
             workflowProperties.setdCREndpointPassword(dcrEPPassword);
+            
+            OMElement listTasksElement = workflowConfigurationElement
+                    .getFirstChildWithName(new QName(APIConstants.WorkflowConfigConstants.LIST_PENDING_TASKS));
+            if (listTasksElement != null) {
+                workflowProperties.setListTasks(JavaUtils.isTrueExplicitly(listTasksElement.getText()));
+            }
 
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/WorkflowProperties.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/WorkflowProperties.java
@@ -28,6 +28,7 @@ public class WorkflowProperties {
     private String dCREndPoint;
     private String dCREndpointUser;
     private String dCREndpointPassword;
+    private boolean listTasks = true; //default true
     
     public String getdCREndpointUser() {
         return dCREndpointUser;
@@ -83,6 +84,10 @@ public class WorkflowProperties {
     public void setWorkflowCallbackAPI(String workflowCallbackAPI) {
         this.workflowCallbackAPI = workflowCallbackAPI;
     }
-
-    
+    public boolean isListTasks() {
+        return listTasks;
+    }
+    public void setListTasks(boolean listTasks) {
+        this.listTasks = listTasks;
+    }    
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -906,6 +906,9 @@
 
     <WorkflowConfigurations>
         <Enabled>{{apim.workflow.enable}}</Enabled>
+        {% if apim.workflow.list_pending_tasks is defined %}
+        <ListPendingTasks>{{apim.workflow.list_pending_tasks}}</ListPendingTasks>
+        {% endif %}
     	<ServerUrl>{{apim.workflow.service_url}}</ServerUrl>
     	<ServerUser>{{apim.workflow.wf_engine_user}}</ServerUser>
     	<ServerPassword>{{apim.workflow.wf_engine_pass}}</ServerPassword>


### PR DESCRIPTION
Related to https://github.com/wso2/product-apim/issues/8541

By setting following to false, you could stop listing pending tasks in the admin portal. Default behavior is true

[apim.workflow]
list_pending_tasks = false