### PR TITLE
Disable key generation wizard button when all or resident key manager option is not selected

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/Credentials/Credentials.jsx
@@ -343,6 +343,8 @@ class Credentials extends React.Component {
         const isOnlyBasicAuth = api.securityScheme.includes('basic_auth') && !api.securityScheme.includes('oauth2')
          && !api.securityScheme.includes('api_key');
         const isPrototypedAPI = api.lifeCycleStatus && api.lifeCycleStatus.toLowerCase() === 'prototyped';
+        const isSetAllorResidentKeyManagers = api.keyManagers.includes('all')
+            || api.keyManagers.includes('Resident Key Manager');
         const renderCredentialInfo = () => {
             if (isPrototypedAPI) {
                 return (
@@ -425,7 +427,8 @@ class Credentials extends React.Component {
                                                 />
                                             </Typography>
                                             <Link
-                                                to={(isOnlyMutualSSL || isOnlyBasicAuth) ? null
+                                                to={(isOnlyMutualSSL || isOnlyBasicAuth
+                                                    || !isSetAllorResidentKeyManagers) ? null
                                                     : `/apis/${api.id}/credentials/wizard`}
                                                 style={!api.isSubscriptionAvailable
                                                     ? { pointerEvents: 'none' } : null}
@@ -435,7 +438,7 @@ class Credentials extends React.Component {
                                                     color='primary'
                                                     className={classes.buttonElm}
                                                     disabled={!api.isSubscriptionAvailable || isOnlyMutualSSL
-                                                        || isOnlyBasicAuth}
+                                                        || isOnlyBasicAuth || !isSetAllorResidentKeyManagers}
                                                 >
                                                     <FormattedMessage
                                                         id={'Apis.Details.Credentials.'
@@ -571,7 +574,8 @@ class Credentials extends React.Component {
                                 />
                                 {applicationsAvailable.length > 0 && (
                                     <Link
-                                        to={(isOnlyMutualSSL || isOnlyBasicAuth || isPrototypedAPI) ? null
+                                        to={(isOnlyMutualSSL || isOnlyBasicAuth || isPrototypedAPI
+                                            || !isSetAllorResidentKeyManagers) ? null
                                             : `/apis/${api.id}/credentials/wizard`}
                                         style={!api.isSubscriptionAvailable
                                             ? { pointerEvents: 'none' } : null}
@@ -580,7 +584,8 @@ class Credentials extends React.Component {
                                         <Button
                                             color='secondary'
                                             disabled={!api.isSubscriptionAvailable || isOnlyMutualSSL
-                                                 || isOnlyBasicAuth || isPrototypedAPI}
+                                                 || isOnlyBasicAuth || isPrototypedAPI
+                                                 || !isSetAllorResidentKeyManagers}
                                             size='small'
                                         >
                                             <Icon>add_circle_outline</Icon>


### PR DESCRIPTION
### Purpose
As $subject, this will disable the key generation wizard button when a resident key manager or all key manager option is not selected from the publisher for an API.

After disabling it, **Subscription & key Generation Wizard** button will appear as follows

![image](https://user-images.githubusercontent.com/21282060/114267334-7b181300-9a18-11eb-8896-ecb325108b78.png)


### Issues
Fixes https://github.com/wso2/product-apim/issues/9031