### PR TITLE
Add validation for the document source file name

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
@@ -276,6 +276,7 @@
   "Apis.Details.Documents.CreateEditForm.exceeds.document.name.length.helper.text": "Document name exceeds the maximum length of 60 characters",
   "Apis.Details.Documents.CreateEditForm.source": "Source",
   "Apis.Details.Documents.CreateEditForm.source.file": "File",
+  "Apis.Details.Documents.CreateEditForm.source.file.name.error.invalid": "Error when validating the document source file name",
   "Apis.Details.Documents.CreateEditForm.source.inline": "Inline",
   "Apis.Details.Documents.CreateEditForm.source.markdown": "Markdown",
   "Apis.Details.Documents.CreateEditForm.source.url": "URL",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/fr.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/fr.json
@@ -276,6 +276,7 @@
   "Apis.Details.Documents.CreateEditForm.exceeds.document.name.length.helper.text": "",
   "Apis.Details.Documents.CreateEditForm.source": "",
   "Apis.Details.Documents.CreateEditForm.source.file": "",
+  "Apis.Details.Documents.CreateEditForm.source.file.name.error.invalid": "",
   "Apis.Details.Documents.CreateEditForm.source.inline": "",
   "Apis.Details.Documents.CreateEditForm.source.markdown": "",
   "Apis.Details.Documents.CreateEditForm.source.url": "",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
@@ -173,7 +173,17 @@ class CreateEditForm extends React.Component {
     };
 
     onDrop = (acceptedFile) => {
-        this.setState({ file: acceptedFile });
+        const { intl } = this.props;
+        var specialChars = /[ `!@#$%^&*()+\-=\[\]{};':"\\|,<>\/?~]/;
+        if (specialChars.test(acceptedFile[0].name)) {
+            this.setState({ file: null });
+            Alert.error(intl.formatMessage({
+                id: 'Apis.Details.Documents.CreateEditForm.source.file.name.error.invalid',
+                defaultMessage: 'Error when validating the document source file name',
+            }));
+        } else {
+            this.setState({ file: acceptedFile });
+        }
     };
 
     addDocument = (apiId) => {


### PR DESCRIPTION
### Purpose
As $subject from this pr, add the validation for the source file name when uploading the source file when creating an API document.

### Fixes
https://github.com/wso2/product-apim/issues/9721