### PR TITLE
Limit local scope names in Publisher Portal

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Scopes/CreateScope.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Scopes/CreateScope.jsx
@@ -211,8 +211,13 @@ class CreateScope extends React.Component {
 
         apiScope[id] = value;
         valid[id].invalid = !(value && value.length > 0);
+        // length validation
         if (valid[id].invalid) {
             valid[id].error = 'Scope name cannot be empty';
+        }
+        valid[id].invalid = !(value && value.length <= 60);
+        if (valid[id].invalid) {
+            valid[id].error = 'Scope name cannot be more than 60 characters';
         }
 
         if (/\s/.test(value)) {
@@ -389,7 +394,6 @@ class CreateScope extends React.Component {
                                         }}
                                         value={this.state.apiScope.name || ''}
                                         onChange={this.handleScopeNameInput}
-                                        inputProps={{ maxLength: 60 }}
                                     />
                                 </FormControl>
                                 <FormControl margin='normal' classes={{ root: classes.descriptionForm }}>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Scopes/CreateScope.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Scopes/CreateScope.jsx
@@ -389,6 +389,7 @@ class CreateScope extends React.Component {
                                         }}
                                         value={this.state.apiScope.name || ''}
                                         onChange={this.handleScopeNameInput}
+                                        inputProps={{ maxLength: 60 }}
                                     />
                                 </FormControl>
                                 <FormControl margin='normal' classes={{ root: classes.descriptionForm }}>


### PR DESCRIPTION
fix https://github.com/wso2/product-apim/issues/9132
- Limit local scope names to 60 in Publisher Portal

![image](https://user-images.githubusercontent.com/23183042/90762895-6957f300-e303-11ea-8113-39274f9f5c74.png)

