### PR TITLE
Fix API Categories Dashboard card 

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/AdminPages/Dashboard/APICategoriesCard.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/AdminPages/Dashboard/APICategoriesCard.jsx
@@ -43,6 +43,11 @@ const useStyles = makeStyles(() => ({
         fontSize: 20,
         fontWeight: 'fontWeightBold',
     },
+    cardText: {
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+    },
 }));
 
 /**
@@ -158,11 +163,11 @@ export default function APICategoriesCard() {
                         {apiCategoriesList.map((category) => {
                             return (
                                 <Box display='flex' alignItems='center'>
-                                    <Box flexGrow={1} mt={0.5}>
-                                        <Typography variant='subtitle2'>
+                                    <Box width={50} flexGrow={1} mt={0.5}>
+                                        <Typography className={classes.cardText} variant='subtitle2'>
                                             {category.name}
                                         </Typography>
-                                        <Typography variant='body2'>
+                                        <Typography className={classes.cardText} variant='body2'>
                                             {category.description || (
                                                 <FormattedMessage
                                                     id='Dashboard.apiCategories.apiCategoriesListing.no.description'


### PR DESCRIPTION
Fixes: wso2/product-apim#9157

Overflowing text will be clipped and partially displayed since this is a dashboard card.

#### Screenshot of the fix

![](https://user-images.githubusercontent.com/25490163/90854698-4f69ef00-e39b-11ea-9bf3-4e50ba8a923f.png)