### PR TITLE
Remove On the Fly Migration of json_fault.xml for 2.0.0 to 2.1.0

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1406,7 +1406,6 @@ public final class APIConstants {
     public static final String API_CUSTOM_SEQ_IN_EXT = "--In";
     public static final String API_CUSTOM_SEQ_OUT_EXT = "--Out";
     public static final String API_CUSTOM_SEQ_FAULT_EXT = "--Fault";
-    public static final String API_CUSTOM_SEQ_JSON_FAULT = "json_fault.xml";
 
     public static final String API_MANAGER_HOSTNAME = "HostName";
     public static final String API_MANAGER_HOSTNAME_UNKNOWN = "UNKNOWN_HOST";


### PR DESCRIPTION
## Purpose
Remove on the fly migration of json_fault.xml for 2.0.0 to 2.1.0. This will now be handled by the migration client [1].
Related Issue: wso2/product-apim#10238

[1] https://github.com/wso2-extensions/apim-migration-resources/pull/99