### PR TITLE
[git actions] increase runners to 5 in forked builds

### DIFF
--- a/.github/workflows/main-forks.yml
+++ b/.github/workflows/main-forks.yml
@@ -46,11 +46,15 @@ jobs:
       matrix:
         include:
           - id: 1
-            segment: apim-integration-tests-api-common,apim-integration-tests-api-change-endpoint,apim-integration-tests-api-product,apim-integration-tests-api-lifecycle,apim-integration-tests-api-lifecycle-2,apim-CORS-tests,apim-integration-emailusername-login
+            segment: apim-integration-tests-api-common,apim-integration-tests-api-change-endpoint,apim-integration-tests-api-product,apim-integration-tests-api-lifecycle,apim-integration-tests-api-lifecycle-2
           - id: 2
-            segment: apim-email-secondary-userstore-tests,apim-integration-tests-samples,apim-publisher-tests,apim-store-tests,apim-integration-tests-graphql,admin-rest-api-tests,rest-api-tests,apim-mediation-tests,apim-streaming-api-tests,apim-integration-tests-workflow
+            segment: apim-email-secondary-userstore-tests,apim-CORS-tests,apim-publisher-tests
           - id: 3
-            segment: apim-websocket-tests,apim-integration-tests-without-restarts,apim-integration-tests-without-advance-throttling,apim-integration-tests-application-sharing,apim-JWT-integration-tests,apim-urlsafe-JWT-integration-tests,apim-integration-tests-endpoint-security,apim-integration-tests-external-idp
+            segment: apim-integration-tests-samples,apim-store-tests,apim-integration-tests-graphql,admin-rest-api-tests,rest-api-tests,apim-mediation-tests,apim-integration-tests-without-restarts,apim-integration-tests-without-advance-throttling,apim-urlsafe-JWT-integration-tests
+          - id: 4
+            segment: apim-streaming-api-tests,apim-JWT-integration-tests,apim-integration-tests-external-idp,apim-integration-tests-workflow
+          - id: 5
+            segment: apim-websocket-tests,apim-integration-tests-application-sharing,apim-integration-tests-endpoint-security,apim-integration-emailusername-login
       fail-fast: false
     steps:
       - name: Run hostname


### PR DESCRIPTION
Current git actions in forked repos is using 3 runners and taking ~2h 15m.
This increases the runners to 5 results with ~1h 30m build time.

Run: https://github.com/malinthaprasan/carbon-apimgt/actions/runs/764499838