### PR TITLE
Fix export Api creates multiple InlineContents/FileContents folders

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIAndAPIProductCommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIAndAPIProductCommonUtil.java
@@ -157,6 +157,7 @@ public class APIAndAPIProductCommonUtil {
                 String sourceType = doc.getSourceType().name();
                 String resourcePath = null;
                 String localFileName = null;
+                docDirectoryPath = File.separator + APIImportExportConstants.DOCUMENT_DIRECTORY;
                 if (Documentation.DocumentSourceType.FILE.toString().equalsIgnoreCase(sourceType)) {
                     localFileName = doc.getFilePath().substring(
                             doc.getFilePath().lastIndexOf(RegistryConstants.PATH_SEPARATOR) + 1);


### PR DESCRIPTION
This fix is the master branch fix for issue: wso2/product-apim-tooling#513.