### PR TITLE
Disable saving when new password doesn't match with the repeat password

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Settings/ChangePassword/ChangePassword.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Settings/ChangePassword/ChangePassword.jsx
@@ -181,47 +181,56 @@ const ChangePassword = () => {
     };
 
     const handleSave = () => {
-        const restApi = new API();
-        return restApi
-            .changePassword(currentPassword, newPassword)
-            .then((res) => {
-                Alert.success(
-                    <FormattedMessage
-                        id='Change.Password.password.changed.success'
-                        defaultMessage='User password changed successfully. Please use the new password on next sign in'
-                    />
-                );
-                window.history.back();
-            })
-            .catch((error) => {
-                const errorCode = error.response.body.code;
-                switch (errorCode) {
-                    case 901450:
-                        Alert.error(
-                            <FormattedMessage
-                                id='Change.Password.password.change.disabled'
-                                defaultMessage='Password change disabled'
-                            />
-                        );
-                        break;
-                    case 901451:
-                        Alert.error(
-                            <FormattedMessage
-                                id='Change.Password.current.password.incorrect'
-                                defaultMessage='Current password is incorrect'
-                            />
-                        );
-                        break;
-                    case 901452:
-                        Alert.error(
-                            <FormattedMessage
-                                id='Change.Password.password.pattern.invalid'
-                                defaultMessage='Invalid password pattern'
-                            />
-                        );
-                        break;
-                }
-            });
+        if (repeatedNewPassword && newPassword !== repeatedNewPassword) {
+            Alert.error(
+                <FormattedMessage
+                    id='Change.Password.password.mismatch'
+                    defaultMessage={'Password doesn\'t match'}
+                />
+            );
+        } else {
+            const restApi = new API();
+            return restApi
+                .changePassword(currentPassword, newPassword)
+                .then((res) => {
+                    Alert.success(
+                        <FormattedMessage
+                            id='Change.Password.password.changed.success'
+                            defaultMessage='User password changed successfully. Please use the new password on next sign in'
+                        />
+                    );
+                    window.history.back();
+                })
+                .catch((error) => {
+                    const errorCode = error.response.body.code;
+                    switch (errorCode) {
+                        case 901450:
+                            Alert.error(
+                                <FormattedMessage
+                                    id='Change.Password.password.change.disabled'
+                                    defaultMessage='Password change disabled'
+                                />
+                            );
+                            break;
+                        case 901451:
+                            Alert.error(
+                                <FormattedMessage
+                                    id='Change.Password.current.password.incorrect'
+                                    defaultMessage='Current password is incorrect'
+                                />
+                            );
+                            break;
+                        case 901452:
+                            Alert.error(
+                                <FormattedMessage
+                                    id='Change.Password.password.pattern.invalid'
+                                    defaultMessage='Invalid password pattern'
+                                />
+                            );
+                            break;
+                    }
+                });
+        }
     };
 
     const title = (


### PR DESCRIPTION
## Purpose
As $subject, this will avoid saving when the repeat password is not matched with the new password

### Issues
Fixes https://github.com/wso2/product-apim/issues/10893