### PR TITLE
check for null gatewayEnvironments API field

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -312,7 +312,7 @@ public class APIMappingUtil {
             model.setTechnicalOwner(apiBusinessInformationDTO.getTechnicalOwner());
             model.setTechnicalOwnerEmail(apiBusinessInformationDTO.getTechnicalOwnerEmail());
         }
-        if (dto.getGatewayEnvironments().size() > 0) {
+        if (dto.getGatewayEnvironments() != null && dto.getGatewayEnvironments().size() > 0) {
             List<String> gatewaysList = dto.getGatewayEnvironments();
             model.setEnvironments(APIUtil.extractEnvironmentsForAPI(gatewaysList));
         } else if (dto.getGatewayEnvironments() != null) {
@@ -2336,7 +2336,7 @@ public class APIMappingUtil {
         String transports = StringUtils.join(dto.getTransport(), ',');
         product.setTransports(transports);
 
-        if (dto.getGatewayEnvironments().size() > 0) {
+        if (dto.getGatewayEnvironments() != null && dto.getGatewayEnvironments().size() > 0) {
             List<String> gatewaysList = dto.getGatewayEnvironments();
             product.setEnvironments(APIUtil.extractEnvironmentsForAPI(gatewaysList));
         } else if (dto.getGatewayEnvironments() != null) {


### PR DESCRIPTION
I ran into an NPE here using generated Scala client code with API Manager 3.2.0 (which I guess runs v6.7.206 of this repo, but this part of the code is the same there and in master).  There's an easy client-side workaround for this of course but since it took me an hour to figure out I thought I'd post what I believe is the proper fix - feel free to do as you wish with it.