### PR TITLE
Add Missing Allowed REST API Resources to the AllowedURIs List

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -391,7 +391,7 @@
         <!-- Scope used for marking Application Tokens. If a token is generated with this scope, they will be treated as Application Access Tokens -->
         <ApplicationTokenScope>{{apim.oauth_config.default_app_scope}}</ApplicationTokenScope>
         <!-- All  scopes under the AllowedScopes element are not validating against roles that has assigned to it.
-             By default ^device_.* and openid scopes have been white listed internally. -->
+             By default ^device_.* and openid scopes have been allowed internally. -->
         <AllowedScopes>
         {%for scope in apim.oauth_config.allowed_scopes%}
             <Scope>{{scope}}</Scope>
@@ -556,7 +556,7 @@
     <!-- VelocityLogger>VELOCITY</VelocityLogger -->
 
     <RESTAPI>
-        <!--Configure white-listed URIs of REST API. Accessing white-listed URIs does not require credentials (does not require Authorization header). -->
+        <!--Configure allowed URIs of REST API. Accessing allowed URIs does not require credentials (does not require Authorization header). -->
         <AllowedURIs>
          {% if apim.rest_api.allowed_uri is defined %}
             {% for uri in apim.rest_api.allowed_uri %}
@@ -615,8 +615,20 @@
                 <HTTPMethods>GET,HEAD</HTTPMethods>
             </AllowedURI>
             <AllowedURI>
+                <URI>/api/am/store/{version}/apis/{apiId}/comments/{commentId}</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </AllowedURI>
+            <AllowedURI>
                  <URI>/api/am/store/{version}/apis/{apiId}/subscription-policies</URI>
                  <HTTPMethods>GET,HEAD</HTTPMethods>
+            </AllowedURI>
+            <AllowedURI>
+                <URI>/api/am/store/{version}/throttling-policies/{policyLevel}</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </AllowedURI>
+            <AllowedURI>
+                <URI>/api/am/store/{version}/throttling-policies/{policyLevel}/{policyId}</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
             </AllowedURI>
             <AllowedURI>
                  <URI>/api/am/store/{version}/apis/{apiId}/graphql-schema</URI>
@@ -636,6 +648,10 @@
             </AllowedURI>
             <AllowedURI>
                 <URI>/api/am/store/{version}/apis/{apiId}/thumbnail</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </AllowedURI>
+            <AllowedURI>
+                <URI>/api/am/store/{version}/apis/{apiId}/ratings</URI>
                 <HTTPMethods>GET,HEAD</HTTPMethods>
             </AllowedURI>
             <AllowedURI>
@@ -701,6 +717,14 @@
             <AllowedURI>
                 <URI>/api/am/store/{version}/api-categories</URI>
                 <HTTPMethods>GET</HTTPMethods>
+            </AllowedURI>
+            <AllowedURI>
+                <URI>/api/am/store/{version}/apis/{apiId}/graphql-policies/complexity</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </AllowedURI>
+            <AllowedURI>
+                <URI>/api/am/store/{version}/apis/{apiId}/graphql-policies/complexity/types</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
             </AllowedURI>
         </AllowedURIs>
         <ETagSkipList>


### PR DESCRIPTION
## Purpose
- Add missing allowed REST API resources to the AllowedURI list.
- Fixes: https://github.com/wso2/product-apim/issues/8549

## Goals
- Provide ability to invoke REST API resources which do not require scopes to be invoked without providing a token.

## Approach
- There were several REST API resources with no scopes attached to its resource definition (OAuth2Security: [ ]), but were missing in the AllowedURIs list defined in the api-manager.xml.j2 file. Those missing resources were added to the AllowedURIs list to provide the ability for those resources to be invoked without providing a token.

## Test Environment
- JDK 1.8.0_241
- Ubuntu 20.04.1 LTS