### PR TITLE
Update accessUrls property name of mgw-label schema

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Environments/MicroGateway.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Environments/MicroGateway.jsx
@@ -132,7 +132,7 @@ export default function MicroGateway(props) {
                                         {row.name}
                                     </TableCell>
                                     <TableCell align='left'>{row.description}</TableCell>
-                                    <TableCell align='left'>{row.access_urls.join(', ')}</TableCell>
+                                    <TableCell align='left'>{row.accessUrls.join(', ')}</TableCell>
                                 </TableRow>
                             ))}
                         </TableBody>


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9679

## Approach
Changed schema property name of microgateway labels from **access_urls** to **accessUrls**