### PR TITLE
Fix token refresh issue in publisher

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -365,7 +365,7 @@ ExceptionCodes implements ErrorHandler {
                                             "A mediation policy with the given name is already attached to the API"),
 
     //mediation policies related common errors
-    MEDIATION_POLICY_NAME_TOO_LONG(90850, "Mediation Policy Name Too Long", 400,
+    MEDIATION_POLICY_NAME_TOO_LONG(900850, "Mediation Policy Name Too Long", 400,
                                                 "The name of the mediation policy exceeds the max length (%s)");
 
     private final long errorCode;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/services/refresh/refresh.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/services/refresh/refresh.jag
@@ -22,10 +22,7 @@
     var app = require("/site/public/conf/settings.js").AppConfig.app;
 
     app.context = appUtils.getTenantBasePublisherContext();
-    var tenantDomain;
-    if (appUtils.isPerTenantServiceProviderEnabled()) {
-        tenantDomain = appUtils.getTenantDomain();
-    }
+    var tenantDomain = appUtils.getServiceProviderTenantDomain();
     var log = new Log();
     var cookieToken = request.getCookie("AM_REF_TOKEN_DEFAULT_P2");
     var tokenParam = request.getParameter("refresh_token", "UTF-8")


### PR DESCRIPTION
Fixes: https://github.com/wso2/product-apim/issues/9150

![token_refresh_fix](https://user-images.githubusercontent.com/1591316/90783949-57d01480-e31e-11ea-94c7-21c8733a71fa.gif)

```
    var tenantDomain;
    if (appUtils.isPerTenantServiceProviderEnabled()) {
        tenantDomain = appUtils.getTenantDomain();
    }
```

The above code block which initializes the tenantDomain doesn't get executed when isPerTenantServiceProviderEnabled is false (default). Hence tenantDomain remains uninitialized which cases the issue in token refreshing.
