### PR TITLE
[Streaming API] Load WebSub event receiver endpoint details from config

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Environment.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/Environment.java
@@ -38,6 +38,7 @@ public class Environment implements Serializable {
     private String password;
     private String apiGatewayEndpoint;
     private String websocketGatewayEndpoint;
+    private String webSubGatewayEndpoint;
     private boolean isDefault;
 
     // New fields added with dynamic environments
@@ -63,6 +64,14 @@ public class Environment implements Serializable {
 
     public void setWebsocketGatewayEndpoint(String websocketGatewayEndpoint) {
         this.websocketGatewayEndpoint = websocketGatewayEndpoint;
+    }
+
+    public String getWebSubGatewayEndpoint() {
+        return webSubGatewayEndpoint;
+    }
+
+    public void setWebSubGatewayEndpoint(String webSubGatewayEndpoint) {
+        this.webSubGatewayEndpoint = webSubGatewayEndpoint;
     }
 
     public boolean isShowInConsole() {
@@ -196,7 +205,11 @@ public class Environment implements Serializable {
     }
 
     public void setEndpointsAsVhost() throws APIManagementException {
-        String[] endpoints = (apiGatewayEndpoint + "," + websocketGatewayEndpoint).split(",", 4);
+        // Prefix websub endpoints with 'websub_', since API type will be identified with this URL.
+        String modifiedWebSubGatewayEndpoint = webSubGatewayEndpoint.replaceAll("http://", "websub_http://")
+                .replaceAll("https://", "websub_https://");
+        String[] endpoints = (apiGatewayEndpoint + "," + websocketGatewayEndpoint + "," + modifiedWebSubGatewayEndpoint)
+                .split(",", 6);
         getVhosts().add(VHost.fromEndpointUrls(endpoints));
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
@@ -35,17 +35,24 @@ public class VHost {
     private Integer httpsPort = DEFAULT_HTTPS_PORT;
     private Integer wsPort = DEFAULT_WS_PORT;
     private Integer wssPort = DEFAULT_WSS_PORT;
+    private Integer websubHttpPort = DEFAULT_WEBSUB_HTTP_PORT;
+    private Integer websubHttpsPort = DEFAULT_WEBSUB_HTTPS_PORT;
 
     public static final int DEFAULT_HTTP_PORT = 80;
     public static final int DEFAULT_HTTPS_PORT = 443;
     public static final int DEFAULT_WS_PORT = 9099;
     public static final int DEFAULT_WSS_PORT = 8099;
+    public static final int DEFAULT_WEBSUB_HTTP_PORT = 9021;
+    public static final int DEFAULT_WEBSUB_HTTPS_PORT = 8021;
 
     public static final String HTTP_PROTOCOL = "http";
     public static final String HTTPS_PROTOCOL = "https";
     public static final String WS_PROTOCOL = "ws";
     public static final String WSS_PROTOCOL = "wss";
     public static final String PROTOCOL_SEPARATOR = "://";
+
+    private static final String WEBSUB_HTTP_PROTOCOL = "websub_http";
+    private static final String WEBSUB_HTTPS_PROTOCOL = "websub_https";
 
     public VHost() {
     }
@@ -96,6 +103,22 @@ public class VHost {
 
     public void setWssPort(Integer wssPort) {
         this.wssPort = wssPort;
+    }
+
+    public Integer getWebsubHttpPort() {
+        return websubHttpPort;
+    }
+
+    public void setWebsubHttpPort(Integer websubHttpPort) {
+        this.websubHttpPort = websubHttpPort;
+    }
+
+    public Integer getWebsubHttpsPort() {
+        return websubHttpsPort;
+    }
+
+    public void setWebsubHttpsPort(Integer websubHttpsPort) {
+        this.websubHttpsPort = websubHttpsPort;
     }
 
     public String getHttpUrl() {
@@ -162,6 +185,14 @@ public class VHost {
                         // URL is not parsing for ws protocols, hence change to http
                         url = new URL(HTTP_PROTOCOL + PROTOCOL_SEPARATOR + elem[1]);
                         vhost.setWsPort(url.getPort() < 0 ? DEFAULT_WS_PORT : url.getPort());
+                        break;
+                    case WEBSUB_HTTP_PROTOCOL:
+                        url = new URL(HTTP_PROTOCOL + PROTOCOL_SEPARATOR + elem[1]);
+                        vhost.setWebsubHttpPort(url.getPort() < 0 ? DEFAULT_WEBSUB_HTTP_PORT : url.getPort());
+                        break;
+                    case WEBSUB_HTTPS_PROTOCOL:
+                        url = new URL(HTTPS_PROTOCOL + PROTOCOL_SEPARATOR + elem[1]);
+                        vhost.setWebsubHttpsPort(url.getPort() < 0 ? DEFAULT_WEBSUB_HTTPS_PORT : url.getPort());
                         break;
                 }
             } catch (MalformedURLException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -675,6 +675,7 @@ public final class APIConstants {
     public static final String API_GATEWAY_PASSWORD = "Password";
     public static final String API_GATEWAY_ENDPOINT = "GatewayEndpoint";
     public static final String API_WEBSOCKET_GATEWAY_ENDPOINT = "GatewayWSEndpoint";
+    public static final String API_WEBSUB_GATEWAY_ENDPOINT = "GatewayWebSubEndpoint";
     public static final String API_GATEWAY_TYPE = "GatewayType";
     public static final String API_GATEWAY_TYPE_SYNAPSE = "Synapse";
     public static final String API_GATEWAY_VIRTUAL_HOSTS = "VirtualHosts";
@@ -683,6 +684,8 @@ public final class APIConstants {
     public static final String API_GATEWAY_VIRTUAL_HOST_HTTPS_ENDPOINT = "HttpsEndpoint";
     public static final String API_GATEWAY_VIRTUAL_HOST_WS_ENDPOINT = "WsEndpoint";
     public static final String API_GATEWAY_VIRTUAL_HOST_WSS_ENDPOINT = "WssEndpoint";
+    public static final String API_GATEWAY_VIRTUAL_HOST_WEBSUB_HTTP_ENDPOINT = "WebSubHttpEndpoint";
+    public static final String API_GATEWAY_VIRTUAL_HOST_WEBSUB_HTTPS_ENDPOINT = "WebSubHttpsEndpoint";
     public static final String API_GATEWAY_NONE = "none";
     public static final String GATEWAY_STATS_SERVICE = "GatewayStatsUpdateService";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -96,6 +96,7 @@ public class APIManagerConfiguration {
     public static final String JMS_PORT = "jms.port";
     public static final String CARBON_CONFIG_PORT_OFFSET_NODE = "Ports.Offset";
     public static final String WEBSOCKET_DEFAULT_GATEWAY_URL = "ws://localhost:9099";
+    public static final String WEBSUB_DEFAULT_GATEWAY_URL = "http://localhost:9021";
     private Map<String, Map<String, String>> loginConfiguration = new ConcurrentHashMap<String, Map<String, String>>();
     private JSONArray applicationAttributes = new JSONArray();
     private JSONArray monetizationAttributes = new JSONArray();
@@ -410,6 +411,14 @@ public class APIManagerConfiguration {
                     } else {
                         environment.setWebsocketGatewayEndpoint(WEBSOCKET_DEFAULT_GATEWAY_URL);
                     }
+                    OMElement webSubGatewayEndpoint = environmentElem
+                            .getFirstChildWithName(new QName(APIConstants.API_WEBSUB_GATEWAY_ENDPOINT));
+                    if (webSubGatewayEndpoint != null) {
+                        environment.setWebSubGatewayEndpoint(
+                                APIUtil.replaceSystemProperty(webSubGatewayEndpoint.getText()));
+                    } else {
+                        environment.setWebSubGatewayEndpoint(WEBSUB_DEFAULT_GATEWAY_URL);
+                    }
                     OMElement description =
                             environmentElem.getFirstChildWithName(new QName("Description"));
                     if (description != null) {
@@ -434,8 +443,20 @@ public class APIManagerConfiguration {
                                 APIConstants.API_GATEWAY_VIRTUAL_HOST_WS_ENDPOINT)).getText());
                         String wssEp = APIUtil.replaceSystemProperty(vhostElem.getFirstChildWithName(new QName(
                                 APIConstants.API_GATEWAY_VIRTUAL_HOST_WSS_ENDPOINT)).getText());
+                        String webSubHttpEp = APIUtil.replaceSystemProperty(vhostElem.getFirstChildWithName(new QName(
+                                APIConstants.API_GATEWAY_VIRTUAL_HOST_WEBSUB_HTTP_ENDPOINT)).getText());
+                        String webSubHttpsEp = APIUtil.replaceSystemProperty(vhostElem.getFirstChildWithName(new QName(
+                                APIConstants.API_GATEWAY_VIRTUAL_HOST_WEBSUB_HTTPS_ENDPOINT)).getText());
 
-                        VHost vhost = VHost.fromEndpointUrls(new String[]{httpEp, httpsEp, wsEp, wssEp});
+                        /*
+                         Prefix websub endpoints with 'websub_' so that the endpoint URL
+                         would begin with: 'websub_http://', since API type is identified by the URL protocol below.
+                         */
+                        webSubHttpEp = "websub_" + webSubHttpEp;
+                        webSubHttpsEp = "websub_" + webSubHttpsEp;
+
+                        VHost vhost = VHost.fromEndpointUrls(new String[]{
+                                httpEp, httpsEp, wsEp, wssEp, webSubHttpEp, webSubHttpsEp});
                         vhosts.add(vhost);
                     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/VHostDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/VHostDTO.java
@@ -26,6 +26,8 @@ public class VHostDTO   {
     private Integer httpsPort = null;
     private Integer wsPort = null;
     private Integer wssPort = null;
+    private Integer websubHttpPort = null;
+    private Integer websubHttpsPort = null;
 
   /**
    **/
@@ -129,6 +131,40 @@ public class VHostDTO   {
     this.wssPort = wssPort;
   }
 
+  /**
+   **/
+  public VHostDTO websubHttpPort(Integer websubHttpPort) {
+    this.websubHttpPort = websubHttpPort;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "9021", value = "")
+  @JsonProperty("websubHttpPort")
+  public Integer getWebsubHttpPort() {
+    return websubHttpPort;
+  }
+  public void setWebsubHttpPort(Integer websubHttpPort) {
+    this.websubHttpPort = websubHttpPort;
+  }
+
+  /**
+   **/
+  public VHostDTO websubHttpsPort(Integer websubHttpsPort) {
+    this.websubHttpsPort = websubHttpsPort;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "8021", value = "")
+  @JsonProperty("websubHttpsPort")
+  public Integer getWebsubHttpsPort() {
+    return websubHttpsPort;
+  }
+  public void setWebsubHttpsPort(Integer websubHttpsPort) {
+    this.websubHttpsPort = websubHttpsPort;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -144,12 +180,14 @@ public class VHostDTO   {
         Objects.equals(httpPort, vhost.httpPort) &&
         Objects.equals(httpsPort, vhost.httpsPort) &&
         Objects.equals(wsPort, vhost.wsPort) &&
-        Objects.equals(wssPort, vhost.wssPort);
+        Objects.equals(wssPort, vhost.wssPort) &&
+        Objects.equals(websubHttpPort, vhost.websubHttpPort) &&
+        Objects.equals(websubHttpsPort, vhost.websubHttpsPort);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, httpContext, httpPort, httpsPort, wsPort, wssPort);
+    return Objects.hash(host, httpContext, httpPort, httpsPort, wsPort, wssPort, websubHttpPort, websubHttpsPort);
   }
 
   @Override
@@ -163,6 +201,8 @@ public class VHostDTO   {
     sb.append("    httpsPort: ").append(toIndentedString(httpsPort)).append("\n");
     sb.append("    wsPort: ").append(toIndentedString(wsPort)).append("\n");
     sb.append("    wssPort: ").append(toIndentedString(wssPort)).append("\n");
+    sb.append("    websubHttpPort: ").append(toIndentedString(websubHttpPort)).append("\n");
+    sb.append("    websubHttpsPort: ").append(toIndentedString(websubHttpsPort)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/EnvironmentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/EnvironmentMappingUtil.java
@@ -92,6 +92,8 @@ public class EnvironmentMappingUtil {
         vHostDTO.setHttpsPort(vHost.getHttpsPort());
         vHostDTO.setWsPort(vHost.getWsPort());
         vHostDTO.setWssPort(vHost.getWssPort());
+        vHostDTO.setWebsubHttpPort(vHost.getWebsubHttpPort());
+        vHostDTO.setWebsubHttpsPort(vHost.getWebsubHttpsPort());
         return vHostDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -9646,6 +9646,12 @@ components:
         wssPort:
           type: integer
           example: 8099
+        websubHttpPort:
+          type: integer
+          example: 9021
+        websubHttpsPort:
+          type: integer
+          example: 8021
     FileInfo:
       title: File Information including meta data
       type: object

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -156,6 +156,16 @@
                 {% else %}
                 <GatewayWSEndpoint></GatewayWSEndpoint>
                 {% endif %}
+                <!-- Endpoint URLs of the WebSub APIs hosted in this API Gateway -->
+                {% if environment_name.websub_event_receiver_http_endpoint is defined and environment_name.websub_event_receiver_https_endpoint is defined %}
+                <GatewayWebSubEndpoint>{{environment_name.websub_event_receiver_http_endpoint}},{{environment_name.websub_event_receiver_https_endpoint}}</GatewayWebSubEndpoint>
+                {% elif environment_name.websub_event_receiver_http_endpoint is not defined and environment_name.websub_event_receiver_https_endpoint is defined %}
+                <GatewayWebSubEndpoint>{{environment_name.websub_event_receiver_https_endpoint}}</GatewayWebSubEndpoint>
+                {% elif environment_name.websub_event_receiver_http_endpoint is defined and environment_name.websub_event_receiver_https_endpoint is not defined %}
+                <GatewayWebSubEndpoint>{{environment_name.websub_event_receiver_http_endpoint}}</GatewayWebSubEndpoint>
+                {% else %}
+                <GatewayWebSubEndpoint></GatewayWebSubEndpoint>
+                {% endif %}
                 <VirtualHosts>
                     {% for vhost in environment_name.virtual_host %}
                     <VirtualHost>
@@ -163,6 +173,8 @@
                         <HttpsEndpoint>{{vhost.https_endpoint}}</HttpsEndpoint>
                         <WsEndpoint>{{vhost.ws_endpoint}}</WsEndpoint>
                         <WssEndpoint>{{vhost.wss_endpoint}}</WssEndpoint>
+                        <WebSubHttpEndpoint>{{vhost.websub_event_receiver_http_endpoint}}</WebSubHttpEndpoint>
+                        <WebSubHttpsEndpoint>{{vhost.websub_event_receiver_https_endpoint}}</WebSubHttpsEndpoint>
                     </VirtualHost>
                     {% endfor %}
                 </VirtualHosts>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
@@ -112,6 +112,8 @@
                 <GatewayEndpoint>http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}</GatewayEndpoint>
                 <!-- Endpoint of the Websocket APIs hosted in this API Gateway -->
                 <GatewayWSEndpoint>ws://${carbon.local.ip}:9099</GatewayWSEndpoint>
+                <!-- Endpoint of the WebSub APIs hosted in this API Gateway -->
+                <GatewayWebSubEndpoint>http://${carbon.local.ip}:9021</GatewayWebSubEndpoint>
             </Environment>
         </Environments>
     </APIGateway>

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/package.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/package.json
@@ -60,6 +60,7 @@
         "react-autosuggest": "^9.3.4",
         "react-circular-progressbar": "^2.0.2",
         "react-color": "^2.17.3",
+        "react-copy-to-clipboard": "^5.0.1",
         "react-diff-viewer": "^3.1.1",
         "react-draft-wysiwyg": "^1.13.2",
         "react-dropzone": "^v10.1.7",

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -63,7 +63,7 @@ import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import API from 'AppData/api';
 import { ConfirmDialog } from 'AppComponents/Shared/index';
 import { useRevisionContext } from 'AppComponents/Shared/RevisionContext';
-import CONSTS from 'AppData/Constants';
+import Utils from 'AppData/Utils';
 import DisplayDevportal from './DisplayDevportal';
 
 const useStyles = makeStyles((theme) => ({
@@ -326,19 +326,7 @@ export default function Environments() {
 
     // allEnvDeployments represents all deployments of the API with mapping
     // environment -> {revision deployed to env, vhost deployed to env with revision}
-    const allEnvDeployments = [];
-    settings.environment.forEach((env) => {
-        const revision = allEnvRevision && allEnvRevision.find(
-            (r) => r.deploymentInfo.some((e) => e.name === env.name),
-        );
-        const envDetails = revision && revision.deploymentInfo.find((e) => e.name === env.name);
-        const disPlayDevportal = envDetails && envDetails.displayOnDevportal;
-        let vhost = envDetails && env.vhosts && env.vhosts.find((e) => e.host === envDetails.vhost);
-        if (!vhost) { // if vhost is deleted after deploying the revision, there is no matching vhost
-            vhost = { ...CONSTS.DEFAULT_VHOST, host: envDetails && envDetails.vhost };
-        }
-        allEnvDeployments[env.name] = { revision, vhost, disPlayDevportal };
-    });
+    const allEnvDeployments = Utils.getAllEnvironmentDeployments(settings.environment, allEnvRevision);
 
     const toggleOpenConfirmDelete = (revisionName, revisionId) => {
         setRevisionToDelete([revisionName, revisionId]);

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Constants.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Constants.js
@@ -36,6 +36,8 @@ const CONSTS = {
         httpsPort: 443,
         wsPort: 9099,
         wssPort: 8099,
+        websubHttpPort: 9021,
+        websubHttpsPort: 8021,
     },
 };
 

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/data/Utils.js
@@ -16,6 +16,8 @@
  * under the License.
  */
 
+import CONSTS from 'AppData/Constants';
+
 /**
  * Utility class for Publisher application
  */
@@ -425,6 +427,25 @@ class Utils {
         }
 
         return username;
+    }
+
+    static getAllEnvironmentDeployments(environments, allEnvRevision) {
+        // allEnvDeployments represents all deployments of the API with mapping
+        // environment -> {revision deployed to env, vhost deployed to env with revision}
+        const allEnvDeployments = [];
+        environments.forEach((env) => {
+            const revision = allEnvRevision && allEnvRevision.find(
+                (r) => r.deploymentInfo.some((e) => e.name === env.name),
+            );
+            const envDetails = revision && revision.deploymentInfo.find((e) => e.name === env.name);
+            const disPlayDevportal = envDetails && envDetails.displayOnDevportal;
+            let vhost = envDetails && env.vhosts && env.vhosts.find((e) => e.host === envDetails.vhost);
+            if (!vhost) { // if vhost is deleted after deploying the revision, there is no matching vhost
+                vhost = { ...CONSTS.DEFAULT_VHOST, host: envDetails && envDetails.vhost };
+            }
+            allEnvDeployments[env.name] = { revision, vhost, disPlayDevportal };
+        });
+        return allEnvDeployments;
     }
 }
 


### PR DESCRIPTION
## Purpose
The following properties are added to `deployment.toml`, to configure WebSub event receiver HTTP endpoint and HTTPS endpoint.
```toml
[[apim.gateway.environment]]
######## other properties ########
websub_event_receiver_http_endpoint = "http://localhost:7788"
websub_event_receiver_https_endpoint = "https://localhost:7789"
```
- Load these configurations and show WebSub event receiver endpoint URLs (Fixes https://github.com/wso2/product-apim/issues/10756 , Fixes https://github.com/wso2/product-apim/issues/10754).
- Add Copy to Clipboard button to the above (Fixes https://github.com/wso2/product-apim/issues/10360).

<img width="1452" alt="Screen Shot 2021-04-11 at 6 58 32 PM" src="https://user-images.githubusercontent.com/24828296/114306064-41b6d480-9af8-11eb-8475-7543e993e7ce.png">

## Related PRs
https://github.com/wso2/product-apim/pull/10956