### PR TITLE
Adding JTI claim for JWT.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/generator/AbstractAPIMgtGatewayJWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/generator/AbstractAPIMgtGatewayJWTGenerator.java
@@ -39,6 +39,7 @@ import java.security.cert.Certificate;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public abstract class AbstractAPIMgtGatewayJWTGenerator {
     private static final Log log = LogFactory.getLog(AbstractAPIMgtGatewayJWTGenerator.class);
@@ -224,6 +225,8 @@ public abstract class AbstractAPIMgtGatewayJWTGenerator {
                 jwtClaimSetBuilder.claim(claimEntry.getKey(), claimEntry.getValue());
             }
         }
+        //Adding JWT standard claim
+        jwtClaimSetBuilder.jwtID(UUID.randomUUID().toString());
         JWTClaimsSet jwtClaimsSet = jwtClaimSetBuilder.build();
         return jwtClaimsSet.toJSONObject().toString();
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/AbstractJWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/AbstractJWTGenerator.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
+import java.util.UUID;
 
 /**
  * This class represents the JSON Web Token generator.
@@ -244,6 +245,8 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
                         jwtClaimsSetBuilder.claim(claimURI, claimVal);
                     }
                 }
+                //Adding JTI standard claim
+                jwtClaimsSetBuilder.jwtID(UUID.randomUUID().toString());
             }
             return jwtClaimsSetBuilder.build().toJSONObject().toJSONString();
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/token/TokenGenTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/token/TokenGenTest.java
@@ -254,27 +254,6 @@ public class TokenGenTest {
         Assert.assertTrue(header.contains(encodedThumbprint));
     }
 
-    @Test public void testJTI() throws Exception {
-
-        AbstractJWTGenerator jwtGen = new JWTGenerator();
-        APIKeyValidationInfoDTO dto=new APIKeyValidationInfoDTO();
-        TokenValidationContext validationContext = new TokenValidationContext();
-        validationContext.setValidationInfoDTO(dto);
-        validationContext.setContext("testAPI");
-        validationContext.setVersion("1.0.0");
-        validationContext.setAccessToken("DUMMY_TOKEN_STRING");
-        dto.setSubscriber("admin");
-        dto.setApplicationName("application");
-        dto.setApplicationId("1");
-        dto.setApplicationTier("UNLIMITED");
-        dto.setEndUserName("subscriber");
-        dto.setUserType(APIConstants.ACCESS_TOKEN_USER_TYPE_APPLICATION);
-        String token = jwtGen.buildBody(validationContext);
-
-        Assert.assertTrue("Contains JTI value in access token", token.contains("jti"));
-    }
-
-
     /**
      * Helper method to hexify a byte array.
      * TODO:need to verify the logic

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/token/TokenGenTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/token/TokenGenTest.java
@@ -254,6 +254,27 @@ public class TokenGenTest {
         Assert.assertTrue(header.contains(encodedThumbprint));
     }
 
+    @Test public void testJTI() throws Exception {
+
+        AbstractJWTGenerator jwtGen = new JWTGenerator();
+        APIKeyValidationInfoDTO dto=new APIKeyValidationInfoDTO();
+        TokenValidationContext validationContext = new TokenValidationContext();
+        validationContext.setValidationInfoDTO(dto);
+        validationContext.setContext("testAPI");
+        validationContext.setVersion("1.0.0");
+        validationContext.setAccessToken("DUMMY_TOKEN_STRING");
+        dto.setSubscriber("admin");
+        dto.setApplicationName("application");
+        dto.setApplicationId("1");
+        dto.setApplicationTier("UNLIMITED");
+        dto.setEndUserName("subscriber");
+        dto.setUserType(APIConstants.ACCESS_TOKEN_USER_TYPE_APPLICATION);
+        String token = jwtGen.buildBody(validationContext);
+
+        Assert.assertTrue("Contains JTI value in access token", token.contains("jti"));
+    }
+
+
     /**
      * Helper method to hexify a byte array.
      * TODO:need to verify the logic


### PR DESCRIPTION
JTI standard claim was missing in JWT token. Hence it is added.
Fixing https://github.com/wso2/product-apim/issues/9501