### PR TITLE
Add the support for API Products params file via APICTL

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -209,6 +209,7 @@ public final class ImportExportConstants {
     public static final String ENDPOINTS_FIELD = "endpoints";
     public static final String LOAD_BALANCE_ENDPOINTS_FIELD = "loadBalanceEndpoints";
     public static final String FAILOVER_ENDPOINTS_FIELD = "failoverEndpoints";
+    public static final String DEPENDENT_APIS_FIELD = "dependentAPIs";
 
     //Security config related constants
     public static final String ENDPOINT_SECURITY_ENABLED = "enabled";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -30,6 +30,9 @@ public final class ImportExportConstants {
     // Location of the API definition file
     public static final String API_FILE_LOCATION = File.separator + "api";
 
+    // Location of the API definition file
+    public static final String API_PRODUCT_FILE_LOCATION = File.separator + "api_product";
+
     // Location of the definitions such as swagger, graphql schema etc
     public static final String DEFINITIONS_DIRECTORY = "Definitions";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/ImportExportAPIServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/ImportExportAPIServiceImpl.java
@@ -187,7 +187,7 @@ public class ImportExportAPIServiceImpl implements ImportExportAPI {
             throw new APIManagementException(e);
         }
         return ImportUtils.importApi(extractedFolderPath, null, preserveProvider, rotateRevision, overwrite,
-                false, tokenScopes);
+                false, tokenScopes, null);
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -75,6 +75,37 @@ public class APIControllerUtil {
     }
 
     /**
+     * Method retrieve the params configurations dependent APIs of an API Product
+     *
+     * @param path Path of the archive project
+     * @return JsonObject of environment parameters of the dependent APIs
+     * @throws IOException If an error occurs when resolving API controller environment parameters
+     */
+    public static JsonObject getDependentAPIsParams(String path) throws IOException {
+        JsonObject paramsConfigObject = APIControllerUtil.resolveAPIControllerEnvParams(path);
+        JsonObject dependentAPIsParams = null;
+        if (paramsConfigObject != null && paramsConfigObject.has(ImportExportConstants.DEPENDENT_APIS_FIELD)) {
+            dependentAPIsParams = paramsConfigObject.get(ImportExportConstants.DEPENDENT_APIS_FIELD).getAsJsonObject();
+        }
+        return dependentAPIsParams;
+    }
+
+    /**
+     * Method retrieve the params configurations for a dependent API of an API Product specified by the
+     * API directory name
+     *
+     * @param dependentAPIsParams Env params array of dependent APIs of the API Product
+     * @param apiDirectoryName    Dependent API directory name
+     * @return JsonObject of environment parameters of the dependent API
+     */
+    public static JsonObject getDependentAPIParams(JsonObject dependentAPIsParams, String apiDirectoryName) {
+        if (dependentAPIsParams.has(apiDirectoryName)) {
+            return dependentAPIsParams.get(apiDirectoryName).getAsJsonObject();
+        }
+        return null;
+    }
+
+    /**
      * This method will be used to add Extracted environment parameters to the imported Api object
      *
      * @param pathToArchive  Path to API or API Product archive
@@ -850,5 +881,4 @@ public class APIControllerUtil {
             throw new APIManagementException(e);
         }
     }
-
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -950,7 +950,7 @@ public class ExportUtils {
                 log.debug(
                         "Meta information retrieved successfully for API Product: " + apiProductDtoToReturn.getName());
             }
-            CommonUtil.writeDtoToFile(archivePath + ImportExportConstants.API_FILE_LOCATION, exportFormat,
+            CommonUtil.writeDtoToFile(archivePath + ImportExportConstants.API_PRODUCT_FILE_LOCATION, exportFormat,
                     ImportExportConstants.TYPE_API_PRODUCT, apiProductDtoToReturn);
         } catch (APIManagementException e) {
             throw new APIImportExportException(

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -1832,7 +1832,8 @@ public class ImportUtils {
             JsonObject paramsConfigObject = APIControllerUtil.resolveAPIControllerEnvParams(extractedFolderPath);
             // If above the params configurations are not null, then resolve those
             if (paramsConfigObject != null) {
-                importedApiProductDTO = APIControllerUtil.injectEnvParamsToAPIProduct(importedApiProductDTO, paramsConfigObject);
+                importedApiProductDTO = APIControllerUtil
+                        .injectEnvParamsToAPIProduct(importedApiProductDTO, paramsConfigObject, extractedFolderPath);
                 JsonElement deploymentsParam = paramsConfigObject.get(ImportExportConstants.DEPLOYMENT_ENVIRONMENTS);
                 if (deploymentsParam != null && !deploymentsParam.isJsonNull()) {
                     deploymentInfoArray = deploymentsParam.getAsJsonArray();


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/650

## Goals
Adding the support for API Product params file via APICTL.

## Approach
- Added the support to override the parameters of **dependentAPIs** of an API Product
- Added the support to override the parameters such as Mutual SSL certificates, subscription policies, deployment environments using the API Product params file.
- Refactored the existing functions used to override API params to enhance the functionality for API Products.

_**Sample params file for an API Product**_
```
environments:
    - name: production
      configs:
        policies:
            - Gold
            - Silver
        deploymentEnvironments:
            - displayOnDevportal: true
              deploymentEnvironment: Production and Sandbox
        mutualSslCerts:
             - tierName: Gold
               alias: Alice
               path: alice.crt
             - tierName: Silver
               alias: Bob
               path: bob.cr
        dependentAPIs:
            PizzaShackAPI-1.0.0:
                endpoints:
                    production:
                        url: 'https://pizza.prod.wso2.com'
            SwaggerPetstore-1.0.5:
                endpoints:
                    production:
                        url: 'https://petstore.prod.wso2.com'
```

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/652

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS