### PR TITLE
Adding the missing attributes (operational level) when importing an API using the API Controller

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -276,13 +276,14 @@ public final class APIImportUtil {
                 swaggerContent = OASParserUtil.preProcess(swaggerContent);
 
                 addSwaggerDefinition(importedApi.getId(), swaggerContent, apiProvider);
+                APIDefinition apiDefinition = OASParserUtil.getOASParser(swaggerContent);
+
                 //If graphQL API, import graphQL schema definition to registry
                 if (StringUtils.equals(importedApi.getType(), APIConstants.APITransportType.GRAPHQL.toString())) {
                     String schemaDefinition = loadGraphqlSDLFile(pathToArchive);
                     addGraphqlSchemaDefinition(importedApi, schemaDefinition, apiProvider);
                 } else {
                     //Load required properties from swagger to the API
-                    APIDefinition apiDefinition = OASParserUtil.getOASParser(swaggerContent);
                     Set<URITemplate> uriTemplates = apiDefinition.getURITemplates(swaggerContent);
                     for (URITemplate uriTemplate : uriTemplates) {
                         Scope scope = uriTemplate.getScope();
@@ -303,10 +304,8 @@ public final class APIImportUtil {
 
                 // Generate API definition using the given API's URI templates and the swagger
                 // (Adding missing attributes to swagger)
-                String oldDefinition = apiProvider.getOpenAPIDefinition(importedApi.getId());
-                APIDefinition apiDefinition = OASParserUtil.getOASParser(oldDefinition);
                 SwaggerData swaggerData = new SwaggerData(importedApi);
-                String newDefinition = apiDefinition.generateAPIDefinition(swaggerData, oldDefinition);
+                String newDefinition = apiDefinition.generateAPIDefinition(swaggerData, swaggerContent);
                 apiProvider.saveSwaggerDefinition(importedApi, newDefinition);
             }
             // This is required to make url templates and scopes get effected

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -43,6 +43,7 @@ import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIStatus;
 import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
 import org.wso2.carbon.apimgt.api.model.Scope;
+import org.wso2.carbon.apimgt.api.model.SwaggerData;
 import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.APIConstants;
@@ -299,6 +300,14 @@ public final class APIImportUtil {
                     //Set extensions from API definition to API object
                     importedApi = OASParserUtil.setExtensionsToAPI(swaggerContent, importedApi);
                 }
+
+                // Generate API definition using the given API's URI templates and the swagger
+                // (Adding missing attributes to swagger)
+                String oldDefinition = apiProvider.getOpenAPIDefinition(importedApi.getId());
+                APIDefinition apiDefinition = OASParserUtil.getOASParser(oldDefinition);
+                SwaggerData swaggerData = new SwaggerData(importedApi);
+                String newDefinition = apiDefinition.generateAPIDefinition(swaggerData, oldDefinition);
+                apiProvider.saveSwaggerDefinition(importedApi, newDefinition);
             }
             // This is required to make url templates and scopes get effected
             apiProvider.updateAPI(importedApi);


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/437

## Goals
Add missing properties related to operational level attributes.

## Approach
- Used the function **generateAPIDefinition** to generate API definition using the given API's URI templates and the swagger while also adding missing properties related to operational level attributes.
- The attributes such as **x-auth-type**, **x-throttling-tier** and **security: - default: []** will be added where necessary.
- The attributes such as **x-scopes-bindings** will be modified as required.

## User stories
- When a user imports an API using the Dev First Approach, the operational level attributes such as security, rate-limiting policies and operation scopes for resources will be visible/enabled in the Publisher Portal.

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS