### PR TITLE
Remove download postman collection button for GraphQL APIs

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/GraphQLConsole/GraphQLConsole.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/GraphQLConsole/GraphQLConsole.jsx
@@ -25,9 +25,6 @@ import { FormattedMessage } from 'react-intl';
 import { makeStyles } from '@material-ui/core/styles';
 import AuthManager from 'AppData/AuthManager';
 import Icon from '@material-ui/core/Icon';
-import { Icon as Icons } from '@iconify/react';
-import postmanIcon from '@iconify/icons-simple-icons/postman';
-import Button from '@material-ui/core/Button';
 import fileDownload from 'js-file-download';
 import converter from 'graphql-to-postman';
 import GraphQLUI from './GraphQLUI';
@@ -36,7 +33,6 @@ import { ApiContext } from '../ApiContext';
 import Api from '../../../../data/api';
 import Progress from '../../../Shared/Progress';
 
-let graphQLSchema;
 
 const useStyles = makeStyles((theme) => ({
     buttonIcon: {
@@ -179,9 +175,6 @@ export default function GraphQLConsole() {
             }
         });
     }
-    function handleSchema(schema) {
-        graphQLSchema = schema;
-    }
 
     if (api == null) {
         return <Progress />;
@@ -256,22 +249,6 @@ export default function GraphQLConsole() {
                     environmentObject={environmentObject}
                     api={api}
                 />
-                <Paper />
-                <Grid container>
-                    <Grid xs={11} item />
-                    <Grid xs={1} item>
-                        <Button size='small' onClick={() => grapgQLToPostman(graphQLSchema, URLs)}>
-                            <Icons icon={postmanIcon} width={30} height={30} />
-                            <FormattedMessage
-                                id='Apis.Details.GraphQLConsole.GraphQLConsole.download.postman'
-                                defaultMessage='Postman collection'
-                            />
-
-                        </Button>
-
-                    </Grid>
-
-                </Grid>
             </Paper>
             <Paper className={classes.paper}>
                 <GraphQLUI
@@ -279,7 +256,6 @@ export default function GraphQLConsole() {
                     URLs={URLs}
                     securitySchemeType={securitySchemeType}
                     accessTokenProvider={accessTokenProvider}
-                    handleSchema={handleSchema}
                 />
             </Paper>
         </>

--- a/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/GraphQLConsole/GraphQLUI.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.store.feature/src/main/resources/devportal/source/src/app/components/Apis/Details/GraphQLConsole/GraphQLUI.jsx
@@ -46,7 +46,6 @@ export default function GraphQLUI(props) {
         URLs,
         securitySchemeType,
         accessTokenProvider,
-        handleSchema,
 
     } = props;
     const { api } = useContext(ApiContext);
@@ -64,7 +63,6 @@ export default function GraphQLUI(props) {
             .then((res) => {
                 const graphqlSchemaObj = buildSchema(res.data);
                 setSchema(graphqlSchemaObj);
-                handleSchema(res.data);
             });
     }, []);
 


### PR DESCRIPTION
### Purpose
Fixes: https://github.com/wso2/product-apim/issues/10976

### Goals
Remove 'Postman Collection' download option for GraphQL APIs in devportal.

### Approach
Removed GraphQL schema processing from `GraphQLConsole`.
