### PR TITLE
[Master]Ability to Change LC state from  PUBLISHED -> CREATED by updating api.yaml 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -523,6 +523,7 @@ public final class APIConstants {
     public static final String LC_CHECK_ITEM_NAME = "name:";
     public static final String LC_CHECK_ITEM_VALUE = "value:";
     public static final String LC_CHECK_ITEM_ORDER = "order:";
+    public static final String LC_PUBLISH_LC_STATE = "Publish";
 
     public static final String SUPER_TENANT_DOMAIN = "carbon.super";
     public static final String TENANT_PREFIX = "/t/";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -331,8 +331,10 @@ public final class APIImportUtil {
             // Change API lifecycle if state transition is required
             if (StringUtils.isNotEmpty(lifecycleAction)) {
                 log.info("Changing lifecycle from " + currentStatus + " to " + targetStatus);
-                apiProvider.changeAPILCCheckListItems(importedApi.getId(),
-                        APIImportExportConstants.REFER_REQUIRE_RE_SUBSCRIPTION_CHECK_ITEM, true);
+                if (StringUtils.equals(lifecycleAction, APIConstants.LC_PUBLISH_LC_STATE)) {
+                    apiProvider.changeAPILCCheckListItems(importedApi.getId(),
+                            APIImportExportConstants.REFER_REQUIRE_RE_SUBSCRIPTION_CHECK_ITEM, true);
+                }
                 apiProvider.changeLifeCycleStatus(importedApi.getId(), lifecycleAction);
                 //Change the status of the imported API to targetStatus
                 importedApi.setStatus(targetStatus);


### PR DESCRIPTION
### Purpose
PUBLISHED -> CREATED transition is a valid API Lifecycle transition which is normally done by "Demote to Created" lifecycle action.

By editing the api.yaml of an exported API, we should be able to to that transition and this PR will provide that ability by fixing the issues that occurred previously when importing an API using API controller.

```
availableTiers:
- name: Unlimited
status: CREATED
visibility: public
transports: http,https
```

### Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/478
and https://github.com/wso2/product-apim-tooling/issues/460 for Master branch


### User stories
Import API via API Controller.
Import API via Publisher Portal

### Documentation
No doc changes required.

### Test environment
Ubuntu 20.04 LTS
Java JDK 1.8_241
APIM 3.2.0
APICTL 3.2.0