### PR TITLE
Add new scopes to tenant-conf.json

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -293,6 +293,22 @@
       {
         "Name": "apim:environment_read",
         "Roles": "admin"
+      },
+      {
+        "Name": "service_catalog:service_view",
+        "Roles": "admin,Internal/creator,Internal/publisher"
+      },
+      {
+        "Name": "service_catalog:service_write",
+        "Roles": "admin,Internal/creator"
+      },
+      {
+        "Name": "apim:comment_view",
+        "Roles": "admin,Internal/creator,Internal/publisher"
+      },
+      {
+        "Name": "apim:comment_write",
+        "Roles": "admin,Internal/creator,Internal/publisher"
       }
     ]
   },


### PR DESCRIPTION
Adds scopes related to service-catalog and comments are not added to tenant-conf.json. Fixes https://github.com/wso2/product-apim/issues/11041