### PR TITLE
Provide Markdown Editor to Add/Edit Description

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
@@ -213,6 +213,8 @@
   "Apis.Details.Configuration.components.KeyManager.configuration": "Key Manager Configuration",
   "Apis.Details.Configuration.components.KeyManager.more.than.one.error": "Select at least one Key Manager",
   "Apis.Details.Configuration.components.KeyManager.more.than.one.info": "Select one or more Key Managers",
+  "Apis.Details.Configuration.components.MarkdownEditor.add.description.button": "Add Description",
+  "Apis.Details.Configuration.components.MarkdownEditor.edit.description.button": "Edit Description",
   "Apis.Details.Configuration.components.MaxBackendTps.formattedMessage": "Maximum backend transactions per second in integers",
   "Apis.Details.Configuration.components.MaxBackendTps.tooltip": "Limits the total number of calls the API Manager is allowed to make to the backend",
   "Apis.Details.Configuration.components.ResponseCaching.tooltip": "If enabled, the API response will be cached at the gateway level to improve the response time and minimize the backend load",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/fr.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/fr.json
@@ -213,6 +213,8 @@
   "Apis.Details.Configuration.components.KeyManager.configuration": "",
   "Apis.Details.Configuration.components.KeyManager.more.than.one.error": "",
   "Apis.Details.Configuration.components.KeyManager.more.than.one.info": "",
+  "Apis.Details.Configuration.components.MarkdownEditor.add.description.button": "",
+  "Apis.Details.Configuration.components.MarkdownEditor.edit.description.button": "",
   "Apis.Details.Configuration.components.MaxBackendTps.formattedMessage": "",
   "Apis.Details.Configuration.components.MaxBackendTps.tooltip": "",
   "Apis.Details.Configuration.components.ResponseCaching.tooltip": "",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/si.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/si.json
@@ -73,6 +73,8 @@
     "Apis.Details.Configuration.Configuration.visibility.public": "පොදු",
     "Apis.Details.Configuration.Configuration.visibility.restricted.by.roles": "භූමිකාවන් මගින් සීමා කර ඇත",
     "Apis.Details.Configuration.Configuration.workflow.status": "කාර්ය ප්‍රවාහ තත්වය",
+    "Apis.Details.Configuration.components.MarkdownEditor.add.description.button": "විස්තරය එක් කරන්න",
+    "Apis.Details.Configuration.components.MarkdownEditor.edit.description.button": "විස්තරය සංස්කරණය කරන්න",
     "Apis.Details.Documents.Create.markdown.editor.add.document.button": "ලේඛනය එක් කරන්න",
     "Apis.Details.Documents.Create.markdown.editor.add.document.cancel.button": "අවලංගු කරන්න",
     "Apis.Details.Documents.Create.markdown.editor.add.error": "ලේඛනය එකතු කිරීමේදී දෝෂයකි",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
@@ -34,7 +34,7 @@ import ThumbnailView from 'AppComponents/Apis/Listing/components/ImageGenerator/
 import { isRestricted } from 'AppData/AuthManager';
 import API from 'AppData/api.js';
 import DefaultVersion from './components/DefaultVersion';
-import Description from './components/Description';
+import MarkdownEditor from './components/MarkdownEditor';
 import AccessControl from './components/AccessControl';
 import StoreVisibility from './components/StoreVisibility';
 import Tags from './components/Tags';
@@ -260,7 +260,7 @@ export default function DesignConfigurations() {
                                                 />
                                             </Grid>
                                             <Grid item xs={12} md={10}>
-                                                <Description api={apiConfig} configDispatcher={configDispatcher} />
+                                                <MarkdownEditor api={apiConfig} configDispatcher={configDispatcher} />
                                             </Grid>
                                         </Grid>
                                     </Box>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/MarkdownEditor.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/MarkdownEditor.jsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState, Suspense, lazy } from 'react';
