### PR TITLE
Add handler to remove transport headers

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/TransportHeaderHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/TransportHeaderHandler.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.handlers.common;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.nio.NHttpConnection;
+import org.apache.synapse.AbstractSynapseHandler;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.transport.passthru.SourceContext;
+import org.apache.synapse.transport.passthru.SourceRequest;
+import org.wso2.carbon.apimgt.gateway.utils.TransportHeaderUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TransportHeaderHandler extends AbstractSynapseHandler {
+    private static final Log log = LogFactory.getLog(TransportHeaderHandler.class);
+
+    private boolean isRemoveRequestHeadersOnFaultEnabled = false;
+
+    /** Well-known request headers to be removed in a response */
+    private List<String> standardRequestHeaders = new ArrayList<String>();
+    /** Well-known response headers to be removed in a request */
+    private List<String> standardResponseHeaders = new ArrayList<String>();
+    /** Request headers to be preserved in response if request has not reached backend */
+    private List<String> preserveRequestHeaders = new ArrayList<String>();
+
+    /**
+     * Processes the request as it is.
+     *
+     * @param synCtx Synapse Message Context
+     * @return true
+     */
+    public boolean handleRequestInFlow(MessageContext synCtx) {
+        return true;
+    }
+
+    /**
+     * Removes any standard well known response headers present in the request outgoing.
+     *
+     * @param synCtx Synapse Message Context
+     * @return true
+     */
+    public boolean handleRequestOutFlow(MessageContext synCtx) {
+	if (log.isDebugEnabled()) {
+            log.debug("Starting to remove standard Response headers defined from the request out flow.");
+	}
+        //Remove all the standard well known response headers from the request outgoing
+        TransportHeaderUtil.removeTransportHeadersFromList(synCtx, this.standardResponseHeaders);
+        TransportHeaderUtil.removeExcessTransportHeadersFromList(synCtx, this.standardResponseHeaders);
+	if (log.isDebugEnabled()) {
+            log.debug("Removing headers completed in request out flow");
+	}
+        return true;
+    }
+
+    /**
+     * Sets a flag in the Message Context to identify that the message has gone to Response Inflow
+     *
+     * @param synCtx Synapse Message Context
+     * @return true
+     */
+    public boolean handleResponseInFlow(MessageContext synCtx) {
+        synCtx.setProperty(TransportHeaderUtil.RESPONSE_INFLOW_INVOKED, Boolean.TRUE);
+        return true;
+    }
+
+    /**
+     * Removes standard well known request headers from the final response.
+     * Removes all the headers present in the request if the request has not reached the backend.
+     *
+     * @param synCtx Synapse Message Context
+     * @return true
+     */
+    public boolean handleResponseOutFlow(MessageContext synCtx) {
+	if (log.isDebugEnabled()) {
+            log.debug("Starting to remove standard Request headers defined from the response out flow.");
+	}
+        //Remove all the standard well known request headers from the final response
+        TransportHeaderUtil.removeTransportHeadersFromList(synCtx, this.standardRequestHeaders);
+        TransportHeaderUtil.removeExcessTransportHeadersFromList(synCtx, this.standardRequestHeaders);
+	if (log.isDebugEnabled()) {
+            log.debug("Removing headers completed in response out flow");
+	}
+        if (this.isRemoveRequestHeadersOnFaultEnabled) {
+            //Remove all the headers present in the request if the request has not reached the backend.
+            NHttpConnection sourceHttpConnection =
+                    (NHttpConnection)((Axis2MessageContext)synCtx).getAxis2MessageContext().
+                            getProperty(TransportHeaderUtil.PASSTHROUGH_SOURCE_CONNECTION);
+            SourceRequest sourceRequest = SourceContext.getRequest(sourceHttpConnection);
+            if (TransportHeaderUtil.isRemovingRequestHeadersInResponseRequired(synCtx, sourceRequest)) {
+                TransportHeaderUtil.removeRequestHeadersFromResponseHeaders(
+                        sourceRequest.getHeaders(), TransportHeaderUtil.getTransportHeaders(synCtx),
+                        this.preserveRequestHeaders);
+                TransportHeaderUtil.removeRequestHeadersFromResponseHeaders(
+                        sourceRequest.getExcessHeaders(), TransportHeaderUtil.getExcessTransportHeaders(synCtx),
+                        this.preserveRequestHeaders);
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Populates the standard request headers  to be excluded.
+     * By default list is empty
+     *
+     * @param excludeHeaders Comma separated header list
+     */
+    public void setExcludeRequestHeaders(String excludeHeaders) {
+        this.standardRequestHeaders = TransportHeaderUtil.populateStandardHeaders(excludeHeaders);
+    }
+
+    /**
+     * Populates the standard response headers  to be excluded.
+     * By default list is empty
+     *
+     * @param excludeHeaders Comma separated header list
+     */
+    public void setExcludeResponseHeaders(String excludeHeaders) {
+        this.standardResponseHeaders = TransportHeaderUtil.populateStandardHeaders(excludeHeaders);
+    }
+
+    /**
+     * Populates headers to be preserved when removing request headers in response.
+     * By default list is empty
+     *
+     * @param preserveHeaders Comma separated header list
+     */
+    public void setPreserveRequestHeaders(String preserveHeaders) {
+        this.preserveRequestHeaders = TransportHeaderUtil.populateStandardHeaders(preserveHeaders);
+    }
+
+    /**
+     * Enables/Disables removing request headers in response. By default it is disabled.
+     *
+     * @param isEnable Boolean flag
+     */
+    public void setRemoveRequestHeaders(boolean isEnable) {
+        this.isRemoveRequestHeadersOnFaultEnabled = isEnable;
+    }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/TransportHeaderUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/TransportHeaderUtil.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.gateway.utils;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.transport.nhttp.NhttpConstants;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.apache.synapse.transport.passthru.SourceRequest;
+import org.apache.synapse.transport.passthru.util.PassThroughTransportUtils;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class TransportHeaderUtil {
+    private static final Log log = LogFactory.getLog(TransportHeaderUtil.class);
+
+    public static final String PASSTHROUGH_SOURCE_CONNECTION = "pass-through.Source-Connection";
+    public static final String RESPONSE_INFLOW_INVOKED = "HANDLER_INTERNAL_RESPONSE_INFLOW_INVOKED";
+
+    /**
+     * Populates standard request headers from comma separate string.
+     *
+     * @param standardHeadersStr Comma separated preserve enable http headers
+     * @return list of parsed headers from the given header object
+     */
+    public static List<String> populateStandardHeaders(String standardHeadersStr) {
+        List<String> standardHeaders = new ArrayList<String>();
+        if (StringUtils.isNotEmpty(standardHeadersStr)) {
+            String[] headerList = standardHeadersStr.trim().split(",");
+            for (String header: headerList) {
+                standardHeaders.add(header.trim());
+            }
+        }
+        return standardHeaders;
+    }
+
+    /**
+     * Removes the provided headers from the Transport Headers list in synCtx.
+     *
+     * @param synCtx            Synapse Message Context
+     * @param removableHeaders  Header list that needs to be removed
+     */
+    public static void removeTransportHeadersFromList(MessageContext synCtx, List<String> removableHeaders) {
+        Map<String, String> transportHeaders = getTransportHeaders(synCtx);
+        for (String header : removableHeaders) {
+            if (transportHeaders.containsKey(header)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("'" + header + "' is removed from the Transport header list");
+                }
+                transportHeaders.remove(header);
+            }
+        }
+    }
+
+    /**
+     * Removes the provided headers from the Excess Transport Headers list in synCtx.
+     *
+     * @param synCtx            Synapse Message Context
+     * @param removableHeaders  Header list that needs to be removed
+     */
+    public static void removeExcessTransportHeadersFromList(MessageContext synCtx, List<String> removableHeaders) {
+        Map<String, String> excessTransportHeaders = getExcessTransportHeaders(synCtx);
+        Iterator<String> headerIter = excessTransportHeaders.keySet().iterator();
+        while (headerIter.hasNext()) {
+            String headerName = headerIter.next();
+            for (String removableHeader : removableHeaders) {
+                if (removableHeader.equalsIgnoreCase(headerName)) {
+                    headerIter.remove();
+                    if (log.isDebugEnabled()) {
+                        log.debug("'" + headerName + "' is removed from the Excess Transport header list");
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Removes the header set from one map from another.
+     *
+     * @param requestHeaders           Headers present in request
+     * @param responseHeaders   Headers present in the response
+     * @param preserveHeaders   Headers to be preserved
+     */
+    public static void removeRequestHeadersFromResponseHeaders(Map requestHeaders, Map responseHeaders,
+                                                               List<String> preserveHeaders) {
+        for (Object headerObj : requestHeaders.keySet()) {
+            String headerName = (String) headerObj;
+            if (!preserveHeaders.contains(headerName) && responseHeaders.containsKey(headerName)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Request header '" + headerName + "' is removed from the Response");
+                }
+                responseHeaders.remove(headerName);
+            }
+        }
+    }
+
+    /**
+     * Axis2 Message Context has two lists of transport headers: TransportHeaders and ExcessTransportHeaders
+     * This method returns TransportHeaders.
+     *
+     * @param synCtx Synapse Message Context
+     * @return map of Transport headers present in Axis2 Message Context
+     */
+    public static Map getTransportHeaders(MessageContext synCtx) {
+        return (Map)((Axis2MessageContext) synCtx).getAxis2MessageContext().
+                getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
+    }
+
+    /**
+     * Axis2 Message Context has two lists of transport headers: TransportHeaders and ExcessTransportHeaders
+     * This method returns ExcessTransportHeaders
+     *
+     * @param synCtx Synapse Message Context
+     * @return map of Excess Transport headers present in Axis2 Message Context
+     */
+    public static Map getExcessTransportHeaders(MessageContext synCtx) {
+        return (Map)((Axis2MessageContext) synCtx).getAxis2MessageContext().
+                getProperty(NhttpConstants.EXCESS_TRANSPORT_HEADERS);
+    }
+
+    /**
+     * Determines whether Response headers must be removed in response
+     *
+     * @param synCtx Synapse message context
+     * @param request Source Request retrieved from the message context
+     * @return true or false
+     */
+    public static boolean isRemovingRequestHeadersInResponseRequired(MessageContext synCtx, SourceRequest request) {
+        if (PassThroughConstants.HTTP_OPTIONS.equals(request.getMethod())) {
+            return true;
+        }
+        int httpSc = PassThroughTransportUtils.determineHttpStatusCode(
+                ((Axis2MessageContext) synCtx).getAxis2MessageContext());
+        return synCtx.getProperty(TransportHeaderUtil.RESPONSE_INFLOW_INVOKED) == null && httpSc >= 400;
+    }
+}
+


### PR DESCRIPTION
This PR adds **TransportHeaderHandler** to the gateway component.

**TransportHeaderHandler** is a global synapse handler which can be used to filter out the request and response headers in WSO2 API Manager.

The following configurations will be added to <APIM_HOME>/repository/conf/synapse-handlers.xml file to enable the handler when invoking an API.

```
<handler name = "TransportHeaderHandler" class="org.wso2.carbon.apimgt.gateway.handlers.common.TransportHeaderHandler">
    <parameter name="removeRequestHeaders" value="true"/>
    <parameter name="preserveRequestHeaders" value=""/>
    <parameter name="excludeRequestHeaders" value=""/>
    <parameter name="excludeResponseHeaders" value=""/>
</handler>
```

### Configuration

Parameter Name | Description
-- | --
removeRequestHeaders | true or false indicating whether to remove the Request headers from the response in a failure scenario. For OPTIONS call, request headers will always be removed. Default value is false
preserveRequestHeaders | Comma separated List of headers preserved while removing request headers from the response. Default is empty. This list of headers will be preserved only when removeRequestHeaders is set to true
excludeRequestHeaders | Comma separated List of well known request headers that should be removed in a Response to the client. Default list is empty.
excludeResponseHeaders | Comma separated List of well known response headers that should be removed in a Request sent to backend. Default list is empty