### PR TITLE
change whitelisted term to allowed

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -55,7 +55,7 @@
   "apim.oauth_config.revoke_endpoint": "https://localhost:${mgt.transport.https.port}/oauth2/revoke",
   "apim.oauth_config.enable_token_encryption": false,
   "apim.oauth_config.enable_token_hashing": false,
-  "apim.oauth_config.white_listed_scopes": [
+  "apim.oauth_config.allowed_scopes": [
     "^device_.*",
     "openid"
   ],

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -377,7 +377,7 @@
         <!-- All  scopes under the AllowedScopes element are not validating against roles that has assigned to it.
              By default ^device_.* and openid scopes have been white listed internally. -->
         <AllowedScopes>
-        {%for scope in apim.oauth_config.white_listed_scopes%}
+        {%for scope in apim.oauth_config.allowed_scopes%}
             <Scope>{{scope}}</Scope>
         {% endfor %}
         </AllowedScopes>


### PR DESCRIPTION
With this change, if one wants to specify some additional scope that are needed to skip validating while scope validation below config should be added in deployment.toml

[apim.oauth_config]
    allowed_scopes = ["^device_.*", "some_random_scope"]