### PR TITLE
Stop adding incorrect transitions for Prototyped and Published states

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryLCManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryLCManager.java
@@ -47,6 +47,10 @@ public class RegistryLCManager {
 
     private static Log log = LogFactory.getLog(RegistryLCManager.class);
     private static final int ENTITY_EXPANSION_LIMIT = 0;
+    private static final String STATE_ID_PROTOTYPED = "Prototyped";
+    private static final String STATE_ID_PUBLISHED = "Published";
+    private static final String TRANSITION_TARGET_PROTOTYPED = "Prototyped";
+    private static final String TRANSITION_TARGET_PUBLISHED = "Published";
     private Map<String, String> stateTransitionMap = new HashMap<String, String>();
     private Map<String, StateInfo> stateInfoMap = new HashMap<String, StateInfo>();
     private HashMap<String, LifeCycleTransition> stateHashMap = new HashMap<String, LifeCycleTransition>();
@@ -81,11 +85,21 @@ public class RegistryLCManager {
                     if ("transition".equals(transition.getNodeName())) {
                         Node target = transition.getAttributes().getNamedItem("target");
                         Node action = transition.getAttributes().getNamedItem("event");
-                        if (target != null && action != null) {
-                            lifeCycleTransition.addTransition(target.getNodeValue().toUpperCase(),
-                                    action.getNodeValue());
-                            stateTransitionMap.put(action.getNodeValue(), target.getNodeValue().toUpperCase());
-                            actions.add(action.getNodeValue());
+                        if (id.getNodeValue().equals(STATE_ID_PROTOTYPED)
+                                && (target.getNodeValue().equals(TRANSITION_TARGET_PROTOTYPED)
+                                || target.getNodeValue().equals(TRANSITION_TARGET_PUBLISHED))) {
+                            // skip adding "Publish" and "Deploy as a Prototype" transitions as having those transitions
+                            // in Prototyped state is invalid
+                        } else if (id.getNodeValue().equals(STATE_ID_PUBLISHED)
+                                && target.getNodeValue().equals(TRANSITION_TARGET_PUBLISHED)) {
+                            // skip adding "Publish" transition as having this transition in Published state is invalid
+                        } else {
+                            if (target != null && action != null) {
+                                lifeCycleTransition.addTransition(target.getNodeValue().toUpperCase(),
+                                        action.getNodeValue());
+                                stateTransitionMap.put(action.getNodeValue(), target.getNodeValue().toUpperCase());
+                                actions.add(action.getNodeValue());
+                            }
                         }
                     }
                     if ("datamodel".equals(transition.getNodeName())) {


### PR DESCRIPTION
Fixes the following issues: 
https://github.com/wso2/product-apim/issues/10505
https://github.com/wso2/product-apim/issues/10690

Workflows: https://github.com/RAVEENSR/carbon-apimgt/runs/2269521213


API in Published state(Before):
![api_publish_then](https://user-images.githubusercontent.com/19996612/113575859-29e4d980-963c-11eb-8554-0bc6cf1594af.png)

API in Published state(After):
![api_publish_now](https://user-images.githubusercontent.com/19996612/113575922-4254f400-963c-11eb-806b-d40e3f42f196.png)


----------------------------------------------------------------------------------------------------------


API in Prototyped state(Before):
![prototype_then](https://user-images.githubusercontent.com/19996612/113575965-500a7980-963c-11eb-953e-7f18ef272cae.png)

API in Prototyped state(After):
![prototype_now](https://user-images.githubusercontent.com/19996612/113575988-60225900-963c-11eb-9637-3b554e633b67.png)
