### PR TITLE
Fix naming issues with secure web socket inbound in tenant space

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/TenantServiceCreator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/TenantServiceCreator.java
@@ -61,7 +61,7 @@ public class TenantServiceCreator extends AbstractAxis2ConfigurationContextObser
     private String corsSequenceName = "_cors_request_handler_";
     private String threatFaultSequenceName = "_threat_fault_";
     private String webSocketInboundEp = "WebSocketInboundEndpoint";
-    private String securedWebSocketInboundEp = "SecureWebSocketEP";
+    private String securedWebSocketInboundEp = "SecureWebSocketInboundEndpoint";
     private String webHookServerHTTP = "WebhookServer";
     private String synapseConfigRootPath = CarbonBaseUtils.getCarbonHome() + "/repository/resources/apim-synapse-config/";
 


### PR DESCRIPTION
$subject. This caused the issue of both secured websocket and http inbound to be not present in the tenant when its loaded.