### PR TITLE
Fix pagination issue in services search

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ServiceCatalog.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ServiceCatalog.java
@@ -155,4 +155,13 @@ public interface ServiceCatalog {
      * @throws APIManagementException
      */
     List<API> getServiceUsage(String serviceId, int tenantId) throws APIManagementException;
+
+    /**
+     * Retrieve the count of available services
+     * @param tenantId      Logged-in user tenant ID
+     * @param filterParams  Service Filer Params
+     * @return              Number of services that match to the given search conditions
+     * @throws APIManagementException
+     */
+    int getServicesCount(int tenantId, ServiceFilterParams filterParams) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/ServiceCatalogImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/ServiceCatalogImpl.java
@@ -105,4 +105,9 @@ public class ServiceCatalogImpl implements ServiceCatalog {
     public List<API> getServiceUsage(String serviceId, int tenantId) throws APIManagementException {
         return catalogDAO.getServiceUsage(serviceId, tenantId);
     }
+
+    @Override
+    public int getServicesCount(int tenantId, ServiceFilterParams filterParams) throws APIManagementException {
+        return catalogDAO.getServicesCount(tenantId, filterParams);
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
@@ -328,13 +328,14 @@ public class ServicesApiServiceImpl implements ServicesApiService {
             ServiceFilterParams filterParams = ServiceEntryMappingUtil.getServiceFilterParams(name, version,
                     definitionType, key, sortBy, sortOrder, limit, offset);
             List<ServiceEntry> services = serviceCatalog.getServices(filterParams, tenantId, shrink);
+            int totalServices = serviceCatalog.getServicesCount(tenantId, filterParams);
             for (ServiceEntry service : services) {
                 serviceDTOList.add(ServiceEntryMappingUtil.fromServiceToDTO(service, shrink));
             }
             ServiceListDTO serviceListDTO = new ServiceListDTO();
             serviceListDTO.setList(serviceDTOList);
             ServiceEntryMappingUtil.setPaginationParams(serviceListDTO, filterParams.getOffset(), filterParams.getLimit(),
-                    serviceDTOList.size(), filterParams);
+                    totalServices, filterParams);
             return Response.ok().entity(serviceListDTO).build();
         } catch (APIManagementException e) {
             String errorMessage = "Error while retrieving Services";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/utils/ServiceEntryMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/utils/ServiceEntryMappingUtil.java
@@ -335,10 +335,11 @@ public class ServiceEntryMappingUtil {
     }
 
     private static String getServicesPaginatedUrl(Integer offset, Integer limit, ServiceFilterParams filterParams) {
-        return  "/service-entries?name=" + filterParams.getName() + "&version=" + filterParams.getVersion()
+        String sortBy = "SERVICE_NAME".equals(filterParams.getSortBy()) ? "name" : "definitionType";
+        return  "/services?name=" + filterParams.getName() + "&version=" + filterParams.getVersion()
                 + "&definitionType=" + filterParams.getDefinitionType() + "&displayName="
                 + filterParams.getDisplayName() + "&key=" + filterParams.getKey() + "&sortBy="
-                + filterParams.getSortBy() + "&sortOrder=" + filterParams.getSortOrder() + "&limit=" + limit
+                + sortBy + "&sortOrder=" + filterParams.getSortOrder() + "&limit=" + limit
                 + "&offset=" + offset;
     }
 


### PR DESCRIPTION
Fixes  https://github.com/wso2/product-apim/issues/10730
With this fix, for the request ```https://127.0.0.1:9443/api/am/service-catalog/v0/services?limit=1```, the response would be:
```
{
    "list": [
        {
            "id": "aac98982-e160-4c0d-af0c-901323ba83d1",
            "name": "Car",
            "description": "This is a sample server Uber server",
            "version": "2.0.0",
            "serviceKey": "Car-2.0.0",
            "serviceUrl": "http://www.mocky.io/v2/5d01e59f3100005100ab2a62",
            ...
        }
    ],
    "pagination": {
        "offset": 0,
        "limit": 1,
        "total": 4,
        "next": "/services?name=&version=&definitionType=&displayName=null&key=&sortBy=name&sortOrder=asc&limit=1&offset=1",
        "previous": ""
    }
}
```