### PR TITLE
Fix the error when importing an Open API Definition without additionalProperties

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3485,6 +3485,11 @@ public class ApisApiServiceImpl implements ApisApiService {
     public Response importOpenAPIDefinition(InputStream fileInputStream, Attachment fileDetail, String url,
                                             String additionalProperties, MessageContext messageContext) {
 
+        // validate 'additionalProperties' json
+        if (StringUtils.isBlank(additionalProperties)) {
+            RestApiUtil.handleBadRequest("'additionalProperties' is required and should not be null", log);
+        }
+
         // Validate and retrieve the OpenAPI definition
         Map validationResponseMap = null;
         try {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/8528

## Goals
Handle throwing a null pointer exception and internal server error (500) as response when the publisher rest api is invoked without 'additionalProperties'(/api/am/publisher/v1/apis/import-openapi).

## Approach

Added validation part to the begining of importOpenAPIDefinition() to check whether the additionalProperties is null.

