### PR TITLE
Improve monetization UX

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Monetization/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Monetization/index.jsx
@@ -247,7 +247,7 @@ class Monetization extends Component {
                                     (monetizationAttributes.length > 0) ? (
                                         (monetizationAttributes.map((monetizationAttribute, i) => (
                                             <TextField
-                                                disabled={isRestricted(['apim:api_publish'], api)}
+                                                disabled={!monStatus || isRestricted(['apim:api_publish'], api)}
                                                 fullWidth
                                                 id={'attribute' + i}
                                                 label={monetizationAttribute.displayName}


### PR DESCRIPTION
Improve user experience of monetization UI by disabling the monetization properties to be edited when the checkbox to enable monetization is not checked.
![image](https://user-images.githubusercontent.com/24529961/113680960-12aaf800-96df-11eb-885e-83513e359fea.png)
