### PR TITLE
[Streaming API] Select streaming API protocol automatically

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/APICreateRoutes.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/APICreateRoutes.jsx
@@ -56,7 +56,7 @@ function APICreateRoutes(props) {
                 <Route path='/apis/create/wsdl' component={ApiCreateWSDL} />
                 {/* TODO: Remove ApiCreateWebSocket components and associated routes */}
                 <Route path='/apis/create/ws' component={ApiCreateWebSocket} />
-                <Route path='/apis/create/streamingapi' component={APICreateStreamingAPI} />
+                <Route path='/apis/create/streamingapi/:apiType' component={APICreateStreamingAPI} />
                 <Route path='/apis/create/asyncapi' component={APICreateAsyncAPI} />
                 <Route component={ResourceNotFound} />
             </Switch>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 import React, { useReducer, useState } from 'react';
-import { useParams } from 'react-router-dom';
 import Typography from '@material-ui/core/Typography';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { withRouter } from 'react-router';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
 import ListItemText from '@material-ui/core/ListItemText';

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import React, { useReducer, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import Typography from '@material-ui/core/Typography';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { withRouter } from 'react-router';
@@ -71,11 +72,9 @@ const APICreateStreamingAPI = (props) => {
         SSE: 'SSE',
         WEBSUB: 'WebSub',
     };
-
-    const { match: { params } } = props;
-    let apiType = null;
-    if (params && params.apiType) {
-        apiType = params.apiType.toUpperCase();
+    let { apiType } = useParams();
+    if (apiType) {
+        apiType = apiType.toUpperCase();
     }
     const [hideEndpoint, setHideEndpoint] = useState(!apiType || apiType === protocolKeys.WebSub);
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
@@ -46,7 +46,6 @@ const APICreateStreamingAPI = (props) => {
     const [pageError, setPageError] = useState(null);
     const [isCreating, setIsCreating] = useState();
     const classes = useStyles();
-    const [hideEndpoint, setHideEndpoint] = useState(true);
 
     const protocols = [
         {
@@ -67,6 +66,18 @@ const APICreateStreamingAPI = (props) => {
         SSE: 'SSE',
         WebSub: 'WEBSUB',
     };
+    const protocolDisplayNames = {
+        WS: 'WebSocket',
+        SSE: 'SSE',
+        WEBSUB: 'WebSub',
+    };
+
+    const { match: { params } } = props;
+    let apiType = null;
+    if (params && params.apiType) {
+        apiType = params.apiType.toUpperCase();
+    }
+    const [hideEndpoint, setHideEndpoint] = useState(!apiType || apiType === protocolKeys.WebSub);
 
     /**
      *
@@ -127,7 +138,7 @@ const APICreateStreamingAPI = (props) => {
             version,
             context,
             endpoint,
-            type: protocol.toUpperCase(),
+            type: apiType || protocol.toUpperCase(),
             policies,
         };
 
@@ -225,7 +236,8 @@ const APICreateStreamingAPI = (props) => {
                                     <sup className={classes.mandatoryStar}>*</sup>
                                 </>
                             )}
-                            value={apiInputs.protocol}
+                            value={apiType ? protocolDisplayNames[apiType] : apiInputs.protocol}
+                            disabled={apiType}
                             name='protocol'
                             SelectProps={{
                                 multiple: false,

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Landing/Menus/StreamingAPIMenu.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Landing/Menus/StreamingAPIMenu.jsx
@@ -23,7 +23,7 @@ const StreamingAPIMenu = (props) => {
             <LandingMenuItem
                 dense={dense}
                 id='itest-id-create-streaming-api-ws'
-                linkTo='/apis/create/streamingapi'
+                linkTo='/apis/create/streamingapi/ws'
                 helperText={(
                     <FormattedMessage
                         id='Apis.Listing.SampleAPI.SampleAPI.streaming.design.new.ws.content'
@@ -39,7 +39,7 @@ const StreamingAPIMenu = (props) => {
             <LandingMenuItem
                 dense={dense}
                 id='itest-id-create-streaming-api-web-hook'
-                linkTo='/apis/create/streamingapi'
+                linkTo='/apis/create/streamingapi/websub'
                 helperText={(
                     <FormattedMessage
                         id='Apis.Listing.SampleAPI.SampleAPI.streaming.websub.content'
@@ -55,7 +55,7 @@ const StreamingAPIMenu = (props) => {
             <LandingMenuItem
                 dense={dense}
                 id='itest-id-create-streaming-api-sse'
-                linkTo='/apis/create/streamingapi'
+                linkTo='/apis/create/streamingapi/sse'
                 helperText={(
                     <FormattedMessage
                         id='Apis.Listing.SampleAPI.SampleAPI.streaming.sse.content'


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-apim/issues/10759

When the user selects a Streaming API type as shown in [1], the protocol will be automatically selected as shown in [2].

[1]
<img width="1268" alt="design-new-streaming-api" src="https://user-images.githubusercontent.com/24828296/113733319-f9726d80-9717-11eb-991b-ec44d0f5c4f4.png">

[2]
<img width="822" alt="Screen Shot 2021-04-06 at 8 25 17 PM" src="https://user-images.githubusercontent.com/24828296/113733012-b4e6d200-9717-11eb-91ae-6f0be3e8b519.png">
