### PR TITLE
[Improvement] Add support for "x-wso2-disable-security" mgw extension in API level 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
@@ -215,4 +215,15 @@ public abstract class APIDefinition {
      */
     public abstract API setExtensionsToAPI(String swaggerContent, API api)
             throws APIManagementException;
+
+    /**
+     * This method will extractX-WSO2-disable-security extension provided in API level
+     * by mgw and inject that extension to all resources in OAS file
+     *
+     * @param swaggerContent String
+     * @return String
+     * @throws APIManagementException
+     */
+    public abstract String processDisableSecurityExtension(String swaggerContent)
+            throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -1568,4 +1568,50 @@ public class OAS2Parser extends APIDefinition {
         return api;
     }
 
+    /**
+     * This method will extractX-WSO2-disable-security extension provided in API level
+     * by mgw and inject that extension to all resources in OAS file
+     *
+     * @param swaggerContent String
+     * @return String
+     * @throws APIManagementException
+     */
+    @Override
+    public String processDisableSecurityExtension(String swaggerContent) throws APIManagementException {
+        Swagger swagger = getSwagger(swaggerContent);
+        Map<String, Object> apiExtensions = swagger.getVendorExtensions();
+        if (apiExtensions == null) {
+            return swaggerContent;
+        }
+        //Check Disable Security is enabled in API level
+        boolean apiLevelDisableSecurity = OASParserUtil.getDisableSecurity(apiExtensions);
+        Map<String, Path> paths = swagger.getPaths();
+        for (String pathKey : paths.keySet()) {
+            Map<HttpMethod, Operation> operationsMap = paths.get(pathKey).getOperationMap();
+            for (Map.Entry<HttpMethod, Operation> entry : operationsMap.entrySet()) {
+                Operation operation = entry.getValue();
+                Map<String, Object> resourceExtensions = operation.getVendorExtensions();
+                boolean extensionsAreEmpty = false;
+                if (apiLevelDisableSecurity) {
+                    if (resourceExtensions == null) {
+                        resourceExtensions = new HashMap<>();
+                        extensionsAreEmpty = true;
+                    }
+                    resourceExtensions.put(APIConstants.SWAGGER_X_AUTH_TYPE, "None");
+                    if (extensionsAreEmpty) {
+                        operation.setVendorExtensions(resourceExtensions);
+                    }
+                } else if (resourceExtensions != null && resourceExtensions.containsKey(APIConstants.X_WSO2_DISABLE_SECURITY)) {
+                    //Check Disable Security is enabled in resource level
+                    boolean resourceLevelDisableSecurity = Boolean.parseBoolean(String.valueOf(resourceExtensions.get(APIConstants.X_WSO2_DISABLE_SECURITY)));
+                    if (resourceLevelDisableSecurity) {
+                        resourceExtensions.put(APIConstants.SWAGGER_X_AUTH_TYPE, "None");
+                    }
+                }
+            }
+        }
+
+        return getSwaggerJsonString(swagger);
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1788,4 +1788,49 @@ public class OAS3Parser extends APIDefinition {
         }
     }
 
+    /**
+     * This method will extractX-WSO2-disable-security extension provided in API level
+     * by mgw and inject that extension to all resources in OAS file
+     *
+     * @param swaggerContent String
+     * @return String
+     * @throws APIManagementException
+     */
+    @Override
+    public String processDisableSecurityExtension(String swaggerContent) throws APIManagementException {
+        OpenAPI openAPI = getOpenAPI(swaggerContent);
+        Map<String, Object> apiExtensions = openAPI.getExtensions();
+        if (apiExtensions == null) {
+            return swaggerContent;
+        }
+        //Check Disable Security is enabled in API level
+        boolean apiLevelDisableSecurity = OASParserUtil.getDisableSecurity(apiExtensions);
+        Paths paths = openAPI.getPaths();
+        for (String pathKey : paths.keySet()) {
+            Map<PathItem.HttpMethod, Operation> operationsMap = paths.get(pathKey).readOperationsMap();
+            for (Map.Entry<PathItem.HttpMethod, Operation> entry : operationsMap.entrySet()) {
+                Operation operation = entry.getValue();
+                Map<String, Object> resourceExtensions = operation.getExtensions();
+                boolean extensionsAreEmpty = false;
+                if (apiLevelDisableSecurity) {
+                    if (resourceExtensions == null) {
+                        resourceExtensions = new HashMap<>();
+                        extensionsAreEmpty = true;
+                    }
+                    resourceExtensions.put(APIConstants.SWAGGER_X_AUTH_TYPE, "None");
+                    if (extensionsAreEmpty) {
+                        operation.setExtensions(resourceExtensions);
+                    }
+                } else if (resourceExtensions != null && resourceExtensions.containsKey(APIConstants.X_WSO2_DISABLE_SECURITY)) {
+                    //Check Disable Security is enabled in resource level
+                    boolean resourceLevelDisableSecurity = Boolean.parseBoolean(String.valueOf(resourceExtensions.get(APIConstants.X_WSO2_DISABLE_SECURITY)));
+                    if (resourceLevelDisableSecurity) {
+                        resourceExtensions.put(APIConstants.SWAGGER_X_AUTH_TYPE, "None");
+                    }
+                }
+            }
+        }
+        return Json.pretty(openAPI);
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -710,6 +710,9 @@ public class OASParserUtil {
         File[] listOfFiles = new File(extractedLocation).listFiles();
         File archiveDirectory = null;
         if (listOfFiles != null) {
+            if (listOfFiles.length > 1) {
+                throw new APIManagementException("Swagger Definitions should be placed under one root folder.");
+            }
             for (File file: listOfFiles) {
                 if (file.isDirectory()) {
                     archiveDirectory = file.getAbsoluteFile();
@@ -717,7 +720,8 @@ public class OASParserUtil {
                 }
             }
         }
-        //verify whether the zipped input is archive or file.
+        //Verify whether the zipped input is archive or file.
+        //If it is a single  swagger file without remote references it can be imported directly, without zipping.
         if (archiveDirectory == null) {
             throw new APIManagementException("Could not find an archive in the given ZIP file.");
         }
@@ -1325,6 +1329,10 @@ public class OASParserUtil {
     public static String preProcess(String swaggerContent) throws APIManagementException {
         //Load required properties from swagger to the API
         APIDefinition apiDefinition = getOASParser(swaggerContent);
+        //Inject and map mgw throttling extensions to default type
+        swaggerContent = apiDefinition.injectMgwThrottlingExtensionsToDefault(swaggerContent);
+        //Process mgw disable security extension
+        swaggerContent = apiDefinition.processDisableSecurityExtension(swaggerContent);
         return apiDefinition.processOtherSchemeScopes(swaggerContent);
     }
 
@@ -1481,6 +1489,7 @@ public class OASParserUtil {
         }
         return disableSecurity;
     }
+
     /**
      * This method returns extension of application security types related to micro-gw
      *

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -710,9 +710,6 @@ public class OASParserUtil {
         File[] listOfFiles = new File(extractedLocation).listFiles();
         File archiveDirectory = null;
         if (listOfFiles != null) {
-            if (listOfFiles.length > 1) {
-                throw new APIManagementException("Swagger Definitions should be placed under one root folder.");
-            }
             for (File file: listOfFiles) {
                 if (file.isDirectory()) {
                     archiveDirectory = file.getAbsoluteFile();
@@ -720,8 +717,7 @@ public class OASParserUtil {
                 }
             }
         }
-        //Verify whether the zipped input is archive or file.
-        //If it is a single  swagger file without remote references it can be imported directly, without zipping.
+        //verify whether the zipped input is archive or file.
         if (archiveDirectory == null) {
             throw new APIManagementException("Could not find an archive in the given ZIP file.");
         }
@@ -1329,8 +1325,6 @@ public class OASParserUtil {
     public static String preProcess(String swaggerContent) throws APIManagementException {
         //Load required properties from swagger to the API
         APIDefinition apiDefinition = getOASParser(swaggerContent);
-        //Inject and map mgw throttling extensions to default type
-        swaggerContent = apiDefinition.injectMgwThrottlingExtensionsToDefault(swaggerContent);
         return apiDefinition.processOtherSchemeScopes(swaggerContent);
     }
 
@@ -1473,6 +1467,20 @@ public class OASParserUtil {
         return authorizationHeader == null ? null : authorizationHeader.toString();
     }
 
+    /**
+     * This method returns extension of custom authorization Header related to micro-gw
+     *
+     * @param extensions Map<String, Object>
+     * @return String
+     * @throws APIManagementException throws if an error occurred
+     */
+    public static boolean getDisableSecurity(Map<String, Object> extensions) throws APIManagementException {
+        boolean disableSecurity = false;
+        if (extensions.containsKey(APIConstants.X_WSO2_DISABLE_SECURITY)) {
+            disableSecurity = Boolean.parseBoolean(String.valueOf(extensions.get(APIConstants.X_WSO2_DISABLE_SECURITY)));
+        }
+        return disableSecurity;
+    }
     /**
      * This method returns extension of application security types related to micro-gw
      *


### PR DESCRIPTION
### Purpose
When importing OpenAPI definitions via API controller or via publisher portal, those definitions have resource level security defined inside them. Currently, this security extension is supported only with _**x-auth-type**_ when defining resource level security. But there is a extension  in the micro gateway which can uses to disable any type of security for any resource in API definition. That is the  **`x-wso2-disable-security`** extension. This extension can be provided in API level to disable security for all resources and define in resource level to disable security for single resource. This PR will provide that support for both cases.

### Goals
Improve the extension support which are used by micro gateway.

### Approach
In OASParsers of APIM, there are methods to preprocess swagger definitions before actually processing and creating API objects. On that level, the OAS parsers can map x-wso2-disable-security extension values into x-auth-typein OAS parsers before creating API objects using these OpenAPI definitions. 

### User stories
Import API via API Controller.
Import API via Publisher Portal

### Documentation
No doc changes required.

### Test environment
Ubuntu 20.04 LTS
Java JDK 1.8_241
APIM 3.2.0
APICTL 3.2.0