### PR TITLE
Import Async API definition during the API import via APICTL

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -96,6 +96,10 @@ public final class ImportExportConstants {
     public static final String JSON_ASYNCAPI_DEFINITION_LOCATION =
             File.separator + DEFINITIONS_DIRECTORY + File.separator + "asyncapi.json";
 
+    // Location of the AsyncAPI definition file
+    public static final String YAML_ASYNCAPI_DEFINITION_LOCATION =
+            File.separator + DEFINITIONS_DIRECTORY + File.separator + "asyncapi.yaml";
+
     // Name of the API provider element tag of the api.json file
     public static final String PROVIDER_ELEMENT = "provider";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapseArtifactGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapseArtifactGenerator.java
@@ -131,9 +131,9 @@ public class SynapseArtifactGenerator implements GatewayArtifactGenerator {
                                         (APIConstants.APITransportType.WS.toString().equals(api.getType()) ||
                                                 APIConstants.APITransportType.SSE.toString().equals(api.getType()) ||
                                                 APIConstants.APITransportType.WEBSUB.toString().equals(api.getType()))) {
-                                    String asyncApiDefinition =
+                                    APIDefinitionValidationResponse asyncApiDefinition =
                                             ImportUtils.retrieveValidatedAsyncApiDefinitionFromArchive(extractedFolderPath);
-                                    api.setAsyncApiDefinition(asyncApiDefinition);
+                                    api.setAsyncApiDefinition(asyncApiDefinition.getContent());
                                     gatewayAPIDTO = TemplateBuilderUtil
                                             .retrieveGatewayAPIDtoForStreamingAPI(api, environment, tenantDomain,
                                                     apidto, extractedFolderPath);


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/654

## Goals
The functionality to import/update an Async API definition should be added for **apictl import api**.

## Approach
- Validate the Async API definition during import API, before adding the API to the APIM
- Import/update (overwrite) the Async API definition that comes inside the API archive to the APIM
- Provide the support for both YAML and JSON Async API definitions to get read.

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS