### PR TITLE
Support to export/import multiple custom mediation policies attached to an API through APICTL

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -112,16 +112,28 @@ public final class ImportExportConstants {
     public static final String SEQUENCES_RESOURCE = "Sequences";
 
     // Location of the in sequence
-    public static final String IN_SEQUENCE_LOCATION = File.separator + SEQUENCES_RESOURCE
+    public static final String IN_SEQUENCE_LOCATION_OLD = File.separator + SEQUENCES_RESOURCE
             + File.separator + "in-sequence" + File.separator;
 
     // Location of the out sequence
-    public static final String OUT_SEQUENCE_LOCATION = File.separator + SEQUENCES_RESOURCE
+    public static final String OUT_SEQUENCE_LOCATION_OLD = File.separator + SEQUENCES_RESOURCE
             + File.separator + "out-sequence" + File.separator;
 
     //Location of the fault sequence
-    public static final String FAULT_SEQUENCE_LOCATION = File.separator + SEQUENCES_RESOURCE
+    public static final String FAULT_SEQUENCE_LOCATION_OLD = File.separator + SEQUENCES_RESOURCE
             + File.separator + "fault-sequence" + File.separator;
+
+    // Sequence location post fix
+    public static final String SEQUENCE_LOCATION_POSTFIX = "-sequence";
+
+    // Location of the in sequence
+    public static final String IN_SEQUENCE_PREFIX = "in";
+
+    // Location of the out sequence
+    public static final String OUT_SEQUENCE_PREFIX = "out";
+
+    // Location of the fault sequence
+    public static final String FAULT_SEQUENCE_PREFIX = "fault";
 
     public static final String CERTIFICATE_CONTENT_JSON_KEY = "certificate";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -111,18 +111,6 @@ public final class ImportExportConstants {
     // Sequences resource
     public static final String SEQUENCES_RESOURCE = "Sequences";
 
-    // Location of the in sequence
-    public static final String IN_SEQUENCE_LOCATION_OLD = File.separator + SEQUENCES_RESOURCE
-            + File.separator + "in-sequence" + File.separator;
-
-    // Location of the out sequence
-    public static final String OUT_SEQUENCE_LOCATION_OLD = File.separator + SEQUENCES_RESOURCE
-            + File.separator + "out-sequence" + File.separator;
-
-    //Location of the fault sequence
-    public static final String FAULT_SEQUENCE_LOCATION_OLD = File.separator + SEQUENCES_RESOURCE
-            + File.separator + "fault-sequence" + File.separator;
-
     // Sequence location post fix
     public static final String SEQUENCE_LOCATION_POSTFIX = "-sequence";
 
@@ -134,6 +122,18 @@ public final class ImportExportConstants {
 
     // Location of the fault sequence
     public static final String FAULT_SEQUENCE_PREFIX = "fault";
+
+    // Location of the in sequence
+    public static final String IN_SEQUENCE_LOCATION = File.separator + SEQUENCES_RESOURCE
+            + File.separator + IN_SEQUENCE_PREFIX + SEQUENCE_LOCATION_POSTFIX + File.separator;
+
+    // Location of the out sequence
+    public static final String OUT_SEQUENCE_LOCATION = File.separator + SEQUENCES_RESOURCE
+            + File.separator + OUT_SEQUENCE_PREFIX + SEQUENCE_LOCATION_POSTFIX + File.separator;
+
+    // Location of the fault sequence
+    public static final String FAULT_SEQUENCE_LOCATION = File.separator + SEQUENCES_RESOURCE
+            + File.separator + FAULT_SEQUENCE_PREFIX + SEQUENCE_LOCATION_POSTFIX + File.separator;
 
     public static final String CERTIFICATE_CONTENT_JSON_KEY = "certificate";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -580,12 +580,12 @@ public class ExportUtils {
                         InputStream fileInputStream = mediationFile.getContentStream()) {
                     IOUtils.copy(fileInputStream, outputStream);
                 } catch (IOException e) {
-                    throw new APIManagementException("Error while writing the mediation sequence"+ mediationName+ "to file");
+                    throw new APIManagementException("Error while writing the mediation sequence"+ mediationName+ "to file", e);
                 }
             } else {
-                // Log error and avoid throwing as we give capability to export an API without sequences
-                log.error("Sequence resource for API/API Product: " + apiIdentifier.getName() + " not found in "
-                        + resourcePath);
+                throw new APIManagementException(
+                        "Resource specified by " + resourcePath + " cannot be found in the registry",
+                        ExceptionCodes.RESOURCE_NOT_FOUND);
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -25,7 +25,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
-import org.apache.axiom.om.OMElement;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -89,19 +88,16 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import org.xml.sax.SAXException;
 
-import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -925,27 +921,6 @@ public class ImportUtils {
                 }
             }
         }
-    }
-
-    /**
-     * @param pathToArchive         Location of the extracted folder of the API
-     * @param registry              Registry
-     * @param regResourcePath       Resource path in the registry
-     * @param sequenceFileName      File name of the sequence
-     * @param sequenceLocation      Location of the sequence file
-     * @param apiCustomSequenceType Custom sequence type (can be in, out or fault)
-     */
-    private static void addCustomSequenceToRegistry(String pathToArchive, Registry registry, String regResourcePath,
-            String sequenceFileName, String sequenceLocation, String apiCustomSequenceType) {
-        String sequenceFileLocation =
-                pathToArchive + sequenceLocation + ImportExportConstants.CUSTOM_TYPE + File.separator
-                        + sequenceFileName;
-        // Adding sequence, if any
-//        if (CommonUtil.checkFileExistence(sequenceFileLocation + APIConstants.XML_EXTENSION)) {
-//            String sequencePath = apiCustomSequenceType + RegistryConstants.PATH_SEPARATOR + sequenceFileName;
-//            addSequenceToRegistry(true, registry, sequenceFileLocation + APIConstants.XML_EXTENSION,
-//                    regResourcePath + sequencePath);
-//        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -1086,8 +1086,8 @@ public class ImportUtils {
                 if (StringUtils.equals(certificateFileName, endpointsCertificate.getName())) {
                     certificateContent = FileUtils.readFileToString(
                             new File(pathToCertificatesDirectory + File.separator + certificateFileName));
-                    certificateContent = certificateContent.replace(APIConstants.BEGIN_CERTIFICATE_STRING, "");
-                    certificateContent = certificateContent.replace(APIConstants.END_CERTIFICATE_STRING, "");
+                    certificateContent = StringUtils.substringBetween(certificateContent,
+                            APIConstants.BEGIN_CERTIFICATE_STRING, APIConstants.END_CERTIFICATE_STRING);
                 }
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -891,9 +891,12 @@ public class ImportUtils {
         String sequencesDirectoryPath = pathToArchive + File.separator + APIImportExportConstants.SEQUENCES_RESOURCE;
 
         // Add multiple custom sequences to registry for each type in/out/fault
-        addCustomSequencesToRegistry(sequencesDirectoryPath, apiResourcePath, registry, ImportExportConstants.IN_SEQUENCE_PREFIX);
-        addCustomSequencesToRegistry(sequencesDirectoryPath, apiResourcePath, registry, ImportExportConstants.OUT_SEQUENCE_PREFIX);
-        addCustomSequencesToRegistry(sequencesDirectoryPath, apiResourcePath, registry, ImportExportConstants.FAULT_SEQUENCE_PREFIX);
+        addCustomSequencesToRegistry(sequencesDirectoryPath, apiResourcePath, registry,
+                ImportExportConstants.IN_SEQUENCE_PREFIX);
+        addCustomSequencesToRegistry(sequencesDirectoryPath, apiResourcePath, registry,
+                ImportExportConstants.OUT_SEQUENCE_PREFIX);
+        addCustomSequencesToRegistry(sequencesDirectoryPath, apiResourcePath, registry,
+                ImportExportConstants.FAULT_SEQUENCE_PREFIX);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -845,7 +845,7 @@ public class ImportUtils {
 
         String inSequenceFileName = importedApi.getInSequence() + APIConstants.XML_EXTENSION;
         String inSequenceFileLocation =
-                pathToArchive + ImportExportConstants.IN_SEQUENCE_LOCATION_OLD + inSequenceFileName;
+                pathToArchive + ImportExportConstants.IN_SEQUENCE_LOCATION + inSequenceFileName;
         String regResourcePath;
 
         //Adding in-sequence, if any
@@ -856,7 +856,7 @@ public class ImportUtils {
 
         String outSequenceFileName = importedApi.getOutSequence() + APIConstants.XML_EXTENSION;
         String outSequenceFileLocation =
-                pathToArchive + ImportExportConstants.OUT_SEQUENCE_LOCATION_OLD + outSequenceFileName;
+                pathToArchive + ImportExportConstants.OUT_SEQUENCE_LOCATION + outSequenceFileName;
 
         //Adding out-sequence, if any
         if (CommonUtil.checkFileExistence(outSequenceFileLocation)) {
@@ -866,7 +866,7 @@ public class ImportUtils {
 
         String faultSequenceFileName = importedApi.getFaultSequence() + APIConstants.XML_EXTENSION;
         String faultSequenceFileLocation =
-                pathToArchive + ImportExportConstants.FAULT_SEQUENCE_LOCATION_OLD + faultSequenceFileName;
+                pathToArchive + ImportExportConstants.FAULT_SEQUENCE_LOCATION + faultSequenceFileName;
 
         //Adding fault-sequence, if any
         if (CommonUtil.checkFileExistence(faultSequenceFileLocation)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -288,15 +288,15 @@ public class ImportUtils {
     /**
      * This method sets the operations which were retrieved from the swagger definition to the API DTO.
      *
-     * @param apiDto             API DTO
-     * @param response          API Validation Response
+     * @param apiDto   API DTO
+     * @param response API Validation Response
      * @throws APIManagementException If an error occurs when retrieving the URI templates
      */
     private static void setOperationsToDTO(APIDTO apiDto, APIDefinitionValidationResponse response)
             throws APIManagementException {
         List<URITemplate> uriTemplates = new ArrayList<>();
         uriTemplates.addAll(response.getParser().getURITemplates(response.getJsonContent()));
-        List<APIOperationsDTO> apiOperationsDtos =APIMappingUtil.fromURITemplateListToOprationList(uriTemplates);
+        List<APIOperationsDTO> apiOperationsDtos = APIMappingUtil.fromURITemplateListToOprationList(uriTemplates);
         apiDto.setOperations(apiOperationsDtos);
     }
 


### PR DESCRIPTION
## Purpose
Fixes the issue mentioned in https://github.com/wso2/product-apim-tooling/issues/330#issuecomment-737692783

## Goals
Export multiple custom mediation policies attached to an API and import those when importing that particular API.

## Approach
- Previously only one mediation policy per direction (in/out/fault) was exported. But with this improvement, all the attached mediations to a particular API will be exported for all the directions.
   ```
   PizzaShackAPI-1.0.0
   ├── api.yaml
   ├── Definitions
   │   └── swagger.yaml
   └── Sequences
       ├── fault-sequence
       │   └── Custom
       │       └── sequence1.xml
       ├── in-sequence
       │   └── Custom
       │       ├── sequence1.xml
       │       └── sequence2.xml
       └── out-sequence
           └── disable_chunking.xml
   ```
   As shown in the above example, you can see that there are multiple **in-sequences** inside the **Custom** directory. Earlier we were able only to export the sequence which has been set in runtime.
- If you import the above like API archive, all the custom sequences will be imported which are attached to it. For example, both **sequence1.xml** and **sequence2.xml** will be imported under the API specific registry path for in-sequences. Also, there will be three (3) mediation policy objects inside the api.yaml file (Inside the API DTO) as below.
   ```
     mediationPolicies:
      -
       id: 9f8941e6-b056-4c3d-a84a-1adafed4cc60
       name: sequence1
       type: IN
       shared: false
      -
       id: 507c7c9d-6542-4420-a285-f7b4d9bbe88c
       name: disable_chunking
       type: OUT
       shared: true
      -
       id: a90b38dd-93e9-4ad3-8ca7-8511bde4b9cf
       name: sequence1
       type: FAULT
       shared: false
   ```
   These will be the policies that will be enforced during the runtime. Simply it means, even you have imported both **sequence1.xml** and **sequence2.xml** as in-sequences, only **sequence1.xml** will be enforced during the runtime.

## User stories
User stories related to https://github.com/wso2/product-apim-tooling/issues/330#issuecomment-737692783 will be satisfied.

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/9464

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.1 LTS