### PR TITLE
Update scopes for Internal/publisher

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -36,7 +36,7 @@
       },
       {
         "Name": "apim:api_generate_key",
-        "Roles": "admin,Internal/creator"
+        "Roles": "admin,Internal/creator,Internal/publisher"
       },
       {
         "Name": "apim:api_view",


### PR DESCRIPTION
This PR adds `apim:api_generate_key` for publisher role.
Fixes https://github.com/wso2/product-apim/issues/10854