### PR TITLE
Add CORS allowedOrigins Property to CrossOriginResourceSharingFilter of Product REST APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.gateway/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.gateway/src/main/webapp/WEB-INF/beans.xml
@@ -56,6 +56,9 @@
             </list>
         </property>
         <property name="allowCredentials" value="true"/>
+        <property name="allowOrigins"
+                  value="#{systemProperties['rest.api.gateway.allowed.origins'] != null ?
+                      systemProperties['rest.api.gateway.allowed.origins'].split(',') : {}}"/>
     </bean>
     <cxf:bus>
         <cxf:inInterceptors>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
@@ -66,6 +66,9 @@
             </list>
         </property>
         <property name="allowCredentials" value="true" />
+        <property name="allowOrigins"
+                  value="#{systemProperties['rest.api.publisher.allowed.origins'] != null ?
+                      systemProperties['rest.api.publisher.allowed.origins'].split(',') : {}}"/>
     </bean>
 
     <!-- Out interceptors -->

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/webapp/WEB-INF/beans.xml
@@ -49,6 +49,9 @@
       </list>
     </property>
     <property name="allowCredentials" value="true" />
+    <property name="allowOrigins"
+              value="#{systemProperties['rest.api.service.catalog.allowed.origins'] != null ?
+                      systemProperties['rest.api.service.catalog.allowed.origins'].split(',') : {}}"/>
   </bean>
 
   <!-- Out interceptors -->

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/webapp/WEB-INF/beans.xml
@@ -60,6 +60,9 @@
             </list>
         </property>
         <property name="allowCredentials" value="true"/>
+        <property name="allowOrigins"
+                  value="#{systemProperties['rest.api.devportal.allowed.origins'] != null ?
+                      systemProperties['rest.api.devportal.allowed.origins'].split(',') : {}}"/>
     </bean>
 
     <!-- Out interceptors -->


### PR DESCRIPTION
## Purpose
This PR adds the "allowedOrigins" property to the "CrossOriginResourceSharingFilter" of the Product REST APIs. 

## Approach

This "allowedOrigins" property will be reading values from System parameters. The defined system parameters are as follows.

- For Publisher REST APIs : rest.api.publisher.allowed.origins
- For Store REST APIs : rest.api.store.allowed.origins
- For Gateway REST APIs : rest.api.gateway.allowed.origins
- For Service Catalog REST APIs : rest.api.service.catalog.allowed.origins

Hence, the allowed origins for a particular REST API should be configured as a system parameter as follows.

#### Method 1: Specify the allowed origins in the deployment.toml file under [system.parameter]

[system.parameter]
'rest.api.publisher.allowed.origins' = "https://null.jsbin.com"
'rest.api.store.allowed.origins' = "https://null.jsbin.com,https://fiddle.jshell.net"
'rest.api.gateway.allowed.origins' = "https://null.jsbin.com"
'rest.api.service.catalog.allowed.origins' = "https://js.do"

#### Method 2: Specify the allowed origins when starting the server

sh wso2server.sh -Drest.api.publisher.allowed.origins=https://null.jsbin.com -Drest.api.devportal.allowed.origins=https://null.jsbin.com,https://fiddle.jshell.net -Drest.api.gateway.allowed.origins=https://null.jsbin.com -Drest.api.service.catalog.allowed.origins=https://js.do