### PR TITLE
Fixing enum missing issue for subscription in publisher rest API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/SubscriptionDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/SubscriptionDTO.java
@@ -24,7 +24,7 @@ public class SubscriptionDTO   {
 @XmlEnum(String.class)
 public enum SubscriptionStatusEnum {
 
-    @XmlEnumValue("BLOCKED") BLOCKED(String.valueOf("BLOCKED")), @XmlEnumValue("PROD_ONLY_BLOCKED") PROD_ONLY_BLOCKED(String.valueOf("PROD_ONLY_BLOCKED")), @XmlEnumValue("UNBLOCKED") UNBLOCKED(String.valueOf("UNBLOCKED")), @XmlEnumValue("ON_HOLD") ON_HOLD(String.valueOf("ON_HOLD")), @XmlEnumValue("REJECTED") REJECTED(String.valueOf("REJECTED"));
+    @XmlEnumValue("BLOCKED") BLOCKED(String.valueOf("BLOCKED")), @XmlEnumValue("PROD_ONLY_BLOCKED") PROD_ONLY_BLOCKED(String.valueOf("PROD_ONLY_BLOCKED")), @XmlEnumValue("UNBLOCKED") UNBLOCKED(String.valueOf("UNBLOCKED")), @XmlEnumValue("ON_HOLD") ON_HOLD(String.valueOf("ON_HOLD")), @XmlEnumValue("REJECTED") REJECTED(String.valueOf("REJECTED")), @XmlEnumValue("TIER_UPDATE_PENDING") TIER_UPDATE_PENDING(String.valueOf("TIER_UPDATE_PENDING"));
 
 
     private String value;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -8819,6 +8819,7 @@ definitions:
           - UNBLOCKED
           - ON_HOLD
           - REJECTED
+          - TIER_UPDATE_PENDING
         example: BLOCKED
 
   #-----------------------------------------------------


### PR DESCRIPTION
## Issue
When enabled subscription update workflow and subscription update is in pending state, when viewing publisher subscriptions throws missing enum error.