### PR TITLE
Fix "Too long names for API Documentation is not validated in the UI" issue

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
@@ -270,7 +270,7 @@
   "Apis.Details.Documents.CreateEditForm.document.summary.helper.text": "Provide a brief description for the document",
   "Apis.Details.Documents.CreateEditForm.duplicate.document.name.helper.text": "Duplicate document name",
   "Apis.Details.Documents.CreateEditForm.empty.document.name.helper.text": "Document name cannot be empty",
-  "Apis.Details.Documents.CreateEditForm.exceeds.document.name.length.helper.text": "Document name exceeds the max length(60)",
+  "Apis.Details.Documents.CreateEditForm.exceeds.document.name.length.helper.text": "Document name exceeds the maximum length of 60 characters",
   "Apis.Details.Documents.CreateEditForm.source": "Source",
   "Apis.Details.Documents.CreateEditForm.source.file": "File",
   "Apis.Details.Documents.CreateEditForm.source.inline": "Inline",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
@@ -270,6 +270,7 @@
   "Apis.Details.Documents.CreateEditForm.document.summary.helper.text": "Provide a brief description for the document",
   "Apis.Details.Documents.CreateEditForm.duplicate.document.name.helper.text": "Duplicate document name",
   "Apis.Details.Documents.CreateEditForm.empty.document.name.helper.text": "Document name cannot be empty",
+  "Apis.Details.Documents.CreateEditForm.exceeds.document.name.length.helper.text": "Document name exceeds the max length(60)",
   "Apis.Details.Documents.CreateEditForm.source": "Source",
   "Apis.Details.Documents.CreateEditForm.source.file": "File",
   "Apis.Details.Documents.CreateEditForm.source.inline": "Inline",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/fr.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/fr.json
@@ -270,6 +270,7 @@
   "Apis.Details.Documents.CreateEditForm.document.summary.helper.text": "",
   "Apis.Details.Documents.CreateEditForm.duplicate.document.name.helper.text": "",
   "Apis.Details.Documents.CreateEditForm.empty.document.name.helper.text": "",
+  "Apis.Details.Documents.CreateEditForm.exceeds.document.name.length.helper.text": "",
   "Apis.Details.Documents.CreateEditForm.source": "",
   "Apis.Details.Documents.CreateEditForm.source.file": "",
   "Apis.Details.Documents.CreateEditForm.source.inline": "",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/si.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/si.json
@@ -90,6 +90,7 @@
     "Apis.Details.Documents.CreateEditForm.document.create.type.sample": "නියැදිය සහ එස්ඩීකේ",
     "Apis.Details.Documents.CreateEditForm.document.create.type.support.forum": "සහාය සංසදය",
     "Apis.Details.Documents.CreateEditForm.document.name": "නම *",
+    "Apis.Details.Documents.CreateEditForm.exceeds.document.name.length.helper.text": "ලේඛනයේ නම උපරිම දිග(60) ඉක්මවයි",
     "Apis.Details.Documents.CreateEditForm.document.name.helper.text": "ලේඛනය සඳහා නම සපයන්න",
     "Apis.Details.Documents.CreateEditForm.document.summary": "සාරාංශය *",
     "Apis.Details.Documents.CreateEditForm.document.summary.helper.text": "ලේඛනය සඳහා කෙටි විස්තරයක් සපයන්න",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/si.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/si.json
@@ -90,7 +90,7 @@
     "Apis.Details.Documents.CreateEditForm.document.create.type.sample": "නියැදිය සහ එස්ඩීකේ",
     "Apis.Details.Documents.CreateEditForm.document.create.type.support.forum": "සහාය සංසදය",
     "Apis.Details.Documents.CreateEditForm.document.name": "නම *",
