### PR TITLE
Adding initial event publisher client for APIM

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -315,6 +315,10 @@
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.am.analytics.publisher</groupId>
+            <artifactId>org.wso2.am.analytics.publisher.client</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -148,6 +148,7 @@ public class APIMgtGatewayConstants {
     public static final String CUSTOM_ANALYTICS_REQUEST_PROPERTIES = "apim.analytics.request.properties";
     public static final String CUSTOM_ANALYTICS_RESPONSE_PROPERTIES = "apim.analytics.response.properties";
     public static final String CUSTOM_ANALYTICS_PROPERTY_SEPARATOR = ",";
+    public static final String API_UUID_PROPERTY = "API_UUID";
 
     /**
      * Constants for swagger schema validator

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsMetricsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsMetricsHandler.java
@@ -1,0 +1,223 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.gateway.handlers.analytics;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.AbstractExtendedSynapseHandler;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.rest.RESTConstants;
+import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.analytics.dto.ResponseEvent;
+import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityUtils;
+import org.wso2.carbon.apimgt.gateway.handlers.security.AuthenticationContext;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Global synapse handler to publish analytics data to analytics cloud.
+ */
+public class AnalyticsMetricsHandler extends AbstractExtendedSynapseHandler {
+    private static final Log log = LogFactory.getLog(AnalyticsMetricsHandler.class);
+    private static final String REQUEST_START_TIME_PROPERTY = "apim.analytics.request.start.time";
+    private static final String BACKEND_START_TIME_PROPERTY = "apim.analytics.backend.start.time";
+    private static final String BACKEND_LATENCY_PROPERTY = "api.analytics.backend.latency";
+    private static final String BACKEND_RESPONSE_CODE = "api.analytics.backend.response_code";
+    private static final String USER_AGENT_PROPERTY = "api.analytics.user.agent";
+    private static final String CACHED_RESPONSE_KEY = "CachableResponse";
+
+    private static final String REGION_ID = "asia";
+    private static final String DEPLOYMENT_ID = "prod";
+    private static final String SUCCESS_EVENT_TYPE = "response";
+    private static final String METRIC_NAME = "apim.response";
+    private static final String UNKNOWN_VALUE = "UNKNOWN";
+
+    @Override
+    public boolean handleError(MessageContext messageContext) {
+        // Nothing to implement
+        return true;
+    }
+
+    @Override
+    public boolean handleRequestInFlow(MessageContext messageContext) {
+        messageContext.setProperty(REQUEST_START_TIME_PROPERTY, System.currentTimeMillis());
+        //Set user agent in request flow
+        String userAgent = getUserAgent(messageContext);
+        messageContext.setProperty(USER_AGENT_PROPERTY, userAgent);
+        return true;
+    }
+
+    @Override
+    public boolean handleRequestOutFlow(MessageContext messageContext) {
+        messageContext.setProperty(BACKEND_START_TIME_PROPERTY, System.currentTimeMillis());
+        return true;
+    }
+
+    @Override
+    public boolean handleResponseInFlow(MessageContext messageContext) {
+        long backendStartTime = (long) messageContext.getProperty(BACKEND_START_TIME_PROPERTY);
+        messageContext.setProperty(BACKEND_LATENCY_PROPERTY, (System.currentTimeMillis() - backendStartTime));
+        Object responseCode = ((Axis2MessageContext) messageContext).getAxis2MessageContext()
+                .getProperty(SynapseConstants.HTTP_SC);
+        messageContext.setProperty(BACKEND_RESPONSE_CODE, responseCode);
+        return true;
+    }
+
+    @Override
+    public boolean handleResponseOutFlow(MessageContext messageContext) {
+        if (!isSuccessRequest(messageContext)) {
+            log.warn("Not support un-managed APIs and requests not flowing in default path.");
+            return true;
+        }
+
+        String httpMethod = (String) messageContext.getProperty(APIMgtGatewayConstants.HTTP_METHOD);
+        String apiResourceTemplate = (String) messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE);
+        String apiName = (String) messageContext.getProperty(APIMgtGatewayConstants.API);
+        String apiUuid = (String) messageContext.getProperty(APIMgtGatewayConstants.API_UUID_PROPERTY);
+        String apiCreator = (String) messageContext.getProperty(APIMgtGatewayConstants.API_PUBLISHER);
+        String apiVersion = (String) messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION);
+        boolean isCacheHit = messageContext.getPropertyKeySet().contains(CACHED_RESPONSE_KEY);
+
+        long requestInTime = (long) messageContext.getProperty(REQUEST_START_TIME_PROPERTY);
+        long responseTime = System.currentTimeMillis() - requestInTime;
+        long backendLatency = (Long) messageContext.getProperty(BACKEND_LATENCY_PROPERTY);
+
+        AuthenticationContext authContext = APISecurityUtils.getAuthenticationContext(messageContext);
+        if (authContext != null) {
+            if (APIConstants.END_USER_ANONYMOUS.equalsIgnoreCase(authContext.getUsername())) {
+                authContext.setApplicationName(UNKNOWN_VALUE);
+                authContext.setApplicationId(UNKNOWN_VALUE);
+                authContext.setSubscriber(UNKNOWN_VALUE);
+                authContext.setKeyType(UNKNOWN_VALUE);
+            }
+        } else {
+            log.warn("Ignore API request without authentication context.");
+            return true;
+        }
+        String applicationName = authContext.getApplicationName();
+        String applicationId = authContext.getApplicationId();
+        String applicationOwner = authContext.getSubscriber();
+        String keyType = authContext.getKeyType();
+
+        String endpointAddress = (String) messageContext.getProperty(APIMgtGatewayConstants.SYNAPSE_ENDPOINT_ADDRESS);
+        int targetResponseCode = (Integer) messageContext.getProperty(BACKEND_RESPONSE_CODE);
+
+        Object clientResponseCodeObj = ((Axis2MessageContext) messageContext).getAxis2MessageContext()
+                .getProperty(SynapseConstants.HTTP_SC);
+        int proxyResponseCode;
+        if (clientResponseCodeObj instanceof Integer) {
+            proxyResponseCode = (int) clientResponseCodeObj;
+        } else {
+            proxyResponseCode = Integer.parseInt((String) clientResponseCodeObj);
+        }
+
+        String userAgent = (String) messageContext.getProperty(USER_AGENT_PROPERTY);
+        long reqMediationLatency = getRequestMediationLatency(messageContext);
+        long resMediationLatency = getResponseMediationLatency(messageContext);
+
+        ResponseEvent responseEvent = new ResponseEvent();
+        responseEvent.setCorrelationId(UUID.randomUUID().toString());
+        responseEvent.setKeyType(keyType);
+        responseEvent.setApiId(apiUuid);
+        responseEvent.setApiName(apiName);
+        responseEvent.setApiVersion(apiVersion);
+        responseEvent.setApiCreator(apiCreator);
+        responseEvent.setApiMethod(httpMethod);
+        responseEvent.setApiCreatorTenantDomain(MultitenantUtils.getTenantDomain(apiCreator));
+        responseEvent.setApiResourceTemplate(apiResourceTemplate);
+        responseEvent.setDestination(endpointAddress);
+        responseEvent.setApplicationId(applicationId);
+        responseEvent.setApplicationName(applicationName);
+        responseEvent.setApplicationOwner(applicationOwner);
+
+        responseEvent.setRegionId(REGION_ID);
+        responseEvent.setGatewayType(APIMgtGatewayConstants.GATEWAY_TYPE);
+        responseEvent.setUserAgent(userAgent);
+        responseEvent.setProxyResponseCode(String.valueOf(proxyResponseCode));
+        responseEvent.setTargetResponseCode(String.valueOf(targetResponseCode));
+        responseEvent.setResponseCacheHit(String.valueOf(isCacheHit));
+        responseEvent.setResponseLatency(String.valueOf(responseTime));
+        responseEvent.setBackendLatency(String.valueOf(backendLatency));
+        responseEvent.setRequestMediationLatency(String.valueOf(reqMediationLatency));
+        responseEvent.setResponseMediationLatency(String.valueOf(resMediationLatency));
+        responseEvent.setDeploymentId(DEPLOYMENT_ID);
+        responseEvent.setEventType(SUCCESS_EVENT_TYPE);
+
+        OffsetDateTime time = OffsetDateTime.now(Clock.systemUTC());
+        responseEvent.setRequestTimeStamp(time.toString());
+
+        PublisherUtils.doPublish(METRIC_NAME, responseEvent);
+
+        return true;
+    }
+
+    @Override
+    public boolean handleServerInit() {
+        // Nothing to implement
+        return true;
+    }
+
+    @Override
+    public boolean handleServerShutDown() {
+        // Nothing to implement
+        return true;
+    }
+
+    @Override
+    public boolean handleArtifactDeployment(String s, String s1, String s2) {
+        // Nothing to implement
+        return true;
+    }
+
+    @Override
+    public boolean handleArtifactUnDeployment(String s, String s1, String s2) {
+        // Nothing to implement
+        return true;
+    }
+
+    private boolean isSuccessRequest(MessageContext messageContext) {
+        return !messageContext.getPropertyKeySet().contains(SynapseConstants.ERROR_CODE)
+                && APISecurityUtils.getAuthenticationContext(messageContext) != null;
+    }
+
+    private String getUserAgent(MessageContext messageContext) {
+        Map<?, ?> headers = (Map<?, ?>) ((Axis2MessageContext) messageContext).getAxis2MessageContext()
+                .getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
+        return (String) headers.get(APIConstants.USER_AGENT);
+    }
+
+    public static long getRequestMediationLatency(MessageContext messageContext) {
+
+        Object reqMediationLatency = messageContext.getProperty(APIMgtGatewayConstants.REQUEST_MEDIATION_LATENCY);
+        return reqMediationLatency == null ? 0 : ((Number) reqMediationLatency).longValue();
+    }
+
+    public static long getResponseMediationLatency(MessageContext messageContext) {
+
+        Object resMediationLatency = messageContext.getProperty(APIMgtGatewayConstants.RESPONSE_MEDIATION_LATENCY);
+        return resMediationLatency == null ? 0 : ((Number) resMediationLatency).longValue();
+    }
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/PublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/PublisherUtils.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.gateway.handlers.analytics;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.am.analytics.publisher.exception.MetricCreationException;
+import org.wso2.am.analytics.publisher.exception.MetricReportingException;
+import org.wso2.am.analytics.publisher.reporter.CounterMetric;
+import org.wso2.am.analytics.publisher.reporter.MetricReporter;
+import org.wso2.am.analytics.publisher.reporter.MetricReporterFactory;
+import org.wso2.am.analytics.publisher.reporter.MetricSchema;
+import org.wso2.carbon.apimgt.gateway.handlers.analytics.dto.ResponseEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * event publisher Util to handle even publishing.
+ */
+public class PublisherUtils {
+    private static final Log log = LogFactory.getLog(AnalyticsMetricsHandler.class);
+    public static final String AUTH_API_URL = "auth.api.url";
+    public static final String TOKEN_API_URL = "token.api.url";
+    public static final String CONSUMER_KEY = "consumer.key";
+    public static final String CONSUMER_SECRET = "consumer.secret";
+    public static final String SAS_TOKEN = "sas.token";
+    public static final Map<String, String> configs = new HashMap<String, String>() {{
+        put(TOKEN_API_URL, "localhost/token-api");
+        put(AUTH_API_URL, "localhost/auth-api");
+        put(CONSUMER_KEY, "consumer_key");
+        put(CONSUMER_SECRET, "consumer_secret");
+        put(SAS_TOKEN, null);
+    }};
+    public static final ObjectMapper mapper = new ObjectMapper();
+    public static final TypeReference<Map<String, String>> typeRef = new TypeReference<Map<String, String>>() {
+    };
+
+    public static void doPublish(String metricName, ResponseEvent responseEvent) {
+        MetricReporter metricReporter;
+        try {
+            metricReporter = MetricReporterFactory.getInstance().createMetricReporter(null, configs);
+            CounterMetric counterMetric = metricReporter.createCounterMetric(metricName, MetricSchema.RESPONSE);
+            Map<String, String> responseEventMap = mapper.convertValue(responseEvent, typeRef);
+            counterMetric.incrementCount(responseEventMap);
+        } catch (MetricCreationException e) {
+            log.error("Error initializing event publisher.", e);
+        } catch (MetricReportingException e) {
+            log.error("Error occurred when publishing event.", e);
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/dto/ResponseEvent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/dto/ResponseEvent.java
@@ -1,0 +1,258 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.gateway.handlers.analytics.dto;
+
+/**
+ * Response event data DTO
+ */
+public class ResponseEvent {
+    private String correlationId;
+    private String keyType;
+    private String apiId;
+    private String apiName;
+    private String apiVersion;
+    private String apiCreator;
+    private String apiMethod;
+    private String apiCreatorTenantDomain;
+    private String apiResourceTemplate;
+    private String destination;
+    private String applicationId;
+    private String applicationName;
+    private String applicationOwner;
+    private String regionId;
+    private String gatewayType;
+    private String userAgent;
+    private String proxyResponseCode;
+    private String targetResponseCode;
+    private String responseCacheHit;
+    private String responseLatency;
+    private String backendLatency;
+    private String requestMediationLatency;
+    private String responseMediationLatency;
+    private String deploymentId;
+    private String eventType;
+    private String requestTimeStamp;
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+    }
+
+    public String getKeyType() {
+        return keyType;
+    }
+
+    public void setKeyType(String keyType) {
+        this.keyType = keyType;
+    }
+
+    public String getApiId() {
+        return apiId;
+    }
+
+    public void setApiId(String apiId) {
+        this.apiId = apiId;
+    }
+
+    public String getApiName() {
+        return apiName;
+    }
+
+    public void setApiName(String apiName) {
+        this.apiName = apiName;
+    }
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    public String getApiCreator() {
+        return apiCreator;
+    }
+
+    public void setApiCreator(String apiCreator) {
+        this.apiCreator = apiCreator;
+    }
+
+    public String getApiMethod() {
+        return apiMethod;
+    }
+
+    public void setApiMethod(String apiMethod) {
+        this.apiMethod = apiMethod;
+    }
+
+    public String getApiCreatorTenantDomain() {
+        return apiCreatorTenantDomain;
+    }
+
+    public void setApiCreatorTenantDomain(String apiCreatorTenantDomain) {
+        this.apiCreatorTenantDomain = apiCreatorTenantDomain;
+    }
+
+    public String getApiResourceTemplate() {
+        return apiResourceTemplate;
+    }
+
+    public void setApiResourceTemplate(String apiResourceTemplate) {
+        this.apiResourceTemplate = apiResourceTemplate;
+    }
+
+    public String getDestination() {
+        return destination;
+    }
+
+    public void setDestination(String destination) {
+        this.destination = destination;
+    }
+
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    public void setApplicationName(String applicationName) {
+        this.applicationName = applicationName;
+    }
+
+    public String getApplicationOwner() {
+        return applicationOwner;
+    }
+
+    public void setApplicationOwner(String applicationOwner) {
+        this.applicationOwner = applicationOwner;
+    }
+
+    public String getRegionId() {
+        return regionId;
+    }
+
+    public void setRegionId(String regionId) {
+        this.regionId = regionId;
+    }
+
+    public String getGatewayType() {
+        return gatewayType;
+    }
+
+    public void setGatewayType(String gatewayType) {
+        this.gatewayType = gatewayType;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+    public String getProxyResponseCode() {
+        return proxyResponseCode;
+    }
+
+    public void setProxyResponseCode(String proxyResponseCode) {
+        this.proxyResponseCode = proxyResponseCode;
+    }
+
+    public String getResponseCacheHit() {
+        return responseCacheHit;
+    }
+
+    public void setResponseCacheHit(String responseCacheHit) {
+        this.responseCacheHit = responseCacheHit;
+    }
+
+    public String getResponseLatency() {
+        return responseLatency;
+    }
+
+    public void setResponseLatency(String responseLatency) {
+        this.responseLatency = responseLatency;
+    }
+
+    public String getBackendLatency() {
+        return backendLatency;
+    }
+
+    public void setBackendLatency(String backendLatency) {
+        this.backendLatency = backendLatency;
+    }
+
+    public String getRequestMediationLatency() {
+        return requestMediationLatency;
+    }
+
+    public void setRequestMediationLatency(String requestMediationLatency) {
+        this.requestMediationLatency = requestMediationLatency;
+    }
+
+    public String getResponseMediationLatency() {
+        return responseMediationLatency;
+    }
+
+    public void setResponseMediationLatency(String responseMediationLatency) {
+        this.responseMediationLatency = responseMediationLatency;
+    }
+
+    public String getDeploymentId() {
+        return deploymentId;
+    }
+
+    public void setDeploymentId(String deploymentId) {
+        this.deploymentId = deploymentId;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getTargetResponseCode() {
+        return targetResponseCode;
+    }
+
+    public void setTargetResponseCode(String targetResponseCode) {
+        this.targetResponseCode = targetResponseCode;
+    }
+
+    public String getRequestTimeStamp() {
+        return requestTimeStamp;
+    }
+
+    public void setRequestTimeStamp(String requestTimeStamp) {
+        this.requestTimeStamp = requestTimeStamp;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
@@ -45,6 +45,7 @@ public class APIMgtLatencyStatsHandler extends AbstractHandler {
     }
 
     public boolean handleRequest(MessageContext messageContext) {
+        messageContext.setProperty(APIMgtGatewayConstants.API_UUID_PROPERTY, apiUUID);
         org.apache.axis2.context.MessageContext axis2MsgContext =
                 ((Axis2MessageContext) messageContext).getAxis2MessageContext();
 

--- a/pom.xml
+++ b/pom.xml
@@ -1790,6 +1790,11 @@
                 <artifactId>javax.cache.wso2</artifactId>
                 <version>${carbon.kernel.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.am.analytics.publisher</groupId>
+                <artifactId>org.wso2.am.analytics.publisher.client</artifactId>
+                <version>${analytics.event.publisher.client.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -2052,5 +2057,6 @@
         <version.checkstyle>8.34</version.checkstyle>
         <org.wso2.orbit.org.mapstruct.version>1.4.1.wso2v1</org.wso2.orbit.org.mapstruct.version>
         <org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
+        <analytics.event.publisher.client.version>0.1.0-SNAPSHOT</analytics.event.publisher.client.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2057,6 +2057,6 @@
         <version.checkstyle>8.34</version.checkstyle>
         <org.wso2.orbit.org.mapstruct.version>1.4.1.wso2v1</org.wso2.orbit.org.mapstruct.version>
         <org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-        <analytics.event.publisher.client.version>0.1.0-SNAPSHOT</analytics.event.publisher.client.version>
+        <analytics.event.publisher.client.version>0.1.0</analytics.event.publisher.client.version>
     </properties>
 </project>


### PR DESCRIPTION
- Adding initial event publisher client for APIM

To engage the analytics handler, add the following code to deployment.toml
```
enabled_global_handlers=["external_call_logger", "open_tracing", "analytics"]

[synapse_handlers.analytics]
name="analytics"
class="org.wso2.carbon.apimgt.gateway.handlers.analytics.AnalyticsMetricsHandler"
```
