### PR TITLE
Removing the port from header x_forwarded_for

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/DataPublisherUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.usage/org.wso2.carbon.apimgt.usage.publisher/src/main/java/org/wso2/carbon/apimgt/usage/publisher/DataPublisherUtil.java
@@ -78,10 +78,16 @@ public class DataPublisherUtil {
             if (idx > -1) {
                 clientIp = clientIp.substring(0, idx);
             }
-        }else{
+        } else {
          clientIp = (String) axis2MsgContext.getProperty(MessageContext.REMOTE_ADDR);
         }
-        return clientIp;
+        if (clientIp.contains(":") && clientIp.split(":").length == 2) {
+            log.warn("Client port will be ignored and only the IP address will concern from " + clientIp);
+            clientIp = clientIp.split(":")[0];
+            return clientIp;
+        } else {
+            return clientIp;
+        }
     }
 
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9740

## Goals
Removing the port from the extracted X-Forwarded-For value