### PR TITLE
Policy name Limit to 30 characters

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Throttling/Advanced/AddEdit.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Throttling/Advanced/AddEdit.jsx
@@ -155,7 +155,7 @@ function AddEdit(props) {
                         id: 'Throttling.Advanced.AddEdit.is.empty.error',
                         defaultMessage: ' is empty',
                     })}`;
-                } else if (fieldValue.length > 60) {
+                } else if (fieldValue.length > 30) {
                     error = intl.formatMessage({
                         id: 'Throttling.Advanced.AddEdit.policy.name.too.long.error.msg',
                         defaultMessage: 'Throttling policy name is too long',

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Throttling/Application/AddEdit.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Throttling/Application/AddEdit.jsx
@@ -166,7 +166,7 @@ function AddEdit(props) {
                         id: 'Throttling.Application.Policy.policy.name.space',
                         defaultMessage: 'Name contains spaces',
                     });
-                } else if (value.length > 60) {
+                } else if (value.length > 30) {
                     error = intl.formatMessage({
                         id: 'Throttling.Application.Policy.policy.name.too.long',
                         defaultMessage: 'Application policy name is too long',

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Throttling/Custom/AddEdit.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Throttling/Custom/AddEdit.jsx
@@ -181,7 +181,7 @@ function AddEdit(props) {
                         id: 'Throttling.Custom.Policy.policy.name.space',
                         defaultMessage: 'Name contains spaces',
                     });
-                } else if (value.length > 60) {
+                } else if (value.length > 30) {
                     error = intl.formatMessage({
                         id: 'Throttling.Custom.Policy.policy.name.too.long.error.msg',
                         defaultMessage: 'Custom policy name is too long',

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Throttling/Subscription/AddEdit.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Throttling/Subscription/AddEdit.jsx
@@ -301,7 +301,7 @@ function AddEdit(props) {
                         id: 'Throttling.Subscription.Policy.policy.name.space.error.msg',
                         defaultMessage: 'Name contains spaces',
                     });
-                } else if (value.length > 60) {
+                } else if (value.length > 30) {
                     error = intl.formatMessage({
                         id: 'Throttling.Subscription.Policy.policy.name.too.long.error.msg',
                         defaultMessage: 'Subscription policy name is too long',


### PR DESCRIPTION
### Description
This PR set the policy name length validation limit to 30 characters. (considering the database storing limits and consistency)