### PR TITLE
Support to override subscription policies of an API using the api_params.yaml

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -184,6 +184,7 @@ public final class ImportExportConstants {
     public static final String MUTUAL_SSL_CERTIFICATES_FIELD = "mutualSslCerts";
     public static final String ENDPOINT_CERTIFICATES_FIELD = "certs";
     public static final String ENDPOINT_SECURITY_FIELD = "security";
+    public static final String POLICIES_FIELD = "policies";
     public static final String ROUTING_POLICY_FIELD = "endpointRoutingPolicy";
     public static final String ENDPOINTS_FIELD = "endpoints";
     public static final String LOAD_BALANCE_ENDPOINTS_FIELD = "loadBalanceEndpoints";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -270,9 +270,6 @@ public class APIControllerUtil {
      * @throws APIManagementException If an error occurs when setting policies
      */
     private static void handleSubscriptionPolicies(JsonElement policies, APIDTO importedApiDto) {
-        if (policies == null) {
-            return;
-        }
         JsonArray definedPolicies = policies.getAsJsonArray();
         List<String> policiesListToAdd = new ArrayList<>();
         for (JsonElement definedPolicy : definedPolicies) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -194,6 +194,12 @@ public class APIControllerUtil {
         if (securityConfigs != null) {
             handleEndpointSecurityConfigs(envParams, importedApiDto);
         }
+
+        // handle available subscription policies
+        JsonElement policies = envParams.get(ImportExportConstants.POLICIES_FIELD);
+        if (!policies.isJsonNull()) {
+            handleSubscriptionPolicies(policies, importedApiDto);
+        }
         return importedApiDto;
     }
 
@@ -253,6 +259,35 @@ public class APIControllerUtil {
                 }
             }
             importedApiDto.setEndpointSecurity(apiEndpointSecurityDTO);
+        }
+    }
+
+    /**
+     * This method will add the defined available subscription policies in an environment to the particular imported API
+     *
+     * @param importedApiDto API DTO object to be updated
+     * @param policies       policies with the values
+     * @throws APIManagementException If an error occurs when setting policies
+     */
+    private static void handleSubscriptionPolicies(JsonElement policies, APIDTO importedApiDto) {
+        if (policies == null) {
+            return;
+        }
+        JsonArray definedPolicies = policies.getAsJsonArray();
+        List<String> policiesListToAdd = new ArrayList<>();
+        for (JsonElement definedPolicy : definedPolicies) {
+            if (!definedPolicy.isJsonNull()) {
+                String policyToAdd = definedPolicy.getAsString();
+                if (!StringUtils.isEmpty(policyToAdd)) {
+                    policiesListToAdd.add(definedPolicy.getAsString());
+                }
+            }
+        }
+        // If the policies are not defined in api_params.yaml, the values in the api.yaml should be considered.
+        // Hence, this if statement will prevent setting the policies in api.yaml to an empty array if the policies
+        // are not properly defined in the api_params.yaml
+        if (policiesListToAdd.size() > 0) {
+            importedApiDto.setPolicies(policiesListToAdd);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -267,7 +267,6 @@ public class APIControllerUtil {
      *
      * @param importedApiDto API DTO object to be updated
      * @param policies       policies with the values
-     * @throws APIManagementException If an error occurs when setting policies
      */
     private static void handleSubscriptionPolicies(JsonElement policies, APIDTO importedApiDto) {
         JsonArray definedPolicies = policies.getAsJsonArray();


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/564

## Goals
Enhance the current capability of defining subscription tiers (of an API) in api.yaml file by providing the capability to override them using api_params.yaml file, if the user wants.

## Approach
This procedure modified the template of api_params.yaml as shown in the below example. 
 - A new field was added as **policies** which is an array that consists of the subscription tier names for an API in an environment.
```
environments:
    - name: dev
      configs:
        endpoints:
            production:
                url: 'https://dev.wso2.com'
        security:
            enabled: true
            type: basic
            username: admin
            password: admin
        certs:
            - hostName: 'https://dev.wso2.com'
              alias: Dev
              path: dev.crt 
        gatewayEnvironments:
            - Production and Sandbox
        policies:
            - Gold
            - Silver   
```

## User stories
- If the policies parameter is set in api_params.yaml file, override the values in api.yaml file.
- If the policies parameter is not set in api_params.yaml file, use the values in api.yaml file. (The old procedure)

## Release note
Enhance the current capability of defining the subscription policies in api.yaml file by providing the capability to override them using api_params.yaml file, if the user wants.

## Documentation
Documentation changes should be done. 

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/568

## Test environment
- jdk 1.8.0_251
- Ubuntu 20.04.1 LTS