### PR TITLE
fix for https://github.com/wso2/product-apim/issues/9581

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/apikey/ApiKeyAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/apikey/ApiKeyAuthenticator.java
@@ -470,6 +470,9 @@ public class ApiKeyAuthenticator implements Authenticator {
                     }
                     throw new APISecurityException(APISecurityConstants.API_AUTH_FORBIDDEN,
                             "Access forbidden for the invocations");
+                } else {
+                    throw new APISecurityException(APISecurityConstants.API_AUTH_FORBIDDEN,
+                            "Access forbidden for the invocations");
                 }
             }
         }


### PR DESCRIPTION
This pr is for restricting an APIKey protected API when refere header is not provided while App is protected by permittedrefere.