### PR TITLE
Improve error mesage and allow some characters for document source file

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
@@ -2284,7 +2284,7 @@
   "Apis.Details.Documents.CreateEditForm.source.file.name.error.invalid": [
     {
       "type": 0,
-      "value": "Error when validating the document source file name"
+      "value": "Document Source file name cannot contain spaces or special characters"
     }
   ],
   "Apis.Details.Documents.CreateEditForm.source.inline": [

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
@@ -2284,7 +2284,7 @@
   "Apis.Details.Documents.CreateEditForm.source.file.name.error.invalid": [
     {
       "type": 0,
-      "value": "Document Source file name cannot contain spaces or special characters"
+      "value": "Document source file name cannot contain spaces or special characters"
     }
   ],
   "Apis.Details.Documents.CreateEditForm.source.inline": [

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/raw.en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/raw.en.json
@@ -1042,7 +1042,7 @@
     "defaultMessage": "File"
   },
   "Apis.Details.Documents.CreateEditForm.source.file.name.error.invalid": {
-    "defaultMessage": "Document Source file name cannot contain spaces or special characters"
+    "defaultMessage": "Document source file name cannot contain spaces or special characters"
   },
   "Apis.Details.Documents.CreateEditForm.source.inline": {
     "defaultMessage": "Inline"

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/raw.en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/raw.en.json
@@ -1042,7 +1042,7 @@
     "defaultMessage": "File"
   },
   "Apis.Details.Documents.CreateEditForm.source.file.name.error.invalid": {
-    "defaultMessage": "Error when validating the document source file name"
+    "defaultMessage": "Document Source file name cannot contain spaces or special characters"
   },
   "Apis.Details.Documents.CreateEditForm.source.inline": {
     "defaultMessage": "Inline"

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
@@ -181,7 +181,7 @@ class CreateEditForm extends React.Component {
             this.setState({ file: null });
             Alert.error(intl.formatMessage({
                 id: 'Apis.Details.Documents.CreateEditForm.source.file.name.error.invalid',
-                defaultMessage: 'Document Source file name cannot contain spaces or special characters',
+                defaultMessage: 'Document source file name cannot contain spaces or special characters',
             }));
         } else {
             this.setState({ file: acceptedFile });

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
@@ -176,12 +176,12 @@ class CreateEditForm extends React.Component {
 
     onDrop = (acceptedFile) => {
         const { intl } = this.props;
-        var specialChars = /[`!@#$%^*()+\-={};'"\\|,<>\/?~]/;
+        var specialChars = /[`!@#%^*()+\={};'"\\|,<>\/~]/;
         if (specialChars.test(acceptedFile[0].name)) {
             this.setState({ file: null });
             Alert.error(intl.formatMessage({
                 id: 'Apis.Details.Documents.CreateEditForm.source.file.name.error.invalid',
-                defaultMessage: 'Error when validating the document source file name',
+                defaultMessage: 'Document Source file name cannot contain spaces or special characters',
             }));
         } else {
             this.setState({ file: acceptedFile });


### PR DESCRIPTION
## Purpose
As $subject, this will improve the error message and allow some characters to have in the source file name when uploading source files as API documents. Otherwise, if this has other special characters it throws backend exceptions when uploading the file.

### Issues
Fixes https://github.com/wso2/product-apim/issues/10841