### PR TITLE
Fix icon alignment issue in DevPortal

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -479,8 +479,8 @@ class ApiConsole extends React.Component {
                     />
 
                     <Grid container>
-                        <Grid xs={10} item />
-                        <Grid xs={1} item>
+                        <Grid xs={8} item />
+                        <Grid xs={2} item>
                             <Button size='small' onClick={() => this.convertToPostman(downloadSwagger)}>
                                 <Icons icon={postmanIcon} width={30} height={30} />
                                 <FormattedMessage
@@ -490,7 +490,7 @@ class ApiConsole extends React.Component {
                             </Button>
 
                         </Grid>
-                        <Grid xs={1} item>
+                        <Grid xs={2} item>
                             <a href={downloadLink} download={fileName}>
                                 <Button size='small'>
                                     <Icons icon={openapiinitiativeIcon} width={30} height={30} className={classes.buttonIcon} />


### PR DESCRIPTION
Fix icon alignment issue Postman Collection and OpenAPI icon in dev portal
<img width="730" alt="Screenshot 2021-04-08 at 17 48 24" src="https://user-images.githubusercontent.com/38608578/114025346-a244d800-9892-11eb-890a-ac910f5ac97c.png">