### PR TITLE
Restricting API "Test Console" Menu Item when API is in PUBLISHED state

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/index.jsx
@@ -634,7 +634,7 @@ class Details extends Component {
                             Icon={<DocumentsIcon />}
                         />
                         {!api.isWebSocket() && !isAPIProduct && !api.isGraphql() && !isRestricted(['apim:api_publish'],
-                            api) && (
+                            api) && api.lifeCycleStatus !== 'PUBLISHED' && (
                             <LeftMenuItem
                                 text={intl.formatMessage({
                                     id: 'Apis.Details.index.Tryout',


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9718

## Goals
Removing the "Test Console" menu item from the left bar of Publisher portal if the API is in PUBLISHED state

## User stories
Users are restricted to use the test console when an API is in the PUBLISHED state.