### PR TITLE
Add support for API creation when Unlimited throttling tier is disabled

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8477,7 +8477,7 @@ public final class APIUtil {
     }
 
     /**
-     * This method is used to get the labels in a given tenant space
+     * This method is used to get the default policy in a given tenant space
      *
      * @param tenantDomain tenant domain name
      * @return default throttling policy for a given tenant

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8480,6 +8480,30 @@ public final class APIUtil {
      * This method is used to get the labels in a given tenant space
      *
      * @param tenantDomain tenant domain name
+     * @return default throttling policy for a given tenant
+     */
+    public static String getDefaultThrottlingPolicy(String tenantDomain) {
+        String defaultTier = APIConstants.UNLIMITED_TIER;
+        if (!isEnabledUnlimitedTier()) {
+            // Set an available value if the Unlimited policy is disabled
+            try {
+                Map<String, Tier> tierMap = getTiers(APIConstants.TIER_RESOURCE_TYPE, tenantDomain);
+                if (tierMap.size() > 0) {
+                    defaultTier = tierMap.keySet().toArray()[0].toString();
+                } else {
+                    log.error("No throttle policies available in the tenant " + tenantDomain);
+                }
+            } catch (APIManagementException e) {
+                log.error("Error while getting throttle policies for tenant " + tenantDomain);
+            }
+        }
+        return defaultTier;
+    }
+
+    /**
+     * This method is used to get the labels in a given tenant space
+     *
+     * @param tenantDomain tenant domain name
      * @return micro gateway labels in a given tenant space
      * @throws APIManagementException if failed to fetch micro gateway labels
      */

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -2089,6 +2089,9 @@ public class APIMappingUtil {
             supportedMethods = APIConstants.HTTP_DEFAULT_METHODS;
         }
 
+        String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
+        String defaultThrottlingPolicy = APIUtil.getDefaultThrottlingPolicy(tenantDomain);
+
         for (String verb : supportedMethods) {
             APIOperationsDTO operationsDTO = new APIOperationsDTO();
             if (apiType.equals((APIConstants.API_TYPE_WEBSUB))) {
@@ -2097,7 +2100,7 @@ public class APIMappingUtil {
                 operationsDTO.setTarget("/*");
             }
             operationsDTO.setVerb(verb);
-            operationsDTO.setThrottlingPolicy(APIConstants.UNLIMITED_TIER);
+            operationsDTO.setThrottlingPolicy(defaultThrottlingPolicy);
             operationsDTO.setAuthType(APIConstants.AUTH_APPLICATION_OR_USER_LEVEL_TOKEN);
             operationsDTOs.add(operationsDTO);
         }


### PR DESCRIPTION
This PR fixes an issue where API creation is blocked when the Unlimited throttling tier is disabled.

Fixes https://github.com/wso2/product-apim/issues/9974