### PR TITLE
Add ISKM Reverse Proxy Support

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -204,5 +204,18 @@ public class APIMgtGatewayConstants {
     public static final String SPAN_ENDPOINT = "span.endpoint";
 
     public static final String TEST_KEY = "testkey";
+
+    /**
+     * Synapse Properties related Constants
+     */
+    public static final String HOST = "Host";
+    public static final String HOST_HEADER = "HostHeader";
+    public static final String LOCATION = "Location";
+    public static final String AUTHORIZE_CONTEXT = "/authorize";
+    public static final String COMMON_AUTH_CONTEXT = "/commonauth";
+    public static final String OIDC_CONTEXT = "/oidc";
+    public static final String AUTHENTICATION_ENDPOINT_CONTEXT = "/authenticationendpoint";
+    public static final String LOGIN_CONTEXT = "/logincontext";
+    public static final String OAUTH2_CONTEXT = "/oauth2";
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/SynapsePropertiesHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/SynapsePropertiesHandler.java
@@ -18,14 +18,23 @@ package org.wso2.carbon.apimgt.gateway.handlers.common;
 import org.apache.axis2.Constants;
 import org.apache.http.HttpHeaders;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.AbstractHandler;
+import org.apache.synapse.rest.RESTConstants;
+import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
+import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 
 import javax.ws.rs.core.MediaType;
 import java.util.Map;
+import java.util.TreeMap;
 
-public class SynapsePropertiesHandler extends AbstractHandler{
+public class SynapsePropertiesHandler extends AbstractHandler {
+
+    private static APIManagerConfiguration config = null;
+    private static boolean iskmReverseProxyEnabled = false;
 
     public boolean handleRequest(MessageContext messageContext) {
         String httpport = System.getProperty("http.nio.port");
@@ -33,9 +42,9 @@ public class SynapsePropertiesHandler extends AbstractHandler{
         messageContext.setProperty("http.nio.port", httpport);
         messageContext.setProperty("https.nio.port", httpsport);
         String mgtHttpsPort = System.getProperty(APIConstants.KEYMANAGER_PORT);
-        messageContext.setProperty("keyManager.port",mgtHttpsPort);
+        messageContext.setProperty("keyManager.port", mgtHttpsPort);
         String keyManagerHost = System.getProperty(APIConstants.KEYMANAGER_HOSTNAME);
-        messageContext.setProperty("keyManager.hostname",keyManagerHost);
+        messageContext.setProperty("keyManager.hostname", keyManagerHost);
 
         String httpMethod = (String) ((Axis2MessageContext) messageContext).getAxis2MessageContext().
                 getProperty(Constants.Configuration.HTTP_METHOD);
@@ -46,6 +55,13 @@ public class SynapsePropertiesHandler extends AbstractHandler{
         boolean isContentTypeNotSet = false;
         if (headers != null) {
             isContentTypeNotSet = headers.get("Content-Type") == null || headers.get("Content-Type").equals("");
+            if (headers.get(APIMgtGatewayConstants.HOST) != null || !("")
+                    .equals(headers.get(APIMgtGatewayConstants.HOST))) {
+                // Derive the outward facing host and port from host header
+                String hostHeader = (String) headers.get(APIMgtGatewayConstants.HOST);
+                // Set it as a message context property to retrieve in HandleResponse method
+                messageContext.setProperty(APIMgtGatewayConstants.HOST_HEADER, hostHeader);
+            }
         }
         if (isContentTypeNotSet && (httpMethod.equals(Constants.Configuration.HTTP_METHOD_POST) ||
                 httpMethod.equals(Constants.Configuration.HTTP_METHOD_PUT))) {
@@ -61,6 +77,62 @@ public class SynapsePropertiesHandler extends AbstractHandler{
     }
 
     public boolean handleResponse(MessageContext messageContext) {
+        if (config == null) {
+            // Retrieve the ISKMReverseProxyEnabled property value from api manager configurations.
+            // This value indicates whether the IS Authentication endpoint has been reverse proxied through
+            // the Gateway.
+            config = ServiceReferenceHolder.getInstance().getApiManagerConfigurationService()
+                    .getAPIManagerConfiguration();
+            iskmReverseProxyEnabled = Boolean.parseBoolean(
+                    config.getFirstProperty(APIConstants.AUTH_MANAGER + APIConstants.IS_KM_REVERSE_PROXY_ENABLED));
+        }
+        // Modify location header only if ISKMReverseProxyEnabled property is set to true
+        if (iskmReverseProxyEnabled) {
+            // The logic is related if the API context is "/authorize", "/commonauth" or "/oidc" while status code is 302
+            if (messageContext.getProperty(RESTConstants.REST_API_CONTEXT)
+                    .equals(APIMgtGatewayConstants.AUTHORIZE_CONTEXT) || messageContext
+                    .getProperty(RESTConstants.REST_API_CONTEXT).equals(APIMgtGatewayConstants.COMMON_AUTH_CONTEXT)
+                    || messageContext.getProperty(RESTConstants.REST_API_CONTEXT)
+                    .equals(APIMgtGatewayConstants.OIDC_CONTEXT)) {
+                if (302 == (Integer) ((Axis2MessageContext) messageContext).getAxis2MessageContext()
+                        .getProperty(SynapseConstants.HTTP_SC)) {
+                    // Retrieve the transport headers in the response and identify the location header
+                    TreeMap<String, String> headers = (TreeMap) ((Axis2MessageContext) messageContext)
+                            .getAxis2MessageContext().getProperty(APIMgtGatewayConstants.TRANSPORT_HEADERS);
+                    String locationURI = headers.get(APIMgtGatewayConstants.LOCATION);
+                    // KM host and port which is included in the location header value
+                    String kmHost = messageContext.getProperty("keyManager.hostname") + ":" + messageContext
+                            .getProperty("keyManager.port");
+                    String hostHeader = (String) messageContext.getProperty(APIMgtGatewayConstants.HOST_HEADER);
+
+                    // This check to change the location header is done to make sure that only location headers of the
+                    // appropriate endpoints which have been proxied are changed. Without this check condition to change
+                    // the location header, any endpoint which is having KM host as part of the URL will be redirected
+                    // which could lead to wrong endpoints.
+                    if (locationURI.contains(APIMgtGatewayConstants.AUTHENTICATION_ENDPOINT_CONTEXT) || locationURI
+                            .contains(APIMgtGatewayConstants.OAUTH2_CONTEXT + APIMgtGatewayConstants.AUTHORIZE_CONTEXT)
+                            || locationURI.contains(APIMgtGatewayConstants.COMMON_AUTH_CONTEXT) || locationURI
+                            .contains(APIMgtGatewayConstants.LOGIN_CONTEXT) || locationURI
+                            .contains(APIMgtGatewayConstants.OIDC_CONTEXT)) {
+                        // Replacing KM host with Gateway host
+                        locationURI = locationURI.replaceFirst(kmHost, hostHeader);
+                    }
+
+                    ((Axis2MessageContext) messageContext).getAxis2MessageContext()
+                            .setProperty("PRE_LOCATION_HEADER", locationURI);
+                    if (messageContext.getProperty(RESTConstants.REST_API_CONTEXT)
+                            .equals(APIMgtGatewayConstants.COMMON_AUTH_CONTEXT)) {
+                        // Commonauth endpoints return location header /oauth2/authorize. Since GW has /authorize we have to
+                        // omit the /oauth2 portion from the location header value
+                        locationURI = locationURI.replaceFirst(APIMgtGatewayConstants.OAUTH2_CONTEXT, "");
+                    }
+                    // Inserting modified headers to the message context
+                    headers.put(APIMgtGatewayConstants.LOCATION, locationURI);
+                    ((Axis2MessageContext) messageContext).getAxis2MessageContext().
+                            setProperty(APIMgtGatewayConstants.TRANSPORT_HEADERS, headers);
+                }
+            }
+        }
         return true;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -796,6 +796,7 @@ public final class APIConstants {
     public static final String AUTH_MANAGER_USERNAME = AUTH_MANAGER + "Username";
     public static final String AUTH_MANAGER_PASSWORD = AUTH_MANAGER + "Password";
     public static final String ENABLE_MTLS_FOR_APIS = "EnableMTLSForAPIs";
+    public static final String IS_KM_REVERSE_PROXY_ENABLED = "ISKMReverseProxyEnabled";
 
     public static final String IDENTITY_PROVIDER = "IdentityProvider.";
     public static final String IDENTITY_PROVIDER_AUTHORIZE_ENDPOINT = IDENTITY_PROVIDER + "AuthorizeEndpoint";

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -161,5 +161,6 @@
   "apim.cache.invalidation.stream":"cache.invalidation.stream:1.0.0",
   "apim.cache_invalidation.username":"${admin.username}",
   "apim.cache_invalidation.password":"${admin.password}",
-  "apim.cache_invalidation.topic_name":"globalCacheInvalidation"
+  "apim.cache_invalidation.topic_name":"globalCacheInvalidation",
+  "apim.auth_manager.iskm_reverseproxy_enabled": false
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -33,6 +33,11 @@
         <!-- Indicates whether the permissions checking of the user (on the Publisher and Developer Portal) should be done
            via a remote service. The check will be done on the local server when false. -->
         <CheckPermissionsRemotely>false</CheckPermissionsRemotely>
+        <!-- Indicates whether the authentication endpoint has been reverse proxied through the Gateway when using
+             APIM with IS-KM. -->
+        {% if apim.auth_manager.iskm_reverseproxy_enabled is defined %}
+        <ISKMReverseProxyEnabled>{{apim.auth_manager.iskm_reverseproxy_enabled}}</ISKMReverseProxyEnabled>
+        {% endif %}
     </AuthManager>
 
     {% if apim.idp is defined %}


### PR DESCRIPTION
## Purpose
Front Porting https://github.com/wso2-support/carbon-apimgt/pull/2274

## Approach
- A new configurations has been introduced for IS-KM Reverse Proxy which is disabled by default. To enable the support, the following should be added to the /repository/conf/deployment.toml
    **[apim.auth_manager]**
    **iskm_reverseproxy_enabled = true**

- When this configurations is enabled, the code will check whether the API context is "/authorize", "/commonauth" or "/oidc" while status code is 302 and if so, modify the location header value by replacing the Key Manager host with the Gateway host.
- This modification is done only if the location header contains "/authenticationendpoint", "/oauth2/authorize", "/commonauth", "/logincontext"or "/oidc".

## Related PRs
- IS Related PRs
    - https://github.com/wso2/carbon-identity-framework/pull/3039
    - https://github.com/wso2/identity-apps/pull/1124
- 3.1.0 PR
    - https://github.com/wso2-support/carbon-apimgt/pull/2274
- 2.6.0 PR
    - https://github.com/wso2-support/carbon-apimgt/pull/2271

## Test Environment
- JDK 1.8.0_241
- Ubuntu 20.04 LTS

Related Issue: wso2/product-apim#8758