### PR TITLE
Modify the structure of deployment_environments.yaml for APICTL tasks

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -176,6 +176,8 @@ public final class ImportExportConstants {
 
     public static final String TYPE_CLIENT_CERTIFICATES = "client_certificates";
 
+    public static final String TYPE_DEPLOYMENT_ENVIRONMENTS = "deployment_environments";
+
     public static final String APIM_VERSION = "v4";
 
     public static final String ENDPOINT_CONFIG = "endpointConfig";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -178,7 +178,7 @@ public final class ImportExportConstants {
 
     public static final String TYPE_DEPLOYMENT_ENVIRONMENTS = "deployment_environments";
 
-    public static final String APIM_VERSION = "v4";
+    public static final String APIM_VERSION = "v4.0.0";
 
     public static final String ENDPOINT_CONFIG = "endpointConfig";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -677,8 +677,8 @@ public class ExportUtils {
                 deploymentsArray.put(deploymentObject);
             }
             if (deploymentsArray.length() > 0) {
-                CommonUtil.writeToYamlOrJson(archivePath + ImportExportConstants.DEPLOYMENT_INFO_LOCATION, exportFormat,
-                        deploymentsArray.toString());
+                CommonUtil.writeDtoToFile(archivePath + ImportExportConstants.DEPLOYMENT_INFO_LOCATION, exportFormat,
+                        ImportExportConstants.TYPE_DEPLOYMENT_ENVIRONMENTS, deploymentsArray);
             }
         } catch (APIImportExportException e) {
             throw new APIManagementException(

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -668,15 +668,15 @@ public class ExportUtils {
 
         try {
             List<APIRevisionDeployment> deploymentsList = apiProvider.getAPIRevisionDeploymentList(apiID);
-            JSONArray deploymentsArray = new JSONArray();
+            JsonArray deploymentsArray = new JsonArray();
             for (APIRevisionDeployment deployment : deploymentsList) {
-                JSONObject deploymentObject = new JSONObject();
-                deploymentObject.put(ImportExportConstants.DEPLOYMENT_NAME, deployment.getDeployment());
-                deploymentObject
-                        .put(ImportExportConstants.DISPLAY_ON_DEVPORTAL_OPTION, deployment.isDisplayOnDevportal());
-                deploymentsArray.put(deploymentObject);
+                JsonObject deploymentObject = new JsonObject();
+                deploymentObject.addProperty(ImportExportConstants.DEPLOYMENT_NAME, deployment.getDeployment());
+                deploymentObject.addProperty(ImportExportConstants.DISPLAY_ON_DEVPORTAL_OPTION,
+                        deployment.isDisplayOnDevportal());
+                deploymentsArray.add(deploymentObject);
             }
-            if (deploymentsArray.length() > 0) {
+            if (deploymentsArray.size() > 0) {
                 CommonUtil.writeDtoToFile(archivePath + ImportExportConstants.DEPLOYMENT_INFO_LOCATION, exportFormat,
                         ImportExportConstants.TYPE_DEPLOYMENT_ENVIRONMENTS, deploymentsArray);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -855,10 +855,12 @@ public class ImportUtils {
                     getFileContentAsJson(new File(pathToArchive).getParentFile().getParent()
                             + File.separator + ImportExportConstants.DEPLOYMENT_INFO_LOCATION) :
                     getFileContentAsJson(pathToArchive + ImportExportConstants.DEPLOYMENT_INFO_LOCATION);
+            // Retrieving the field "data" in deployment_environments.yaml
+            JsonElement configElement = new JsonParser().parse(jsonContent).getAsJsonObject().get(APIConstants.DATA);
             if (jsonContent == null) {
                 return null;
             }
-            return new Gson().fromJson(jsonContent, JsonArray.class);
+            return configElement.getAsJsonArray();
         } catch (IOException e) {
             throw new APIManagementException("Error while reading deployment environments info from path: "
                     + pathToArchive, e, ExceptionCodes.ERROR_READING_META_DATA);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -855,11 +855,11 @@ public class ImportUtils {
                     getFileContentAsJson(new File(pathToArchive).getParentFile().getParent()
                             + File.separator + ImportExportConstants.DEPLOYMENT_INFO_LOCATION) :
                     getFileContentAsJson(pathToArchive + ImportExportConstants.DEPLOYMENT_INFO_LOCATION);
-            // Retrieving the field "data" in deployment_environments.yaml
-            JsonElement configElement = new JsonParser().parse(jsonContent).getAsJsonObject().get(APIConstants.DATA);
             if (jsonContent == null) {
                 return null;
             }
+            // Retrieving the field "data" in deployment_environments.yaml
+            JsonElement configElement = new JsonParser().parse(jsonContent).getAsJsonObject().get(APIConstants.DATA);
             return configElement.getAsJsonArray();
         } catch (IOException e) {
             throw new APIManagementException("Error while reading deployment environments info from path: "


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/637

## Goals
 Change the structure of the `deployment_environments.yaml` to be more descriptive and follow the standard of other yaml files found in the project.

## Approach
Updated the deployment_environment.yaml to be exported in the following format.
```
type: deployment_environments
version: v4.0.0
data:
 -
   displayOnDevportal: true
   deploymentEnvironment: Production and Sandbox
 -
   displayOnDevportal: true  
   deploymentEnvironment: Label1  
 -
   displayOnDevportal: false  
   deploymentEnvironment: Label2 
```

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/648

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS