### PR TITLE
Remove Token Type Field from Applications Overview Page

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/site/public/locales/en.json
@@ -247,7 +247,6 @@
   "Applications.Details.Invoice.view.btn": "View Invoice",
   "Applications.Details.Overview.application.owner": "Application Owner",
   "Applications.Details.Overview.description": "Description",
-  "Applications.Details.Overview.token.type": "Token Type",
   "Applications.Details.Overview.workflow.status": "Workflow Status",
   "Applications.Details.SubscriptionTableData.cancel": "Cancel",
   "Applications.Details.SubscriptionTableData.delete": "Delete",

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Details/Overview.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Applications/Details/Overview.jsx
@@ -170,24 +170,6 @@ function Overview(props) {
                         <TableRow>
                             <TableCell component='th' scope='row' className={classes.leftCol}>
                                 <div className={classes.iconAligner}>
-                                    <Icon className={classes.iconEven}>vpn_key</Icon>
-                                    <span className={classes.iconTextWrapper}>
-                                        <Typography variant='caption' gutterBottom align='left'>
-                                            <FormattedMessage
-                                                id='Applications.Details.Overview.token.type'
-                                                defaultMessage='Token Type'
-                                            />
-                                        </Typography>
-                                    </span>
-                                </div>
-                            </TableCell>
-                            <TableCell>
-                                {Application.TOKEN_TYPES[application.tokenType].displayName}
-                            </TableCell>
-                        </TableRow>
-                        <TableRow>
-                            <TableCell component='th' scope='row' className={classes.leftCol}>
-                                <div className={classes.iconAligner}>
                                     <Icon className={classes.iconOdd}>assignment_turned_in</Icon>
                                     <span className={classes.iconTextWrapper}>
                                         <Typography variant='caption' gutterBottom align='left'>


### PR DESCRIPTION
## Purpose
- Remove the Token Type field display from Applications Overview page in the DevPortal
- Fixing of https://github.com/wso2/product-apim/issues/9441 for APIM-4.0.0

## Approach
- The Applications Overview Page in the DevPortal contains the Token Type field as shown below.

![BeforeTokenRemovalEdited](https://user-images.githubusercontent.com/30455603/104877693-6596ce00-5980-11eb-994b-fc8ad616fc9f.png)

- This PR removes the Token Type field from Applications Overview Page. After removal, the Applications Overview Page looks as shown below.

![AfterTokenRemoval](https://user-images.githubusercontent.com/30455603/104877779-9c6ce400-5980-11eb-8add-041fe24f7c68.png)
