### PR TITLE
Fixing null pointer error when using gateway type as production or sandbox

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -11306,6 +11306,12 @@ public final class APIUtil {
         if (map.containsKey(APIConstants.GATEWAY_ENV_TYPE_HYBRID)) {
             return map.get(APIConstants.GATEWAY_ENV_TYPE_HYBRID);
         }
+        if (map.containsKey(APIConstants.GATEWAY_ENV_TYPE_PRODUCTION)) {
+            return map.get(APIConstants.GATEWAY_ENV_TYPE_PRODUCTION);
+        }
+        if (map.containsKey(APIConstants.GATEWAY_ENV_TYPE_SANDBOX)) {
+            return map.get(APIConstants.GATEWAY_ENV_TYPE_SANDBOX);
+        }
         return map.get(type);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilTest.java
@@ -1944,4 +1944,28 @@ public class APIUtilTest {
         Assert.assertFalse(APIUtil.isRoleExistForUser(userName, "test"));
         */
     }
+
+    @Test
+    public void testGetTokenEndpointsByType () throws Exception {
+        Environment environment = new Environment();
+        environment.setType("production");
+        environment.setName("Production");
+        environment.setDefault(true);
+        environment.setApiGatewayEndpoint("http://localhost:8280,https://localhost:8243");
+        Map<String, Environment> environmentMap = new HashMap<String, Environment>();
+        environmentMap.put("Production", environment);
+
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        APIManagerConfigurationService apiManagerConfigurationService =
+                Mockito.mock(APIManagerConfigurationService.class);
+        APIManagerConfiguration apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
+        Mockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService())
+                .thenReturn(apiManagerConfigurationService);
+        Mockito.when(apiManagerConfigurationService.getAPIManagerConfiguration()).thenReturn(apiManagerConfiguration);
+        Mockito.when(apiManagerConfiguration.getApiGatewayEnvironments()).thenReturn(environmentMap);
+        String tokenEndpointType = APIUtil.getTokenEndpointsByType("production");
+        Assert.assertEquals("https://localhost:8243", tokenEndpointType);
+    }
 }


### PR DESCRIPTION
### **Purpose**

- The fixes wso2/product-apim#9463
- Fixing throwing a null pointer error when the gateway type is set to production or sandbox and when trying to access the applications on devportal.