### PR TITLE
Fix scope does not work with trailing "/" issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>jackson-jaxrs</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.orbit.io.swagger</groupId>
+            <artifactId>swagger-parser</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -20,7 +20,7 @@ package org.wso2.carbon.apimgt.rest.api.publisher.v1.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.gson.Gson;
-import io.swagger.v3.core.util.Json;
+import io.swagger.util.Json;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -1202,7 +1202,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             }
             apiDefinitionJson.put(APIConstants.SWAGGER_PATHS, clonePathMap);
             return Json.mapper().writeValueAsString(apiDefinitionJson);
-        } catch (JsonProcessingException | ParseException e) {
+        } catch (JsonProcessingException | ParseException | JSONException e) {
             String errorMessage = "Error while validating the swagger Definition";
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -41,7 +41,6 @@ import org.wso2.carbon.apimgt.api.model.policy.APIPolicy;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.GZIPUtils;
 import org.wso2.carbon.apimgt.impl.definitions.APIDefinitionFromOpenAPISpec;
-import org.wso2.carbon.apimgt.impl.definitions.APIDefinitionUsingOASParser;
 import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
 import org.wso2.carbon.apimgt.impl.soaptorest.SequenceGenerator;
 import org.wso2.carbon.apimgt.impl.soaptorest.util.SOAPOperationBindingUtils;
@@ -53,7 +52,14 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.Map;
+import java.util.Set;
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+
 
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.utils.RestApiPublisherUtils;


### PR DESCRIPTION
### Purpose

Resource with a trailing slash being treated as a resource without a trailing slash ( /echo/ --> /echo )
This PR fixes that issue.

Public fix for https://github.com/wso2-support/carbon-apimgt/pull/2514

### Approach

- Remove trailing slash when adding a resource with trailing slash.
- Remove trailing slash in Create API using swagger Definition workflow
- Remove trailing slash in editing swagger from UI
- Remove trailing slash in the REST API operations of,

  - Create API
  - Update API  
  - Update Swagger Definitions

