### PR TITLE
Fix onboarding page permissions for publisher user

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/en.json
@@ -6701,6 +6701,18 @@
       "value": "Version"
     }
   ],
+  "Apis.Listing.Landing.Menus.RestAPIMenu.no.permission": [
+    {
+      "type": 0,
+      "value": "You do not have enough permission to create an API"
+    }
+  ],
+  "Apis.Listing.Landing.Menus.SoapAPIMenu.no.permission": [
+    {
+      "type": 0,
+      "value": "You do not have enough permission to create an API"
+    }
+  ],
   "Apis.Listing.SampleAPI.SampleAPI.create.new": [
     {
       "type": 0,
@@ -6729,6 +6741,12 @@
     {
       "type": 0,
       "value": "Import GraphQL SDL"
+    }
+  ],
+  "Apis.Listing.SampleAPI.SampleAPI.graphql.no permission": [
+    {
+      "type": 0,
+      "value": "You do not have enough permission to create an API"
     }
   ],
   "Apis.Listing.SampleAPI.SampleAPI.rest.api": [

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/raw.en.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/site/public/locales/raw.en.json
@@ -3180,6 +3180,12 @@
   "Apis.Listing.ApiThumb.version": {
     "defaultMessage": "Version"
   },
+  "Apis.Listing.Landing.Menus.RestAPIMenu.no.permission": {
+    "defaultMessage": "You do not have enough permission to create an API"
+  },
+  "Apis.Listing.Landing.Menus.SoapAPIMenu.no.permission": {
+    "defaultMessage": "You do not have enough permission to create an API"
+  },
   "Apis.Listing.SampleAPI.SampleAPI.create.new": {
     "defaultMessage": "Let’s get started !"
   },
@@ -3194,6 +3200,9 @@
   },
   "Apis.Listing.SampleAPI.SampleAPI.graphql.import.sdl.title": {
     "defaultMessage": "Import GraphQL SDL"
+  },
+  "Apis.Listing.SampleAPI.SampleAPI.graphql.no permission": {
+    "defaultMessage": "You do not have enough permission to create an API"
   },
   "Apis.Listing.SampleAPI.SampleAPI.rest.api": {
     "defaultMessage": "REST API"

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Landing/Menus/GraphqlAPIMenu.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Landing/Menus/GraphqlAPIMenu.jsx
@@ -21,9 +21,11 @@ import { FormattedMessage } from 'react-intl';
 import LandingMenuItem from 'AppComponents/Apis/Listing/Landing/components/LandingMenuItem';
 import LandingMenu from 'AppComponents/Apis/Listing/Landing/components/LandingMenu';
 import APICreateMenuSection from 'AppComponents/Apis/Listing/components/APICreateMenuSection';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
 
 const GraphqlAPIMenu = (props) => {
-    const { icon, isCreateMenu } = props;
+    const { icon, isCreateMenu, isDisabled } = props;
     const Component = isCreateMenu ? APICreateMenuSection : LandingMenu;
     const dense = isCreateMenu;
 
@@ -38,22 +40,36 @@ const GraphqlAPIMenu = (props) => {
             )}
             icon={icon}
         >
-            <LandingMenuItem
-                dense={dense}
-                id='itest-id-create-graphql-api'
-                linkTo='/apis/create/graphQL'
-                helperText={(
+            {!isDisabled ? (
+                <LandingMenuItem
+                    dense={dense}
+                    id='itest-id-create-graphql-api'
+                    linkTo='/apis/create/graphQL'
+                    helperText={(
+                        <FormattedMessage
+                            id='Apis.Listing.SampleAPI.SampleAPI.graphql.import.sdl.content'
+                            defaultMessage='Use an existing definition'
+                        />
+                    )}
+                >
                     <FormattedMessage
-                        id='Apis.Listing.SampleAPI.SampleAPI.graphql.import.sdl.content'
-                        defaultMessage='Use an existing definition'
+                        id='Apis.Listing.SampleAPI.SampleAPI.graphql.import.sdl.title'
+                        defaultMessage='Import GraphQL SDL'
                     />
-                )}
-            >
-                <FormattedMessage
-                    id='Apis.Listing.SampleAPI.SampleAPI.graphql.import.sdl.title'
-                    defaultMessage='Import GraphQL SDL'
-                />
-            </LandingMenuItem>
+                </LandingMenuItem>
+            ) : (
+                <Grid
+                    item
+                    xs={12}
+                >
+                    <Typography align='center' variant='body1'>
+                        <FormattedMessage
+                            id='Apis.Listing.SampleAPI.SampleAPI.graphql.no permission'
+                            defaultMessage='You do not have enough permission to create an API'
+                        />
+                    </Typography>
+                </Grid>
+            )}
         </Component>
     );
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Landing/Menus/RestAPIMenu.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Landing/Menus/RestAPIMenu.jsx
@@ -24,12 +24,14 @@ import LandingMenu from 'AppComponents/Apis/Listing/Landing/components/LandingMe
 import APICreateMenuSection from 'AppComponents/Apis/Listing/components/APICreateMenuSection';
 import SampleAPI from 'AppComponents/Apis/Listing/SampleAPI/SampleAPI';
 import Divider from '@material-ui/core/Divider';
+import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 import Configurations from 'Config';
 import API from 'AppData/api';
+import Grid from '@material-ui/core/Grid';
 
 const RestAPIMenu = (props) => {
-    const { icon, isCreateMenu } = props;
+    const { icon, isCreateMenu, isDisabled } = props;
     const Component = isCreateMenu ? APICreateMenuSection : LandingMenu;
     const dense = isCreateMenu;
     const { alwaysShowDeploySampleButton } = Configurations.apis;
@@ -61,46 +63,62 @@ const RestAPIMenu = (props) => {
             )}
             icon={icon}
         >
-            <LandingMenuItem
-                dense={dense}
-                id='itest-id-landing-rest-create-default'
-                linkTo='/apis/create/rest'
-                helperText={(
-                    <FormattedMessage
-                        id='Apis.Listing.SampleAPI.SampleAPI.rest.api.scratch.content'
-                        defaultMessage='Design and prototype a new REST API'
-                    />
-                )}
-            >
-                <FormattedMessage
-                    id='Apis.Listing.SampleAPI.SampleAPI.rest.api.scratch.title'
-                    defaultMessage='Start From Scratch'
-                />
-            </LandingMenuItem>
-
-            <LandingMenuItem
-                dense={dense}
-                id='itest-id-landing-upload-oas'
-                linkTo='/apis/create/openapi'
-                helperText={(
-                    <FormattedMessage
-                        id='Apis.Listing.SampleAPI.SampleAPI.rest.api.import.open.content'
-                        defaultMessage='Import OAS 3 or Swagger 2.0 definition'
-                    />
-                )}
-            >
-                <FormattedMessage
-                    id='Apis.Listing.SampleAPI.SampleAPI.rest.api.import.open.title'
-                    defaultMessage='Import Open API'
-                />
-            </LandingMenuItem>
-            {(!isCreateMenu || (isCreateMenu && alwaysShowDeploySampleButton)) && showSampleDeploy && (
+            {!isDisabled ? (
                 <>
-                    <Box width={1}>
-                        <Divider light variant='middle' />
-                    </Box>
-                    <SampleAPI dense={dense} />
+                    <LandingMenuItem
+                        dense={dense}
+                        id='itest-id-landing-rest-create-default'
+                        linkTo='/apis/create/rest'
+                        helperText={(
+                            <FormattedMessage
+                                id='Apis.Listing.SampleAPI.SampleAPI.rest.api.scratch.content'
+                                defaultMessage='Design and prototype a new REST API'
+                            />
+                        )}
+                    >
+                        <FormattedMessage
+                            id='Apis.Listing.SampleAPI.SampleAPI.rest.api.scratch.title'
+                            defaultMessage='Start From Scratch'
+                        />
+                    </LandingMenuItem>
+
+                    <LandingMenuItem
+                        dense={dense}
+                        id='itest-id-landing-upload-oas'
+                        linkTo='/apis/create/openapi'
+                        helperText={(
+                            <FormattedMessage
+                                id='Apis.Listing.SampleAPI.SampleAPI.rest.api.import.open.content'
+                                defaultMessage='Import OAS 3 or Swagger 2.0 definition'
+                            />
+                        )}
+                    >
+                        <FormattedMessage
+                            id='Apis.Listing.SampleAPI.SampleAPI.rest.api.import.open.title'
+                            defaultMessage='Import Open API'
+                        />
+                    </LandingMenuItem>
+                    {(!isCreateMenu || (isCreateMenu && alwaysShowDeploySampleButton)) && showSampleDeploy && (
+                        <>
+                            <Box width={1}>
+                                <Divider light variant='middle' />
+                            </Box>
+                            <SampleAPI dense={dense} />
+                        </>
+                    )}
                 </>
+            ) : (
+                <Grid
+                    item
+                    xs={12}
+                >
+                    <Typography align='center' variant='body1'>
+                        <FormattedMessage
+                            id='Apis.Listing.Landing.Menus.RestAPIMenu.no.permission'
+                            defaultMessage='You do not have enough permission to create an API'
+                        />
+                    </Typography>
+                </Grid>
             )}
         </Component>
     );

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Landing/Menus/SoapAPIMenu.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Landing/Menus/SoapAPIMenu.jsx
@@ -21,9 +21,11 @@ import { FormattedMessage } from 'react-intl';
 import LandingMenuItem from 'AppComponents/Apis/Listing/Landing/components/LandingMenuItem';
 import LandingMenu from 'AppComponents/Apis/Listing/Landing/components/LandingMenu';
 import APICreateMenuSection from 'AppComponents/Apis/Listing/components/APICreateMenuSection';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
 
 const SoapAPIMenu = (props) => {
-    const { icon, isCreateMenu } = props;
+    const { icon, isCreateMenu, isDisabled } = props;
 
     const Component = isCreateMenu ? APICreateMenuSection : LandingMenu;
     const dense = isCreateMenu;
@@ -38,22 +40,36 @@ const SoapAPIMenu = (props) => {
             )}
             icon={icon}
         >
-            <LandingMenuItem
-                dense={dense}
-                id='itest-id-create-soap-api'
-                linkTo='/apis/create/wsdl'
-                helperText={(
+            {!isDisabled ? (
+                <LandingMenuItem
+                    dense={dense}
+                    id='itest-id-create-soap-api'
+                    linkTo='/apis/create/wsdl'
+                    helperText={(
+                        <FormattedMessage
+                            id='Apis.Listing.SampleAPI.SampleAPI.soap.import.wsdl.content'
+                            defaultMessage='Generate REST or create a pass-through API'
+                        />
+                    )}
+                >
                     <FormattedMessage
-                        id='Apis.Listing.SampleAPI.SampleAPI.soap.import.wsdl.content'
-                        defaultMessage='Generate REST or create a pass-through API'
+                        id='Apis.Listing.SampleAPI.SampleAPI.soap.import.wsdl.title'
+                        defaultMessage='Import WSDL'
                     />
-                )}
-            >
-                <FormattedMessage
-                    id='Apis.Listing.SampleAPI.SampleAPI.soap.import.wsdl.title'
-                    defaultMessage='Import WSDL'
-                />
-            </LandingMenuItem>
+                </LandingMenuItem>
+            ) : (
+                <Grid
+                    item
+                    xs={12}
+                >
+                    <Typography align='center' variant='body1'>
+                        <FormattedMessage
+                            id='Apis.Listing.Landing.Menus.SoapAPIMenu.no.permission'
+                            defaultMessage='You do not have enough permission to create an API'
+                        />
+                    </Typography>
+                </Grid>
+            )}
         </Component>
     );
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Landing/Menus/StreamingAPIMenu.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Landing/Menus/StreamingAPIMenu.jsx
@@ -21,9 +21,11 @@ import { FormattedMessage } from 'react-intl';
 import LandingMenuItem from 'AppComponents/Apis/Listing/Landing/components/LandingMenuItem';
 import LandingMenu from 'AppComponents/Apis/Listing/Landing/components/LandingMenu';
 import APICreateMenuSection from 'AppComponents/Apis/Listing/components/APICreateMenuSection';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
 
 const StreamingAPIMenu = (props) => {
-    const { icon, isCreateMenu } = props;
+    const { icon, isCreateMenu, isDisabled } = props;
     const Component = isCreateMenu ? APICreateMenuSection : LandingMenu;
     const dense = isCreateMenu;
     return (
@@ -37,70 +39,86 @@ const StreamingAPIMenu = (props) => {
             )}
             icon={icon}
         >
-            <LandingMenuItem
-                dense={dense}
-                id='itest-id-create-streaming-api-ws'
-                linkTo='/apis/create/streamingapi/ws'
-                helperText={(
-                    <FormattedMessage
-                        id='Apis.Listing.SampleAPI.SampleAPI.streaming.design.new.ws.content'
-                        defaultMessage='Create a Web Socket API'
-                    />
-                )}
-            >
-                <FormattedMessage
-                    id='Apis.Listing.SampleAPI.SampleAPI.streaming.design.new.title'
-                    defaultMessage='Web Socket API'
-                />
-            </LandingMenuItem>
-            <LandingMenuItem
-                dense={dense}
-                id='itest-id-create-streaming-api-web-hook'
-                linkTo='/apis/create/streamingapi/websub'
-                helperText={(
-                    <FormattedMessage
-                        id='Apis.Listing.SampleAPI.SampleAPI.streaming.websub.content'
-                        defaultMessage='Create a Webhook/WebSub API'
-                    />
-                )}
-            >
-                <FormattedMessage
-                    id='Apis.Listing.SampleAPI.SampleAPI.streaming.websub.title'
-                    defaultMessage='Webhook API'
-                />
-            </LandingMenuItem>
-            <LandingMenuItem
-                dense={dense}
-                id='itest-id-create-streaming-api-sse'
-                linkTo='/apis/create/streamingapi/sse'
-                helperText={(
-                    <FormattedMessage
-                        id='Apis.Listing.SampleAPI.SampleAPI.streaming.sse.content'
-                        defaultMessage='Create a Server-Sent Events API'
-                    />
-                )}
-            >
-                <FormattedMessage
-                    id='Apis.Listing.SampleAPI.SampleAPI.streaming.sse.title'
-                    defaultMessage='SSE API'
-                />
-            </LandingMenuItem>
-            <LandingMenuItem
-                dense={dense}
-                id='itest-id-create-streaming-api-import'
-                linkTo='/apis/create/asyncapi'
-                helperText={(
-                    <FormattedMessage
-                        id='Apis.Listing.SampleAPI.SampleAPI.streaming.import.content'
-                        defaultMessage='Upload a file or provide an Async API URL'
-                    />
-                )}
-            >
-                <FormattedMessage
-                    id='Apis.Listing.SampleAPI.SampleAPI.streaming.import.title'
-                    defaultMessage='Import an AsyncAPI'
-                />
-            </LandingMenuItem>
+            {!isDisabled ? (
+                <>
+                    <LandingMenuItem
+                        dense={dense}
+                        id='itest-id-create-streaming-api-ws'
+                        linkTo='/apis/create/streamingapi/ws'
+                        helperText={(
+                            <FormattedMessage
+                                id='Apis.Listing.SampleAPI.SampleAPI.streaming.design.new.ws.content'
+                                defaultMessage='Create a Web Socket API'
+                            />
+                        )}
+                    >
+                        <FormattedMessage
+                            id='Apis.Listing.SampleAPI.SampleAPI.streaming.design.new.title'
+                            defaultMessage='Web Socket API'
+                        />
+                    </LandingMenuItem>
+                    <LandingMenuItem
+                        dense={dense}
+                        id='itest-id-create-streaming-api-web-hook'
+                        linkTo='/apis/create/streamingapi/websub'
+                        helperText={(
+                            <FormattedMessage
+                                id='Apis.Listing.SampleAPI.SampleAPI.streaming.websub.content'
+                                defaultMessage='Create a Webhook/WebSub API'
+                            />
+                        )}
+                    >
+                        <FormattedMessage
+                            id='Apis.Listing.SampleAPI.SampleAPI.streaming.websub.title'
+                            defaultMessage='Webhook API'
+                        />
+                    </LandingMenuItem>
+                    <LandingMenuItem
+                        dense={dense}
+                        id='itest-id-create-streaming-api-sse'
+                        linkTo='/apis/create/streamingapi/sse'
+                        helperText={(
+                            <FormattedMessage
+                                id='Apis.Listing.SampleAPI.SampleAPI.streaming.sse.content'
+                                defaultMessage='Create a Server-Sent Events API'
+                            />
+                        )}
+                    >
+                        <FormattedMessage
+                            id='Apis.Listing.SampleAPI.SampleAPI.streaming.sse.title'
+                            defaultMessage='SSE API'
+                        />
+                    </LandingMenuItem>
+                    <LandingMenuItem
+                        dense={dense}
+                        id='itest-id-create-streaming-api-import'
+                        linkTo='/apis/create/asyncapi'
+                        helperText={(
+                            <FormattedMessage
+                                id='Apis.Listing.SampleAPI.SampleAPI.streaming.import.content'
+                                defaultMessage='Upload a file or provide an Async API URL'
+                            />
+                        )}
+                    >
+                        <FormattedMessage
+                            id='Apis.Listing.SampleAPI.SampleAPI.streaming.import.title'
+                            defaultMessage='Import an AsyncAPI'
+                        />
+                    </LandingMenuItem>
+                </>
+            ) : (
+                <Grid
+                    item
+                    xs={12}
+                >
+                    <Typography align='center' variant='body1'>
+                        <FormattedMessage
+                            id='Apis.Listing.SampleAPI.SampleAPI.graphql.no permission'
+                            defaultMessage='You do not have enough permission to create an API'
+                        />
+                    </Typography>
+                </Grid>
+            )}
         </Component>
     );
 };

