### PR TITLE
Add category descriptions to Devportal

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/TryOut/TryOutConsole.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/TryOut/TryOutConsole.jsx
@@ -124,7 +124,7 @@ const TryOutConsole = () => {
                 + `${selectedDeploymentVhost.httpContext}${api.context}/${api.version}`;
                     return { url };
                 });
-                oasCopy.servers = servers;
+                oasCopy.servers = servers.sort((a, b) => ((a.url > b.url) ? -1 : 1));
             } else { // Assume the API definition is Swagger 2
                 let transportPort = selectedDeploymentVhost.httpsPort;
                 if (api.transport.length === 1 && !api.transport.includes('https')) {
@@ -136,7 +136,7 @@ const TryOutConsole = () => {
                 }
                 const host = `${selectedDeploymentVhost.host}:${transportPort}`;
                 const basePath = `${pathSeparator}${selectedDeploymentVhost.httpContext}${api.context}/${api.version}`;
-                oasCopy.schemes = api.transport;
+                oasCopy.schemes = api.transport.slice().sort((a, b) => ((a > b) ? -1 : 1));
                 oasCopy.basePath = basePath;
                 oasCopy.host = host;
             }

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/APICategoryThumb.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Listing/APICategoryThumb.jsx
@@ -22,6 +22,7 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import Icon from '@material-ui/core/Icon';
+import Tooltip from '@material-ui/core/Tooltip';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
@@ -53,14 +54,24 @@ function APICategoryThumb(props) {
         category, path, classes,
     } = props;
     const categoryLink = path + ':' + category.name;
+    let categoryDesc = category.description;
+    if (categoryDesc.length > 50) {
+        categoryDesc = categoryDesc.substring(0, 50) + '...';
+    }
     return (
         <Link to={categoryLink} className={classes.textWrapper}>
-            <ListItem button>
-                <ListItemIcon>
-                    <Icon>label</Icon>
-                </ListItemIcon>
-                <ListItemText primary={category.name} classes={{ primary: classes.listItemText }} />
-            </ListItem>
+            <Tooltip placement='right' title={category.description.length <= 50 ? '' : category.description}>
+                <ListItem button alignItems='flex-start'>
+                    <ListItemIcon>
+                        <Icon>label</Icon>
+                    </ListItemIcon>
+                    <ListItemText
+                        primary={category.name}
+                        secondary={categoryDesc}
+                        classes={{ primary: classes.listItemText }}
+                    />
+                </ListItem>
+            </Tooltip>
         </Link>
     );
 }


### PR DESCRIPTION
This PR,
1. Adds category descriptions to Devportal
2. Set Https by default in the publisher test console

Fixes https://github.com/wso2/product-apim/issues/10450, https://github.com/wso2/product-apim/issues/10510