### PR TITLE
Fixing certs import issue when both the deployment and source repos have certs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -923,6 +923,14 @@ public class APIControllerUtil {
         //generate meta-data yaml file
         String metadataFilePath = pathToArchive + ImportExportConstants.CLIENT_CERTIFICATES_META_DATA_FILE_PATH;
         try {
+            if (CommonUtil.checkFileExistence(metadataFilePath + ImportExportConstants.YAML_EXTENSION)) {
+                File oldFile = new File(metadataFilePath + ImportExportConstants.YAML_EXTENSION);
+                oldFile.delete();
+            }
+            if (CommonUtil.checkFileExistence(metadataFilePath + ImportExportConstants.JSON_EXTENSION)) {
+                File oldFile = new File(metadataFilePath + ImportExportConstants.JSON_EXTENSION);
+                oldFile.delete();
+            }
             CommonUtil.writeDtoToFile(metadataFilePath, ExportFormat.JSON,
                     ImportExportConstants.TYPE_CLIENT_CERTIFICATES, jsonElement);
         } catch (APIImportExportException e) {
@@ -984,6 +992,14 @@ public class APIControllerUtil {
         //generate meta-data yaml file
         String metadataFilePath = pathToArchive + ImportExportConstants.ENDPOINT_CERTIFICATES_META_DATA_FILE_PATH;
         try {
+            if (CommonUtil.checkFileExistence(metadataFilePath + ImportExportConstants.YAML_EXTENSION)) {
+                File oldFile = new File(metadataFilePath + ImportExportConstants.YAML_EXTENSION);
+                oldFile.delete();
+            }
+            if (CommonUtil.checkFileExistence(metadataFilePath + ImportExportConstants.JSON_EXTENSION)) {
+                File oldFile = new File(metadataFilePath + ImportExportConstants.JSON_EXTENSION);
+                oldFile.delete();
+            }
             CommonUtil.writeDtoToFile(metadataFilePath, ExportFormat.JSON,
                     ImportExportConstants.TYPE_ENDPOINT_CERTIFICATES, updatedCertsArray);
         } catch (APIImportExportException e) {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/697

## Goals
Fixing the issue of certificates are not getting imported when both the deployment and source repos have certs

## Approach
- Deleted the existing certificates meta files before writing the new meta files in **APIControllerUtil.java**
- Ran all the apictl integration tests and got passed.
  ![image](https://user-images.githubusercontent.com/25246848/115060802-ede82900-9f05-11eb-8a13-830bda0fc115.png)

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS
