### PR TITLE
Limit global scope names in Publisher Portal

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
@@ -1058,6 +1058,7 @@
   "Scopes.Create.CreateScope.short.description.display.name": "Enter Scope Display Name ( E.g.,: creator )",
   "Scopes.Create.CreateScope.short.description.name": "Enter Scope Name ( E.g.,: creator )",
   "Scopes.Create.Scope.description.length.exceeded": "Exceeds maximum length limit of 512 characters",
+  "Scopes.Create.Scope.name.length.exceeded": "Exceeds maximum length limit of 60 characters",
   "Scopes.Create.ScopeCreate.Roles.Invalid": "Role is invalid",
   "Scopes.Delete.Delete.document.scope.label.ok.confirm": "Are you sure you want to delete scope {scope} ?",
   "Scopes.Delete.Delete.scope.delete": "Delete",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/fr.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/fr.json
@@ -1058,6 +1058,7 @@
   "Scopes.Create.CreateScope.short.description.display.name": "",
   "Scopes.Create.CreateScope.short.description.name": "",
   "Scopes.Create.Scope.description.length.exceeded": "",
+  "Scopes.Create.Scope.name.length.exceeded": "",
   "Scopes.Create.ScopeCreate.Roles.Invalid": "",
   "Scopes.Delete.Delete.document.scope.label.ok.confirm": "",
   "Scopes.Delete.Delete.scope.delete": "",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Scopes/CreateScope.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Scopes/CreateScope.jsx
@@ -208,7 +208,7 @@ class CreateScope extends React.Component {
         const {
             api: { scopes },
         } = this.props;
-
+        const { intl } = this.props;
         apiScope[id] = value;
         valid[id].invalid = !(value && value.length > 0);
         // length validation
@@ -217,7 +217,10 @@ class CreateScope extends React.Component {
         }
         valid[id].invalid = !(value && value.length <= 60);
         if (valid[id].invalid) {
-            valid[id].error = 'Scope name cannot be more than 60 characters';
+            valid[id].error = intl.formatMessage({
+                id: 'Scopes.Create.Scope.name.length.exceeded',
+                defaultMessage: 'Exceeds maximum length limit of 60 characters',
+            });
         }
 
         if (/\s/.test(value)) {

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Scopes/Create/CreateScope.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Scopes/Create/CreateScope.jsx
@@ -243,6 +243,10 @@ class CreateScope extends React.Component {
         if (valid[id].invalid) {
             valid[id].error = 'Scope name cannot be empty';
         }
+        valid[id].invalid = !(value && value.length <= 60);
+        if (valid[id].invalid) {
+            valid[id].error = 'Scope name cannot be more than 60 characters';
+        }
 
         if (/\s/.test(value)) {
             valid[id].invalid = true;

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Scopes/Create/CreateScope.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Scopes/Create/CreateScope.jsx
@@ -237,7 +237,7 @@ class CreateScope extends React.Component {
      */
     validateScopeName(id, value) {
         const { valid, sharedScope } = this.state;
-
+        const { intl } = this.props;
         sharedScope[id] = value;
         valid[id].invalid = !(value && value.length > 0);
         if (valid[id].invalid) {
@@ -245,7 +245,10 @@ class CreateScope extends React.Component {
         }
         valid[id].invalid = !(value && value.length <= 60);
         if (valid[id].invalid) {
-            valid[id].error = 'Scope name cannot be more than 60 characters';
+            valid[id].error = intl.formatMessage({
+                id: 'Scopes.Create.Scope.name.length.exceeded',
+                defaultMessage: 'Exceeds maximum length limit of 60 characters',
+            });
         }
 
         if (/\s/.test(value)) {


### PR DESCRIPTION
This is a similar fix as https://github.com/wso2/carbon-apimgt/pull/9218 for global scpoes names.

UI validation shows in the UI as follows
![image](https://user-images.githubusercontent.com/21282060/90902082-8c5cd280-e3e9-11ea-8c6a-15be4d67b3b8.png)



fixes wso2/product-apim#9132