### PR TITLE
Clear the REST API scopes and tenant-conf caches of APIM and extensions caches from the listener

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1049,6 +1049,7 @@ public final class APIConstants {
     public static final String REST_API_TOKEN_CACHE_NAME = "RESTAPITokenCache";
     public static final String REST_API_INVALID_TOKEN_CACHE_NAME = "RESTAPIInvalidTokenCache";
     public static final String GATEWAY_JWT_TOKEN_CACHE = "GatewayJWTTokenCache";
+    public static final String EXTENTIONS_CACHE_MANAGER = "EXTENTIONS_CACHE_MANAGER";
 
     public static final String KEY_CACHE_NAME = "keyCache";
     public static final String API_CONTEXT_CACHE = "apiContextCache";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/caching/CacheProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/caching/CacheProvider.java
@@ -96,6 +96,13 @@ public class CacheProvider {
     }
 
     /**
+     * @return Product REST API scope cache
+     */
+    public static Cache getRESTAPIScopeCache() {
+        return getCache(APIConstants.REST_API_SCOPE_CACHE);
+    }
+
+    /**
      * @return Product REST API invalid token cache
      */
     public static Cache getRESTAPIInvalidTokenCache() {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/handlers/TenantConfigMediaTypeHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/handlers/TenantConfigMediaTypeHandler.java
@@ -17,6 +17,7 @@
 
 package org.wso2.carbon.apimgt.impl.handlers;
 
+import org.eclipse.wst.validation.internal.ResourceConstants;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.caching.CacheProvider;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -24,6 +25,8 @@ import org.wso2.carbon.registry.core.jdbc.handlers.Handler;
 import org.wso2.carbon.registry.core.jdbc.handlers.RequestContext;
 
 import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
 
 public class TenantConfigMediaTypeHandler extends Handler {
 
@@ -36,12 +39,28 @@ public class TenantConfigMediaTypeHandler extends Handler {
     }
 
     private void clearConfigCache() {
+
+        // Clear the necessary caches of the product
+        CacheManager apimCacheManager = Caching.getCacheManager(APIConstants.API_MANAGER_CACHE_MANAGER);
         Cache tenantConfigCache = CacheProvider.getTenantConfigCache();
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         String cacheName = tenantId + "_" + APIConstants.TENANT_CONFIG_CACHE_NAME;
+        // Clear the tenant-config cache of the product
         if (tenantConfigCache.containsKey(cacheName)) {
             tenantConfigCache.remove(cacheName);
         }
+        // Clear the REST API Scope cache of the product
+        apimCacheManager.getCache(APIConstants.REST_API_SCOPE_CACHE).put(tenantDomain, null);
 
+        // Clear the necessary caches of the extensions
+        CacheManager extensionsCacheManager = Caching.getCacheManager(APIConstants.EXTENTIONS_CACHE_MANAGER);
+        Cache tenantConfigCacheOfExtensionsCacheManagerTenantConfigCache = extensionsCacheManager.getCache(APIConstants.TENANT_CONFIG_CACHE_NAME);
+        // Clear the tenant-config cache of the extensions
+        if (tenantConfigCacheOfExtensionsCacheManagerTenantConfigCache.containsKey(cacheName)) {
+            tenantConfigCacheOfExtensionsCacheManagerTenantConfigCache.remove(cacheName);
+        }
+        // Clear the REST API Scope cache of the extensions
+        extensionsCacheManager.getCache(APIConstants.REST_API_SCOPE_CACHE).put(tenantDomain, null);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/handlers/TenantConfigMediaTypeHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/handlers/TenantConfigMediaTypeHandler.java
@@ -17,7 +17,6 @@
 
 package org.wso2.carbon.apimgt.impl.handlers;
 
-import org.eclipse.wst.validation.internal.ResourceConstants;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.caching.CacheProvider;
 import org.wso2.carbon.context.PrivilegedCarbonContext;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -11390,10 +11390,6 @@ public final class APIUtil {
         if (log.isDebugEnabled()) {
             log.debug("Finalized tenant-conf.json: " + formattedTenantConf);
         }
-        // Invalidate Cache
-        Caching.getCacheManager(APIConstants.API_MANAGER_CACHE_MANAGER)
-                .getCache(APIConstants.REST_API_SCOPE_CACHE)
-                .put(tenantDomain, null);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/10549
Fixes: https://github.com/wso2/product-apim/issues/10640

## Goals
Clear the APIM and extensions cache manager REST API scopes and tenant-conf from the listener

## Approach
- The REST API Scopes cache has been cleared for both APIM and extensions cache managers by adding the code to TenantConfigMediaTypeHandler.
- Clear the tenant-conf cache of the extensions cache manager by adding the code to TenantConfigMediaTypeHandler.

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS
