### PR TITLE
Add SecureVault support for AWS Lambda credentials

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayUtils.java
@@ -133,6 +133,7 @@ public class GatewayUtils {
                 .concat(APIConstants.ENDPOINT_SECURITY_TYPE_OAUTH).concat("--")
                 .concat(APIConstants.ENDPOINT_SECURITY_CLIENT_SECRET).concat("--").concat(type);
     }
+
     public static String retrieveOAuthPasswordAlias(String name, String version, String type) {
 
         return name.concat("--v").concat(version).concat("--")
@@ -144,6 +145,12 @@ public class GatewayUtils {
 
         return name.concat("--v").concat(version).concat("--").concat(type);
     }
+
+    public static String retrieveAWSCredAlias(String name, String version, String type) {
+
+        return name.concat("--v").concat(version).concat("--").concat(type);
+    }
+
     public static String retrieveUniqueIdentifier(String apiId, String type) {
 
         return apiId.concat("--").concat(type);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
@@ -939,7 +939,29 @@ public class TemplateBuilderUtil {
                             APIConstants.ENDPOINT_SECURITY_SANDBOX);
 
                 }
+            } else if (APIConstants.ENDPOINT_TYPE_AWSLAMBDA
+                    .equals(endpointConfig.get(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE))) {
+                addAWSCredentialsToList(prefix, api, gatewayAPIDTO, endpointConfig);
             }
+        }
+    }
+
+    private static void addAWSCredentialsToList(String prefix, API api, GatewayAPIDTO gatewayAPIDTO,
+                                                org.json.JSONObject endpointConfig) {
+
+        if (StringUtils.isNotEmpty((String) endpointConfig.get(APIConstants.AMZN_SECRET_KEY))) {
+            CredentialDto awsSecretDto = new CredentialDto();
+            if (StringUtils.isNotEmpty(prefix)) {
+                awsSecretDto.setAlias(prefix.concat("--")
+                        .concat(GatewayUtils.retrieveAWSCredAlias(api.getId().getApiName(),
+                                api.getId().getVersion(), APIConstants.ENDPOINT_TYPE_AWSLAMBDA)));
+            } else {
+                awsSecretDto.setAlias(GatewayUtils.retrieveAWSCredAlias(api.getId().getApiName(),
+                        api.getId().getVersion(), APIConstants.ENDPOINT_TYPE_AWSLAMBDA));
+            }
+            awsSecretDto.setPassword((String) endpointConfig.get(APIConstants.AMZN_SECRET_KEY));
+            gatewayAPIDTO.setCredentialsToBeAdd(addCredentialsToList(awsSecretDto,
+                    gatewayAPIDTO.getCredentialsToBeAdd()));
         }
     }
 


### PR DESCRIPTION
This PR adds support to get AWS Secret Key from secure vault when secure vault is enabled.
Fixes https://github.com/wso2/product-apim/issues/10715