--- a/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Landing/index.jsx
+++ b/features/apimgt/org.wso2.carbon.apimgt.publisher.feature/src/main/resources/publisher/source/src/app/components/Apis/Listing/Landing/index.jsx
@@ -29,6 +29,7 @@ import RestAPIMenu from 'AppComponents/Apis/Listing/Landing/Menus/RestAPIMenu';
 import SoapAPIMenu from 'AppComponents/Apis/Listing/Landing/Menus/SoapAPIMenu';
 import GraphqlAPIMenu from 'AppComponents/Apis/Listing/Landing/Menus/GraphqlAPIMenu';
 import StreamingAPIMenu from 'AppComponents/Apis/Listing/Landing/Menus/StreamingAPIMenu';
+import { isRestricted } from 'AppData/AuthManager';
 
 const useStyles = makeStyles({
     root: {
@@ -83,10 +84,10 @@ const APILanding = () => {
                             alignItems='flex-start'
                             spacing={3}
                         >
-                            <RestAPIMenu icon={restApiIcon} />
-                            <SoapAPIMenu icon={soapApiIcon} />
-                            <GraphqlAPIMenu icon={graphqlIcon} />
-                            <StreamingAPIMenu icon={streamingApiIcon} />
+                            <RestAPIMenu icon={restApiIcon} isDisabled={isRestricted(['apim:api_create'])} />
+                            <SoapAPIMenu icon={soapApiIcon} isDisabled={isRestricted(['apim:api_create'])} />
+                            <GraphqlAPIMenu icon={graphqlIcon} isDisabled={isRestricted(['apim:api_create'])} />
+                            <StreamingAPIMenu icon={streamingApiIcon} isDisabled={isRestricted(['apim:api_create'])} />
                         </Grid>
                     </Box>
                 </Grid>


### PR DESCRIPTION
Fixes https://github.com/wso2/product-apim/issues/11059 and adds an improvement to it so that a publisher user will not be able to click on any create api option. When the card is flipped, the below text is shown.

<img width="1678" alt="Screenshot 2021-04-18 at 12 27 45" src="https://user-images.githubusercontent.com/8557410/115186864-091e8880-a100-11eb-925d-ce7e6bd71dd1.png">
