### PR TITLE
Add validation for category name in REST api v2

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ApiCategoriesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ApiCategoriesApiServiceImpl.java
@@ -36,6 +36,8 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.ws.rs.core.Response;
 
 public class ApiCategoriesApiServiceImpl implements ApiCategoriesApiService {
@@ -64,6 +66,22 @@ public class ApiCategoriesApiServiceImpl implements ApiCategoriesApiService {
             APIAdmin apiAdmin = new APIAdminImpl();
             String userName = RestApiCommonUtil.getLoggedInUsername();
             apiCategory = APICategoryMappingUtil.fromCategoryDTOToCategory(body);
+
+            if (!org.apache.commons.lang3.StringUtils.isEmpty(apiCategory.getName())) {
+                String regExSpecialChars = "!@#$%^&*(),?\"{}[\\]|<>";
+                String regExSpecialCharsReplaced = regExSpecialChars.replaceAll(".", "\\\\$0");
+                Pattern pattern = Pattern.compile("[" + regExSpecialCharsReplaced + "\\s" + "]");// include \n,\t, space
+                Matcher matcher = pattern.matcher(apiCategory.getName());
+                if (matcher.find()) {
+                    RestApiUtil.handleBadRequest("Name field contains special characters.", log);
+                }
+                if (apiCategory.getName().length() > 255) {
+                    RestApiUtil.handleBadRequest("API Category name is too long.", log);
+                }
+            } else {
+                RestApiUtil.handleBadRequest("API Category name is empty.", log);
+            }
+
             APICategoryDTO categoryDTO = APICategoryMappingUtil.
                     fromCategoryToCategoryDTO(apiAdmin.addCategory(apiCategory, userName));
             URI location = new URI(RestApiConstants.RESOURCE_PATH_CATEGORY + "/" + categoryDTO.getId());


### PR DESCRIPTION
Fix for wso2/product-apim#8951

As the fix, used the same validation done in the UI https://github.com/wso2/carbon-apimgt/blob/master/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/APICategories/AddEditAPICategory.jsx#L93