### PR TITLE
Fix issue with doc content indexing

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2332,6 +2332,11 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 }
                 RegistryPersistenceUtil.setResourcePermissions(apiProviderName, visibility, authorizedRoles,
                         contentPath, registry);
+                GenericArtifact updateDocArtifact = RegistryPersistenceDocUtil.createDocArtifactContent(docArtifact,
+                        apiProviderName, apiName, apiVersion, doc);
+                Boolean toggle = Boolean.parseBoolean(updateDocArtifact.getAttribute("toggle"));
+                updateDocArtifact.setAttribute("toggle", Boolean.toString(!toggle));
+                docArtifactManager.updateGenericArtifact(updateDocArtifact);
             } 
         } catch (APIPersistenceException | RegistryException | APIManagementException | PersistenceException
                 | UserStoreException e) {


### PR DESCRIPTION
Fixes https://github.com/wso2/product-apim/issues/10946

Approach :

* Here I have introduced a new toggle field (within the code, the field does not need to be added to document rxt)
* The issue earlier was because the document indexer did not get invoked because there was no change on the actual document artifact upon a document content update.
* The new toggle field will contain a boolean value which will be inverted each time a new document content update is done, thus a change in underlying document artifact and the document indexer will get triggered.