### PR TITLE
Fix TRY OUT button for Prototyped APIs

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/GoToTryOut.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/GoToTryOut.jsx
@@ -100,6 +100,7 @@ export default function GoToTryOut() {
         && (api.type === CONSTANTS.API_TYPES.WS
             || api.type === CONSTANTS.API_TYPES.WEBSUB
             || api.type === CONSTANTS.API_TYPES.SSE));
+    const isPrototypedAPI = api.lifeCycleStatus && api.lifeCycleStatus.toLowerCase() === 'prototyped';
     const getKeyRequest = async () => {
         const promisedKeyManagers = restApi.getKeyManagers();
         return promisedKeyManagers
@@ -260,7 +261,8 @@ export default function GoToTryOut() {
         || subscribedApplications.length > 0
         || api.advertiseInfo.advertised
         || !user
-        || isAsyncAPI) {
+        || isAsyncAPI
+        || isPrototypedAPI) {
         return (
             <>{redirectButton}</>
 


### PR DESCRIPTION
Fixes issue https://github.com/wso2/product-apim/issues/10788.

Now when clicking on the try out button, redirects to the Try Out section.