### PR TITLE
Disable Subscription and Key Generation Wizard for prototype APIs

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
@@ -342,8 +342,8 @@ class Credentials extends React.Component {
         && !api.securityScheme.includes('api_key') && !api.securityScheme.includes('basic_auth');
         const isOnlyBasicAuth = api.securityScheme.includes('basic_auth') && !api.securityScheme.includes('oauth2')
          && !api.securityScheme.includes('api_key');
+        const isPrototypedAPI = api.lifeCycleStatus && api.lifeCycleStatus.toLowerCase() === 'prototyped';
         const renderCredentialInfo = () => {
-            const isPrototypedAPI = api.lifeCycleStatus && api.lifeCycleStatus.toLowerCase() === 'prototyped';
             if (isPrototypedAPI) {
                 return (
                     <>
@@ -571,7 +571,7 @@ class Credentials extends React.Component {
                                 />
                                 {applicationsAvailable.length > 0 && (
                                     <Link
-                                        to={(isOnlyMutualSSL || isOnlyBasicAuth) ? null
+                                        to={(isOnlyMutualSSL || isOnlyBasicAuth || isPrototypedAPI) ? null
                                             : `/apis/${api.id}/credentials/wizard`}
                                         style={!api.isSubscriptionAvailable
                                             ? { pointerEvents: 'none' } : null}
@@ -580,7 +580,7 @@ class Credentials extends React.Component {
                                         <Button
                                             color='secondary'
                                             disabled={!api.isSubscriptionAvailable || isOnlyMutualSSL
-                                                 || isOnlyBasicAuth}
+                                                 || isOnlyBasicAuth || isPrototypedAPI}
                                             size='small'
                                         >
                                             <Icon>add_circle_outline</Icon>


### PR DESCRIPTION
Fixes issue https://github.com/wso2/product-apim/issues/10515.

Before: 
![before](https://user-images.githubusercontent.com/19996612/113710599-8958ed00-9701-11eb-90e2-4973cc592b08.png)

After:
![after](https://user-images.githubusercontent.com/19996612/113710603-8c53dd80-9701-11eb-994d-28be951c1614.png)


Even though in the issue it is stated that we need to remove **Subscription and Key Generation Wizard** option, did not removed it. Instead disabled it. The main reason is we have followed this approach when it comes to:

- Mutual SSL APIs
- APIs with only Basic Authentication
