### PR TITLE
Preserving endpoint credentials when exporting an API via APICTL

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/ImportExportAPIServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/ImportExportAPIServiceImpl.java
@@ -70,12 +70,13 @@ public class ImportExportAPIServiceImpl implements ImportExportAPI {
             String provider = ExportUtils.validateExportParams(name, version, providerName);
             apiIdentifier = new APIIdentifier(APIUtil.replaceEmailDomain(provider), name, version);
             api = apiProvider.getAPI(apiIdentifier);
+            apiDtoToReturn = APIMappingUtil.fromAPItoDTO(api, preserveCredentials);
         } else {
             apiIdentifier = APIMappingUtil.getAPIIdentifierFromUUID(apiId);
             api = apiProvider.getAPIbyUUID(apiId, tenantDomain);
+            apiDtoToReturn = APIMappingUtil.fromAPItoDTO(api);
         }
         if (api != null) {
-            apiDtoToReturn = APIMappingUtil.fromAPItoDTO(api);
             return ExportUtils.exportApi(apiProvider, apiIdentifier, apiDtoToReturn, userName, format, preserveStatus,
                     preserveDocs);
         }


### PR DESCRIPTION
## Purpose
Preserving endpoint credentials when exporting an API using the APICTL.

## Goals
Preserve the endpoint credentials when exporting an API, so that when importing it would be easy.

## Approach
Manipulate the preserveCredentials variable introduced in [1]

## User stories
- When someone is downloading the API from the Publisher UI, the endpoint credentials will not be preserved.
- When someone is exporting the API from APICTL, the endpoint credentials will be preserved.

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/9458
- https://github.com/wso2/carbon-apimgt/pull/9406

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.1 LTS

[1] https://github.com/wso2/carbon-apimgt/pull/9458
