### PR TITLE
Changing WWW-Authenticate header to Bearer

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
@@ -473,7 +473,7 @@ public class OAuthAuthenticator implements Authenticator {
     }
 
     public String getChallengeString() {
-        return "OAuth2 realm=\"WSO2 API Manager\"";
+        return "Bearer realm=\"WSO2 API Manager\"";
     }
 
     private String getClientDomain(MessageContext synCtx) {


### PR DESCRIPTION
This PR updates the WWW-Authenticate header to `Bearer` as specified in https://tools.ietf.org/html/rfc6750#section-3.
The response header would look as follows.
`"WWW-Authenticate: Bearer realm="WSO2 API Manager", error="invalid_token", error_description="The access token expired"`

Fixes - https://github.com/wso2/product-apim/issues/9110