### PR TITLE
Add ref support for requestBodies when content is null

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -398,9 +398,11 @@ public class OASParserUtil {
                 if (REQUEST_BODIES.equalsIgnoreCase(category)) {
                     Map<String, RequestBody> sourceRequestBodies = sourceComponents.getRequestBodies();
 
-                    for (String refKey : refCategoryEntry.getValue()) {
-                        RequestBody requestBody = sourceRequestBodies.get(refKey);
-                        setRefOfRequestBody(requestBody, context);
+                    if (sourceRequestBodies != null) {
+                        for (String refKey : refCategoryEntry.getValue()) {
+                            RequestBody requestBody = sourceRequestBodies.get(refKey);
+                            setRefOfRequestBody(requestBody, context);
+                        }
                     }
                 }
 
@@ -582,8 +584,12 @@ public class OASParserUtil {
     private static void setRefOfRequestBody(RequestBody requestBody, SwaggerUpdateContext context) {
         if (requestBody != null) {
             Content content = requestBody.getContent();
-
-            extractReferenceFromContent(content, context);
+            if (content != null) {
+                extractReferenceFromContent(content, context);
+            } else {
+                String ref = requestBody.get$ref();
+                addToReferenceObjectMap(ref, context);
+            }
         }
     }
 


### PR DESCRIPTION
Currently, requestBody definition with the following format is supported when creating an API Product.
```
requestBody:
  content:
    application/json:
      schema:
        type: object
  required: true
```

If the requestBody definition in the original API takes the following format, an error will be shown when accessing the Resources of the API Product.
```
requestBody:
  $ref: '#/components/requestBodies/Order'

components:
  requestBodies:
      Order:
        description: Order object that needs to be added
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Order'
        required: true
```
This issue is fixed through this PR.
Fixes https://github.com/wso2/product-apim/issues/10325
Fixes https://github.com/wso2/product-apim/issues/10423