### PR TITLE
Fixing error when multiple value additional properties send without selecting any value.

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
@@ -244,7 +244,11 @@ class TokenManager extends React.Component {
         const additionalProperties = {};
 
         applicationConfiguration.forEach(confItem => {
-            additionalProperties[confItem.name] = confItem.default || '';
+            if ( confItem.multiple && typeof confItem.default === 'string' ){
+                additionalProperties[confItem.name] = [];
+            } else {
+                additionalProperties[confItem.name] = confItem.default || '';
+            }
         });
         return additionalProperties;
     }


### PR DESCRIPTION
This fix will set the key gen request to have the default value of a multiple value additional property not as a string but an empty array.