### PR TITLE
Add missing mandatory elements to OAS definitions

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -861,6 +861,9 @@ public class OAS2Parser extends APIDefinition {
                 scopeBindings.put(scope.getKey(), roles);
             }
             oAuth2Definition.setVendorExtension(APIConstants.SWAGGER_X_SCOPES_BINDINGS, scopeBindings);
+        } else {
+            // prevent showing 'missing scopes' critical validation errors in Swagger validators i.e.42Crunch
+            oAuth2Definition.addScope(null, null);
         }
         swagger.addSecurityDefinition(APIConstants.SWAGGER_APIM_DEFAULT_SECURITY, oAuth2Definition);
         if (swagger.getSecurity() == null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -691,6 +691,37 @@ public class OAS3Parser extends APIDefinition {
     }
 
     /**
+     * Include authorizationUrl and scopes, mandatory elements to the OpenAPI definition if not present under
+     * securitySchemes in provided definition.
+     *
+     * @param swaggerContent OpenAPI Definition content
+     */
+    private String processSecuritySchemes(String swaggerContent) {
+        OpenAPI openAPI = getOpenAPI(swaggerContent);
+        Components components = openAPI.getComponents();
+        if (components != null) {
+            Map<String, SecurityScheme> securitySchemes = components.getSecuritySchemes();
+            if (securitySchemes != null) {
+                SecurityScheme defaultSecurityScheme = openAPI.getComponents().getSecuritySchemes()
+                        .get(OPENAPI_SECURITY_SCHEMA_KEY);
+                if (defaultSecurityScheme != null) {
+                    OAuthFlow oAuthFlow = defaultSecurityScheme.getFlows().getImplicit();
+                    String authUrl = oAuthFlow.getAuthorizationUrl();
+                    if (StringUtils.isBlank(authUrl)) {
+                        oAuthFlow.setAuthorizationUrl(OPENAPI_DEFAULT_AUTHORIZATION_URL);
+                    }
+                    Scopes scopes = oAuthFlow.getScopes();
+                    if (scopes == null) {
+                        Scopes newScopes = new Scopes();
+                        oAuthFlow.setScopes(newScopes);
+                    }
+                }
+            }
+        }
+        return Json.pretty(openAPI);
+    }
+
+    /**
      * This method validates the given OpenAPI definition by content
      *
      * @param apiDefinition     OpenAPI Definition content
@@ -704,6 +735,7 @@ public class OAS3Parser extends APIDefinition {
         OpenAPIV3Parser openAPIV3Parser = new OpenAPIV3Parser();
         ParseOptions options = new ParseOptions();
         options.setResolve(true);
+        apiDefinition = processSecuritySchemes(apiDefinition);
         SwaggerParseResult parseAttemptForV3 = openAPIV3Parser.readContents(apiDefinition, null, options);
         if (CollectionUtils.isNotEmpty(parseAttemptForV3.getMessages())) {
             validationResponse.setValid(false);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -695,6 +695,7 @@ public class OAS3Parser extends APIDefinition {
      * securitySchemes in provided definition.
      *
      * @param swaggerContent OpenAPI Definition content
+     * @return updated OpenAPI Definition content as String
      */
     private String processSecuritySchemes(String swaggerContent) {
         OpenAPI openAPI = getOpenAPI(swaggerContent);


### PR DESCRIPTION
### Purpose
To solve below issues associated with support tickets.
**For OAS3:**
When importing the API via apictl or publisher the security and securitySchemes have been introduced. The implicit flow is added in this scenario. According to the OAS3 specification, the security or securitySchemes are not mandatory. But if we defined for code or implicit grants then we need to provide authorizationURL as it is a mandatory field.
**For OAS2:**
To solve critical error shows when validating auto updated swagger 2.0 definition after uploading the original definition to APIM-3.X.X.

### Goal
To prevent from https://github.com/wso2/product-apim/issues/9889 and https://github.com/wso2/product-apim/issues/9912 issues in future

### Approach
Add mock authorizatoinURL (https://test.com) to the authorizationUrl if it is not present and add empty scopes object if there is no scopes provided on OAS3 definitions. For OAS2 definitions, add an empty object "scopes: {}" when generating definition in APIM if there is no any scopes defined in uploaded definition.