### PR TITLE
Validate for long API custom property and validate spaces and overflow of table content

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Properties/EditableRow.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Properties/EditableRow.jsx
@@ -29,10 +29,16 @@ import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import { injectIntl } from 'react-intl';
 import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles(() => ({
     link: {
         cursor: 'pointer',
+    },
+    content: {
+        margin: 'auto',
+        wordBreak: 'break-all',
+        whiteSpace: 'normal',
     },
 }));
 
@@ -108,7 +114,11 @@ function EditableRow(props) {
                     />
                 </TableCell>
             ) : (
-                <TableCell>{oldKey}</TableCell>
+                <TableCell>
+                    <Typography className={classes.content}>
+                        {oldKey}
+                    </Typography>
+                </TableCell>
             )}
             {editMode ? (
                 <TableCell>
@@ -130,7 +140,11 @@ function EditableRow(props) {
                     />
                 </TableCell>
             ) : (
-                <TableCell>{oldValue}</TableCell>
+                <TableCell>
+                    <Typography className={classes.content}>
+                        {oldValue}
+                    </Typography>
+                </TableCell>
             )}
             <TableCell align='right'>
                 {editMode ? (

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Properties/Properties.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Properties/Properties.jsx
@@ -150,14 +150,10 @@ function Properties(props) {
     const [isAdditionalPropertiesStale, setIsAdditionalPropertiesStale] = useState(false);
     const iff = (condition, then, otherwise) => (condition ? then : otherwise);
 
-    let isKeyWord = false;
     const keywords = ['provider', 'version', 'context', 'status', 'description',
         'subcontext', 'doc', 'lcState', 'name', 'tags'];
-    if (keywords.includes(propertyKey)) {
-        isKeyWord = true;
-    } else {
-        isKeyWord = false;
-    }
+    const isInvalidName = keywords.includes(propertyKey) || /\s/g.test(propertyKey)
+        || (propertyKey && propertyKey.length > 80);
 
     const toggleAddProperty = () => {
         setShowAddProperty(!showAddProperty);
@@ -463,8 +459,8 @@ function Properties(props) {
                                                         onChange={handleChange('propertyKey')}
                                                         onKeyDown={handleKeyDown('propertyKey')}
                                                         helperText={validateEmpty(propertyKey) ? ''
-                                                            : iff(isKeyWord, 'Invalid property name', '')}
-                                                        error={validateEmpty(propertyKey) || isKeyWord}
+                                                            : iff(isInvalidName, 'Invalid property name', '')}
+                                                        error={validateEmpty(propertyKey) || isInvalidName}
                                                         disabled={isRestricted(
                                                             ['apim:api_create', 'apim:api_publish'],
                                                             api,
@@ -503,7 +499,7 @@ function Properties(props) {
                                                             || isRestricted(
                                                                 ['apim:api_create', 'apim:api_publish'], api,
                                                             )
-                                                            || isKeyWord
+                                                            || isInvalidName
                                                         }
                                                         onClick={handleAddToList}
                                                         className={classes.marginRight}
@@ -529,8 +525,9 @@ function Properties(props) {
                                                             id='Apis.Details.Properties.Properties.help'
                                                             defaultMessage={
                                                                 'Property name should be unique, should not contain '
-                                                                + 'spaces and cannot be any '
-                                                                + 'of the following reserved keywords : '
+                                                                + 'spaces, cannot be more than 80 chars '
+                                                                + 'and cannot be any of the following '
+                                                                + 'reserved keywords : '
                                                                 + 'provider, version, context, status, description, '
                                                                 + 'subcontext, doc, lcState, name, tags.'
                                                             }


### PR DESCRIPTION
fix https://github.com/wso2/product-apim/issues/9165

- Validate space for API custom property name
- Overflow of table content
- Validate for long API custom property

#### Validate for no spaces
![image](https://user-images.githubusercontent.com/23183042/90899360-6af9e780-e3e5-11ea-9630-432c0efc8724.png)

#### Wrap content
![image](https://user-images.githubusercontent.com/23183042/90899615-cdeb7e80-e3e5-11ea-9a33-b951c0164dbb.png)
