### PR TITLE
Improve error handling when protocol is not given in Async API Service Definition

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -454,7 +454,9 @@ public enum ExceptionCodes implements ErrorHandler {
     SERVICE_IMPORT_FAILED_WITHOUT_OVERWRITE(900910, "Service import is failed" , 412, "Cannot update existing services " +
                                                     "when overwrite is false"),
     MISSING_PROTOCOL_IN_ASYNC_API_DEFINITION(900911, "Missing protocol in Async API Definition", 400,
-            "Missing protocol in Async API Definition");
+            "Missing protocol in Async API Definition"),
+    UNSUPPORTED_PROTOCOL_SPECIFIED_IN_ASYNC_API_DEFINITION(900912, "Unsupported protocol specified in Async API " +
+               "Definition", 400, "Unsupported protocol specified in Async API Definition");
 
     private final long errorCode;
     private final String errorMessage;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -802,7 +802,7 @@ public class PublisherCommonUtils {
             throws APIManagementException {
         if (ServiceEntry.DefinitionType.ASYNC_API.equals(definitionType)) {
             if (protocol.isEmpty()) {
-                throw new APIManagementException("A protocol should be specified in the ASync API definition",
+                throw new APIManagementException("A protocol should be specified in the Async API definition",
                         ExceptionCodes.MISSING_PROTOCOL_IN_ASYNC_API_DEFINITION);
             } else if (!APIConstants.API_TYPE_WEBSUB.equals(protocol.toUpperCase()) &&
                     !APIConstants.API_TYPE_SSE.equals(protocol.toUpperCase()) &&

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -798,8 +798,20 @@ public class PublisherCommonUtils {
         return sb.toString();
     }
 
-    public static APIDTO.TypeEnum getAPIType(ServiceEntry.DefinitionType definitionType, String protocol) {
+    public static APIDTO.TypeEnum getAPIType(ServiceEntry.DefinitionType definitionType, String protocol)
+            throws APIManagementException {
+        if (ServiceEntry.DefinitionType.ASYNC_API.equals(definitionType)) {
+            if (protocol.isEmpty()) {
+                throw new APIManagementException("A protocol should be specified in the ASync API definition",
+                        ExceptionCodes.MISSING_PROTOCOL_IN_ASYNC_API_DEFINITION);
+            } else if (!APIConstants.API_TYPE_WEBSUB.equals(protocol.toUpperCase()) &&
+                    !APIConstants.API_TYPE_SSE.equals(protocol.toUpperCase()) &&
+                    !APIConstants.API_TYPE_WS.equals(protocol.toUpperCase())) {
+                throw new APIManagementException("Unsupported protocol specified in Async API Definition",
+                        ExceptionCodes.UNSUPPORTED_PROTOCOL_SPECIFIED_IN_ASYNC_API_DEFINITION);
+            }
 
+        }
         switch (definitionType) {
             case WSDL1:
             case WSDL2:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -4753,10 +4753,10 @@ public class ApisApiServiceImpl implements ApisApiService {
         } catch (APIManagementException e) {
             if (ExceptionCodes.MISSING_PROTOCOL_IN_ASYNC_API_DEFINITION.getErrorCode() == e.getErrorHandler()
                     .getErrorCode()) {
-                RestApiUtil.handleBadRequest("Missing protocol in Async API Definition", log);
+                RestApiUtil.handleBadRequest("Missing protocol in the Service Definition", log);
             } else if (ExceptionCodes.UNSUPPORTED_PROTOCOL_SPECIFIED_IN_ASYNC_API_DEFINITION.getErrorCode() ==
                     e.getErrorHandler().getErrorCode()) {
-                RestApiUtil.handleBadRequest("Unsupported protocol specified in Async API Definition. Protocol " +
+                RestApiUtil.handleBadRequest("Unsupported protocol specified in the Service Definition. Protocol " +
                         "should be either sse or websub or ws", log);
             }
             RestApiUtil.handleInternalServerError("Error while retrieving the service key of the service " +

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -4753,7 +4753,11 @@ public class ApisApiServiceImpl implements ApisApiService {
         } catch (APIManagementException e) {
             if (ExceptionCodes.MISSING_PROTOCOL_IN_ASYNC_API_DEFINITION.getErrorCode() == e.getErrorHandler()
                     .getErrorCode()) {
-                RestApiUtil.handleInternalServerError("Missing protocol in Async API Definition", log);
+                RestApiUtil.handleBadRequest("Missing protocol in Async API Definition", log);
+            } else if (ExceptionCodes.UNSUPPORTED_PROTOCOL_SPECIFIED_IN_ASYNC_API_DEFINITION.getErrorCode() ==
+                    e.getErrorHandler().getErrorCode()) {
+                RestApiUtil.handleBadRequest("Unsupported protocol specified in Async API Definition. Protocol " +
+                        "should be either sse or websub or ws", log);
             }
             RestApiUtil.handleInternalServerError("Error while retrieving the service key of the service " +
                     "associated with API with id " + apiId, log);


### PR DESCRIPTION
This pr improves error handling when protocol is not given in Async API Service Definition. Related issue - https://github.com/wso2/product-apim/issues/10933

Fixes: https://github.com/wso2/product-apim/issues/10970