### PR TITLE
Fix scope validation issue when invoking default API with Oauth token

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/DefaultKeyValidationHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/DefaultKeyValidationHandler.java
@@ -158,10 +158,17 @@ public class DefaultKeyValidationHandler extends AbstractKeyValidationHandler {
         } else {
             resourceArray = new ArrayList<>(Arrays.asList(resourceList));
         }
+
+        String actualVersion = validationContext.getVersion();
+        //Check if the api version has been prefixed with _default_
+        if (actualVersion != null && actualVersion.startsWith(APIConstants.DEFAULT_VERSION_PREFIX)) {
+            //Remove the prefix from the version.
+            actualVersion = actualVersion.split(APIConstants.DEFAULT_VERSION_PREFIX)[1];
+        }
         SubscriptionDataStore tenantSubscriptionStore =
                 SubscriptionDataHolder.getInstance().getTenantSubscriptionStore(tenantDomain);
         API api = tenantSubscriptionStore.getApiByContextAndVersion(validationContext.getContext(),
-                validationContext.getVersion());
+                actualVersion);
         boolean scopesValidated = false;
         if (api != null) {
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9386

## Goals
To solve the failure of scope validation when invoking default version of an API using Oauth as token type with no version in the uri.

## Approach
Defined new variable inside the DefaultKeyValidationHandler.java to store pure api version since default api versions are prefixed with `_default_` and it causes to fail the api search using `getApiByContextAndVersion()`.