### PR TITLE
Use different error codes for graphQL errors

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandler.java
@@ -348,7 +348,7 @@ public class GraphQLAPIHandler extends AbstractHandler {
     private void handleFailure(MessageContext messageContext, String errorDescription) {
         OMElement payload = getFaultPayload(errorDescription);
         Utils.setFaultPayload(messageContext, payload);
-        Mediator sequence = messageContext.getSequence(APISecurityConstants.GRAPHQL_API_FAILURE_HANDLER);
+        Mediator sequence = messageContext.getSequence(GraphQLConstants.GRAPHQL_API_FAILURE_HANDLER);
         if (sequence != null && !sequence.mediate(messageContext)) {
             return;
         }
@@ -366,9 +366,9 @@ public class GraphQLAPIHandler extends AbstractHandler {
         OMElement payload = fac.createOMElement("fault", ns);
 
         OMElement errorCode = fac.createOMElement("code", ns);
-        errorCode.setText(APISecurityConstants.GRAPHQL_INVALID_QUERY + "");
+        errorCode.setText(GraphQLConstants.GRAPHQL_INVALID_QUERY + "");
         OMElement errorMessage = fac.createOMElement("message", ns);
-        errorMessage.setText(APISecurityConstants.GRAPHQL_INVALID_QUERY_MESSAGE);
+        errorMessage.setText(GraphQLConstants.GRAPHQL_INVALID_QUERY_MESSAGE);
         OMElement errorDetail = fac.createOMElement("description", ns);
         errorDetail.setText(description);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLConstants.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.gateway.handlers.graphQL;
+
+import org.wso2.carbon.apimgt.gateway.handlers.throttling.APIThrottleConstants;
+
+/**
+ * GraphQL related gateway constants
+ */
+public class GraphQLConstants {
+    public static final int GRAPHQL_QUERY_TOO_DEEP = APIThrottleConstants.GRAPHQL_QUERY_TOO_DEEP;
+    public static final String GRAPHQL_QUERY_TOO_DEEP_MESSAGE = "QUERY TOO DEEP";
+
+    public static final int GRAPHQL_QUERY_TOO_COMPLEX = APIThrottleConstants.GRAPHQL_QUERY_TOO_COMPLEX;
+    public static final String GRAPHQL_QUERY_TOO_COMPLEX_MESSAGE = "QUERY TOO COMPLEX";
+
+    public static final int GRAPHQL_INVALID_QUERY = 900422;
+    public static final String GRAPHQL_API_FAILURE_HANDLER = "_graphql_failure_handler";
+    public static final String GRAPHQL_INVALID_QUERY_MESSAGE= "INVALID QUERY";
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLQueryAnalysisHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLQueryAnalysisHandler.java
@@ -150,8 +150,8 @@ public class GraphQLQueryAnalysisHandler extends AbstractHandler {
                         }
                         return true;
                     }
-                    handleFailure(APISecurityConstants.GRAPHQL_QUERY_TOO_DEEP, messageContext,
-                            APISecurityConstants.GRAPHQL_QUERY_TOO_DEEP_MESSAGE, errorList.toString());
+                    handleFailure(GraphQLConstants.GRAPHQL_QUERY_TOO_DEEP, messageContext,
+                            GraphQLConstants.GRAPHQL_QUERY_TOO_DEEP_MESSAGE, errorList.toString());
                     log.error(errorList.toString());
                     return false;
                 }
@@ -207,8 +207,8 @@ public class GraphQLQueryAnalysisHandler extends AbstractHandler {
                         errorList.clear();
                         errorList.add("maximum query complexity exceeded");
                     }
-                    handleFailure(APISecurityConstants.GRAPHQL_QUERY_TOO_COMPLEX, messageContext,
-                            APISecurityConstants.GRAPHQL_QUERY_TOO_COMPLEX_MESSAGE, errorList.toString());
+                    handleFailure(GraphQLConstants.GRAPHQL_QUERY_TOO_COMPLEX, messageContext,
+                            GraphQLConstants.GRAPHQL_QUERY_TOO_COMPLEX_MESSAGE, errorList.toString());
                     return false;
                 }
                 return true;
@@ -255,7 +255,7 @@ public class GraphQLQueryAnalysisHandler extends AbstractHandler {
                                String errorMessage, String errorDescription) {
         OMElement payload = getFaultPayload(errorCodeValue, errorMessage, errorDescription);
         Utils.setFaultPayload(messageContext, payload);
-        Mediator sequence = messageContext.getSequence(APISecurityConstants.GRAPHQL_API_FAILURE_HANDLER);
+        Mediator sequence = messageContext.getSequence(GraphQLConstants.GRAPHQL_API_FAILURE_HANDLER);
         if (sequence != null && !sequence.mediate(messageContext)) {
             return;
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APISecurityConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APISecurityConstants.java
@@ -64,16 +64,6 @@ public class APISecurityConstants {
     public static final int API_AUTH_MISSING_OPEN_API_DEF = 900911;
     public static final String API_AUTH_MISSING_OPEN_API_DEF_ERROR_MESSAGE = "Internal Server Error";
 
-    public static final int GRAPHQL_QUERY_TOO_DEEP = 900912;
-    public static final String GRAPHQL_QUERY_TOO_DEEP_MESSAGE = "QUERY TOO DEEP";
-
-    public static final int GRAPHQL_QUERY_TOO_COMPLEX = 900913;
-    public static final String GRAPHQL_QUERY_TOO_COMPLEX_MESSAGE = "QUERY TOO COMPLEX";
-
-    public static final int GRAPHQL_INVALID_QUERY = 900422;
-    public static final String GRAPHQL_API_FAILURE_HANDLER = "_graphql_failure_handler";
-    public static final String GRAPHQL_INVALID_QUERY_MESSAGE= "INVALID QUERY";
-
     public static final int OAUTH_TEMPORARY_SERVER_ERROR = 900424;
     public static final String OAUTH_TEMPORARY_SERVER_ERROR_MESSAGE = "Temporary Server Error";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/APIThrottleConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/APIThrottleConstants.java
@@ -29,8 +29,8 @@ public class APIThrottleConstants {
     public static final int BLOCKED_ERROR_CODE = 900805;
     public static final int CUSTOM_POLICY_THROTTLE_OUT_ERROR_CODE = 900806;
 
-    public static final int GRAPHQL_QUERY_TOO_DEEP = 900920;
-    public static final int GRAPHQL_QUERY_TOO_COMPLEX = 900921;
+    public static final int GRAPHQL_QUERY_TOO_DEEP = 900820;
+    public static final int GRAPHQL_QUERY_TOO_COMPLEX = 900821;
 
     public static final String API_LIMIT_EXCEEDED = APIConstants.THROTTLE_OUT_REASON_API_LIMIT_EXCEEDED;
     public static final String RESOURCE_LIMIT_EXCEEDED = APIConstants.THROTTLE_OUT_REASON_RESOURCE_LIMIT_EXCEEDED;

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/APIThrottleConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/APIThrottleConstants.java
@@ -29,6 +29,9 @@ public class APIThrottleConstants {
     public static final int BLOCKED_ERROR_CODE = 900805;
     public static final int CUSTOM_POLICY_THROTTLE_OUT_ERROR_CODE = 900806;
 
+    public static final int GRAPHQL_QUERY_TOO_DEEP = 900920;
+    public static final int GRAPHQL_QUERY_TOO_COMPLEX = 900921;
+
     public static final String API_LIMIT_EXCEEDED = APIConstants.THROTTLE_OUT_REASON_API_LIMIT_EXCEEDED;
     public static final String RESOURCE_LIMIT_EXCEEDED = APIConstants.THROTTLE_OUT_REASON_RESOURCE_LIMIT_EXCEEDED;
     public static final String APPLICATION_LIMIT_EXCEEDED = APIConstants.THROTTLE_OUT_REASON_APPLICATION_LIMIT_EXCEEDED;


### PR DESCRIPTION
- Use throttled out error code for "QUERY TOO DEEP" and "QUERY TOO COMPLEX" error codes. 
- Fixed https://github.com/wso2/product-apim/issues/9972