### PR TITLE
Support for endpoint security for production/sandbox separately and validate Application projects

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -432,11 +432,13 @@ public enum ExceptionCodes implements ErrorHandler {
     ALIAS_CANNOT_BE_EMPTY(900855, "The alias cannot be empty", 400, "The alias cannot be empty"),
 
     // API import/export related codes
-    ERROR_READING_META_DATA(900900, "Error while reading meta information from the definition", 400,
+    ERROR_READING_META_DATA(900907, "Error while reading meta information from the definition", 400,
             "Error while reading meta information from the definition"),
-    ERROR_READING_PARAMS_FILE(900901, "Error while reading meta information from the params file", 400,
+    ERROR_READING_PARAMS_FILE(900908, "Error while reading meta information from the params file", 400,
             "Error while reading meta information from the params file"),
-    NO_API_ARTIFACT_FOUND(900902, "No Api artifacts found for given criteria", 404,
+    ERROR_FETCHING_DEFINITION_FILE(900909, "Cannot find the definition file of the project", 400,
+            "Cannot find the yaml/json file with the project definition."),
+    NO_API_ARTIFACT_FOUND(900910, "No Api artifacts found for given criteria", 404,
             "No Api artifacts found for given criteria"),
 
     //AsyncApi related error codes

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -205,7 +205,6 @@ public final class ImportExportConstants {
     public static final String 
             INTERMEDIATE_PARAMS_FILE_LOCATION = File.separator + "intermediate_params";
     //Env param fields
-    public static final String ENV_NAME_FIELD = "name";
     public static final String ENDPOINT_TYPE_FIELD = "endpointType";
     public static final String GATEWAY_ENVIRONMENTS_FIELD = "gatewayEnvironments";
     public static final String MUTUAL_SSL_CERTIFICATES_FIELD = "mutualSslCerts";
@@ -219,12 +218,7 @@ public final class ImportExportConstants {
     public static final String DEPENDENT_APIS_FIELD = "dependentAPIs";
 
     //Security config related constants
-    public static final String ENDPOINT_SECURITY_ENABLED = "enabled";
-    public static final String ENDPOINT_UT_USERNAME = "username";
-    public static final String ENDPOINT_UT_PASSWORD = "password";
-    public static final String ENDPOINT_SECURITY_TYPE = "type";
-    public static final String ENDPOINT_DIGEST_SECURITY_TYPE = "digest";
-    public static final String ENDPOINT_BASIC_SECURITY_TYPE = "basic";
+    public static final String ENDPOINT_NONE_SECURITY_TYPE = "NONE";
 
     //Default values for Endpoints
     public static final String ENDPOINT_URL = "url";
@@ -247,12 +241,8 @@ public final class ImportExportConstants {
 
     // AWS endpoint related constants
     public static final String AWS_LAMBDA_ENDPOINT_JSON_PROPERTY = "awsLambdaEndpoints";
-    public static final String AWS_LAMBDA_ENDPOINT_PROPERTY = "AWSLambdaEndpoints";
     public static final String AWS_ACCESS_METHOD_JSON_PROPERTY = "accessMethod";
     public static final String AWS_ACCESS_METHOD_PROPERTY = "access_method";
-    public static final String AWS_AMZN_REGION_PROPERTY = "amznRegion";
-    public static final String AWS_AMZN_ACCESS_KEY_PROPERTY = "amznAccessKey";
-    public static final String AWS_AMZN_SECRET_KEY_PROPERTY = "amznSecretKey";
     public static final String AWS_STORED_ACCESS_METHOD = "stored";
     public static final String AWS_ROLE_SUPPLIED_ACCESS_METHOD = "role-supplied";
 
@@ -274,15 +264,9 @@ public final class ImportExportConstants {
 
     //Certificate related constants
     public static final String MUTUAL_SSL_ENABLED = "mutualssl";
-    public static final String CERTIFICATE_API_IDENTIFIER_PROPERTY = "apiIdentifier";
     public static final String CERTIFICATE_PATH_PROPERTY = "path";
-    public static final String CERTIFICATE_CERTIFICATE_CONTENT_PROPERTY = "file";
     public static final String CERTIFICATE_HOST_NAME_PROPERTY = "hostName";
     public static final String CERTIFICATE_TIER_NAME_PROPERTY = "tierName";
-    public static final String DATA_PROPERTY = "data";
-
-
-    public static final String CERTIFICATE_FILE_EXTENSION = ".crt";
     public static final String CERTIFICATE_DIRECTORY = File.separator + "certificates";
     public static final String ENDPOINT_CERTIFICATES_DIRECTORY_PATH = File.separator + "Endpoint-certificates";
     public static final String CLIENT_CERTIFICATES_DIRECTORY_PATH = File.separator + "Client-certificates";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIProduct;
 import org.wso2.carbon.apimgt.api.model.Identifier;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
 import org.wso2.carbon.apimgt.impl.importexport.ExportFormat;
 import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
@@ -143,6 +144,12 @@ public class APIControllerUtil {
 
         //Handle multiple end points
         JsonObject jsonObject = setupMultipleEndpoints(envParams, endpointType);
+
+        // Handle endpoint security configs
+        if (envParams.get(ImportExportConstants.ENDPOINT_SECURITY_FIELD) != null) {
+            handleEndpointSecurityConfigs(envParams, jsonObject);
+        }
+
         ObjectMapper mapper = new ObjectMapper();
         HashMap<String, Object> endpointConfig;
         try {
@@ -175,12 +182,6 @@ public class APIControllerUtil {
                 String errorMessage = "Error while generating meta information of client certificates from path.";
                 throw new APIManagementException(errorMessage, e, ExceptionCodes.ERROR_READING_PARAMS_FILE);
             }
-        }
-
-        //handle security configs
-        JsonElement securityConfigs = envParams.get(ImportExportConstants.ENDPOINT_SECURITY_FIELD);
-        if (securityConfigs != null) {
-            handleEndpointSecurityConfigs(envParams, importedApiDto);
         }
 
         // handle available subscription policies
@@ -288,11 +289,11 @@ public class APIControllerUtil {
     /**
      * This method will be used to add Endpoint security related environment parameters to imported Api object.
      *
-     * @param importedApiDto APIDTO object to be updated
      * @param envParams      Env params object with required parameters
+     * @param endpointConfig Endpoint config object to be updated
      * @throws APIManagementException If an error occurs when setting security env parameters
      */
-    private static void handleEndpointSecurityConfigs(JsonObject envParams, APIDTO importedApiDto)
+    private static void handleEndpointSecurityConfigs(JsonObject envParams, JsonObject endpointConfig)
             throws APIManagementException {
         // If the user has set (either true or false) the enabled field under security in the params file,
         // the following code should be executed.
@@ -300,48 +301,68 @@ public class APIControllerUtil {
         if (security == null) {
             return;
         }
-        String securityEnabled = security.get(ImportExportConstants.ENDPOINT_SECURITY_ENABLED).getAsString();
-        boolean isSecurityEnabled = Boolean.parseBoolean(securityEnabled);
-        //set endpoint security details to API
-        APIEndpointSecurityDTO apiEndpointSecurityDTO = new APIEndpointSecurityDTO();
 
-        // If endpoint security is enabled
-        if (isSecurityEnabled) {
-            // Check whether the username, password and type fields have set in the params file
-            JsonElement username = security.get(ImportExportConstants.ENDPOINT_UT_USERNAME);
-            JsonElement password = security.get(ImportExportConstants.ENDPOINT_UT_PASSWORD);
-            JsonElement type = security.get(ImportExportConstants.ENDPOINT_SECURITY_TYPE);
+        String[] endpointTypes = { APIConstants.ENDPOINT_SECURITY_PRODUCTION, APIConstants.ENDPOINT_SECURITY_SANDBOX };
+        for (String endpointType : endpointTypes) {
+            if (security.has(endpointType)) {
+                JsonObject endpointSecurityDetails = security.get(endpointType).getAsJsonObject();
+                if (endpointSecurityDetails.has(APIConstants.ENDPOINT_SECURITY_ENABLED)) {
+                    String securityEnabled = endpointSecurityDetails.get(APIConstants.ENDPOINT_SECURITY_ENABLED)
+                            .getAsString();
 
-            if (username == null) {
-                throw new APIManagementException("You have enabled endpoint security but the username is not found "
-                        + "in the params file. Please specify username field for and continue...",
-                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
-            } else if (password == null) {
-                throw new APIManagementException("You have enabled endpoint security but the password is not found "
-                        + "in the params file. Please specify password field for and continue...",
-                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
-            } else if (type == null) {
-                throw new APIManagementException("You have enabled endpoint security but the password is not found "
-                        + "in the params file. Please specify password field for and continue...",
-                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
-            } else {
-                apiEndpointSecurityDTO.setPassword(password.toString());
-                apiEndpointSecurityDTO.setUsername(username.getAsString());
-                //setup security type (basic or digest)
-                if (StringUtils.equals(type.getAsString(), ImportExportConstants.ENDPOINT_DIGEST_SECURITY_TYPE)) {
-                    apiEndpointSecurityDTO.setType(APIEndpointSecurityDTO.TypeEnum.DIGEST);
-                } else if (StringUtils.equals(type.getAsString(), ImportExportConstants.ENDPOINT_BASIC_SECURITY_TYPE)) {
-                    apiEndpointSecurityDTO.setType(APIEndpointSecurityDTO.TypeEnum.BASIC);
-                } else {
-                    // If the type is not either basic or digest, return an error
-                    throw new APIManagementException("Invalid endpoint security type found in the params file. "
-                            + "Should be either basic or digest"
-                            + "Please specify correct security types field for and continue...",
-                            ExceptionCodes.ERROR_READING_PARAMS_FILE);
+                    // Set endpoint security details to API
+                    if (Boolean.parseBoolean(securityEnabled)) {
+                        // Check whether the username, password and type fields have set in the params file
+                        JsonElement type = endpointSecurityDetails.get(APIConstants.ENDPOINT_SECURITY_TYPE);
+                        if (endpointSecurityDetails.get(APIConstants.ENDPOINT_SECURITY_USERNAME) == null) {
+                            throw new APIManagementException(
+                                    "You have enabled endpoint security but the username is not found "
+                                            + "in the params file. Please specify username field for and continue...",
+                                    ExceptionCodes.ERROR_READING_PARAMS_FILE);
+                        } else if (endpointSecurityDetails.get(APIConstants.ENDPOINT_SECURITY_PASSWORD) == null) {
+                            throw new APIManagementException(
+                                    "You have enabled endpoint security but the password is not found "
+                                            + "in the params file. Please specify password field for and continue...",
+                                    ExceptionCodes.ERROR_READING_PARAMS_FILE);
+                        } else if (type == null) {
+                            throw new APIManagementException(
+                                    "You have enabled endpoint security but the password is not found "
+                                            + "in the params file. Please specify password field for and continue...",
+                                    ExceptionCodes.ERROR_READING_PARAMS_FILE);
+                        } else {
+                            // Setup security type (basic or digest)
+                            endpointSecurityDetails.remove(APIConstants.ENDPOINT_SECURITY_TYPE);
+                            if (StringUtils.equals(type.getAsString().toLowerCase(),
+                                    APIConstants.ENDPOINT_SECURITY_TYPE_DIGEST)) {
+                                endpointSecurityDetails.addProperty(APIConstants.ENDPOINT_SECURITY_TYPE,
+                                        APIEndpointSecurityDTO.TypeEnum.DIGEST.toString());
+                            } else if (StringUtils.equals(type.getAsString().toLowerCase(),
+                                    APIConstants.ENDPOINT_SECURITY_TYPE_BASIC)) {
+                                endpointSecurityDetails.addProperty(APIConstants.ENDPOINT_SECURITY_TYPE,
+                                        APIEndpointSecurityDTO.TypeEnum.BASIC.toString());
+                            } else {
+                                // If the type is not either basic or digest, return an error
+                                throw new APIManagementException(
+                                        "Invalid endpoint security type found in the params file. "
+                                                + "Should be either basic or digest"
+                                                + "Please specify correct security types field for and continue...",
+                                        ExceptionCodes.ERROR_READING_PARAMS_FILE);
+                            }
+                        }
+                    }
                 }
+            } else {
+                // Even though the security field is defined, if either production/sandbox is not defined under that,
+                // set endpoint security to none. Otherwise the security will be blank if you check from the UI.
+                JsonObject endpointSecurityForNotDefinedEndpointType = new JsonObject();
+                endpointSecurityForNotDefinedEndpointType.addProperty(APIConstants.ENDPOINT_SECURITY_TYPE,
+                        ImportExportConstants.ENDPOINT_NONE_SECURITY_TYPE);
+                endpointSecurityForNotDefinedEndpointType
+                        .addProperty(APIConstants.ENDPOINT_SECURITY_ENABLED, Boolean.FALSE);
+                security.add(endpointType, endpointSecurityForNotDefinedEndpointType);
             }
-            importedApiDto.setEndpointSecurity(apiEndpointSecurityDTO);
         }
+        endpointConfig.add(APIConstants.ENDPOINT_SECURITY, security);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -577,11 +577,11 @@ public class ImportUtils {
      * @param pathToArchive            Path to the extracted folder
      * @param isDefaultProviderAllowed Preserve provider flag value
      * @param currentUser              Username of the current user
-     * @throws APIMgtAuthorizationFailedException If an error occurs while authorizing the provider
+     * @throws APIManagementException If an error occurs while authorizing the provider or retrieving the definition
      */
     private static JsonElement retrieveValidatedDTOObject(String pathToArchive, Boolean isDefaultProviderAllowed,
                                                           String currentUser, String type)
-            throws IOException, APIMgtAuthorizationFailedException {
+            throws IOException, APIManagementException {
 
         JsonObject configObject = (StringUtils.equals(type, ImportExportConstants.TYPE_API)) ?
                 retrievedAPIDtoJson(pathToArchive) :
@@ -591,23 +591,26 @@ public class ImportUtils {
     }
 
     @NotNull
-    private static JsonObject retrievedAPIDtoJson(String pathToArchive) throws IOException {
+    private static JsonObject retrievedAPIDtoJson(String pathToArchive) throws IOException, APIManagementException {
         // Get API Definition as JSON
         String jsonContent =
                 getFileContentAsJson(pathToArchive + ImportExportConstants.API_FILE_LOCATION);
         if (jsonContent == null) {
-            throw new IOException("Cannot find API definition. api.yaml or api.json should present");
+            throw new APIManagementException("Cannot find API definition. api.yaml or api.json should present",
+                    ExceptionCodes.ERROR_FETCHING_DEFINITION_FILE);
         }
         return processRetrievedDefinition(jsonContent);
     }
 
     @NotNull
-    private static JsonObject retrievedAPIProductDtoJson(String pathToArchive) throws IOException {
+    private static JsonObject retrievedAPIProductDtoJson(String pathToArchive)
+            throws IOException, APIManagementException {
         // Get API Product Definition as JSON
         String jsonContent = getFileContentAsJson(pathToArchive + ImportExportConstants.API_PRODUCT_FILE_LOCATION);
         if (jsonContent == null) {
-            throw new IOException(
-                    "Cannot find API Product definition. api_product.yaml or api_product.json should present");
+            throw new APIManagementException(
+                    "Cannot find API Product definition. api_product.yaml or api_product.json should present",
+                    ExceptionCodes.ERROR_FETCHING_DEFINITION_FILE);
         }
         return processRetrievedDefinition(jsonContent);
     }
@@ -653,13 +656,13 @@ public class ImportUtils {
         return configObject;
     }
 
-    public static APIDTO retrievedAPIDto(String pathToArchive) throws IOException {
+    public static APIDTO retrievedAPIDto(String pathToArchive) throws IOException, APIManagementException {
 
         JsonObject jsonObject = retrievedAPIDtoJson(pathToArchive);
         return new Gson().fromJson(jsonObject, APIDTO.class);
     }
 
-    public static APIProductDTO retrieveAPIProductDto(String pathToArchive) throws IOException {
+    public static APIProductDTO retrieveAPIProductDto(String pathToArchive) throws IOException, APIManagementException {
 
         JsonObject jsonObject = retrievedAPIProductDtoJson(pathToArchive);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -630,8 +630,6 @@ public class ImportUtils {
         JsonElement configElement = new JsonParser().parse(jsonContent).getAsJsonObject().get(APIConstants.DATA);
         JsonObject configObject = configElement.getAsJsonObject();
 
-        configObject = preProcessEndpointConfig(configObject);
-
         // Locate the "provider" within the "id" and set it as the current user
         String apiName = configObject.get(ImportExportConstants.API_NAME_ELEMENT).getAsString();
 
@@ -667,45 +665,6 @@ public class ImportUtils {
         JsonObject jsonObject = retrievedAPIProductDtoJson(pathToArchive);
 
         return new Gson().fromJson(jsonObject, APIProductDTO.class);
-    }
-
-    /**
-     * This function will preprocess endpoint config security.
-     *
-     * @param configObject Data object from the API/API Product configuration
-     * @return API config object with pre processed endpoint config
-     */
-    private static JsonObject preProcessEndpointConfig(JsonObject configObject) {
-
-        if (configObject.has(ImportExportConstants.ENDPOINT_CONFIG)) {
-            JsonObject endpointConfig = configObject.get(ImportExportConstants.ENDPOINT_CONFIG).getAsJsonObject();
-            if (endpointConfig.has(APIConstants.ENDPOINT_SECURITY)) {
-                JsonObject endpointSecurity = endpointConfig.get(APIConstants.ENDPOINT_SECURITY).getAsJsonObject();
-                if (endpointSecurity.has(APIConstants.ENDPOINT_SECURITY_SANDBOX)) {
-                    JsonObject endpointSecuritySandbox = endpointSecurity.get(APIConstants.ENDPOINT_SECURITY_SANDBOX)
-                            .getAsJsonObject();
-                    if (endpointSecuritySandbox.has(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS)) {
-                        String customParameters = endpointSecuritySandbox
-                                .get(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS).toString();
-                        endpointSecuritySandbox.remove(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS);
-                        endpointSecuritySandbox
-                                .addProperty(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS, customParameters);
-                    }
-                }
-                if (endpointSecurity.has(APIConstants.ENDPOINT_SECURITY_PRODUCTION)) {
-                    JsonObject endpointSecuritySandbox = endpointSecurity.get(APIConstants.ENDPOINT_SECURITY_PRODUCTION)
-                            .getAsJsonObject();
-                    if (endpointSecuritySandbox.has(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS)) {
-                        String customParameters = endpointSecuritySandbox
-                                .get(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS).toString();
-                        endpointSecuritySandbox.remove(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS);
-                        endpointSecuritySandbox
-                                .addProperty(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS, customParameters);
-                    }
-                }
-            }
-        }
-        return configObject;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -630,6 +630,8 @@ public class ImportUtils {
         JsonElement configElement = new JsonParser().parse(jsonContent).getAsJsonObject().get(APIConstants.DATA);
         JsonObject configObject = configElement.getAsJsonObject();
 
+        configObject = preProcessEndpointConfig(configObject);
+
         // Locate the "provider" within the "id" and set it as the current user
         String apiName = configObject.get(ImportExportConstants.API_NAME_ELEMENT).getAsString();
 
@@ -665,6 +667,45 @@ public class ImportUtils {
         JsonObject jsonObject = retrievedAPIProductDtoJson(pathToArchive);
 
         return new Gson().fromJson(jsonObject, APIProductDTO.class);
+    }
+
+    /**
+     * This function will preprocess endpoint config security.
+     *
+     * @param configObject Data object from the API/API Product configuration
+     * @return API config object with pre processed endpoint config
+     */
+    private static JsonObject preProcessEndpointConfig(JsonObject configObject) {
+
+        if (configObject.has(ImportExportConstants.ENDPOINT_CONFIG)) {
+            JsonObject endpointConfig = configObject.get(ImportExportConstants.ENDPOINT_CONFIG).getAsJsonObject();
+            if (endpointConfig.has(APIConstants.ENDPOINT_SECURITY)) {
+                JsonObject endpointSecurity = endpointConfig.get(APIConstants.ENDPOINT_SECURITY).getAsJsonObject();
+                if (endpointSecurity.has(APIConstants.ENDPOINT_SECURITY_SANDBOX)) {
+                    JsonObject endpointSecuritySandbox = endpointSecurity.get(APIConstants.ENDPOINT_SECURITY_SANDBOX)
+                            .getAsJsonObject();
+                    if (endpointSecuritySandbox.has(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS)) {
+                        String customParameters = endpointSecuritySandbox
+                                .get(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS).toString();
+                        endpointSecuritySandbox.remove(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS);
+                        endpointSecuritySandbox
+                                .addProperty(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS, customParameters);
+                    }
+                }
+                if (endpointSecurity.has(APIConstants.ENDPOINT_SECURITY_PRODUCTION)) {
+                    JsonObject endpointSecuritySandbox = endpointSecurity.get(APIConstants.ENDPOINT_SECURITY_PRODUCTION)
+                            .getAsJsonObject();
+                    if (endpointSecuritySandbox.has(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS)) {
+                        String customParameters = endpointSecuritySandbox
+                                .get(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS).toString();
+                        endpointSecuritySandbox.remove(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS);
+                        endpointSecuritySandbox
+                                .addProperty(ImportExportConstants.ENDPOINT_CUSTOM_PARAMETERS, customParameters);
+                    }
+                }
+            }
+        }
+        return configObject;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
@@ -61,7 +61,8 @@ public class ImportUtils {
      * Retrieve Application Definition as JSON.
      *
      * @param pathToArchive Path Application archive
-     * @throws IOException If an error occurs while reading the file
+     * @throws IOException            If an error occurs while reading the file
+     * @throws APIManagementException If an error occurs while fetching the application definition
      */
     public static String getApplicationDefinitionAsJson(String pathToArchive) throws IOException,
             APIManagementException {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.json.simple.JSONObject;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIKey;
@@ -62,7 +63,8 @@ public class ImportUtils {
      * @param pathToArchive Path Application archive
      * @throws IOException If an error occurs while reading the file
      */
-    public static String getApplicationDefinitionAsJson(String pathToArchive) throws IOException {
+    public static String getApplicationDefinitionAsJson(String pathToArchive) throws IOException,
+            APIManagementException {
         String jsonContent = null;
         String pathToYamlFile = pathToArchive + ImportExportConstants.YAML_APPLICATION_FILE_LOCATION;
         String pathToJsonFile = pathToArchive + ImportExportConstants.JSON_APPLICATION_FILE_LOCATION;
@@ -80,6 +82,10 @@ public class ImportUtils {
                 log.debug("Found application definition file " + pathToJsonFile);
             }
             jsonContent = FileUtils.readFileToString(new File(pathToJsonFile));
+        } else {
+            throw new APIManagementException(
+                    "Cannot find Application definition. application.yaml or application.json should present",
+                    ExceptionCodes.ERROR_FETCHING_DEFINITION_FILE);
         }
         return jsonContent;
     }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/670
Fixes: https://github.com/wso2/product-apim-tooling/issues/672

## Goals
Add the directory/archive validation for applications and support endpoint security for production and sandbox separately.

## Approach
- Validated the application directory/archive and throw exceptions if incorrect.
- Introduced the support to override endpoint security using the params file for Production and Sandbox separately. Below is a sample params file with the changes.
```
environments:
    - name: production
      configs:
        endpoints:
            production:
                url: 'https://localhost:9443/am/sample/prod/pizzashack/v1/api/'
            sandbox:
                url: 'https://localhost:9443/am/sample/sand/pizzashack/v1/api/'
        security:
            production:
                enabled: true
                type: basic
                username: admin
                password: admin
            sandbox:
                enabled: true
                type: digest
                username: admin
                password: admin
```

## User stories
User stories covered by the above params file.

## Documentation
Changes need to be done.

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/673

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS
