### PR TITLE
Fixing connector configuration missing for initial editing

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -259,6 +259,8 @@ function AddEditKeyManager(props) {
                 dispatch({ field: 'all', value: editState });
                 updateKeyManagerConnectorConfiguration(editState.type);
             });
+        } else {
+            updateKeyManagerConnectorConfiguration(defaultKMType);
         }
     }, []);
 


### PR DESCRIPTION
Admin app key manager config is missing the connector config for initial loading.