### PR TITLE
Fixing the issues of not using the persistence instance when importing thumbnails, documents, WSDL files and SOAP to REST mediations

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -440,6 +440,9 @@ public enum ExceptionCodes implements ErrorHandler {
             "Cannot find the yaml/json file with the project definition."),
     NO_API_ARTIFACT_FOUND(900910, "No Api artifacts found for given criteria", 404,
             "No Api artifacts found for given criteria"),
+    ERROR_UPLOADING_THUMBNAIL(900914,
+            "Error while updating thumbnail of API/API Product", 500,
+            "Error while updating thumbnail of API/API Product: %s-%s"),
 
     //AsyncApi related error codes
     ASYNCAPI_URL_MALFORMED(900756, "AsyncAPI specification retrieval from URL failed", 400, "Exception occurred while retrieving the AsyncAPI Specification from URL"),

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -173,7 +173,7 @@ public class ExportUtils {
 
             CommonUtil.createDirectory(archivePath);
             if (preserveDocs) {
-                addThumbnailToArchive(archivePath, apiIdentifier, apiProvider, APIConstants.API_IDENTIFIER_TYPE);
+                addThumbnailToArchive(archivePath, apiIdentifier, apiProvider);
             }
             addSOAPToRESTMediationToArchive(archivePath, apiIdentifier, registry);
             if (preserveDocs) {
@@ -259,8 +259,7 @@ public class ExportUtils {
         CommonUtil.createDirectory(archivePath);
 
         if (preserveDocs) {
-            addThumbnailToArchive(archivePath, apiProductIdentifier, apiProvider,
-                    APIConstants.API_PRODUCT_IDENTIFIER_TYPE);
+            addThumbnailToArchive(archivePath, apiProductIdentifier, apiProvider);
             addDocumentationToArchive(archivePath, apiProductIdentifier, exportFormat, apiProvider,
                     APIConstants.API_PRODUCT_IDENTIFIER_TYPE);
 
@@ -287,19 +286,16 @@ public class ExportUtils {
      * @param archivePath File path to export the thumbnail image
      * @param identifier  ID of the requesting API or API Product
      * @param apiProvider API Provider
-     * @param type        Type (whether an API or an API Product
      * @throws APIImportExportException If an error occurs while retrieving image from the registry or
      *                                  storing in the archive directory
      */
-    public static void addThumbnailToArchive(String archivePath, Identifier identifier, APIProvider apiProvider,
-                                             String type) throws APIImportExportException, APIManagementException {
+    public static void addThumbnailToArchive(String archivePath, Identifier identifier, APIProvider apiProvider)
+            throws APIImportExportException, APIManagementException {
 
         String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
         String localImagePath = archivePath + File.separator + ImportExportConstants.IMAGE_RESOURCE;
         try {
-            ResourceFile thumbnailResource = StringUtils.equals(type, APIConstants.API_IDENTIFIER_TYPE) ?
-                    apiProvider.getIcon(identifier.getUUID(), tenantDomain) :
-                    apiProvider.getProductIcon((APIProductIdentifier) identifier);
+            ResourceFile thumbnailResource = apiProvider.getIcon(identifier.getUUID(), tenantDomain);
             if (thumbnailResource != null) {
                 String mediaType = thumbnailResource.getContentType();
                 String extension = ImportExportConstants.fileExtensionMapping.get(mediaType);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -88,9 +88,6 @@ import java.util.Set;
 public class ExportUtils {
 
     private static final Log log = LogFactory.getLog(ExportUtils.class);
-    private static final String IN = "in";
-    private static final String OUT = "out";
-    private static final String SOAPTOREST = "SoapToRest";
 
     /**
      * Validate name, version and provider before exporting an API/API Product.

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -59,7 +59,6 @@ import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
 import org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
-import org.wso2.carbon.apimgt.impl.wsdl.util.SOAPToRESTConstants;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIDTO;
@@ -67,7 +66,6 @@ import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIProductDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.AdvertiseInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.GraphQLQueryComplexityInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ProductAPIDTO;
-import org.wso2.carbon.registry.api.Collection;
 import org.wso2.carbon.registry.api.RegistryException;
 import org.wso2.carbon.registry.core.RegistryConstants;
 import org.wso2.carbon.registry.core.session.UserRegistry;
@@ -175,13 +173,13 @@ public class ExportUtils {
             if (preserveDocs) {
                 addThumbnailToArchive(archivePath, apiIdentifier, apiProvider);
             }
-            addSOAPToRESTMediationToArchive(archivePath, apiIdentifier, registry);
             if (preserveDocs) {
                 addDocumentationToArchive(archivePath, apiIdentifier, exportFormat, apiProvider,
                         APIConstants.API_IDENTIFIER_TYPE);
             }
 
-            if (StringUtils.isNotEmpty(apiDtoToReturn.getWsdlUrl()) && preserveDocs) {
+            if (StringUtils.equals(apiDtoToReturn.getType().toString().toLowerCase(),
+                    APIConstants.API_TYPE_SOAP.toLowerCase()) && preserveDocs) {
                 addWSDLtoArchive(archivePath, apiIdentifier, apiProvider);
             } else if (log.isDebugEnabled()) {
                 log.debug("No WSDL URL found for API: " + apiIdentifier + ". Skipping WSDL export.");
@@ -325,61 +323,6 @@ public class ExportUtils {
             //Exception is ignored by logging due to the reason that Thumbnail is not essential for
             //an API to be recreated.
             log.error("I/O error while writing API/API Product Thumbnail to file", e);
-        }
-    }
-
-    /**
-     * Retrieve SOAP to REST mediation logic for the exporting API and store it in the archive directory.
-     *
-     * @param archivePath   File path to export the SOAPToREST mediation logic
-     * @param apiIdentifier ID of the requesting API
-     * @param registry      Current tenant registry
-     * @throws APIImportExportException If an error occurs while retrieving image from the registry or
-     *                                  storing in the archive directory
-     */
-    public static void addSOAPToRESTMediationToArchive(String archivePath, APIIdentifier apiIdentifier,
-                                                       UserRegistry registry) throws APIImportExportException {
-
-        String soapToRestBaseUrl =
-                "/apimgt/applicationdata/provider" + RegistryConstants.PATH_SEPARATOR + apiIdentifier.getProviderName()
-                        + RegistryConstants.PATH_SEPARATOR + apiIdentifier.getApiName()
-                        + RegistryConstants.PATH_SEPARATOR + apiIdentifier.getVersion()
-                        + RegistryConstants.PATH_SEPARATOR + SOAPToRESTConstants.SOAP_TO_REST_RESOURCE;
-        try {
-            if (registry.resourceExists(soapToRestBaseUrl)) {
-                Collection inFlow = (org.wso2.carbon.registry.api.Collection) registry
-                        .get(soapToRestBaseUrl + RegistryConstants.PATH_SEPARATOR + IN);
-                Collection outFlow = (org.wso2.carbon.registry.api.Collection) registry
-                        .get(soapToRestBaseUrl + RegistryConstants.PATH_SEPARATOR + OUT);
-
-                CommonUtil.createDirectory(archivePath + File.separator + SOAPTOREST + File.separator + IN);
-                CommonUtil.createDirectory(archivePath + File.separator + SOAPTOREST + File.separator + OUT);
-                if (inFlow != null) {
-                    for (String inFlowPath : inFlow.getChildren()) {
-                        try (InputStream inputStream = registry.get(inFlowPath).getContentStream();
-                             OutputStream outputStream = new FileOutputStream(
-                                     archivePath + File.separator + SOAPTOREST + File.separator + IN + inFlowPath
-                                             .substring(
-                                                     inFlowPath.lastIndexOf(RegistryConstants.PATH_SEPARATOR)));) {
-                            IOUtils.copy(inputStream, outputStream);
-                        }
-                    }
-                }
-                if (outFlow != null) {
-                    for (String outFlowPath : outFlow.getChildren()) {
-                        try (InputStream inputStream = registry.get(outFlowPath).getContentStream();
-                             OutputStream outputStream = new FileOutputStream(
-                                     archivePath + File.separator + SOAPTOREST + File.separator + OUT + outFlowPath.
-                                             substring(outFlowPath.lastIndexOf(RegistryConstants.PATH_SEPARATOR)))) {
-                            IOUtils.copy(inputStream, outputStream);
-                        }
-                    }
-                }
-            }
-        } catch (IOException e) {
-            throw new APIImportExportException("I/O error while writing API SOAP to REST logic to file", e);
-        } catch (RegistryException e) {
-            throw new APIImportExportException("Error while retrieving SOAP to REST logic", e);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -49,6 +49,8 @@ import org.wso2.carbon.apimgt.api.model.APIProduct;
 import org.wso2.carbon.apimgt.api.model.APIProductIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIProductResource;
 import org.wso2.carbon.apimgt.api.model.Documentation;
+import org.wso2.carbon.apimgt.api.model.DocumentationContent;
+import org.wso2.carbon.apimgt.api.model.ResourceFile;
 import org.wso2.carbon.apimgt.api.model.ServiceEntry;
 import org.wso2.carbon.apimgt.api.model.SwaggerData;
 import org.wso2.carbon.apimgt.api.model.Tier;
@@ -77,6 +79,7 @@ import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.core.util.CryptoUtil;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1170,6 +1173,22 @@ public class PublisherCommonUtils {
     }
 
     /**
+     * Update thumbnail of an API/API Product
+     *
+     * @param fileInputStream Input stream
+     * @param fileContentType The content type of the image
+     * @param apiProvider     API Provider
+     * @param apiId           API/API Product UUID
+     * @param tenantDomain    Tenant domain of the API
+     * @throws APIManagementException If an error occurs while updating the thumbnail
+     */
+    public static void updateThumbnail(InputStream fileInputStream, String fileContentType, APIProvider apiProvider,
+            String apiId, String tenantDomain) throws APIManagementException {
+        ResourceFile apiImage = new ResourceFile(fileInputStream, fileContentType);
+        apiProvider.setThumbnailToAPI(apiId, apiImage, tenantDomain);
+    }
+
+    /**
      * Add document DTO.
      *
      * @param documentDto Document DTO
@@ -1209,6 +1228,48 @@ public class PublisherCommonUtils {
         documentation = apiProvider.addDocumentation(apiId, documentation, tenantDomain);
 
         return documentation;
+    }
+
+    /**
+     * Add documentation content of inline and markdown documents.
+     *
+     * @param documentation Documentation
+     * @param apiProvider   API Provider
+     * @param apiId         API/API Product UUID
+     * @param documentId    Document ID
+     * @param tenantDomain  Tenant domain of the API/API Product
+     * @param inlineContent Inline content string
+     * @throws APIManagementException If an error occurs while adding the documentation content
+     */
+    public static void addDocumentationContent(Documentation documentation, APIProvider apiProvider, String apiId,
+            String documentId, String tenantDomain, String inlineContent) throws APIManagementException {
+        DocumentationContent content = new DocumentationContent();
+        content.setSourceType(DocumentationContent.ContentSourceType.valueOf(documentation.getSourceType().toString()));
+        content.setTextContent(inlineContent);
+        apiProvider.addDocumentationContent(apiId, documentId, tenantDomain, content);
+    }
+
+    /**
+     * Add documentation content of files.
+     *
+     * @param inputStream  Input Stream
+     * @param mediaType    Media type of the document
+     * @param filename     File name
+     * @param apiProvider  API Provider
+     * @param apiId        API/API Product UUID
+     * @param documentId   Document ID
+     * @param tenantDomain Tenant domain of the API/API Product
+     * @throws APIManagementException If an error occurs while adding the documentation file
+     */
+    public static void addDocumentationContentForFile(InputStream inputStream, String mediaType, String filename,
+            APIProvider apiProvider, String apiId, String documentId, String tenantDomain)
+            throws APIManagementException {
+        DocumentationContent content = new DocumentationContent();
+        ResourceFile resourceFile = new ResourceFile(inputStream, mediaType);
+        resourceFile.setName(filename);
+        content.setResourceFile(resourceFile);
+        content.setSourceType(DocumentationContent.ContentSourceType.FILE);
+        apiProvider.addDocumentationContent(apiId, documentId, tenantDomain, content);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -51,6 +51,7 @@ import org.wso2.carbon.apimgt.api.model.APIProductResource;
 import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.api.model.DocumentationContent;
 import org.wso2.carbon.apimgt.api.model.ResourceFile;
+import org.wso2.carbon.apimgt.api.model.SOAPToRestSequence;
 import org.wso2.carbon.apimgt.api.model.ServiceEntry;
 import org.wso2.carbon.apimgt.api.model.SwaggerData;
 import org.wso2.carbon.apimgt.api.model.Tier;
@@ -64,6 +65,7 @@ import org.wso2.carbon.apimgt.impl.definitions.OAS2Parser;
 import org.wso2.carbon.apimgt.impl.definitions.OAS3Parser;
 import org.wso2.carbon.apimgt.impl.definitions.OASParserUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.impl.wsdl.SequenceGenerator;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
@@ -1478,5 +1480,24 @@ public class PublisherCommonUtils {
         }
         api.setWsdlResource(wsdlResource);
         apiProvider.addWSDLResource(api.getUuid(), wsdlResource, null, tenantDomain);
+    }
+
+    /**
+     * Set the generated SOAP to REST sequences from the swagger file to the API and update it.
+     *
+     * @param swaggerContent Swagger content
+     * @param api            API to update
+     * @param apiProvider    API Provider
+     * @param tenantDomain   Tenant domain of the API
+     * @return Updated API Object
+     * @throws APIManagementException If an error occurs while generating the sequences or updating the API
+     * @throws FaultGatewaysException If an error occurs while updating the API
+     */
+    public static API updateAPIBySettingGenerateSequencesFromSwagger(String swaggerContent, API api,
+            APIProvider apiProvider, String tenantDomain) throws APIManagementException, FaultGatewaysException {
+        List<SOAPToRestSequence> list = SequenceGenerator.generateSequencesFromSwagger(swaggerContent, api.getId());
+        API updatedAPI = apiProvider.getAPIbyUUID(api.getUuid(), tenantDomain);
+        updatedAPI.setSoapToRestSequences(list);
+        return apiProvider.updateAPI(updatedAPI, api);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -1456,4 +1456,27 @@ public class PublisherCommonUtils {
         return APIDTO.TypeEnum.WS.equals(apidto.getType()) || APIDTO.TypeEnum.SSE.equals(apidto.getType()) ||
                 APIDTO.TypeEnum.WEBSUB.equals(apidto.getType());
     }
+
+    /**
+     * Add WSDL file of an API.
+     *
+     * @param fileContentType Content type of the file
+     * @param fileInputStream Input Stream
+     * @param api             API to which the WSDL belongs to
+     * @param apiProvider     API Provider
+     * @param tenantDomain    Tenant domain of the API
+     * @throws APIManagementException If an error occurs while adding the WSDL resource
+     */
+    public static void addWsdl(String fileContentType, InputStream fileInputStream, API api, APIProvider apiProvider,
+            String tenantDomain) throws APIManagementException {
+        ResourceFile wsdlResource;
+        if (APIConstants.APPLICATION_ZIP.equals(fileContentType) || APIConstants.APPLICATION_X_ZIP_COMPRESSED
+                .equals(fileContentType)) {
+            wsdlResource = new ResourceFile(fileInputStream, APIConstants.APPLICATION_ZIP);
+        } else {
+            wsdlResource = new ResourceFile(fileInputStream, fileContentType);
+        }
+        api.setWsdlResource(wsdlResource);
+        apiProvider.addWSDLResource(api.getUuid(), wsdlResource, null, tenantDomain);
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
@@ -205,10 +205,9 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
                     RestApiUtil.handleBadRequest(
                             "Source type of product document " + documentId + " is not INLINE " + "or MARKDOWN", log);
                 }
-                DocumentationContent content = new DocumentationContent();
-                content.setSourceType(ContentSourceType.valueOf(documentation.getSourceType().toString()));
-                content.setTextContent(inlineContent);
-                apiProvider.addDocumentationContent(apiProductId, documentId, tenantDomain, content);
+                PublisherCommonUtils
+                        .addDocumentationContent(documentation, apiProvider, apiProductId, documentId, tenantDomain,
+                                inlineContent);
             } else {
                 RestApiUtil.handleBadRequest("Either 'file' or 'inlineContent' should be specified", log);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -1634,11 +1634,9 @@ public class ApisApiServiceImpl implements ApisApiService {
                     RestApiUtil.handleBadRequest("Source type of document " + documentId + " is not INLINE " +
                             "or MARKDOWN", log);
                 }
-                DocumentationContent content = new DocumentationContent();
-                content.setSourceType(ContentSourceType.valueOf(documentation.getSourceType().toString()));
-                content.setTextContent(inlineContent);
-                // apiProvider.addDocumentationContent(api, documentation.getName(), inlineContent);
-                apiProvider.addDocumentationContent(apiId, documentId, tenantDomain, content);
+                PublisherCommonUtils
+                        .addDocumentationContent(documentation, apiProvider, apiId, documentId, tenantDomain,
+                                inlineContent);
             } else {
                 RestApiUtil.handleBadRequest("Either 'file' or 'inlineContent' should be specified", log);
             }
@@ -3019,11 +3017,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             if (org.apache.commons.lang3.StringUtils.isBlank(fileContentType)) {
                 fileContentType = fileDetail.getContentType().toString();
             }
-
-            ResourceFile apiImage = new ResourceFile(fileInputStream, fileContentType);
-            apiProvider.setThumbnailToAPI(apiId, apiImage, tenantDomain);
-            String uriString = RestApiConstants.RESOURCE_PATH_THUMBNAIL
-                    .replace(RestApiConstants.APIID_PARAM, apiId);
+            PublisherCommonUtils.updateThumbnail(fileInputStream, fileContentType, apiProvider, apiId, tenantDomain);
+            String uriString = RestApiConstants.RESOURCE_PATH_THUMBNAIL.replace(RestApiConstants.APIID_PARAM, apiId);
             URI uri = new URI(uriString);
             FileInfoDTO infoDTO = new FileInfoDTO();
             infoDTO.setRelativePath(uriString);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3439,16 +3439,9 @@ public class ApisApiServiceImpl implements ApisApiService {
                 apiToAdd.setWsdlUrl(url);
                 apiProvider.addWSDLResource(apiToAdd.getUuid(), null, url, tenantDomain);
             } else if (fileDetail != null && fileInputStream != null) {
-                ResourceFile wsdlResource = new ResourceFile(fileInputStream,
-                        fileDetail.getContentType().toString());
-                if (APIConstants.APPLICATION_ZIP.equals(fileDetail.getContentType().toString()) ||
-                        APIConstants.APPLICATION_X_ZIP_COMPRESSED.equals(fileDetail.getContentType().toString())) {
-                    wsdlResource = new ResourceFile(fileInputStream, APIConstants.APPLICATION_ZIP);
-                } else {
-                    wsdlResource = new ResourceFile(fileInputStream, fileDetail.getContentType().toString());
-                }
-                apiToAdd.setWsdlResource(wsdlResource);
-                apiProvider.addWSDLResource(apiToAdd.getUuid(), wsdlResource, null, tenantDomain);
+                PublisherCommonUtils
+                        .addWsdl(fileDetail.getContentType().toString(), fileInputStream, apiToAdd, apiProvider,
+                                tenantDomain);
             }
 
             //add the generated swagger definition to SOAP

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3511,12 +3511,9 @@ public class ApisApiServiceImpl implements ApisApiService {
                 }
             }
             String updatedSwagger = updateSwagger(createdApi.getUUID(), swaggerStr);
-            List<SOAPToRestSequence> list = SequenceGenerator.generateSequencesFromSwagger(updatedSwagger,
-                    apiToAdd.getId());
-            API updatedAPI = apiProvider.getAPIbyUUID(createdApi.getUuid(), tenantDomain);
-            updatedAPI.setSoapToRestSequences(list);
-            apiProvider.updateAPI(updatedAPI, createdApi);
-            return updatedAPI;
+            return PublisherCommonUtils
+                    .updateAPIBySettingGenerateSequencesFromSwagger(updatedSwagger, createdApi, apiProvider,
+                            tenantDomain);
         } catch (FaultGatewaysException | IOException e) {
             throw new APIManagementException("Error while importing WSDL to create a SOAP-to-REST API", e);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -27,12 +27,10 @@ import org.apache.cxf.jaxrs.ext.multipart.ContentDisposition;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.model.Documentation;
-import org.wso2.carbon.apimgt.api.model.DocumentationContent;
-import org.wso2.carbon.apimgt.api.model.DocumentationContent.ContentSourceType;
-import org.wso2.carbon.apimgt.api.model.ResourceFile;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings.PublisherCommonUtils;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -89,14 +87,9 @@ public class RestApiPublisherUtils {
             docInputStream = new FileInputStream(docFile.getAbsolutePath() + File.separator + filename);
             String mediaType = fileDetails.getHeader(RestApiConstants.HEADER_CONTENT_TYPE);
             mediaType = mediaType == null ? RestApiConstants.APPLICATION_OCTET_STREAM : mediaType;
-            DocumentationContent content = new DocumentationContent();
-            ResourceFile resourceFile = new ResourceFile(docInputStream, mediaType);
-            resourceFile.setName(filename);
-            content.setResourceFile(resourceFile);
-            content.setSourceType(ContentSourceType.FILE);
-            //apiProvider.addFileToDocumentation(apiIdentifier, documentation, filename, docInputStream, mediaType);
-            //apiProvider.updateDocumentation(apiIdentifier, documentation);
-            apiProvider.addDocumentationContent(apiId, documentId, tenantDomain, content);
+            PublisherCommonUtils
+                    .addDocumentationContentForFile(docInputStream, mediaType, filename, apiProvider, apiId,
+                            documentId, tenantDomain);
             docFile.deleteOnExit();
         } catch (FileNotFoundException e) {
             RestApiUtil.handleInternalServerError("Unable to read the file from path ", e, log);
@@ -181,14 +174,9 @@ public class RestApiPublisherUtils {
             docInputStream = new FileInputStream(docFile.getAbsolutePath() + File.separator + filename);
             String mediaType = fileDetails.getHeader(RestApiConstants.HEADER_CONTENT_TYPE);
             mediaType = mediaType == null ? RestApiConstants.APPLICATION_OCTET_STREAM : mediaType;
-            DocumentationContent content = new DocumentationContent();
-            ResourceFile resourceFile = new ResourceFile(docInputStream, mediaType);
-            resourceFile.setName(filename);
-            content.setResourceFile(resourceFile);
-            content.setSourceType(ContentSourceType.FILE);
-            //apiProvider.addFileToProductDocumentation(productIdentifier, documentation, filename, docInputStream, mediaType);
-            //apiProvider.updateDocumentation(productIdentifier, documentation);
-            apiProvider.addDocumentationContent(productId, documentId, tenantDomain, content);
+            PublisherCommonUtils
+                    .addDocumentationContentForFile(docInputStream, mediaType, filename, apiProvider, productId,
+                            documentId, tenantDomain);
             docFile.deleteOnExit();
         } catch (FileNotFoundException e) {
             RestApiUtil.handleInternalServerError("Unable to read the file from path ", e, log);


### PR DESCRIPTION
## Purpose
Fixes partially:  https://github.com/wso2/product-apim-tooling/issues/675

## Goals
Fixes the issues of not using the persistence instance when importing thumbnails, documents, WSDL files and SOAP to REST mediations according to [1]. 

## Approach
- Refactor the code to use persistence instance when adding the thumbnails, documents, WSDL files and SOAP to REST mediations
- Limited exporting WSDL files only for SOAP APIs (not for SOAP to REST)
- Restricted exporting SOAP to REST mediations since those can be derived from the swagger file during the import.
- Fix an issue of not exporting API Product thumbnails.

[1] https://github.com/wso2/product-apim-tooling/issues/675