### PR TITLE
Fixing devportal issues

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/TryOutController.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/TryOutController.jsx
@@ -107,11 +107,14 @@ function TryOutController(props) {
     const {
         securitySchemeType, selectedEnvironment, environments, containerMngEnvironments, labels,
         productionAccessToken, sandboxAccessToken, selectedKeyType, setKeys, setSelectedKeyType,
-        selectedKeyManager, setSelectedKeyManager,
+        setSelectedKeyManager,
         setSelectedEnvironment, setProductionAccessToken, setSandboxAccessToken, scopes,
         setSecurityScheme, setUsername, setPassword, username, password, updateSwagger,
         setProductionApiKey, setSandboxApiKey, productionApiKey, sandboxApiKey, environmentObject, setURLs, api,
     } = props;
+    let { selectedKeyManager } = props;
+    selectedKeyManager = selectedKeyManager || 'Resident Key Manager';
+
     const classes = styles();
     const [showToken, setShowToken] = useState(false);
     const [isUpdating, setIsUpdating] = useState(false);

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/ImportExternalApp.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/ImportExternalApp.jsx
@@ -21,6 +21,7 @@ import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
+import Typography from '@material-ui/core/Typography';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import PlayForWorkIcon from '@material-ui/icons/PlayForWork';
 import { ScopeValidation, resourceMethods, resourcePaths } from 'AppComponents/Shared/ScopeValidation';

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
@@ -301,7 +301,7 @@ class TokenManager extends React.Component {
                     // Selecting a key manager from the list of key managers.
                     let { selectedTab } = this.state;
                     if (!selectedTab && responseKeyManagerList.length > 0) {
-                        selectedTab = !!responseKeyManagerList.find(x => x.name === 'Default') ? 'Default'
+                        selectedTab = !!responseKeyManagerList.find(x => x.name === 'Resident Key Manager') ? 'Resident Key Manager'
                             : responseKeyManagerList[0].name;
                     }
                     const selectdKM = responseKeyManagerList.find(x => x.name === selectedTab);


### PR DESCRIPTION
Fixing

Application Prod,Sandbox key view generate page break after enabling key provisioning
https://github.com/wso2/product-apim/issues/8952

and
Developer Portal Try out page Get Test Key not working for GraphQL
https://github.com/wso2/product-apim/issues/8954