### PR TITLE
[Improvement] Add support for "x-wso2-application-security" mgw extension in API level

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
@@ -204,4 +204,15 @@ public abstract class APIDefinition {
      */
     public abstract API setExtensionsToAPI(String swaggerContent, API api)
             throws APIManagementException;
+
+    /**
+     * This method will extract X-WSO2-application-security extension provided in API level
+     * by mgw and inject that extension to all resources in OAS file
+     *
+     * @param swaggerContent String
+     * @return String
+     * @throws APIManagementException
+     */
+    public abstract String processApplicationSecurityExtension(String swaggerContent)
+            throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
@@ -204,5 +204,4 @@ public abstract class APIDefinition {
      */
     public abstract API setExtensionsToAPI(String swaggerContent, API api)
             throws APIManagementException;
-
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
@@ -205,14 +205,4 @@ public abstract class APIDefinition {
     public abstract API setExtensionsToAPI(String swaggerContent, API api)
             throws APIManagementException;
 
-    /**
-     * This method will extract X-WSO2-application-security extension provided in API level
-     * by mgw and inject that extension to all resources in OAS file
-     *
-     * @param swaggerContent String
-     * @return String
-     * @throws APIManagementException
-     */
-    public abstract String processApplicationSecurityExtension(String swaggerContent)
-            throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -51,9 +51,6 @@ import io.swagger.parser.util.DeserializationUtils;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 import io.swagger.util.Json;
 import io.swagger.util.Yaml;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.PathItem;
-import io.swagger.v3.oas.models.Paths;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -1461,6 +1458,27 @@ public class OAS2Parser extends APIDefinition {
         if (StringUtils.isNotBlank(authHeader)) {
             api.setAuthorizationHeader(authHeader);
         }
+        //Setup application Security
+        List<String> applicationSecurity = OASParserUtil.getApplicationSecurityTypes(extensions);
+        Boolean isOptional = OASParserUtil.getAppSecurityStateFromSwagger(extensions);
+        if (!applicationSecurity.isEmpty()) {
+            String securityList = api.getApiSecurity();
+            for (String securityType : applicationSecurity) {
+                if (APIConstants.DEFAULT_API_SECURITY_OAUTH2.equals(securityType)) {
+                    securityList = securityList + "," + APIConstants.DEFAULT_API_SECURITY_OAUTH2;
+                }
+                if (APIConstants.API_SECURITY_BASIC_AUTH.equals(securityType)) {
+                    securityList = securityList + "," + APIConstants.API_SECURITY_BASIC_AUTH;
+                }
+                if (APIConstants.API_SECURITY_API_KEY.equals(securityType)) {
+                    securityList = securityList + "," + APIConstants.API_SECURITY_API_KEY;
+                }
+            }
+            if (!isOptional) {
+                securityList = securityList + "," + APIConstants.MANDATORY;
+            }
+            api.setApiSecurity(securityList);
+        }
         //Setup mutualSSL configuration
         String mutualSSL = OASParserUtil.getMutualSSLEnabledFromSwagger(extensions);
         if (StringUtils.isNotBlank(mutualSSL)) {
@@ -1472,23 +1490,6 @@ public class OAS2Parser extends APIDefinition {
                 securityList = securityList + "," + APIConstants.API_SECURITY_MUTUAL_SSL;
             } else if (APIConstants.MANDATORY.equals(mutualSSL)) {
                 securityList = securityList + "," + APIConstants.API_SECURITY_MUTUAL_SSL_MANDATORY;
-            }
-            api.setApiSecurity(securityList);
-        }
-        //Setup application Security
-        String applicationSecurity = OASParserUtil.getApplicationSecurity(extensions);
-        if (StringUtils.isNotBlank(applicationSecurity)) {
-            String securityList = api.getApiSecurity();
-            if (StringUtils.contains("api_key", applicationSecurity)) {
-                securityList = securityList + "," + "api_key";
-            }
-            if (StringUtils.contains("basic_auth", applicationSecurity)) {
-                securityList = securityList + "," + "basic_auth";
-            }
-            if (StringUtils.contains("mandatory", applicationSecurity)) {
-                securityList = securityList + "," + "mandatory";
-            } else {
-                securityList = securityList + "," + "optional";
             }
             api.setApiSecurity(securityList);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1629,6 +1629,27 @@ public class OAS3Parser extends APIDefinition {
         if (StringUtils.isNotBlank(authHeader)) {
             api.setAuthorizationHeader(authHeader);
         }
+        //Setup application Security
+        List<String> applicationSecurity = OASParserUtil.getApplicationSecurityTypes(extensions);
+        Boolean isOptional = OASParserUtil.getAppSecurityStateFromSwagger(extensions);
+        if (!applicationSecurity.isEmpty()) {
+            String securityList = api.getApiSecurity();
+            for (String securityType : applicationSecurity) {
+                if (APIConstants.DEFAULT_API_SECURITY_OAUTH2.equals(securityType)) {
+                    securityList = securityList + "," + APIConstants.DEFAULT_API_SECURITY_OAUTH2;
+                }
+                if (APIConstants.API_SECURITY_BASIC_AUTH.equals(securityType)) {
+                    securityList = securityList + "," + APIConstants.API_SECURITY_BASIC_AUTH;
+                }
+                if (APIConstants.API_SECURITY_API_KEY.equals(securityType)) {
+                    securityList = securityList + "," + APIConstants.API_SECURITY_API_KEY;
+                }
+            }
+            if (!isOptional) {
+                securityList = securityList + "," + APIConstants.MANDATORY;
+            }
+            api.setApiSecurity(securityList);
+        }
         //Setup mutualSSL configuration
         String mutualSSL = OASParserUtil.getMutualSSLEnabledFromSwagger(extensions);
         if (StringUtils.isNotBlank(mutualSSL)) {
@@ -1640,23 +1661,6 @@ public class OAS3Parser extends APIDefinition {
                 securityList = securityList + "," + APIConstants.API_SECURITY_MUTUAL_SSL;
             } else if (APIConstants.MANDATORY.equals(mutualSSL)) {
                 securityList = securityList + "," + APIConstants.API_SECURITY_MUTUAL_SSL_MANDATORY;
-            }
-            api.setApiSecurity(securityList);
-        }
-        //Setup application Security
-        String applicationSecurity = OASParserUtil.getApplicationSecurity(extensions);
-        if (StringUtils.isNotBlank(applicationSecurity)) {
-            String securityList = api.getApiSecurity();
-            if (StringUtils.contains("api_key", applicationSecurity)) {
-                securityList = securityList + "," + "api_key";
-            }
-            if (StringUtils.contains("basic_auth", applicationSecurity)) {
-                securityList = securityList + "," + "basic_auth";
-            }
-            if (StringUtils.contains("mandatory", applicationSecurity)) {
-                securityList = securityList + "," + "mandatory";
-            } else {
-                securityList = securityList + "," + "optional";
             }
             api.setApiSecurity(securityList);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1701,4 +1701,47 @@ public class OAS3Parser extends APIDefinition {
         }
     }
 
+    /**
+     * This method will extract X-WSO2-application-security extension provided in API level
+     * by mgw and inject that extension to all resources in OAS file
+     *
+     * @param swaggerContent String
+     * @return String
+     * @throws APIManagementException
+     */
+    @Override
+    public String processApplicationSecurityExtension(String swaggerContent) throws APIManagementException {
+        OpenAPI openAPI = getOpenAPI(swaggerContent);
+        Map<String, Object> apiExtensions = openAPI.getExtensions();
+        if (apiExtensions == null) {
+            return swaggerContent;
+        }
+        //Check Disable Security is enabled in API level
+        String applicationSecurity = OASParserUtil.getApplicationSecurity(apiExtensions);
+        Paths paths = openAPI.getPaths();
+        for (String pathKey : paths.keySet()) {
+            Map<PathItem.HttpMethod, Operation> operationsMap = paths.get(pathKey).readOperationsMap();
+            for (Map.Entry<PathItem.HttpMethod, Operation> entry : operationsMap.entrySet()) {
+                Operation operation = entry.getValue();
+                Map<String, Object> resourceExtensions = operation.getExtensions();
+                if (StringUtils.isNotBlank(applicationSecurity)) {
+                    if (resourceExtensions == null) {
+                        resourceExtensions = new HashMap<>();
+                    }
+                    resourceExtensions.put(APIConstants.X_WSO2_APP_SECURITY, applicationSecurity);
+                    operation.setExtensions(resourceExtensions);
+
+                } else if (resourceExtensions != null && resourceExtensions.containsKey(APIConstants.X_WSO2_APP_SECURITY)) {
+                    //Check Disable Security is enabled in resource level
+                    Object applicationSecurityInResources = resourceExtensions.get(APIConstants.X_WSO2_APP_SECURITY);
+
+                    if (StringUtils.isNotBlank(applicationSecurityInResources.toString())) {
+                        resourceExtensions.put(APIConstants.SWAGGER_X_AUTH_TYPE, applicationSecurityInResources.toString());
+                    }
+                }
+            }
+        }
+        return Json.pretty(openAPI);
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1467,4 +1467,16 @@ public class OASParserUtil {
         return authorizationHeader == null ? null : authorizationHeader.toString();
     }
 
+    /**
+     * This method returns extension of mutualSSL related to micro-gw
+     *
+     * @param extensions Map<String, Object>
+     * @return String
+     * @throws APIManagementException throws if an error occurred
+     */
+    public static String getApplicationSecurity(Map<String, Object> extensions) throws APIManagementException {
+        Object applicationSecurity = extensions.get(APIConstants.X_WSO2_APP_SECURITY);
+        return applicationSecurity == null ? null : applicationSecurity.toString();
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1325,6 +1325,7 @@ public class OASParserUtil {
     public static String preProcess(String swaggerContent) throws APIManagementException {
         //Load required properties from swagger to the API
         APIDefinition apiDefinition = getOASParser(swaggerContent);
+
         return apiDefinition.processOtherSchemeScopes(swaggerContent);
     }
 
@@ -1468,7 +1469,7 @@ public class OASParserUtil {
     }
 
     /**
-     * This method returns extension of mutualSSL related to micro-gw
+     * This method returns extension of application security related to micro-gw
      *
      * @param extensions Map<String, Object>
      * @return String

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1325,7 +1325,6 @@ public class OASParserUtil {
     public static String preProcess(String swaggerContent) throws APIManagementException {
         //Load required properties from swagger to the API
         APIDefinition apiDefinition = getOASParser(swaggerContent);
-
         return apiDefinition.processOtherSchemeScopes(swaggerContent);
     }
 
@@ -1469,15 +1468,39 @@ public class OASParserUtil {
     }
 
     /**
-     * This method returns extension of application security related to micro-gw
+     * This method returns extension of application security types related to micro-gw
      *
      * @param extensions Map<String, Object>
      * @return String
      * @throws APIManagementException throws if an error occurred
      */
-    public static String getApplicationSecurity(Map<String, Object> extensions) throws APIManagementException {
-        Object applicationSecurity = extensions.get(APIConstants.X_WSO2_APP_SECURITY);
-        return applicationSecurity == null ? null : applicationSecurity.toString();
+    public static List<String> getApplicationSecurityTypes(Map<String, Object> extensions) throws APIManagementException {
+        ObjectMapper mapper = new ObjectMapper();
+        List<String> appSecurityTypes = new ArrayList<>();
+        if (extensions.containsKey(APIConstants.X_WSO2_APP_SECURITY)) {
+            Object applicationSecurityTypes = extensions.get(APIConstants.X_WSO2_APP_SECURITY);
+            ObjectNode appSecurityTypesNode = mapper.convertValue(applicationSecurityTypes, ObjectNode.class);
+            appSecurityTypes = mapper.convertValue(appSecurityTypesNode.get("security-types"), ArrayList.class);
+        }
+        return appSecurityTypes;
+    }
+
+    /**
+     * This method returns extension of application security types state related to micro-gw
+     *
+     * @param extensions Map<String, Object>
+     * @return boolean
+     * @throws APIManagementException throws if an error occurred
+     */
+    public static boolean getAppSecurityStateFromSwagger(Map<String, Object> extensions) throws APIManagementException {
+        ObjectMapper mapper = new ObjectMapper();
+        boolean appSecurityState = false;
+        if (extensions.containsKey(APIConstants.X_WSO2_APP_SECURITY)) {
+            Object applicationSecurityTypes = extensions.get(APIConstants.X_WSO2_APP_SECURITY);
+            ObjectNode appSecurityTypesNode = mapper.convertValue(applicationSecurityTypes, ObjectNode.class);
+            appSecurityState = Boolean.parseBoolean(String.valueOf(appSecurityTypesNode.get("optional")));
+        }
+        return appSecurityState;
     }
 
 }


### PR DESCRIPTION
### Purpose
x-wso2-application-security is not supported when defined in API definition when creating an API with existing API definition.
This application security values should be applied under the runtime configurations in API. 

When the Following extension is defined in the API definition this should reflect it's changed configs in publisher UI which is not supported currently.
```
 x-wso2-application-security: 
        security-types: 
          - "api_key"
        optional: false
```
This PR will support this task.

### Goals
Improve the extension support which is used by the micro gateway.
Fixes https://github.com/wso2/product-apim/issues/9133
and https://github.com/wso2/product-apim-tooling/issues/469

### Approach
In OASParsers of APIM, there are methods to preprocess swagger definitions before actually processing and creating API objects. On that level, the OAS parsers can map x-wso2-application-security extension values into API object in OAS parsers when creating API objects using these OpenAPI definitions. 

### User stories
Import API via API Controller.
Import API via Publisher Portal

### Documentation
No doc changes required.

### Test environment
Ubuntu 20.04 LTS
Java JDK 1.8_241
APIM 3.2.0
APICTL 3.2.0