### PR TITLE
Fixing JSON schema validation errors

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
@@ -267,7 +267,13 @@ public class SchemaValidator extends AbstractHandler {
      */
     private JsonElement getMessageContent(MessageContext messageContext) {
         JsonElement payloadObject = null;
-        if (messageContext.getEnvelope().getBody() != null) {
+        org.apache.axis2.context.MessageContext axis2Context = ((Axis2MessageContext) messageContext)
+                .getAxis2MessageContext();
+        if (JsonUtil.hasAJsonPayload(axis2Context)) {
+            String jsonString = JsonUtil.jsonPayloadToString(axis2Context);
+            JsonParser jsonParser = new JsonParser();
+            payloadObject = jsonParser.parse(jsonString);
+        } else if (messageContext.getEnvelope().getBody() != null) {
             Object objFirstElement = messageContext.getEnvelope().getBody().getFirstElement();
             if (objFirstElement != null) {
                 OMElement xmlResponse = messageContext.getEnvelope().getBody().getFirstElement();


### PR DESCRIPTION
### **Purpose**

- This fixes wso2/product-apim#8079
- This PR resolves the JSON schema validation errors when integer value is provided in quotes for a string field and when there is an array with one element.