### PR TITLE
Fix analytics corelation id to be consistent wth APIM

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
@@ -58,4 +58,6 @@ public class Constants {
     public static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
 
     public static final String HEADER_X_FORWARDED_FOR = "X-FORWARDED-FOR";
+
+    public static final String CORRELATION_ID = "correlation_id";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
@@ -58,6 +58,4 @@ public class Constants {
     public static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
 
     public static final String HEADER_X_FORWARDED_FOR = "X-FORWARDED-FOR";
-
-    public static final String CORRELATION_ID = "correlation_id";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -49,7 +49,6 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.UUID;
 
 
 public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
@@ -186,7 +185,11 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
     @Override
     public MetaInfo getMetaInfo() {
         MetaInfo metaInfo = new MetaInfo();
-        metaInfo.setCorrelationId(UUID.randomUUID().toString());
+        Object correlationId  = ((Axis2MessageContext) messageContext).getAxis2MessageContext()
+                .getProperty(Constants.CORRELATION_ID);
+        if (correlationId instanceof String){
+            metaInfo.setCorrelationId((String) correlationId);
+        }
         metaInfo.setGatewayType(APIMgtGatewayConstants.GATEWAY_TYPE);
         Map<String, String> configMap = ServiceReferenceHolder.getInstance().getApiManagerConfigurationService()
                 .getAPIAnalyticsConfiguration().getReporterProperties();

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.commons.CorrelationConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.RESTConstants;
 import org.wso2.carbon.apimgt.common.gateway.analytics.exceptions.DataNotFoundException;
@@ -186,7 +187,7 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
     public MetaInfo getMetaInfo() {
         MetaInfo metaInfo = new MetaInfo();
         Object correlationId  = ((Axis2MessageContext) messageContext).getAxis2MessageContext()
-                .getProperty(Constants.CORRELATION_ID);
+                .getProperty(CorrelationConstants.CORRELATION_ID);
         if (correlationId instanceof String){
             metaInfo.setCorrelationId((String) correlationId);
         }


### PR DESCRIPTION
Changed the correlation id of analytics to the Id in axis2 context in order to be consistent with APIM.

Fixes https://github.com/wso2/product-apim/issues/10441