### PR TITLE
Resolve default vhost to null DB value and Update swagger server URL

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -74,6 +74,7 @@ import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.api.model.TierPermission;
 import org.wso2.carbon.apimgt.api.model.Documentation.DocumentSourceType;
 import org.wso2.carbon.apimgt.api.model.Documentation.DocumentVisibility;
+import org.wso2.carbon.apimgt.api.model.VHost;
 import org.wso2.carbon.apimgt.api.model.webhooks.Subscription;
 import org.wso2.carbon.apimgt.api.model.webhooks.Topic;
 import org.wso2.carbon.apimgt.impl.caching.CacheProvider;
@@ -107,6 +108,7 @@ import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIVersionComparator;
 import org.wso2.carbon.apimgt.impl.utils.ApplicationUtils;
 import org.wso2.carbon.apimgt.impl.utils.ContentSearchResultNameComparator;
+import org.wso2.carbon.apimgt.impl.utils.VHostUtils;
 import org.wso2.carbon.apimgt.impl.workflow.GeneralWorkflowResponse;
 import org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants;
 import org.wso2.carbon.apimgt.impl.workflow.WorkflowException;
@@ -5575,45 +5577,6 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
 
     /**
      * Get server URL updated Open API definition for given deployment (synapse gateway or container managed cluster)
-     * @param apiId Id of the API
-     * @param synapseEnvName Name of the synapse gateway environment
-     * @param clusterName Name of the container managed cluster
-     * @return Updated Open API definition
-     * @throws APIManagementException
-     */
-    private String getOpenAPIDefinitionForDeployment(Identifier apiId, String synapseEnvName, String clusterName)
-            throws APIManagementException {
-        String apiTenantDomain;
-        String updatedDefinition = null;
-        Map<String,String> hostsWithSchemes;
-        String definition = super.getOpenAPIDefinition(apiId, tenantDomain);
-        APIDefinition oasParser = OASParserUtil.getOASParser(definition);
-        if (apiId instanceof APIIdentifier) {
-            API api = getLightweightAPI((APIIdentifier) apiId, tenantDomain);
-            //todo: use get api by id, so no need to set scopes or uri templates
-            api.setScopes(oasParser.getScopes(definition));
-            api.setUriTemplates(oasParser.getURITemplates(definition));
-            apiTenantDomain = MultitenantUtils.getTenantDomain(
-                    APIUtil.replaceEmailDomainBack(api.getId().getProviderName()));
-            if (!StringUtils.isEmpty(synapseEnvName)) {
-                hostsWithSchemes = getHostWithSchemeMappingForEnvironment(apiTenantDomain, synapseEnvName);
-            } else {
-                hostsWithSchemes = getHostWithSchemeMappingForClusterName(clusterName);
-            }
-            api.setContext(getBasePath(apiTenantDomain, api.getContext()));
-            updatedDefinition = oasParser.getOASDefinitionForStore(api, definition, hostsWithSchemes);
-        } else if (apiId instanceof APIProductIdentifier) {
-            APIProduct apiProduct = getAPIProduct((APIProductIdentifier) apiId);
-            apiTenantDomain = MultitenantUtils.getTenantDomain(apiProduct.getId().getProviderName());
-            hostsWithSchemes = getHostWithSchemeMappingForEnvironment(apiTenantDomain, synapseEnvName);
-            apiProduct.setContext(getBasePath(apiTenantDomain, apiProduct.getContext()));
-            updatedDefinition = oasParser.getOASDefinitionForStore(apiProduct, definition, hostsWithSchemes);
-        }
-        return updatedDefinition;
-    }
-
-    /**
-     * Get server URL updated Open API definition for given deployment (synapse gateway or container managed cluster)
      * @param synapseEnvName Name of the synapse gateway environment
      * @param clusterName Name of the container managed cluster
      * @return Updated Open API definition
@@ -5636,7 +5599,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         apiTenantDomain = MultitenantUtils.getTenantDomain(
                 APIUtil.replaceEmailDomainBack(api.getId().getProviderName()));
         if (!StringUtils.isEmpty(synapseEnvName)) {
-            hostsWithSchemes = getHostWithSchemeMappingForEnvironment(apiTenantDomain, synapseEnvName);
+            hostsWithSchemes = getHostWithSchemeMappingForEnvironment(api, apiTenantDomain, synapseEnvName);
         } else {
             hostsWithSchemes = getHostWithSchemeMappingForClusterName(clusterName);
         }
@@ -5762,7 +5725,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
      * @return Host name to transport scheme mapping
      * @throws APIManagementException if an error occurs when getting host names with schemes
      */
