### PR TITLE
Fix the issue on certificate overriding for dependent APIs of API Products via params

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -48,7 +48,7 @@
       },
       {
         "Name": "apim:subscribe",
-        "Roles": "admin,Internal/subscriber"
+        "Roles": "admin,Internal/subscriber,Internal/devops"
       },
       {
         "Name": "apim:tier_view",

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json
@@ -44,7 +44,7 @@
       },
       {
         "Name": "apim:subscribe",
-        "Roles": "admin,Internal/subscriber"
+        "Roles": "admin,Internal/subscriber,Internal/devops"
       },
       {
         "Name": "apim:tier_view",

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -2112,6 +2112,20 @@ public class ImportUtils {
                 if (dependentAPIsParams != null) {
                     dependentAPIParamsConfigObject = APIControllerUtil
                             .getDependentAPIParams(dependentAPIsParams, apiDirectory.getName());
+                    // If the "certificates" directory is specified, copy it inside Deployment directory of the
+                    // dependent API since there may be certificates required for APIs
+                    String deploymentCertificatesDirectoryPath = path + ImportExportConstants.DEPLOYMENT_DIRECTORY
+                            + ImportExportConstants.CERTIFICATE_DIRECTORY;
+                    if (CommonUtil.checkFileExistence(deploymentCertificatesDirectoryPath)) {
+                        try {
+                            CommonUtil.copyDirectory(deploymentCertificatesDirectoryPath,
+                                    apiDirectoryPath + ImportExportConstants.DEPLOYMENT_DIRECTORY
+                                            + ImportExportConstants.CERTIFICATE_DIRECTORY);
+                        } catch (APIImportExportException e) {
+                            throw new APIManagementException(
+                                    "Error while copying the directory " + deploymentCertificatesDirectoryPath, e);
+                        }
+                    }
                 }
 
                 JsonElement jsonObject = retrieveValidatedDTOObject(apiDirectoryPath, isDefaultProviderAllowed,


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/650
When you provide --params with the deployment directory link when importing an API Product, overriding the certificates of the dependent APIs will get failed due to an issue in the directory path.

## Goals
Fix the above stated problem