### PR TITLE
Add monetization config changes required to support Cloud analytics

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -912,10 +912,12 @@
     <Monetization>
         <MonetizationImpl>{{apim.monetization.monetization_impl}}</MonetizationImpl>
         <UsagePublisher>
-            <Granularity>{{apim.monetization.granularity}}</Granularity>
-            <!--Number of days to reduce from the current time to get the last publish time of monetization
-            usgae publish job, when there is no record of the last publish time.-->
-            <PublishTimeDurationInDays>{{apim.monetization.publish_duration}}</PublishTimeDurationInDays>
+             {% if apim.monetization.analytics_query_api_endpoint is defined %}
+                   <AnalyticsQueryAPIEndpoint>{{apim.monetization.analytics_query_api_endpoint}}</AnalyticsQueryAPIEndpoint>
+             {% endif %}
+             {% if apim.monetization.analytics_access_token is defined %}
+                    <AnalyticsAccessToken>{{apim.monetization.analytics_access_token}}</AnalyticsAccessToken>
+             {% endif %}
         </UsagePublisher>
         {% if apim.monetization.additional_attributes is defined %}
             <AdditionalAttributes>


### PR DESCRIPTION
Add monetization config required to support  data retrieval from Choroe analytics. It includes two new configs to configure the query api endpoint of choro which is used to retreive data and the token required to authenticate to the above endpoint. 

With the intrroduction of this config, it has to be configured as follows in the deployment.toml

[apim.monetization]
analytics_query_api_endpoint= "<query api endpoint of choroe analytics>"
analytics_access_token = "<token retrieved from choreo analytics>"

Fixes https://github.com/wso2-enterprise/choreo-analytics-apim/issues/164
