### PR TITLE
Adding login permission to the Internal/devops role

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -4862,6 +4862,7 @@ public final class APIUtil {
     public static void createDevOpsRole(String roleName, int tenantId) throws APIManagementException {
 
         Permission[] devOpsPermissions = new Permission[]{
+                new Permission(APIConstants.Permissions.LOGIN, UserMgtConstants.EXECUTE_ACTION),
                 new Permission(APIConstants.Permissions.API_CREATE, UserMgtConstants.EXECUTE_ACTION),
                 new Permission(APIConstants.Permissions.API_PUBLISH, UserMgtConstants.EXECUTE_ACTION),
                 new Permission(APIConstants.Permissions.API_SUBSCRIBE, UserMgtConstants.EXECUTE_ACTION),


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/521

## Goals
Adding login permission to the Internal/devops role.

## Approach
Added login permission when creating the Internal/devops role.

## User stories
- A user with the Internal/devops role can login using "apictl login".

## Related PRs
https://github.com/wso2-support/carbon-apimgt/pull/2589

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.1 LTS