### PR TITLE
Adding the REST API restriction when anonymous mode is disabled for developer portal

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
@@ -1007,14 +1007,6 @@ public interface APIConsumer extends APIManager {
     String getRequestedTenant();
 
     /**
-     * Checks whether the DevPortal Anonymous Mode is enabled.
-     *
-     * @param tenantDomain       tenant domain
-     * @throws APIManagementException if an error occurs while reading configs
-     */
-    boolean isDevPortalAnonymousEnabled(String tenantDomain) throws APIManagementException;
-
-    /**
      *
      * @param apiId API UUID
      * @return Set of Topics defined in a specified Async API

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5930,29 +5930,6 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         return apiMgtDAO.getKeyMappingFromApplicationIdAndKeyMappingId(applicationId, keyMappingId);
     }
 
-    /**
-     * To check whether the DevPortal Anonymous Mode is enabled. It can be either enabled globally or tenant vice.
-     *
-     * @param tenantDomain Tenant domain
-     * @return whether devportal anonymous mode is enabled or not
-     */
-
-    public boolean isDevPortalAnonymousEnabled(String tenantDomain) {
-
-        try {
-            org.json.simple.JSONObject tenantConfig = APIUtil.getTenantConfig(tenantDomain);
-            Object value = tenantConfig.get(APIConstants.API_TENANT_CONF_ENABLE_ANONYMOUS_MODE);
-            if (value != null) {
-                return Boolean.parseBoolean(value.toString());
-            } else {
-                return APIUtil.isDevPortalAnonymous();
-            }
-        } catch (APIManagementException e) {
-            log.error("Error while retrieving Anonymous config from registry", e);
-        }
-        return true;
-    }
-
     @Override
     public Set<Topic> getTopics(String apiId) throws APIManagementException {
         return apiMgtDAO.getAPITopics(apiId);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiConstants.java
@@ -33,6 +33,7 @@ public final class RestApiConstants {
     public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
     public static final String APPLICATION_XML = "application/xml";
     public static final String AUTHENTICATION_REQUIRED = "authentication_required";
+    public static final String MESSAGE_BASE_PATH = "org.apache.cxf.message.Message.BASE_PATH";
 
     public static final String REQUEST_AUTHENTICATION_SCHEME = "request_authentication_scheme";
     public static final String OAUTH2_AUTHENTICATION = "oauth2";
@@ -140,12 +141,15 @@ public final class RestApiConstants {
     public static final String RESOURCE_PATH_PRODUCT_DOCUMENT_CONTENT = RESOURCE_PATH_PRODUCT_DOCUMENTS_DOCUMENT_ID + "/content";
     public static final String RESOURCE_PATH_RESOURCE_PATHS = "/resource-paths";
     public static final String RESOURCE_PATH_COMMENTS = "/comments";
+    public static final String RESOURCE_PATH_SWAGGER= "/swagger.yaml";
     public static final String REST_API_STORE_VERSION_0 ="v0.16";
     public static final String RESOURCE_PATH_API_CATEGORIES = "/api-categories";
     public static final String RESOURCE_PATH_CATEGORY_THUMBNAIL = RESOURCE_PATH_API_CATEGORIES + "/" + APICATEGORYID_PARAM + "/thumbnail";
     public static final String REST_API_DEVELOPER_PORTAL_VERSION ="v2";
     public static final String REST_API_STORE_CONTEXT="/api/am/store/";
     public static final String REST_API_DEVELOPER_PORTAL_CONTEXT = "api/am/devportal";
+    public static final String REST_API_STORE_RESOURCE_PATH_SETTINGS = "/settings";
+    public static final String REST_API_STORE_RESOURCE_PATH_TENANTS = "/tenants";
     public static final String REST_API_STORE_CONTEXT_FULL_0 = REST_API_STORE_CONTEXT + REST_API_STORE_VERSION_0;
     public static final String REST_API_DEVELOPER_PORTAL_CONTEXT_FULL = REST_API_DEVELOPER_PORTAL_CONTEXT +
             REST_API_DEVELOPER_PORTAL_VERSION;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiConstants.java
@@ -33,7 +33,7 @@ public final class RestApiConstants {
     public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
     public static final String APPLICATION_XML = "application/xml";
     public static final String AUTHENTICATION_REQUIRED = "authentication_required";
-    public static final String MESSAGE_BASE_PATH = "org.apache.cxf.message.Message.BASE_PATH";
+    public static final String HEADER_X_WSO2_TENANT = "x-wso2-tenant";
 
     public static final String REQUEST_AUTHENTICATION_SCHEME = "request_authentication_scheme";
     public static final String OAUTH2_AUTHENTICATION = "oauth2";
@@ -148,8 +148,8 @@ public final class RestApiConstants {
     public static final String REST_API_DEVELOPER_PORTAL_VERSION ="v2";
     public static final String REST_API_STORE_CONTEXT="/api/am/store/";
     public static final String REST_API_DEVELOPER_PORTAL_CONTEXT = "api/am/devportal";
-    public static final String REST_API_STORE_RESOURCE_PATH_SETTINGS = "/settings";
-    public static final String REST_API_STORE_RESOURCE_PATH_TENANTS = "/tenants";
+    public static final String REST_API_DEVELOPER_PORTAL_RESOURCE_PATH_SETTINGS = "/settings";
+    public static final String REST_API_DEVELOPER_PORTAL_RESOURCE_PATH_TENANTS = "/tenants";
     public static final String REST_API_STORE_CONTEXT_FULL_0 = REST_API_STORE_CONTEXT + REST_API_STORE_VERSION_0;
     public static final String REST_API_DEVELOPER_PORTAL_CONTEXT_FULL = REST_API_DEVELOPER_PORTAL_CONTEXT +
             REST_API_DEVELOPER_PORTAL_VERSION;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SettingsApiServiceImpl.java
@@ -54,7 +54,7 @@ public class SettingsApiServiceImpl implements SettingsApiService {
             String requestedTenantDomain = RestApiUtil.getRequestedTenantDomain(xWSO2Tenant);
             boolean monetizationEnabled = apiConsumer.isMonetizationEnabled(requestedTenantDomain);
             boolean recommendationEnabled = apiConsumer.isRecommendationEnabled(requestedTenantDomain);
-            boolean anonymousEnabled = apiConsumer.isDevPortalAnonymousEnabled(requestedTenantDomain);
+            boolean anonymousEnabled = RestApiUtil.isDevPortalAnonymousEnabled(requestedTenantDomain);
             boolean isUserAvailable = false;
             if (!APIConstants.WSO2_ANONYMOUS_USER.equalsIgnoreCase(username)) {
                 isUserAvailable = true;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
@@ -1368,4 +1368,25 @@ public class RestApiUtil {
         }
         return portalScopeList;
     }
+
+    /**
+     * To check whether the DevPortal Anonymous Mode is enabled. It can be either enabled globally or tenant vice.
+     *
+     * @param tenantDomain Tenant domain
+     * @return whether devportal anonymous mode is enabled or not
+     */
+    public static boolean isDevPortalAnonymousEnabled(String tenantDomain) {
+        try {
+            org.json.simple.JSONObject tenantConfig = APIUtil.getTenantConfig(tenantDomain);
+            Object value = tenantConfig.get(APIConstants.API_TENANT_CONF_ENABLE_ANONYMOUS_MODE);
+            if (value != null) {
+                return Boolean.parseBoolean(value.toString());
+            } else {
+                return APIUtil.isDevPortalAnonymous();
+            }
+        } catch (APIManagementException e) {
+            log.error("Error while retrieving Anonymous config from registry", e);
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9722

## Goals
the REST API restriction when the anonymous mode is disabled for developer portal

## Approach
- Used **PreAuthenticationInterceptor.java** to do the restriction for REST APIs
- Executed the integration tests and all were passed.
  ![image](https://user-images.githubusercontent.com/25246848/109375124-3b6def80-78e0-11eb-9dde-fda05b594f42.png)

## User stories
- When the "EnableAnonymous" is "false", a user cannot access the Devportal REST APIs without any credentials.
   ```
   wasura@wasura:~$ curl 'https://localhost:9443/api/am/devportal/v2/apis?limit=10&offset=0' -k 
   {"code":401,"message":"","description":"Unauthenticated request","moreInfo":"","error":[]}
   ```

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS