### PR TITLE
Consider App custom attribute hidden property as true when it is not set

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/ApplicationFormHandler.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/ApplicationFormHandler.jsx
@@ -236,7 +236,7 @@ class ApplicationFormHandler extends React.Component {
         const attributeNameList = Object.keys(attributes);
         if (allAppAttributes.length > 0) {
             for (let i = 0; i < allAppAttributes.length; i++) {
-                if (allAppAttributes[i].required === 'true' && allAppAttributes[i].hidden === 'false') {
+                if (allAppAttributes[i].required === 'true' && allAppAttributes[i].hidden !== 'true') {
                     if (attributeNameList.indexOf(allAppAttributes[i].attribute) === -1) {
                         isValidAttribute = false;
                     } else if (attributeNameList.indexOf(allAppAttributes[i].attribute) > -1


### PR DESCRIPTION
fix wso2/product-apim#9130

- When hidden value is not set, consider it as `'true'`
- Make validation logic of attribute is not hidden as hidden is not true