-    private Map<String, String> getHostWithSchemeMappingForEnvironment(String apiTenantDomain, String environmentName)
+    private Map<String, String> getHostWithSchemeMappingForEnvironment(API api, String apiTenantDomain, String environmentName)
             throws APIManagementException {
 
         Map<String, String> domains = getTenantDomainMappings(apiTenantDomain, APIConstants.API_DOMAIN_MAPPINGS_GATEWAY);
@@ -5782,15 +5745,27 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 handleResourceNotFoundException("Could not find provided environment '" + environmentName + "'");
             }
 
-            assert environment != null;
-            String[] hostsWithScheme = environment.getApiGatewayEndpoint().split(",");
-            for (String url : hostsWithScheme) {
-                if (url.startsWith(APIConstants.HTTPS_PROTOCOL_URL_PREFIX)) {
-                    hostsWithSchemes.put(APIConstants.HTTPS_PROTOCOL, url);
+            List<APIRevisionDeployment> deploymentList = getAPIRevisionDeploymentListOfAPI(api.getUuid());
+            String host = "";
+            for (APIRevisionDeployment deployment : deploymentList) {
+                if (!deployment.isDisplayOnDevportal()) {
+                    continue;
                 }
-                if (url.startsWith(APIConstants.HTTP_PROTOCOL_URL_PREFIX)) {
-                    hostsWithSchemes.put(APIConstants.HTTP_PROTOCOL, url);
+                if (StringUtils.equals(deployment.getDeployment(), environmentName)) {
+                    host = deployment.getVhost();
                 }
+            }
+            if (StringUtils.isEmpty(host)) {
+                handleResourceNotFoundException("Could not find a deployment in provided environment '"
+                        + environmentName + "'");
+            }
+
+            VHost vhost = VHostUtils.getVhostFromEnvironment(environment, host);
+            if (StringUtils.containsIgnoreCase(api.getTransports(), APIConstants.HTTP_PROTOCOL)) {
+                hostsWithSchemes.put(APIConstants.HTTP_PROTOCOL, vhost.getHttpUrl());
+            }
+            if (StringUtils.containsIgnoreCase(api.getTransports(), APIConstants.HTTPS_PROTOCOL)) {
+                hostsWithSchemes.put(APIConstants.HTTPS_PROTOCOL, vhost.getHttpsUrl());
             }
         }
         return hostsWithSchemes;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5756,8 +5756,9 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 }
             }
             if (StringUtils.isEmpty(host)) {
-                handleResourceNotFoundException("Could not find a deployment in provided environment '"
-                        + environmentName + "'");
+                // returns empty server urls
+                hostsWithSchemes.put(APIConstants.HTTP_PROTOCOL, "");
+                return hostsWithSchemes;
             }
 
             VHost vhost = VHostUtils.getVhostFromEnvironment(environment, host);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -16803,9 +16803,11 @@ public class ApiMgtDAO {
                     apiRevision.setDescription(rs.getString("DESCRIPTION"));
                     apiRevision.setCreatedTime(rs.getString("CREATED_TIME"));
                     apiRevision.setCreatedBy(rs.getString("CREATED_BY"));
-                    if (!StringUtils.isEmpty(rs.getString("NAME"))) {
-                        apiRevisionDeployment.setDeployment(rs.getString("NAME"));
-                        apiRevisionDeployment.setVhost(rs.getString("VHOST"));
+                    String environmentName = rs.getString("NAME");
+                    if (!StringUtils.isEmpty(environmentName)) {
+                        apiRevisionDeployment.setDeployment(environmentName);
+                        String vhost = rs.getString("VHOST");
+                        apiRevisionDeployment.setVhost(getResolvedVhost(environmentName, vhost));
                         //apiRevisionDeployment.setRevisionUUID(rs.getString(8));
                         apiRevisionDeployment.setDisplayOnDevportal(rs.getBoolean("DISPLAY_ON_DEVPORTAL"));
                         apiRevisionDeployment.setDeployedTime(rs.getString("DEPLOYED_TIME"));
@@ -16856,6 +16858,7 @@ public class ApiMgtDAO {
      */
     public void addAPIRevisionDeployment(String apiRevisionId, List<APIRevisionDeployment> apiRevisionDeployments)
             throws APIManagementException {
+        Map<String, org.wso2.carbon.apimgt.impl.dto.Environment> readOnlyEnvs = APIUtil.getReadOnlyEnvironments();
         try (Connection connection = APIMgtDBUtil.getConnection()) {
             try {
                 connection.setAutoCommit(false);
@@ -16863,8 +16866,16 @@ public class ApiMgtDAO {
                 PreparedStatement statement = connection
                         .prepareStatement(SQLConstants.APIRevisionSqlConstants.ADD_API_REVISION_DEPLOYMENT_MAPPING);
                 for (APIRevisionDeployment apiRevisionDeployment : apiRevisionDeployments) {
+                    String envName = apiRevisionDeployment.getDeployment();
+                    String vhost = apiRevisionDeployment.getVhost();
+                    // set VHost as null, if it is the default vhost of the read only environment
+                    if (readOnlyEnvs.get(envName) != null
+                            && StringUtils.equalsIgnoreCase(vhost,
+                            APIUtil.getDefaultVhostOfReadOnlyEnvironment(envName).getHost())) {
+                        vhost = null;
+                    }
                     statement.setString(1, apiRevisionDeployment.getDeployment());
-                    statement.setString(2, apiRevisionDeployment.getVhost());
+                    statement.setString(2, vhost);
                     statement.setString(3, apiRevisionId);
                     statement.setBoolean(4, apiRevisionDeployment.isDisplayOnDevportal());
                     statement.addBatch();
@@ -16896,8 +16907,10 @@ public class ApiMgtDAO {
             statement.setString(1, name);
             try (ResultSet rs = statement.executeQuery()) {
                 while (rs.next()) {
-                    apiRevisionDeployment.setDeployment(rs.getString("NAME"));
-                    apiRevisionDeployment.setVhost(rs.getString("VHOST"));
+                    String environmentName = rs.getString("NAME");
+                    String vhost = rs.getString("VHOST");
+                    apiRevisionDeployment.setDeployment(environmentName);
+                    apiRevisionDeployment.setVhost(getResolvedVhost(environmentName, vhost));
                     apiRevisionDeployment.setRevisionUUID(rs.getString("REVISION_UUID"));
                     apiRevisionDeployment.setDisplayOnDevportal(rs.getBoolean("DISPLAY_ON_DEVPORTAL"));
                     apiRevisionDeployment.setDeployedTime(rs.getString("DEPLOYED_TIME"));
@@ -16925,8 +16938,10 @@ public class ApiMgtDAO {
             try (ResultSet rs = statement.executeQuery()) {
                 while (rs.next()) {
                     APIRevisionDeployment apiRevisionDeployment = new APIRevisionDeployment();
-                    apiRevisionDeployment.setDeployment(rs.getString("NAME"));
-                    apiRevisionDeployment.setVhost(rs.getString("VHOST"));
+                    String environmentName = rs.getString("NAME");
+                    String vhost = rs.getString("VHOST");
+                    apiRevisionDeployment.setDeployment(environmentName);
+                    apiRevisionDeployment.setVhost(getResolvedVhost(environmentName, vhost));
                     apiRevisionDeployment.setRevisionUUID(rs.getString("REVISION_UUID"));
                     apiRevisionDeployment.setDisplayOnDevportal(rs.getBoolean("DISPLAY_ON_DEVPORTAL"));
                     apiRevisionDeployment.setDeployedTime(rs.getString("DEPLOYED_TIME"));
@@ -16956,8 +16971,10 @@ public class ApiMgtDAO {
             try (ResultSet rs = statement.executeQuery()) {
                 while (rs.next()) {
                     APIRevisionDeployment apiRevisionDeployment = new APIRevisionDeployment();
-                    apiRevisionDeployment.setDeployment(rs.getString("NAME"));
-                    apiRevisionDeployment.setVhost(rs.getString("VHOST"));
+                    String environmentName = rs.getString("NAME");
+                    String vhost = rs.getString("VHOST");
+                    apiRevisionDeployment.setDeployment(environmentName);
+                    apiRevisionDeployment.setVhost(getResolvedVhost(environmentName, vhost));
                     apiRevisionDeployment.setRevisionUUID(rs.getString("REVISION_UUID"));
                     apiRevisionDeployment.setDisplayOnDevportal(rs.getBoolean("DISPLAY_ON_DEVPORTAL"));
                     apiRevisionDeployment.setDeployedTime(rs.getString("DEPLOYED_TIME"));
@@ -16987,8 +17004,10 @@ public class ApiMgtDAO {
             try (ResultSet rs = statement.executeQuery()) {
                 while (rs.next()) {
                     APIRevisionDeployment apiRevisionDeployment = new APIRevisionDeployment();
-                    apiRevisionDeployment.setDeployment(rs.getString("NAME"));
-                    apiRevisionDeployment.setVhost(rs.getString("VHOST"));
+                    String environmentName = rs.getString("NAME");
+                    String vhost = rs.getString("VHOST");
+                    apiRevisionDeployment.setDeployment(environmentName);
+                    apiRevisionDeployment.setVhost(getResolvedVhost(environmentName, vhost));
                     apiRevisionDeployment.setRevisionUUID(rs.getString("REVISION_UUID"));
                     apiRevisionDeployment.setDisplayOnDevportal(rs.getBoolean("DISPLAY_ON_DEVPORTAL"));
                     apiRevisionDeployment.setDeployedTime(rs.getString("DEPLOYED_TIME"));
@@ -17807,5 +17826,19 @@ public class ApiMgtDAO {
             statement.setInt(3, apiId);
             statement.executeUpdate();
         }
+    }
+
+    /**
+     *
+     * @param environmentName Environment name
+     * @param vhost Host of the vhost
+     * @return Resolved vhost
+     * @throws APIManagementException if failed to find the read only environment
+     */
+    private String getResolvedVhost(String environmentName, String vhost) throws APIManagementException {
+        if (StringUtils.isEmpty(vhost)) {
+            return APIUtil.getDefaultVhostOfReadOnlyEnvironment(environmentName).getHost();
+        }
+        return vhost;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -118,6 +118,7 @@ import org.wso2.carbon.apimgt.api.model.ResourceFile;
 import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
+import org.wso2.carbon.apimgt.api.model.VHost;
 import org.wso2.carbon.apimgt.api.model.WebsubSubscriptionConfiguration;
 import org.wso2.carbon.apimgt.api.model.graphql.queryanalysis.GraphqlComplexityInfo;
 import org.wso2.carbon.apimgt.api.model.policy.APIPolicy;
@@ -10030,6 +10031,24 @@ public final class APIUtil {
     public static Map<String, Environment> getReadOnlyEnvironments() {
         return ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                 .getAPIManagerConfiguration().getApiGatewayEnvironments();
+    }
+
+    /**
+     * Get default (first) vhost of the given read only environment
+     * @param environmentName name of the read only environment
+     * @return default vhost of environment
+     */
+    public static VHost getDefaultVhostOfReadOnlyEnvironment(String environmentName) throws APIManagementException {
+        Map<String, Environment> readOnlyEnvironments = getReadOnlyEnvironments();
+        if (readOnlyEnvironments.get(environmentName) == null) {
+            throw new APIManagementException("Configured read only environment not found: "
+                    + environmentName);
+        }
+        if (readOnlyEnvironments.get(environmentName).getVhosts().isEmpty()) {
+            throw new APIManagementException("VHosts not found for the environment: "
+                    + environmentName);
+        }
+        return readOnlyEnvironments.get(environmentName).getVhosts().get(0);
     }
 
     private static QName getQNameWithIdentityNS(String localPart) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/VHostUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/VHostUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.utils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.wso2.carbon.apimgt.api.model.VHost;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.dto.Environment;
+
+public class VHostUtils {
+
+    /**
+     * Get VHost object of given environment and given host name
+     *
+     * @param environment Gateway environment name
+     * @param host Host name of the VHost
+     * @return VHost object of the given host
+     */
+    public static VHost getVhostFromEnvironment(Environment environment, String host) {
+        // If there are any inconstancy (if VHost not found) use default VHost
+        VHost defaultVhost = new VHost();
+        defaultVhost.setHost(host);
+        defaultVhost.setHttpContext("");
+        defaultVhost.setHttpsPort(APIConstants.HTTPS_PROTOCOL_PORT);
+        defaultVhost.setHttpPort(APIConstants.HTTP_PROTOCOL_PORT);
+        defaultVhost.setWsPort(APIConstants.WS_PROTOCOL_PORT);
+        defaultVhost.setWssPort(APIConstants.WSS_PROTOCOL_PORT);
+
+        if (host == null && environment.getVhosts().size() > 0) {
+            // VHost is NULL set first Vhost (set in deployment toml)
+            return environment.getVhosts().get(0);
+        }
+
+        return environment.getVhosts().stream()
+                .filter(v -> StringUtils.equals(v.getHost(), host))
+                .findAny()
+                .orElse(defaultVhost);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -4338,6 +4338,13 @@ public class ApisApiServiceImpl implements ApisApiService {
             apiRevisionDeployment.setRevisionUUID(revisionId);
             apiRevisionDeployment.setDeployment(apiRevisionDeploymentDTO.getName());
             apiRevisionDeployment.setVhost(apiRevisionDeploymentDTO.getVhost());
+            if (StringUtils.isEmpty(apiRevisionDeploymentDTO.getVhost())) {
+                // vhost is only required when deploying an revision, not required when un-deploying a revision
+                // since the same scheme 'APIRevisionDeployment' is used for deploy and undeploy, handle it here.
+                RestApiUtil.handleBadRequest(
+                        "Required field 'vhost' not found in deployment", log
+                );
+            }
             apiRevisionDeployment.setDisplayOnDevportal(apiRevisionDeploymentDTO.isDisplayOnDevportal());
             apiRevisionDeployments.add(apiRevisionDeployment);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApisApiServiceImpl.java
@@ -1132,10 +1132,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             if (APIConstants.PUBLISHED.equals(status) || APIConstants.PROTOTYPED.equals(status)
                             || APIConstants.DEPRECATED.equals(status)) {
 
-                APIDTO apidto = APIMappingUtil.fromAPItoDTO(api, requestedTenantDomain);
-                List<APIRevisionDeployment> revisionDeployments = apiConsumer.getAPIRevisionDeploymentListOfAPI(apiId);
-                apidto.setEndpointURLs(APIMappingUtil.fromAPIRevisionListToEndpointsList(apidto, revisionDeployments));
-                return apidto;
+                return APIMappingUtil.fromAPItoDTO(api, requestedTenantDomain);
             } else {
                 RestApiUtil.handleAuthorizationFailure(RestApiConstants.RESOURCE_API, apiId, log);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.apimgt.impl.containermgt.ContainerBasedConstants;
 import org.wso2.carbon.apimgt.impl.dto.Environment;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.impl.utils.VHostUtils;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.*;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
@@ -190,8 +191,6 @@ public class APIMappingUtil {
         dto.setTiers(tiersToReturn);
 
         dto.setTransport(Arrays.asList(model.getTransports().split(",")));
-
-        dto.setEndpointURLs(APIUtils.extractEndpointURLs(model, tenantDomain));
 
         dto.setIngressURLs(extractIngressURLs(model));
 
@@ -380,8 +379,6 @@ public class APIMappingUtil {
 
         dto.setTransport(Arrays.asList(model.getTransports().split(",")));
 
-        dto.setEndpointURLs(APIUtils.extractEndpointURLs(model, tenantDomain));
-
         APIBusinessInformationDTO apiBusinessInformationDTO = new APIBusinessInformationDTO();
         apiBusinessInformationDTO.setBusinessOwner(model.getBusinessOwner());
         apiBusinessInformationDTO.setBusinessOwnerEmail(model.getBusinessOwnerEmail());
@@ -433,18 +430,31 @@ public class APIMappingUtil {
 
 
     public static APIDTO fromAPItoDTO(ApiTypeWrapper model, String tenantDomain) throws APIManagementException {
+        APIDTO apidto;
         if (model.isAPIProduct()) {
-            return fromAPItoDTO(model.getApiProduct(), tenantDomain);
+            apidto = fromAPItoDTO(model.getApiProduct(), tenantDomain);
         } else {
-            return fromAPItoDTO(model.getApi(), tenantDomain);
+            apidto = fromAPItoDTO(model.getApi(), tenantDomain);
         }
+        apidto.setEndpointURLs(fromAPIRevisionListToEndpointsList(apidto, tenantDomain));
+        return apidto;
     }
 
-    public static List<APIEndpointURLsDTO> fromAPIRevisionListToEndpointsList(
-            APIDTO apidto,
-            List<APIRevisionDeployment> revisionDeployments) throws APIManagementException {
+    public static List<APIEndpointURLsDTO> fromAPIRevisionListToEndpointsList(APIDTO apidto, String tenantDomain)
+            throws APIManagementException {
 
         Map<String, Environment> environments = APIUtil.getEnvironments();
+        APIConsumer apiConsumer = RestApiCommonUtil.getLoggedInUserConsumer();
+        List<APIRevisionDeployment> revisionDeployments = apiConsumer.getAPIRevisionDeploymentListOfAPI(apidto.getId());
+
+        // custom gateway URL of tenant
+        Map<String, String> domains = new HashMap<>();
+        if (tenantDomain != null) {
+            domains = apiConsumer.getTenantDomainMappings(tenantDomain,
+                    APIConstants.API_DOMAIN_MAPPINGS_GATEWAY);
+        }
+        String customGatewayUrl = domains.get(APIConstants.CUSTOM_URL);
+
         List<APIEndpointURLsDTO> endpointUrls = new ArrayList<>();
         for (APIRevisionDeployment revisionDeployment : revisionDeployments) {
             if (revisionDeployment.isDisplayOnDevportal()) {
@@ -452,7 +462,7 @@ public class APIMappingUtil {
                 Environment environment = environments.get(revisionDeployment.getDeployment());
                 if (environment != null) {
                     APIEndpointURLsDTO apiEndpointURLsDTO = fromAPIRevisionToEndpoints(apidto, environment,
-                            revisionDeployment.getVhost());
+                            revisionDeployment.getVhost(), customGatewayUrl, tenantDomain);
                     endpointUrls.add(apiEndpointURLsDTO);
                 }
             }
@@ -460,26 +470,20 @@ public class APIMappingUtil {
         return endpointUrls;
     }
 
-    private static APIEndpointURLsDTO fromAPIRevisionToEndpoints(APIDTO apidto, Environment environment, String host) {
-        // If there are any inconstancy (if VHost not found) use default VHost
-        VHost defaultVhost = new VHost();
-        defaultVhost.setHost(host);
-        defaultVhost.setHttpContext("");
-        defaultVhost.setHttpsPort(APIConstants.HTTPS_PROTOCOL_PORT);
-        defaultVhost.setHttpPort(APIConstants.HTTP_PROTOCOL_PORT);
-        defaultVhost.setWsPort(APIConstants.WS_PROTOCOL_PORT);
-        defaultVhost.setWssPort(APIConstants.WSS_PROTOCOL_PORT);
-
+    private static APIEndpointURLsDTO fromAPIRevisionToEndpoints(APIDTO apidto, Environment environment,
+                                                                 String host, String customGatewayUrl,
+                                                                 String tenantDomain) throws APIManagementException {
         // Deployed VHost
         VHost vHost;
-        if (host == null && environment.getVhosts().size() > 0) {
-            // VHost is NULL set first Vhost (set in deployment toml)
-            vHost = environment.getVhosts().get(0);
+        String context = apidto.getContext();
+        if (StringUtils.isEmpty(customGatewayUrl)) {
+            vHost = VHostUtils.getVhostFromEnvironment(environment, host);
         } else {
-            vHost = environment.getVhosts().stream()
-                    .filter(v -> StringUtils.equals(v.getHost(), host))
-                    .findAny()
-                    .orElse(defaultVhost);
+            if (!StringUtils.contains(customGatewayUrl, "://")) {
+                customGatewayUrl = APIConstants.HTTPS_PROTOCOL_URL_PREFIX + customGatewayUrl;
+            }
+            vHost = VHost.fromEndpointUrls(new String[]{customGatewayUrl});
+            context = context.replace("/t/" + tenantDomain, "");
         }
 
         APIEndpointURLsDTO apiEndpointURLsDTO = new APIEndpointURLsDTO();
@@ -487,11 +491,14 @@ public class APIMappingUtil {
         apiEndpointURLsDTO.setEnvironmentType(environment.getType());
 
         APIURLsDTO apiurLsDTO = new APIURLsDTO();
-        String context = apidto.getContext();
         boolean isWs = StringUtils.equalsIgnoreCase("WS", apidto.getType());
         if (!isWs) {
-            apiurLsDTO.setHttp(vHost.getHttpUrl() + context);
-            apiurLsDTO.setHttps(vHost.getHttpsUrl() + context);
+            if (apidto.getTransport().contains(APIConstants.HTTP_PROTOCOL)) {
+                apiurLsDTO.setHttp(vHost.getHttpUrl() + context);
+            }
+            if (apidto.getTransport().contains(APIConstants.HTTPS_PROTOCOL)) {
+                apiurLsDTO.setHttps(vHost.getHttpsUrl() + context);
+            }
         } else {
             apiurLsDTO.setWs(vHost.getWsUrl() + context);
             apiurLsDTO.setWss(vHost.getWssUrl() + context);
@@ -502,8 +509,12 @@ public class APIMappingUtil {
         if (apidto.isIsDefaultVersion() != null && apidto.isIsDefaultVersion()) {
             String defaultContext = context.replaceAll("/" + apidto.getVersion() + "$", "");
             if (!isWs) {
-                apiDefaultVersionURLsDTO.setHttp(vHost.getHttpUrl() + defaultContext);
-                apiDefaultVersionURLsDTO.setHttps(vHost.getHttpsUrl() + defaultContext);
+                if (apidto.getTransport().contains(APIConstants.HTTP_PROTOCOL)) {
+                    apiDefaultVersionURLsDTO.setHttp(vHost.getHttpUrl() + defaultContext);
+                }
+                if (apidto.getTransport().contains(APIConstants.HTTPS_PROTOCOL)) {
+                    apiDefaultVersionURLsDTO.setHttps(vHost.getHttpsUrl() + defaultContext);
+                }
             } else {
                 apiDefaultVersionURLsDTO.setWs(vHost.getWsUrl() + defaultContext);
                 apiDefaultVersionURLsDTO.setWss(vHost.getWssUrl() + defaultContext);


### PR DESCRIPTION
### Description
- fix https://github.com/wso2/product-apim/issues/10151 : Resolve default vhost to null DB value (so users are able to change default vhost eg: first it was "localhost" and now it is changed to "dev.wso2.com")
  -  If default vhost is coming from the payload of deploy revision request, set null as the Vhost in `AM_DEPLOYMENT_REVISION_MAPPING`.
  - If null is set in `AM_DEPLOYMENT_REVISION_MAPPING` as vhost set default vhost (first) of read-only environment
- Refactor setting endpoint URLs in GET /api of store Rest API
  - Set custom URL for tenants
- Set swagger server URLs for vhost

Enforce vhost not null when deploy a revision:
This is for checking default vhost (only in read only environments - to reduce DB lookups also - So there should not be a vhost with dynamic environment in the DB table “AM_DEPLOYMENT_REVISION_MAPPING” and do not want to check dynamic environments when resolving null DB values to vhosts) and setting null in DB