### PR TITLE
Fixing runtimeArfifact zip serving issue.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/RuntimeArtifactsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/RuntimeArtifactsApiServiceImpl.java
@@ -46,13 +46,9 @@ public class RuntimeArtifactsApiServiceImpl implements RuntimeArtifactsApiServic
         if (runtimeArtifactDto != null) {
             if (runtimeArtifactDto.isFile()) {
                 File artifact = (File) runtimeArtifactDto.getArtifact();
-                try (FileInputStream fileInputStream = new FileInputStream(artifact)) {
-                    return Response.ok(fileInputStream).header(RestApiConstants.HEADER_CONTENT_DISPOSITION,
-                            "attachment; filename=apis.zip").header(RestApiConstants.HEADER_CONTENT_TYPE,
-                            APIConstants.APPLICATION_ZIP).build();
-                } catch (IOException e) {
-                    throw new APIManagementException("Error while sending api achieve", e);
-                }
+                return Response.ok(artifact)
+                        .header(RestApiConstants.HEADER_CONTENT_DISPOSITION, "attachment; filename=apis.zip")
+                        .header(RestApiConstants.HEADER_CONTENT_TYPE, APIConstants.APPLICATION_ZIP).build();
             } else {
                 return Response.ok().entity(runtimeArtifactDto.getArtifact()).build();
             }


### PR DESCRIPTION
Then the apis.zip was downloaded over the https://localhost:9443/internal/data/v1/runtime-artifacts, it gave an error related io.StreamClosed.
While debugging I found out that the fileinputstream is not necessary.