### PR TITLE
Hybrid endpoint support when invoking APIs secured with ApiKey only or BasicAuth only

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/template/APIConfigContext.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/template/APIConfigContext.java
@@ -121,10 +121,23 @@ public class APIConfigContext extends ConfigContext {
         context.put("apiIsBlocked", Boolean.FALSE);
 
         String apiSecurity = apiProduct.getApiSecurity();
+        //if API is secured with ouath2
         if (apiSecurity == null || apiSecurity.contains(APIConstants.DEFAULT_API_SECURITY_OAUTH2)) {
             context.put("apiIsOauthProtected", Boolean.TRUE);
         } else {
             context.put("apiIsOauthProtected", Boolean.FALSE);
+        }
+        //if API is secured with api_Key
+        if (apiSecurity.contains(APIConstants.API_SECURITY_API_KEY)) {
+            context.put("apiIsApiKeyProtected", Boolean.TRUE);
+        } else {
+            context.put("apiIsApiKeyProtected", Boolean.FALSE);
+        }
+        //if API is secured with basic_auth
+        if (apiSecurity.contains(APIConstants.API_SECURITY_BASIC_AUTH)) {
+            context.put("apiIsBasicAuthProtected", Boolean.TRUE);
+        } else {
+            context.put("apiIsBasicAuthProtected", Boolean.FALSE);
         }
         if (apiProduct.isEnabledSchemaValidation()) {
             context.put("enableSchemaValidation", Boolean.TRUE);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/template/APIConfigContext.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/template/APIConfigContext.java
@@ -85,10 +85,23 @@ public class APIConfigContext extends ConfigContext {
             context.put("apiIsBlocked", Boolean.FALSE);
         }
         String apiSecurity = api.getApiSecurity();
+        //if API is secured with ouath2
         if (apiSecurity == null || apiSecurity.contains(APIConstants.DEFAULT_API_SECURITY_OAUTH2)) {
             context.put("apiIsOauthProtected", Boolean.TRUE);
         } else {
             context.put("apiIsOauthProtected", Boolean.FALSE);
+        }
+        //if API is secured with api_Key
+        if (apiSecurity.contains(APIConstants.API_SECURITY_API_KEY)) {
+            context.put("apiIsApiKeyProtected", Boolean.TRUE);
+        } else {
+            context.put("apiIsApiKeyProtected", Boolean.FALSE);
+        }
+        //if API is secured with basic_auth
+        if (apiSecurity.contains(APIConstants.API_SECURITY_BASIC_AUTH)) {
+            context.put("apiIsBasicAuthProtected", Boolean.TRUE);
+        } else {
+            context.put("apiIsBasicAuthProtected", Boolean.FALSE);
         }
         if (api.isEnabledSchemaValidation()) {
             context.put("enableSchemaValidation", Boolean.TRUE);


### PR DESCRIPTION
### Purpose
After configuring an API to use only API Key security or Basic Auth security type, when invoking the API using the sandbox API Key, the request is directed to the production endpoint. This PR will solve that issue.

### Goal 
Fixes https://github.com/wso2/product-apim/issues/8483

### Approach
The velocity template was not checking for `apiKey authenticated` property and `basic_aut authenticated`  property. It only checks `oauth2 authenticated` property when mapping hybrid endpoints. Therefore, the api.xml resources are generated without both endpoint types(SandBox and Production). This fix will check for the missing properties and make the validation and templating will be done after that.

