### PR TITLE
Publisher TryOutConsole - Use default ports when vhost is deleted after a deployment and show DisplayName

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -63,6 +63,7 @@ import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import API from 'AppData/api';
 import { ConfirmDialog } from 'AppComponents/Shared/index';
 import { useRevisionContext } from 'AppComponents/Shared/RevisionContext';
+import CONSTS from 'AppData/Constants';
 import DisplayDevportal from './DisplayDevportal';
 
 const useStyles = makeStyles((theme) => ({
@@ -324,7 +325,7 @@ export default function Environments() {
     const [openDeployPopup, setOpenDeployPopup] = useState(history.location.state === 'deploy');
 
     // allEnvDeployments represents all deployments of the API with mapping
-    // environment -> {revision deployed to env, vhost deployed to env with revisino}
+    // environment -> {revision deployed to env, vhost deployed to env with revision}
     const allEnvDeployments = [];
     settings.environment.forEach((env) => {
         const revision = allEnvRevision && allEnvRevision.find(
@@ -332,7 +333,10 @@ export default function Environments() {
         );
         const envDetails = revision && revision.deploymentInfo.find((e) => e.name === env.name);
         const disPlayDevportal = envDetails && envDetails.displayOnDevportal;
-        const vhost = envDetails && env.vhosts && env.vhosts.find((e) => e.host === envDetails.vhost);
+        let vhost = envDetails && env.vhosts && env.vhosts.find((e) => e.host === envDetails.vhost);
+        if (!vhost) { // if vhost is deleted after deploying the revision, there is no matching vhost
+            vhost = { ...CONSTS.DEFAULT_VHOST, host: envDetails.vhost };
+        }
         allEnvDeployments[env.name] = { revision, vhost, disPlayDevportal };
     });
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Constants.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Constants.js
@@ -29,6 +29,14 @@ const CONSTS = {
         DESCRIPTION: 'description',
         OVERVIEW: '_overview',
     },
+    DEFAULT_VHOST: {
+        host: '',
+        httpContext: '',
+        httpPort: 80,
+        httpsPort: 443,
+        wsPort: 9099,
+        wssPort: 8099,
+    },
 };
 
 export default CONSTS;


### PR DESCRIPTION
# Description

- When vhost is deleted after a revision is deloyed with that vhsot, use default ports.
- Show display name instead of name of gateway environemnt

fix https://github.com/wso2/product-apim/issues/10710
fix https://github.com/wso2/product-apim/issues/10711 

show Display Name of gw environment
- name: us-region
- displanName: US Region

![image](https://user-images.githubusercontent.com/23183042/113330506-6f538f00-933c-11eb-884e-2c4a6c83dde2.png)
