### PR TITLE
Update http method to subscribe for websub and sse

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/StreamingApiHanlder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/StreamingApiHanlder.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.handlers.streaming;
+
+import org.apache.axis2.Constants;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.rest.AbstractHandler;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+
+/**
+ * Include common functionality for websub and sse protocol.
+ */
+public class StreamingApiHanlder extends AbstractHandler {
+
+    @Override
+    public boolean handleRequest(MessageContext synCtx) {
+
+        Object apiType = synCtx.getProperty(APIConstants.API_TYPE);
+        if (APIConstants.API_TYPE_SSE.equals(apiType) || APIConstants.API_TYPE_WEBSUB.equals(apiType)) {
+            ((Axis2MessageContext) synCtx).getAxis2MessageContext().
+                    setProperty(Constants.Configuration.HTTP_METHOD, synCtx.getProperty(APIConstants.HTTP_VERB));
+        }
+        return true;
+    }
+
+    @Override
+    public boolean handleResponse(MessageContext messageContext) {
+        return true;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/sse/SseApiHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/sse/SseApiHandler.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.wso2.carbon.apimgt.gateway.handlers.streaming.sse;
+
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.rest.AbstractHandler;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+
+import static org.apache.axis2.Constants.Configuration.HTTP_METHOD;
+
+public class SseApiHandler extends AbstractHandler {
+
+    @Override
+    public boolean handleRequest(MessageContext synCtx) {
+        org.apache.axis2.context.MessageContext axisCtx = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+        Object httpVerb = axisCtx.getProperty(HTTP_METHOD);
+        synCtx.setProperty(APIConstants.HTTP_VERB, httpVerb);
+        axisCtx.setProperty(HTTP_METHOD, APIConstants.SubscriptionCreatedStatus.SUBSCRIBE);
+        synCtx.setProperty(APIConstants.API_TYPE, APIConstants.API_TYPE_SSE);
+        return true;
+    }
+
+    @Override
+    public boolean handleResponse(MessageContext messageContext) {
+        return true;
+    }
+
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/webhook/WebhookApiHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/webhook/WebhookApiHandler.java
@@ -28,6 +28,7 @@ import org.apache.http.HttpStatus;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.api.ApiUtils;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.AbstractHandler;
 import org.apache.synapse.rest.RESTConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.Utils;
@@ -37,6 +38,8 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 
+import static org.apache.axis2.Constants.Configuration.HTTP_METHOD;
+
 /**
  * Handler used for web hook apis. This handler retrieves the topic name, to which subscription request is coming and
  * will set it to the synapse msg context.
@@ -44,7 +47,7 @@ import java.net.URLDecoder;
  * {@code
  * <handler class="org.wso2.carbon.apimgt.gateway.handlers.streaming.webhook.WebhookApiHandler">
  *     <property name="eventReceiverResourcePath" value="/webhooks_events_receiver_resource"/>
- *     <property name="topicQueryParamName" value="hub.secret"/>
+ *     <property name="topicQueryParamName" value="hub.topic"/>
  * </handler>
  * }
  * </pre>
@@ -52,7 +55,7 @@ import java.net.URLDecoder;
 public class WebhookApiHandler extends AbstractHandler {
 
     private static final Log log = LogFactory.getLog(WebhookApiHandler.class);
-    private static final String DEFAULT_TOPIC_QUERY_PARAM_NAME = "hub.secret";
+    private static final String DEFAULT_TOPIC_QUERY_PARAM_NAME = "hub.topic";
     private static final String EMPTY_STRING = "";
     private static final String WEB_HOOK_SUBSCRIPTION_FAILURE_HANDLER = "_web_hook_subscription_failure_handler";
     private static final String DEFAULT_SUBSCRIPTION_RESOURCE_PATH = "/webhooks_events_receiver_resource";
@@ -71,6 +74,11 @@ public class WebhookApiHandler extends AbstractHandler {
                 handleFailure(synCtx, "Topic name not found for web hook subscription request");
                 return false;
             }
+            org.apache.axis2.context.MessageContext axisCtx = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+            Object httpVerb = axisCtx.getProperty(HTTP_METHOD);
+            synCtx.setProperty(APIConstants.HTTP_VERB, httpVerb);
+            axisCtx.setProperty(HTTP_METHOD, APIConstants.SubscriptionCreatedStatus.SUBSCRIBE);
+            synCtx.setProperty(APIConstants.API_TYPE, APIConstants.API_TYPE_WEBSUB);
             synCtx.setProperty(APIConstants.API_ELECTED_RESOURCE, topicName);
         }
         return true;


### PR DESCRIPTION
This sets the http method as subscribe  before the authentication handler and reset it as after it, since this DB entry is added as susbcribe.