### PR TITLE
Support new directory structure when bundling Deployment directory when importing APIs [APIM]

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -405,7 +405,9 @@ ExceptionCodes implements ErrorHandler {
 
     // API import/export related codes
     ERROR_READING_META_DATA(900900, "Error while reading meta information from the definition", 400,
-            "Error while reading meta information from the definition");
+            "Error while reading meta information from the definition"),
+    ERROR_READING_PARAMS_FILE(900901, "Error while reading meta information from the api_params.yaml file", 400,
+            "Error while reading meta information from the api_params.yaml file");
 
     private final long errorCode;
     private final String errorMessage;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -262,4 +262,9 @@ public final class ImportExportConstants {
     public static final String CLIENT_CERTIFICATES_META_DATA_FILE_PATH =
             CLIENT_CERTIFICATES_DIRECTORY_PATH + File.separator + "client_certificates";
 
+    //Deployment directory related constants
+    public static final String DEPLOYMENT_DIRECTORY_NAME= "Deployment";
+    public static final String DEPLOYMENT_DIRECTORY= File.separator + DEPLOYMENT_DIRECTORY_NAME;
+    public static final String SOURCE_ZIP_DIRECTORY_NAME = "SourceArchive.zip";
+    public static final String API_PARAMS_FILE_NAME = "api_params.yaml";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/CommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/CommonUtil.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.logging.Log;
@@ -371,6 +372,40 @@ public class CommonUtil {
         } catch (IOException e) {
             String errorMessage = "Error while moving file from" + source + "to" + dest;
             throw new APIManagementException(errorMessage, e);
+        }
+    }
+
+
+    /**
+     * This method will be used to copy files from source to destination
+     *
+     * @param source String of the source file path
+     * @param dest   String of the destination file path
+     * @throws APIImportExportException If an error occurs when copying files
+     */
+    public static void copyFile(String source, String dest) throws APIImportExportException {
+        try {
+            FileUtils.copyFile(new File(source), new File(dest));
+        } catch (IOException e) {
+            String errorMessage = "Error while moving file from " + source + " to " + dest;
+            throw new APIImportExportException(errorMessage, e);
+        }
+    }
+
+    /**
+     * This method will be used to copy a whole directory to a new location preserving the file dates.
+     *
+     * @param sourceDir String of the source Directory path
+     * @param destDir   String of the destination Directory path
+     * @throws APIImportExportException If an error occurs when copying directory
+     */
+    public static void copyDirectory(String sourceDir, String destDir) throws APIImportExportException {
+
+        try {
+            FileUtils.copyDirectory(new File(sourceDir), new File(destDir));
+        } catch (IOException e) {
+            String errorMessage = "Error while moving file from " + sourceDir + " to " + destDir;
+            throw new APIImportExportException(errorMessage, e);
         }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -331,6 +331,11 @@ public class APIControllerUtil {
         if (envParams.get(ImportExportConstants.ENDPOINTS_FIELD) != null) {
             endpointsObject = envParams.get(ImportExportConstants.ENDPOINTS_FIELD).getAsJsonObject();
         }
+        // if the endpoint type is REST or SOAP return null
+        if (ImportExportConstants.REST_TYPE_ENDPOINT.equals(endpointType) || ImportExportConstants.SOAP_TYPE_ENDPOINT
+                .equals(endpointType) || ImportExportConstants.HTTP_TYPE_ENDPOINT.equals(endpointType)) {
+            return null;
+        }
         // if endpoint type is Dynamic
         if (ImportExportConstants.DYNAMIC_TYPE_ENDPOINT.equals(endpointType)) {
             JsonObject updatedDynamicEndpointParams = new JsonObject();
@@ -638,7 +643,7 @@ public class APIControllerUtil {
      * @param defaultSandboxEndpoint    Default sandbox endpoint json object
      */
     private static void handleEndpointValues(JsonObject endpointConfigs, JsonObject updatedEndpointParams,
-            JsonObject defaultProductionEndpoint, JsonObject defaultSandboxEndpoint) {
+            JsonObject defaultProductionEndpoint, JsonObject defaultSandboxEndpoint) throws APIManagementException {
 
         //check api params file to get provided endpoints
         if (endpointConfigs == null) {
@@ -654,6 +659,17 @@ public class APIControllerUtil {
             if (endpointConfigs.get(ImportExportConstants.SANDBOX_ENDPOINTS_JSON_PROPERTY) != null) {
                 updatedEndpointParams.add(ImportExportConstants.SANDBOX_ENDPOINTS_PROPERTY,
                         endpointConfigs.get(ImportExportConstants.SANDBOX_ENDPOINTS_JSON_PROPERTY));
+            }
+            if (updatedEndpointParams.get(ImportExportConstants.SANDBOX_ENDPOINTS_PROPERTY) == null
+                    && updatedEndpointParams.get(ImportExportConstants.PRODUCTION_ENDPOINTS_PROPERTY) == null) {
+                throw new APIManagementException(
+                        "Please specify production sandbox or endpoints for the environment and continue...");
+            }
+
+            if (updatedEndpointParams.get(ImportExportConstants.SANDBOX_ENDPOINTS_PROPERTY).isJsonNull()
+                    && updatedEndpointParams.get(ImportExportConstants.PRODUCTION_ENDPOINTS_PROPERTY).isJsonNull()) {
+                throw new APIManagementException(
+                        "Please specify production or sandbox endpoints for the environment and continue...");
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -681,11 +681,16 @@ public class APIControllerUtil {
                 throw new APIManagementException(
                         "Please specify production sandbox or endpoints for the environment and continue...",
                         ExceptionCodes.ERROR_READING_PARAMS_FILE);
-            } else if (updatedEndpointParams.get(ImportExportConstants.SANDBOX_ENDPOINTS_PROPERTY).isJsonNull()
-                    && updatedEndpointParams.get(ImportExportConstants.PRODUCTION_ENDPOINTS_PROPERTY).isJsonNull()) {
-                throw new APIManagementException(
-                        "Please specify production or sandbox endpoints for the environment and continue...",
-                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
+            } else if ((updatedEndpointParams.get(ImportExportConstants.SANDBOX_ENDPOINTS_PROPERTY) != null)
+                    && (updatedEndpointParams.get(ImportExportConstants.SANDBOX_ENDPOINTS_PROPERTY).isJsonNull())) {
+
+                if ((updatedEndpointParams.get(ImportExportConstants.PRODUCTION_ENDPOINTS_PROPERTY) != null)
+                        && updatedEndpointParams.get(ImportExportConstants.PRODUCTION_ENDPOINTS_PROPERTY)
+                        .isJsonNull()) {
+                    throw new APIManagementException(
+                            "Please specify production or sandbox endpoints for the environment and continue...",
+                            ExceptionCodes.ERROR_READING_PARAMS_FILE);
+                }
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -664,9 +664,7 @@ public class APIControllerUtil {
                     && updatedEndpointParams.get(ImportExportConstants.PRODUCTION_ENDPOINTS_PROPERTY) == null) {
                 throw new APIManagementException(
                         "Please specify production sandbox or endpoints for the environment and continue...");
-            }
-
-            if (updatedEndpointParams.get(ImportExportConstants.SANDBOX_ENDPOINTS_PROPERTY).isJsonNull()
+            } else if (updatedEndpointParams.get(ImportExportConstants.SANDBOX_ENDPOINTS_PROPERTY).isJsonNull()
                     && updatedEndpointParams.get(ImportExportConstants.PRODUCTION_ENDPOINTS_PROPERTY).isJsonNull()) {
                 throw new APIManagementException(
                         "Please specify production or sandbox endpoints for the environment and continue...");
@@ -746,7 +744,8 @@ public class APIControllerUtil {
                 }
             }
             //copy certs file from certificates
-            String userCertificatesTempDirectory = pathToArchive + ImportExportConstants.CERTIFICATE_DIRECTORY;
+            String userCertificatesTempDirectory = pathToArchive + ImportExportConstants.DEPLOYMENT_DIRECTORY
+                    + ImportExportConstants.CERTIFICATE_DIRECTORY;
             String sourcePath = userCertificatesTempDirectory + File.separator + certName;
             String destinationPath = clientCertificatesDirectory + File.separator + certName;
             if (Files.notExists(Paths.get(sourcePath))) {
@@ -807,7 +806,8 @@ public class APIControllerUtil {
                 }
             }
             //copy certs file from certificates
-            String userCertificatesTempDirectory = pathToArchive + ImportExportConstants.CERTIFICATE_DIRECTORY;
+            String userCertificatesTempDirectory = pathToArchive + ImportExportConstants.DEPLOYMENT_DIRECTORY
+                    + ImportExportConstants.CERTIFICATE_DIRECTORY;
             String sourcePath = userCertificatesTempDirectory + File.separator + certName;
             String destinationPath = endpointCertificatesDirectory + File.separator + certName;
             if (Files.notExists(Paths.get(sourcePath))) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.dto.CertificateMetadataDTO;
 import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
 import org.wso2.carbon.apimgt.api.model.API;
@@ -138,7 +139,8 @@ public class APIControllerUtil {
         try {
             endpointConfig = mapper.readValue(jsonObject.toString(), HashMap.class);
         } catch (JsonProcessingException e) {
-            throw new APIManagementException(e);
+            String errorMessage = "Error while reading endpointConfig information in the api_params.yaml.";
+            throw new APIManagementException(errorMessage, e, ExceptionCodes.ERROR_READING_PARAMS_FILE);
         }
         importedApiDto.setEndpointConfig(endpointConfig);
 
@@ -170,7 +172,7 @@ public class APIControllerUtil {
             } catch (IOException e) {
                 //Error is logged and when generating certificate details and certs in the archive
                 String errorMessage = "Error while generating meta information of client certificates from path.";
-                throw new APIManagementException(errorMessage, e);
+                throw new APIManagementException(errorMessage, e, ExceptionCodes.ERROR_READING_PARAMS_FILE);
             }
         }
 
@@ -183,7 +185,7 @@ public class APIControllerUtil {
             } catch (IOException e) {
                 //Error is logged and when generating certificate details and certs in the archive
                 String errorMessage = "Error while generating meta information of client certificates from path.";
-                throw new APIManagementException(errorMessage, e);
+                throw new APIManagementException(errorMessage, e, ExceptionCodes.ERROR_READING_PARAMS_FILE);
             }
         }
 
@@ -224,13 +226,16 @@ public class APIControllerUtil {
 
             if (username == null) {
                 throw new APIManagementException("You have enabled endpoint security but the username is not found "
-                        + "in the api_params.yaml. Please specify username field for and continue...");
+                        + "in the api_params.yaml. Please specify username field for and continue...",
+                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
             } else if (password == null) {
                 throw new APIManagementException("You have enabled endpoint security but the password is not found "
-                        + "in the api_params.yaml. Please specify password field for and continue...");
+                        + "in the api_params.yaml. Please specify password field for and continue...",
+                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
             } else if (type == null) {
                 throw new APIManagementException("You have enabled endpoint security but the password is not found "
-                        + "in the api_params.yaml. Please specify password field for and continue...");
+                        + "in the api_params.yaml. Please specify password field for and continue...",
+                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
             } else {
                 apiEndpointSecurityDTO.setPassword(password.toString());
                 apiEndpointSecurityDTO.setUsername(username.getAsString());
@@ -243,7 +248,8 @@ public class APIControllerUtil {
                     // If the type is not either basic or digest, return an error
                     throw new APIManagementException("Invalid endpoint security type found in the api_params.yaml. "
                             + "Should be either basic or digest"
-                            + "Please specify correct security types field for and continue...");
+                            + "Please specify correct security types field for and continue...",
+                            ExceptionCodes.ERROR_READING_PARAMS_FILE);
                 }
             }
             importedApiDto.setEndpointSecurity(apiEndpointSecurityDTO);
@@ -357,7 +363,8 @@ public class APIControllerUtil {
             //if aws config is not provided
             if (envParams.get(ImportExportConstants.AWS_LAMBDA_ENDPOINT_JSON_PROPERTY) == null) {
                 throw new APIManagementException(
-                        "Please specify awsLambdaEndpoints field for the environment and continue...");
+                        "Please specify awsLambdaEndpoints field for the environment and continue...",
+                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
             }
             JsonObject awsEndpointParams = envParams.get(ImportExportConstants.AWS_LAMBDA_ENDPOINT_JSON_PROPERTY)
                     .getAsJsonObject();
@@ -384,7 +391,8 @@ public class APIControllerUtil {
             return updatedAwsEndpointParams;
         } else {
             throw new APIManagementException(
-                    "Please specify valid endpoint configurations for the environment and continue...");
+                    "Please specify valid endpoint configurations for the environment and continue...",
+                    ExceptionCodes.ERROR_READING_PARAMS_FILE);
         }
     }
 
@@ -420,7 +428,8 @@ public class APIControllerUtil {
             JsonObject loadBalancedConfigs;
             if (loadBalancedConfigElement == null) {
                 throw new APIManagementException(
-                        "Please specify loadBalanceEndpoints for the environment and continue...");
+                        "Please specify loadBalanceEndpoints for the environment and continue...",
+                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
             } else {
                 loadBalancedConfigs = loadBalancedConfigElement.getAsJsonObject();
             }
@@ -461,7 +470,8 @@ public class APIControllerUtil {
             JsonObject failoverConfigs;
             if (failoverConfigElement == null) {
                 throw new APIManagementException(
-                        "Please specify failoverEndpoints field for the environment and continue...");
+                        "Please specify failoverEndpoints field for the environment and continue...",
+                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
             } else {
                 failoverConfigs = failoverConfigElement.getAsJsonObject();
             }
@@ -478,7 +488,8 @@ public class APIControllerUtil {
                 //if failover endpoints are not specified but general endpoints are specified
                 if (productionEndpoints != null) {
                     throw new APIManagementException(
-                            "Please specify production failover field for the environment and continue...");
+                            "Please specify production failover field for the environment and continue...",
+                            ExceptionCodes.ERROR_READING_PARAMS_FILE);
                 }
             } else if (!productionFailOvers.isJsonNull()) {
                 updatedRESTEndpointParams
@@ -493,7 +504,8 @@ public class APIControllerUtil {
                 //if failover endpoints are not specified but general endpoints are specified
                 if (sandboxEndpoints != null) {
                     throw new APIManagementException(
-                            "Please specify sandbox failover field for for the environment and continue...");
+                            "Please specify sandbox failover field for for the environment and continue...",
+                            ExceptionCodes.ERROR_READING_PARAMS_FILE);
                 }
             } else if (!sandboxFailOvers.isJsonNull()) {
                 updatedRESTEndpointParams
@@ -537,7 +549,8 @@ public class APIControllerUtil {
             JsonObject loadBalancedConfigs;
             if (loadBalancedConfigElement == null) {
                 throw new APIManagementException(
-                        "Please specify loadBalanceEndpoints field for for the environment and continue...");
+                        "Please specify loadBalanceEndpoints field for for the environment and continue...",
+                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
             } else {
                 loadBalancedConfigs = loadBalancedConfigElement.getAsJsonObject();
             }
@@ -588,7 +601,8 @@ public class APIControllerUtil {
             JsonObject failoverConfigs;
             if (failoverConfigElement == null) {
                 throw new APIManagementException(
-                        "Please specify failoverEndpoints field for the environment and continue...");
+                        "Please specify failoverEndpoints field for the environment and continue...",
+                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
             } else {
                 failoverConfigs = failoverConfigElement.getAsJsonObject();
             }
@@ -605,7 +619,8 @@ public class APIControllerUtil {
                 //if failover endpoints are not specified but general endpoints are specified
                 if (productionEndpoints != null) {
                     throw new APIManagementException(
-                            "Please specify production failover field for the environment and continue...");
+                            "Please specify production failover field for the environment and continue...",
+                            ExceptionCodes.ERROR_READING_PARAMS_FILE);
                 }
             } else if (!productionFailOvers.isJsonNull()) {
                 updatedSOAPEndpointParams.add(ImportExportConstants.PRODUCTION_FAILOVERS_ENDPOINTS_PROPERTY,
@@ -620,7 +635,8 @@ public class APIControllerUtil {
                 //if failover endpoints are not specified but general endpoints are specified
                 if (sandboxEndpoints != null) {
                     throw new APIManagementException(
-                            "Please specify sandbox failover field for the environment and continue...");
+                            "Please specify sandbox failover field for the environment and continue...",
+                            ExceptionCodes.ERROR_READING_PARAMS_FILE);
                 }
             } else if (!sandboxFailOvers.isJsonNull()) {
                 updatedSOAPEndpointParams.add(ImportExportConstants.SANDBOX_FAILOVERS_ENDPOINTS_PROPERTY,
@@ -663,11 +679,13 @@ public class APIControllerUtil {
             if (updatedEndpointParams.get(ImportExportConstants.SANDBOX_ENDPOINTS_PROPERTY) == null
                     && updatedEndpointParams.get(ImportExportConstants.PRODUCTION_ENDPOINTS_PROPERTY) == null) {
                 throw new APIManagementException(
-                        "Please specify production sandbox or endpoints for the environment and continue...");
+                        "Please specify production sandbox or endpoints for the environment and continue...",
+                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
             } else if (updatedEndpointParams.get(ImportExportConstants.SANDBOX_ENDPOINTS_PROPERTY).isJsonNull()
                     && updatedEndpointParams.get(ImportExportConstants.PRODUCTION_ENDPOINTS_PROPERTY).isJsonNull()) {
                 throw new APIManagementException(
-                        "Please specify production or sandbox endpoints for the environment and continue...");
+                        "Please specify production or sandbox endpoints for the environment and continue...",
+                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
             }
         }
     }
@@ -751,7 +769,7 @@ public class APIControllerUtil {
             if (Files.notExists(Paths.get(sourcePath))) {
                 String errorMessage =
                         "The mentioned certificate file " + certName + " is not in the certificates directory";
-                throw new IOException(errorMessage);
+                throw new APIManagementException(errorMessage, ExceptionCodes.ERROR_READING_PARAMS_FILE);
             }
             CommonUtil.moveFile(sourcePath, destinationPath);
         }
@@ -813,7 +831,7 @@ public class APIControllerUtil {
             if (Files.notExists(Paths.get(sourcePath))) {
                 String errorMessage =
                         "The mentioned certificate file " + certName + " is not in the certificates directory";
-                throw new APIManagementException(errorMessage);
+                throw new APIManagementException(errorMessage, ExceptionCodes.ERROR_READING_PARAMS_FILE);
             }
             CommonUtil.moveFile(sourcePath, destinationPath);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -328,6 +328,54 @@ public class ImportUtils {
         return apiProvider.getAPI(apiIdentifier);
     }
 
+    public static String preprocessImportedArtifact(String tempDirectory) throws APIImportExportException {
+        String sourceFileName = "SourceArchive.zip";
+        String apiParamsFileName = "api_params.yaml";
+        String deploymentDirectoryFileName = "Deployment";
+        String tempDirectoryAbsolutePath = tempDirectory + File.separator;
+        boolean isParamsFileAvailable = CommonUtil.checkFileExistence(tempDirectoryAbsolutePath + apiParamsFileName);
+        boolean isDeploymentDirectoryAvailable = CommonUtil
+                .checkFileExistence(tempDirectoryAbsolutePath + deploymentDirectoryFileName);
+
+        //When api controller is provided with api_params.file
+        if (isParamsFileAvailable) {
+            if (!CommonUtil.checkFileExistence(tempDirectoryAbsolutePath + sourceFileName)) {
+                throw new APIImportExportException("The source artifact is not provided properly");
+            } else {
+                String newExtractedFolderName = CommonUtil
+                        .extractArchive(new File(tempDirectoryAbsolutePath + sourceFileName),
+                                tempDirectoryAbsolutePath);
+                //Copy api_params.yaml file to working directory
+                CommonUtil.copyFile(tempDirectoryAbsolutePath + apiParamsFileName,
+                        newExtractedFolderName + apiParamsFileName);
+                return tempDirectoryAbsolutePath + newExtractedFolderName;
+            }
+        }
+        //When api controller is provided with the "Deployment" directory
+        if (isDeploymentDirectoryAvailable) {
+            if (!CommonUtil.checkFileExistence(tempDirectoryAbsolutePath + sourceFileName)) {
+                throw new APIImportExportException("The source artifact is not provided properly");
+            } else {
+                String newExtractedFolderName = CommonUtil
+                        .extractArchive(new File(tempDirectoryAbsolutePath + sourceFileName),
+                                tempDirectoryAbsolutePath);
+                //Copy api_params.yaml file to working directory
+                String srcParamsFilePath = tempDirectoryAbsolutePath + deploymentDirectoryFileName + File.separator + apiParamsFileName;
+                String destParamsFilePath =
+                        tempDirectoryAbsolutePath + newExtractedFolderName + File.separator + apiParamsFileName;
+                CommonUtil.copyFile(srcParamsFilePath, destParamsFilePath);
+                //move deployment directory into working directory
+                String srcDeploymentDirectoryPath = tempDirectoryAbsolutePath + deploymentDirectoryFileName;
+                String destDeploymentDirectoryPath = tempDirectoryAbsolutePath + newExtractedFolderName + File.separator
+                        + deploymentDirectoryFileName;
+                CommonUtil.copyDirectory(srcDeploymentDirectoryPath, destDeploymentDirectoryPath);
+
+                return tempDirectoryAbsolutePath + newExtractedFolderName;
+            }
+        }
+        return tempDirectory;
+    }
+
     /**
      * Extract the imported archive to a temporary folder and return the folder path of it
      *

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -409,7 +409,7 @@ public class ImportUtils {
         String absolutePath = importFolder.getAbsolutePath() + File.separator;
         CommonUtil.transferFile(uploadedInputStream, uploadFileName, absolutePath);
         String extractedFolderName = CommonUtil.extractArchive(new File(absolutePath + uploadFileName), absolutePath);
-        return absolutePath + extractedFolderName;
+        return preprocessImportedArtifact(absolutePath + extractedFolderName);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -328,46 +328,63 @@ public class ImportUtils {
         return apiProvider.getAPI(apiIdentifier);
     }
 
+    /**
+     * Process the extracted temporary directory in order to detect the flow and alter the directory structure
+     * according to the flow
+     *
+     * @param tempDirectory String of the temporary directory path value
+     * @return Path to the extracted directory
+     * @throws APIImportExportException If an error occurs while creating the directory, transferring files or
+     *                                  extracting the content
+     */
     public static String preprocessImportedArtifact(String tempDirectory) throws APIImportExportException {
-        String sourceFileName = "SourceArchive.zip";
-        String apiParamsFileName = "api_params.yaml";
-        String deploymentDirectoryFileName = "Deployment";
+
         String tempDirectoryAbsolutePath = tempDirectory + File.separator;
-        boolean isParamsFileAvailable = CommonUtil.checkFileExistence(tempDirectoryAbsolutePath + apiParamsFileName);
+        boolean isParamsFileAvailable = CommonUtil
+                .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.API_PARAMS_FILE_NAME);
         boolean isDeploymentDirectoryAvailable = CommonUtil
-                .checkFileExistence(tempDirectoryAbsolutePath + deploymentDirectoryFileName);
+                .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.DEPLOYMENT_DIRECTORY_NAME);
 
         //When api controller is provided with api_params.file
         if (isParamsFileAvailable) {
-            if (!CommonUtil.checkFileExistence(tempDirectoryAbsolutePath + sourceFileName)) {
+            if (!CommonUtil
+                    .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME)) {
                 throw new APIImportExportException("The source artifact is not provided properly");
             } else {
-                String newExtractedFolderName = CommonUtil
-                        .extractArchive(new File(tempDirectoryAbsolutePath + sourceFileName),
-                                tempDirectoryAbsolutePath);
+                String newExtractedFolderName = CommonUtil.extractArchive(
+                        new File(tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME),
+                        tempDirectoryAbsolutePath);
+
                 //Copy api_params.yaml file to working directory
-                CommonUtil.copyFile(tempDirectoryAbsolutePath + apiParamsFileName,
-                        newExtractedFolderName + apiParamsFileName);
+                CommonUtil.copyFile(tempDirectoryAbsolutePath + ImportExportConstants.API_PARAMS_FILE_NAME,
+                        newExtractedFolderName + ImportExportConstants.API_PARAMS_FILE_NAME);
+
                 return tempDirectoryAbsolutePath + newExtractedFolderName;
             }
         }
         //When api controller is provided with the "Deployment" directory
         if (isDeploymentDirectoryAvailable) {
-            if (!CommonUtil.checkFileExistence(tempDirectoryAbsolutePath + sourceFileName)) {
+            if (!CommonUtil
+                    .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME)) {
                 throw new APIImportExportException("The source artifact is not provided properly");
             } else {
-                String newExtractedFolderName = CommonUtil
-                        .extractArchive(new File(tempDirectoryAbsolutePath + sourceFileName),
-                                tempDirectoryAbsolutePath);
+                String newExtractedFolderName = CommonUtil.extractArchive(
+                        new File(tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME),
+                        tempDirectoryAbsolutePath);
+
                 //Copy api_params.yaml file to working directory
-                String srcParamsFilePath = tempDirectoryAbsolutePath + deploymentDirectoryFileName + File.separator + apiParamsFileName;
-                String destParamsFilePath =
-                        tempDirectoryAbsolutePath + newExtractedFolderName + File.separator + apiParamsFileName;
+                String srcParamsFilePath =
+                        tempDirectoryAbsolutePath + ImportExportConstants.DEPLOYMENT_DIRECTORY_NAME + File.separator
+                                + ImportExportConstants.API_PARAMS_FILE_NAME;
+                String destParamsFilePath = tempDirectoryAbsolutePath + newExtractedFolderName + File.separator
+                        + ImportExportConstants.API_PARAMS_FILE_NAME;
                 CommonUtil.copyFile(srcParamsFilePath, destParamsFilePath);
+
                 //move deployment directory into working directory
-                String srcDeploymentDirectoryPath = tempDirectoryAbsolutePath + deploymentDirectoryFileName;
+                String srcDeploymentDirectoryPath =
+                        tempDirectoryAbsolutePath + ImportExportConstants.DEPLOYMENT_DIRECTORY_NAME;
                 String destDeploymentDirectoryPath = tempDirectoryAbsolutePath + newExtractedFolderName + File.separator
-                        + deploymentDirectoryFileName;
+                        + ImportExportConstants.DEPLOYMENT_DIRECTORY_NAME;
                 CommonUtil.copyDirectory(srcDeploymentDirectoryPath, destDeploymentDirectoryPath);
 
                 return tempDirectoryAbsolutePath + newExtractedFolderName;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -356,8 +356,10 @@ public class ImportUtils {
                         tempDirectoryAbsolutePath);
 
                 //Copy api_params.yaml file to working directory
-                CommonUtil.copyFile(tempDirectoryAbsolutePath + ImportExportConstants.API_PARAMS_FILE_NAME,
-                        newExtractedFolderName + ImportExportConstants.API_PARAMS_FILE_NAME);
+                String srcParamsFilePath = tempDirectoryAbsolutePath + ImportExportConstants.API_PARAMS_FILE_NAME;
+                String destParamsFilePath = tempDirectoryAbsolutePath + newExtractedFolderName + File.separator
+                        + ImportExportConstants.API_PARAMS_FILE_NAME;
+                CommonUtil.copyFile(srcParamsFilePath, destParamsFilePath);
 
                 return tempDirectoryAbsolutePath + newExtractedFolderName;
             }


### PR DESCRIPTION
## Purpose

- The proposal is to be able to maintain deployment-specific resources external to the API project in its folder structure so that it can be maintained in its deployment repo. So the same API Project can be paired with different deployment data by the deployment job in a CI/CD pipeline.
- This is more of a best practice guideline that we are providing for separately maintain project data and deployment data so that it can be leveraged by apictl to deploy to across multiple environments effectively.

## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/545

## Approach
The resource artefact to be passed with publisher/v1/api/import REST API calls a single zip artefact. Therefore the folder structure based on the use case that user is referring should be identified and the packaging of the information should be handled in the client-side. To achieve this the 3 use cases will have three different folder structures and contents inside the zip artefact to be imported. 

Then at the server-side, the zip will be resolved and the folder structure of the extracted file will be checked. Based on the differences at that folder structure the server will detect the path to proceed with further with the given use case.

**1.Import API without an external parameter file**


```
└── temp_directory
   └── CustomerInfo-V1 (Source file)
    ├── api.yaml
    ├── Docs
    │   └── Doc1
    │       └── document.yaml
    ├── Image
    │   └── icon.png
    ├── Definitions
    │   └── swagger.yaml
    └── Sequences
```



**2.Import API with external parameters.yaml configurations file.**

```
└── temp_directory
   └── CustomerInfo-V1.zip **(Source file)**
   └── api_params.yaml
```
    

**3. Import API with deployment repository directory which contains all the environment-related parameters.**

```
└── temp_directory
   └── CustomerInfo-V1.zip **(Source file)**
   └── deploy **(deployment directory)**
    ├── api_params.yaml
    ├── Scripts
    │   └── Script_migrate
    │       └── script1.sh
    ├── configMaps
    │   └── map1.yaml
    │   └── map2.yaml
    ├── certificates
    │   └── endpoint1.crt
    │   └── endpoint2.crt
    │   └── mutualssl.crt
    └── readMes
```


** This temp_directory is the one to be zipped as a single directory or consolidated directory before passing as a resource via REST API call when importing APIs.

## User stories
The deployment repository and source repository both have to transfer to the APIM Server-side using the single resource that is used in publisher/v1/api/import REST API call. There will be 3 use cases to consider when implementing this feature.

**1. Import API without external parameters file.**

In here the source repository directory will be the only one import and transfer to the apim-server. There won’t be any consolidated bundle created as an intermediate step.

`apictl import api -f /home/chamindu/.wso2apictl/exported/apis/dev1/customer-info_1.0.0.zip  -e dev1 
`

**2. Import API with external parameters.yaml configurations file.**

In here the configurations related to the environment will be defined in a single params.yaml file without any external references (such as certificates) and that file will be provided as the input for --params flag when importing the API.

`apictl import api -f /home/chamindu/.wso2apictl/exported/apis/dev1/customer-info_1.0.0.zip  -e dev1 --params deploy_directory/env_params.yaml
`


**3. Import API with deployment  directory which contains all the environment-related parameters.**

In here the configuration related to deployment will store in a separate directory (which will be the deployment repository directory) and inside that repository, the certificates, api_params.yaml file and all the other contents should be included. Then that directory will be provided as the input for --params flag when importing the API.

`apictl import api -f /home/chamindu/.wso2apictl/exported/apis/dev1/customer-info_1.0.0.zip  -e dev1 --params deploy_directory
`
## Documentation
Docs need to be changed

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/553

## Test environment
OS - Ubuntu 20.04 LTS
Java - JDK 1.8_252
APIM - Latest Master branch version
 
