### PR TITLE
Add the support to overwrite deployment envs at import with params 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -197,7 +197,7 @@ public class APIControllerUtil {
 
         // handle available subscription policies
         JsonElement policies = envParams.get(ImportExportConstants.POLICIES_FIELD);
-        if (!policies.isJsonNull()) {
+        if (policies != null && !policies.isJsonNull()) {
             handleSubscriptionPolicies(policies, importedApiDto);
         }
         return importedApiDto;


### PR DESCRIPTION
Added the support to overwrite deployment environments specified in the api artifact at import with the api_params.yaml file. 
Also fixed https://github.com/wso2/product-apim-tooling/issues/623