### PR TITLE
[Admin Portal][UI]Update error message on application ownership change

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/ApplicationSettings/EditApplication.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/ApplicationSettings/EditApplication.jsx
@@ -76,7 +76,7 @@ function Edit(props) {
     };
 
     const validateOwner = () => {
-        let validationError = '';
+        let validationError = 'Something went wrong when validating user';
 
         const applicationsWithSameName = applicationList.filter(
             (app) => app.name === name && app.owner === owner,
@@ -95,14 +95,12 @@ function Edit(props) {
                 }).catch((error) => {
                     const { response } = error;
                     // This api returns 404 when the $owner is not found.
-                    // identify the case specially with error code 901502 and display error.
-                    if (response.body) {
-                        if (response.body.code === 901502) {
-                            validationError = `${owner} is not a valid Subscriber`;
-                            reject(validationError);
-                        }
-                    } else {
-                        validationError = 'Something went wrong when validating user';
+                    // error codes: 901502, 901500 for user not found and scope not found
+                    if (response?.body?.code === 901502 || response?.body?.code === 901500) {
+                        validationError = `${owner} is not a valid Subscriber`;
+                    }
+                }).finally(() => {
+                    if (validationError) {
                         reject(validationError);
                     }
                 });

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/ApplicationSettings/EditApplication.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/ApplicationSettings/EditApplication.jsx
@@ -124,9 +124,12 @@ function Edit(props) {
                 })
                 .catch((error) => {
                     const { response } = error;
-                    if (response.body.code === 500) {
+                    if (response?.body?.code === 500) {
                         const notValidSubscriber = 'Error while updating ownership to ' + owner;
                         throw notValidSubscriber;
+                    } else {
+                        const updateError = 'Something went wrong when updating owner';
+                        throw updateError;
                     }
                 })
                 .finally(() => {

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/ApplicationSettings/EditApplication.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/ApplicationSettings/EditApplication.jsx
@@ -124,8 +124,9 @@ function Edit(props) {
                 })
                 .catch((error) => {
                     const { response } = error;
-                    if (response.body) {
-                        throw response.body.description;
+                    if (response.body.code === 500) {
+                        const notValidSubscriber = 'Error while updating ownership to ' + owner;
+                        throw notValidSubscriber;
                     }
                 })
                 .finally(() => {


### PR DESCRIPTION
### Description
When changing the ownership of an application using the admin portal UI, 
when the target application owner is a valid `subscriber` and hasn't logged into the devportal at least once,
the REST API responses with `500`. But since this is a special troubleshooting step which is included in the [docs](http://localhost:8000/learn/consume-api/manage-application/advanced-topics/changing-the-owner-of-an-application/) too, we need to display a meaningful Error alert.

> Please note that the separate API call which is used for checking the target owner is a subscriber or not is returning with true even if that user hasn't logged into the devportal at least once. (which is expected behavior IMO). Therefore, the error message update is needed.

This PR updates the error message to `Error while updating ownership to <owner>`