### PR TITLE
Handle Error Scenarios when Switching from Custom or Common Mediation Policy to NONE Mediation Policy

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/MediationPolicies/EditMediationPolicy.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/MediationPolicies/EditMediationPolicy.jsx
@@ -315,7 +315,11 @@ function EditMediationPolicy(props) {
     function handleChangeProvideBy(event) {
         const inputValue = event.target.value;
         setProvideBy(inputValue);
-        setActivePolicy({});
+        if (inputValue === NONE) {
+            setActivePolicy({ name: NONE, type: NONE });
+        } else {
+            setActivePolicy({});
+        }
     }
     return (
         <Dialog


### PR DESCRIPTION
## Purpose
- Fixes: https://github.com/wso2/product-apim/issues/9690

## Approach
- When NONE mediation policy is selected, an object with **name: "none"** and **type: "none"** is created and set as the active policy. This solves scenarios when switching from Custom or Common mediation policy to NONE mediation policy.

## Test Environment
- JDK 1.8.0_241
- Ubuntu 20.04.1 LTS