-    "Apis.Details.Documents.CreateEditForm.exceeds.document.name.length.helper.text": "ලේඛනයේ නම උපරිම දිග(60) ඉක්මවයි",
+    "Apis.Details.Documents.CreateEditForm.exceeds.document.name.length.helper.text": "ලේඛනයේ නම උපරිම දිග අක්ෂර 60 ඉක්මවයි",
     "Apis.Details.Documents.CreateEditForm.document.name.helper.text": "ලේඛනය සඳහා නම සපයන්න",
     "Apis.Details.Documents.CreateEditForm.document.summary": "සාරාංශය *",
     "Apis.Details.Documents.CreateEditForm.document.summary.helper.text": "ලේඛනය සඳහා කෙටි විස්තරයක් සපයන්න",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
@@ -300,7 +300,7 @@ class CreateEditForm extends React.Component {
             return (
                 <FormattedMessage
                     id='Apis.Details.Documents.CreateEditForm.exceeds.document.name.length.helper.text'
-                    defaultMessage='Document name exceeds the max length(60)'
+                    defaultMessage='Document name exceeds the maximum length of 60 characters'
                 />
             );
         } else if (nameNotDuplicate && !nameEmpty) {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
@@ -128,6 +128,7 @@ class CreateEditForm extends React.Component {
             disableName: false,
             otherTypeName: null,
             nameNotDuplicate: true,
+            nameMaxLengthExceeds: false,
             invalidUrl: true,
             nameEmpty: false,
             summeryEmpty: false,
@@ -272,9 +273,11 @@ class CreateEditForm extends React.Component {
             }
 
             if (value === '') {
-                this.setState({ nameEmpty: true });
+                this.setState({ nameEmpty: true, nameMaxLengthExceeds: false });
+            } else if (value && value.length > 60) {
+                this.setState({ nameEmpty: false, nameMaxLengthExceeds: true });
             } else {
-                this.setState({ nameEmpty: false });
+                this.setState({ nameEmpty: false, nameMaxLengthExceeds: false });
             }
         } else if (field === 'summary') {
             if (value === '') {
@@ -292,8 +295,15 @@ class CreateEditForm extends React.Component {
         }
     }
     showNameHelper() {
-        const { nameEmpty, nameNotDuplicate } = this.state;
-        if (nameNotDuplicate && !nameEmpty) {
+        const { nameEmpty, nameNotDuplicate, nameMaxLengthExceeds } = this.state;
+        if (nameMaxLengthExceeds) {
+            return (
+                <FormattedMessage
+                    id='Apis.Details.Documents.CreateEditForm.exceeds.document.name.length.helper.text'
+                    defaultMessage='Document name exceeds the max length(60)'
+                />
+            );
+        } else if (nameNotDuplicate && !nameEmpty) {
             return (
                 <FormattedMessage
                     id='Apis.Details.Documents.CreateEditForm.document.name.helper.text'
@@ -354,6 +364,7 @@ class CreateEditForm extends React.Component {
             otherTypeName,
             invalidUrl,
             nameNotDuplicate,
+            nameMaxLengthExceeds,
             nameEmpty,
             summeryEmpty,
             urlEmpty,
@@ -365,6 +376,7 @@ class CreateEditForm extends React.Component {
             name !== '' &&
             summary !== '' &&
             nameNotDuplicate &&
+            !nameMaxLengthExceeds &&
             ((!invalidUrl && sourceUrl !== '') || sourceType !== 'URL')
         ) {
             setSaveDisabled(false);
@@ -399,7 +411,7 @@ class CreateEditForm extends React.Component {
                         }}
                         autoFocus
                         disabled={disableName}
-                        error={!nameNotDuplicate || nameEmpty}
+                        error={!nameNotDuplicate || nameEmpty || nameMaxLengthExceeds}
                     />
                 </FormControl>
                 <FormControl margin='normal' className={classes.FormControlOdd}>


### PR DESCRIPTION
This PR fixes the issue https://github.com/wso2/product-apim/issues/9103 only in the UI level by adding a UI validation to restrict the document name length to 60characters.

<img width="1440" alt="Screenshot 2020-08-20 at 18 05 05" src="https://user-images.githubusercontent.com/19996612/90771057-5d266280-e310-11ea-9262-acc7145454f7.png">
