### PR TITLE
Update throttle event message type to json

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/JMSMessageListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/JMSMessageListener.java
@@ -18,6 +18,9 @@
 
 package org.wso2.carbon.apimgt.gateway.listeners;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.simple.parser.ParseException;
@@ -37,6 +40,7 @@ import javax.jms.JMSException;
 import javax.jms.MapMessage;
 import javax.jms.Message;
 import javax.jms.MessageListener;
+import javax.jms.TextMessage;
 import javax.jms.Topic;
 
 public class JMSMessageListener implements MessageListener {
@@ -68,16 +72,12 @@ public class JMSMessageListener implements MessageListener {
                     log.debug("Event received in JMS Event Receiver - " + message);
                 }
                 Topic jmsDestination = (Topic) message.getJMSDestination();
-                if (message instanceof MapMessage) {
-                    MapMessage mapMessage = (MapMessage) message;
-                    Map<String, Object> map = new HashMap<String, Object>();
-                    Enumeration enumeration = mapMessage.getMapNames();
-                    while (enumeration.hasMoreElements()) {
-                        String key = (String) enumeration.nextElement();
-                        map.put(key, mapMessage.getObject(key));
-                    }
+                if (message instanceof TextMessage) {
+                    String textMessage = ((TextMessage) message).getText();
+                    JsonNode payloadData = new ObjectMapper().readTree(textMessage).path(APIConstants.EVENT_PAYLOAD).
+                            path(APIConstants.EVENT_PAYLOAD_DATA);
                     if (APIConstants.TopicNames.TOPIC_THROTTLE_DATA.equalsIgnoreCase(jmsDestination.getTopicName())) {
-                        if (map.get(APIConstants.THROTTLE_KEY) != null) {
+                        if (payloadData.get(APIConstants.THROTTLE_KEY) != null) {
                             /*
                              * This message contains throttle data in map which contains Keys
                              * throttleKey - Key of particular throttling level
@@ -85,22 +85,22 @@ public class JMSMessageListener implements MessageListener {
                              * expiryTimeStamp - When the throttling time window will expires
                              */
 
-                            handleThrottleUpdateMessage(map);
-                        } else if (map.get(APIConstants.BLOCKING_CONDITION_KEY) != null) {
+                            handleThrottleUpdateMessage(payloadData);
+                        } else if (payloadData.get(APIConstants.BLOCKING_CONDITION_KEY) != null) {
                             /*
                              * This message contains blocking condition data
                              * blockingCondition - Blocking condition type
                              * conditionValue - blocking condition value
                              * state - State whether blocking condition is enabled or not
                              */
-                            handleBlockingMessage(map);
-                        } else if (map.get(APIConstants.POLICY_TEMPLATE_KEY) != null) {
+                            handleBlockingMessage(payloadData);
+                        } else if (payloadData.get(APIConstants.POLICY_TEMPLATE_KEY) != null) {
                             /*
                              * This message contains key template data
                              * keyTemplateValue - Value of key template
                              * keyTemplateState - whether key template active or not
                              */
-                            handleKeyTemplateMessage(map);
+                            handleKeyTemplateMessage(payloadData);
                         }
                     }
                 } else {
@@ -111,17 +111,16 @@ public class JMSMessageListener implements MessageListener {
             }
         } catch (JMSException e) {
             log.error("JMSException occurred when processing the received message ", e);
-        } catch (ParseException e) {
+        } catch (ParseException | JsonProcessingException e) {
             log.error("Error while processing evaluatedConditions", e);
         }
     }
 
-    private void handleThrottleUpdateMessage(Map<String, Object> map) throws ParseException {
-
-        String throttleKey = map.get(APIConstants.AdvancedThrottleConstants.THROTTLE_KEY).toString();
-        String throttleState = map.get(APIConstants.AdvancedThrottleConstants.IS_THROTTLED).toString();
-        Long timeStamp = Long.parseLong(map.get(APIConstants.AdvancedThrottleConstants.EXPIRY_TIMESTAMP).toString());
-        Object evaluatedConditionObject = map.get(APIConstants.AdvancedThrottleConstants.EVALUATED_CONDITIONS);
+    private void handleThrottleUpdateMessage(JsonNode msg) throws ParseException {
+        String throttleKey = msg.get(APIConstants.AdvancedThrottleConstants.THROTTLE_KEY).toString();
+        String throttleState = msg.get(APIConstants.AdvancedThrottleConstants.IS_THROTTLED).toString();
+        Long timeStamp = Long.parseLong(msg.get(APIConstants.AdvancedThrottleConstants.EXPIRY_TIMESTAMP).toString());
+        Object evaluatedConditionObject = msg.get(APIConstants.AdvancedThrottleConstants.EVALUATED_CONDITIONS);
 
         if (log.isDebugEnabled()) {
             log.debug("Received Key -  throttleKey : " + throttleKey + " , " +
@@ -138,7 +137,7 @@ public class JMSMessageListener implements MessageListener {
                 if (evaluatedConditionObject != null) {
                     ServiceReferenceHolder.getInstance().getAPIThrottleDataService().addThrottledApiConditions
                             (extractedKey.getResourceKey(), extractedKey.getName(), APIUtil.extractConditionDto(
-                                    (String) evaluatedConditionObject));
+                                    evaluatedConditionObject.toString()));
                 }
                 if (!ServiceReferenceHolder.getInstance().getAPIThrottleDataService().isAPIThrottled(extractedKey
                         .getResourceKey())) {
@@ -169,20 +168,19 @@ public class JMSMessageListener implements MessageListener {
     //Synchronized due to blocking data contains or not can updated by multiple threads. Will not be a performance
     // isssue
     //as this will not happen more frequently
-    private synchronized void handleBlockingMessage(Map<String, Object> map) {
-
+    private synchronized void handleBlockingMessage(JsonNode msg) {
         if (log.isDebugEnabled()) {
-            log.debug("Received Key -  blockingCondition : " + map.get(APIConstants.BLOCKING_CONDITION_KEY).toString() +
+            log.debug("Received Key -  blockingCondition : " + msg.get(APIConstants.BLOCKING_CONDITION_KEY).toString() +
                     " , " +
-                    "conditionValue :" + map.get(APIConstants.BLOCKING_CONDITION_VALUE).toString() + " , " +
-                    "tenantDomain : " + map.get(APIConstants.BLOCKING_CONDITION_DOMAIN));
+                    "conditionValue :" + msg.get(APIConstants.BLOCKING_CONDITION_VALUE).toString() + " , " +
+                    "tenantDomain : " + msg.get(APIConstants.BLOCKING_CONDITION_DOMAIN));
         }
 
-        String condition = map.get(APIConstants.BLOCKING_CONDITION_KEY).toString();
-        String conditionValue = map.get(APIConstants.BLOCKING_CONDITION_VALUE).toString();
-        String conditionState = map.get(APIConstants.BLOCKING_CONDITION_STATE).toString();
-        int conditionId = (int) map.get(APIConstants.BLOCKING_CONDITION_ID);
-        String tenantDomain = map.get(APIConstants.BLOCKING_CONDITION_DOMAIN).toString();
+        String condition = msg.get(APIConstants.BLOCKING_CONDITION_KEY).toString();
+        String conditionValue = msg.get(APIConstants.BLOCKING_CONDITION_VALUE).toString();
+        String conditionState = msg.get(APIConstants.BLOCKING_CONDITION_STATE).toString();
+        int conditionId = msg.get(APIConstants.BLOCKING_CONDITION_ID).asInt();
+        String tenantDomain = msg.get(APIConstants.BLOCKING_CONDITION_DOMAIN).toString();
 
         if (APIConstants.BLOCKING_CONDITIONS_APPLICATION.equals(condition)) {
             if (APIConstants.AdvancedThrottleConstants.TRUE.equals(conditionState)) {
@@ -230,7 +228,6 @@ public class JMSMessageListener implements MessageListener {
     }
 
     private APICondition extractAPIorResourceKey(String throttleKey) {
-
         Matcher m = resourcePattern.matcher(throttleKey);
         if (m.matches()) {
             if (m.groupCount() == RESOURCE_PATTERN_GROUPS) {
@@ -269,13 +266,12 @@ public class JMSMessageListener implements MessageListener {
         return null;
     }
 
-    private synchronized void handleKeyTemplateMessage(Map<String, Object> map) {
-
+    private synchronized void handleKeyTemplateMessage(JsonNode msg) {
         if (log.isDebugEnabled()) {
-            log.debug("Received Key -  KeyTemplate : " + map.get(APIConstants.POLICY_TEMPLATE_KEY).toString());
+            log.debug("Received Key -  KeyTemplate : " + msg.get(APIConstants.POLICY_TEMPLATE_KEY).toString());
         }
-        String keyTemplateValue = map.get(APIConstants.POLICY_TEMPLATE_KEY).toString();
-        String keyTemplateState = map.get(APIConstants.TEMPLATE_KEY_STATE).toString();
+        String keyTemplateValue = msg.get(APIConstants.POLICY_TEMPLATE_KEY).toString();
+        String keyTemplateState = msg.get(APIConstants.TEMPLATE_KEY_STATE).toString();
         if (APIConstants.AdvancedThrottleConstants.ADD.equals(keyTemplateState)) {
             ServiceReferenceHolder.getInstance().getAPIThrottleDataService()
                     .addKeyTemplate(keyTemplateValue, keyTemplateValue);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/JMSMessageListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/JMSMessageListener.java
@@ -111,15 +111,17 @@ public class JMSMessageListener implements MessageListener {
             }
         } catch (JMSException e) {
             log.error("JMSException occurred when processing the received message ", e);
-        } catch (ParseException | JsonProcessingException e) {
+        } catch (ParseException e) {
             log.error("Error while processing evaluatedConditions", e);
+        } catch (JsonProcessingException e) {
+            log.error("Error while parsing JMS payload", e);
         }
     }
 
     private void handleThrottleUpdateMessage(JsonNode msg) throws ParseException {
-        String throttleKey = msg.get(APIConstants.AdvancedThrottleConstants.THROTTLE_KEY).toString();
-        String throttleState = msg.get(APIConstants.AdvancedThrottleConstants.IS_THROTTLED).toString();
-        Long timeStamp = Long.parseLong(msg.get(APIConstants.AdvancedThrottleConstants.EXPIRY_TIMESTAMP).toString());
+        String throttleKey = msg.get(APIConstants.AdvancedThrottleConstants.THROTTLE_KEY).asText();
+        String throttleState = msg.get(APIConstants.AdvancedThrottleConstants.IS_THROTTLED).asText();
+        Long timeStamp = Long.parseLong(msg.get(APIConstants.AdvancedThrottleConstants.EXPIRY_TIMESTAMP).asText());
         Object evaluatedConditionObject = msg.get(APIConstants.AdvancedThrottleConstants.EVALUATED_CONDITIONS);
 
         if (log.isDebugEnabled()) {
@@ -170,17 +172,17 @@ public class JMSMessageListener implements MessageListener {
     //as this will not happen more frequently
     private synchronized void handleBlockingMessage(JsonNode msg) {
         if (log.isDebugEnabled()) {
-            log.debug("Received Key -  blockingCondition : " + msg.get(APIConstants.BLOCKING_CONDITION_KEY).toString() +
+            log.debug("Received Key -  blockingCondition : " + msg.get(APIConstants.BLOCKING_CONDITION_KEY).asText() +
                     " , " +
-                    "conditionValue :" + msg.get(APIConstants.BLOCKING_CONDITION_VALUE).toString() + " , " +
-                    "tenantDomain : " + msg.get(APIConstants.BLOCKING_CONDITION_DOMAIN));
+                    "conditionValue :" + msg.get(APIConstants.BLOCKING_CONDITION_VALUE).asText() + " , " +
+                    "tenantDomain : " + msg.get(APIConstants.BLOCKING_CONDITION_DOMAIN).asText());
         }
 
-        String condition = msg.get(APIConstants.BLOCKING_CONDITION_KEY).toString();
-        String conditionValue = msg.get(APIConstants.BLOCKING_CONDITION_VALUE).toString();
-        String conditionState = msg.get(APIConstants.BLOCKING_CONDITION_STATE).toString();
+        String condition = msg.get(APIConstants.BLOCKING_CONDITION_KEY).asText();
+        String conditionValue = msg.get(APIConstants.BLOCKING_CONDITION_VALUE).asText();
+        String conditionState = msg.get(APIConstants.BLOCKING_CONDITION_STATE).asText();
         int conditionId = msg.get(APIConstants.BLOCKING_CONDITION_ID).asInt();
-        String tenantDomain = msg.get(APIConstants.BLOCKING_CONDITION_DOMAIN).toString();
+        String tenantDomain = msg.get(APIConstants.BLOCKING_CONDITION_DOMAIN).asText();
 
         if (APIConstants.BLOCKING_CONDITIONS_APPLICATION.equals(condition)) {
             if (APIConstants.AdvancedThrottleConstants.TRUE.equals(conditionState)) {
@@ -268,10 +270,10 @@ public class JMSMessageListener implements MessageListener {
 
     private synchronized void handleKeyTemplateMessage(JsonNode msg) {
         if (log.isDebugEnabled()) {
-            log.debug("Received Key -  KeyTemplate : " + msg.get(APIConstants.POLICY_TEMPLATE_KEY).toString());
+            log.debug("Received Key -  KeyTemplate : " + msg.get(APIConstants.POLICY_TEMPLATE_KEY).asText());
         }
-        String keyTemplateValue = msg.get(APIConstants.POLICY_TEMPLATE_KEY).toString();
-        String keyTemplateState = msg.get(APIConstants.TEMPLATE_KEY_STATE).toString();
+        String keyTemplateValue = msg.get(APIConstants.POLICY_TEMPLATE_KEY).asText();
+        String keyTemplateState = msg.get(APIConstants.TEMPLATE_KEY_STATE).asText();
         if (APIConstants.AdvancedThrottleConstants.ADD.equals(keyTemplateState)) {
             ServiceReferenceHolder.getInstance().getAPIThrottleDataService()
                     .addKeyTemplate(keyTemplateValue, keyTemplateValue);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -32,6 +32,7 @@ import org.apache.axis2.util.JavaUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -6856,8 +6857,14 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
      * @param blockConditionsDTO Blockcondition Dto event
      */
     private void publishBlockingEvent(BlockConditionsDTO blockConditionsDTO, String state) {
+        String conditionType = blockConditionsDTO.getConditionType();
+        String conditionValue = blockConditionsDTO.getConditionValue();
+        if (APIConstants.BLOCKING_CONDITIONS_IP.equals(conditionType) ||
+                APIConstants.BLOCK_CONDITION_IP_RANGE.equals(conditionType)) {
+            conditionValue = StringEscapeUtils.escapeJava(conditionValue);
+        }
         Object[] objects = new Object[]{blockConditionsDTO.getConditionId(), blockConditionsDTO.getConditionType(),
-                blockConditionsDTO.getConditionValue(),state, tenantDomain};
+                conditionValue, state, tenantDomain};
         Event blockingMessage = new Event(APIConstants.BLOCKING_CONDITIONS_STREAM_ID, System.currentTimeMillis(),
                 null, null, objects);
         ThrottleProperties throttleProperties = getAPIManagerConfiguration().getThrottleProperties();

--- a/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventpublishers/blockingEventJMSPublisher.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventpublishers/blockingEventJMSPublisher.xml
@@ -2,7 +2,7 @@
 <eventPublisher name="blockingEventJMSPublisher" statistics="disable"
   trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
   <from streamName="org.wso2.blocking.request.stream" version="1.0.0"/>
-  <mapping customMapping="disable" type="map"/>
+  <mapping customMapping="disable" type="json"/>
   <to eventAdapterType="jms">
     <property name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</property>
     <property name="java.naming.provider.url">repository/conf/jndi.properties</property>

--- a/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventpublishers/jmsEventPublisher.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventpublishers/jmsEventPublisher.xml
@@ -2,7 +2,7 @@
 <eventPublisher name="jmsEventPublisher" statistics="disable"
   trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
   <from streamName="org.wso2.throttle.globalThrottle.stream" version="1.0.0"/>
-  <mapping customMapping="disable" type="map"/>
+  <mapping customMapping="disable" type="json"/>
   <to eventAdapterType="jms">
     <property name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</property>
     <property name="java.naming.provider.url">repository/conf/jndi.properties</property>

--- a/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventpublishers/jmsEventPublisher_1.10.0.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventpublishers/jmsEventPublisher_1.10.0.xml
@@ -2,7 +2,7 @@
 <eventPublisher name="jmsEventPublisher-1.0.0" statistics="disable"
   trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
   <from streamName="org.wso2.throttle.globalThrottle.stream" version="1.1.0"/>
-  <mapping customMapping="disable" type="map"/>
+  <mapping customMapping="disable" type="json"/>
   <to eventAdapterType="jms">
     <property name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</property>
     <property name="java.naming.provider.url">repository/conf/jndi.properties</property>

--- a/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventpublishers/keyTemplateEventPublisher.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/src/main/resources/conf/eventpublishers/keyTemplateEventPublisher.xml
@@ -2,7 +2,7 @@
 <eventPublisher name="keyTemplateEventPublisher" statistics="disable"
   trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
   <from streamName="org.wso2.keytemplate.request.stream" version="1.0.0"/>
-  <mapping customMapping="disable" type="map"/>
+  <mapping customMapping="disable" type="json"/>
   <to eventAdapterType="jms">
     <property name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</property>
     <property name="java.naming.provider.url">repository/conf/jndi.properties</property>


### PR DESCRIPTION
MGW need this to be in json format for processing. Current impl sends the message in 'JMS Content-Type: amqp/map' format which is not parsable easily. This response has to be in a protocol agnostic format. Earlier we have made this change (with #9560) to other event publishers except throttle publishers