### PR TITLE
Update gateway env name validation regex to avoid unicode

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/EnvironmentDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/EnvironmentDTO.java
@@ -58,7 +58,7 @@ public class EnvironmentDTO   {
   @ApiModelProperty(example = "us-region", required = true, value = "")
   @JsonProperty("name")
   @NotNull
- @Pattern(regexp="(^[^~!@#;:%^*()+={}|\\\\<>\"',&$\\s+]*$)") @Size(min=1,max=255)  public String getName() {
+ @Pattern(regexp="^[a-zA-Z0-9_-]+$") @Size(min=1,max=255)  public String getName() {
     return name;
   }
   public void setName(String name) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -3806,7 +3806,7 @@ components:
         name:
           maxLength: 255
           minLength: 1
-          pattern: '(^[^~!@#;:%^*()+={}|\\<>"'',&$\s+]*$)'
+          pattern: '^[a-zA-Z0-9_-]+$'
           type: string
           example: us-region
         displayName:

--- a/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.admin.feature/src/main/resources/admin/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
@@ -166,11 +166,11 @@ function AddEditGWEnvironment(props) {
                             defaultMessage: 'Name is Empty',
                         })
                     );
-                } else if (/[!@#$%^&*(),?"{}[\]|<>\t\n]/i.test(value)) {
+                } else if (!(/^[A-Za-z0-9_-]+$/).test(value)) {
                     error = (
                         intl.formatMessage({
                             id: 'GatewayEnvironments.AddEditGWEnvironment.form.environment.name.invalid',
-                            defaultMessage: 'Name field contains special characters',
+                            defaultMessage: 'Name must not contain special characters or spaces',
                         })
                     );
                 } else {


### PR DESCRIPTION
$subject

Fixes https://github.com/wso2/product-apim/issues/10578 
Fixes https://github.com/wso2/product-apim/issues/10573

Workflow : https://github.com/SuKSW/carbon-apimgt/runs/2317817809?check_suite_focus=true