### PR TITLE
Fixing for https://github.com/wso2/product-apim/issues/9573

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/site/public/conf/defaultTheme.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/site/public/conf/defaultTheme.js
@@ -7,10 +7,9 @@ const AppThemes = {
     light: {
         palette: {
             primary: {
-                // light: will be calculated from palette.primary.main,
-                main: '#15b8cf',
-                // dark: will be calculated from palette.primary.main,
-                // contrastText: will be calculated to contrast with palette.primary.main
+                light: '#63ccff',
+                main: '#009be5',
+                dark: '#006db3',
             },
             secondary: {
                 light: '#0066ff',
@@ -34,11 +33,119 @@ const AppThemes = {
             h4: {
                 fontSize: '1.3rem',
             },
+            h5: {
+                fontWeight: 500,
+                fontSize: 26,
+                letterSpacing: 0.5,
+            },
+        },
+        shape: {
+            borderRadius: 8,
+        },
+        props: {
+            MuiTab: {
+                disableRipple: true,
+            },
+        },
+        mixins: {
+            toolbar: {
+                minHeight: 48,
+            },
         },
         custom: {
-            logo: '/site/public/images/logo-inverse.svg', // todo: change logo here
-            logoHeight: 30,
-            logoWidth: 222,
+            drawerWidth: 256,
+            logo: '/site/public/images/logo.svg',
+            logoWidth: 180,
+        },
+        overrides: {
+            MuiRadio: {
+                colorSecondary: {
+                    '&$checked': { color: '#009be5' },
+                    '&$disabled': {
+                        color: 'rgba(0, 0, 0, 0.26)',
+                    },
+                },
+            },
+            MuiButton: {
+                label: {
+                    textTransform: 'none',
+                },
+                contained: {
+                    boxShadow: 'none',
+                    '&:active': {
+                        boxShadow: 'none',
+                    },
+                },
+            },
+            MuiTabs: {
+                root: {
+                    marginLeft: 8,
+                },
+                indicator: {
+                    height: 3,
+                    borderTopLeftRadius: 3,
+                    borderTopRightRadius: 3,
+                    backgroundColor: '#ffffff',
+                },
+            },
+            MuiTab: {
+                root: {
+                    textTransform: 'none',
+                    margin: '0 16px',
+                    minWidth: 0,
+                    padding: 0,
+                },
+            },
+            MuiIconButton: {
+                root: {
+                    padding: 8,
+                },
+            },
+            MuiTooltip: {
+                tooltip: {
+                    borderRadius: 4,
+                },
+            },
+            MuiDivider: {
+                root: {
+                    backgroundColor: '#404854',
+                },
+            },
+            MuiListItemText: {
+                primary: {
+                    fontWeight: 500,
+                },
+            },
+            MuiListItemIcon: {
+                root: {
+                    color: 'inherit',
+                    marginRight: 0,
+                    '& svg': {
+                        fontSize: 20,
+                    },
+                },
+            },
+            MuiAvatar: {
+                root: {
+                    width: 32,
+                    height: 32,
+                },
+            },
+            MuiDrawer: {
+                paper: {
+                    backgroundColor: '#18202c',
+                },
+            },
+            MuiListItem: {
+                root: {
+                    '&.itemCategory': {
+                        backgroundColor: '#232f3e',
+                        boxShadow: '0 -1px 0 #404854 inset',
+                        paddingTop: 8,
+                        paddingBottom: 8,
+                    },
+                },
+            },
         },
     },
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/ProtectedApp.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/ProtectedApp.jsx
@@ -30,7 +30,6 @@ import AuthManager from 'AppData/AuthManager';
 import Header from 'AppComponents/Base/Header';
 import Avatar from 'AppComponents/Base/Header/Avatar';
 import Themes from 'Themes';
-import merge from 'lodash.merge';
 import AppErrorBoundary from 'AppComponents/Shared/AppErrorBoundary';
 import RedirectToLogin from 'AppComponents/Shared/RedirectToLogin';
 import { IntlProvider, injectIntl } from 'react-intl';
@@ -43,131 +42,9 @@ import Progress from 'AppComponents/Shared/Progress';
 import Dashboard from 'AppComponents/AdminPages/Dashboard/Dashboard';
 import Alert from 'AppComponents/Shared/Alert';
 
-const drawerWidth = 256;
 
-const themeJSON = merge(Themes.light, {
-    palette: {
-        primary: {
-            light: '#63ccff',
-            main: '#009be5',
-            dark: '#006db3',
-        },
-    },
-    typography: {
-        h5: {
-            fontWeight: 500,
-            fontSize: 26,
-            letterSpacing: 0.5,
-        },
-    },
-    shape: {
-        borderRadius: 8,
-    },
-    props: {
-        MuiTab: {
-            disableRipple: true,
-        },
-    },
-    mixins: {
-        toolbar: {
-            minHeight: 48,
-        },
-    },
-    custom: {
-        drawerWidth,
-    },
-});
-let theme = createMuiTheme(themeJSON);
-
-theme = {
-    ...theme,
-    overrides: {
-        MuiRadio: {
-            colorSecondary: {
-                '&$checked': { color: theme.palette.primary.main },
-                '&$disabled': {
-                    color: theme.palette.action.disabled,
-                },
-            },
-        },
-        MuiDrawer: {
-            paper: {
-                backgroundColor: '#18202c',
-            },
-        },
-        MuiButton: {
-            label: {
-                textTransform: 'none',
-            },
-            contained: {
-                boxShadow: 'none',
-                '&:active': {
-                    boxShadow: 'none',
-                },
-            },
-        },
-        MuiTabs: {
-            root: {
-                marginLeft: theme.spacing(1),
-            },
-            indicator: {
-                height: 3,
-                borderTopLeftRadius: 3,
-                borderTopRightRadius: 3,
-                backgroundColor: theme.palette.common.white,
-            },
-        },
-        MuiTab: {
-            root: {
-                textTransform: 'none',
-                margin: '0 16px',
-                minWidth: 0,
-                padding: 0,
-                [theme.breakpoints.up('md')]: {
-                    padding: 0,
-                    minWidth: 0,
-                },
-            },
-        },
-        MuiIconButton: {
-            root: {
-                padding: theme.spacing(1),
-            },
-        },
-        MuiTooltip: {
-            tooltip: {
-                borderRadius: 4,
-            },
-        },
-        MuiDivider: {
-            root: {
-                backgroundColor: '#404854',
-            },
-        },
-        MuiListItemText: {
-            primary: {
-                fontWeight: theme.typography.fontWeightMedium,
-            },
-        },
-        MuiListItemIcon: {
-            root: {
-                color: 'inherit',
-                marginRight: 0,
-                '& svg': {
-                    fontSize: 20,
-                },
-            },
-        },
-        MuiAvatar: {
-            root: {
-                width: 32,
-                height: 32,
-            },
-        },
-    },
-};
-
-
+const theme = createMuiTheme(Themes.light);
+const { drawerWidth } = Themes.light.custom;
 /**
  * Language.
  * @type {string}

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Base/Navigator.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/Base/Navigator.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useAppContext } from 'AppComponents/Shared/AppContext';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, useTheme } from '@material-ui/core/styles';
 import { useIntl } from 'react-intl';
 import Drawer from '@material-ui/core/Drawer';
 import List from '@material-ui/core/List';
@@ -33,12 +33,6 @@ const styles = (theme) => ({
         '&:hover,&:focus': {
             backgroundColor: 'rgba(255, 255, 255, 0.08)',
         },
-    },
-    itemCategory: {
-        backgroundColor: '#232f3e',
-        boxShadow: '0 -1px 0 #404854 inset',
-        paddingTop: theme.spacing(1),
-        paddingBottom: theme.spacing(1),
     },
     firebase: {
         fontSize: 24,
@@ -73,6 +67,7 @@ function Navigator(props) {
     const {
         classes, history, ...other
     } = props;
+    const theme = useTheme();
     const intl = useIntl();
     const { settings, user: { _scopes } } = useAppContext();
     const isAnalyticsEnabled = settings.analyticsEnabled;
@@ -127,16 +122,31 @@ function Navigator(props) {
     const { location: { pathname: currentPath } } = history;
     updateAllRoutePaths(currentPath);
 
+    let logoUrl = '/site/public/images/logo.svg';
+    let logoWidth = 180;
+    let logoHeight = '';
+    if (theme.custom && theme.custom.logo) {
+        logoUrl = theme.custom.logo;
+    }
+    if (theme.custom && theme.custom.logoWidth) {
+        logoWidth = theme.custom.logoWidth;
+    }
+    if (theme.custom && theme.custom.logoHeight) {
+        logoHeight = theme.custom.logoHeight;
+    }
+
     return (
         // eslint-disable-next-line react/jsx-props-no-spreading
         <Drawer variant='permanent' {...other}>
             <List disablePadding>
-                <ListItem className={clsx(classes.firebase, classes.item, classes.itemCategory, classes.logoWrapper)}>
+                <ListItem className={clsx(classes.firebase, classes.item, 'itemCategory', classes.logoWrapper)}>
                     <Link component={RouterLink} to='/'>
                         <img
                             alt='logo'
-                            src={Configurations.app.context + '/site/public/images/logo.svg'}
-                            width='180'
+                            src={Configurations.app.context
+                                + logoUrl}
+                            width={logoWidth}
+                            height={logoHeight}
                         />
                     </Link>
                 </ListItem>
@@ -150,7 +160,7 @@ function Navigator(props) {
                                 <ListItem
                                     className={clsx(
                                         classes.item,
-                                        classes.itemCategory,
+                                        'itemCategory',
                                         parentActive && classes.itemActiveItem,
                                     )}
                                 >


### PR DESCRIPTION
Fixed by taking the override styles out of the jsx files and in to the defaultTheme.js.

Now users can user theme.overrides object to override material UI component styles.

Example to override the left menu background colors. The following config is there in the newly updated defaultTheme.js. The backgroundColor can be changed accordingly to update the background colors of the left drawer.

```
           MuiDrawer: {
                paper: {
                    backgroundColor: '#18202c',
                },
            },
            MuiListItem: {
                root: {
                    '&.itemCategory': {
                        backgroundColor: '#232f3e',
                        boxShadow: '0 -1px 0 #404854 inset',
                        paddingTop: 8,
                        paddingBottom: 8,
                    },
                },
            },
        },
```