### PR TITLE
Initializing throttle publisher via ServerStartupObserver

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
@@ -486,6 +486,11 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
                 new org.wso2.carbon.databridge.commons.Event(
                         "org.wso2.throttle.request.stream:1.0.0", System.currentTimeMillis(), null,
                         null, objects);
+        if (ServiceReferenceHolder.getInstance().getThrottleDataPublisher() == null) {
+            log.error("Cannot publish events to traffic manager because ThrottleDataPublisher " +
+                    "has not been initialised");
+            return true;
+        }
         ServiceReferenceHolder.getInstance().getThrottleDataPublisher().getDataPublisher().tryPublish(event);
         return true;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleHandler.java
@@ -501,6 +501,11 @@ public class ThrottleHandler extends AbstractHandler implements ManagedLifecycle
      * false to notify error with handler
      */
     public boolean handleRequest(MessageContext messageContext) {
+        if (ServiceReferenceHolder.getInstance().getThrottleDataPublisher() == null) {
+            log.error("Cannot publish events to traffic manager because ThrottleDataPublisher " +
+                    "has not been initialised");
+            return true;
+        }
 
         Timer timer3 = getTimer(MetricManager.name(
                 APIConstants.METRICS_PREFIX, this.getClass().getSimpleName(), THROTTLE_MAIN));

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.apimgt.gateway.handlers.security.keys.APIKeyValidatorClie
 import org.wso2.carbon.apimgt.gateway.jwt.RevokedJWTMapCleaner;
 import org.wso2.carbon.apimgt.gateway.jwt.RevokedJWTTokensRetriever;
 import org.wso2.carbon.apimgt.gateway.listeners.GatewayStartupListener;
+import org.wso2.carbon.apimgt.gateway.listeners.ServerStartupListener;
 import org.wso2.carbon.apimgt.gateway.service.APIThrottleDataServiceImpl;
 import org.wso2.carbon.apimgt.gateway.service.CacheInvalidationServiceImpl;
 import org.wso2.carbon.apimgt.gateway.service.RevokedTokenDataImpl;
@@ -106,18 +107,7 @@ public class APIHandlerServiceComponent {
                 // Register Tenant service creator to deploy tenant specific common synapse configurations
                 TenantServiceCreator listener = new TenantServiceCreator();
                 bundleContext.registerService(Axis2ConfigurationContextObserver.class.getName(), listener, null);
-                    ServiceReferenceHolder.getInstance().setThrottleDataPublisher(new ThrottleDataPublisher());
-                    ThrottleDataHolder throttleDataHolder = new ThrottleDataHolder();
-                    APIThrottleDataServiceImpl throttleDataServiceImpl =
-                            new APIThrottleDataServiceImpl(throttleDataHolder);
-                    CacheInvalidationService cacheInvalidationService = new CacheInvalidationServiceImpl();
-                    // Register APIThrottleDataService so that ThrottleData maps are available to other components.
-                    ServiceReferenceHolder.getInstance().setCacheInvalidationService(cacheInvalidationService);
-                    ServiceReferenceHolder.getInstance().setAPIThrottleDataService(throttleDataServiceImpl);
-                    ServiceReferenceHolder.getInstance().setThrottleDataHolder(throttleDataHolder);
-                    ServiceReferenceHolder.getInstance().setRevokedTokenService(new RevokedTokenDataImpl());
-                    log.debug("APIThrottleDataService Registered...");
-                    // start web service throttle data retriever as separate thread and start it.
+                bundleContext.registerService(ServerStartupObserver.class.getName(), new ServerStartupListener(), null);
 
                 // Set APIM Gateway JWT Generator
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/ServerStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/ServerStartupListener.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.listeners;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.gateway.internal.APIHandlerServiceComponent;
+import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.gateway.service.APIThrottleDataServiceImpl;
+import org.wso2.carbon.apimgt.gateway.service.CacheInvalidationServiceImpl;
+import org.wso2.carbon.apimgt.gateway.service.RevokedTokenDataImpl;
+import org.wso2.carbon.apimgt.gateway.throttling.ThrottleDataHolder;
+import org.wso2.carbon.apimgt.gateway.throttling.publisher.ThrottleDataPublisher;
+import org.wso2.carbon.apimgt.impl.caching.CacheInvalidationService;
+import org.wso2.carbon.core.ServerStartupObserver;
+
+public class ServerStartupListener implements ServerStartupObserver {
+
+    private static final Log log = LogFactory.getLog(ServerStartupListener.class);
+
+    @Override
+    public void completingServerStartup() {
+    }
+
+    @Override
+    public void completedServerStartup() {
+        // This prevents errors in an All in one setup caused by the ThrottleDataPublisher trying to connect to the
+        // event receiver, before the event receiver has been started on completion of server startup.
+        ServiceReferenceHolder.getInstance().setThrottleDataPublisher(new ThrottleDataPublisher());
+        ThrottleDataHolder throttleDataHolder = new ThrottleDataHolder();
+        APIThrottleDataServiceImpl throttleDataServiceImpl =
+                new APIThrottleDataServiceImpl(throttleDataHolder);
+        CacheInvalidationService cacheInvalidationService = new CacheInvalidationServiceImpl();
+        // Register APIThrottleDataService so that ThrottleData maps are available to other components.
+        ServiceReferenceHolder.getInstance().setCacheInvalidationService(cacheInvalidationService);
+        ServiceReferenceHolder.getInstance().setAPIThrottleDataService(throttleDataServiceImpl);
+        ServiceReferenceHolder.getInstance().setThrottleDataHolder(throttleDataHolder);
+        ServiceReferenceHolder.getInstance().setRevokedTokenService(new RevokedTokenDataImpl());
+        log.debug("APIThrottleDataService Registered...");
+    }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottlingHandlerWrapper.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottlingHandlerWrapper.java
@@ -25,7 +25,9 @@ import org.apache.synapse.commons.throttle.core.AccessInformation;
 import org.apache.synapse.commons.throttle.core.ThrottleContext;
 import org.apache.synapse.commons.throttle.core.ThrottleException;
 import org.apache.synapse.core.SynapseEnvironment;
+import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.throttling.ThrottleDataHolder;
+import org.wso2.carbon.apimgt.gateway.throttling.publisher.ThrottleDataPublisher;
 import org.wso2.carbon.metrics.manager.Timer;
 
 public class ThrottlingHandlerWrapper extends ThrottleHandler {
@@ -40,6 +42,7 @@ public class ThrottlingHandlerWrapper extends ThrottleHandler {
         this.timer = timer;
         this.throttleDataHolder = throttleDataHolder;
         this.throttleConditionEvaluator = throttleConditionEvaluator;
+        ServiceReferenceHolder.getInstance().setThrottleDataPublisher(new ThrottleDataPublisher());
     }
 
     public ThrottlingHandlerWrapper(Timer timer, ThrottleDataHolder throttleDataHolder, ThrottleConditionEvaluator throttleConditionEvaluator, AccessInformation accessInformation) {
@@ -47,6 +50,7 @@ public class ThrottlingHandlerWrapper extends ThrottleHandler {
         this.throttleDataHolder = throttleDataHolder;
         this.throttleConditionEvaluator = throttleConditionEvaluator;
         this.accessInformation = accessInformation;
+        ServiceReferenceHolder.getInstance().setThrottleDataPublisher(new ThrottleDataPublisher());
     }
 
     @Override


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9226

## Goals
Providing an alternative fix for https://github.com/wso2/product-apim/issues/8144

## Approach
Frontporting the below PRs.
- https://github.com/wso2-support/carbon-apimgt/pull/2373
- https://github.com/wso2-support/carbon-apimgt/pull/2417

## Related PRs
- https://github.com/wso2-support/carbon-apimgt/pull/2373
- https://github.com/wso2-support/carbon-apimgt/pull/2417
- https://github.com/wso2-support/carbon-analytics-common/pull/209

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS