### PR TITLE
Fix Issue of API Products Subscription Blocking

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5068,9 +5068,11 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     public void updateSubscription(SubscribedAPI subscribedAPI) throws APIManagementException {
         apiMgtDAO.updateSubscription(subscribedAPI);
         subscribedAPI = apiMgtDAO.getSubscriptionByUUID(subscribedAPI.getUUID());
-        int apiId = apiMgtDAO.getAPIID(subscribedAPI.getApiId(), null);
+        Identifier identifier =
+                subscribedAPI.getApiId() != null ? subscribedAPI.getApiId() : subscribedAPI.getProductId();
+        int apiId = apiMgtDAO.getAPIID(identifier, null);
         String tenantDomain = MultitenantUtils
-                .getTenantDomain(APIUtil.replaceEmailDomainBack(subscribedAPI.getApiId().getProviderName()));
+                .getTenantDomain(APIUtil.replaceEmailDomainBack(identifier.getProviderName()));
         SubscriptionEvent subscriptionEvent = new SubscriptionEvent(UUID.randomUUID().toString(),
                 System.currentTimeMillis(), APIConstants.EventType.SUBSCRIPTIONS_UPDATE.name(), tenantId, tenantDomain,
                 subscribedAPI.getSubscriptionId(), apiId,


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9706

## Approach
- The problem arised due to a null value. Its because the updateSubscription method had only considered the APIIdentifier and not the APIProductIdentifier.
- When the resource is an API Product, the SubscribedAPI has an APIIdentifier value of null and has a value to APIProductIdentifier. In the current scenario, the code retrieves the APIIdentifier value of the SubscribedAPI (which is null) and pass it to other methods which eventually causes the error.
- Updated the code to to consider the APIProductIdentifier value, when APIIdentifier value of SubscribedAPI is null. 

## Test Environment
- JDK 1.8.0_241
- Ubuntu 20.04.1 LTS
