### PR TITLE
Add scope based access control for web socket apis

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -341,9 +341,11 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.ops4j.pax.logging:pax-logging-api</classpathDependencyExclude>
                         <classpathDependencyExclude>org.wso2.orbit.com.fasterxml.jackson.core:jackson-core</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                     <systemProperties>
+                        <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager</java.util.logging.manager>
                         <property>
                             <name>org.opensaml.httpclient.https.disableHostnameVerification</name>
                             <value>true</value>

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
@@ -363,7 +363,7 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
                     }
                     String keyValidatorClientType = APISecurityUtils.getKeyValidatorClientType();
                     if (APIConstants.API_KEY_VALIDATOR_WS_CLIENT.equals(keyValidatorClientType)) {
-                        info = getApiKeyDataForWSClient(apiKey, tenantDomain, apiContext, version, matchingResource);
+                        info = getApiKeyDataForWSClient(apiKey, tenantDomain, apiContext, version);
                     } else {
                         return false;
                     }
@@ -400,10 +400,9 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
     }
 
     protected APIKeyValidationInfoDTO getApiKeyDataForWSClient(String key, String domain, String apiContextUri,
-                                                             String apiVersion, String matchingResource)
-            throws APISecurityException {
+                                                               String apiVersion) throws APISecurityException {
 
-        return new WebsocketWSClient().getAPIKeyData(apiContextUri, apiVersion, key, domain, matchingResource);
+        return new WebsocketWSClient().getAPIKeyData(apiContextUri, apiVersion, key, domain);
     }
 
     protected APIManagerAnalyticsConfiguration getApiManagerAnalyticsConfiguration() {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketWSClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketWSClient.java
@@ -40,14 +40,18 @@ public class WebsocketWSClient {
 	 * @param context
 	 * @param apiVersion
 	 * @param apiKey
+	 * @param tenantDomain
+	 * @param matchingResource
 	 * @return
 	 * @throws APISecurityException
 	 */
-	public APIKeyValidationInfoDTO getAPIKeyData(String context, String apiVersion, String apiKey, String tenantDomain)
-			throws APISecurityException {
+	public APIKeyValidationInfoDTO getAPIKeyData(String context, String apiVersion, String apiKey, String tenantDomain,
+	                                             String matchingResource) throws APISecurityException {
 		try {
 			return apiKeyValidationService.validateKeyForHandshake(context, apiVersion, apiKey, tenantDomain,
-					Arrays.asList(APIConstants.KeyManager.API_LEVEL_ALL_KEY_MANAGERS));
+			                                                       Arrays.asList(
+					                                                       APIConstants.KeyManager.API_LEVEL_ALL_KEY_MANAGERS),
+			                                                       matchingResource);
 		} catch (Exception e) {
 			throw new APISecurityException(APISecurityConstants.API_AUTH_GENERAL_ERROR,
 			                               "Error while accessing backend services for API key validation", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketWSClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketWSClient.java
@@ -41,17 +41,15 @@ public class WebsocketWSClient {
 	 * @param apiVersion
 	 * @param apiKey
 	 * @param tenantDomain
-	 * @param matchingResource
 	 * @return
 	 * @throws APISecurityException
 	 */
-	public APIKeyValidationInfoDTO getAPIKeyData(String context, String apiVersion, String apiKey, String tenantDomain,
-	                                             String matchingResource) throws APISecurityException {
+	public APIKeyValidationInfoDTO getAPIKeyData(String context, String apiVersion, String apiKey, String tenantDomain)
+			throws APISecurityException {
 		try {
 			return apiKeyValidationService.validateKeyForHandshake(context, apiVersion, apiKey, tenantDomain,
 			                                                       Arrays.asList(
-					                                                       APIConstants.KeyManager.API_LEVEL_ALL_KEY_MANAGERS),
-			                                                       matchingResource);
+					                                                       APIConstants.KeyManager.API_LEVEL_ALL_KEY_MANAGERS));
 		} catch (Exception e) {
 			throw new APISecurityException(APISecurityConstants.API_AUTH_GENERAL_ERROR,
 			                               "Error while accessing backend services for API key validation", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/websocket/WebSocketApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/websocket/WebSocketApiConstants.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.handlers.websocket;
+
+public class WebSocketApiConstants {
+
+    WebSocketApiConstants() {
+    }
+
+    public static final String WEBSOCKET_DUMMY_HTTP_METHOD_NAME = "WS";
+    public static final String WS_ENDPOINT_NAME = "WebSocketInboundEndpoint";
+    public static final String WS_SECURED_ENDPOINT_NAME = "SecureWebSocketEP";
+    public static final String URL_SEPARATOR = "/";
+    public static final String DEFAULT_RESOURCE_NAME = "/_default_resource_of_api_";
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/websocket/WebSocketApiException.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/websocket/WebSocketApiException.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.handlers.websocket;
+
+public class WebSocketApiException extends Exception {
+
+    public WebSocketApiException(String message) {
+        super(message);
+    }
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/TenantServiceCreator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/TenantServiceCreator.java
@@ -60,6 +60,9 @@ public class TenantServiceCreator extends AbstractAxis2ConfigurationContextObser
     private String mainSequenceName = "main";
     private String corsSequenceName = "_cors_request_handler_";
     private String threatFaultSequenceName = "_threat_fault_";
+    private String webSocketInboundEp = "WebSocketInboundEndpoint";
+    private String securedWebSocketInboundEp = "SecureWebSocketEP";
+    private String webHookServerHTTP = "WebhookServer";
     private String synapseConfigRootPath = CarbonBaseUtils.getCarbonHome() + "/repository/resources/apim-synapse-config/";
 
     public void createdConfigurationContext(ConfigurationContext configurationContext) {
@@ -236,6 +239,18 @@ public class TenantServiceCreator extends AbstractAxis2ConfigurationContextObser
                 FileUtils.copyFile(new File(synapseConfigRootPath + threatFaultSequenceName + ".xml"),
                         new File(synapseConfigDir.getAbsolutePath() + File.separator + "sequences"
                                 + File.separator + threatFaultSequenceName + ".xml"));
+                FileUtils.copyFile(new File(synapseConfigRootPath + webSocketInboundEp + ".xml"), new File(
+                        synapseConfigDir.getAbsolutePath() + File.separator
+                                + MultiXMLConfigurationBuilder.INBOUND_ENDPOINT_DIR + File.separator
+                                + webSocketInboundEp + ".xml"));
+                FileUtils.copyFile(new File(synapseConfigRootPath + securedWebSocketInboundEp + ".xml"), new File(
+                        synapseConfigDir.getAbsolutePath() + File.separator
+                                + MultiXMLConfigurationBuilder.INBOUND_ENDPOINT_DIR + File.separator
+                                + securedWebSocketInboundEp + ".xml"));
+                FileUtils.copyFile(new File(synapseConfigRootPath + webHookServerHTTP + ".xml"), new File(
+                        synapseConfigDir.getAbsolutePath() + File.separator
+                                + MultiXMLConfigurationBuilder.INBOUND_ENDPOINT_DIR + File.separator + webHookServerHTTP
+                                + ".xml"));
             } catch (IOException e) {
                 log.error("Error while copying API manager specific synapse sequences" + e);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandlerTestCase.java
@@ -288,7 +288,7 @@ public class WebsocketInboundHandlerTestCase {
         APIKeyValidationService apiKeyValidationService = Mockito.mock(APIKeyValidationService.class);
         WebsocketWSClient websocketWSClient = Mockito.mock(WebsocketWSClient.class);
         try {
-            PowerMockito.when(websocketWSClient.getAPIKeyData(TENANT_URL, "1.0", "587hfbt4i8ydno87ywq", "abc.com", ""))
+            PowerMockito.when(websocketWSClient.getAPIKeyData(TENANT_URL, "1.0", "587hfbt4i8ydno87ywq", "abc.com"))
                     .thenReturn(apiKeyValidationInfoDTO);
             PowerMockito.whenNew(WebsocketWSClient.class).withNoArguments().thenReturn(websocketWSClient);
             websocketInboundHandler1.channelRead(channelHandlerContext, fullHttpRequest);
@@ -432,7 +432,7 @@ public class WebsocketInboundHandlerTestCase {
         WebsocketWSClient websocketWSClient = Mockito.mock(WebsocketWSClient.class);
         try {
             PowerMockito.when(
-                    websocketWSClient.getAPIKeyData(SUPER_TENANT_URL, "1.0", "587hfbt4i8ydno87ywq", "carbon.super", ""))
+                    websocketWSClient.getAPIKeyData(SUPER_TENANT_URL, "1.0", "587hfbt4i8ydno87ywq", "carbon.super"))
                     .thenReturn(apiKeyValidationInfoDTO);
             PowerMockito.whenNew(WebsocketWSClient.class).withAnyArguments().thenReturn(websocketWSClient);
             websocketInboundHandler1.channelRead(channelHandlerContext, fullHttpRequest);
@@ -446,7 +446,7 @@ public class WebsocketInboundHandlerTestCase {
 
             @Override
             protected APIKeyValidationInfoDTO getApiKeyDataForWSClient(String key, String domain, String apiContextUri,
-                                                                       String apiVersion, String matchingResource) {
+                                                                       String apiVersion) {
                 return info;
             }
 
@@ -488,7 +488,7 @@ public class WebsocketInboundHandlerTestCase {
 
             @Override
             protected APIKeyValidationInfoDTO getApiKeyDataForWSClient(String key, String domain, String apiKey,
-                                                                       String tenantDomain, String matchingResource)
+                                                                       String tenantDomain)
                     throws APISecurityException {
                 info.setAuthorized(true);
                 info.setApiName("Phoneverify*1.0");

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketUtilTestCase.java
@@ -52,6 +52,7 @@ import javax.cache.Caching;
 public class WebsocketUtilTestCase {
     private String apiKey = "abc";
     private String apiContext = "/ishara";
+    private String resource = "/resource";
     private String resourceKey = "resourceKey";
     private String subscriptionKey = "subscriptionKey";
     private String apiName = "PhoneVerify";
@@ -135,16 +136,19 @@ public class WebsocketUtilTestCase {
 
     @Test
     public void testGetAccessTokenCacheKey() {
-        Assert.assertEquals("235erwytgtkyb:/ishara", WebsocketUtil.getAccessTokenCacheKey(cachedToken,apiContext ));
+        Assert.assertEquals("235erwytgtkyb:/ishara:/resource",
+                            WebsocketUtil.getAccessTokenCacheKey(cachedToken, apiContext, resource));
     }
 
     @Test
     public void testInitParams() {
-        Assert.assertEquals("235erwytgtkyb:/ishara", WebsocketUtil.getAccessTokenCacheKey(cachedToken,apiContext ));
+        Assert.assertEquals("235erwytgtkyb:/ishara:/resource",
+                            WebsocketUtil.getAccessTokenCacheKey(cachedToken, apiContext, resource));
     }
 
     @Test
     public void testIsRemoveOAuthHeadersFromOutMessage() {
-        Assert.assertEquals("235erwytgtkyb:/ishara", WebsocketUtil.getAccessTokenCacheKey(cachedToken,apiContext ));
+        Assert.assertEquals("235erwytgtkyb:/ishara:/resource",
+                            WebsocketUtil.getAccessTokenCacheKey(cachedToken, apiContext, resource));
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import javax.xml.namespace.QName;
 
 /**
@@ -588,7 +587,6 @@ public final class APIConstants {
     public static final String IDENTITY_TOKEN_ENDPOINT_CONTEXT = "/oauth2/token";
     public static final String GATEWAY_SIGNED_JWT_CACHE = "SignedJWTParseCache";
 
-    public static final String DEFAULT_WEBSOCKET_VERSION = "defaultVersion";
     public static final String ENCRYPTED_VALUE = "encrypted";
     public static final String VALUE = "value";
     public static final String GATEWAY_INTROSPECT_CACHE_NAME = "GatewayIntrospectCache";

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/AbstractKeyValidationHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/AbstractKeyValidationHandler.java
@@ -217,10 +217,6 @@ public abstract class AbstractKeyValidationHandler implements KeyValidationHandl
         //TODO add a check to see whether datastore is initialized an load data using rest api if it is not loaded
         if (datastore != null) {
             api = datastore.getApiByContextAndVersion(context, version);
-            if (api == null && APIConstants.DEFAULT_WEBSOCKET_VERSION.equals(version)) {
-                // for websocket default version.
-                api = datastore.getDefaultApiByContext(context);
-            }
             if (api != null) {
                 key = datastore.getKeyMappingByKeyAndKeyManager(consumerKey, keyManager);
                 if (key != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyValidationService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyValidationService.java
@@ -465,14 +465,12 @@ public class APIKeyValidationService {
      * @param accessToken      access token of the request
      * @param tenantDomain
      * @param keyManagers
-     * @param matchingResource matching resource
      * @return
      * @throws APIKeyMgtException
      * @throws APIManagementException
      */
     public APIKeyValidationInfoDTO validateKeyForHandshake(String context, String version, String accessToken,
-                                                           String tenantDomain, List<String> keyManagers,
-                                                           String matchingResource)
+                                                           String tenantDomain, List<String> keyManagers)
             throws APIKeyMgtException, APIManagementException {
         APIKeyValidationInfoDTO info = new APIKeyValidationInfoDTO();
         info.setAuthorized(false);
@@ -484,15 +482,11 @@ public class APIKeyValidationService {
         validationContext.setTenantDomain(tenantDomain);
         validationContext.setRequiredAuthenticationLevel("Any");
         validationContext.setKeyManagers(keyManagers);
-        validationContext.setMatchingResource(matchingResource);
         KeyValidationHandler keyValidationHandler =
                 ServiceReferenceHolder.getInstance().getKeyValidationHandler(tenantDomain);
         boolean state = keyValidationHandler.validateToken(validationContext);
         if (state) {
             state = keyValidationHandler.validateSubscription(validationContext);
-            if (state) {
-                state = keyValidationHandler.validateScopes(validationContext);
-            }
             if (state) {
                 if (APIKeyMgtDataHolder.isJwtGenerationEnabled() &&
                         validationContext.getValidationInfoDTO().getEndUserName() != null

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyValidationServiceTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyValidationServiceTest.java
@@ -160,7 +160,7 @@ public class APIKeyValidationServiceTest {
         try {
             APIKeyValidationService apiKeyValidationService = new APIKeyValidationService();
             apiKeyValidationService.validateKeyForHandshake(API_CONTEXT, API_VERSION, ACCESS_TOKEN, TENANT_DOMAIN,
-                                                            keymanagers, API_RESOURCE);
+                                                            keymanagers);
             Assert.fail("NullPointerException expected");
         } catch (Exception e) {
             Assert.assertEquals(e.getMessage(), e.getMessage());
@@ -169,7 +169,7 @@ public class APIKeyValidationServiceTest {
         try {
             APIKeyValidationService apiKeyValidationService = new APIKeyValidationService();
             apiKeyValidationService.validateKeyForHandshake(API_CONTEXT, API_VERSION, ACCESS_TOKEN, TENANT_DOMAIN,
-                                                            keymanagers, API_RESOURCE);
+                                                            keymanagers);
             Assert.fail("NullPointerException expected");
         } catch (Exception e) {
             Assert.assertEquals(e.getMessage(), e.getMessage());
@@ -178,7 +178,7 @@ public class APIKeyValidationServiceTest {
         try {
             APIKeyValidationService apiKeyValidationService = new APIKeyValidationService();
             apiKeyValidationService.validateKeyForHandshake(API_CONTEXT, API_VERSION, ACCESS_TOKEN, TENANT_DOMAIN,
-                                                            keymanagers, API_RESOURCE);
+                                                            keymanagers);
             Assert.fail("NullPointerException expected");
         } catch (Exception e) {
             Assert.assertEquals(e.getMessage(), e.getMessage());

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyValidationServiceTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyValidationServiceTest.java
@@ -61,6 +61,7 @@ public class APIKeyValidationServiceTest {
 
     private final String USER_NAME = "admin";
     private final String API_CONTEXT = "apicontext";
+    private final String API_RESOURCE = "";
     private final String API_NAME = "apiname";
     private final String API_VERSION = "1.0.0";
     private final String TENANT_DOMAIN = "foo.com";
@@ -158,8 +159,8 @@ public class APIKeyValidationServiceTest {
                 .thenThrow(ClassNotFoundException.class);
         try {
             APIKeyValidationService apiKeyValidationService = new APIKeyValidationService();
-            apiKeyValidationService
-                    .validateKeyForHandshake(API_CONTEXT, API_VERSION, ACCESS_TOKEN, TENANT_DOMAIN, keymanagers);
+            apiKeyValidationService.validateKeyForHandshake(API_CONTEXT, API_VERSION, ACCESS_TOKEN, TENANT_DOMAIN,
+                                                            keymanagers, API_RESOURCE);
             Assert.fail("NullPointerException expected");
         } catch (Exception e) {
             Assert.assertEquals(e.getMessage(), e.getMessage());
@@ -167,8 +168,8 @@ public class APIKeyValidationServiceTest {
 
         try {
             APIKeyValidationService apiKeyValidationService = new APIKeyValidationService();
-            apiKeyValidationService
-                    .validateKeyForHandshake(API_CONTEXT, API_VERSION, ACCESS_TOKEN, TENANT_DOMAIN, keymanagers);
+            apiKeyValidationService.validateKeyForHandshake(API_CONTEXT, API_VERSION, ACCESS_TOKEN, TENANT_DOMAIN,
+                                                            keymanagers, API_RESOURCE);
             Assert.fail("NullPointerException expected");
         } catch (Exception e) {
             Assert.assertEquals(e.getMessage(), e.getMessage());
@@ -176,8 +177,8 @@ public class APIKeyValidationServiceTest {
 
         try {
             APIKeyValidationService apiKeyValidationService = new APIKeyValidationService();
-            apiKeyValidationService
-                    .validateKeyForHandshake(API_CONTEXT, API_VERSION, ACCESS_TOKEN, TENANT_DOMAIN, keymanagers);
+            apiKeyValidationService.validateKeyForHandshake(API_CONTEXT, API_VERSION, ACCESS_TOKEN, TENANT_DOMAIN,
+                                                            keymanagers, API_RESOURCE);
             Assert.fail("NullPointerException expected");
         } catch (Exception e) {
             Assert.assertEquals(e.getMessage(), e.getMessage());


### PR DESCRIPTION
This PR add scope based access control for web socket APIs depending on the introduction of  of resources for web socket APIs https://github.com/wso2/wso2-synapse/pull/1691.

**Handle Scope Based Access Control**
Before the request is authenticated, the matching resource is selected from the request path and passed for authentication.

**Handle Default Versioned API**
For the default version of API, a relevant api is assumed to be present in synapse config with the
name of corresponding api + _d + version of corresponding api
and when it is identified, the corresponding matching api  name is reconstructed and the request is processed in the normal path thereafter.

 