### PR TITLE
[Streaming API] Validate WebSocket endpoint URL

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
@@ -217,6 +217,13 @@ export default function DefaultAPIForm(props) {
                 }
                 break;
             }
+            case 'endpoint': {
+                if (isWebSocket && value && value.length > 0) {
+                    const wsUrlValidity = APIValidation.wsUrl.validate(value).error;
+                    updateValidity({ ...validity, endpointURL: wsUrlValidity });
+                }
+                break;
+            }
             default: {
                 break;
             }
@@ -400,25 +407,22 @@ export default function DefaultAPIForm(props) {
                         value={api.endpoint}
                         onChange={onChange}
                         helperText={
-                            validity.endpointURL && (
-                                <span>
-                                    Enter a valid
-                                    <a
-                                        rel='noopener noreferrer'
-                                        target='_blank'
-                                        href='http://tools.ietf.org/html/rfc3986'
-                                    >
-                                        RFC 3986
-                                    </a>
-                                    {' '}
-                                    URI
-                                </span>
-                            )
+                            (validity.endpointURL
+                                && validity.endpointURL.details.map((detail, index) => {
+                                    return (
+                                        <div style={{ marginTop: index !== 0 && '10px' }}>
+                                            {detail.message}
+                                        </div>
+                                    );
+                                }))
                         }
                         error={validity.endpointURL}
                         margin='normal'
                         variant='outlined'
                         InputProps={{
+                            onBlur: ({ target: { value } }) => {
+                                validate('endpoint', value);
+                            },
                             endAdornment: (
                                 <InputAdornment position='end'>
                                     {statusCode && (

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
@@ -221,6 +221,8 @@ const APICreateStreamingAPI = (props) => {
                         endpointPlaceholderText='Streaming Provider'
                         appendChildrenBeforeEndpoint
                         hideEndpoint={hideEndpoint}
+                        isWebSocket={(apiType && apiType === protocolKeys.WebSocket)
+                            || apiInputs.protocol === protocolKeys.WebSocket}
                     >
                         <TextField
                             fullWidth

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/APIValidation.js
@@ -157,6 +157,17 @@ const definition = {
         });
         return tmpErrors;
     }),
+    wsUrl: Joi.string().uri({ scheme: ['ws', 'wss'] }).error((errors) => {
+        const tmpErrors = [...errors];
+        errors.forEach((err, index) => {
+            const tmpError = { ...err };
+            const errType = err.type;
+            tmpError.message = errType === 'string.uriCustomScheme' ? 'Invalid WebSocket URL'
+                : 'WebSocket URL ' + getMessage(errType);
+            tmpErrors[index] = tmpError;
+        });
+        return tmpErrors;
+    }),
     alias: Joi.string().max(30).regex(/^[^~!@#;:%^*()+={}|\\<>"',&$\s+[\]/]*$/).required()
         .error((errors) => {
             return errors.map((error) => ({ ...error, message: 'Alias ' + getMessage(error.type, 30) }));


### PR DESCRIPTION
## Purpose
- Validate WebSocket endpoint URL [1]
- Disable the verify endpoint button for WebSocket Streaming APIs. Fixes https://github.com/wso2/product-apim/issues/10773

[1] 
<img width="845" alt="Screen Shot 2021-04-11 at 11 19 14 AM" src="https://user-images.githubusercontent.com/24828296/114294041-f03b2500-9ab8-11eb-8fdd-066a68def364.png">
