### PR TITLE
Fix pagination issues with Subscriptions in Devportal

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SubscriptionsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SubscriptionsApiServiceImpl.java
@@ -124,6 +124,9 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
                 subscriptionListDTO = SubscriptionMappingUtil
                         .fromSubscriptionListToDTO(subscribedAPIList, limit, offset);
 
+                SubscriptionMappingUtil.setPaginationParams(subscriptionListDTO, apiId, "", limit,
+                        offset, subscribedAPIList.size());
+
                 return Response.ok().entity(subscriptionListDTO).build();
             } else if (!StringUtils.isEmpty(applicationId)) {
                 Application application = apiConsumer.getApplicationByUUID(applicationId);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SubscriptionMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SubscriptionMappingUtil.java
@@ -30,13 +30,16 @@ import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
 import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ApplicationInfoDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.PaginationDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SubscriptionDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SubscriptionListDTO;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /** This class is responsible for mapping APIM core subscription related objects into REST API subscription related DTOs 
  *
@@ -146,5 +149,45 @@ public class SubscriptionMappingUtil {
 
         subscriptionListDTO.setCount(subscriptionDTOs.size());
         return subscriptionListDTO;
+    }
+
+    /**
+     * Sets pagination urls for a SubscriptionListDTO object given pagination parameters and url parameters
+     *
+     * @param subscriptionListDTO a SubscriptionListDTO object
+     * @param apiId               uuid/id of API
+     * @param groupId             group id of the applications to be returned
+     * @param limit               max number of objects returned
+     * @param offset              starting index
+     * @param size                max offset
+     */
+    public static void setPaginationParams(SubscriptionListDTO subscriptionListDTO, String apiId,
+                                           String groupId, int limit, int offset, int size) {
+
+        String paginatedPrevious = "";
+        String paginatedNext = "";
+
+        Map<String, Integer> paginatedParams = RestApiCommonUtil.getPaginationParams(offset, limit, size);
+
+        if (paginatedParams.get(RestApiConstants.PAGINATION_PREVIOUS_OFFSET) != null) {
+            paginatedPrevious = RestApiCommonUtil
+                    .getSubscriptionPaginatedURLForAPIId(
+                            paginatedParams.get(RestApiConstants.PAGINATION_PREVIOUS_OFFSET),
+                            paginatedParams.get(RestApiConstants.PAGINATION_PREVIOUS_LIMIT), apiId, groupId);
+        }
+
+        if (paginatedParams.get(RestApiConstants.PAGINATION_NEXT_OFFSET) != null) {
+            paginatedNext = RestApiCommonUtil
+                    .getSubscriptionPaginatedURLForAPIId(paginatedParams.get(RestApiConstants.PAGINATION_NEXT_OFFSET),
+                            paginatedParams.get(RestApiConstants.PAGINATION_NEXT_LIMIT), apiId, groupId);
+        }
+
+        PaginationDTO pagination = new PaginationDTO();
+        pagination.setOffset(offset);
+        pagination.setLimit(limit);
+        pagination.setNext(paginatedNext);
+        pagination.setPrevious(paginatedPrevious);
+        pagination.setTotal(size);
+        subscriptionListDTO.setPagination(pagination);
     }
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/index.jsx
@@ -247,8 +247,8 @@ class Details extends React.Component {
             }
             if (user != null) {
                 this.setState({open:user.isSideBarOpen});
-                existingSubscriptions = restApi.getSubscriptions(this.api_uuid, null);
                 const subscriptionLimit = Settings.app.subscribeApplicationLimit || 5000;
+                existingSubscriptions = restApi.getSubscriptions(this.api_uuid, null, subscriptionLimit);
                 promisedApplications = restApi.getAllApplications(null, subscriptionLimit);
 
                 Promise.all([existingSubscriptions, promisedApplications])

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/data/api.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/data/api.jsx
@@ -531,14 +531,16 @@ export default class API extends Resource {
     /**
      * Get keys of an application
      * @param applicationId id of the application that needs to get the keys
+     * @param limit subscription count to return
      * @param callback {function} Function which needs to be called upon success
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
-    getSubscriptions(apiId, applicationId, callback = null) {
+    getSubscriptions(apiId, applicationId, limit=25, callback = null) {
         const payload = { apiId };
         if (applicationId) {
             payload[applicationId] = applicationId;
         }
+        payload['limit'] = limit;
         const promisedGet = this.client.then((client) => {
             return client.apis.Subscriptions.get_subscriptions(payload, this._requestMetaData());
         });


### PR DESCRIPTION
This PR fixes the following issues:
- Subscriptions REST API not returning the pagination in the response
- Only first 25 subscriptions are shown under Subscriptions in an API in Devportal.

Fixes https://github.com/wso2/product-apim/issues/10140
Fixes https://github.com/wso2/product-apim/issues/10127