### PR TITLE
Fix missing admin portal scope-mapping scopes for Service Catalog

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
@@ -1347,7 +1347,7 @@ public class RestApiUtil {
     public static  Map<String, List<String>> getScopesInfoFromAPIYamlDefinitions() throws APIManagementException {
 
         Map<String, List<String>>   portalScopeList = new HashMap<>();
-        String [] fileNameArray = {"/admin-api.yaml", "/publisher-api.yaml", "/devportal-api.yaml"};
+        String [] fileNameArray = {"/admin-api.yaml", "/publisher-api.yaml", "/devportal-api.yaml", "/service-catalog-api.yaml"};
         for (String fileName : fileNameArray) {
             String definition = null;
             try {


### PR DESCRIPTION
### Purpose
Fixes: https://github.com/wso2/product-apim/issues/10999

### Goals
To show scopes in admin portal scope mapping that are available for Service Catalog api.

### Approach
Added missing `service-catalog-api.yaml` to `fileNameArray`

Actions: https://github.com/YasasRangika/carbon-apimgt/actions/runs/766825899