### PR TITLE
Read the api provider from Authentication handler properties

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIAuthenticationHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIAuthenticationHandler.java
@@ -93,15 +93,25 @@ public class APIAuthenticationHandler extends AbstractHandler implements Managed
     private String certificateInformation;
     private String apiUUID;
     private String apiType = String.valueOf(APIConstants.ApiTypes.API); // Default API Type
+    private String provider;
     private OpenAPI openAPI;
     private String keyManagers;
     private List<String> keyManagersList = new ArrayList<>();
+
     public String getApiUUID() {
         return apiUUID;
     }
 
     public void setApiUUID(String apiUUID) {
         this.apiUUID = apiUUID;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
     }
 
     /**
@@ -651,11 +661,17 @@ public class APIAuthenticationHandler extends AbstractHandler implements Managed
         String apiPublisher = (String) messageContext.getProperty(APIMgtGatewayConstants.API_PUBLISHER);
         //if publisher is null,extract the publisher from the api_version
         if (apiPublisher == null) {
-            int ind = apiVersion.indexOf("--");
-            apiPublisher = apiVersion.substring(0, ind);
-            if (apiPublisher.contains(APIConstants.EMAIL_DOMAIN_SEPARATOR_REPLACEMENT)) {
-                apiPublisher = apiPublisher
-                        .replace(APIConstants.EMAIL_DOMAIN_SEPARATOR_REPLACEMENT, APIConstants.EMAIL_DOMAIN_SEPARATOR);
+            if (provider == null) {
+                int ind = apiVersion.indexOf("--");
+                apiPublisher = apiVersion.substring(0, ind);
+                if (apiPublisher.contains(APIConstants.EMAIL_DOMAIN_SEPARATOR_REPLACEMENT)) {
+                    apiPublisher = apiPublisher
+                            .replace(APIConstants.EMAIL_DOMAIN_SEPARATOR_REPLACEMENT,
+                                    APIConstants.EMAIL_DOMAIN_SEPARATOR);
+                }
+            } else {
+                // If provider defined, set the provider as the apiPublisher
+                apiPublisher = provider;
             }
         }
         int index = apiVersion.indexOf("--");

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -3847,6 +3847,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             if (clientCertificateObject != null) {
                 authProperties.put(APIConstants.CERTIFICATE_INFORMATION, clientCertificateObject.toString());
             }
+            authProperties.put(APIConstants.PROVIDER_KEY, api.getId().getProviderName());
+
             //Get RemoveHeaderFromOutMessage from tenant registry or api-manager.xml
             String removeHeaderFromOutMessage = APIUtil
                     .getOAuthConfiguration(tenantId, APIConstants.REMOVE_OAUTH_HEADER_FROM_OUT_MESSAGE);
@@ -4008,6 +4010,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (clientCertificateObject != null) {
             authProperties.put(APIConstants.CERTIFICATE_INFORMATION, clientCertificateObject.toString());
         }
+        authProperties.put(APIConstants.PROVIDER_KEY, apiProduct.getId().getProviderName());
 
         //Get RemoveHeaderFromOutMessage from tenant registry or api-manager.xml
         String removeHeaderFromOutMessage = APIUtil


### PR DESCRIPTION
This PR fixes the issue API publisher resolve as Prod when using an unsecured resource in API product.

Fixes https://github.com/wso2/product-apim/issues/9760