### PR TITLE
Produce Alerts when trying to generate key from a disabled key manager

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
@@ -460,10 +460,10 @@ class TokenManager extends React.Component {
                 if (status === 404) {
                     this.setState({ notFound: true });
                 }
-                Alert.error(intl.formatMessage({
-                    id: 'Shared.AppsAndKeys.TokenManager.key.update.error',
-                    defaultMessage: 'Error occurred when updating application keys',
-                }));
+                const { response } = error;
+                if (response.body) {
+                    Alert.error(response.body.message);
+                }
             }).finally(() => this.setState({ isLoading: false }));
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
@@ -461,7 +461,7 @@ class TokenManager extends React.Component {
                     this.setState({ notFound: true });
                 }
                 const { response } = error;
-                if (response.body) {
+                if (response && response.body) {
                     Alert.error(response.body.message);
                 }
             }).finally(() => this.setState({ isLoading: false }));

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/ViewKeys.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/ViewKeys.jsx
@@ -293,7 +293,7 @@ class ViewKeys extends React.Component {
                 }
                 this.setState({ isUpdating: false });
                 const { response } = error;
-                if (response.body) {
+                if (response && response.body) {
                     Alert.error(response.body.message);
                 }
             });

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/ViewKeys.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/ViewKeys.jsx
@@ -36,6 +36,7 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
+import Alert from 'AppComponents/Shared/Alert';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import ResourceNotFound from '../../Base/Errors/ResourceNotFound';
 import Loading from '../../Base/Loading/Loading';
@@ -291,6 +292,10 @@ class ViewKeys extends React.Component {
                     this.setState({ notFound: true });
                 }
                 this.setState({ isUpdating: false });
+                const { response } = error;
+                if (response.body) {
+                    Alert.error(response.body.message);
+                }
             });
     };
 


### PR DESCRIPTION
When a key manager is disabled and we are trying to generate Access Tokens from it, the UI doesn't produce a proper error message.

This PR produces an error Alert stating that Key Manager is not enabled.

Fixes: https://github.com/wso2/product-apim/issues/8930