### PR TITLE
Restructuring functionalities to Export/Import an Application with new schemas with relevant DTOs for APICTL

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -176,10 +176,6 @@ public final class ImportExportConstants {
 
     public static final String ENDPOINT_CUSTOM_PARAMETERS = "customParameters";
 
-    public static final String APPLICATION_KEY_TYPE_SANDBOX = "SANDBOX";
-
-    public static final String APPLICATION_KEY_TYPE_PRODUCTION = "PRODUCTION";
-
     public static final String UPLOAD_APPLICATION_FILE_NAME = "ApplicationArchive.zip";
 
     // Location of the Application YAML file

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -162,6 +162,8 @@ public final class ImportExportConstants {
 
     public static final String TYPE_API_PRODUCT = "api_product";
 
+    public static final String TYPE_APPLICATION = "application";
+
     public static final String TYPE_DOCUMENTS = "document";
 
     public static final String TYPE_ENDPOINT_CERTIFICATES = "endpoint_certificates";
@@ -173,6 +175,10 @@ public final class ImportExportConstants {
     public static final String ENDPOINT_CONFIG = "endpointConfig";
 
     public static final String ENDPOINT_CUSTOM_PARAMETERS = "customParameters";
+
+    public static final String APPLICATION_KEY_TYPE_SANDBOX = "SANDBOX";
+
+    public static final String APPLICATION_KEY_TYPE_PRODUCTION = "PRODUCTION";
 
     //Api controller Env Params related constants
     public static final String YAML_API_PARAMS_FILE_LOCATION = File.separator + "api_params.yaml";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -71,7 +71,7 @@ public final class ImportExportConstants {
 
     public static final Map<String, String> fileExtensionMapping = new HashMap<>();
 
-    public static final String UPLOAD_FILE_NAME = "APIArchive.zip";
+    public static final String UPLOAD_API_FILE_NAME = "APIArchive.zip";
 
     // Location of the API YAML file
     public static final String YAML_API_FILE_LOCATION = File.separator + "api.yaml";
@@ -179,6 +179,14 @@ public final class ImportExportConstants {
     public static final String APPLICATION_KEY_TYPE_SANDBOX = "SANDBOX";
 
     public static final String APPLICATION_KEY_TYPE_PRODUCTION = "PRODUCTION";
+
+    public static final String UPLOAD_APPLICATION_FILE_NAME = "ApplicationArchive.zip";
+
+    // Location of the Application YAML file
+    public static final String YAML_APPLICATION_FILE_LOCATION = File.separator + "application.yaml";
+
+    // Location of the Application JSON file
+    public static final String JSON_APPLICATION_FILE_LOCATION = File.separator + "application.json";
 
     //Api controller Env Params related constants
     public static final String YAML_API_PARAMS_FILE_LOCATION = File.separator + "api_params.yaml";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/CommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/CommonUtil.java
@@ -469,4 +469,22 @@ public class CommonUtil {
         String jsonContent = gson.toJson(jsonObject);
         writeToYamlOrJson(filePath, exportFormat, jsonContent);
     }
+
+    /**
+     * Extract the imported archive to a temporary folder and return the folder path of it
+     *
+     * @param uploadedInputStream Input stream from the REST request
+     * @return Path to the extracted directory
+     * @throws APIImportExportException If an error occurs while creating the directory, transferring files or
+     *                                  extracting the content
+     */
+    public static String getArchivePathOfExtractedDirectory(InputStream uploadedInputStream, String uploadFileName)
+            throws APIImportExportException {
+        // Temporary directory is used to create the required folders
+        File importFolder = CommonUtil.createTempDirectory(null);
+        String absolutePath = importFolder.getAbsolutePath() + File.separator;
+        CommonUtil.transferFile(uploadedInputStream, uploadFileName, absolutePath);
+        String extractedFolderName = CommonUtil.extractArchive(new File(absolutePath + uploadFileName), absolutePath);
+        return absolutePath + extractedFolderName;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/CommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/CommonUtil.java
@@ -25,6 +25,10 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.apache.commons.io.FileUtils;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.logging.Log;
@@ -34,6 +38,8 @@ import org.wso2.carbon.apimgt.api.model.Identifier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.importexport.APIImportExportConstants;
 import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
+import org.wso2.carbon.apimgt.impl.importexport.ExportFormat;
+import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -407,5 +413,60 @@ public class CommonUtil {
             String errorMessage = "Error while moving file from " + sourceDir + " to " + destDir;
             throw new APIImportExportException(errorMessage, e);
         }
+    }
+
+
+    /**
+     * Add the type and the version to the artifact file when exporting.
+     *
+     * @param type        Type of the artifact to be exported
+     * @param version     API Manager version
+     * @param jsonElement JSON element to be added as data
+     */
+    public static JsonObject addTypeAndVersionToFile(String type, String version, JsonElement jsonElement) {
+
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty(APIConstants.TYPE, type);
+        jsonObject.addProperty(APIConstants.API_DATA_VERSION, version);
+        jsonObject.add(APIConstants.DATA, jsonElement);
+        return jsonObject;
+    }
+
+    /**
+     * Write the file content of an API or API related artifact based on the format.
+     *
+     * @param filePath     Path to the location where the file content should be written
+     * @param exportFormat Format to be exported
+     * @param fileContent  Content to be written
+     */
+    public static void writeToYamlOrJson(String filePath, ExportFormat exportFormat, String fileContent)
+            throws APIImportExportException, IOException {
+
+        switch (exportFormat) {
+        case YAML:
+            String fileInYaml = jsonToYaml(fileContent);
+            writeFile(filePath + ImportExportConstants.YAML_EXTENSION, fileInYaml);
+            break;
+        case JSON:
+            writeFile(filePath + ImportExportConstants.JSON_EXTENSION, fileContent);
+        }
+    }
+
+    /**
+     * Write the DTO an artifact based on the format.
+     *
+     * @param filePath     Path to the location where the file content should be written
+     * @param exportFormat Format to be exported
+     * @param type         Type of the file to be written
+     * @param dtoObject    DTO object
+     */
+    public static void writeDtoToFile(String filePath, ExportFormat exportFormat, String type, Object dtoObject)
+            throws APIImportExportException, IOException {
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        JsonObject jsonObject = addTypeAndVersionToFile(type, ImportExportConstants.APIM_VERSION,
+                gson.toJsonTree(dtoObject));
+        String jsonContent = gson.toJson(jsonObject);
+        writeToYamlOrJson(filePath, exportFormat, jsonContent);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/CommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/utils/CommonUtil.java
@@ -422,6 +422,7 @@ public class CommonUtil {
      * @param type        Type of the artifact to be exported
      * @param version     API Manager version
      * @param jsonElement JSON element to be added as data
+     * @return The artifact object with the type and version added to it
      */
     public static JsonObject addTypeAndVersionToFile(String type, String version, JsonElement jsonElement) {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -814,7 +814,7 @@ public class APIControllerUtil {
         //generate meta-data yaml file
         String metadataFilePath = pathToArchive + ImportExportConstants.CLIENT_CERTIFICATES_META_DATA_FILE_PATH;
         try {
-            ExportUtils.writeDtoToFile(metadataFilePath, ExportFormat.JSON,
+            CommonUtil.writeDtoToFile(metadataFilePath, ExportFormat.JSON,
                     ImportExportConstants.TYPE_ENDPOINT_CERTIFICATES, jsonElement);
         } catch (APIImportExportException e) {
             throw new APIManagementException(e);
@@ -875,7 +875,7 @@ public class APIControllerUtil {
         //generate meta-data yaml file
         String metadataFilePath = pathToArchive + ImportExportConstants.ENDPOINT_CERTIFICATES_META_DATA_FILE_PATH;
         try {
-            ExportUtils.writeDtoToFile(metadataFilePath, ExportFormat.JSON,
+            CommonUtil.writeDtoToFile(metadataFilePath, ExportFormat.JSON,
                     ImportExportConstants.TYPE_ENDPOINT_CERTIFICATES, updatedCertsArray);
         } catch (APIImportExportException e) {
             throw new APIManagementException(e);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -21,7 +21,6 @@ package org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
@@ -405,7 +404,7 @@ public class ExportUtils {
                                 APIUtil.getAPIOrAPIProductDocPath(identifier) + APIConstants.INLINE_DOCUMENT_CONTENT_DIR
                                         + RegistryConstants.PATH_SEPARATOR + localFileName;
                     }
-                    writeDtoToFile(individualDocDirectoryPath + ImportExportConstants.DOCUMENT_FILE_NAME, exportFormat,
+                    CommonUtil.writeDtoToFile(individualDocDirectoryPath + ImportExportConstants.DOCUMENT_FILE_NAME, exportFormat,
                             ImportExportConstants.TYPE_DOCUMENTS,
                             DocumentationMappingUtil.fromDocumentationToDTO(individualDocument));
 
@@ -637,7 +636,7 @@ public class ExportUtils {
                 endpointCertificatesDetails.addAll(certificateListOfUrl);
             }
             if (endpointCertificatesDetails.size() > 0) {
-                writeDtoToFile(endpointCertsDirectoryPath + ImportExportConstants.ENDPOINTS_CERTIFICATE_FILE,
+                CommonUtil.writeDtoToFile(endpointCertsDirectoryPath + ImportExportConstants.ENDPOINTS_CERTIFICATE_FILE,
                         exportFormat, ImportExportConstants.TYPE_ENDPOINT_CERTIFICATES, endpointCertificatesDetails);
             } else if (log.isDebugEnabled()) {
                 log.debug("No endpoint certificates available for API: " + apiDto.getName() + StringUtils.SPACE
@@ -781,7 +780,7 @@ public class ExportUtils {
                 if (!APIConstants.APITransportType.GRAPHQL.toString().equalsIgnoreCase(apiType)) {
                     String formattedSwaggerJson = RestApiCommonUtil.retrieveSwaggerDefinition(
                             APIMappingUtil.fromDTOtoAPI(apiDtoToReturn, apiDtoToReturn.getProvider()), apiProvider);
-                    writeToYamlOrJson(archivePath + ImportExportConstants.SWAGGER_DEFINITION_LOCATION, exportFormat,
+                    CommonUtil.writeToYamlOrJson(archivePath + ImportExportConstants.SWAGGER_DEFINITION_LOCATION, exportFormat,
                             formattedSwaggerJson);
                 }
                 if (log.isDebugEnabled()) {
@@ -789,7 +788,7 @@ public class ExportUtils {
                             + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": " + apiDtoToReturn.getVersion());
                 }
             }
-            writeDtoToFile(archivePath + ImportExportConstants.API_FILE_LOCATION, exportFormat,
+            CommonUtil.writeDtoToFile(archivePath + ImportExportConstants.API_FILE_LOCATION, exportFormat,
                     ImportExportConstants.TYPE_API, apiDtoToReturn);
         } catch (APIManagementException e) {
             throw new APIImportExportException(
@@ -832,7 +831,7 @@ public class ExportUtils {
                         clientCertsDirectoryPath);
 
                 if (certificateList.size() > 0) {
-                    writeDtoToFile(clientCertsDirectoryPath + ImportExportConstants.CLIENT_CERTIFICATE_FILE,
+                    CommonUtil.writeDtoToFile(clientCertsDirectoryPath + ImportExportConstants.CLIENT_CERTIFICATE_FILE,
                             exportFormat, ImportExportConstants.TYPE_CLIENT_CERTIFICATES, certificateList);
                 }
             }
@@ -893,14 +892,14 @@ public class ExportUtils {
         try {
             String formattedSwaggerJson = apiProvider.getAPIDefinitionOfAPIProduct(
                     APIMappingUtil.fromDTOtoAPIProduct(apiProductDtoToReturn, apiProductDtoToReturn.getProvider()));
-            writeToYamlOrJson(archivePath + ImportExportConstants.SWAGGER_DEFINITION_LOCATION, exportFormat,
+            CommonUtil.writeToYamlOrJson(archivePath + ImportExportConstants.SWAGGER_DEFINITION_LOCATION, exportFormat,
                     formattedSwaggerJson);
 
             if (log.isDebugEnabled()) {
                 log.debug(
                         "Meta information retrieved successfully for API Product: " + apiProductDtoToReturn.getName());
             }
-            writeDtoToFile(archivePath + ImportExportConstants.API_FILE_LOCATION, exportFormat,
+            CommonUtil.writeDtoToFile(archivePath + ImportExportConstants.API_FILE_LOCATION, exportFormat,
                     ImportExportConstants.TYPE_API_PRODUCT, apiProductDtoToReturn);
         } catch (APIManagementException e) {
             throw new APIImportExportException(
@@ -942,57 +941,4 @@ public class ExportUtils {
         }
     }
 
-    /**
-     * Add the type and the version to the artifact file when exporting.
-     *
-     * @param type        Type of the artifact to be exported
-     * @param version     API Manager version
-     * @param jsonElement JSON element to be added as data
-     */
-    public static JsonObject addTypeAndVersionToFile(String type, String version, JsonElement jsonElement) {
-
-        JsonObject jsonObject = new JsonObject();
-        jsonObject.addProperty(APIConstants.TYPE, type);
-        jsonObject.addProperty(APIConstants.API_DATA_VERSION, version);
-        jsonObject.add(APIConstants.DATA, jsonElement);
-        return jsonObject;
-    }
-
-    /**
-     * Write the DTO an artifact based on the format.
-     *
-     * @param filePath     Path to the location where the file content should be written
-     * @param exportFormat Format to be exported
-     * @param type         Type of the file to be written
-     * @param dtoObject    DTO object
-     */
-    public static void writeDtoToFile(String filePath, ExportFormat exportFormat, String type, Object dtoObject)
-            throws APIImportExportException, IOException {
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        JsonObject jsonObject = addTypeAndVersionToFile(type, ImportExportConstants.APIM_VERSION,
-                gson.toJsonTree(dtoObject));
-        String jsonContent = gson.toJson(jsonObject);
-        writeToYamlOrJson(filePath, exportFormat, jsonContent);
-    }
-
-    /**
-     * Write the file content of an API or API related artifact based on the format.
-     *
-     * @param filePath     Path to the location where the file content should be written
-     * @param exportFormat Format to be exported
-     * @param fileContent  Content to be written
-     */
-    public static void writeToYamlOrJson(String filePath, ExportFormat exportFormat, String fileContent)
-            throws APIImportExportException, IOException {
-
-        switch (exportFormat) {
-        case YAML:
-            String fileInYaml = CommonUtil.jsonToYaml(fileContent);
-            CommonUtil.writeFile(filePath + ImportExportConstants.YAML_EXTENSION, fileInYaml);
-            break;
-        case JSON:
-            CommonUtil.writeFile(filePath + ImportExportConstants.JSON_EXTENSION, fileContent);
-        }
-    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -407,7 +407,7 @@ public class ImportUtils {
             throws APIImportExportException {
         // Temporary directory is used to create the required folders
         File importFolder = CommonUtil.createTempDirectory(null);
-        String uploadFileName = ImportExportConstants.UPLOAD_FILE_NAME;
+        String uploadFileName = ImportExportConstants.UPLOAD_API_FILE_NAME;
         String absolutePath = importFolder.getAbsolutePath() + File.separator;
         CommonUtil.transferFile(uploadedInputStream, uploadFileName, absolutePath);
         String extractedFolderName = CommonUtil.extractArchive(new File(absolutePath + uploadFileName), absolutePath);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApplicationsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApplicationsApi.java
@@ -13,6 +13,7 @@ import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationTokenDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationTokenGenerateRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ErrorDTO;
+import java.io.File;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.WorkflowResponseDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.ApplicationsApiService;
 import org.wso2.carbon.apimgt.rest.api.store.v1.impl.ApplicationsApiServiceImpl;
@@ -409,6 +410,24 @@ ApplicationsApiService delegate = new ApplicationsApiServiceImpl();
         @ApiResponse(code = 412, message = "Precondition Failed. The request has not been performed because one of the preconditions is not met.", response = ErrorDTO.class) })
     public Response applicationsApplicationIdPut(@ApiParam(value = "Application Identifier consisting of the UUID of the Application. ",required=true) @PathParam("applicationId") String applicationId, @ApiParam(value = "Application object that needs to be updated " ,required=true) ApplicationDTO applicationDTO,  @ApiParam(value = "Validator for conditional requests; based on ETag. " )@HeaderParam("If-Match") String ifMatch) throws APIManagementException{
         return delegate.applicationsApplicationIdPut(applicationId, applicationDTO, ifMatch, securityContext);
+    }
+
+    @GET
+    @Path("/export")
+    
+    @Produces({ "application/zip", "application/json" })
+    @ApiOperation(value = "Export an Application", notes = "This operation can be used to export the details of a particular application as a zip file. ", response = File.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:app_import_export", description = "Import and export applications related operations")
+        })
+    }, tags={ "Import Export",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Export Successful. ", response = File.class),
+        @ApiResponse(code = 400, message = "Bad Request. Invalid request or validation error.", response = ErrorDTO.class),
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
+        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class) })
+    public Response applicationsExportGet( @NotNull @ApiParam(value = "Application Name ",required=true)  @QueryParam("appName") String appName,  @NotNull @ApiParam(value = "Owner of the Application ",required=true)  @QueryParam("appOwner") String appOwner,  @ApiParam(value = "Export application keys ")  @QueryParam("withKeys") Boolean withKeys,  @ApiParam(value = "Format of output documents. Can be YAML or JSON. ", allowableValues="JSON, YAML")  @QueryParam("format") String format) throws APIManagementException{
+        return delegate.applicationsExportGet(appName, appOwner, withKeys, format, securityContext);
     }
 
     @GET

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApplicationsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApplicationsApi.java
@@ -1,9 +1,11 @@
 package org.wso2.carbon.apimgt.rest.api.store.v1;
 
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIInfoListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIKeyDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIKeyGenerateRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIKeyRevokeRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationKeyDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationKeyGenerateRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationKeyListDTO;
@@ -448,6 +450,24 @@ ApplicationsApiService delegate = new ApplicationsApiServiceImpl();
         @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class) })
     public Response applicationsGet( @ApiParam(value = "Application Group Id ")  @QueryParam("groupId") String groupId,  @ApiParam(value = "**Search condition**.  You can search for an application by specifying the name as \"query\" attribute.  Eg. \"app1\" will match an application if the name is exactly \"app1\".  Currently this does not support wildcards. Given name must exactly match the application name. ")  @QueryParam("query") String query,  @ApiParam(value = "", allowableValues="name, throttlingPolicy, status")  @QueryParam("sortBy") String sortBy,  @ApiParam(value = "", allowableValues="asc, desc")  @QueryParam("sortOrder") String sortOrder,  @ApiParam(value = "Maximum size of resource array to return. ", defaultValue="25") @DefaultValue("25") @QueryParam("limit") Integer limit,  @ApiParam(value = "Starting point within the complete list of items qualified. ", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset,  @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved variant of the resourec. " )@HeaderParam("If-None-Match") String ifNoneMatch) throws APIManagementException{
         return delegate.applicationsGet(groupId, query, sortBy, sortOrder, limit, offset, ifNoneMatch, securityContext);
+    }
+
+    @POST
+    @Path("/import")
+    @Consumes({ "multipart/form-data" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Import an Application", notes = "This operation can be used to import an application. ", response = ApplicationInfoDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:app_import_export", description = "Import and export applications related operations")
+        })
+    }, tags={ "Application (Individual)",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Successful response with the updated object information as entity in the body. ", response = ApplicationInfoDTO.class),
+        @ApiResponse(code = 207, message = "Multi Status. Partially successful response with skipped APIs information object as entity in the body. ", response = APIInfoListDTO.class),
+        @ApiResponse(code = 400, message = "Bad Request. Invalid request or validation error.", response = ErrorDTO.class),
+        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class) })
+    public Response applicationsImportPost( @Multipart(value = "file") InputStream fileInputStream, @Multipart(value = "file" ) Attachment fileDetail,  @ApiParam(value = "Preserve Original Creator of the Application ")  @QueryParam("preserveOwner") Boolean preserveOwner,  @ApiParam(value = "Skip importing Subscriptions of the Application ")  @QueryParam("skipSubscriptions") Boolean skipSubscriptions,  @ApiParam(value = "Expected Owner of the Application in the Import Environment ")  @QueryParam("appOwner") String appOwner,  @ApiParam(value = "Skip importing Keys of the Application ")  @QueryParam("skipApplicationKeys") Boolean skipApplicationKeys,  @ApiParam(value = "Update if application exists ")  @QueryParam("update") Boolean update) throws APIManagementException{
+        return delegate.applicationsImportPost(fileInputStream, fileDetail, preserveOwner, skipSubscriptions, appOwner, skipApplicationKeys, update, securityContext);
     }
 
     @POST

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApplicationsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApplicationsApiService.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationTokenDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationTokenGenerateRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ErrorDTO;
+import java.io.File;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.WorkflowResponseDTO;
 
 import java.util.List;
@@ -52,6 +53,7 @@ public interface ApplicationsApiService {
       public Response applicationsApplicationIdOauthKeysKeyMappingIdPut(String applicationId, String keyMappingId, ApplicationKeyDTO applicationKeyDTO, MessageContext messageContext) throws APIManagementException;
       public Response applicationsApplicationIdOauthKeysKeyMappingIdRegenerateSecretPost(String applicationId, String keyMappingId, MessageContext messageContext) throws APIManagementException;
       public Response applicationsApplicationIdPut(String applicationId, ApplicationDTO applicationDTO, String ifMatch, MessageContext messageContext) throws APIManagementException;
+      public Response applicationsExportGet(String appName, String appOwner, Boolean withKeys, String format, MessageContext messageContext) throws APIManagementException;
       public Response applicationsGet(String groupId, String query, String sortBy, String sortOrder, Integer limit, Integer offset, String ifNoneMatch, MessageContext messageContext) throws APIManagementException;
       public Response applicationsPost(ApplicationDTO applicationDTO, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApplicationsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApplicationsApiService.java
@@ -9,10 +9,12 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 
 import org.wso2.carbon.apimgt.api.APIManagementException;
 
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIInfoListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIKeyDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIKeyGenerateRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIKeyRevokeRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationKeyDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationKeyGenerateRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationKeyListDTO;
@@ -55,5 +57,6 @@ public interface ApplicationsApiService {
       public Response applicationsApplicationIdPut(String applicationId, ApplicationDTO applicationDTO, String ifMatch, MessageContext messageContext) throws APIManagementException;
       public Response applicationsExportGet(String appName, String appOwner, Boolean withKeys, String format, MessageContext messageContext) throws APIManagementException;
       public Response applicationsGet(String groupId, String query, String sortBy, String sortOrder, Integer limit, Integer offset, String ifNoneMatch, MessageContext messageContext) throws APIManagementException;
+      public Response applicationsImportPost(InputStream fileInputStream, Attachment fileDetail, Boolean preserveOwner, Boolean skipSubscriptions, String appOwner, Boolean skipApplicationKeys, Boolean update, MessageContext messageContext) throws APIManagementException;
       public Response applicationsPost(ApplicationDTO applicationDTO, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIInfoListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIInfoListDTO.java
@@ -1,0 +1,106 @@
+package org.wso2.carbon.apimgt.rest.api.store.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIInfoDTO;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class APIInfoListDTO   {
+  
+    private Integer count = null;
+    private List<APIInfoDTO> list = new ArrayList<APIInfoDTO>();
+
+  /**
+   * Number of API Info objects returned. 
+   **/
+  public APIInfoListDTO count(Integer count) {
+    this.count = count;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "1", value = "Number of API Info objects returned. ")
+  @JsonProperty("count")
+  public Integer getCount() {
+    return count;
+  }
+  public void setCount(Integer count) {
+    this.count = count;
+  }
+
+  /**
+   **/
+  public APIInfoListDTO list(List<APIInfoDTO> list) {
+    this.list = list;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("list")
+  public List<APIInfoDTO> getList() {
+    return list;
+  }
+  public void setList(List<APIInfoDTO> list) {
+    this.list = list;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    APIInfoListDTO apIInfoList = (APIInfoListDTO) o;
+    return Objects.equals(count, apIInfoList.count) &&
+        Objects.equals(list, apIInfoList.list);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(count, list);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class APIInfoListDTO {\n");
+    
+    sb.append("    count: ").append(toIndentedString(count)).append("\n");
+    sb.append("    list: ").append(toIndentedString(list)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
@@ -46,10 +46,8 @@ import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerFactory;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
-import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
 import org.wso2.carbon.apimgt.impl.importexport.ExportFormat;
 import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
-import org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.ApplicationsApiService;
@@ -343,7 +341,8 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
      * @param withKeys Export keys with application
      * @return Zip file containing exported Application
      */
-    @Override public Response applicationsExportGet(String appName, String appOwner, Boolean withKeys, String format,
+    @Override
+    public Response applicationsExportGet(String appName, String appOwner, Boolean withKeys, String format,
             MessageContext messageContext) throws APIManagementException {
         APIConsumer apiConsumer;
         Application application = null;
@@ -375,7 +374,7 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
         // clear all duplicate keys with tokens
         application.getKeys().clear();
 
-        // export keys for application
+        // Export keys for application
         if (withKeys == null || !withKeys) {
             application.clearOAuthApps();
         } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
@@ -21,20 +21,25 @@ package org.wso2.carbon.apimgt.rest.api.store.v1.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.jaxrs.ext.MessageContext;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.APIMgtResourceAlreadyExistsException;
 import org.wso2.carbon.apimgt.api.EmptyCallbackURLForCodeGrantsException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIKey;
 import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
 import org.wso2.carbon.apimgt.api.model.Application;
@@ -46,15 +51,19 @@ import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerFactory;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
 import org.wso2.carbon.apimgt.impl.importexport.ExportFormat;
 import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
+import org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.ApplicationsApiService;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIInfoListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIKeyDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIKeyGenerateRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIKeyRevokeRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationKeyDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationKeyGenerateRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationKeyListDTO;
@@ -64,16 +73,23 @@ import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationTokenDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationTokenGenerateRequestDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.PaginationDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ScopeInfoDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.mappings.APIInfoMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.mappings.ApplicationKeyMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.mappings.ApplicationMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
+import org.wso2.carbon.apimgt.rest.api.store.v1.models.ExportedApplication;
 import org.wso2.carbon.apimgt.rest.api.store.v1.utils.ExportUtils;
+import org.wso2.carbon.apimgt.rest.api.store.v1.utils.ImportUtils;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestAPIStoreUtils;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -152,6 +168,142 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
     }
 
     /**
+     * Import an Application which has been exported to a zip file
+     *
+     * @param appOwner            target owner of the application
+     * @param preserveOwner       if true, preserve the original owner of the application
+     * @param skipSubscriptions   if true, skip subscriptions of the application
+     * @param fileInputStream     content stream of the zip file which contains exported Application
+     * @param fileDetail          meta information of the zip file
+     * @param skipApplicationKeys Skip application keys while importing
+     * @param update              update if existing application found or import
+     * @return imported Application
+     */
+    @Override public Response applicationsImportPost(InputStream fileInputStream, Attachment fileDetail,
+            Boolean preserveOwner, Boolean skipSubscriptions, String appOwner, Boolean skipApplicationKeys,
+            Boolean update, MessageContext messageContext) throws APIManagementException {
+        String ownerId;
+        Application application;
+
+        try {
+            String username = RestApiCommonUtil.getLoggedInUsername();
+            APIConsumer apiConsumer = RestApiCommonUtil.getConsumer(username);
+            String extractedFolderPath = CommonUtil.getArchivePathOfExtractedDirectory(fileInputStream,
+                    ImportExportConstants.UPLOAD_APPLICATION_FILE_NAME);
+            String jsonContent = ImportUtils.getApplicationDefinitionAsJson(extractedFolderPath);
+
+            // Retrieving the field "data" in api.yaml/json and convert it to a JSON object for further processing
+            JsonElement configElement = new JsonParser().parse(jsonContent).getAsJsonObject().get(APIConstants.DATA);
+            ExportedApplication exportedApplication = new Gson().fromJson(configElement, ExportedApplication.class);
+
+            // Retrieve the application DTO object from the aggregated exported application
+            ApplicationDTO applicationDTO = exportedApplication.getApplicationInfo();
+
+            if (!StringUtils.isBlank(appOwner)) {
+                ownerId = appOwner;
+            } else if (preserveOwner != null && preserveOwner) {
+                ownerId = applicationDTO.getOwner();
+            } else {
+                ownerId = username;
+            }
+            if (!MultitenantUtils.getTenantDomain(ownerId).equals(MultitenantUtils.getTenantDomain(username))) {
+                throw new APIManagementException("Cross Tenant Imports are not allowed",
+                        ExceptionCodes.TENANT_MISMATCH);
+            }
+
+            String applicationGroupId = String.join(",", applicationDTO.getGroups());
+
+            if (applicationDTO.getGroups() != null && applicationDTO.getGroups().size() > 0) {
+                ImportUtils.validateOwner(username, applicationGroupId, apiConsumer);
+            }
+
+            if (APIUtil.isApplicationExist(ownerId, applicationDTO.getName(), applicationGroupId) && update != null
+                    && update) {
+                int appId = APIUtil.getApplicationId(applicationDTO.getName(), ownerId);
+                Application oldApplication = apiConsumer.getApplicationById(appId);
+                application = preProcessAndUpdateApplication(ownerId, applicationDTO, oldApplication,
+                        oldApplication.getUUID());
+            } else {
+                application = preProcessAndAddApplication(ownerId, applicationDTO);
+            }
+
+            Map<String, Map<String, OAuthApplicationInfo>> oauthApplicationInfo = exportedApplication
+                    .getKeyManagerWiseOAuthApp();
+
+            // Decode Oauth secrets
+            Map<String, OAuthApplicationInfo> keyManagerWiseProductionOauthApplicationInfo = oauthApplicationInfo
+                    .get(ImportExportConstants.APPLICATION_KEY_TYPE_PRODUCTION);
+            if (keyManagerWiseProductionOauthApplicationInfo != null) {
+                keyManagerWiseProductionOauthApplicationInfo.forEach((keyManagerName, oAuthApplicationInfo) -> {
+                    String encodedConsumerSecretBytes = oAuthApplicationInfo.getClientSecret();
+                    String decodedConsumerSecret = new String(
+                            org.apache.commons.codec.binary.Base64.decodeBase64(encodedConsumerSecretBytes));
+                    oAuthApplicationInfo.setClientSecret(decodedConsumerSecret);
+                    APIKey apiKeyFromOauthApp = ImportUtils
+                            .getAPIKeyFromOauthApp(ImportExportConstants.APPLICATION_KEY_TYPE_PRODUCTION,
+                                    oAuthApplicationInfo);
+                    apiKeyFromOauthApp.setKeyManager(keyManagerName);
+                    application.addKey(apiKeyFromOauthApp);
+                });
+
+            }
+            Map<String, OAuthApplicationInfo> keyManagerWiseSandboxOauthApplicationInfo = oauthApplicationInfo
+                    .get(ImportExportConstants.APPLICATION_KEY_TYPE_SANDBOX);
+            if (keyManagerWiseSandboxOauthApplicationInfo != null) {
+                keyManagerWiseSandboxOauthApplicationInfo.forEach((keyManagerName, sandboxOAuthApplicationInfo) -> {
+                    String encodedConsumerSecretBytes = sandboxOAuthApplicationInfo.getClientSecret();
+                    String decodedConsumerSecret = new String(
+                            org.apache.commons.codec.binary.Base64.decodeBase64(encodedConsumerSecretBytes));
+                    sandboxOAuthApplicationInfo.setClientSecret(decodedConsumerSecret);
+                    APIKey apiKeyFromOauthApp = ImportUtils
+                            .getAPIKeyFromOauthApp(ImportExportConstants.APPLICATION_KEY_TYPE_SANDBOX,
+                                    sandboxOAuthApplicationInfo);
+                    apiKeyFromOauthApp.setKeyManager(keyManagerName);
+                    application.addKey(apiKeyFromOauthApp);
+                });
+            }
+
+            apiConsumer.updateApplication(application);
+
+            List<APIIdentifier> skippedAPIs = new ArrayList<>();
+            if (skipSubscriptions == null || !skipSubscriptions) {
+                skippedAPIs = ImportUtils
+                        .importSubscriptions(exportedApplication.getSubscribedAPIs(), ownerId, application.getId(),
+                                update, apiConsumer);
+            }
+            Application importedApplication = apiConsumer.getApplicationById(application.getId());
+            importedApplication.setOwner(ownerId);
+            ApplicationInfoDTO importedApplicationDTO = ApplicationMappingUtil
+                    .fromApplicationToInfoDTO(importedApplication);
+            URI location = new URI(
+                    RestApiConstants.RESOURCE_PATH_APPLICATIONS + "/" + importedApplicationDTO.getApplicationId());
+
+            // check whether keys need to be skipped while import
+            if (skipApplicationKeys == null || !skipApplicationKeys) {
+                // Add application keys if present and keys does not exists in the current application
+                if (application.getKeys().size() > 0 && importedApplication.getKeys().size() == 0) {
+                    for (APIKey apiKey : application.getKeys()) {
+                        ImportUtils.addApplicationKey(ownerId, importedApplication, apiKey, apiConsumer);
+                    }
+                }
+            }
+
+            if (skippedAPIs.isEmpty()) {
+                return Response.created(location).entity(importedApplicationDTO).build();
+            } else {
+                APIInfoListDTO skippedAPIListDTO = APIInfoMappingUtil.fromAPIInfoListToDTO(skippedAPIs);
+                return Response.created(location).status(207).entity(skippedAPIListDTO).build();
+            }
+        } catch (URISyntaxException | UserStoreException | APIImportExportException e) {
+            throw new APIManagementException("Error while importing Application", e);
+        } catch (UnsupportedEncodingException e) {
+            throw new APIManagementException("Error while Decoding apiId", e);
+        } catch (IOException e) {
+            throw new APIManagementException("Error while reading the application definition", e);
+        }
+    }
+
+    /**
      * Creates a new application
      *
      * @param body        request body containing application details
@@ -161,38 +313,7 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
     public Response applicationsPost(ApplicationDTO body, MessageContext messageContext){
         String username = RestApiCommonUtil.getLoggedInUsername();
         try {
-            APIConsumer apiConsumer = APIManagerFactory.getInstance().getAPIConsumer(username);
-            String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
-
-            //validate the tier specified for the application
-            String tierName = body.getThrottlingPolicy();
-            if (tierName == null) {
-                RestApiUtil.handleBadRequest("Throttling tier cannot be null", log);
-            }
-
-            Map<String, Tier> appTierMap = APIUtil.getTiers(APIConstants.TIER_APPLICATION_TYPE, tenantDomain);
-            if (appTierMap == null || RestApiUtil.findTier(appTierMap.values(), tierName) == null) {
-                RestApiUtil.handleBadRequest("Specified tier " + tierName + " is invalid", log);
-            }
-
-            Object applicationAttributesFromUser = body.getAttributes();
-            Map<String, String> applicationAttributes =
-                    new ObjectMapper().convertValue(applicationAttributesFromUser, Map.class);
-            if (applicationAttributes != null) {
-                body.setAttributes(applicationAttributes);
-            }
-
-            //we do not honor tokenType sent in the body and
-            //all the applications created will of 'JWT' token type
-            body.setTokenType(ApplicationDTO.TokenTypeEnum.JWT);
-
-            //subscriber field of the body is not honored. It is taken from the context
-            Application application = ApplicationMappingUtil.fromDTOtoApplication(body, username);
-
-            int applicationId = apiConsumer.addApplication(application, username);
-
-            //retrieves the created application and send as the response
-            Application createdApplication = apiConsumer.getApplicationById(applicationId);
+            Application createdApplication = preProcessAndAddApplication(username, body);
             ApplicationDTO createdApplicationDTO = ApplicationMappingUtil.fromApplicationtoDTO(createdApplication);
 
             //to be set as the Location header
@@ -214,6 +335,49 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
             }
         }
         return null;
+    }
+
+    /**
+     * Preprocess and add the application
+     *
+     * @param username       Username
+     * @param applicationDto Application DTO
+     * @return Created application
+     */
+    private Application preProcessAndAddApplication(String username, ApplicationDTO applicationDto)
+            throws APIManagementException {
+        APIConsumer apiConsumer = APIManagerFactory.getInstance().getAPIConsumer(username);
+        String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
+
+        //validate the tier specified for the application
+        String tierName = applicationDto.getThrottlingPolicy();
+        if (tierName == null) {
+            RestApiUtil.handleBadRequest("Throttling tier cannot be null", log);
+        }
+
+        Map<String, Tier> appTierMap = APIUtil.getTiers(APIConstants.TIER_APPLICATION_TYPE, tenantDomain);
+        if (appTierMap == null || RestApiUtil.findTier(appTierMap.values(), tierName) == null) {
+            RestApiUtil.handleBadRequest("Specified tier " + tierName + " is invalid", log);
+        }
+
+        Object applicationAttributesFromUser = applicationDto.getAttributes();
+        Map<String, String> applicationAttributes = new ObjectMapper()
+                .convertValue(applicationAttributesFromUser, Map.class);
+        if (applicationAttributes != null) {
+            applicationDto.setAttributes(applicationAttributes);
+        }
+
+        //we do not honor tokenType sent in the body and
+        //all the applications created will of 'JWT' token type
+        applicationDto.setTokenType(ApplicationDTO.TokenTypeEnum.JWT);
+
+        //subscriber field of the body is not honored. It is taken from the context
+        Application application = ApplicationMappingUtil.fromDTOtoApplication(applicationDto, username);
+
+        int applicationId = apiConsumer.addApplication(application, username);
+
+        //retrieves the created application and send as the response
+        return apiConsumer.getApplicationById(applicationId);
     }
 
     /**
@@ -293,32 +457,9 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
                 RestApiUtil.handleAuthorizationFailure(RestApiConstants.RESOURCE_APPLICATION, applicationId, log);
             }
 
-            Object applicationAttributesFromUser = body.getAttributes();
-            Map<String, String> applicationAttributes = new ObjectMapper()
-                    .convertValue(applicationAttributesFromUser, Map.class);
-
-            if (applicationAttributes != null) {
-                body.setAttributes(applicationAttributes);
-            }
-
-            //we do not honor tokenType sent in the body and all the applications are considered of 'JWT' token type
-            //unless the current application is already of 'OAUTH' type
-            if (!ApplicationDTO.TokenTypeEnum.OAUTH.toString().equals(oldApplication.getTokenType())) {
-                body.setTokenType(ApplicationDTO.TokenTypeEnum.JWT);
-            }
-            
-            //we do not honor the subscriber coming from the request body as we can't change the subscriber of the application
-            Application application = ApplicationMappingUtil.fromDTOtoApplication(body, username);
-
-            //we do not honor the application id which is sent via the request body
-            application.setUUID(oldApplication != null ? oldApplication.getUUID() : null);
-
-            apiConsumer.updateApplication(application);
-
-            //retrieves the updated application and send as the response
-            Application updatedApplication = apiConsumer.getApplicationByUUID(applicationId);
-            ApplicationDTO updatedApplicationDTO = ApplicationMappingUtil
-                    .fromApplicationtoDTO(updatedApplication);
+            Application updatedApplication = preProcessAndUpdateApplication(username, body, oldApplication,
+                    applicationId);
+            ApplicationDTO updatedApplicationDTO = ApplicationMappingUtil.fromApplicationtoDTO(updatedApplication);
             return Response.ok().entity(updatedApplicationDTO).build();
                 
         } catch (APIManagementException e) {
@@ -331,6 +472,44 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
             }
         }
         return null;
+    }
+
+    /**
+     * Preprocess and update the application
+     *
+     * @param username       Username
+     * @param applicationDto Application DTO
+     * @param oldApplication Old application
+     * @param applicationId  Application UUID
+     * @return Updated application
+     */
+    private Application preProcessAndUpdateApplication(String username, ApplicationDTO applicationDto,
+            Application oldApplication, String applicationId) throws APIManagementException {
+        APIConsumer apiConsumer = APIManagerFactory.getInstance().getAPIConsumer(username);
+        Object applicationAttributesFromUser = applicationDto.getAttributes();
+        Map<String, String> applicationAttributes = new ObjectMapper()
+                .convertValue(applicationAttributesFromUser, Map.class);
+
+        if (applicationAttributes != null) {
+            applicationDto.setAttributes(applicationAttributes);
+        }
+
+        //we do not honor tokenType sent in the body and all the applications are considered of 'JWT' token type
+        //unless the current application is already of 'OAUTH' type
+        if (!ApplicationDTO.TokenTypeEnum.OAUTH.toString().equals(oldApplication.getTokenType())) {
+            applicationDto.setTokenType(ApplicationDTO.TokenTypeEnum.JWT);
+        }
+
+        //we do not honor the subscriber coming from the request body as we can't change the subscriber of the application
+        Application application = ApplicationMappingUtil.fromDTOtoApplication(applicationDto, username);
+
+        //we do not honor the application id which is sent via the request body
+        application.setUUID(oldApplication != null ? oldApplication.getUUID() : null);
+
+        apiConsumer.updateApplication(application);
+
+        //retrieves the updated application and send as the response
+        return apiConsumer.getApplicationByUUID(applicationId);
     }
 
     /**
@@ -365,10 +544,8 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
         if (application == null) {
             throw new APIManagementException("No application found with name " + appName + " owned by " + appOwner, ExceptionCodes.APPLICATION_NOT_FOUND);
         } else if (!MultitenantUtils.getTenantDomain(application.getSubscriber().getName())
-                .equals(MultitenantUtils.getTenantDomain(username))) {  // normal non-migration flow
-            String errorMsg = "Cross Tenant Exports are not allowed";
-            log.error(errorMsg);
-            return Response.status(Response.Status.FORBIDDEN).entity(errorMsg).build();
+                .equals(MultitenantUtils.getTenantDomain(username))) {
+            throw new APIManagementException("Cross Tenant Exports are not allowed", ExceptionCodes.TENANT_MISMATCH);
         }
 
         // clear all duplicate keys with tokens

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIInfoMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIInfoMappingUtil.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.rest.api.store.v1.mappings;
+
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIInfoDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIInfoListDTO;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+
+public class APIInfoMappingUtil {
+
+    /**
+     * Converts a APIIdentifier object into APIInfoDTO
+     *
+     * @param apiId APIIdentifier object
+     * @return APIInfoDTO corresponds to APIIdentifier object
+     */
+    private static APIInfoDTO fromAPIInfoToDTO(APIIdentifier apiId)
+            throws UnsupportedEncodingException {
+        APIInfoDTO apiInfoDTO = new APIInfoDTO();
+        APIIdentifier apiIdEmailReplacedBack = new APIIdentifier(APIUtil.replaceEmailDomainBack(apiId.getProviderName
+                ()).replace(RestApiConstants.API_ID_DELIMITER, RestApiConstants.URL_ENCODED_API_ID_DELIMITER),
+                URLEncoder.encode(apiId.getApiName(), RestApiConstants.CHARSET).replace(RestApiConstants
+                        .API_ID_DELIMITER, RestApiConstants.URL_ENCODED_API_ID_DELIMITER), apiId.getVersion().
+                replace(RestApiConstants.API_ID_DELIMITER, RestApiConstants.URL_ENCODED_API_ID_DELIMITER));
+        apiInfoDTO.setName(apiIdEmailReplacedBack.getApiName());
+        apiInfoDTO.setVersion(apiIdEmailReplacedBack.getVersion());
+        apiInfoDTO.setProvider(apiIdEmailReplacedBack.getProviderName());
+        return apiInfoDTO;
+    }
+
+    /**
+     * Converts a List object of APIIdentifiers into a DTO
+     *
+     * @param apiIds a list of APIIdentifier objects
+     * @return APIInfoListDTO object containing APIInfoDTOs
+     */
+    public static APIInfoListDTO fromAPIInfoListToDTO(List<APIIdentifier> apiIds) throws
+            UnsupportedEncodingException {
+        APIInfoListDTO apiInfoListDTO = new APIInfoListDTO();
+        List<APIInfoDTO> apiInfoDTOs = apiInfoListDTO.getList();
+        if (apiInfoDTOs == null) {
+            apiInfoDTOs = new ArrayList<>();
+            apiInfoListDTO.setList(apiInfoDTOs);
+        }
+        for (APIIdentifier apiId : apiIds) {
+            apiInfoDTOs.add(fromAPIInfoToDTO(apiId));
+        }
+        apiInfoListDTO.setCount(apiInfoDTOs.size());
+        return apiInfoListDTO;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIInfoMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIInfoMappingUtil.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/models/ExportedApplication.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/models/ExportedApplication.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/models/ExportedApplication.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/models/ExportedApplication.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.rest.api.store.v1.models;
+
+import org.wso2.carbon.apimgt.api.model.OAuthApplicationInfo;
+import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationDTO;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class represent the Exported Application model which is an aggregated model
+ */
+public class ExportedApplication {
+
+    private ApplicationDTO applicationInfo;
+    private Set<SubscribedAPI> subscribedAPIs;
+    private Map<String, Map<String, OAuthApplicationInfo>> keyManagerWiseOAuthApp;
+
+    public ExportedApplication(ApplicationDTO applicationDto) {
+        this.applicationInfo = applicationDto;
+    }
+
+    public Set<SubscribedAPI> getSubscribedAPIs() {
+        return subscribedAPIs;
+    }
+
+    public void setSubscribedAPIs(Set<SubscribedAPI> subscribedAPIs) {
+        this.subscribedAPIs = subscribedAPIs;
+    }
+
+    public ApplicationDTO getApplicationInfo() {
+        return applicationInfo;
+    }
+
+    public void setApplicationInfo(ApplicationDTO applicationInfo) {
+        this.applicationInfo = applicationInfo;
+    }
+
+    public Map<String, Map<String, OAuthApplicationInfo>> getKeyManagerWiseOAuthApp() {
+        return keyManagerWiseOAuthApp;
+    }
+
+    public void setKeyManagerWiseOAuthApp(Map<String, Map<String, OAuthApplicationInfo>> keyManagerWiseOAuthApp) {
+        this.keyManagerWiseOAuthApp = keyManagerWiseOAuthApp;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/models/ExportedApplication.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/models/ExportedApplication.java
@@ -18,11 +18,9 @@
 
 package org.wso2.carbon.apimgt.rest.api.store.v1.models;
 
-import org.wso2.carbon.apimgt.api.model.OAuthApplicationInfo;
-import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationKeyDTO;
 
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -31,18 +29,18 @@ import java.util.Set;
 public class ExportedApplication {
 
     private ApplicationDTO applicationInfo;
-    private Set<SubscribedAPI> subscribedAPIs;
-    private Map<String, Map<String, OAuthApplicationInfo>> keyManagerWiseOAuthApp;
+    private Set<ExportedSubscribedAPI> subscribedAPIs;
+    private Set<ApplicationKeyDTO> applicationKeys;
 
     public ExportedApplication(ApplicationDTO applicationDto) {
         this.applicationInfo = applicationDto;
     }
 
-    public Set<SubscribedAPI> getSubscribedAPIs() {
+    public Set<ExportedSubscribedAPI> getSubscribedAPIs() {
         return subscribedAPIs;
     }
 
-    public void setSubscribedAPIs(Set<SubscribedAPI> subscribedAPIs) {
+    public void setSubscribedAPIs(Set<ExportedSubscribedAPI> subscribedAPIs) {
         this.subscribedAPIs = subscribedAPIs;
     }
 
@@ -54,11 +52,11 @@ public class ExportedApplication {
         this.applicationInfo = applicationInfo;
     }
 
-    public Map<String, Map<String, OAuthApplicationInfo>> getKeyManagerWiseOAuthApp() {
-        return keyManagerWiseOAuthApp;
+    public Set<ApplicationKeyDTO> getApplicationKeys() {
+        return applicationKeys;
     }
 
-    public void setKeyManagerWiseOAuthApp(Map<String, Map<String, OAuthApplicationInfo>> keyManagerWiseOAuthApp) {
-        this.keyManagerWiseOAuthApp = keyManagerWiseOAuthApp;
+    public void setApplicationKeys(Set<ApplicationKeyDTO> applicationKeys) {
+        this.applicationKeys = applicationKeys;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/models/ExportedSubscribedAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/models/ExportedSubscribedAPI.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/models/ExportedSubscribedAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/models/ExportedSubscribedAPI.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.rest.api.store.v1.models;
+
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.Subscriber;
+
+public class ExportedSubscribedAPI {
+        private APIIdentifier apiId;
+        private Subscriber subscriber;
+        private String throttlingPolicy;
+
+    public ExportedSubscribedAPI(APIIdentifier apiId, Subscriber subscriber, String throttlingPolicy) {
+        this.apiId = apiId;
+        this.subscriber = subscriber;
+        this.throttlingPolicy = throttlingPolicy;
+    }
+
+    public APIIdentifier getApiId() {
+        return apiId;
+    }
+
+    public void setApiId(APIIdentifier apiId) {
+        this.apiId = apiId;
+    }
+
+    public Subscriber getSubscriber() {
+        return subscriber;
+    }
+
+    public void setSubscriber(Subscriber subscriber) {
+        this.subscriber = subscriber;
+    }
+
+    public String getThrottlingPolicy() {
+        return throttlingPolicy;
+    }
+
+    public void setThrottlingPolicy(String throttlingPolicy) {
+        this.throttlingPolicy = throttlingPolicy;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ExportUtils.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.rest.api.store.v1.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIConsumer;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.Application;
+import org.wso2.carbon.apimgt.api.model.Identifier;
+import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.importexport.APIImportExportConstants;
+import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
+import org.wso2.carbon.apimgt.impl.importexport.ExportFormat;
+import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
+import org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.rest.api.store.v1.mappings.ApplicationMappingUtil;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Set;
+
+import static org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil.createDirectory;
+
+public class ExportUtils {
+    private static final Log log = LogFactory.getLog(ExportUtils.class);
+
+    /**
+     * Retrieve all the details of an Application by name for a given user.
+     *
+     * @param appName name of the application
+     * @return {@link Application} instance
+     * @throws APIManagementException if an error occurs while retrieving Application details
+     */
+    public static Application getApplicationDetails(String appName, String username, APIConsumer apiConsumer)
+            throws APIManagementException {
+        Application application;
+        int appId = APIUtil.getApplicationId(appName, username);
+        String groupId = apiConsumer.getGroupId(appId);
+        application = apiConsumer.getApplicationById(appId);
+        if (application != null) {
+            application.setGroupId(groupId);
+            application.setOwner(application.getSubscriber().getName());
+        }
+        return application;
+    }
+
+    /**
+     * Export a given Application to a file system as zip archive.
+     * The export root location is given by {@link @path}/exported-application.
+     *
+     * @param exportApplication Application{@link Application} to be exported
+     * @param apiConsumer       API Consumer
+     * @return Path to the exported directory with exported artifacts
+     * @throws APIManagementException If an error occurs while exporting an application to a file system
+     */
+    public static File exportApplication(Application exportApplication, APIConsumer apiConsumer,
+            ExportFormat exportFormat) throws APIManagementException {
+        String archivePath = null;
+        String exportApplicationBasePath;
+        String appName = exportApplication.getName();
+        String appOwner = exportApplication.getOwner();
+        try {
+            // Creates a temporary directory to store the exported application artifact
+            File exportFolder = createTempApplicationDirectory(appName, appOwner);
+            exportApplicationBasePath = exportFolder.toString();
+            archivePath = exportApplicationBasePath
+                    .concat(File.separator + appOwner + "-" +appName);
+            // Files.createDirectories(Paths.get(applicationArtifactBaseDirectoryPath));
+        } catch (APIImportExportException e) {
+            throw new APIManagementException("Unable to create the temporary directory to export the Application", e);
+        }
+        Set<SubscribedAPI> subscriptions = apiConsumer
+                .getSubscribedAPIs(exportApplication.getSubscriber(), appName,
+                        exportApplication.getGroupId());
+        exportApplication.setSubscribedAPIs(subscriptions);
+        try {
+            createDirectory(archivePath);
+            // Export application details
+            CommonUtil.writeDtoToFile(archivePath + File.separator + ImportExportConstants.TYPE_APPLICATION,
+                    exportFormat, ImportExportConstants.TYPE_APPLICATION,
+                    ApplicationMappingUtil.fromApplicationtoDTO(exportApplication));
+            CommonUtil.archiveDirectory(exportApplicationBasePath);
+            FileUtils.deleteQuietly(new File(exportApplicationBasePath));
+            return new File(exportApplicationBasePath + APIConstants.ZIP_FILE_EXTENSION);
+        } catch (IOException | APIImportExportException e) {
+            throw new APIManagementException("Error while exporting Application: " + exportApplication.getName(), e);
+        }
+    }
+
+    /**
+     * Create temporary directory for an Application in temporary location.
+     * The format of the name of the directory would be {application_owner}_{application_name}
+     *
+     * @throws APIImportExportException If an error occurs while creating temporary location
+     */
+    public static File createTempApplicationDirectory(String appName, String appOwner) throws APIImportExportException {
+        String currentDirectory = System.getProperty(APIConstants.JAVA_IO_TMPDIR);
+        File tempDirectory = new File(currentDirectory + File.separator + appOwner + "_" + appName);
+        createDirectory(tempDirectory.getPath());
+        return tempDirectory;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ExportUtils.java
@@ -17,42 +17,25 @@
 
 package org.wso2.carbon.apimgt.rest.api.store.v1.utils;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
-import org.wso2.carbon.apimgt.api.model.APIKey;
 import org.wso2.carbon.apimgt.api.model.Application;
-import org.wso2.carbon.apimgt.api.model.Identifier;
 import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
 import org.wso2.carbon.apimgt.impl.APIConstants;
-import org.wso2.carbon.apimgt.impl.dto.SubscribedApiDTO;
-import org.wso2.carbon.apimgt.impl.importexport.APIImportExportConstants;
 import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
 import org.wso2.carbon.apimgt.impl.importexport.ExportFormat;
 import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
 import org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationDTO;
-import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationKeyDTO;
-import org.wso2.carbon.apimgt.rest.api.store.v1.mappings.ApplicationKeyMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.mappings.ApplicationMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.models.ExportedApplication;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 import static org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil.createDirectory;
@@ -129,13 +112,6 @@ public class ExportUtils {
     private static ExportedApplication createApplicationDTOToExport(Application application, APIConsumer apiConsumer)
             throws APIManagementException {
         ApplicationDTO applicationDto = ApplicationMappingUtil.fromApplicationtoDTO(application);
-
-//        List<ApplicationKeyDTO> applicationKeyDTOs = new ArrayList<>();
-//        for (APIKey apiKey : application.getKeys()) {
-//            ApplicationKeyDTO applicationKeyDTO = ApplicationKeyMappingUtil.fromApplicationKeyToDTO(apiKey);
-//            applicationKeyDTOs.add(applicationKeyDTO);
-//        }
-//        applicationDto.setKeys(applicationKeyDTOs);
         ExportedApplication exportedApplication = new ExportedApplication(applicationDto);
 
         Set<SubscribedAPI> subscriptions = apiConsumer

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ExportUtils.java
@@ -93,7 +93,6 @@ public class ExportUtils {
             File exportFolder = createTempApplicationDirectory(appName, appOwner);
             exportApplicationBasePath = exportFolder.toString();
             archivePath = exportApplicationBasePath.concat(File.separator + appOwner + "-" + appName);
-            // Files.createDirectories(Paths.get(applicationArtifactBaseDirectoryPath));
         } catch (APIImportExportException e) {
             throw new APIManagementException("Unable to create the temporary directory to export the Application", e);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ExportUtils.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
@@ -1,0 +1,291 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.rest.api.store.v1.utils;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.simple.JSONObject;
+import org.wso2.carbon.apimgt.api.APIConsumer;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.APIKey;
+import org.wso2.carbon.apimgt.api.model.APIProduct;
+import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
+import org.wso2.carbon.apimgt.api.model.Application;
+import org.wso2.carbon.apimgt.api.model.ApplicationConstants;
+import org.wso2.carbon.apimgt.api.model.OAuthApplicationInfo;
+import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
+import org.wso2.carbon.apimgt.api.model.Subscriber;
+import org.wso2.carbon.apimgt.api.model.Tier;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
+import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
+import org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ImportUtils {
+    private static final Log log = LogFactory.getLog(ImportUtils.class);
+    private static final String GRANT_TYPES = "grant_types";
+    private static final String GRANT_TYPE_IMPLICIT = "implicit";
+    private static final String GRANT_TYPE_CODE = "code";
+    private static final String REDIRECT_URIS = "redirect_uris";
+    private static final String DEFAULT_TOKEN_SCOPE = "am_application_scope default";
+
+    /**
+     * Retrieve Application Definition as JSON.
+     *
+     * @param pathToArchive Path Application archive
+     * @throws IOException If an error occurs while reading the file
+     */
+    public static String getApplicationDefinitionAsJson(String pathToArchive) throws IOException {
+        String jsonContent = null;
+        String pathToYamlFile = pathToArchive + ImportExportConstants.YAML_APPLICATION_FILE_LOCATION;
+        String pathToJsonFile = pathToArchive + ImportExportConstants.JSON_APPLICATION_FILE_LOCATION;
+
+        // Load yaml representation first if it is present
+        if (CommonUtil.checkFileExistence(pathToYamlFile)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Found application definition file " + pathToYamlFile);
+            }
+            String yamlContent = FileUtils.readFileToString(new File(pathToYamlFile));
+            jsonContent = CommonUtil.yamlToJson(yamlContent);
+        } else if (CommonUtil.checkFileExistence(pathToJsonFile)) {
+            // load as a json fallback
+            if (log.isDebugEnabled()) {
+                log.debug("Found application definition file " + pathToJsonFile);
+            }
+            jsonContent = FileUtils.readFileToString(new File(pathToJsonFile));
+        }
+        return jsonContent;
+    }
+
+    /**
+     * Check whether a provided userId corresponds to a valid consumer of the store and subscribe if valid
+     *
+     * @param userId      Username of the Owner
+     * @param groupId     The groupId to which the target subscriber belongs to
+     * @param apiConsumer API Consumer
+     * @throws APIManagementException if an error occurs while checking the validity of user
+     */
+    public static void validateOwner(String userId, String groupId, APIConsumer apiConsumer)
+            throws APIManagementException {
+        Subscriber subscriber = apiConsumer.getSubscriber(userId);
+        try {
+            if (subscriber == null && !APIUtil.isPermissionCheckDisabled()) {
+                APIUtil.checkPermission(userId, APIConstants.Permissions.API_SUBSCRIBE);
+                apiConsumer.addSubscriber(userId, groupId);
+            }
+        } catch (APIManagementException e) {
+            throw new APIManagementException("Provided Application Owner is Invalid", e);
+        }
+    }
+
+    /**
+     * This extracts information for creating an APIKey from an OAuthApplication
+     *
+     * @param type                 Type of the OAuthApp(SANDBOX or PRODUCTION)
+     * @param oAuthApplicationInfo OAuth Application information
+     * @return An APIKey containing keys from OAuthApplication
+     */
+    public static APIKey getAPIKeyFromOauthApp(String type, OAuthApplicationInfo oAuthApplicationInfo) {
+        APIKey apiKey = new APIKey();
+        apiKey.setType(type);
+        apiKey.setConsumerKey(oAuthApplicationInfo.getClientId());
+        apiKey.setConsumerSecret(oAuthApplicationInfo.getClientSecret());
+        apiKey.setGrantTypes((String) oAuthApplicationInfo.getParameter(GRANT_TYPES));
+        if (apiKey.getGrantTypes() != null && apiKey.getGrantTypes().contains(GRANT_TYPE_IMPLICIT) && apiKey
+                .getGrantTypes().contains(GRANT_TYPE_CODE)) {
+            apiKey.setCallbackUrl((String) oAuthApplicationInfo.getParameter(REDIRECT_URIS));
+        }
+        long validityPeriod = OAuthServerConfiguration.getInstance().getApplicationAccessTokenValidityPeriodInSeconds();
+        apiKey.setValidityPeriod(validityPeriod);
+        apiKey.setTokenScope(DEFAULT_TOKEN_SCOPE);
+        return apiKey;
+    }
+
+    /**
+     * Import and add subscriptions of a particular application for the available APIs and API products
+     *
+     * @param subscribedAPIs Subscribed APIs
+     * @param userId         Username of the subscriber
+     * @param appId          Application Id
+     * @param apiConsumer    API Consumer
+     * @return a list of APIIdentifiers of the skipped subscriptions
+     * @throws APIManagementException if an error occurs while importing and adding subscriptions
+     */
+    public static List<APIIdentifier> importSubscriptions(Set<SubscribedAPI> subscribedAPIs, String userId, int appId,
+            Boolean update, APIConsumer apiConsumer) throws APIManagementException, UserStoreException {
+        List<APIIdentifier> skippedAPIList = new ArrayList<>();
+        for (SubscribedAPI subscribedAPI : subscribedAPIs) {
+            APIIdentifier apiIdentifier = subscribedAPI.getApiId();
+            String tenantDomain = MultitenantUtils
+                    .getTenantDomain(APIUtil.replaceEmailDomainBack(apiIdentifier.getProviderName()));
+            if (!StringUtils.isEmpty(tenantDomain) && APIUtil.isTenantAvailable(tenantDomain)) {
+                String name = apiIdentifier.getApiName();
+                String version = apiIdentifier.getVersion();
+                //creating a solr compatible search query, here we will execute a search query without wildcard *s
+                StringBuilder searchQuery = new StringBuilder();
+                String[] searchCriteria = { name, "version:" + version };
+                for (int i = 0; i < searchCriteria.length; i++) {
+                    if (i == 0) {
+                        searchQuery = new StringBuilder(
+                                APIUtil.getSingleSearchCriteria(searchCriteria[i]).replace("*", ""));
+                    } else {
+                        searchQuery.append(APIConstants.SEARCH_AND_TAG)
+                                .append(APIUtil.getSingleSearchCriteria(searchCriteria[i]).replace("*", ""));
+                    }
+                }
+                Map matchedAPIs;
+                matchedAPIs = apiConsumer
+                        .searchPaginatedAPIs(searchQuery.toString(), tenantDomain, 0, Integer.MAX_VALUE, false);
+                Set<Object> apiSet = (Set<Object>) matchedAPIs.get("apis");
+                if (apiSet != null && !apiSet.isEmpty()) {
+                    Object type = apiSet.iterator().next();
+                    ApiTypeWrapper apiTypeWrapper = null;
+                    //Check whether the object is ApiProduct
+                    if (isApiProduct(type)) {
+                        APIProduct apiProduct = (APIProduct) apiSet.iterator().next();
+                        apiTypeWrapper = new ApiTypeWrapper(apiProduct);
+                    } else {
+                        API api = (API) apiSet.iterator().next();
+                        apiTypeWrapper = new ApiTypeWrapper(api);
+                    }
+                    //tier of the imported subscription
+                    Tier tier = subscribedAPI.getTier();
+                    //checking whether the target tier is available
+                    if (isTierAvailable(tier, apiTypeWrapper) && apiTypeWrapper.getStatus() != null
+                            && APIConstants.PUBLISHED.equals(apiTypeWrapper.getStatus())) {
+                        apiTypeWrapper.setTier(tier.getName());
+                        // add subscription if update flag is not specified
+                        // it will throw an error if subscriber already exists
+                        if (update == null || !update) {
+                            apiConsumer.addSubscription(apiTypeWrapper, userId, appId);
+                        } else if (!apiConsumer.isSubscribedToApp(subscribedAPI.getApiId(), userId, appId)) {
+                            // on update skip subscriptions that already exists
+                            apiConsumer.addSubscription(apiTypeWrapper, userId, appId);
+                        }
+                    } else {
+                        log.error("Failed to import Subscription as API/API Product " + name + "-" + version
+                                + " as one or more tiers may be unavailable or the API/API Product may not have been published ");
+                        skippedAPIList.add(subscribedAPI.getApiId());
+                    }
+                } else {
+                    log.error("Failed to import Subscription as API " + name + "-" + version + " is not available");
+                    skippedAPIList.add(subscribedAPI.getApiId());
+                }
+            } else {
+                log.error("Failed to import Subscription as Tenant domain: " + tenantDomain + " is not available");
+                skippedAPIList.add(subscribedAPI.getApiId());
+            }
+        }
+        return skippedAPIList;
+    }
+
+    /**
+     * Check whether the object is a type of ApiProduct
+     *
+     * @param object - {@link Object}
+     * @return true, if the object is an ApiProduct, otherwise false
+     */
+    private static boolean isApiProduct(Object object) {
+        //Check whether the object is an instance of ApiProduct
+        return (object) instanceof APIProduct;
+    }
+
+    /**
+     * Check whether a target Tier is available to subscribe
+     *
+     * @param targetTier     Target Tier
+     * @param apiTypeWrapper - {@link ApiTypeWrapper}
+     * @return true, if the target tier is available
+     */
+    private static boolean isTierAvailable(Tier targetTier, ApiTypeWrapper apiTypeWrapper) {
+        Set<Tier> availableTiers = null;
+        API api = null;
+        APIProduct apiProduct = null;
+        if (!apiTypeWrapper.isAPIProduct()) {
+            api = apiTypeWrapper.getApi();
+            availableTiers = api.getAvailableTiers();
+        } else {
+            apiProduct = apiTypeWrapper.getApiProduct();
+            availableTiers = apiProduct.getAvailableTiers();
+        }
+        if (availableTiers.contains(targetTier)) {
+            return true;
+        } else {
+            if (!apiTypeWrapper.isAPIProduct()) {
+                log.error("Tier:" + targetTier.getName() + " is not available for API " + api.getId().getApiName() + "-"
+                        + api.getId().getVersion());
+            } else {
+                log.error("Tier:" + targetTier.getName() + " is not available for API Product " + apiProduct.getId()
+                        .getName() + "-" + apiProduct.getId().getVersion());
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Adds a key to a given Application
+     *
+     * @param username    User for import application
+     * @param application Application used to add key
+     * @param apiKey      API key for adding to application
+     * @param apiConsumer API Consumer
+     * @throws APIManagementException
+     */
+    public static void addApplicationKey(String username, Application application, APIKey apiKey,
+            APIConsumer apiConsumer)
+            throws APIManagementException {
+        String[] accessAllowDomainsArray = { "ALL" };
+        JSONObject jsonParamObj = new JSONObject();
+        jsonParamObj.put(ApplicationConstants.OAUTH_CLIENT_USERNAME, username);
+        String grantTypes = apiKey.getGrantTypes();
+        if (!StringUtils.isEmpty(grantTypes)) {
+            jsonParamObj.put(APIConstants.JSON_GRANT_TYPES, grantTypes);
+        }
+        /* Read clientId & clientSecret from ApplicationKeyGenerateRequestDTO object.
+           User can provide clientId only or both clientId and clientSecret
+           User cannot provide clientSecret only
+         */
+        if (!StringUtils.isEmpty(apiKey.getConsumerKey())) {
+            jsonParamObj.put(APIConstants.JSON_CLIENT_ID, apiKey.getConsumerKey());
+            if (!StringUtils.isEmpty(apiKey.getConsumerSecret())) {
+                jsonParamObj.put(APIConstants.JSON_CLIENT_SECRET, apiKey.getConsumerSecret());
+            }
+        }
+        String jsonParams = jsonParamObj.toString();
+        String tokenScopes = apiKey.getTokenScope();
+        apiConsumer.requestApprovalForApplicationRegistration(username, application.getName(), apiKey.getType(),
+                apiKey.getCallbackUrl(), accessAllowDomainsArray, Long.toString(apiKey.getValidityPeriod()),
+                tokenScopes, application.getGroupId(), jsonParams, apiKey.getKeyManager());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
@@ -2005,6 +2005,74 @@ paths:
         source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
           -H "Content-Type: application/json" -X POST -d @data.json "https://localhost:9443/api/am/store/v1/applications/16cd2684-9657-4a01-a956-4efd89e96077/api-keys/PRODUCTION/revoke"'
 
+  /applications/export:
+    get:
+      tags:
+        - Import Export
+      summary: Export an Application
+      description: |
+        This operation can be used to export the details of a particular application as a zip file.
+      parameters:
+        - name: appName
+          in: query
+          description: |
+            Application Name
+          required: true
+          schema:
+            type: string
+        - name: appOwner
+          in: query
+          description: |
+            Owner of the Application
+          required: true
+          schema:
+            type: string
+        - name: withKeys
+          in: query
+          description: |
+            Export application keys
+          schema:
+            type: boolean
+        - name: format
+          in: query
+          description: |
+            Format of output documents. Can be YAML or JSON.
+          schema:
+            type: string
+            enum:
+              - JSON
+              - YAML
+      responses:
+        200:
+          description: |
+            OK.
+            Export Successful.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+      security:
+        - OAuth2Security:
+            - apim:app_import_export
+      x-code-samples:
+        - lang: Shell
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/store/v1/applications/import?appName=sampleApp&appOwner=admin&withKeys=true"
+          > exportedApplication.zip'
+
   ######################################################
   # The "Subscription Collection" resource APIs
   ######################################################

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
@@ -2073,6 +2073,92 @@ paths:
           "https://127.0.0.1:9443/api/am/store/v1/applications/import?appName=sampleApp&appOwner=admin&withKeys=true"
           > exportedApplication.zip'
 
+  /applications/import:
+    post:
+      tags:
+        - Application (Individual)
+      summary: Import an Application
+      description: |
+        This operation can be used to import an application.
+      parameters:
+        - name: preserveOwner
+          in: query
+          description: |
+            Preserve Original Creator of the Application
+          schema:
+            type: boolean
+        - name: skipSubscriptions
+          in: query
+          description: |
+            Skip importing Subscriptions of the Application
+          schema:
+            type: boolean
+        - name: appOwner
+          in: query
+          description: |
+            Expected Owner of the Application in the Import Environment
+          schema:
+            type: string
+        - name: skipApplicationKeys
+          in: query
+          description: |
+            Skip importing Keys of the Application
+          schema:
+            type: boolean
+        - name: update
+          in: query
+          description: |
+            Update if application exists
+          schema:
+            type: boolean
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  description: |
+                    Zip archive consisting of exported Application Configuration.
+                  format: binary
+        required: true
+      responses:
+        200:
+          description: |
+            OK.
+            Successful response with the updated object information as entity in the body.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationInfo'
+        207:
+          description: |
+            Multi Status.
+            Partially successful response with skipped APIs information object as entity in the body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIInfoList'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+      security:
+        - OAuth2Security:
+            - apim:app_import_export
+      x-code-samples:
+        - lang: Shell
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          -F file=@exportedApplication.zip "https://127.0.0.1:9443/api/am/store/v1/applications/import?preserveOwner=true&skipSubscriptions=false&appOwner=admin&skipApplicationKeys=false&update=true"'
+
   ######################################################
   # The "Subscription Collection" resource APIs
   ######################################################
@@ -3400,6 +3486,19 @@ components:
         monetizationLabel:
           type: string
           example: Free
+    APIInfoList:
+      title: API Info List
+      type: object
+      properties:
+        count:
+          type: integer
+          description: |
+            Number of API Info objects returned.
+          example: 1
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/APIInfo'
     API:
       title: API object
       required:


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/324

## Goals
Restructure the code segments related to exporting/importing an Application by introducing new schemas via reading required DTOs.

## Approach
- Created Store REST API resources to export/import an Application The resources are as follows.
  1. POST applications/import
  2. GET applications/export
 - The old implementations of exporting/importing Applications have been modified to read DTOs from the importing files, instead of models.
 - Introduced a parameter to define the format as JSON or YAML when exporting an Application.

Below is an example of an exported application with keys and subscriptions, in the new schema format.
```
type: application
version: v4
data:
  applicationInfo:
    applicationId: 93bf6b68-74dc-4c56-a4e4-66bad2883ea5
    name: TestApp
    throttlingPolicy: 10PerMin
    description: test
    tokenType: JWT
    status: APPROVED
    groups: []
    subscriptionCount: 0
    keys:
     -
      keyMappingId: f7f27a62-8619-40fd-96c6-bdb4f15f738a
      keyManager: Resident Key Manager
      consumerKey: WWJiF8GOY4YbnYJiD0W4dzTL0p4a
      consumerSecret: QXdBVFVPVGdJelRoZ053RXNFSE5jSGxlb05jYQ==
      supportedGrantTypes:
       - refresh_token
       - urn:ietf:params:oauth:grant-type:saml2-bearer
       - password
       - client_credentials
       - iwa:ntlm
       - urn:ietf:params:oauth:grant-type:jwt-bearer
      callbackUrl: ""
      keyState: COMPLETED
      keyType: SANDBOX
      token:
        tokenScopes: []
        validityTime: 0
      additionalProperties:
        id_token_expiry_time: 3600
        application_access_token_expiry_time: 3600
        user_access_token_expiry_time: 3600
        refresh_token_expiry_time: 86400
     -
      keyMappingId: 4f3f44ab-d313-4b62-a7cd-3a86129112ee
      keyManager: Resident Key Manager
      consumerKey: GGCjHXUTevp6PzY6i4guFDutzl8a
      consumerSecret: eVJRc05BRHZGdDE0NzVQcnpWenBKVWdEeUt3YQ==
      supportedGrantTypes:
       - refresh_token
       - urn:ietf:params:oauth:grant-type:saml2-bearer
       - password
       - client_credentials
       - iwa:ntlm
       - urn:ietf:params:oauth:grant-type:jwt-bearer
      callbackUrl: ""
      keyState: COMPLETED
      keyType: PRODUCTION
      token:
        tokenScopes: []
        validityTime: 0
      additionalProperties:
        id_token_expiry_time: 3600
        application_access_token_expiry_time: 3600
        user_access_token_expiry_time: 3600
        refresh_token_expiry_time: 86400
    attributes: {}
    subscriptionScopes: []
    owner: admin
  subscribedAPIs:
   -
    apiId:
      providerName: admin
      apiName: PizzaShackAPI
      version: 1.0.0
      id: 0
    subscriber:
      name: admin
      id: 3
      tenantId: 0
    throttlingPolicy: Unlimited
```

## User stories
The users can use the newly introduced Store REST API resources to export/import an Application with the new schema structure.

## Documentation
Documentation changes need to be done according to the structure changes.

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.1 LTS