### PR TITLE
Update the correct default API version when importing an API via APICTL

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -443,6 +443,33 @@ public interface APIProvider extends APIManager {
             throws DuplicateAPIException, APIManagementException;
 
     /**
+     * Disable the default API version in other APIs and update the current API as the default version
+     *
+     * @param api                    API
+     * @param previousDefaultVersion API ID of the previous default version
+     * @throws APIManagementException
+     */
+    void updateOtherAPIVersionsForNewDefaultAPIChange(API api, String previousDefaultVersion)
+            throws APIManagementException;
+
+    /**
+     * Update the default API in the registry.
+     *
+     * @param apiIdentifier Identifier of the default API
+     * @param value         Whether the API is the default version or not
+     * @throws APIManagementException if an error occurs while updating the default API version of the API in registry
+     */
+    void updateDefaultAPIInRegistry(APIIdentifier apiIdentifier, boolean value) throws APIManagementException;
+
+    /**
+     * Add/update the default API version of an API.
+     *
+     * @param api API
+     * @throws APIManagementException if an error occurs while adding/updating the default API version of the API
+     */
+    void addUpdateAPIAsDefaultVersion(API api) throws APIManagementException;
+
+    /**
      * Retrieve the Key of the Service used in the API
      * @param apiId Unique Identifier of the API
      * @param tenantId Logged-in tenant domain

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1630,7 +1630,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             String previousDefaultVersion = getDefaultVersion(api.getId());
             String publishedDefaultVersion = getPublishedDefaultVersion(api.getId());
 
-            updateOtherAPIversionsForNewDefautlAPIChange(api, previousDefaultVersion);
+            updateOtherAPIVersionsForNewDefaultAPIChange(api, previousDefaultVersion);
 
             updateEndpointSecurity(oldApi, api);
 
@@ -1705,7 +1705,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         return api;
     }
 
-    private void updateOtherAPIversionsForNewDefautlAPIChange(API api, String previousDefaultVersion)
+    public void updateOtherAPIVersionsForNewDefaultAPIChange(API api, String previousDefaultVersion)
             throws APIManagementException {
 
         if (previousDefaultVersion != null) {
@@ -3139,6 +3139,16 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     + apiIdentifier.getApiName();
             handleException(msg, e);
         }
+    }
+
+    /**
+     * Add/update the default API version of an API.
+     *
+     * @param api API to add
+     * @throws APIManagementException if an error occurs while adding/updating the default API version of the API
+     */
+    public void addUpdateAPIAsDefaultVersion(API api) throws APIManagementException {
+        apiMgtDAO.addUpdateAPIAsDefaultVersion(api);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -6235,6 +6235,14 @@ public class ApiMgtDAO {
         return publishedDefaultVersion;
     }
 
+    public void addUpdateAPIAsDefaultVersion(API api) throws APIManagementException {
+        try (Connection connection = APIMgtDBUtil.getConnection()) {
+            addUpdateAPIAsDefaultVersion(api, connection);
+        } catch (SQLException e) {
+            throw new APIManagementException("Error while setting default API version of ", e);
+        }
+    }
+
     public void addUpdateAPIAsDefaultVersion(API api, Connection connection) throws APIManagementException {
         String publishedDefaultVersion = getPublishedDefaultVersion(api.getId());
         removeAPIFromDefaultVersion(api.getId(), connection);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -102,6 +102,8 @@ public final class ImportExportConstants {
     // Name of the API version element tag of the api.json file
     public static final String VERSION_ELEMENT = "version";
 
+    public static final String IS_DEFAULT_VERSION = "isDefaultVersion";
+
     public static final String WSDL_URL = "wsdlUrl";
 
     // Swagger definition version of the imported API

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -178,7 +178,7 @@ public final class ImportExportConstants {
 
     public static final String TYPE_CLIENT_CERTIFICATES = "client_certificates";
 
-    public static final String APIM_VERSION = "v4";
+    public static final String APIM_VERSION = "v4.0.0";
 
     public static final String ENDPOINT_CONFIG = "endpointConfig";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -614,7 +614,7 @@ public class ImportUtils {
 
         // Check whether the isDefaultVersion field exists. If not, add it with false value
         if (!configObject.has(ImportExportConstants.IS_DEFAULT_VERSION)) {
-            configObject.addProperty(ImportExportConstants.IS_DEFAULT_VERSION, false);
+            configObject.addProperty(ImportExportConstants.IS_DEFAULT_VERSION, Boolean.FALSE);
         }
 
         // Remove spaces of API Name/version if present


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/533

## Goals
Fixing the behaviour of the default API version when there is an API already inside the APIM which the default API version is true.

## Approach
- The default API version and the published default API version will be updated in the AM_API_DEFAULT_VERSION table.
- The registry artifacts will be updated accordingly as well.
- The new default API version will be added to the gateway by removing the old one.

## User stories
- If there is not any, default API in the APIM, when you import an API with the default API version, it will be assigned as the default one.
- If there is already an API with the default API version inside APIM, when you are importing an API with the default API version, it will be assigned as the default one by making the old API default version false.

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS