### PR TITLE
[Streaming API] UI fixes in DevPortal

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/AsyncApiConsole/GenericSubscriptionUI.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/AsyncApiConsole/GenericSubscriptionUI.jsx
@@ -29,56 +29,67 @@ import TextField from '@material-ui/core/TextField';
 import Alert from 'AppComponents/Shared/Alert';
 import { makeStyles } from '@material-ui/core/styles/index';
 import { FormattedMessage } from 'react-intl';
+import Utils from 'AppData/Utils';
 import Grid from '@material-ui/core/Grid';
-
-const useStyles = makeStyles((theme) => (
-    {
-        bootstrapRoot: {
-            padding: 0,
-            'label + &': {
-                marginTop: theme.spacing(1),
-            },
-        },
-        bootstrapCurl: {
-            borderRadius: 4,
-            backgroundColor: theme.custom.curlGenerator.backgroundColor,
-            color: theme.custom.curlGenerator.color,
-            border: '1px solid #ced4da',
-            padding: '5px 12px',
-            marginTop: '11px',
-            marginBottom: '11px',
-            width: '100%',
-            transition: theme.transitions.create(['border-color', 'box-shadow']),
-            '&:focus': {
-                borderColor: '#80bdff',
-                boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
-            },
-            fontSize: 12,
-            fontFamily: 'monospace',
-            fontWeight: 600,
-        },
-        subscriptionSummary: {
-            backgroundColor: theme.custom.AsyncTryOut.backgroundColor,
-            maxHeight: '40px',
-            borderColor: '#80bdff',
-            '&$expanded': {
-                maxHeight: '40px',
-            },
-        },
-        subscription: {
-            paddingBottom: '10px',
-        },
-    }
-));
+import Badge from '@material-ui/core/Badge';
 
 export default function GenericSubscriptionUI(props) {
-    const classes = useStyles();
+    const verb = props.topic.type.toLowerCase();
+    const trimmedVerb = verb === 'publish' || verb === 'subscribe' ? verb.substr(0, 3) : verb;
+    const useStyles = makeStyles((theme) => {
+        const backgroundColor = theme.custom.resourceChipColors[trimmedVerb];
+        return {
+            bootstrapRoot: {
+                padding: 0,
+                'label + &': {
+                    marginTop: theme.spacing(1),
+                },
+            },
+            bootstrapCurl: {
+                borderRadius: 4,
+                backgroundColor: theme.custom.curlGenerator.backgroundColor,
+                color: theme.custom.curlGenerator.color,
+                border: '1px solid #ced4da',
+                padding: '5px 12px',
+                marginTop: '11px',
+                marginBottom: '11px',
+                width: '100%',
+                transition: theme.transitions.create(['border-color', 'box-shadow']),
+                '&:focus': {
+                    borderColor: '#80bdff',
+                    boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
+                },
+                fontSize: 12,
+                fontFamily: 'monospace',
+                fontWeight: 600,
+            },
+            subscriptionSummary: {
+                backgroundColor: Utils.hexToRGBA(backgroundColor, 0.1),
+                maxHeight: '40px',
+                '&$expanded': {
+                    maxHeight: '40px',
+                },
+            },
+            customButton: {
+                backgroundColor: '#ffffff',
+                borderColor: backgroundColor,
+                color: backgroundColor,
+                width: theme.spacing(2),
+            },
+            subscription: {
+                marginBottom: '10px',
+                border: `1px solid ${backgroundColor}`,
+            },
+        };
+    });
     const { generateGenericSubscriptionCommand, topic } = props;
     const [command, setCommand] = useState(generateGenericSubscriptionCommand(topic));
 
     const handleClick = () => {
         setCommand(generateGenericSubscriptionCommand(topic));
     };
+
+    const classes = useStyles();
 
     return (
         <Accordion className={classes.subscription}>
@@ -88,7 +99,23 @@ export default function GenericSubscriptionUI(props) {
                 id='generic-subscription-header'
                 className={classes.subscriptionSummary}
             >
-                <Typography>{topic.name}</Typography>
+                <Grid container direction='row' justify='space-between' alignItems='center' spacing={0}>
+                    <Grid item md={11}>
+                        <Badge invisible='false' color='error' variant='dot'>
+                            <Button
+                                disableFocusRipple
+                                variant='outlined'
+                                size='small'
+                                className={classes.customButton}
+                            >
+                                {trimmedVerb.toUpperCase()}
+                            </Button>
+                        </Badge>
+                        <Typography display='inline' style={{ margin: '0px 30px' }} gutterBottom>
+                            {topic.name}
+                        </Typography>
+                    </Grid>
+                </Grid>
             </AccordionSummary>
             <AccordionDetails>
                 <Grid container direction='column' wrap='nowrap'>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/AsyncApiConsole/WebhookSubscriptionUI.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/AsyncApiConsole/WebhookSubscriptionUI.jsx
@@ -33,68 +33,78 @@ import Radio from '@material-ui/core/Radio';
 import { RadioGroup } from '@material-ui/core';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { FormattedMessage, injectIntl } from 'react-intl';
-
-const useStyles = makeStyles((theme) => (
-    {
-        bootstrapRoot: {
-            padding: 0,
-            'label + &': {
-                marginTop: theme.spacing(1),
-            },
-        },
-        bootstrapInput: {
-            borderRadius: 4,
-            backgroundColor: theme.palette.common.white,
-            border: '1px solid #ced4da',
-            padding: '5px 12px',
-            marginTop: '11px',
-            marginBottom: '11px',
-            width: '100%',
-            transition: theme.transitions.create(['border-color', 'box-shadow']),
-            '&:focus': {
-                borderColor: '#80bdff',
-                boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
-            },
-            fontSize: 12,
-        },
-        bootstrapCurl: {
-            borderRadius: 4,
-            backgroundColor: theme.custom.curlGenerator.backgroundColor,
-            color: theme.custom.curlGenerator.color,
-            border: '1px solid #ced4da',
-            padding: '5px 12px',
-            marginTop: '11px',
-            marginBottom: '11px',
-            width: '100%',
-            transition: theme.transitions.create(['border-color', 'box-shadow']),
-            '&:focus': {
-                borderColor: '#80bdff',
-                boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
-            },
-            fontSize: 12,
-            fontFamily: 'monospace',
-            fontWeight: 600,
-        },
-        subscriptionSummary: {
-            backgroundColor: theme.custom.AsyncTryOut.backgroundColor,
-            maxHeight: '40px',
-            borderColor: '#80bdff',
-            '&$expanded': {
-                maxHeight: '40px',
-            },
-        },
-        subscription: {
-            paddingBottom: '10px',
-        },
-    }
-));
+import Utils from 'AppData/Utils';
+import Badge from '@material-ui/core/Badge';
 
 function reducer(state, { field, value }) {
     return { ...state, [field]: value };
 }
 
 function WebhookSubscriptionUI(props) {
-    const classes = useStyles();
+    const verb = props.topic.type.toLowerCase();
+    const trimmedVerb = verb === 'publish' || verb === 'subscribe' ? verb.substr(0, 3) : verb;
+    const useStyles = makeStyles((theme) => {
+        const backgroundColor = theme.custom.resourceChipColors[trimmedVerb];
+        return {
+            bootstrapRoot: {
+                padding: 0,
+                'label + &': {
+                    marginTop: theme.spacing(1),
+                },
+            },
+            bootstrapInput: {
+                borderRadius: 4,
+                backgroundColor: theme.palette.common.white,
+                border: '1px solid #ced4da',
+                padding: '5px 12px',
+                marginTop: '11px',
+                marginBottom: '11px',
+                width: '100%',
+                transition: theme.transitions.create(['border-color', 'box-shadow']),
+                '&:focus': {
+                    borderColor: '#80bdff',
+                    boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
+                },
+                fontSize: 12,
+            },
+            bootstrapCurl: {
+                borderRadius: 4,
+                backgroundColor: theme.custom.curlGenerator.backgroundColor,
+                color: theme.custom.curlGenerator.color,
+                border: '1px solid #ced4da',
+                padding: '5px 12px',
+                marginTop: '11px',
+                marginBottom: '11px',
+                width: '100%',
+                transition: theme.transitions.create(['border-color', 'box-shadow']),
+                '&:focus': {
+                    borderColor: '#80bdff',
+                    boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
+                },
+                fontSize: 12,
+                fontFamily: 'monospace',
+                fontWeight: 600,
+            },
+            subscriptionSummary: {
+                backgroundColor: Utils.hexToRGBA(backgroundColor, 0.1),
+                maxHeight: '40px',
+                borderColor: '#80bdff',
+                '&$expanded': {
+                    maxHeight: '40px',
+                },
+            },
+            customButton: {
+                backgroundColor: '#ffffff',
+                borderColor: backgroundColor,
+                color: backgroundColor,
+                width: theme.spacing(2),
+            },
+            subscription: {
+                marginBottom: '10px',
+                border: `1px solid ${backgroundColor}`,
+            },
+        };
+    });
     const { generateGenericWHSubscriptionCurl, topic, intl } = props;
     const initialSubscriptionState = {
         topic: topic.name,
@@ -120,6 +130,8 @@ function WebhookSubscriptionUI(props) {
         dispatch({ field: e.target.name, value: e.target.value });
     };
 
+    const classes = useStyles();
+
     return (
         <Accordion className={classes.subscription}>
             <AccordionSummary
@@ -128,7 +140,23 @@ function WebhookSubscriptionUI(props) {
                 id='wh-subscription-header'
                 className={classes.subscriptionSummary}
             >
-                <Typography>{topic.name}</Typography>
+                <Grid container direction='row' justify='space-between' alignItems='center' spacing={0}>
+                    <Grid item md={11}>
+                        <Badge invisible='false' color='error' variant='dot'>
+                            <Button
+                                disableFocusRipple
+                                variant='outlined'
+                                size='small'
+                                className={classes.customButton}
+                            >
+                                {trimmedVerb.toUpperCase()}
+                            </Button>
+                        </Badge>
+                        <Typography display='inline' style={{ margin: '0px 30px' }} gutterBottom>
+                            {topic.name}
+                        </Typography>
+                    </Grid>
+                </Grid>
             </AccordionSummary>
             <AccordionDetails>
                 <Grid container direction='column' wrap='nowrap'>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Definitions/AsyncApi/AsyncApiDefinitionUI.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Definitions/AsyncApi/AsyncApiDefinitionUI.jsx
@@ -54,6 +54,9 @@ class AsyncApiDefinitionUI extends Component {
 
     render() {
         const { classes } = this.props;
+        // Avoid rendering the 'servers' portion from the AsyncAPI definition.
+        const asyncApiDefinition = JSON.parse(this.context.api.apiDefinition);
+        delete asyncApiDefinition.servers;
         return (
             <>
                 <Typography variant='h4' className={classes.titleSub}>
@@ -64,7 +67,7 @@ class AsyncApiDefinitionUI extends Component {
                 </Typography>
                 <Grid container spacing={1} className={classes.editorRoot}>
                     <Grid item className={classes.editorPane}>
-                        <AsyncApiComponent schema={this.context.api.apiDefinition} />
+                        <AsyncApiComponent schema={JSON.stringify(asyncApiDefinition)} />
                     </Grid>
                 </Grid>
             </>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/data/Utils.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/data/Utils.jsx
@@ -264,6 +264,18 @@ class Utils {
         const languageWithoutRegionCode = language.toLowerCase().split(/[_-]+/)[0];
         return(languageWithoutRegionCode || language);
     }
+
+    static hexToRGBA(hex, alpha) {
+        const r = parseInt(hex.slice(1, 3), 16);
+        const g = parseInt(hex.slice(3, 5), 16);
+        const b = parseInt(hex.slice(5, 7), 16);
+
+        if (alpha) {
+            return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + alpha + ')';
+        } else {
+            return 'rgb(' + r + ', ' + g + ', ' + b + ')';
+        }
+    }
 }
 
 Utils.CONST = {

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/data/defaultTheme.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/data/defaultTheme.js
@@ -113,6 +113,8 @@ const DefaultConfigurations = {
             options: '#5f7c8a',
             patch: '#785446',
             head: '#785446',
+            sub: '#38a169',
+            pub: '#4299e1',
         },
         operationChipColor: {
             query: '#b3e6fe',


### PR DESCRIPTION
## Purpose
- Use the same colors used in API publisher, when rendering topics in the 'Try Out' page of Dev portal [1].
- Avoid rendering the 'servers' portion from the AsyncAPI definition. Fixes: https://github.com/wso2/product-apim/issues/10744

[1] 
<img width="1499" alt="Screen Shot 2021-04-06 at 10 55 08 AM" src="https://user-images.githubusercontent.com/24828296/113663052-f13e1200-96c6-11eb-8733-295e269f9a63.png">
