### PR TITLE
Fix Streaming Integrator Doc link not mentioned in the Service Catalog view

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
@@ -7898,13 +7898,19 @@
   "ServiceCatalog.Listing.Onboarding.learn.heading.text": [
     {
       "type": 0,
-      "value": "Create and Deploy your first Integration Service"
+      "value": "Create and Deploy your first Integration Service with WSO2 Micro Integrator or Streaming Integrator"
     }
   ],
-  "ServiceCatalog.Listing.Onboarding.learn.link": [
+  "ServiceCatalog.Listing.Onboarding.learn.link.micro.integrator": [
     {
       "type": 0,
-      "value": "Get Started"
+      "value": "Micro Integrator"
+    }
+  ],
+  "ServiceCatalog.Listing.Onboarding.learn.link.streaming.integrator": [
+    {
+      "type": 0,
+      "value": "Streaming Integrator"
     }
   ],
   "ServiceCatalog.Listing.Onboarding.sample.add": [

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/raw.en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/raw.en.json
@@ -3766,10 +3766,13 @@
     "defaultMessage": "Integration Service"
   },
   "ServiceCatalog.Listing.Onboarding.learn.heading.text": {
-    "defaultMessage": "Create and Deploy your first Integration Service"
+    "defaultMessage": "Create and Deploy your first Integration Service with WSO2 Micro Integrator or Streaming Integrator"
   },
-  "ServiceCatalog.Listing.Onboarding.learn.link": {
-    "defaultMessage": "Get Started"
+  "ServiceCatalog.Listing.Onboarding.learn.link.micro.integrator": {
+    "defaultMessage": "Micro Integrator"
+  },
+  "ServiceCatalog.Listing.Onboarding.learn.link.streaming.integrator": {
+    "defaultMessage": "Streaming Integrator"
   },
   "ServiceCatalog.Listing.Onboarding.sample.add": {
     "defaultMessage": "Add Sample Service"

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
@@ -101,13 +101,29 @@ function Onboarding() {
                     description={(
                         <FormattedMessage
                             id='ServiceCatalog.Listing.Onboarding.learn.heading.text'
-                            defaultMessage='Create and Deploy your first Integration Service'
+                            defaultMessage={'Create and Deploy your first Integration Service with WSO2 Micro'
+                            + ' Integrator or Streaming Integrator'}
                         />
                     )}
                 >
+                    &nbsp;&nbsp;
                     <Button
                         className={classes.actionStyle}
-                        size='large'
+                        size='small'
+                        variant='outlined'
+                        color='primary'
+                        href='https://apim.docs.wso2.com/en/4.0.0/design/create-api/create-an-api-using-a-service/'
+                        endIcon={<LaunchIcon style={{ fontSize: 15 }} />}
+                    >
+                        <FormattedMessage
+                            id='ServiceCatalog.Listing.Onboarding.learn.link.micro.integrator'
+                            defaultMessage='Micro Integrator'
+                        />
+                    </Button>
+                    &nbsp;&nbsp;
+                    <Button
+                        className={classes.actionStyle}
+                        size='small'
                         variant='outlined'
                         color='primary'
                         href='https://apim.docs.wso2.com/en/4.0.0/design/create-api/create-an-api-using-a-service/'
@@ -116,10 +132,11 @@ function Onboarding() {
                         endIcon={<LaunchIcon style={{ fontSize: 15 }} />}
                     >
                         <FormattedMessage
-                            id='ServiceCatalog.Listing.Onboarding.learn.link'
-                            defaultMessage='Get Started'
+                            id='ServiceCatalog.Listing.Onboarding.learn.link.streaming.integrator'
+                            defaultMessage='Streaming Integrator'
                         />
                     </Button>
+                    &nbsp;&nbsp;
                 </OnboardingMenuCard>
                 {/* Deploy Sample Service */}
                 <OnboardingMenuCard

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
@@ -106,7 +106,6 @@ function Onboarding() {
                         />
                     )}
                 >
-                    {' '}
                     <Button
                         style={{ marginLeft: '10px' }}
                         className={classes.actionStyle}
@@ -121,7 +120,6 @@ function Onboarding() {
                             defaultMessage='Micro Integrator'
                         />
                     </Button>
-                    {' '}
                     <Button
                         style={{ marginLeft: '10px', marginRight: '10px' }}
                         className={classes.actionStyle}
@@ -139,7 +137,6 @@ function Onboarding() {
                             defaultMessage='Streaming Integrator'
                         />
                     </Button>
-                    {' '}
                 </OnboardingMenuCard>
                 {/* Deploy Sample Service */}
                 <OnboardingMenuCard

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
@@ -126,7 +126,8 @@ function Onboarding() {
                         size='small'
                         variant='outlined'
                         color='primary'
-                        href='https://apim.docs.wso2.com/en/4.0.0/design/create-api/create-an-api-using-a-service/'
+                        href={'https://apim.docs.wso2.com/en/4.0.0/use-cases/streaming-usecase/'
+                        + 'exposing-stream-as-managed-api-in-service-catalog/'}
                         target='_blank'
                         rel='noopener noreferrer'
                         endIcon={<LaunchIcon style={{ fontSize: 15 }} />}

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
@@ -108,6 +108,7 @@ function Onboarding() {
                 >
                     {' '}
                     <Button
+                        style={{ marginLeft: '10px' }}
                         className={classes.actionStyle}
                         size='small'
                         variant='outlined'
@@ -122,6 +123,7 @@ function Onboarding() {
                     </Button>
                     {' '}
                     <Button
+                        style={{ marginLeft: '10px', marginRight: '10px' }}
                         className={classes.actionStyle}
                         size='small'
                         variant='outlined'

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
@@ -106,7 +106,7 @@ function Onboarding() {
                         />
                     )}
                 >
-                    &nbsp;&nbsp;
+                    {' '}
                     <Button
                         className={classes.actionStyle}
                         size='small'
@@ -120,7 +120,7 @@ function Onboarding() {
                             defaultMessage='Micro Integrator'
                         />
                     </Button>
-                    &nbsp;&nbsp;
+                    {' '}
                     <Button
                         className={classes.actionStyle}
                         size='small'
@@ -137,7 +137,7 @@ function Onboarding() {
                             defaultMessage='Streaming Integrator'
                         />
                     </Button>
-                    &nbsp;&nbsp;
+                    {' '}
                 </OnboardingMenuCard>
                 {/* Deploy Sample Service */}
                 <OnboardingMenuCard

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
@@ -36,6 +36,18 @@ const useStyles = makeStyles((theme) => ({
         paddingLeft: theme.spacing(4),
         paddingRight: theme.spacing(4),
     },
+    actionStyleGetStartedMI: {
+        marginLeft: theme.spacing(1),
+        marginRight: theme.spacing(0.5),
+        paddingLeft: theme.spacing(3),
+        paddingRight: theme.spacing(3),
+    },
+    actionStyleGetStartedSI: {
+        marginLeft: theme.spacing(0.5),
+        marginRight: theme.spacing(1),
+        paddingLeft: theme.spacing(3),
+        paddingRight: theme.spacing(3),
+    },
 }));
 
 /**
@@ -107,8 +119,7 @@ function Onboarding() {
                     )}
                 >
                     <Button
-                        style={{ marginLeft: '10px' }}
-                        className={classes.actionStyle}
+                        className={classes.actionStyleGetStartedMI}
                         size='small'
                         variant='outlined'
                         color='primary'
@@ -121,8 +132,7 @@ function Onboarding() {
                         />
                     </Button>
                     <Button
-                        style={{ marginLeft: '10px', marginRight: '10px' }}
-                        className={classes.actionStyle}
+                        className={classes.actionStyleGetStartedSI}
                         size='small'
                         variant='outlined'
                         color='primary'


### PR DESCRIPTION
## Purpose

- This PR fixes https://github.com/wso2/product-apim/issues/10851
- This PR adds a button to navigate to the documentation related to streaming integrator

## Approach

![Screenshot from 2021-04-19 07-58-57](https://user-images.githubusercontent.com/35601987/115173529-209c4800-a0e5-11eb-8516-7b3417a0733b.png)
