### PR TITLE
Display displayName of environment in DevPortal instead of name of environment

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIEndpointURLsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIEndpointURLsDTO.java
@@ -23,6 +23,7 @@ import javax.validation.Valid;
 public class APIEndpointURLsDTO   {
   
     private String environmentName = null;
+    private String environmentDisplayName = null;
     private String environmentType = null;
     private APIURLsDTO urLs = null;
     private APIDefaultVersionURLsDTO defaultVersionURLs = null;
@@ -42,6 +43,23 @@ public class APIEndpointURLsDTO   {
   }
   public void setEnvironmentName(String environmentName) {
     this.environmentName = environmentName;
+  }
+
+  /**
+   **/
+  public APIEndpointURLsDTO environmentDisplayName(String environmentDisplayName) {
+    this.environmentDisplayName = environmentDisplayName;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Production and Sandbox", value = "")
+  @JsonProperty("environmentDisplayName")
+  public String getEnvironmentDisplayName() {
+    return environmentDisplayName;
+  }
+  public void setEnvironmentDisplayName(String environmentDisplayName) {
+    this.environmentDisplayName = environmentDisplayName;
   }
 
   /**
@@ -108,6 +126,7 @@ public class APIEndpointURLsDTO   {
     }
     APIEndpointURLsDTO apIEndpointURLs = (APIEndpointURLsDTO) o;
     return Objects.equals(environmentName, apIEndpointURLs.environmentName) &&
+        Objects.equals(environmentDisplayName, apIEndpointURLs.environmentDisplayName) &&
         Objects.equals(environmentType, apIEndpointURLs.environmentType) &&
         Objects.equals(urLs, apIEndpointURLs.urLs) &&
         Objects.equals(defaultVersionURLs, apIEndpointURLs.defaultVersionURLs);
@@ -115,7 +134,7 @@ public class APIEndpointURLsDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(environmentName, environmentType, urLs, defaultVersionURLs);
+    return Objects.hash(environmentName, environmentDisplayName, environmentType, urLs, defaultVersionURLs);
   }
 
   @Override
@@ -124,6 +143,7 @@ public class APIEndpointURLsDTO   {
     sb.append("class APIEndpointURLsDTO {\n");
     
     sb.append("    environmentName: ").append(toIndentedString(environmentName)).append("\n");
+    sb.append("    environmentDisplayName: ").append(toIndentedString(environmentDisplayName)).append("\n");
     sb.append("    environmentType: ").append(toIndentedString(environmentType)).append("\n");
     sb.append("    urLs: ").append(toIndentedString(urLs)).append("\n");
     sb.append("    defaultVersionURLs: ").append(toIndentedString(defaultVersionURLs)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -488,6 +488,7 @@ public class APIMappingUtil {
 
         APIEndpointURLsDTO apiEndpointURLsDTO = new APIEndpointURLsDTO();
         apiEndpointURLsDTO.setEnvironmentName(environment.getName());
+        apiEndpointURLsDTO.setEnvironmentDisplayName(environment.getDisplayName());
         apiEndpointURLsDTO.setEnvironmentType(environment.getType());
 
         APIURLsDTO apiurLsDTO = new APIURLsDTO();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -3893,6 +3893,9 @@ components:
               environmentName:
                 type: string
                 example: Production and Sandbox
+              environmentDisplayName:
+                type: string
+                example: Production and Sandbox
               environmentType:
                 type: string
                 example: hybrid

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -141,7 +141,9 @@ class ApiConsole extends React.Component {
             .then((apiResponse) => {
                 apiData = apiResponse.obj;
                 if (apiData.endpointURLs) {
-                    environments = apiData.endpointURLs.map((endpoint) => { return endpoint.environmentName; });
+                    environments = apiData.endpointURLs.map((endpoint) => {
+                        return { name: endpoint.environmentName, displayName: endpoint.environmentDisplayName };
+                    });
                 }
                 containerMngEnvironments = apiData.ingressURLs;
                 if (apiData.labels) {
@@ -152,7 +154,7 @@ class ApiConsole extends React.Component {
                     this.setState({ scopes: scopeList });
                 }
                 if (environments && environments.length > 0) {
-                    [selectedEnvironment] = environments;
+                    selectedEnvironment = environments[0].name;
                     return this.apiClient.getSwaggerByAPIIdAndEnvironment(apiID, selectedEnvironment);
                 } else if (containerMngEnvironments
                     && containerMngEnvironments.some((env) => env.clusterDetails.length > 0)) {
@@ -396,7 +398,7 @@ class ApiConsole extends React.Component {
         let promiseSwagger;
 
         if (environment) {
-            if (environments.includes(environment)) {
+            if (environments.find((e) => e.name === environment)) {
                 promiseSwagger = this.apiClient.getSwaggerByAPIIdAndEnvironment(api.id, environment);
             } else if (containerMngEnvironments.some((env) => env.clusterDetails.length > 0
                 && env.clusterDetails.some((cluster) => cluster.clusterName === environment))) {

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/TryOutController.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/TryOutController.jsx
@@ -779,7 +779,7 @@ function TryOutController(props) {
                                                             id='Apis.Details.ApiConsole.environment'
                                                         />
                                                     )}
-                                                    value={selectedEnvironment || (environments && environments[0])}
+                                                    value={selectedEnvironment || (environments && environments[0].name)}
                                                     name='selectedEnvironment'
                                                     onChange={handleChanges}
                                                     helperText={(
@@ -804,11 +804,11 @@ function TryOutController(props) {
                                                     {environments && (
                                                         environments.map((env) => (
                                                             <MenuItem
-                                                                value={env}
-                                                                key={env}
+                                                                value={env.name}
+                                                                key={env.name}
                                                                 className={classes.menuItem}
                                                             >
-                                                                {env}
+                                                                {env.displayName}
                                                             </MenuItem>
                                                         )))}
                                                     {containerMngEnvMenuItems}

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Environments.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Environments.jsx
@@ -334,10 +334,7 @@ class Environments extends React.Component {
                                     <Grid item xs={12}>
                                         <Box>
                                             <Typography variant='body2'>
-                                                {endpoint.environmentName}
-                                                <Typography variant='caption'>
-                                                    ({endpoint.environmentType})
-                                            </Typography>
+                                                {endpoint.environmentDisplayName}
                                             </Typography>
                                         </Box>
                                         <TextField


### PR DESCRIPTION
#### Description
- $subject
- Use environment name for calling Rest APIs (to get the swagger definition of the environment)

fix https://github.com/wso2/product-apim/issues/10268

#### Screen shots
##### Overview Page
![image](https://user-images.githubusercontent.com/23183042/111136216-7f7d1780-85a3-11eb-8cb5-43873fad7410.png)

##### Try Out Page
![image](https://user-images.githubusercontent.com/23183042/111136462-c8cd6700-85a3-11eb-8bad-4b5cec373fce.png)
