### PR TITLE
Fix client claims in Admin portal not changing, IP range deny policy not working and add support to enable failover for loadbalance endpoints

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/utils/BlockConditionDBUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/utils/BlockConditionDBUtil.java
@@ -128,11 +128,12 @@ public final class BlockConditionDBUtil {
                 String tenantDomain = rs.getString("DOMAIN");
                 int conditionId = rs.getInt("CONDITION_ID");
                 if (Boolean.parseBoolean(enabled)) {
-                    if ("API".equals(type)) {
+                    if (APIConstants.BLOCKING_CONDITIONS_API.equals(type)) {
                         api.add(value);
-                    } else if ("APPLICATION".equals(type)) {
+                    } else if (APIConstants.BLOCKING_CONDITIONS_APPLICATION.equals(type)) {
                         application.add(value);
-                    } else if ("IP".equals(type)) {
+                    } else if (APIConstants.BLOCKING_CONDITIONS_IP.equals(type) || APIConstants.
+                            BLOCK_CONDITION_IP_RANGE.equals(type)) {
                         IPLevelDTO ipLevelDTO = new IPLevelDTO();
                         ipLevelDTO.setTenantDomain(tenantDomain);
                         ipLevelDTO.setId(conditionId);
@@ -164,7 +165,7 @@ public final class BlockConditionDBUtil {
                             }
                         }
                         ip.add(ipLevelDTO);
-                    } else if ("USER".equals(type)) {
+                    } else if (APIConstants.BLOCKING_CONDITIONS_USER.equals(type)) {
                         user.add(value);
                     } else if ("CUSTOM".equals(type)) {
                         custom.add(value);

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -236,8 +236,10 @@ function AddEditKeyManager(props) {
                 type: key, defaultConsumerKeyClaim, defaultScopesClaim, configurations,
             }) => {
                 if (key === keyManagerType) {
-                    if (defaultConsumerKeyClaim) {
-                        dispatch({ field: 'consumerKeyClaim', value: defaultConsumerKeyClaim });
+                    if (!id) {
+                        if (defaultConsumerKeyClaim) {
+                            dispatch({ field: 'consumerKeyClaim', value: defaultConsumerKeyClaim });
+                        }
                     }
                     if (defaultScopesClaim) {
                         dispatch({ field: 'scopesClaim', value: defaultScopesClaim });

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
@@ -3501,6 +3501,12 @@
       "value": "Class Name for Algorithm"
     }
   ],
+  "Apis.Details.Endpoints.LoadBalanceConfig.failover": [
+    {
+      "type": 0,
+      "value": "Enable Failover"
+    }
+  ],
   "Apis.Details.Endpoints.LoadBalanceConfig.session.management": [
     {
       "type": 0,

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/raw.en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/raw.en.json
@@ -1653,6 +1653,9 @@
   "Apis.Details.Endpoints.LoadBalanceConfig.class.name.for.algorithm": {
     "defaultMessage": "Class Name for Algorithm"
   },
+  "Apis.Details.Endpoints.LoadBalanceConfig.failover": {
+    "defaultMessage": "Enable Failover"
+  },
   "Apis.Details.Endpoints.LoadBalanceConfig.session.management": {
     "defaultMessage": "Session Management"
   },

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/pages/index.jag
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/pages/index.jag
@@ -47,7 +47,7 @@
     <script src="<%= app.context %>/site/public/conf/userThemes.js"></script>
     <script src="<%= app.context %>/site/public/conf/portalSettings.js"></script>
     <script src="<%= app.context %>/services/settings/settings.js"></script>
-    <script src="<%= app.context %>/site/public/dist/index.4529477b8fa2199fdd67.bundle.js"></script>
+    <script src="<%= app.context %>/site/public/dist/index.308e16f7c2efd5fcab1c.bundle.js"></script>
     <!-- Swagger worker has being removed until we resolve
      *              https://github.com/wso2/product-apim/issues/10694 issue, need to change webpack config too -->
     <!--script src="<%= app.context %>/"></script-->

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Endpoints/LoadBalanceConfig.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Endpoints/LoadBalanceConfig.jsx
@@ -22,6 +22,8 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { isRestricted } from 'AppData/AuthManager';
 import APIContext from 'AppComponents/Apis/Details/components/ApiContext';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 const algorithms = [
     {
@@ -42,6 +44,7 @@ const defaultTemplateObj = {
     algoCombo: algorithms[0].key,
     sessionManagement: sessionManagementOps[0].key,
     sessionTimeOut: 300,
+    failOver: false,
 };
 
 const styles = (theme) => ({
@@ -63,6 +66,7 @@ function LoadBalanceConfig(props) {
         algoCombo,
         sessionManagement,
         sessionTimeOut,
+        failOver,
         handleLBConfigChange,
         closeLBConfigDialog,
         classes,
@@ -85,6 +89,9 @@ function LoadBalanceConfig(props) {
             }
             if (sessionTimeOut) {
                 tmpLBConfig.sessionTimeOut = sessionTimeOut;
+            }
+            if (failOver) {
+                tmpLBConfig.failOver = failOver;
             }
             return tmpLBConfig;
         });
@@ -112,6 +119,16 @@ function LoadBalanceConfig(props) {
      * */
     const handleFieldChange = (event, field) => {
         setLbConfigObject({ ...lbConfig, [field]: event.target.value });
+    };
+
+    /**
+     * Method to capture the onChange event of the elements.
+     *
+     * @param {any} event The event triggered by the element.
+     * @param {string} field The respective field which is being changed.
+     * */
+    const handleFailoverFieldChange = (event, field) => {
+        setLbConfigObject({ ...lbConfig, [field]: event.target.checked });
     };
 
     /**
@@ -201,6 +218,23 @@ function LoadBalanceConfig(props) {
                     margin='normal'
                     disabled={isRestricted(['apim:api_create'], api)}
                 />
+                <FormControlLabel
+                    control={(
+                        <Checkbox
+                            id='failOver'
+                            checked={lbConfig.failOver}
+                            onChange={(event) => handleFailoverFieldChange(event, 'failOver')}
+                            margin='normal'
+                            disabled={isRestricted(['apim:api_create'], api)}
+                        />
+                    )}
+                    label={(
+                        <FormattedMessage
+                            id='Apis.Details.Endpoints.LoadBalanceConfig.failover'
+                            defaultMessage='Enable Failover'
+                        />
+                    )}
+                />
             </Grid>
             <Grid className={classes.configButtonContainer}>
                 <Button
@@ -236,6 +270,7 @@ LoadBalanceConfig.propTypes = {
     algoCombo: PropTypes.string.isRequired,
     sessionManagement: PropTypes.string.isRequired,
     sessionTimeOut: PropTypes.string.isRequired,
+    failOver: PropTypes.bool.isRequired,
     handleLBConfigChange: PropTypes.func.isRequired,
     closeLBConfigDialog: PropTypes.func.isRequired,
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Endpoints/LoadbalanceFailoverConfig.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Endpoints/LoadbalanceFailoverConfig.jsx
@@ -376,6 +376,7 @@ function LoadbalanceFailoverConfig(props) {
                         algoCombo={epConfig.algoCombo}
                         algoClassName={epConfig.algoClassName}
                         sessionTimeOut={epConfig.sessionTimeOut}
+                        failOver={epConfig.failOver}
                         sessionManagement={epConfig.sessionManagement}
                     />
                 </DialogContent>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Endpoints/endpointUtils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Endpoints/endpointUtils.js
@@ -70,7 +70,7 @@ function getEndpointTemplateByType(endpointType, isAddressEndpoint, currentEndpo
             ? currentEndpointConfig.production_endpoints[0] : currentEndpointConfig.production_endpoints;
         tmpEndpointConfig.sandbox_endpoints = Array.isArray(currentEndpointConfig.sandbox_endpoints)
             ? currentEndpointConfig.sandbox_endpoints[0] : currentEndpointConfig.sandbox_endpoints;
-        tmpEndpointConfig.failOver = 'True';
+        tmpEndpointConfig.failOver = true;
     } else if (endpointType === 'load_balance') {
         tmpEndpointConfig.endpoint_type = endpointType;
         tmpEndpointConfig.algoClassName = 'org.apache.synapse.endpoints.algorithms.RoundRobin';
@@ -85,14 +85,14 @@ function getEndpointTemplateByType(endpointType, isAddressEndpoint, currentEndpo
             tmpEndpointConfig.sandbox_endpoints = Array.isArray(currentEndpointConfig.sandbox_endpoints)
                 ? currentEndpointConfig.sandbox_endpoints : [currentEndpointConfig.sandbox_endpoints];
         }
-        tmpEndpointConfig.failOver = 'False';
+        tmpEndpointConfig.failOver = false;
     } else {
         tmpEndpointConfig.endpoint_type = isAddressEndpoint === true ? 'address' : 'http';
         tmpEndpointConfig.production_endpoints = Array.isArray(currentEndpointConfig.production_endpoints)
             ? currentEndpointConfig.production_endpoints[0] : currentEndpointConfig.production_endpoints;
         tmpEndpointConfig.sandbox_endpoints = Array.isArray(currentEndpointConfig.sandbox_endpoints)
             ? currentEndpointConfig.sandbox_endpoints[0] : currentEndpointConfig.sandbox_endpoints;
-        tmpEndpointConfig.failOver = 'False';
+        tmpEndpointConfig.failOver = false;
     }
     return tmpEndpointConfig;
 }
@@ -147,7 +147,7 @@ function getEndpointConfigByImpl(implementationType) {
         tmpEndpointConfig.endpoint_type = 'http';
         tmpEndpointConfig.production_endpoints = { url: '' };
         tmpEndpointConfig.sandbox_endpoints = { url: '' };
-        tmpEndpointConfig.failOver = 'False';
+        tmpEndpointConfig.failOver = false;
     }
     return tmpEndpointConfig;
 }
@@ -169,11 +169,11 @@ function createEndpointConfig(endpointType) {
     switch (endpointType) {
         case 'http':
             tmpEndpointConfig.endpoint_type = 'http';
-            tmpEndpointConfig.failOver = 'False';
+            tmpEndpointConfig.failOver = false;
             break;
         case 'address':
             tmpEndpointConfig.endpoint_type = 'address';
-            tmpEndpointConfig.failOver = 'False';
+            tmpEndpointConfig.failOver = false;
             break;
         case 'prototyped':
             tmpEndpointConfig.implementation_status = 'prototyped';
@@ -192,7 +192,7 @@ function createEndpointConfig(endpointType) {
             tmpEndpointConfig.endpoint_type = 'default';
             tmpEndpointConfig.production_endpoints = { url: 'default' };
             tmpEndpointConfig.sandbox_endpoints = { url: 'default' };
-            tmpEndpointConfig.failOver = 'False';
+            tmpEndpointConfig.failOver = false;
             break;
     }
     return tmpEndpointConfig;


### PR DESCRIPTION
## Purpose

- This PR 
       1. fixes https://github.com/wso2/product-apim/issues/9686
       2. fixes https://github.com/wso2/product-apim/issues/9767
       3. fixes https://github.com/wso2/product-apim/issues/10196

- This PR ports the following fixes:
       1. https://github.com/wso2-support/carbon-apimgt/pull/2755
       2. https://github.com/wso2-support/carbon-apimgt/pull/2818
       3. https://github.com/wso2-support/carbon-apimgt/pull/3022

- This PR fixes client claim name saved change not reflecting in Admin portal when configuring PingFederate key manager
- This PR fixes IP range Deny policies not working after server restart
- This PR adds the support to enable or disable failover property for load balance endpoints from the Publisher portal