### PR TITLE
Set username to message context when using JWT token

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidator.java
@@ -161,8 +161,10 @@ public class JWTValidator {
                     /*
                      * Set api.ut.apiPublisher of the subscribed api to the message context.
                      * This is necessary for the functionality of Publisher alerts.
+                     * Set API_NAME of the subscribed api to the message context.
                      * */
                     synCtx.setProperty(APIMgtGatewayConstants.API_PUBLISHER, apiKeyValidationInfoDTO.getApiPublisher());
+                    synCtx.setProperty("API_NAME", apiKeyValidationInfoDTO.getApiName());
                     /* GraphQL Query Analysis Information */
                     if (APIConstants.GRAPHQL_API.equals(synCtx.getProperty(APIConstants.API_TYPE))) {
                         synCtx.setProperty(APIConstants.MAXIMUM_QUERY_DEPTH,

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
@@ -300,6 +300,7 @@ public class OAuthAuthenticator implements Authenticator {
                     AuthenticationContext authenticationContext = jwtValidator.authenticate(signedJWTInfo, synCtx);
                     APISecurityUtils.setAuthenticationContext(synCtx, authenticationContext, securityContextHeader);
                     log.debug("User is authorized using JWT token to access the resource.");
+                    synCtx.setProperty(APIMgtGatewayConstants.END_USER_NAME, authenticationContext.getUsername());
                     return new AuthenticationResponse(true, isMandatory, false, 0, null);
 
                 } catch (APISecurityException ex) {


### PR DESCRIPTION
### **Purpose**
- This fixes wso2/product-apim#9349
- This PR will include adding the API name and end user name to message context when using JWT token