### PR TITLE
Fix showing download postman collection and OpenAPI for SOAP APIs

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -475,30 +475,32 @@ class ApiConsole extends React.Component {
                         api={this.state.api}
                     />
 
-                    <Grid container>
-                        <Grid xs={8} item />
-                        <Grid xs={2} item>
-                            <Button size='small' onClick={() => this.convertToPostman(downloadSwagger)}>
-                                <Icons icon={postmanIcon} width={30} height={30} className={classes.buttonIcon} />
-                                <FormattedMessage
-                                    id='Apis.Details.APIConsole.APIConsole.download.postman'
-                                    defaultMessage='Postman collection'
-                                />
-                            </Button>
-
-                        </Grid>
-                        <Grid xs={2} item>
-                            <a href={downloadLink} download={fileName}>
-                                <Button size='small'>
-                                    <Icons icon={openapiinitiativeIcon} width={30} height={30} className={classes.buttonIcon} />
+                    {api.type !== 'SOAP' && (
+                        <Grid container>
+                            <Grid xs={8} item />
+                            <Grid xs={2} item>
+                                <Button size='small' onClick={() => this.convertToPostman(downloadSwagger)}>
+                                    <Icons icon={postmanIcon} width={30} height={30} className={classes.buttonIcon} />
                                     <FormattedMessage
-                                        id='Apis.Details.APIConsole.APIConsole.download.swagger'
-                                        defaultMessage='OpenAPI'
+                                        id='Apis.Details.APIConsole.APIConsole.download.postman'
+                                        defaultMessage='Postman collection'
                                     />
                                 </Button>
-                            </a>
+
+                            </Grid>
+                            <Grid xs={2} item>
+                                <a href={downloadLink} download={fileName}>
+                                    <Button size='small'>
+                                        <Icons icon={openapiinitiativeIcon} width={30} height={30} className={classes.buttonIcon} />
+                                        <FormattedMessage
+                                            id='Apis.Details.APIConsole.APIConsole.download.swagger'
+                                            defaultMessage='OpenAPI'
+                                        />
+                                    </Button>
+                                </a>
+                            </Grid>
                         </Grid>
-                    </Grid>
+                    )}
                 </Paper>
                 <Paper className={classes.swaggerUIPaper}>
                     <SwaggerUI


### PR DESCRIPTION
### Purpose
Fixes: https://github.com/wso2/product-apim/issues/10953

### Goals
Prevent showing 'Postman Collection' and 'OpenAPI' download options for SOAP APIs in devportal

### Approach
Checked the type of API before rendering these buttons