### PR TITLE
Fixing inconsistencies when importing/exporting APIs/API Products/Applications with Throttling Policies using the API Controller

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -814,6 +814,15 @@ public interface APIProvider extends APIManager {
     void validateResourceThrottlingTiers(String swaggerContent, String tenantDomain) throws APIManagementException;
 
     /**
+     * This method validates the existence of all the API level throttling tiers of API
+     *
+     * @param api           api
+     * @param tenantDomain  tenant domain
+     * @throws APIManagementException
+     */
+    void validateAPIThrottlingTier(API api, String tenantDomain) throws APIManagementException;
+
+    /**
      * This method is used to configure monetization for a given API
      *
      * @param api API to be updated with monetization

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -823,6 +823,15 @@ public interface APIProvider extends APIManager {
     void validateAPIThrottlingTier(API api, String tenantDomain) throws APIManagementException;
 
     /**
+     * This method validates the existence of all the API level throttling tiers of API
+     *
+     * @param apiProduct   api product
+     * @param tenantDomain tenant domain
+     * @throws APIManagementException
+     */
+    void validateProductThrottlingTier(APIProduct apiProduct, String tenantDomain) throws APIManagementException;
+
+    /**
      * This method is used to configure monetization for a given API
      *
      * @param api API to be updated with monetization

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -814,7 +814,7 @@ public interface APIProvider extends APIManager {
     void validateResourceThrottlingTiers(String swaggerContent, String tenantDomain) throws APIManagementException;
 
     /**
-     * This method validates the existence of all the API level throttling tiers of API
+     * This method validates the existence of the API level throttling tier of API
      *
      * @param api           api
      * @param tenantDomain  tenant domain
@@ -823,7 +823,7 @@ public interface APIProvider extends APIManager {
     void validateAPIThrottlingTier(API api, String tenantDomain) throws APIManagementException;
 
     /**
-     * This method validates the existence of all the API level throttling tiers of API
+     * This method validates the existence of the API level throttling tier of API
      *
      * @param apiProduct   api product
      * @param tenantDomain tenant domain

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -804,6 +804,16 @@ public interface APIProvider extends APIManager {
     void validateResourceThrottlingTiers(API api, String tenantDomain) throws APIManagementException;
 
     /**
+     * This method validates the existence of all the resource level throttling tiers in URI templates of API
+     * when the swagger file is provided
+     *
+     * @param swaggerContent swagger file
+     * @param tenantDomain   tenant domain
+     * @throws APIManagementException
+     */
+    void validateResourceThrottlingTiers(String swaggerContent, String tenantDomain) throws APIManagementException;
+
+    /**
      * This method is used to configure monetization for a given API
      *
      * @param api API to be updated with monetization

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1643,6 +1643,8 @@ public final class APIConstants {
     public static final String TIME_UNIT_HOUR = "hour";
     public static final String TIME_UNIT_DAY = "day";
 
+    public static final String SUBSCRIPTION_TIERS = "availableTiers";
+
     public static final String DEFAULT_APP_POLICY_FIFTY_REQ_PER_MIN = "50PerMin";
     public static final String DEFAULT_APP_POLICY_TWENTY_REQ_PER_MIN = "20PerMin";
     public static final String DEFAULT_APP_POLICY_TEN_REQ_PER_MIN = "10PerMin";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5500,13 +5500,13 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     @Override
     public void validateProductThrottlingTier(APIProduct apiProduct, String tenantDomain) throws APIManagementException {
         if (log.isDebugEnabled()) {
-            log.debug("Validating apiLevelPolicy defined in the API Product");
+            log.debug("Validating productLevelPolicy defined in the API Product");
         }
         Map<String, Tier> tierMap = APIUtil.getTiers(APIConstants.TIER_RESOURCE_TYPE, tenantDomain);
         if (tierMap != null) {
             String apiLevelPolicy = apiProduct.getProductLevelPolicy();
             if (apiLevelPolicy != null && !tierMap.containsKey(apiLevelPolicy)) {
-                String message = "Invalid API level throttling tier " + apiLevelPolicy + " found in api definition";
+                String message = "Invalid Product level throttling tier " + apiLevelPolicy + " found in api definition";
                 throw new APIManagementException(message);
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5469,7 +5469,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             log.debug("Validating x-throttling tiers defined in swagger api definition resource");
         }
         Set<URITemplate> uriTemplates = api.getUriTemplates();
-        checkResourceThrottlingTiersInURITemplates(uriTemplates);
+        checkResourceThrottlingTiersInURITemplates(uriTemplates, tenantDomain);
     }
 
     @Override
@@ -5479,7 +5479,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         }
         APIDefinition apiDefinition = OASParserUtil.getOASParser(swaggerContent);
         Set<URITemplate> uriTemplates = apiDefinition.getURITemplates(swaggerContent);
-        checkResourceThrottlingTiersInURITemplates(uriTemplates);
+        checkResourceThrottlingTiersInURITemplates(uriTemplates, tenantDomain);
     }
 
     @Override
@@ -5497,7 +5497,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         }
     }
 
-    private void checkResourceThrottlingTiersInURITemplates(Set<URITemplate> uriTemplates)
+    private void checkResourceThrottlingTiersInURITemplates(Set<URITemplate> uriTemplates, String tenantDomain)
             throws APIManagementException {
         Map<String, Tier> tierMap = APIUtil.getTiers(APIConstants.TIER_RESOURCE_TYPE, tenantDomain);
         if (tierMap != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5485,11 +5485,26 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     @Override
     public void validateAPIThrottlingTier(API api, String tenantDomain) throws APIManagementException {
         if (log.isDebugEnabled()) {
-            log.debug("Validating apiLevelPolicy defined in the api");
+            log.debug("Validating apiLevelPolicy defined in the API");
         }
         Map<String, Tier> tierMap = APIUtil.getTiers(APIConstants.TIER_RESOURCE_TYPE, tenantDomain);
         if (tierMap != null) {
             String apiLevelPolicy = api.getApiLevelPolicy();
+            if (apiLevelPolicy != null && !tierMap.containsKey(apiLevelPolicy)) {
+                String message = "Invalid API level throttling tier " + apiLevelPolicy + " found in api definition";
+                throw new APIManagementException(message);
+            }
+        }
+    }
+
+    @Override
+    public void validateProductThrottlingTier(APIProduct apiProduct, String tenantDomain) throws APIManagementException {
+        if (log.isDebugEnabled()) {
+            log.debug("Validating apiLevelPolicy defined in the API Product");
+        }
+        Map<String, Tier> tierMap = APIUtil.getTiers(APIConstants.TIER_RESOURCE_TYPE, tenantDomain);
+        if (tierMap != null) {
+            String apiLevelPolicy = apiProduct.getProductLevelPolicy();
             if (apiLevelPolicy != null && !tierMap.containsKey(apiLevelPolicy)) {
                 String message = "Invalid API level throttling tier " + apiLevelPolicy + " found in api definition";
                 throw new APIManagementException(message);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5482,6 +5482,21 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         checkResourceThrottlingTiersInURITemplates(uriTemplates);
     }
 
+    @Override
+    public void validateAPIThrottlingTier(API api, String tenantDomain) throws APIManagementException {
+        if (log.isDebugEnabled()) {
+            log.debug("Validating apiLevelPolicy defined in the api");
+        }
+        Map<String, Tier> tierMap = APIUtil.getTiers(APIConstants.TIER_RESOURCE_TYPE, tenantDomain);
+        if (tierMap != null) {
+            String apiLevelPolicy = api.getApiLevelPolicy();
+            if (apiLevelPolicy != null && !tierMap.containsKey(apiLevelPolicy)) {
+                String message = "Invalid API level throttling tier " + apiLevelPolicy + " found in api definition";
+                throw new APIManagementException(message);
+            }
+        }
+    }
+
     private void checkResourceThrottlingTiersInURITemplates(Set<URITemplate> uriTemplates)
             throws APIManagementException {
         Map<String, Tier> tierMap = APIUtil.getTiers(APIConstants.TIER_RESOURCE_TYPE, tenantDomain);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5468,9 +5468,24 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (log.isDebugEnabled()) {
             log.debug("Validating x-throttling tiers defined in swagger api definition resource");
         }
+        Set<URITemplate> uriTemplates = api.getUriTemplates();
+        checkResourceThrottlingTiersInURITemplates(uriTemplates);
+    }
+
+    @Override
+    public void validateResourceThrottlingTiers(String swaggerContent, String tenantDomain) throws APIManagementException {
+        if (log.isDebugEnabled()) {
+            log.debug("Validating x-throttling tiers defined in swagger api definition resource");
+        }
+        APIDefinition apiDefinition = OASParserUtil.getOASParser(swaggerContent);
+        Set<URITemplate> uriTemplates = apiDefinition.getURITemplates(swaggerContent);
+        checkResourceThrottlingTiersInURITemplates(uriTemplates);
+    }
+
+    private void checkResourceThrottlingTiersInURITemplates(Set<URITemplate> uriTemplates)
+            throws APIManagementException {
         Map<String, Tier> tierMap = APIUtil.getTiers(APIConstants.TIER_RESOURCE_TYPE, tenantDomain);
         if (tierMap != null) {
-            Set<URITemplate> uriTemplates = api.getUriTemplates();
             for (URITemplate template : uriTemplates) {
                 if (template.getThrottlingTier() != null && !tierMap.containsKey(template.getThrottlingTier())) {
                     String message = "Invalid x-throttling tier " + template.getThrottlingTier() +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIAndAPIProductCommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIAndAPIProductCommonUtil.java
@@ -705,7 +705,7 @@ public class APIAndAPIProductCommonUtil {
                     // If any of the tiers from the API does not have a valid match from the tiers available in the
                     // instance, an error will be thrown
                     if (!tierFound) {
-                        String message = "Invalid subscription throttling tier:" + subscriptionTierName.getAsString() +
+                        String message = "Invalid Subscription level throttling tier:" + subscriptionTierName.getAsString() +
                                 " provided.";
                         throw new APIManagementException(message);
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIAndAPIProductCommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIAndAPIProductCommonUtil.java
@@ -18,10 +18,8 @@
 
 package org.wso2.carbon.apimgt.impl.importexport.utils;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonParser;
+import com.google.common.collect.Sets;
+import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.io.FileUtils;
@@ -30,6 +28,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.json.JSONObject;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -38,10 +37,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.FaultGatewaysException;
 import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
-import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
-import org.wso2.carbon.apimgt.api.model.Documentation;
-import org.wso2.carbon.apimgt.api.model.Identifier;
-import org.wso2.carbon.apimgt.api.model.ResourceFile;
+import org.wso2.carbon.apimgt.api.model.*;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.importexport.APIImportExportConstants;
 import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
@@ -69,7 +65,9 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -637,6 +635,77 @@ public class APIAndAPIProductCommonUtil {
         } catch (APIManagementException e) {
             String errorMessage = "Error while importing client certificate";
             throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Get the subscription level policy names of an API/API Product
+     *
+     * @param apiTypeWrapper API or API Product to be exported
+     * @throws APIImportExportException
+     */
+    public static Set<String> getAvailableTierNamesOfApi(ApiTypeWrapper apiTypeWrapper) {
+        Set<String> tiers = new LinkedHashSet<String>();
+        Set<Tier> tiersFromApi = new LinkedHashSet<Tier>();
+        if (!apiTypeWrapper.isAPIProduct()) {
+            tiersFromApi = apiTypeWrapper.getApi().getAvailableTiers();
+        } else {
+            tiersFromApi = apiTypeWrapper.getApiProduct().getAvailableTiers();
+        }
+        for (Tier tier : tiersFromApi) {
+            tiers.add(tier.getName());
+        }
+        return tiers;
+    }
+
+    /**
+     * Set the subscription level tiers of an API/API Product by validating with the tiers available in the environment
+     *
+     * @param apiJsonContent JSON content of API or API Product to be imported
+     * @param apiProvider    API Provider
+     * @throws APIImportExportException
+     */
+    public static void setSubscriptionTiers(JsonObject apiJsonContent, APIProvider apiProvider)
+            throws APIManagementException {
+        // Retrieve the subscription tier names mentioned in the API
+        JsonArray subscriptionTierNames = apiJsonContent.get(APIConstants.SUBSCRIPTION_TIERS).getAsJsonArray();
+        // Retrieve the subscription tiers that are already available in the instance
+        Set<Tier> allowedTiers = apiProvider.getTiers();
+
+        // An array will be created to store the valid subscription tier details
+        JsonArray subscriptionTiers = new JsonArray();
+        Gson gson = new GsonBuilder().create();
+
+        // Check whether the subscription tiers are provided or not in the API
+        if (subscriptionTierNames != null || subscriptionTierNames.size() > 0) {
+            // If provided, iterate the names array, and check whether those are available in the instance
+            for (JsonElement subscriptionTierName : subscriptionTierNames) {
+                // To store whether the tier is available in the instance
+                Boolean tierFound = false;
+                if (allowedTiers != null) {
+                    // Iterate the available tiers in the instance
+                    for (Tier tier : allowedTiers) {
+                        // If a tier from the API and a tier from the instance is matched, that can be named as a
+                        // valid match ,and the tier will be added to the set and tierFound will be marked as true
+                        if (StringUtils.equals(tier.getName(), subscriptionTierName.getAsString())) {
+                            subscriptionTiers.add(gson.toJsonTree(tier));
+                            tierFound = true;
+                        }
+                    }
+                    // If any of the tiers from the API does not have a valid match from the tiers available in the
+                    // instance, an error will be thrown
+                    if (!tierFound) {
+                        String message = "Invalid subscription throttling tier:" + subscriptionTierName.getAsString() +
+                                " provided.";
+                        throw new APIManagementException(message);
+                    }
+                }
+            }
+            // Remove the old tier names array from the apiJsonContent
+            apiJsonContent.remove(APIConstants.SUBSCRIPTION_TIERS);
+            // Add the new tier array to the apiJsonContent
+            apiJsonContent.add(APIConstants.SUBSCRIPTION_TIERS, subscriptionTiers);
+            System.out.println(apiJsonContent);
         }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIAndAPIProductCommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIAndAPIProductCommonUtil.java
@@ -19,7 +19,13 @@
 package org.wso2.carbon.apimgt.impl.importexport.utils;
 
 import com.google.common.collect.Sets;
-import com.google.gson.*;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.io.FileUtils;
@@ -37,7 +43,11 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.FaultGatewaysException;
 import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
-import org.wso2.carbon.apimgt.api.model.*;
+import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
+import org.wso2.carbon.apimgt.api.model.Documentation;
+import org.wso2.carbon.apimgt.api.model.Identifier;
+import org.wso2.carbon.apimgt.api.model.ResourceFile;
+import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.importexport.APIImportExportConstants;
 import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
@@ -644,9 +654,9 @@ public class APIAndAPIProductCommonUtil {
      * @param apiTypeWrapper API or API Product to be exported
      * @throws APIImportExportException
      */
-    public static Set<String> getAvailableTierNamesOfApi(ApiTypeWrapper apiTypeWrapper) {
+    public static Set<String> getAvailableTierNames(ApiTypeWrapper apiTypeWrapper) {
         Set<String> tiers = new LinkedHashSet<String>();
-        Set<Tier> tiersFromApi = new LinkedHashSet<Tier>();
+        Set<Tier> tiersFromApi;
         if (!apiTypeWrapper.isAPIProduct()) {
             tiersFromApi = apiTypeWrapper.getApi().getAvailableTiers();
         } else {
@@ -705,7 +715,6 @@ public class APIAndAPIProductCommonUtil {
             apiJsonContent.remove(APIConstants.SUBSCRIPTION_TIERS);
             // Add the new tier array to the apiJsonContent
             apiJsonContent.add(APIConstants.SUBSCRIPTION_TIERS, subscriptionTiers);
-            System.out.println(apiJsonContent);
         }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIExportUtil.java
@@ -495,7 +495,7 @@ public class APIExportUtil {
         cleanApiDataToExport(apiToReturn);
         // Get only the subscription tier names of the API, rather than retrieving the whole object array
         ApiTypeWrapper apiTypeWrapper = new ApiTypeWrapper(apiToReturn);
-        Set<String> availableSubscriptionTierNames = APIAndAPIProductCommonUtil.getAvailableTierNamesOfApi(apiTypeWrapper);
+        Set<String> availableSubscriptionTierNames = APIAndAPIProductCommonUtil.getAvailableTierNames(apiTypeWrapper);
 
         try {
             Gson gson = new GsonBuilder().setPrettyPrinting().create();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -255,8 +255,13 @@ public final class APIImportUtil {
                 }
             }
             if (!APIConstants.APITransportType.WS.toString().equalsIgnoreCase(importedApi.getType())) {
-                apiProvider.validateResourceThrottlingTiers(APIAndAPIProductCommonUtil.loadSwaggerFile(pathToArchive),
-                        currentTenantDomain);
+                // Either only API level throttling policy or resource level throttling policies can be defined at once
+                if (importedApi.getApiLevelPolicy() != null) {
+                    apiProvider.validateAPIThrottlingTier(importedApi, currentTenantDomain);
+                } else {
+                    apiProvider.validateResourceThrottlingTiers(APIAndAPIProductCommonUtil.loadSwaggerFile(pathToArchive),
+                            currentTenantDomain);
+                }
             }
 
             if (Boolean.FALSE.equals(overwrite)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -254,6 +254,11 @@ public final class APIImportUtil {
                     importedApi.removeAvailableTiers(unsupportedTiersList);
                 }
             }
+            if (!APIConstants.APITransportType.WS.toString().equalsIgnoreCase(importedApi.getType())) {
+                apiProvider.validateResourceThrottlingTiers(APIAndAPIProductCommonUtil.loadSwaggerFile(pathToArchive),
+                        currentTenantDomain);
+            }
+
             if (Boolean.FALSE.equals(overwrite)) {
                 //Add API in CREATED state
                 apiProvider.addAPI(importedApi);
@@ -355,7 +360,7 @@ public final class APIImportUtil {
                 errorMessage += importedApi.getId().getApiName() + StringUtils.SPACE + APIConstants.API_DATA_VERSION
                         + ": " + importedApi.getId().getVersion();
             }
-            throw new APIImportExportException(errorMessage, e);
+            throw new APIImportExportException(errorMessage + " " + e.getMessage(), e);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIImportUtil.java
@@ -141,6 +141,12 @@ public final class APIImportUtil {
             JsonElement configElement = new JsonParser().parse(jsonContent);
             JsonObject configObject = configElement.getAsJsonObject();
 
+            // Initially, when importing the API, it only contains the subscription tier names without the
+            // details. So, by matching with the names, correct subscription tiers with the details should be added
+            // to the API before doing further processing.
+            APIAndAPIProductCommonUtil.setSubscriptionTiers(configObject, apiProvider);
+            configElement = configObject;
+
             //locate the "providerName" within the "id" and set it as the current user
             JsonObject apiId = configObject.getAsJsonObject(APIImportExportConstants.ID_ELEMENT);
 
@@ -238,22 +244,6 @@ public final class APIImportUtil {
                 }
             }
 
-            Set<Tier> allowedTiers;
-            Set<Tier> unsupportedTiersList;
-            allowedTiers = apiProvider.getTiers();
-
-            if (!(allowedTiers.isEmpty())) {
-                unsupportedTiersList = Sets.difference(importedApi.getAvailableTiers(), allowedTiers);
-
-                //If at least one unsupported tier is found, it should be removed before adding API
-                if (!(unsupportedTiersList.isEmpty())) {
-                    //Process is continued with a warning and only supported tiers are added to the importer API
-                    unsupportedTiersList.forEach(unsupportedTier ->
-                            log.warn("Tier name : " + unsupportedTier.getName() + " is not supported."));
-                    //Remove the unsupported tiers before adding the API
-                    importedApi.removeAvailableTiers(unsupportedTiersList);
-                }
-            }
             if (!APIConstants.APITransportType.WS.toString().equalsIgnoreCase(importedApi.getType())) {
                 // Either only API level throttling policy or resource level throttling policies can be defined at once
                 if (importedApi.getApiLevelPolicy() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIProductExportUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/APIProductExportUtil.java
@@ -25,6 +25,8 @@ import com.google.gson.JsonParser;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.model.API;
@@ -50,6 +52,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This is the util class which consists of all the functions for exporting API Product.
@@ -197,6 +200,9 @@ public class APIProductExportUtil {
         CommonUtil.createDirectory(archivePath + File.separator + APIImportExportConstants.META_INFO_DIRECTORY);
         // Remove unnecessary data from exported API Product
         cleanApiProductDataToExport(apiProductToReturn);
+        // Get only the subscription tier names of the API, rather than retrieving the whole object array
+        ApiTypeWrapper apiTypeWrapper = new ApiTypeWrapper(apiProductToReturn);
+        Set<String> availableSubscriptionTierNames = APIAndAPIProductCommonUtil.getAvailableTierNames(apiTypeWrapper);
 
         try {
             Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -227,6 +233,11 @@ public class APIProductExportUtil {
 
 
             String apiInJson = gson.toJson(apiProductToReturn);
+            JSONParser jsonParser = new JSONParser();
+            org.json.simple.JSONObject apiJsonObject = (org.json.simple.JSONObject) jsonParser.parse(apiInJson);
+            apiJsonObject.remove(APIConstants.SUBSCRIPTION_TIERS);
+            apiJsonObject.put(APIConstants.SUBSCRIPTION_TIERS, availableSubscriptionTierNames);
+            apiInJson = gson.toJson(apiJsonObject);
             switch (exportFormat) {
                 case JSON:
                     CommonUtil.writeFile(archivePath + APIImportExportConstants.JSON_API_FILE_LOCATION, apiInJson);
@@ -245,6 +256,9 @@ public class APIProductExportUtil {
             String errorMessage = "Error while retrieving saving as YAML for API Product: " + apiProductToReturn.getId().getName()
                     + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": " + apiProductToReturn.getId().getVersion();
             throw new APIImportExportException(errorMessage, e);
+        } catch (ParseException e) {
+            String msg = "ParseException thrown when parsing API Product config";
+            throw new APIManagementException(msg, e);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ImportApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ImportApiServiceImpl.java
@@ -192,6 +192,9 @@ public class ImportApiServiceImpl implements ImportApiService {
             } else if (RestApiUtil.isDueToResourceNotFound(e)) {
                 RestApiUtil.handleResourceNotFoundError("Requested " + RestApiConstants.RESOURCE_API_PRODUCT
                         + " not found", e, log);
+            } else if (RestApiUtil.isDueToProvidedThrottlingPolicyMissing(e)) {
+                RestApiUtil.handleResourceNotFoundError("Error while adding the throttling policy. " +
+                        "Provided throttling policy cannot be found.", e, log);
             }
             RestApiUtil.handleInternalServerError("Error while importing API Product", e, log);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ImportApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ImportApiServiceImpl.java
@@ -116,6 +116,9 @@ public class ImportApiServiceImpl implements ImportApiService {
             } else if (RestApiUtil.isDueToMetaInfoIsCorrupted(e)) {
                 RestApiUtil.handleMetaInformationFailureError("Error while reading API meta information from path.",
                         e, log);
+            } else if (RestApiUtil.isDueToProvidedThrottlingPolicyIsMissing(e)) {
+                RestApiUtil.handleResourceNotFoundError("Error while adding the throttling policy. " +
+                                "Provided throttling policy cannot be found.", e, log);
             }
             RestApiUtil.handleInternalServerError("Error while importing API", e, log);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ImportApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ImportApiServiceImpl.java
@@ -274,6 +274,7 @@ public class ImportApiServiceImpl implements ImportApiService {
                 return Response.status(Response.Status.FORBIDDEN).entity(errorMsg).build();
             }
             importExportManager.validateOwner(ownerId, applicationDetails.getGroupId());
+            importExportManager.validateApplicationThrottlingPolicy(applicationDetails);
 
             // check whether we needs to update application or add it
             if (APIUtil.isApplicationExist(ownerId, applicationDetails.getName(), applicationDetails.getGroupId()) && update != null && update) {
@@ -318,6 +319,10 @@ public class ImportApiServiceImpl implements ImportApiService {
         } catch (APIMgtResourceAlreadyExistsException e) {
             RestApiUtil.handleResourceAlreadyExistsError("Error while importing Application", e, log);
         } catch (APIManagementException | URISyntaxException | UserStoreException e) {
+            if (RestApiUtil.isDueToProvidedThrottlingPolicyMissing(e)) {
+                RestApiUtil.handleResourceNotFoundError("Error while adding the throttling policy. " +
+                        "Provided throttling policy cannot be found.", e, log);
+            }
             RestApiUtil.handleInternalServerError("Error while importing Application", e, log);
         } catch (UnsupportedEncodingException e) {
             String errorMessage = "Error while Decoding apiId";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ImportApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ImportApiServiceImpl.java
@@ -116,7 +116,7 @@ public class ImportApiServiceImpl implements ImportApiService {
             } else if (RestApiUtil.isDueToMetaInfoIsCorrupted(e)) {
                 RestApiUtil.handleMetaInformationFailureError("Error while reading API meta information from path.",
                         e, log);
-            } else if (RestApiUtil.isDueToProvidedThrottlingPolicyIsMissing(e)) {
+            } else if (RestApiUtil.isDueToProvidedThrottlingPolicyMissing(e)) {
                 RestApiUtil.handleResourceNotFoundError("Error while adding the throttling policy. " +
                                 "Provided throttling policy cannot be found.", e, log);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/ApplicationImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/ApplicationImportExportManager.java
@@ -23,9 +23,22 @@ import org.apache.commons.logging.LogFactory;
 import org.json.simple.JSONObject;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
-import org.wso2.carbon.apimgt.api.model.*;
+import org.wso2.carbon.apimgt.api.APIProvider;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.APIKey;
+import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
+import org.wso2.carbon.apimgt.api.model.APIProduct;
+import org.wso2.carbon.apimgt.api.model.Application;
+import org.wso2.carbon.apimgt.api.model.ApplicationConstants;
+import org.wso2.carbon.apimgt.api.model.policy.ApplicationPolicy;
+import org.wso2.carbon.apimgt.api.model.policy.PolicyConstants;
+import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
+import org.wso2.carbon.apimgt.api.model.Subscriber;
+import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -80,6 +93,38 @@ public class ApplicationImportExportManager {
             String errorMsg = "Provided Application Owner is Invalid";
             log.error(errorMsg, e);
             throw new APIManagementException(errorMsg, e);
+        }
+    }
+
+    /**
+     * This method validates the existence of the Application level throttling tier of Application
+     *
+     * @param application application
+     * @throws APIManagementException
+     */
+    public void validateApplicationThrottlingPolicy(Application application) throws APIManagementException {
+        if (log.isDebugEnabled()) {
+            log.debug("Validating tier defined in the Application");
+        }
+        APIProvider apiProvider = RestApiUtil.getLoggedInUserProvider();
+        String userName = RestApiUtil.getLoggedInUsername();
+        ApplicationPolicy[] appPolicies = (ApplicationPolicy[]) apiProvider.getPolicies(userName,
+                PolicyConstants.POLICY_LEVEL_APP);
+        if (appPolicies != null || appPolicies.length > 0) {
+            String applicationLevelPolicy = application.getTier();
+            // To store whether the policy is available in the instance
+            Boolean policyFound = false;
+            for (ApplicationPolicy policy : appPolicies) {
+                if (StringUtils.equals(policy.getPolicyName(), applicationLevelPolicy)) {
+                    policyFound = true;
+                    break;
+                }
+            }
+            if (!policyFound) {
+                String message = "Invalid Application level throttling tier " + applicationLevelPolicy +
+                        " found in application definition";
+                throw new APIManagementException(message);
+            }
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
@@ -621,6 +621,17 @@ public class RestApiUtil {
     }
 
     /**
+     * Check if the specified throwable e is happened as the provided throttling policy is missing
+     *
+     * @param e throwable to check
+     * @return true if the specified throwable e is happened as the provided throttling policy is missing, false otherwise
+     */
+    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+    public static boolean isDueToProvidedThrottlingPolicyIsMissing(Throwable e) {
+        return detailedMessageMatches(e, "Invalid x-throttling tier");
+    }
+
+    /**
      * Check if the specified throwable e is happened as the updated/new resource conflicting with an already existing
      * resource
      *

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
@@ -630,7 +630,9 @@ public class RestApiUtil {
     public static boolean isDueToProvidedThrottlingPolicyMissing(Throwable e) {
         return detailedMessageMatches(e, "Invalid x-throttling tier") ||
                 detailedMessageMatches(e, "Invalid API level throttling tier") ||
-                detailedMessageMatches(e, "Invalid subscription throttling tier");
+                detailedMessageMatches(e, "Invalid Product level throttling tier") ||
+                detailedMessageMatches(e, "Invalid Subscription level throttling tier") ||
+                detailedMessageMatches(e, "Invalid Application level throttling tier") ;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
@@ -627,8 +627,9 @@ public class RestApiUtil {
      * @return true if the specified throwable e is happened as the provided throttling policy is missing, false otherwise
      */
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
-    public static boolean isDueToProvidedThrottlingPolicyIsMissing(Throwable e) {
-        return detailedMessageMatches(e, "Invalid x-throttling tier");
+    public static boolean isDueToProvidedThrottlingPolicyMissing(Throwable e) {
+        return detailedMessageMatches(e, "Invalid x-throttling tier") ||
+                detailedMessageMatches(e, "Invalid API level throttling tier");
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
@@ -629,7 +629,8 @@ public class RestApiUtil {
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
     public static boolean isDueToProvidedThrottlingPolicyMissing(Throwable e) {
         return detailedMessageMatches(e, "Invalid x-throttling tier") ||
-                detailedMessageMatches(e, "Invalid API level throttling tier");
+                detailedMessageMatches(e, "Invalid API level throttling tier") ||
+                detailedMessageMatches(e, "Invalid subscription throttling tier");
     }
 
     /**


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/329

## Goals
Eliminate the inconsistencies when adding throttling policies when importing an API/API Product/Application. 

## Approach
The changes have been done related to the three (3) main throttling policies. 
1. **Advanced Throttling Policies**
    1. Modifications related to **API/Product Level Throttling Policies**
        - When we try to import an API/API Product with an Advanced Throttling Policy that has been assigned to the  API/API Product, which is not currently available in the API Manager, an error was displayed earlier. But with this PR, now you will receive an error and the import will be failed.
    2. Modifications related to **Resource Level Throttling Policies**
        - No changes needed to be done.
2. **Application-level Throttling Tiers/Policies**
    - When we try to import an Application, if the Application-level Throttling Tier/Policy is not available in the API Manager instance, the application was imported to that instance, which was wrong. But with this PR, now you will receive an error if you try to do that and the import will be failed.
3. **Subscription-level Throttling Tiers/Policies**
    - When we export an API/API Product with a Subscription-level Throttling Tier/Policy using the API Controller, the throttling policy **details** will be included in the api.yaml file inside the exported directory as an array. But with this PR, the throttling policy **names** will be exported as an array instead of all the **details** of tiers.
    - When we try to import an API/API Product, if any of the Subscription-level Throttling Tiers/Policies were not available in the API Manager, the API Manager ignored it and imported the API/API Product with the existing Subscription-level Throttling Tiers/Policies. But with this PR, now you will receive an error if you are trying to import an API/API Product with the Subscription-level Throttling Tiers/Policies if any of those are not available in the API Manager instance and the import will be failed.

Refer [1] to understand more about the approach.

## User stories
Refer the points in the approach to understand the use cases.

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.1 LTS

 [1] http://wso2-oxygen-tank.10903.n7.nabble.com/APIM-Support-to-Import-Export-Throttling-Policies-Using-the-API-Controller-td162176.html