### PR TITLE
Fixing the issues of not using the persistence instance when importing/exporting mediations and fix other issues

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -57,9 +57,8 @@ import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
 import org.wso2.carbon.apimgt.impl.importexport.ExportFormat;
 import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
 import org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil;
-import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
-import org.wso2.carbon.apimgt.impl.wsdl.util.SOAPToRESTConstants;
+import org.wso2.carbon.apimgt.impl.wsdl.util.SequenceUtils;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIDTO;
@@ -67,10 +66,9 @@ import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIProductDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.AdvertiseInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.GraphQLQueryComplexityInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ProductAPIDTO;
-import org.wso2.carbon.registry.api.Collection;
-import org.wso2.carbon.registry.api.RegistryException;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ResourcePolicyInfoDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ResourcePolicyListDTO;
 import org.wso2.carbon.registry.core.RegistryConstants;
-import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.ByteArrayInputStream;
@@ -155,63 +153,59 @@ public class ExportUtils {
                                  boolean preserveDocs, String originalDevPortalUrl)
             throws APIManagementException, APIImportExportException {
 
-        int tenantId = 0;
+        int tenantId;
         // If explicitly advertise only property has been specified as true, make it true and update the API DTO.
         if (StringUtils.isNotBlank(originalDevPortalUrl)) {
             setAdvertiseOnlySpecificPropertiesToDTO(apiDtoToReturn, originalDevPortalUrl);
         }
 
-        try {
-            // Create temp location for storing API data
-            File exportFolder = CommonUtil.createTempDirectory(apiIdentifier);
-            String exportAPIBasePath = exportFolder.toString();
-            String archivePath = exportAPIBasePath
-                    .concat(File.separator + apiIdentifier.getApiName() + "-" + apiIdentifier.getVersion());
-            tenantId = APIUtil.getTenantId(userName);
-            UserRegistry registry = ServiceReferenceHolder.getInstance().getRegistryService().
-                    getGovernanceSystemRegistry(tenantId);
+        // Create temp location for storing API data
+        File exportFolder = CommonUtil.createTempDirectory(apiIdentifier);
+        String exportAPIBasePath = exportFolder.toString();
+        String archivePath = exportAPIBasePath
+                .concat(File.separator + apiIdentifier.getApiName() + "-" + apiIdentifier.getVersion());
+        tenantId = APIUtil.getTenantId(userName);
 
-            CommonUtil.createDirectory(archivePath);
-            if (preserveDocs) {
-                addThumbnailToArchive(archivePath, apiIdentifier, apiProvider);
+        CommonUtil.createDirectory(archivePath);
+        if (preserveDocs) {
+            addThumbnailToArchive(archivePath, apiIdentifier, apiProvider);
+            addDocumentationToArchive(archivePath, apiIdentifier, exportFormat, apiProvider,
+                    APIConstants.API_IDENTIFIER_TYPE);
+        } else {
+            if (StringUtils.equals(apiDtoToReturn.getType().toString().toLowerCase(),
+                    APIConstants.API_TYPE_SOAPTOREST.toLowerCase())) {
+                addSOAPToRESTMediationToArchive(archivePath, api);
             }
-            addSOAPToRESTMediationToArchive(archivePath, apiIdentifier, registry);
-            if (preserveDocs) {
-                addDocumentationToArchive(archivePath, apiIdentifier, exportFormat, apiProvider,
-                        APIConstants.API_IDENTIFIER_TYPE);
-            }
-
-            if (StringUtils
-                    .equals(apiDtoToReturn.getType().toString().toLowerCase(), APIConstants.API_TYPE_SOAP.toLowerCase())
-                    && preserveDocs) {
-                addWSDLtoArchive(archivePath, apiIdentifier, apiProvider);
-            } else if (log.isDebugEnabled()) {
-                log.debug("No WSDL URL found for API: " + apiIdentifier + ". Skipping WSDL export.");
-            }
-
-            // Set API status to created if the status is not preserved
-            if (!preserveStatus) {
-                apiDtoToReturn.setLifeCycleStatus(APIConstants.CREATED);
-            }
-
-            addGatewayEnvironmentsToArchive(archivePath, apiDtoToReturn.getId(), exportFormat, apiProvider);
-
-            if (!ImportUtils.isAdvertiseOnlyAPI(apiDtoToReturn)) {
-                addEndpointCertificatesToArchive(archivePath, apiDtoToReturn, tenantId, exportFormat);
-                addSequencesToArchive(archivePath, api);
-                // Export mTLS authentication related certificates
-                if (log.isDebugEnabled()) {
-                    log.debug("Mutual SSL enabled. Exporting client certificates.");
-                }
-                addClientCertificatesToArchive(archivePath, apiIdentifier, tenantId, apiProvider, exportFormat);
-            }
-            addAPIMetaInformationToArchive(archivePath, apiDtoToReturn, exportFormat, apiProvider, apiIdentifier);
-            CommonUtil.archiveDirectory(exportAPIBasePath);
-            FileUtils.deleteQuietly(new File(exportAPIBasePath));
-            return new File(exportAPIBasePath + APIConstants.ZIP_FILE_EXTENSION);
-        } catch (RegistryException e) {
-            throw new APIManagementException("Error while getting governance registry for tenant: " + tenantId, e);
         }
+
+        if (StringUtils
+                .equals(apiDtoToReturn.getType().toString().toLowerCase(), APIConstants.API_TYPE_SOAP.toLowerCase())
+                && preserveDocs) {
+            addWSDLtoArchive(archivePath, apiIdentifier, apiProvider);
+        } else if (log.isDebugEnabled()) {
+            log.debug("No WSDL URL found for API: " + apiIdentifier + ". Skipping WSDL export.");
+        }
+
+        // Set API status to created if the status is not preserved
+        if (!preserveStatus) {
+            apiDtoToReturn.setLifeCycleStatus(APIConstants.CREATED);
+        }
+
+        addGatewayEnvironmentsToArchive(archivePath, apiDtoToReturn.getId(), exportFormat, apiProvider);
+
+        if (!ImportUtils.isAdvertiseOnlyAPI(apiDtoToReturn)) {
+            addEndpointCertificatesToArchive(archivePath, apiDtoToReturn, tenantId, exportFormat);
+            addSequencesToArchive(archivePath, api);
+            // Export mTLS authentication related certificates
+            if (log.isDebugEnabled()) {
+                log.debug("Mutual SSL enabled. Exporting client certificates.");
+            }
+            addClientCertificatesToArchive(archivePath, apiIdentifier, tenantId, apiProvider, exportFormat);
+        }
+        addAPIMetaInformationToArchive(archivePath, apiDtoToReturn, exportFormat, apiProvider, apiIdentifier);
+        CommonUtil.archiveDirectory(exportAPIBasePath);
+        FileUtils.deleteQuietly(new File(exportAPIBasePath));
+        return new File(exportAPIBasePath + APIConstants.ZIP_FILE_EXTENSION);
     }
 
     /**
@@ -333,55 +327,41 @@ public class ExportUtils {
     /**
      * Retrieve SOAP to REST mediation logic for the exporting API and store it in the archive directory.
      *
-     * @param archivePath   File path to export the SOAPToREST mediation logic
-     * @param apiIdentifier ID of the requesting API
-     * @param registry      Current tenant registry
+     * @param archivePath File path to export the SOAPToREST mediation logic
+     * @param api         API
      * @throws APIImportExportException If an error occurs while retrieving image from the registry or
      *                                  storing in the archive directory
      */
-    public static void addSOAPToRESTMediationToArchive(String archivePath, APIIdentifier apiIdentifier,
-                                                       UserRegistry registry) throws APIImportExportException {
+    public static void addSOAPToRESTMediationToArchive(String archivePath, API api)
+            throws APIImportExportException, APIManagementException {
 
-        String soapToRestBaseUrl =
-                "/apimgt/applicationdata/provider" + RegistryConstants.PATH_SEPARATOR + apiIdentifier.getProviderName()
-                        + RegistryConstants.PATH_SEPARATOR + apiIdentifier.getApiName()
-                        + RegistryConstants.PATH_SEPARATOR + apiIdentifier.getVersion()
-                        + RegistryConstants.PATH_SEPARATOR + SOAPToRESTConstants.SOAP_TO_REST_RESOURCE;
-        try {
-            if (registry.resourceExists(soapToRestBaseUrl)) {
-                Collection inFlow = (org.wso2.carbon.registry.api.Collection) registry
-                        .get(soapToRestBaseUrl + RegistryConstants.PATH_SEPARATOR + IN);
-                Collection outFlow = (org.wso2.carbon.registry.api.Collection) registry
-                        .get(soapToRestBaseUrl + RegistryConstants.PATH_SEPARATOR + OUT);
+        String sequencePathInArchive = archivePath + File.separator + SOAPTOREST;
+        CommonUtil.createDirectory(sequencePathInArchive);
 
-                CommonUtil.createDirectory(archivePath + File.separator + SOAPTOREST + File.separator + IN);
-                CommonUtil.createDirectory(archivePath + File.separator + SOAPTOREST + File.separator + OUT);
-                if (inFlow != null) {
-                    for (String inFlowPath : inFlow.getChildren()) {
-                        try (InputStream inputStream = registry.get(inFlowPath).getContentStream();
-                             OutputStream outputStream = new FileOutputStream(
-                                     archivePath + File.separator + SOAPTOREST + File.separator + IN + inFlowPath
-                                             .substring(
-                                                     inFlowPath.lastIndexOf(RegistryConstants.PATH_SEPARATOR)));) {
-                            IOUtils.copy(inputStream, outputStream);
-                        }
-                    }
-                }
-                if (outFlow != null) {
-                    for (String outFlowPath : outFlow.getChildren()) {
-                        try (InputStream inputStream = registry.get(outFlowPath).getContentStream();
-                             OutputStream outputStream = new FileOutputStream(
-                                     archivePath + File.separator + SOAPTOREST + File.separator + OUT + outFlowPath.
-                                             substring(outFlowPath.lastIndexOf(RegistryConstants.PATH_SEPARATOR)))) {
-                            IOUtils.copy(inputStream, outputStream);
-                        }
-                    }
-                }
-            }
-        } catch (IOException e) {
-            throw new APIImportExportException("I/O error while writing API SOAP to REST logic to file", e);
-        } catch (RegistryException e) {
-            throw new APIImportExportException("Error while retrieving SOAP to REST logic", e);
+        writeSOAPToRESTSequencesToArchive(api, sequencePathInArchive, IN);
+        writeSOAPToRESTSequencesToArchive(api, sequencePathInArchive, OUT);
+    }
+
+    /**
+     * Retrieve SOAP to REST mediation logic for the exporting API for a particular type (in/out) and store it
+     * in the archive directory.
+     *
+     * @param api                   API
+     * @param sequencePathInArchive Path to the SOAP to REST sequences in the archive
+     * @param type                  Seqeunce type
+     * @throws APIManagementException   If an error occurs while reading/writing SOAP to REST sequences
+     * @throws APIImportExportException If an error occurs while creating the directory
+     */
+    private static void writeSOAPToRESTSequencesToArchive(API api, String sequencePathInArchive, String type)
+            throws APIManagementException, APIImportExportException {
+        String resourcePolicy = SequenceUtils.getRestToSoapConvertedSequence(api, type);
+        ResourcePolicyListDTO resourcePolicyInListDTO = APIMappingUtil.fromResourcePolicyStrToDTO(resourcePolicy);
+        String individualSequencePathInArchive = sequencePathInArchive + File.separator + type;
+        CommonUtil.createDirectory(individualSequencePathInArchive);
+        for (ResourcePolicyInfoDTO resourcePolicyInfoDTO : resourcePolicyInListDTO.getList()) {
+            String sequenceContent = resourcePolicyInfoDTO.getContent();
+            String sequenceName = resourcePolicyInfoDTO.getResourcePath() + "_" + resourcePolicyInfoDTO.getHttpVerb();
+            writeSequenceToArchive(sequenceContent, individualSequencePathInArchive, sequenceName);
         }
     }
 
@@ -551,7 +531,7 @@ public class ExportUtils {
                 if (!CommonUtil.checkFileExistence(individualSequenceExportPath)) {
                     CommonUtil.createDirectory(individualSequenceExportPath);
                 }
-                writeSequenceToArchive(inSequenceMediation, individualSequenceExportPath,
+                writeSequenceToArchive(inSequenceMediation.getConfig(), individualSequenceExportPath,
                         inSequenceMediation.getName());
             }
             if (outSequenceMediation != null) {
@@ -569,7 +549,7 @@ public class ExportUtils {
                 if (!CommonUtil.checkFileExistence(individualSequenceExportPath)) {
                     CommonUtil.createDirectory(individualSequenceExportPath);
                 }
-                writeSequenceToArchive(outSequenceMediation, individualSequenceExportPath,
+                writeSequenceToArchive(outSequenceMediation.getConfig(), individualSequenceExportPath,
                         outSequenceMediation.getName());
             }
             if (faultSequenceMediation != null) {
@@ -588,7 +568,7 @@ public class ExportUtils {
                 if (!CommonUtil.checkFileExistence(individualSequenceExportPath)) {
                     CommonUtil.createDirectory(individualSequenceExportPath);
                 }
-                writeSequenceToArchive(faultSequenceMediation, individualSequenceExportPath,
+                writeSequenceToArchive(faultSequenceMediation.getConfig(), individualSequenceExportPath,
                         faultSequenceMediation.getName());
             }
         }
@@ -597,12 +577,12 @@ public class ExportUtils {
     /**
      * Write the sequence to API archive.
      *
-     * @param mediation                    Mediation resource
+     * @param mediation                    Mediation content
      * @param individualSequenceExportPath Path to export the mediation sequence
      * @param mediationName                Name of the mediation policy
      * @throws APIManagementException If an error occurs while writing the mediation policy to file
      */
-    private static void writeSequenceToArchive(Mediation mediation, String individualSequenceExportPath,
+    private static void writeSequenceToArchive(String mediation, String individualSequenceExportPath,
                                                String mediationName)
             throws APIManagementException {
 
@@ -610,7 +590,7 @@ public class ExportUtils {
             try (OutputStream outputStream = new FileOutputStream(
                     individualSequenceExportPath + File.separator + mediationName + APIConstants.DOT
                             + APIConstants.XML_DOC_EXTENSION);
-                 InputStream fileInputStream = new ByteArrayInputStream(mediation.getConfig().getBytes())) {
+                 InputStream fileInputStream = new ByteArrayInputStream(mediation.getBytes())) {
                 IOUtils.copy(fileInputStream, outputStream);
             } catch (IOException e) {
                 throw new APIManagementException(

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -590,8 +590,7 @@ public class ExportUtils {
     private static void addMultipleAPISpecificSequencesToArchive(String archivePath, API api, APIProvider apiProvider)
             throws APIManagementException, APIImportExportException {
         String seqArchivePath = archivePath.concat(File.separator + ImportExportConstants.SEQUENCES_RESOURCE);
-        String tenantDomain = MultitenantUtils
-                .getTenantDomain(APIUtil.replaceEmailDomain(api.getId().getProviderName()));
+        String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
         if (!CommonUtil.checkFileExistence(seqArchivePath)) {
             CommonUtil.createDirectory(seqArchivePath);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -58,6 +58,7 @@ import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
 import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.Identifier;
+import org.wso2.carbon.apimgt.api.model.Mediation;
 import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.api.model.graphql.queryanalysis.GraphqlComplexityInfo;
@@ -287,8 +288,8 @@ public class ImportUtils {
             addSOAPToREST(importedApi, validationResponse.getContent(), apiProvider);
 
             if (!isAdvertiseOnlyAPI(importedApiDTO)) {
-                addAPISequences(extractedFolderPath, importedApi, registry);
-                addAPISpecificSequences(extractedFolderPath, registry, importedApi.getId());
+                addAPISequences(extractedFolderPath, importedApi, apiProvider);
+                addAPISpecificSequences(extractedFolderPath, importedApi, apiProvider);
                 addEndpointCertificates(extractedFolderPath, importedApi, apiProvider, tenantId);
 
                 if (log.isDebugEnabled()) {
@@ -1309,37 +1310,39 @@ public class ImportUtils {
      *
      * @param pathToArchive Location of the extracted folder of the API
      * @param importedApi   The imported API object
-     * @param registry      Registry
+     * @param apiProvider   API Provider
+     * @throws APIManagementException If an error occurs while adding the mediation policy
      */
-    private static void addAPISequences(String pathToArchive, API importedApi, Registry registry) throws IOException {
+    private static void addAPISequences(String pathToArchive, API importedApi, APIProvider apiProvider)
+            throws APIManagementException {
+        String tenantDomain = MultitenantUtils.getTenantDomain(importedApi.getId().getProviderName());
+        List<Mediation> existingMediationsList = apiProvider.getAllGlobalMediationPolicies();
 
-        String regResourcePath;
+        try {
+            // Adding in-sequence, if any
+            String sequenceContent = retrieveSequenceContent(pathToArchive, false,
+                    APIConstants.API_CUSTOM_SEQUENCE_TYPE_IN, importedApi.getInSequence());
+            PublisherCommonUtils
+                    .addMediationPolicyFromFile(sequenceContent, APIConstants.API_CUSTOM_SEQUENCE_TYPE_IN,
+                            apiProvider, importedApi.getUuid(), tenantDomain, existingMediationsList, Boolean.FALSE);
 
-        //Adding in-sequence, if any
-        String sequenceContent = retrieveSequenceContent(pathToArchive, false, APIConstants.API_CUSTOM_SEQUENCE_TYPE_IN,
-                importedApi.getInSequence());
-        if (StringUtils.isNotEmpty(sequenceContent)) {
-            String inSequenceFileName = importedApi.getInSequence() + APIConstants.XML_EXTENSION;
-            regResourcePath = APIConstants.API_CUSTOM_INSEQUENCE_LOCATION + inSequenceFileName;
-            addSequenceToRegistry(false, registry, sequenceContent, regResourcePath);
+            // Adding out-sequence, if any
+            sequenceContent = retrieveSequenceContent(pathToArchive, false, APIConstants.API_CUSTOM_SEQUENCE_TYPE_OUT,
+                    importedApi.getOutSequence());
+            PublisherCommonUtils
+                    .addMediationPolicyFromFile(sequenceContent, APIConstants.API_CUSTOM_SEQUENCE_TYPE_OUT,
+                            apiProvider, importedApi.getUuid(), tenantDomain, existingMediationsList, Boolean.FALSE);
+
+            // Adding fault-sequence, if any
+            sequenceContent = retrieveSequenceContent(pathToArchive, false, APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT,
+                    importedApi.getFaultSequence());
+            PublisherCommonUtils
+                    .addMediationPolicyFromFile(sequenceContent, APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT,
+                            apiProvider, importedApi.getUuid(), tenantDomain, existingMediationsList, Boolean.FALSE);
+        } catch (Exception e) {
+            throw new APIManagementException(
+                    "An Error has occurred while adding mediation policy" + StringUtils.SPACE + e.getMessage(), e);
         }
-
-        sequenceContent = retrieveSequenceContent(pathToArchive, false, APIConstants.API_CUSTOM_SEQUENCE_TYPE_OUT,
-                importedApi.getOutSequence());
-        if (StringUtils.isNotEmpty(sequenceContent)) {
-            String outSequenceFileName = importedApi.getOutSequence() + APIConstants.XML_EXTENSION;
-            regResourcePath = APIConstants.API_CUSTOM_OUTSEQUENCE_LOCATION + outSequenceFileName;
-            addSequenceToRegistry(false, registry, sequenceContent, regResourcePath);
-        }
-
-        sequenceContent = retrieveSequenceContent(pathToArchive, false, APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT,
-                importedApi.getFaultSequence());
-        if (StringUtils.isNotEmpty(sequenceContent)) {
-            String faultSequenceFileName = importedApi.getFaultSequence() + APIConstants.XML_EXTENSION;
-            regResourcePath = APIConstants.API_CUSTOM_FAULTSEQUENCE_LOCATION + faultSequenceFileName;
-            addSequenceToRegistry(false, registry, sequenceContent, regResourcePath);
-        }
-
     }
 
     public static String retrieveSequenceContent(String pathToArchive, boolean specific, String type,
@@ -1393,34 +1396,38 @@ public class ImportUtils {
      * sequence already exists, it is updated.
      *
      * @param pathToArchive Location of the extracted folder of the API
-     * @param registry      Registry
-     * @param apiIdentifier API Identifier
+     * @param importedApi   Imported API
+     * @param apiProvider   API Provider
+     * @throws APIManagementException If an error occurs while adding the mediation policy
      */
-    private static void addAPISpecificSequences(String pathToArchive, Registry registry, APIIdentifier apiIdentifier) {
-
-        String apiResourcePath = APIUtil.getAPIPath(apiIdentifier);
-        // Getting registry API base path out of apiResourcePath
-        apiResourcePath = apiResourcePath.substring(0, apiResourcePath.lastIndexOf("/"));
+    private static void addAPISpecificSequences(String pathToArchive, API importedApi, APIProvider apiProvider)
+            throws APIManagementException {
         String sequencesDirectoryPath = pathToArchive + File.separator + ImportExportConstants.SEQUENCES_RESOURCE;
+        String tenantDomain = MultitenantUtils.getTenantDomain(importedApi.getId().getProviderName());
+        List<Mediation> existingAPISpecificMediationsList =
+                apiProvider.getAllApiSpecificMediationPolicies(importedApi.getUuid(), tenantDomain);
 
         // Add multiple custom sequences to registry for each type in/out/fault
-        addCustomSequencesToRegistry(sequencesDirectoryPath, apiResourcePath, registry,
-                ImportExportConstants.IN_SEQUENCE_PREFIX);
-        addCustomSequencesToRegistry(sequencesDirectoryPath, apiResourcePath, registry,
-                ImportExportConstants.OUT_SEQUENCE_PREFIX);
-        addCustomSequencesToRegistry(sequencesDirectoryPath, apiResourcePath, registry,
-                ImportExportConstants.FAULT_SEQUENCE_PREFIX);
+        addCustomSequencesToRegistry(sequencesDirectoryPath, ImportExportConstants.IN_SEQUENCE_PREFIX, importedApi,
+                apiProvider, tenantDomain, existingAPISpecificMediationsList);
+        addCustomSequencesToRegistry(sequencesDirectoryPath, ImportExportConstants.OUT_SEQUENCE_PREFIX, importedApi,
+                apiProvider, tenantDomain, existingAPISpecificMediationsList);
+        addCustomSequencesToRegistry(sequencesDirectoryPath, ImportExportConstants.FAULT_SEQUENCE_PREFIX, importedApi,
+                apiProvider, tenantDomain, existingAPISpecificMediationsList);
     }
 
     /**
-     * @param sequencesDirectoryPath Location of the sequences directory inside the extracted folder of the API
-     * @param apiResourcePath        API resource path in the registry
-     * @param registry               Registry
-     * @param type                   Sequence type (in/out/fault)
+     * @param sequencesDirectoryPath            Location of the sequences directory in the extracted folder of the API
+     * @param type                              Sequence type (in/out/fault)
+     * @param importedApi                       Imported API
+     * @param apiProvider                       API Provider
+     * @param tenantDomain                      Tenant domain of the API
+     * @param existingAPISpecificMediationsList Existing API specific mediations list
+     * @throws APIManagementException If an error occurs while adding the mediation policy
      */
-    private static void addCustomSequencesToRegistry(String sequencesDirectoryPath, String apiResourcePath,
-                                                     Registry registry, String type) {
-
+    private static void addCustomSequencesToRegistry(String sequencesDirectoryPath, String type, API importedApi,
+            APIProvider apiProvider, String tenantDomain, List<Mediation> existingAPISpecificMediationsList)
+            throws APIManagementException {
         String apiSpecificSequenceFilePath =
                 sequencesDirectoryPath + File.separator + type + ImportExportConstants.SEQUENCE_LOCATION_POSTFIX
                         + File.separator + ImportExportConstants.CUSTOM_TYPE;
@@ -1431,52 +1438,22 @@ public class ImportUtils {
                 for (File apiSpecificSequence : apiSpecificSequencesDirectoryListing) {
                     String individualSequenceLocation =
                             apiSpecificSequenceFilePath + File.separator + apiSpecificSequence.getName();
-                    // Constructing mediation resource path
-                    String mediationResourcePath = apiResourcePath + RegistryConstants.PATH_SEPARATOR + type
-                            + RegistryConstants.PATH_SEPARATOR + apiSpecificSequence.getName();
                     try {
-                        String content = retrieveSequenceContentFromLocation(individualSequenceLocation);
-                        if (StringUtils.isNotEmpty(content)) {
-                            addSequenceToRegistry(true, registry, content, mediationResourcePath);
-                        }
+                        String sequenceContent = retrieveSequenceContentFromLocation(individualSequenceLocation);
+                        PublisherCommonUtils
+                                .addMediationPolicyFromFile(sequenceContent, type, apiProvider, importedApi.getUuid(),
+                                        tenantDomain, existingAPISpecificMediationsList, Boolean.TRUE);
                     } catch (IOException e) {
                         log.error(
                                 "I/O error while writing sequence data to the registry : " + individualSequenceLocation,
                                 e);
+                    } catch (Exception e) {
+                        throw new APIManagementException(
+                                "An Error has occurred while adding mediation policy" + StringUtils.SPACE + e
+                                        .getMessage(), e);
                     }
                 }
             }
-        }
-    }
-
-    /**
-     * This method adds the sequence files to the registry. This updates the API specific sequences if already exists.
-     *
-     * @param isAPISpecific   Whether the adding sequence is API specific
-     * @param registry        The registry instance
-     * @param sequenceContent Location of the sequence file
-     * @param regResourcePath Resource path in the registry
-     */
-    private static void addSequenceToRegistry(Boolean isAPISpecific, Registry registry, String sequenceContent,
-                                              String regResourcePath) {
-
-        try {
-            if (registry.resourceExists(regResourcePath) && !isAPISpecific) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Sequence already exists in registry path: " + regResourcePath);
-                }
-            } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("Adding Sequence to the registry path : " + regResourcePath);
-                }
-                byte[] inSeqData = sequenceContent.getBytes();
-                Resource inSeqResource = registry.newResource();
-                inSeqResource.setContent(inSeqData);
-                registry.put(regResourcePath, inSeqResource);
-            }
-        } catch (RegistryException e) {
-            //this is logged and ignored because sequences are optional
-            log.error("Failed to add sequences into the registry : " + regResourcePath, e);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -472,8 +472,11 @@ public class ImportUtils {
                         apiRevisionDeployment.setDisplayOnDevportal(displayOnDevportal);
                         apiRevisionDeployments.add(apiRevisionDeployment);
                     } else {
-                        log.error("Label " + deploymentName + " is not a defined gateway environment. Hence " +
-                                "skipped without deployment");
+                        throw new APIManagementException(
+                                "Label " + deploymentName + " is not a defined gateway environment. Hence "
+                                        + "skipped without deployment", ExceptionCodes
+                                .from(ExceptionCodes.GATEWAY_ENVIRONMENT_NOT_FOUND,
+                                        String.format("label '%s'", deploymentName)));
                     }
                 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -29,6 +29,7 @@ import graphql.schema.idl.UnExecutableSchemaGenerator;
 import graphql.schema.idl.errors.SchemaProblem;
 import graphql.schema.validation.SchemaValidationError;
 import graphql.schema.validation.SchemaValidator;
+import org.apache.axiom.om.OMElement;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -50,6 +51,7 @@ import org.wso2.carbon.apimgt.api.model.APIProductIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIProductResource;
 import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.api.model.DocumentationContent;
+import org.wso2.carbon.apimgt.api.model.Mediation;
 import org.wso2.carbon.apimgt.api.model.ResourceFile;
 import org.wso2.carbon.apimgt.api.model.SOAPToRestSequence;
 import org.wso2.carbon.apimgt.api.model.ServiceEntry;
@@ -79,6 +81,7 @@ import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.core.util.CryptoUtil;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
@@ -90,6 +93,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.xml.namespace.QName;
 
 /**
  * This is a publisher rest api utility class.
@@ -1514,5 +1518,95 @@ public class PublisherCommonUtils {
         API updatedAPI = apiProvider.getAPIbyUUID(api.getUuid(), tenantDomain);
         updatedAPI.setSoapToRestSequences(list);
         return apiProvider.updateAPI(updatedAPI, api);
+    }
+
+    /**
+     * Add mediation sequences from file content.
+     *
+     * @param content            File content of the mediation policy to be added
+     * @param type               Type (in/out/fault) of the mediation policy to be added
+     * @param apiProvider        API Provider
+     * @param apiId              API ID of the mediation policy
+     * @param tenantDomain       Tenant domain of the API
+     * @param existingMediations Existing mediation sequences
+     *                           (This can be null when adding an API specific sequence)
+     * @return Added mediation
+     * @throws Exception If an error occurs while adding the mediation sequence
+     */
+    public static Mediation addMediationPolicyFromFile(String content, String type, APIProvider apiProvider,
+            String apiId, String tenantDomain, List<Mediation> existingMediations, boolean isAPISpecific)
+            throws Exception {
+        if (StringUtils.isNotEmpty(content)) {
+            OMElement seqElement = APIUtil.buildOMElement(new ByteArrayInputStream(content.getBytes()));
+            String localName = seqElement.getLocalName();
+            String fileName = seqElement.getAttributeValue(new QName("name"));
+            Mediation existingMediation = (existingMediations != null) ?
+                    checkInExistingMediations(existingMediations, fileName, type) :
+                    null;
+            // existingGlobalMediations will not be null for only API specific sequences.
+            // Otherwise, the value of this variable will be set before coming into this function
+            if (!isAPISpecific) {
+                if (existingMediation != null) {
+                    log.debug("Sequence" + fileName + " already exists");
+                } else {
+                    return addApiSpecificMediationPolicyFromFile(localName, content, fileName, type, apiProvider, apiId,
+                            tenantDomain);
+                }
+            } else {
+                if (existingMediation != null) {
+                    // This will happen only when updating an API specific sequence using apictl
+                    apiProvider.deleteApiSpecificMediationPolicy(apiId, existingMediation.getUuid(), tenantDomain);
+                }
+                return addApiSpecificMediationPolicyFromFile(localName, content, fileName, type, apiProvider, apiId,
+                        tenantDomain);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Add API specific mediation sequences from file content.
+     *
+     * @param localName    Local name of the mediation policy to be added
+     * @param content      File content of the mediation policy to be added
+     * @param fileName     File name of the mediation policy to be added
+     * @param type         Type (in/out/fault) of the mediation policy to be added
+     * @param apiProvider  API Provider
+     * @param apiId        API ID of the mediation policy
+     * @param tenantDomain Tenant domain of the API
+     * @return
+     * @throws APIManagementException If the sequence is malformed.
+     */
+    private static Mediation addApiSpecificMediationPolicyFromFile(String localName, String content, String fileName,
+            String type, APIProvider apiProvider, String apiId, String tenantDomain) throws APIManagementException {
+        if (APIConstants.MEDIATION_SEQUENCE_ELEM.equals(localName)) {
+            Mediation mediationPolicy = new Mediation();
+            mediationPolicy.setConfig(content);
+            mediationPolicy.setName(fileName);
+            mediationPolicy.setType(type);
+            // Adding API specific mediation policy
+            return apiProvider.addApiSpecificMediationPolicy(apiId, mediationPolicy, tenantDomain);
+        } else {
+            throw new APIManagementException("Sequence is malformed");
+        }
+    }
+
+    /**
+     * Check whether a mediation policy included in a list.
+     *
+     * @param existingMediations Existing mediations as a list
+     * @param mediationName      Mediation name to be checked
+     * @param type               Type of the mediation to be checked
+     * @return Matched mediation
+     */
+    public static Mediation checkInExistingMediations(List<Mediation> existingMediations, String mediationName,
+            String type) {
+        for (Mediation mediation : existingMediations) {
+            if (StringUtils.equals(mediation.getName(), mediationName) && StringUtils
+                    .equals(type.toLowerCase(), mediation.getType().toLowerCase())) {
+                return mediation;
+            }
+        }
+        return null;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -189,7 +189,6 @@ import org.wso2.carbon.utils.CarbonUtils;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.xml.namespace.QName;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -2447,26 +2446,14 @@ public class ApisApiServiceImpl implements ApisApiService {
                 if (org.apache.commons.lang3.StringUtils.isBlank(fileContentType)) {
                     fileContentType = fileDetail.getContentType().toString();
                 }
-
                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                 IOUtils.copy(fileInputStream, outputStream);
                 byte[] sequenceBytes = outputStream.toByteArray();
                 InputStream inSequenceStream = new ByteArrayInputStream(sequenceBytes);
                 String content = IOUtils.toString(inSequenceStream, StandardCharsets.UTF_8.name());
-                OMElement seqElement = APIUtil.buildOMElement(new ByteArrayInputStream(sequenceBytes));
-                String localName = seqElement.getLocalName();
-                fileName = seqElement.getAttributeValue(new QName("name"));
-
-                if (APIConstants.MEDIATION_SEQUENCE_ELEM.equals(localName)) {
-                    Mediation mediationPolicy = new Mediation();
-                    mediationPolicy.setConfig(content);
-                    mediationPolicy.setName(fileName);
-                    mediationPolicy.setType(type);
-                    //Adding api specific mediation policy
-                    returnedPolicy  = apiProvider.addApiSpecificMediationPolicy(apiId, mediationPolicy, tenantDomain);
-                } else {
-                    throw new APIManagementException("Sequence is malformed");
-                }
+                returnedPolicy = PublisherCommonUtils
+                        .addMediationPolicyFromFile(content, type, apiProvider, apiId, tenantDomain, null,
+                                Boolean.TRUE);
             }
             if (inlineContent != null) {
                 //Extracting the file name specified in the config
@@ -2504,8 +2491,6 @@ public class ApisApiServiceImpl implements ApisApiService {
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
         } catch (Exception e) {
             RestApiUtil.handleInternalServerError("An Error has occurred while adding mediation policy", e, log);
-        } finally {
-            IOUtils.closeQuietly(fileInputStream);
         }
         return null;
     }


### PR DESCRIPTION
## Purpose
Fixes:  https://github.com/wso2/product-apim-tooling/issues/675

## Goals
Fixes the issues of not using the persistence instance when importing/exporting sequences.

## Approach
- Refactor the code to use persistence instance when adding mediation sequences
- Fix exporting SOAP to REST mediations correctly
- Restricted exporting SOAP to REST mediations only for gateway projects not for apictl projects.
- Restrict import API/API Products when specified nonexisting gateway envs and throw an error.