### PR TITLE
Added a buffer to JWT expiry time of Backend JWT

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/AbstractJWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/AbstractJWTGenerator.java
@@ -68,7 +68,7 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
     public static final String API_GATEWAY_ID = "wso2.org/products/am";
 
     private static final String SHA256_WITH_RSA = "SHA256withRSA";
-    
+
     private static final String NONE = "NONE";
 
     private static volatile long ttl = -1L;
@@ -295,17 +295,19 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
                 String apimKeyCacheExpiry = config.getFirstProperty(APIConstants.TOKEN_CACHE_EXPIRY);
 
                 if (apimKeyCacheExpiry != null) {
-                    ttl = Long.parseLong(apimKeyCacheExpiry);
+                    //added one minute buffer to the expiry time to avoid inconsistencies happen during cache expiry
+                    //task time
+                    ttl = Long.parseLong(apimKeyCacheExpiry) + Long.valueOf(60);
                 } else {
-                    ttl = Long.valueOf(900);
+                    ttl = Long.valueOf(960);
                 }
             } else {
                 String ttlValue = config.getFirstProperty(APIConstants.JWT_EXPIRY_TIME);
                 if (ttlValue != null) {
-                    ttl = Long.parseLong(ttlValue);
+                    ttl = Long.parseLong(ttlValue) + Long.valueOf(60);
                 } else {
                     //15 * 60 (convert 15 minutes to seconds)
-                    ttl = Long.valueOf(900);
+                    ttl = Long.valueOf(960);
                 }
             }
             return ttl;


### PR DESCRIPTION
Previously JWT expiry time was set to the token cache expiry time. During the cache cleanup task window( usually 30seconds), even though the JWT is expired still the previous expired token was returned. To avoid that, added a buffer of one minute.

fixing wso2/product-apim#9380