+import { withRouter } from 'react-router-dom';
+import Link from '@material-ui/core/Link';
+import { FormattedMessage, injectIntl } from 'react-intl';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
+import Slide from '@material-ui/core/Slide';
+import Icon from '@material-ui/core/Icon';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { isRestricted } from 'AppData/AuthManager';
+import { useAPI } from 'AppComponents/Apis/Details/components/ApiContext';
+
+const MonacoEditor = lazy(() => import('react-monaco-editor' /* webpackChunkName: "MDMonacoEditor" */));
+const ReactMarkdown = lazy(() => import('react-markdown' /* webpackChunkName: "MDReactMarkdown" */));
+
+const styles = {
+    flex: {
+        flex: 1,
+    },
+    popupHeader: {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    splitWrapper: {
+        padding: 0,
+    },
+    description: {
+        alignItems: 'center',
+        display: 'flex',
+    },
+    markdownViewWrapper: {
+        height: '100vh',
+        overflowY: 'auto',
+    },
+    button: {
+        height: 30,
+        marginLeft: 30,
+    },
+};
+
+function Transition(props) {
+    return <Slide direction='up' {...props} />;
+}
+
+function MarkdownEditor(props) {
+    const { api, configDispatcher } = props;
+    const [open, setOpen] = useState(false);
+    const [description, setDescription] = useState(null);
+    const [apiFromContext] = useAPI();
+    const [isUpdating, setIsUpdating] = useState(false);
+
+    const toggleOpen = () => {
+        if (!open) setDescription(description || api.description);
+        setOpen(!open);
+    };
+    const changeDescription = (newDescription) => {
+        setDescription(newDescription);
+    };
+    const updateDescription = () => {
+        setIsUpdating(true);
+        configDispatcher({ action: 'description', value: description });
+        toggleOpen();
+        setIsUpdating(false);
+    };
+    const editorDidMount = (editor) => {
+        editor.focus();
+    };
+
+    const { classes } = props;
+    return (
+        <div>
+            <Link onClick={toggleOpen}>
+                <Button
+                    color='primary'
+                    disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                >
+                    {api.description ? (
+                        <FormattedMessage
+                            id='Apis.Details.Configuration.components.MarkdownEditor.edit.description.button'
+                            defaultMessage='Edit Description'
+                        />
+                    ) : (
+                        <FormattedMessage
+                            id='Apis.Details.Configuration.components.MarkdownEditor.add.description.button'
+                            defaultMessage='Add Description'
+                        />
+                    )}
+                </Button>
+            </Link>
+            <Dialog fullScreen open={open} onClose={toggleOpen} TransitionComponent={Transition}>
+                <Paper square className={classes.popupHeader}>
+                    <IconButton color='inherit' onClick={toggleOpen} aria-label='Close'>
+                        <Icon>close</Icon>
+                    </IconButton>
+                    <Typography variant='h4' className={classes.description}>
+                        <FormattedMessage
+                            id='Apis.Details.Documents.MarkdownEditor.edit.content.of'
+                            defaultMessage='Edit Description of '
+                        />
+                        {api.name}
+                    </Typography>
+                    <Button
+                        className={classes.button}
+                        variant='contained'
+                        disabled={isUpdating}
+                        color='primary'
+                        onClick={updateDescription}
+                    >
+                        <FormattedMessage
+                            id='Apis.Details.Documents.MarkdownEditor.update.content.button'
+                            defaultMessage='Update Description'
+                        />
+                        {isUpdating && <CircularProgress size={24} />}
+                    </Button>
+                    <Button className={classes.button} onClick={toggleOpen}>
+                        <FormattedMessage
+                            id='Apis.Details.Documents.MarkdownEditor.cancel.button'
+                            defaultMessage='Cancel'
+                        />
+                    </Button>
+                </Paper>
+                <div className={classes.splitWrapper}>
+                    <Grid container spacing={7}>
+                        <Grid item xs={6}>
+                            <Suspense fallback={<CircularProgress />}>
+                                <MonacoEditor
+                                    width='100%'
+                                    height='100vh'
+                                    language='markdown'
+                                    theme='vs-dark'
+                                    value={description}
+                                    options={{ selectOnLineNumbers: true }}
+                                    onChange={changeDescription}
+                                    editorDidMount={editorDidMount}
+                                />
+                            </Suspense>
+                        </Grid>
+                        <Grid item xs={6}>
+                            <div className={classes.markdownViewWrapper}>
+                                <Suspense fallback={<CircularProgress />}>
+                                    <ReactMarkdown escapeHtml={false} source={description} />
+                                </Suspense>
+                            </div>
+                        </Grid>
+                    </Grid>
+                </div>
+            </Dialog>
+        </div>
+    );
+}
+
+MarkdownEditor.propTypes = {
+    api: PropTypes.shape({}).isRequired,
+    configDispatcher: PropTypes.func.isRequired,
+    classes: PropTypes.shape({}).isRequired,
+    intl: PropTypes.shape({}).isRequired,
+};
+
+export default injectIntl(withRouter(withStyles(styles)(MarkdownEditor)));

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/MarkdownEditor.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Configuration/components/MarkdownEditor.jsx
@@ -17,11 +17,10 @@
  */
 
 import React, { useState, Suspense, lazy } from 'react';
-import { withRouter } from 'react-router-dom';
 import Link from '@material-ui/core/Link';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { makeStyles } from '@material-ui/core/styles';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import IconButton from '@material-ui/core/IconButton';
@@ -37,7 +36,7 @@ import { useAPI } from 'AppComponents/Apis/Details/components/ApiContext';
 const MonacoEditor = lazy(() => import('react-monaco-editor' /* webpackChunkName: "MDMonacoEditor" */));
 const ReactMarkdown = lazy(() => import('react-markdown' /* webpackChunkName: "MDReactMarkdown" */));
 
-const styles = {
+const useStyles = makeStyles(() => ({
     flex: {
         flex: 1,
     },
@@ -61,13 +60,19 @@ const styles = {
         height: 30,
         marginLeft: 30,
     },
-};
+}));
 
 function Transition(props) {
     return <Slide direction='up' {...props} />;
 }
 
-function MarkdownEditor(props) {
+/**
+ * MarkdownEditor for API Description
+ * @param {*} props properties
+ * @returns {*} MarkdownEditor component
+ */
+export default function MarkdownEditor(props) {
+    const classes = useStyles();
     const { api, configDispatcher } = props;
     const [open, setOpen] = useState(false);
     const [description, setDescription] = useState(null);
@@ -91,7 +96,6 @@ function MarkdownEditor(props) {
         editor.focus();
     };
 
-    const { classes } = props;
     return (
         <div>
             <Link onClick={toggleOpen}>
@@ -177,8 +181,4 @@ function MarkdownEditor(props) {
 MarkdownEditor.propTypes = {
     api: PropTypes.shape({}).isRequired,
     configDispatcher: PropTypes.func.isRequired,
-    classes: PropTypes.shape({}).isRequired,
-    intl: PropTypes.shape({}).isRequired,
 };
-
-export default injectIntl(withRouter(withStyles(styles)(MarkdownEditor)));

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/MetaData.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/NewOverview/MetaData.jsx
@@ -20,6 +20,7 @@ import Grid from '@material-ui/core/Grid';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import ReactMarkdown from 'react-markdown';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -60,9 +61,7 @@ function MetaData(props) {
                         <Typography component='p' variant='body1'>
                             {api.description
                             && (
-                                <>
-                                    {capitalizeFirstLetter(api.description)}
-                                </>
+                                <ReactMarkdown source={capitalizeFirstLetter(api.description)} />
                             )}
                         </Typography>
                         <Typography component='p' variant='body1' className={parentClasses.notConfigured}>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/InfoBar.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/InfoBar.jsx
@@ -18,6 +18,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Settings from 'Settings';
+import ReactMarkdown from 'react-markdown';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
@@ -447,7 +448,9 @@ class InfoBar extends React.Component {
                     <Collapse in={showOverview}>
                         <div className={classes.infoContent}>
                             <div className={classes.contentWrapper}>
-                                <Typography>{api.description}</Typography>
+                                <Typography>
+                                    <ReactMarkdown source={api.description} />
+                                </Typography>
                                 <Table className={classes.table}>
                                     <TableBody>
                                         <TableRow>


### PR DESCRIPTION
## Purpose
Provide a markdown editor to add/edit the description in the publisher portal.
Related Issue: https://github.com/wso2/product-apim/issues/9272

## Approach
1. Removed the Description TextField in the Design Configurations UI page and added a link button to Add/Edit Description.
![DesignConfigUI](https://user-images.githubusercontent.com/30455603/97954552-d4c14500-1dc9-11eb-81d3-d4021670bb49.png)


2. Added functionality to open up a Markdown Editor to add/edit the description when the link button is clicked.
![DescriptionMarkdownEditor](https://user-images.githubusercontent.com/30455603/103626665-8c0d4000-4f62-11eb-94fc-09700cda3dc4.png)



## Test Environment
JDK 1.8.0_241
Ubuntu 20.04.1 LTS