### PR TITLE
Map and inject Mgw throttling Extensions To Default extensions when importing an API definition

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
@@ -182,7 +182,7 @@ public abstract class APIDefinition {
             throws APIManagementException;
 
     public abstract String getOASVersion(String oasDefinition) throws APIManagementException;
-    
+
     public abstract String getOASDefinitionWithTierContentAwareProperty(String oasDefinition,
             List<String> contentAwareTiersList, String apiLevelTier) throws APIManagementException;
 
@@ -193,6 +193,17 @@ public abstract class APIDefinition {
      * @return String
      */
     public abstract String processOtherSchemeScopes(String resourceConfigsJSON)
+            throws APIManagementException;
+
+    /**
+     * This method returns OAS definition which replaced X-WSO2-throttling-tier extension comes from
+     * mgw with X-throttling-tier extensions in OAS file
+     *
+     * @param swaggerContent String
+     * @return OpenAPI
+     * @throws APIManagementException
+     */
+    public abstract String injectMgwThrottlingExtensionsToDefault(String swaggerContent)
             throws APIManagementException;
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -1301,18 +1301,13 @@ public class OAS2Parser extends APIDefinition {
             for (Map.Entry<HttpMethod, Operation> entry : operationsMap.entrySet()) {
                 Operation operation = entry.getValue();
                 Map<String, Object> extensions = operation.getVendorExtensions();
-                if (extensions.containsKey(APIConstants.X_WSO2_THROTTLING_TIER)) {
+                if (extensions != null && extensions.containsKey(APIConstants.X_WSO2_THROTTLING_TIER)) {
                     Object tier = extensions.get(APIConstants.X_WSO2_THROTTLING_TIER);
                     extensions.remove(APIConstants.X_WSO2_THROTTLING_TIER);
                     extensions.put(APIConstants.SWAGGER_X_THROTTLING_TIER, tier);
                 }
-                operation.setVendorExtensions(extensions);
-                entry.setValue(operation);
-                operationsMap.put(entry.getKey(), operation);
             }
-            paths.put(pathKey, paths.get(pathKey));
         }
-        swagger.setPaths(paths);
         return getSwaggerJsonString(swagger);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -1467,8 +1467,9 @@ public class OAS2Parser extends APIDefinition {
             }
             if (APIConstants.OPTIONAL.equals(mutualSSL)) {
                 securityList = securityList + "," + APIConstants.API_SECURITY_MUTUAL_SSL;
-            } else if (APIConstants.MANDATORY.equals(mutualSSL)) {
-                securityList = securityList + "," + APIConstants.API_SECURITY_MUTUAL_SSL_MANDATORY;
+            } else if (APIConstants.API_SECURITY_MUTUAL_SSL_MANDATORY.equals(mutualSSL)) {
+                securityList = securityList + "," + APIConstants.API_SECURITY_MUTUAL_SSL + "," +
+                        APIConstants.API_SECURITY_MUTUAL_SSL_MANDATORY;
             }
             api.setApiSecurity(securityList);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -1276,7 +1276,6 @@ public class OAS2Parser extends APIDefinition {
     public String processOtherSchemeScopes(String swaggerContent) throws APIManagementException {
         if (!isDefaultGiven(swaggerContent)) {
             Swagger swagger = getSwagger(swaggerContent);
-            swagger = injectMgwThrottlingExtensionsToDefault(swagger);
             swagger = processLegacyScopes(swagger);
             swagger = injectOtherScopesToDefaultScheme(swagger);
             swagger = injectOtherResourceScopesToDefaultScheme(swagger);
@@ -1289,11 +1288,13 @@ public class OAS2Parser extends APIDefinition {
      * This method returns swagger definition which replaced X-WSO2-throttling-tier extension comes from
      * mgw with X-throttling-tier extensions in swagger file(Swagger version 2)
      *
-     * @param swagger Swagger
-     * @return Swagger
+     * @param swaggerContent String
+     * @return String
      * @throws APIManagementException
      */
-    private Swagger injectMgwThrottlingExtensionsToDefault(Swagger swagger) throws APIManagementException {
+    @Override
+    public String injectMgwThrottlingExtensionsToDefault(String swaggerContent) throws APIManagementException {
+        Swagger swagger = getSwagger(swaggerContent);
         Map<String, Path> paths = swagger.getPaths();
         for (String pathKey : paths.keySet()) {
             Map<HttpMethod, Operation> operationsMap = paths.get(pathKey).getOperationMap();
@@ -1312,7 +1313,7 @@ public class OAS2Parser extends APIDefinition {
             paths.put(pathKey, paths.get(pathKey));
         }
         swagger.setPaths(paths);
-        return swagger;
+        return getSwaggerJsonString(swagger);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1638,8 +1638,9 @@ public class OAS3Parser extends APIDefinition {
             }
             if (APIConstants.OPTIONAL.equals(mutualSSL)) {
                 securityList = securityList + "," + APIConstants.API_SECURITY_MUTUAL_SSL;
-            } else if (APIConstants.MANDATORY.equals(mutualSSL)) {
-                securityList = securityList + "," + APIConstants.API_SECURITY_MUTUAL_SSL_MANDATORY;
+            } else if (APIConstants.API_SECURITY_MUTUAL_SSL_MANDATORY.equals(mutualSSL)) {
+                securityList = securityList + "," + APIConstants.API_SECURITY_MUTUAL_SSL + "," +
+                        APIConstants.API_SECURITY_MUTUAL_SSL_MANDATORY;
             }
             api.setApiSecurity(securityList);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1398,18 +1398,13 @@ public class OAS3Parser extends APIDefinition {
             for (Map.Entry<PathItem.HttpMethod, Operation> entry : operationsMap.entrySet()) {
                 Operation operation = entry.getValue();
                 Map<String, Object> extensions = operation.getExtensions();
-                if (extensions.containsKey(APIConstants.X_WSO2_THROTTLING_TIER)) {
+                if (extensions != null && extensions.containsKey(APIConstants.X_WSO2_THROTTLING_TIER)) {
                     Object tier = extensions.get(APIConstants.X_WSO2_THROTTLING_TIER);
                     extensions.remove(APIConstants.X_WSO2_THROTTLING_TIER);
                     extensions.put(APIConstants.SWAGGER_X_THROTTLING_TIER, tier);
                 }
-                operation.setExtensions(extensions);
-                entry.setValue(operation);
-                operationsMap.put(entry.getKey(), operation);
             }
-            paths.put(pathKey, paths.get(pathKey));
         }
-        openAPI.setPaths(paths);
         return Json.pretty(openAPI);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1347,7 +1347,6 @@ public class OAS3Parser extends APIDefinition {
     @Override
     public String processOtherSchemeScopes(String swaggerContent) throws APIManagementException {
         OpenAPI openAPI = getOpenAPI(swaggerContent);
-        openAPI = injectMgwThrottlingExtensionsToDefault(openAPI);
         Set<Scope> legacyScopes = getScopesFromExtensions(openAPI);
 
         //In case default scheme already exists we check whether the legacy x-wso2-scopes are there in the default scheme
@@ -1386,11 +1385,13 @@ public class OAS3Parser extends APIDefinition {
      * This method returns openAPI definition which replaced X-WSO2-throttling-tier extension comes from
      * mgw with X-throttling-tier extensions in openAPI file(openAPI version 3)
      *
-     * @param openAPI OpenAPI
-     * @return OpenAPI
+     * @param swaggerContent String
+     * @return String
      * @throws APIManagementException
      */
-    private OpenAPI injectMgwThrottlingExtensionsToDefault(OpenAPI openAPI) throws APIManagementException {
+    @Override
+    public String injectMgwThrottlingExtensionsToDefault(String swaggerContent) throws APIManagementException {
+        OpenAPI openAPI = getOpenAPI(swaggerContent);
         Paths paths = openAPI.getPaths();
         for (String pathKey : paths.keySet()) {
             Map<PathItem.HttpMethod, Operation> operationsMap = paths.get(pathKey).readOperationsMap();
@@ -1409,7 +1410,7 @@ public class OAS3Parser extends APIDefinition {
             paths.put(pathKey, paths.get(pathKey));
         }
         openAPI.setPaths(paths);
-        return openAPI;
+        return Json.pretty(openAPI);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1325,6 +1325,8 @@ public class OASParserUtil {
     public static String preProcess(String swaggerContent) throws APIManagementException {
         //Load required properties from swagger to the API
         APIDefinition apiDefinition = getOASParser(swaggerContent);
+        //Inject and map mgw throttling extensions to default type
+        swaggerContent = apiDefinition.injectMgwThrottlingExtensionsToDefault(swaggerContent);
         return apiDefinition.processOtherSchemeScopes(swaggerContent);
     }
 


### PR DESCRIPTION
### Purpose
When importing OpenAPI definitions via API controller or via publisher portal, those definitions have resource level throttling defined inside them. Currently, this throttling level extension is supported only with _**x-throttling-tier**_ when defining resource level throttling. But there is a use case from the micro gateway which defines these throttling tiers with _**x-wso2-throttling-tier**_ in resource level. This PR will provide that support

### Goals
Fixes https://github.com/wso2/product-apim/issues/8974
Fixes https://github.com/wso2/product-apim/issues/8975

### Approach
In OASParsers of APIM, there are methods to preprocess swagger definitions before actually processing and creating API objects. On that level, the OAS parsers can map x-wso2-throttling-tier extension values into x-throttling-tier in OAS parsers before creating API objects using these OpenAPI definitions. 

### User stories
Import API via API Controller.
Import API via Publisher Portal


### Documentation
No doc changes required.

### Test environment
Ubuntu 20.04 LTS
Java JDK 1.8_241
APIM 3.2.0
APICTL 3.2.0