### PR TITLE
Add addtional throtling tier paramaters to the REST API response in the store and publisher

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Tier.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Tier.java
@@ -43,6 +43,9 @@ public class Tier implements Serializable, Comparable<Tier>{
     private boolean stopOnQuotaReached = true;
     private TierPermission tierPermission;
     private Map<String,String> monetizationAttributes;
+    private String quotaPolicyType;
+    private int rateLimitCount;
+    private String rateLimitTimeUnit;
 
     public Map<String, String> getMonetizationAttributes() {
         return monetizationAttributes;
@@ -145,6 +148,30 @@ public class Tier implements Serializable, Comparable<Tier>{
 
     public void setTierPermission(TierPermission tierPermission) {
         this.tierPermission = tierPermission;
+    }
+
+    public void setQuotaPolicyType(String quotaPolicyType) {
+        this.quotaPolicyType = quotaPolicyType;
+    }
+
+    public String getQuotaPolicyType() {
+        return quotaPolicyType;
+    }
+
+    public int getRateLimitCount() {
+        return rateLimitCount;
+    }
+
+    public String getRateLimitTimeUnit() {
+        return rateLimitTimeUnit;
+    }
+
+    public void setRateLimitCount(int rateLimitCount) {
+        this.rateLimitCount = rateLimitCount;
+    }
+
+    public void setRateLimitTimeUnit(String rateLimitTimeUnit) {
+        this.rateLimitTimeUnit = rateLimitTimeUnit;
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Tier.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Tier.java
@@ -46,6 +46,7 @@ public class Tier implements Serializable, Comparable<Tier>{
     private String quotaPolicyType;
     private int rateLimitCount;
     private String rateLimitTimeUnit;
+    private String bandwidthDataUnit;
 
     public Map<String, String> getMonetizationAttributes() {
         return monetizationAttributes;
@@ -172,6 +173,14 @@ public class Tier implements Serializable, Comparable<Tier>{
 
     public void setRateLimitTimeUnit(String rateLimitTimeUnit) {
         this.rateLimitTimeUnit = rateLimitTimeUnit;
+    }
+
+    public void setBandwidthDataUnit(String bandwidthDataUnit) {
+        this.bandwidthDataUnit = bandwidthDataUnit;
+    }
+
+    public String getBandwidthDataUnit() {
+        return bandwidthDataUnit;
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8432,10 +8432,13 @@ public final class APIUtil {
                 Limit limit = policy.getDefaultQuotaPolicy().getLimit();
                 tier.setTimeUnit(limit.getTimeUnit());
                 tier.setUnitTime(limit.getUnitTime());
+                tier.setQuotaPolicyType(policy.getDefaultQuotaPolicy().getType());
 
                 //If the policy is a subscription policy
                 if (policy instanceof SubscriptionPolicy) {
                     SubscriptionPolicy subscriptionPolicy = (SubscriptionPolicy) policy;
+                    tier.setRateLimitCount(subscriptionPolicy.getRateLimitCount());
+                    tier.setRateLimitTimeUnit(subscriptionPolicy.getRateLimitTimeUnit());
                     setBillingPlanAndCustomAttributesToTier(subscriptionPolicy, tier);
                     if (StringUtils.equals(subscriptionPolicy.getBillingPlan(), APIConstants.COMMERCIAL_TIER_PLAN)) {
                         tier.setMonetizationAttributes(subscriptionPolicy.getMonetizationPlanProperties());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8454,6 +8454,7 @@ public final class APIUtil {
                     BandwidthLimit bandwidthLimit = (BandwidthLimit) limit;
                     tier.setRequestsPerMin(bandwidthLimit.getDataAmount());
                     tier.setRequestCount(bandwidthLimit.getDataAmount());
+                    tier.setBandwidthDataUnit(bandwidthLimit.getDataUnit());
                 }
                 if (PolicyConstants.POLICY_LEVEL_SUB.equalsIgnoreCase(policyLevel)) {
                     tier.setTierPlan(((SubscriptionPolicy) policy).getBillingPlan());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/ThrottlingPolicyDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/ThrottlingPolicyDTO.java
@@ -62,6 +62,40 @@ return null;
     private Long requestCount = null;
     private Long unitTime = null;
     private String timeUnit = null;
+    private Integer rateLimitCount = 0;
+    private String rateLimitTimeUnit = null;
+
+    @XmlType(name="QuotaPolicyTypeEnum")
+    @XmlEnum(String.class)
+    public enum QuotaPolicyTypeEnum {
+        REQUESTCOUNT("REQUESTCOUNT"),
+        BANDWIDTHVOLUME("BANDWIDTHVOLUME");
+        private String value;
+
+        QuotaPolicyTypeEnum (String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @JsonCreator
+        public static QuotaPolicyTypeEnum fromValue(String v) {
+            for (QuotaPolicyTypeEnum b : QuotaPolicyTypeEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+return null;
+        }
+    }
+    private QuotaPolicyTypeEnum quotaPolicyType = null;
 
     @XmlType(name="TierPlanEnum")
     @XmlEnum(String.class)
@@ -239,6 +273,60 @@ return null;
   }
 
   /**
+   * Burst control request count
+   **/
+  public ThrottlingPolicyDTO rateLimitCount(Integer rateLimitCount) {
+    this.rateLimitCount = rateLimitCount;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "10", value = "Burst control request count")
+  @JsonProperty("rateLimitCount")
+  public Integer getRateLimitCount() {
+    return rateLimitCount;
+  }
+  public void setRateLimitCount(Integer rateLimitCount) {
+    this.rateLimitCount = rateLimitCount;
+  }
+
+  /**
+   * Burst control time unit
+   **/
+  public ThrottlingPolicyDTO rateLimitTimeUnit(String rateLimitTimeUnit) {
+    this.rateLimitTimeUnit = rateLimitTimeUnit;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "min", value = "Burst control time unit")
+  @JsonProperty("rateLimitTimeUnit")
+  public String getRateLimitTimeUnit() {
+    return rateLimitTimeUnit;
+  }
+  public void setRateLimitTimeUnit(String rateLimitTimeUnit) {
+    this.rateLimitTimeUnit = rateLimitTimeUnit;
+  }
+
+  /**
+   * Default quota limit type
+   **/
+  public ThrottlingPolicyDTO quotaPolicyType(QuotaPolicyTypeEnum quotaPolicyType) {
+    this.quotaPolicyType = quotaPolicyType;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "REQUESTCOUNT", value = "Default quota limit type")
+  @JsonProperty("quotaPolicyType")
+  public QuotaPolicyTypeEnum getQuotaPolicyType() {
+    return quotaPolicyType;
+  }
+  public void setQuotaPolicyType(QuotaPolicyTypeEnum quotaPolicyType) {
+    this.quotaPolicyType = quotaPolicyType;
+  }
+
+  /**
    * This attribute declares whether this policy is available under commercial or free 
    **/
   public ThrottlingPolicyDTO tierPlan(TierPlanEnum tierPlan) {
@@ -312,6 +400,9 @@ return null;
         Objects.equals(requestCount, throttlingPolicy.requestCount) &&
         Objects.equals(unitTime, throttlingPolicy.unitTime) &&
         Objects.equals(timeUnit, throttlingPolicy.timeUnit) &&
+        Objects.equals(rateLimitCount, throttlingPolicy.rateLimitCount) &&
+        Objects.equals(rateLimitTimeUnit, throttlingPolicy.rateLimitTimeUnit) &&
+        Objects.equals(quotaPolicyType, throttlingPolicy.quotaPolicyType) &&
         Objects.equals(tierPlan, throttlingPolicy.tierPlan) &&
         Objects.equals(stopOnQuotaReach, throttlingPolicy.stopOnQuotaReach) &&
         Objects.equals(monetizationProperties, throttlingPolicy.monetizationProperties);
@@ -319,7 +410,7 @@ return null;
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, description, policyLevel, displayName, attributes, requestCount, unitTime, timeUnit, tierPlan, stopOnQuotaReach, monetizationProperties);
+    return Objects.hash(name, description, policyLevel, displayName, attributes, requestCount, unitTime, timeUnit, rateLimitCount, rateLimitTimeUnit, quotaPolicyType, tierPlan, stopOnQuotaReach, monetizationProperties);
   }
 
   @Override
@@ -335,6 +426,9 @@ return null;
     sb.append("    requestCount: ").append(toIndentedString(requestCount)).append("\n");
     sb.append("    unitTime: ").append(toIndentedString(unitTime)).append("\n");
     sb.append("    timeUnit: ").append(toIndentedString(timeUnit)).append("\n");
+    sb.append("    rateLimitCount: ").append(toIndentedString(rateLimitCount)).append("\n");
+    sb.append("    rateLimitTimeUnit: ").append(toIndentedString(rateLimitTimeUnit)).append("\n");
+    sb.append("    quotaPolicyType: ").append(toIndentedString(quotaPolicyType)).append("\n");
     sb.append("    tierPlan: ").append(toIndentedString(tierPlan)).append("\n");
     sb.append("    stopOnQuotaReach: ").append(toIndentedString(stopOnQuotaReach)).append("\n");
     sb.append("    monetizationProperties: ").append(toIndentedString(monetizationProperties)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/ThrottlingPolicyDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/ThrottlingPolicyDTO.java
@@ -60,6 +60,7 @@ return null;
     private String displayName = null;
     private Map<String, String> attributes = new HashMap<String, String>();
     private Long requestCount = null;
+    private String dataUnit = null;
     private Long unitTime = null;
     private String timeUnit = null;
     private Integer rateLimitCount = 0;
@@ -238,6 +239,24 @@ return null;
   }
 
   /**
+   * Unit of data allowed to be transfered. Allowed values are \&quot;KB\&quot;, \&quot;MB\&quot; and \&quot;GB\&quot; 
+   **/
+  public ThrottlingPolicyDTO dataUnit(String dataUnit) {
+    this.dataUnit = dataUnit;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "KB", value = "Unit of data allowed to be transfered. Allowed values are \"KB\", \"MB\" and \"GB\" ")
+  @JsonProperty("dataUnit")
+  public String getDataUnit() {
+    return dataUnit;
+  }
+  public void setDataUnit(String dataUnit) {
+    this.dataUnit = dataUnit;
+  }
+
+  /**
    **/
   public ThrottlingPolicyDTO unitTime(Long unitTime) {
     this.unitTime = unitTime;
@@ -398,6 +417,7 @@ return null;
         Objects.equals(displayName, throttlingPolicy.displayName) &&
         Objects.equals(attributes, throttlingPolicy.attributes) &&
         Objects.equals(requestCount, throttlingPolicy.requestCount) &&
+        Objects.equals(dataUnit, throttlingPolicy.dataUnit) &&
         Objects.equals(unitTime, throttlingPolicy.unitTime) &&
         Objects.equals(timeUnit, throttlingPolicy.timeUnit) &&
         Objects.equals(rateLimitCount, throttlingPolicy.rateLimitCount) &&
@@ -410,7 +430,7 @@ return null;
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, description, policyLevel, displayName, attributes, requestCount, unitTime, timeUnit, rateLimitCount, rateLimitTimeUnit, quotaPolicyType, tierPlan, stopOnQuotaReach, monetizationProperties);
+    return Objects.hash(name, description, policyLevel, displayName, attributes, requestCount, dataUnit, unitTime, timeUnit, rateLimitCount, rateLimitTimeUnit, quotaPolicyType, tierPlan, stopOnQuotaReach, monetizationProperties);
   }
 
   @Override
@@ -424,6 +444,7 @@ return null;
     sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
     sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
     sb.append("    requestCount: ").append(toIndentedString(requestCount)).append("\n");
+    sb.append("    dataUnit: ").append(toIndentedString(dataUnit)).append("\n");
     sb.append("    unitTime: ").append(toIndentedString(unitTime)).append("\n");
     sb.append("    timeUnit: ").append(toIndentedString(timeUnit)).append("\n");
     sb.append("    rateLimitCount: ").append(toIndentedString(rateLimitCount)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ThrottlingPolicyMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ThrottlingPolicyMappingUtil.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings;
 
 import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.apimgt.api.model.Tier;
+import org.wso2.carbon.apimgt.api.model.policy.PolicyConstants;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings.CommonMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.PaginationDTO;
@@ -123,6 +124,11 @@ public class ThrottlingPolicyMappingUtil {
         dto.setStopOnQuotaReach(tier.isStopOnQuotaReached());
         dto.setPolicyLevel((ThrottlingPolicyDTO.PolicyLevelEnum.fromValue(tierLevel)));
         dto.setTimeUnit(tier.getTimeUnit());
+        dto.setRateLimitCount(tier.getRateLimitCount());
+        dto.setRateLimitTimeUnit(tier.getRateLimitTimeUnit());
+        if (tier.getQuotaPolicyType() != null) {
+            dto.setQuotaPolicyType(mapQuotaPolicyTypeFromModeltoDTO(tier.getQuotaPolicyType()));
+        }
         if (tier.getTierPlan() != null) {
             dto.setTierPlan(ThrottlingPolicyDTO.TierPlanEnum.fromValue(tier.getTierPlan()));
         }
@@ -134,5 +140,24 @@ public class ThrottlingPolicyMappingUtil {
             dto.setAttributes(additionalProperties);
         }
         return dto;
+    }
+
+    /**
+     * Map quota policy type from data model to DTO
+     *
+     * @param quotaPolicyType quota policy type
+     * @return ThrottlingPolicyDTO.QuotaPolicyTypeEnum
+     */
+    private static ThrottlingPolicyDTO.QuotaPolicyTypeEnum mapQuotaPolicyTypeFromModeltoDTO(String quotaPolicyType) {
+
+        switch (quotaPolicyType) {
+            case PolicyConstants.REQUEST_COUNT_TYPE:
+                return ThrottlingPolicyDTO.QuotaPolicyTypeEnum.fromValue(PolicyConstants.
+                        REQUEST_COUNT_TYPE.toUpperCase());
+            case PolicyConstants.BANDWIDTH_TYPE:
+                return ThrottlingPolicyDTO.QuotaPolicyTypeEnum.fromValue(PolicyConstants.BANDWIDTH_TYPE.toUpperCase());
+            default:
+                return null;
+        }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ThrottlingPolicyMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ThrottlingPolicyMappingUtil.java
@@ -126,6 +126,7 @@ public class ThrottlingPolicyMappingUtil {
         dto.setTimeUnit(tier.getTimeUnit());
         dto.setRateLimitCount(tier.getRateLimitCount());
         dto.setRateLimitTimeUnit(tier.getRateLimitTimeUnit());
+        dto.setDataUnit(tier.getBandwidthDataUnit());
         if (tier.getQuotaPolicyType() != null) {
             dto.setQuotaPolicyType(mapQuotaPolicyTypeFromModeltoDTO(tier.getQuotaPolicyType()));
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -7708,6 +7708,25 @@ components:
         timeUnit:
           type: string
           example: min
+        rateLimitCount:
+          type: integer
+          default: 0
+          description: Burst control request count
+          example: 10
+          readOnly: true
+        rateLimitTimeUnit:
+          type: string
+          description: Burst control time unit
+          example: min
+          readOnly: true
+        quotaPolicyType:
+          type: string
+          description: Default quota limit type
+          enum:
+            - REQUESTCOUNT
+            - BANDWIDTHVOLUME
+          example: REQUESTCOUNT
+          readOnly: true
         tierPlan:
           type: string
           description: |

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -7701,6 +7701,11 @@ components:
             Maximum number of requests which can be sent within a provided unit time
           format: int64
           example: 50
+        dataUnit:
+          description: |
+            Unit of data allowed to be transfered. Allowed values are "KB", "MB" and "GB"
+          type: string
+          example: KB
         unitTime:
           type: integer
           format: int64
@@ -7713,12 +7718,10 @@ components:
           default: 0
           description: Burst control request count
           example: 10
-          readOnly: true
         rateLimitTimeUnit:
           type: string
           description: Burst control time unit
           example: min
-          readOnly: true
         quotaPolicyType:
           type: string
           description: Default quota limit type
@@ -7726,7 +7729,6 @@ components:
             - REQUESTCOUNT
             - BANDWIDTHVOLUME
           example: REQUESTCOUNT
-          readOnly: true
         tierPlan:
           type: string
           description: |

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/ThrottlingPolicyDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/ThrottlingPolicyDTO.java
@@ -62,6 +62,41 @@ return null;
     private Map<String, String> attributes = new HashMap<String, String>();
     private Long requestCount = null;
     private Long unitTime = null;
+    private String timeUnit = null;
+    private Integer rateLimitCount = 0;
+    private String rateLimitTimeUnit = null;
+
+    @XmlType(name="QuotaPolicyTypeEnum")
+    @XmlEnum(String.class)
+    public enum QuotaPolicyTypeEnum {
+        REQUESTCOUNT("REQUESTCOUNT"),
+        BANDWIDTHVOLUME("BANDWIDTHVOLUME");
+        private String value;
+
+        QuotaPolicyTypeEnum (String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @JsonCreator
+        public static QuotaPolicyTypeEnum fromValue(String v) {
+            for (QuotaPolicyTypeEnum b : QuotaPolicyTypeEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+return null;
+        }
+    }
+    private QuotaPolicyTypeEnum quotaPolicyType = null;
 
     @XmlType(name="TierPlanEnum")
     @XmlEnum(String.class)
@@ -206,6 +241,77 @@ return null;
   }
 
   /**
+   **/
+  public ThrottlingPolicyDTO timeUnit(String timeUnit) {
+    this.timeUnit = timeUnit;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "min", value = "")
+  @JsonProperty("timeUnit")
+  public String getTimeUnit() {
+    return timeUnit;
+  }
+  public void setTimeUnit(String timeUnit) {
+    this.timeUnit = timeUnit;
+  }
+
+  /**
+   * Burst control request count
+   **/
+  public ThrottlingPolicyDTO rateLimitCount(Integer rateLimitCount) {
+    this.rateLimitCount = rateLimitCount;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "10", value = "Burst control request count")
+  @JsonProperty("rateLimitCount")
+  public Integer getRateLimitCount() {
+    return rateLimitCount;
+  }
+  public void setRateLimitCount(Integer rateLimitCount) {
+    this.rateLimitCount = rateLimitCount;
+  }
+
+  /**
+   * Burst control time unit
+   **/
+  public ThrottlingPolicyDTO rateLimitTimeUnit(String rateLimitTimeUnit) {
+    this.rateLimitTimeUnit = rateLimitTimeUnit;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "min", value = "Burst control time unit")
+  @JsonProperty("rateLimitTimeUnit")
+  public String getRateLimitTimeUnit() {
+    return rateLimitTimeUnit;
+  }
+  public void setRateLimitTimeUnit(String rateLimitTimeUnit) {
+    this.rateLimitTimeUnit = rateLimitTimeUnit;
+  }
+
+  /**
+   * Default quota limit type
+   **/
+  public ThrottlingPolicyDTO quotaPolicyType(QuotaPolicyTypeEnum quotaPolicyType) {
+    this.quotaPolicyType = quotaPolicyType;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "REQUESTCOUNT", value = "Default quota limit type")
+  @JsonProperty("quotaPolicyType")
+  public QuotaPolicyTypeEnum getQuotaPolicyType() {
+    return quotaPolicyType;
+  }
+  public void setQuotaPolicyType(QuotaPolicyTypeEnum quotaPolicyType) {
+    this.quotaPolicyType = quotaPolicyType;
+  }
+
+  /**
    * This attribute declares whether this tier is available under commercial or free 
    **/
   public ThrottlingPolicyDTO tierPlan(TierPlanEnum tierPlan) {
@@ -295,6 +401,10 @@ return null;
         Objects.equals(attributes, throttlingPolicy.attributes) &&
         Objects.equals(requestCount, throttlingPolicy.requestCount) &&
         Objects.equals(unitTime, throttlingPolicy.unitTime) &&
+        Objects.equals(timeUnit, throttlingPolicy.timeUnit) &&
+        Objects.equals(rateLimitCount, throttlingPolicy.rateLimitCount) &&
+        Objects.equals(rateLimitTimeUnit, throttlingPolicy.rateLimitTimeUnit) &&
+        Objects.equals(quotaPolicyType, throttlingPolicy.quotaPolicyType) &&
         Objects.equals(tierPlan, throttlingPolicy.tierPlan) &&
         Objects.equals(stopOnQuotaReach, throttlingPolicy.stopOnQuotaReach) &&
         Objects.equals(monetizationAttributes, throttlingPolicy.monetizationAttributes) &&
@@ -303,7 +413,7 @@ return null;
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, description, policyLevel, attributes, requestCount, unitTime, tierPlan, stopOnQuotaReach, monetizationAttributes, throttlingPolicyPermissions);
+    return Objects.hash(name, description, policyLevel, attributes, requestCount, unitTime, timeUnit, rateLimitCount, rateLimitTimeUnit, quotaPolicyType, tierPlan, stopOnQuotaReach, monetizationAttributes, throttlingPolicyPermissions);
   }
 
   @Override
@@ -317,6 +427,10 @@ return null;
     sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
     sb.append("    requestCount: ").append(toIndentedString(requestCount)).append("\n");
     sb.append("    unitTime: ").append(toIndentedString(unitTime)).append("\n");
+    sb.append("    timeUnit: ").append(toIndentedString(timeUnit)).append("\n");
+    sb.append("    rateLimitCount: ").append(toIndentedString(rateLimitCount)).append("\n");
+    sb.append("    rateLimitTimeUnit: ").append(toIndentedString(rateLimitTimeUnit)).append("\n");
+    sb.append("    quotaPolicyType: ").append(toIndentedString(quotaPolicyType)).append("\n");
     sb.append("    tierPlan: ").append(toIndentedString(tierPlan)).append("\n");
     sb.append("    stopOnQuotaReach: ").append(toIndentedString(stopOnQuotaReach)).append("\n");
     sb.append("    monetizationAttributes: ").append(toIndentedString(monetizationAttributes)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/ThrottlingPolicyDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/ThrottlingPolicyDTO.java
@@ -61,6 +61,7 @@ return null;
     private PolicyLevelEnum policyLevel = null;
     private Map<String, String> attributes = new HashMap<String, String>();
     private Long requestCount = null;
+    private String dataUnit = null;
     private Long unitTime = null;
     private String timeUnit = null;
     private Integer rateLimitCount = 0;
@@ -220,6 +221,24 @@ return null;
   }
   public void setRequestCount(Long requestCount) {
     this.requestCount = requestCount;
+  }
+
+  /**
+   * Unit of data allowed to be transfered. Allowed values are \&quot;KB\&quot;, \&quot;MB\&quot; and \&quot;GB\&quot; 
+   **/
+  public ThrottlingPolicyDTO dataUnit(String dataUnit) {
+    this.dataUnit = dataUnit;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "KB", value = "Unit of data allowed to be transfered. Allowed values are \"KB\", \"MB\" and \"GB\" ")
+  @JsonProperty("dataUnit")
+  public String getDataUnit() {
+    return dataUnit;
+  }
+  public void setDataUnit(String dataUnit) {
+    this.dataUnit = dataUnit;
   }
 
   /**
@@ -400,6 +419,7 @@ return null;
         Objects.equals(policyLevel, throttlingPolicy.policyLevel) &&
         Objects.equals(attributes, throttlingPolicy.attributes) &&
         Objects.equals(requestCount, throttlingPolicy.requestCount) &&
+        Objects.equals(dataUnit, throttlingPolicy.dataUnit) &&
         Objects.equals(unitTime, throttlingPolicy.unitTime) &&
         Objects.equals(timeUnit, throttlingPolicy.timeUnit) &&
         Objects.equals(rateLimitCount, throttlingPolicy.rateLimitCount) &&
@@ -413,7 +433,7 @@ return null;
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, description, policyLevel, attributes, requestCount, unitTime, timeUnit, rateLimitCount, rateLimitTimeUnit, quotaPolicyType, tierPlan, stopOnQuotaReach, monetizationAttributes, throttlingPolicyPermissions);
+    return Objects.hash(name, description, policyLevel, attributes, requestCount, dataUnit, unitTime, timeUnit, rateLimitCount, rateLimitTimeUnit, quotaPolicyType, tierPlan, stopOnQuotaReach, monetizationAttributes, throttlingPolicyPermissions);
   }
 
   @Override
@@ -426,6 +446,7 @@ return null;
     sb.append("    policyLevel: ").append(toIndentedString(policyLevel)).append("\n");
     sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
     sb.append("    requestCount: ").append(toIndentedString(requestCount)).append("\n");
+    sb.append("    dataUnit: ").append(toIndentedString(dataUnit)).append("\n");
     sb.append("    unitTime: ").append(toIndentedString(unitTime)).append("\n");
     sb.append("    timeUnit: ").append(toIndentedString(timeUnit)).append("\n");
     sb.append("    rateLimitCount: ").append(toIndentedString(rateLimitCount)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/ThrottlingPolicyMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/ThrottlingPolicyMappingUtil.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.rest.api.store.v1.mappings;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.apimgt.api.model.Tier;
+import org.wso2.carbon.apimgt.api.model.policy.PolicyConstants;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.MonetizationInfoDTO;
@@ -117,9 +118,15 @@ public class ThrottlingPolicyMappingUtil {
         dto.setDescription(throttlingPolicy.getDescription());
         dto.setRequestCount(throttlingPolicy.getRequestCount());
         dto.setUnitTime(throttlingPolicy.getUnitTime());
+        dto.setTimeUnit(throttlingPolicy.getTimeUnit());
+        dto.setRateLimitCount(throttlingPolicy.getRateLimitCount());
+        dto.setRateLimitTimeUnit(throttlingPolicy.getRateLimitTimeUnit());
         dto.setStopOnQuotaReach(throttlingPolicy.isStopOnQuotaReached());
         dto.setPolicyLevel(ThrottlingPolicyDTO.PolicyLevelEnum.valueOf(tierLevel.toUpperCase()));
         dto = setTierPermissions(dto, throttlingPolicy);
+        if (throttlingPolicy.getQuotaPolicyType() != null) {
+            dto.setQuotaPolicyType(mapQuotaPolicyTypeFromModeltoDTO(throttlingPolicy.getQuotaPolicyType()));
+        }
         if (throttlingPolicy.getTierPlan() != null) {
             dto.setTierPlan(ThrottlingPolicyDTO.TierPlanEnum.valueOf(throttlingPolicy.getTierPlan()));
         }
@@ -146,6 +153,25 @@ public class ThrottlingPolicyMappingUtil {
         }
         dto.setMonetizationAttributes(monetizationInfoDTO);
         return dto;
+    }
+
+    /**
+     * Map quota policy type from data model to DTO
+     *
+     * @param quotaPolicyType quota policy type
+     * @return ThrottlingPolicyDTO.QuotaPolicyTypeEnum
+     */
+    private static ThrottlingPolicyDTO.QuotaPolicyTypeEnum mapQuotaPolicyTypeFromModeltoDTO(String quotaPolicyType) {
+
+        switch (quotaPolicyType) {
+            case PolicyConstants.REQUEST_COUNT_TYPE:
+                return ThrottlingPolicyDTO.QuotaPolicyTypeEnum.fromValue(PolicyConstants.
+                        REQUEST_COUNT_TYPE.toUpperCase());
+            case PolicyConstants.BANDWIDTH_TYPE:
+                return ThrottlingPolicyDTO.QuotaPolicyTypeEnum.fromValue(PolicyConstants.BANDWIDTH_TYPE.toUpperCase());
+            default:
+                return null;
+        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
@@ -4016,6 +4016,29 @@ components:
           type: integer
           format: int64
           example: 60000
+        timeUnit:
+          type: string
+          example: min
+          readOnly: true
+        rateLimitCount:
+          type: integer
+          default: 0
+          description: Burst control request count
+          example: 10
+          readOnly: true
+        rateLimitTimeUnit:
+          type: string
+          description: Burst control time unit
+          example: min
+          readOnly: true
+        quotaPolicyType:
+          type: string
+          description: Default quota limit type
+          enum:
+            - REQUESTCOUNT
+            - BANDWIDTHVOLUME
+          example: REQUESTCOUNT
+          readOnly: true
         tierPlan:
           type: string
           description: |

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
@@ -4012,6 +4012,11 @@ components:
             Maximum number of requests which can be sent within a provided unit time
           format: int64
           example: 50
+        dataUnit:
+          description: |
+            Unit of data allowed to be transfered. Allowed values are "KB", "MB" and "GB"
+          type: string
+          example: KB
         unitTime:
           type: integer
           format: int64
@@ -4019,18 +4024,15 @@ components:
         timeUnit:
           type: string
           example: min
-          readOnly: true
         rateLimitCount:
           type: integer
           default: 0
           description: Burst control request count
           example: 10
-          readOnly: true
         rateLimitTimeUnit:
           type: string
           description: Burst control time unit
           example: min
-          readOnly: true
         quotaPolicyType:
           type: string
           description: Default quota limit type
@@ -4038,7 +4040,6 @@ components:
             - REQUESTCOUNT
             - BANDWIDTHVOLUME
           example: REQUESTCOUNT
-          readOnly: true
         tierPlan:
           type: string
           description: |


### PR DESCRIPTION
### Purpose

As $subject, this pr will add the following parameters as read-only parameters for the response of  /throttling-policies REST API in publisher and store.

**Publisher**:    quotaPolicyType, rateLimitCount, rateLimitUnit, dataunit
**Store**:    quotaPolicyType, rateLimitCount, rateLimitUnit, timeUnit, dataunit

After adding the above parameters the responses of the store and publisher  /throttling-policies API as follows.

- **Publisher:**

     curl:   https://localhost:9443/api/am/publisher/v1/throttling-policies/subscription
![image](https://user-images.githubusercontent.com/21282060/104708514-d1d8be00-5743-11eb-89a4-7a581e5b315b.png)


- **Store**

    curl:   https://localhost:9443/api/am/store/v1/throttling-policies/subscription
![image](https://user-images.githubusercontent.com/21282060/104708572-e61cbb00-5743-11eb-8e8a-0b1a538abb53.png)



       

### Fixes
https://github.com/wso2/product-apim/issues/9695