### PR TITLE
Extracting the correct form of username from auth context when using 3rd party KMs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleHandler.java
@@ -194,6 +194,12 @@ public class ThrottleHandler extends AbstractHandler implements ManagedLifecycle
         //If Authz context is not null only we can proceed with throttling
         if (authContext != null) {
             authorizedUser = authContext.getUsername();
+
+            //Check if the tenant domain is appended with authorizedUser and append if it is not there
+            if (!StringUtils.contains(authorizedUser, apiTenantDomain)) {
+                authorizedUser = authContext.getUsername() + "@" + apiTenantDomain;
+            }
+
             //Check if request is blocked. If request is blocked then will not proceed further and
             //inform to client.
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleHandlerTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleHandlerTest.java
@@ -327,7 +327,7 @@ public class ThrottleHandlerTest {
         ArrayList<ConditionGroupDTO> matchingConditions = new ArrayList<>();
         matchingConditions.add(conditionGroupDTO);
         String applicationLevelThrottleKey = authenticationContext.getApplicationId() + ":" + authenticationContext
-                .getUsername();
+                .getUsername()+ "@" + throttleHandler.getTenantDomain();
         //Set application level throttled out
         throttleDataHolder.addThrottleData(applicationLevelThrottleKey, System.currentTimeMillis() + 10000);
 
@@ -392,7 +392,7 @@ public class ThrottleHandlerTest {
         String subscriptionLevelThrottleKey = authenticationContext.getApplicationId() + ":" + apiContext + ":"
                 + apiVersion;
         String applicationLevelThrottleKey = authenticationContext.getApplicationId() + ":" + authenticationContext
-                .getUsername();
+                .getUsername()+ "@" + throttleHandler.getTenantDomain();
         String combinedResourceLevelThrottleKey = resourceLevelThrottleKey + conditionGroupDTO.getConditionGroupId();
 //        Mockito.when(throttleDataHolder.isThrottled(combinedResourceLevelThrottleKey)).thenReturn(false);
 //        Mockito.when(throttleDataHolder.isThrottled(subscriptionLevelThrottleKey)).thenReturn(false);


### PR DESCRIPTION
### Purpose

When the APIM 3.2.0 is configured with third-party keymanager(Ex: Keycloak) and a deny policy is added to block the API invocation to a particular user, that user is able to invoke the API without having any issue. This is happening because the auth context does not contain the correct form of value as the `authorizedUser`.
### Goal
Fixes https://github.com/wso2/product-apim/issues/9957

### Approach

The existing code extracts the **authorizedUser** value from the **authContext** using the `getUSername()` method. But it does not provide the correct form of `<username>@<tenant_domain>` when using a 3rd Party Key manager. The fix will be changed to get the correct form of this **authorizedUser** from the **authContext**.

> authorizedUser = authContext.Username() + "@" + apiTenantDomain;


## Tests

### apimgt-carbon
![Screenshot** from 2021-02-20 10-52-52](https://user-images.githubusercontent.com/42435576/108590073-a15df280-7387-11eb-9ae8-5eecad540eea.png)

### Integration Tests
![Screenshot from 2021-02-20 14-26-55](https://user-images.githubusercontent.com/42435576/108590090-b5a1ef80-7387-11eb-936f-6c3d5ec03ad1.png)


