### PR TITLE
Fix console error when login with secondary user store user

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -979,7 +979,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
             log.debug("Modified query for devportal search: " + modifiedQuery);
 
             String userNameLocal;
-            if (APIConstants.WSO2_ANONYMOUS_USER.equals(holder.getUserName())) {
+            if (holder.isAnonymousMode()) {
                 userNameLocal = APIConstants.WSO2_ANONYMOUS_USER;
             } else {
                 userNameLocal = getTenantAwareUsername(ctx.getUserame());
@@ -2918,14 +2918,14 @@ public class RegistryPersistenceImpl implements APIPersistence {
         private Registry registry;
         private boolean isTenantFlowStarted;
         private int tenantId;
-        private String userName;
+        private boolean isAnonymousMode;
 
-        public String getUserName() {
-            return userName;
+        public boolean isAnonymousMode() {
+            return isAnonymousMode;
         }
 
-        public void setUserName(String userName) {
-            this.userName = userName;
+        public void setAnonymousMode(boolean anonymousMode) {
+            isAnonymousMode = anonymousMode;
         }
 
         public Registry getRegistry() {
@@ -3027,7 +3027,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
                     registry = getRegistryService().getGovernanceUserRegistry(tenantAwareUserName, id);
                     holder.setTenantId(id);
                 } else if (userTenantDomain != null && !userTenantDomain.equals(requestedTenantDomain)) { // cross tenant
-                    holder.setUserName(APIConstants.WSO2_ANONYMOUS_USER);
+                    holder.setAnonymousMode(true);
                     log.debug("Cross tenant user from tenant " + userTenantDomain + " accessing "
                             + requestedTenantDomain + " registry");
                     loadTenantRegistry(id);

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -978,7 +978,12 @@ public class RegistryPersistenceImpl implements APIPersistence {
                     isAllowDisplayAPIsWithMultipleStatus());
             log.debug("Modified query for devportal search: " + modifiedQuery);
 
-            String userNameLocal = getTenantAwareUsername(ctx.getUserame());
+            String userNameLocal;
+            if (APIConstants.WSO2_ANONYMOUS_USER.equals(holder.getUserName())) {
+                userNameLocal = APIConstants.WSO2_ANONYMOUS_USER;
+            } else {
+                userNameLocal = getTenantAwareUsername(ctx.getUserame());
+            }
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(userNameLocal);
 
             if (searchQuery != null && searchQuery.startsWith(APIConstants.DOCUMENTATION_SEARCH_TYPE_PREFIX)) {
@@ -2913,6 +2918,15 @@ public class RegistryPersistenceImpl implements APIPersistence {
         private Registry registry;
         private boolean isTenantFlowStarted;
         private int tenantId;
+        private String userName;
+
+        public String getUserName() {
+            return userName;
+        }
+
+        public void setUserName(String userName) {
+            this.userName = userName;
+        }
 
         public Registry getRegistry() {
             return registry;
@@ -3013,6 +3027,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
                     registry = getRegistryService().getGovernanceUserRegistry(tenantAwareUserName, id);
                     holder.setTenantId(id);
                 } else if (userTenantDomain != null && !userTenantDomain.equals(requestedTenantDomain)) { // cross tenant
+                    holder.setUserName(APIConstants.WSO2_ANONYMOUS_USER);
                     log.debug("Cross tenant user from tenant " + userTenantDomain + " accessing "
                             + requestedTenantDomain + " registry");
                     loadTenantRegistry(id);


### PR DESCRIPTION
### Purpose
To solve console ERROR when trying to access tenant devportal with secondary user store user

### Goal
Fixes: https://github.com/wso2/product-apim/issues/10272

### Approach
Introduced to set "wso2.anonymous.user" for user name, if the user's tenant domain is not equals to the tenant domain which the request has made .