### PR TITLE
Fixed the undeploy resource in Gateway Rest API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
@@ -164,7 +164,7 @@ public class InMemoryAPIDeployer {
                 try {
                     String gatewayRuntimeArtifact = artifactRetriever
                             .retrieveArtifact(apiId, gatewayLabel,
-                                    APIConstants.GatewayArtifactSynchronizer.GATEWAY_INSTRUCTION_REMOVE);
+                                    APIConstants.GatewayArtifactSynchronizer.GATEWAY_INSTRUCTION_ANY);
                     if (gatewayRuntimeArtifact != null) {
                         GatewayAPIDTO gatewayAPIDTO = new Gson().fromJson(gatewayRuntimeArtifact, GatewayAPIDTO.class);
                         APIGatewayAdminClient apiGatewayAdminClient = new APIGatewayAdminClient();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2382,6 +2382,7 @@ public final class APIConstants {
         public static final String DB_RETRIEVER_NAME = "DBRetriever";
         public static final String GATEWAY_INSTRUCTION_PUBLISH = "Publish";
         public static final String GATEWAY_INSTRUCTION_REMOVE = "Remove";
+        public static final String GATEWAY_INSTRUCTION_ANY = "ANY";
         public static final String SYNAPSE_ARTIFACTS = "/synapse-artifacts";
         public static final String SYNAPSE_ATTRIBUTES = "/synapse-attributes";
         public static final String GATEAY_SYNAPSE_ARTIFACTS = "/gateway-synapse-artifacts";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/GatewayArtifactsMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/GatewayArtifactsMgtDAO.java
@@ -112,13 +112,21 @@ public class GatewayArtifactsMgtDAO {
             throws APIManagementException {
         ResultSet rs = null;
         String gatewayRuntimeArtifacts = null;
+        String sqlQuery;
+        if (APIConstants.GatewayArtifactSynchronizer.GATEWAY_INSTRUCTION_ANY.equals(gatewayInstruction)) {
+            sqlQuery = SQLConstants.GET_API_ARTIFACT_ANY_INSTRUCTION;
+        } else {
+            sqlQuery = SQLConstants.GET_API_ARTIFACT;
+        }
         try (Connection connection = GatewayArtifactsMgtDBUtil.getArtifactSynchronizerConnection();
-                PreparedStatement statement = connection.prepareStatement(SQLConstants.GET_API_ARTIFACT)) {
+                PreparedStatement statement = connection.prepareStatement(sqlQuery)) {
             connection.setAutoCommit(false);
             connection.commit();
             statement.setString(1, APIId);
             statement.setString(2, gatewayLabel);
-            statement.setString(3, gatewayInstruction);
+            if (!APIConstants.GatewayArtifactSynchronizer.GATEWAY_INSTRUCTION_ANY.equals(gatewayInstruction)) {
+                statement.setString(3, gatewayInstruction);
+            }
             rs = statement.executeQuery();
             if (rs.next()) {
                 try (InputStream inputStream = rs.getBinaryStream(1)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -3139,6 +3139,9 @@ public class SQLConstants {
     public static final String GET_API_ARTIFACT = "SELECT ARTIFACT FROM AM_GW_API_ARTIFACTS WHERE API_ID =? AND " +
             "GATEWAY_LABEL =? AND GATEWAY_INSTRUCTION = ?";
 
+    public static final String GET_API_ARTIFACT_ANY_INSTRUCTION = "SELECT ARTIFACT FROM AM_GW_API_ARTIFACTS WHERE " +
+            "API_ID =? AND GATEWAY_LABEL =?";
+
     public static final String GET_API_ID = "SELECT API_ID  FROM AM_GW_PUBLISHED_API_DETAILS " +
             "WHERE API_NAME =? AND " + "TENANT_DOMAIN =? AND API_VERSION =?";
 


### PR DESCRIPTION
Previously undeploy method did not work as the API was in the published state and the undeploy method is querying the database based for artifacts in remove state. This returned an empty DTO. With this fix, even though the artifact is in publish state, we will use the same DTO to undeploy the API. DTO already contained information to undeploy the APIs.

Fixes:https://github.com/wso2/product-apim/issues/9026