### PR TITLE
Fix the issue of API Creators can delete Published APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiConstants.java
@@ -46,6 +46,7 @@ public final class RestApiConstants {
 
     public static final String API_IMPORT_EXPORT_SCOPE = "apim:api_import_export";
     public static final String ADMIN_SCOPE = "apim:admin";
+    public static final String PUBLISHER_SCOPE = "apim:api_publish";
 
     public static final String DEFAULT_RESPONSE_CONTENT_TYPE = APPLICATION_JSON;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -531,7 +531,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             if (comment != null) {
                 String[] tokenScopes = (String[]) PhaseInterceptorChain.getCurrentMessage().getExchange()
                         .get(RestApiConstants.USER_REST_API_SCOPES);
-                if (Arrays.asList(tokenScopes).contains("apim:admin") || comment.getUser().equals(username)) {
+                if (Arrays.asList(tokenScopes).contains(RestApiConstants.ADMIN_SCOPE) || comment.getUser().equals(username)) {
                     if (apiProvider.deleteComment(apiTypeWrapper, commentId)) {
                         JSONObject obj = new JSONObject();
                         obj.put("id", commentId);
@@ -1516,7 +1516,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             // check user has publisher role and API is in published or deprecated state
             String[] tokenScopes = (String[]) PhaseInterceptorChain.getCurrentMessage().getExchange()
                     .get(RestApiConstants.USER_REST_API_SCOPES);
-            if (!ArrayUtils.contains(tokenScopes, "apim:api_publish") && (
+            if (!ArrayUtils.contains(tokenScopes, RestApiConstants.PUBLISHER_SCOPE) && (
                     APIConstants.PUBLISHED.equalsIgnoreCase(api.getStatus()) || APIConstants.DEPRECATED
                             .equalsIgnoreCase(api.getStatus()))) {
                 RestApiUtil.handleAuthorizationFailure(username + " cannot remove the API", log);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -1512,6 +1512,13 @@ public class ApisApiServiceImpl implements ApisApiService {
                 RestApiUtil.handleConflict("Cannot remove the API because following resource paths " +
                         usedProductResources.toString() + " are used by one or more API Products", log);
             }
+
+            // check user has publisher role and API is in published or deprecated state
+            if (!APIUtil.isRoleExistForUser(username, "Internal/publisher") && (
+                    APIConstants.PUBLISHED.equalsIgnoreCase(api.getStatus()) || APIConstants.DEPRECATED
+                            .equalsIgnoreCase(api.getStatus()))) {
+                RestApiUtil.handleConflict(username + " cannot remove the API", log);
+            }
             //deletes the API
             apiProvider.deleteAPI(api);
             return Response.ok().build();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -1514,11 +1514,14 @@ public class ApisApiServiceImpl implements ApisApiService {
             }
 
             // check user has publisher role and API is in published or deprecated state
-            if (!APIUtil.isRoleExistForUser(username, "Internal/publisher") && (
+            String[] tokenScopes = (String[]) PhaseInterceptorChain.getCurrentMessage().getExchange()
+                    .get(RestApiConstants.USER_REST_API_SCOPES);
+            if (!ArrayUtils.contains(tokenScopes, "apim:api_publish") && (
                     APIConstants.PUBLISHED.equalsIgnoreCase(api.getStatus()) || APIConstants.DEPRECATED
                             .equalsIgnoreCase(api.getStatus()))) {
-                RestApiUtil.handleConflict(username + " cannot remove the API", log);
+                RestApiUtil.handleAuthorizationFailure(username + " cannot remove the API", log);
             }
+
             //deletes the API
             apiProvider.deleteAPI(api);
             return Response.ok().build();


### PR DESCRIPTION
### Purpose
Fixes: https://github.com/wso2/product-apim/issues/10275

### Goals
To restrict API Creators can delete Published or Deprecated APIs

### Approach
Checked user's role and the status of the API before calling the deleteAPI.

Actions: https://github.com/wso2/carbon-apimgt/actions/runs/735521276