### PR TITLE
Add WebhookApiHandler to velocity template builder

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
@@ -201,6 +201,15 @@ public class TemplateBuilderUtil {
                 vtb.addHandler("org.wso2.carbon.apimgt.gateway.handlers.graphQL.GraphQLAPIHandler",
                         apiUUIDProperty);
             }
+
+            if (APIConstants.APITransportType.WEBSUB.toString().equals(api.getType())) {
+                Map<String, String> webhookApiHandlerProperties = new HashMap<>();
+                webhookApiHandlerProperties.put("eventReceivingResourcePath", "/webhooks_events_receiver_resource");
+                webhookApiHandlerProperties.put("topicQueryParamName", "hub.topic");
+                vtb.addHandler("org.wso2.carbon.apimgt.gateway.handlers.streaming.webhook.WebhookApiHandler",
+                        webhookApiHandlerProperties);
+            }
+
             if (!(APIConstants.APITransportType.WS.toString().equals(api.getType()))) {
                 vtb.addHandler("org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler",
                         authProperties);


### PR DESCRIPTION
## Purpose
Adding the following handler to the API, for Websub Streaming APIs:
```xml
<handler class="org.wso2.carbon.apimgt.gateway.handlers.streaming.webhook.WebhookApiHandler">
      <property name="topicQueryParamName" value="hub.topic" />
      <property name="eventReceivingResourcePath" value="/webhooks_events_receiver_resource" />
</handler>
```