### PR TITLE
Modify the params file name used for APICTL tasks

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -428,8 +428,8 @@ public enum ExceptionCodes implements ErrorHandler {
     // API import/export related codes
     ERROR_READING_META_DATA(900900, "Error while reading meta information from the definition", 400,
             "Error while reading meta information from the definition"),
-    ERROR_READING_PARAMS_FILE(900901, "Error while reading meta information from the api_params.yaml file", 400,
-            "Error while reading meta information from the api_params.yaml file"),
+    ERROR_READING_PARAMS_FILE(900901, "Error while reading meta information from the params file", 400,
+            "Error while reading meta information from the params file"),
     NO_API_ARTIFACT_FOUND(900902, "No Api artifacts found for given criteria", 404,
             "No Api artifacts found for given criteria"),
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -193,8 +193,8 @@ public final class ImportExportConstants {
     public static final String JSON_APPLICATION_FILE_LOCATION = File.separator + "application.json";
 
     //Api controller Env Params related constants
-    public static final String YAML_API_PARAMS_FILE_LOCATION = File.separator + "api_params.yaml";
-    public static final String JSON_API_PARAMS_FILE_LOCATION = File.separator + "api_params.json";
+    public static final String 
+            INTERMEDIATE_PARAMS_FILE_LOCATION = File.separator + "intermediate_params";
     //Env param fields
     public static final String ENV_NAME_FIELD = "name";
     public static final String ENDPOINT_TYPE_FIELD = "endpointType";
@@ -285,7 +285,6 @@ public final class ImportExportConstants {
     public static final String DEPLOYMENT_DIRECTORY_NAME= "Deployment";
     public static final String DEPLOYMENT_DIRECTORY= File.separator + DEPLOYMENT_DIRECTORY_NAME;
     public static final String SOURCE_ZIP_DIRECTORY_NAME = "SourceArchive.zip";
-    public static final String API_PARAMS_FILE_NAME = "api_params.yaml";
 
     // Location of the deployments file
     public static final String DEPLOYMENT_INFO_LOCATION = File.separator + "deployment_environments";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -470,12 +470,13 @@ public class ImportUtils {
     public static String preprocessImportedArtifact(String tempDirectory) throws APIImportExportException {
 
         String tempDirectoryAbsolutePath = tempDirectory + File.separator;
-        boolean isParamsFileAvailable = CommonUtil
-                .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.API_PARAMS_FILE_NAME);
+        String paramsFileName =
+                ImportExportConstants.INTERMEDIATE_PARAMS_FILE_LOCATION + ImportExportConstants.YAML_EXTENSION;
+        boolean isParamsFileAvailable = CommonUtil.checkFileExistence(tempDirectoryAbsolutePath + paramsFileName);
         boolean isDeploymentDirectoryAvailable = CommonUtil
                 .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.DEPLOYMENT_DIRECTORY_NAME);
 
-        //When api controller is provided with api_params.file
+        // When API controller is provided with params file
         if (isParamsFileAvailable) {
             if (!CommonUtil
                     .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME)) {
@@ -485,16 +486,15 @@ public class ImportUtils {
                         new File(tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME),
                         tempDirectoryAbsolutePath);
 
-                //Copy api_params.yaml file to working directory
-                String srcParamsFilePath = tempDirectoryAbsolutePath + ImportExportConstants.API_PARAMS_FILE_NAME;
-                String destParamsFilePath = tempDirectoryAbsolutePath + newExtractedFolderName + File.separator
-                        + ImportExportConstants.API_PARAMS_FILE_NAME;
+                // Copy the params file to working directory
+                String srcParamsFilePath = tempDirectoryAbsolutePath + paramsFileName;
+                String destParamsFilePath =
+                        tempDirectoryAbsolutePath + newExtractedFolderName + File.separator + paramsFileName;
                 CommonUtil.copyFile(srcParamsFilePath, destParamsFilePath);
-
                 return tempDirectoryAbsolutePath + newExtractedFolderName;
             }
         }
-        //When api controller is provided with the "Deployment" directory
+        //When API controller is provided with the "Deployment" directory
         if (isDeploymentDirectoryAvailable) {
             if (!CommonUtil
                     .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME)) {
@@ -504,12 +504,12 @@ public class ImportUtils {
                         new File(tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME),
                         tempDirectoryAbsolutePath);
 
-                //Copy api_params.yaml file to working directory
+                // Copy the params file to working directory
                 String srcParamsFilePath =
                         tempDirectoryAbsolutePath + ImportExportConstants.DEPLOYMENT_DIRECTORY_NAME + File.separator
-                                + ImportExportConstants.API_PARAMS_FILE_NAME;
-                String destParamsFilePath = tempDirectoryAbsolutePath + newExtractedFolderName + File.separator
-                        + ImportExportConstants.API_PARAMS_FILE_NAME;
+                                + paramsFileName;
+                String destParamsFilePath =
+                        tempDirectoryAbsolutePath + newExtractedFolderName + File.separator + paramsFileName;
                 CommonUtil.copyFile(srcParamsFilePath, destParamsFilePath);
 
                 //move deployment directory into working directory


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/541

## Goals
Change the api_params.yaml to intermediate_params.yaml and change the error messages accordingly.

## Approach
- Change the name of the intermediate params file name created by APICTL to intermediate_params.yaml
- Since that file is only for internal use, it will be handled in .yaml format.
- Modified the error messages with **api_params**.
- Remove the unnecessary code segments.

## Related PRs
> List any other related PRs

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS