### PR TITLE
Convert integers in the endpointConfig to strings and fix reflecting the HTTP/SOAP endpoints when provided through params

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -51,7 +51,9 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This Class Used for API Controller related operations.
@@ -145,6 +147,7 @@ public class APIControllerUtil {
         HashMap<String, Object> endpointConfig;
         try {
             endpointConfig = mapper.readValue(jsonObject.toString(), HashMap.class);
+            convertValuesToStrings(endpointConfig);
         } catch (JsonProcessingException e) {
             String errorMessage = "Error while reading endpointConfig information in the params file.";
             throw new APIManagementException(errorMessage, e, ExceptionCodes.ERROR_READING_PARAMS_FILE);
@@ -186,6 +189,24 @@ public class APIControllerUtil {
             handleSubscriptionPolicies(policies, importedApiDto, null);
         }
         return importedApiDto;
+    }
+
+    /**
+     * This method will be used to convert any integer values to strings in a particular map of values.
+     *
+     * @param keyValuePairs Map to be validated and converted
+     */
+    private static void convertValuesToStrings(Map<String, Object> keyValuePairs) {
+        Iterator it = keyValuePairs.entrySet().iterator();
+        while (it.hasNext()) {
+            HashMap.Entry pair = (HashMap.Entry) it.next();
+            if (pair.getValue() instanceof Integer && pair.getKey() instanceof String) {
+                keyValuePairs.replace(pair.getKey().toString(), pair.getValue().toString());
+            }
+            if (pair.getValue() instanceof Map) {
+                convertValuesToStrings((Map) pair.getValue());
+            }
+        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -665,7 +665,7 @@ public class APIControllerUtil {
         // if the endpoint routing policy is not specified, but the endpoints field is specified
         if (StringUtils.isEmpty(routingPolicy)) {
             updatedSOAPEndpointParams.addProperty(ImportExportConstants.ENDPOINT_TYPE_PROPERTY,
-                    ImportExportConstants.SOAP_TYPE_ENDPOINT);
+                    ImportExportConstants.SOAP_ENDPOINT_TYPE_FOR_JSON);
             handleEndpointValues(endpoints, updatedSOAPEndpointParams, defaultProductionEndpoint,
                     defaultSandboxEndpoint);
         } else if (ImportExportConstants.LOAD_BALANCE_ROUTING_POLICY


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/667
Fixes: https://github.com/wso2/product-apim-tooling/issues/665
Fixes: https://github.com/wso2/product-apim-tooling/issues/668

## Goals
Fixes the issue when integer values are passed to **endpointConfigs** via the params file and the issue on reflecting HTTP/SOAP endpoints when passed through params.

## Approach
- Wrote a new function to convert integers in the **endpointConfigs** to strings 
- Corrected the constant used for HTTP/SOAP endpoints via params file