### PR TITLE
Fix for product-apim/issues/9336

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -645,7 +645,12 @@ function AddEditKeyManager(props) {
                                             })}
                                         />
                                         <Box ml={1}>
-                                            <Button margin='dense' variant='outlined' disabled={!wellKnownEndpoint} onClick={importKMConfig}>
+                                            <Button
+                                                margin='dense'
+                                                variant='outlined'
+                                                disabled={!wellKnownEndpoint}
+                                                onClick={importKMConfig}
+                                            >
                                                 <FormattedMessage
                                                     id='KeyManagers.AddEditKeyManager.form.import.button'
                                                     defaultMessage='Import'

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -645,7 +645,7 @@ function AddEditKeyManager(props) {
                                             })}
                                         />
                                         <Box ml={1}>
-                                            <Button margin='dense' variant='outlined' onClick={importKMConfig}>
+                                            <Button margin='dense' variant='outlined' disabled={!wellKnownEndpoint} onClick={importKMConfig}>
                                                 <FormattedMessage
                                                     id='KeyManagers.AddEditKeyManager.form.import.button'
                                                     defaultMessage='Import'


### PR DESCRIPTION
Fix for https://github.com/wso2/product-apim/issues/9336

As the fix, disabled the import button when the URL is empty and enable it when this field is filled

without url
<img width="629" alt="Screenshot 2020-10-07 at 12 30 16" src="https://user-images.githubusercontent.com/4861150/95298275-72902580-0899-11eb-9296-df2d92b98653.png">

with url
<img width="641" alt="Screenshot 2020-10-07 at 12 30 37" src="https://user-images.githubusercontent.com/4861150/95298244-686e2700-0899-11eb-911b-c9cf072c6c3b.png">

