### PR TITLE
Fix context issues when creating new API versions from services

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -170,8 +170,8 @@ public class APIMappingUtil {
 
         context = context.startsWith("/") ? context : ("/" + context);
         String providerDomain = MultitenantUtils.getTenantDomain(provider);
-        if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(providerDomain) &&
-                dto.getId() == null && !context.contains("/t/" + providerDomain)) {
+        if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(providerDomain) && dto.getId() == null
+                && !context.contains("/t/" + providerDomain)) {
             //Create tenant aware context for API
             context = "/t/" + providerDomain + context;
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -171,7 +171,7 @@ public class APIMappingUtil {
         context = context.startsWith("/") ? context : ("/" + context);
         String providerDomain = MultitenantUtils.getTenantDomain(provider);
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(providerDomain) &&
-                dto.getId() == null) {
+                dto.getId() == null && !context.contains("/t/" + providerDomain)) {
             //Create tenant aware context for API
             context = "/t/" + providerDomain + context;
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3733,7 +3733,8 @@ public class ApisApiServiceImpl implements ApisApiService {
                 ServiceCatalogImpl serviceCatalog = new ServiceCatalogImpl();
                 service = serviceCatalog.getServiceByNameAndVersion(serviceName, serviceVersion, tenantId);
             }
-            if (StringUtils.isNotEmpty(serviceVersion) && !serviceVersion.equals(existingAPI.getServiceInfo("version"))) {
+            if (StringUtils.isNotEmpty(serviceVersion) && !serviceVersion
+                    .equals(existingAPI.getServiceInfo("version"))) {
                 APIDTO apidto = createAPIDTO(existingAPI, newVersion);
                 if (ServiceEntry.DefinitionType.OAS2.equals(service.getDefinitionType()) || ServiceEntry
                         .DefinitionType.OAS3.equals(service.getDefinitionType())) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3706,6 +3706,7 @@ public class ApisApiServiceImpl implements ApisApiService {
                 String serviceVersion, MessageContext messageContext) throws APIManagementException {
         URI newVersionedApiUri;
         APIDTO newVersionedApi = new APIDTO();
+        ServiceEntry service = new ServiceEntry();
         try {
             APIIdentifier apiIdentifierFromTable = APIMappingUtil.getAPIIdentifierFromUUID(apiId);
             if (apiIdentifierFromTable == null) {
@@ -3730,7 +3731,9 @@ public class ApisApiServiceImpl implements ApisApiService {
             if (StringUtils.isNotEmpty(serviceVersion)) {
                 String serviceName = existingAPI.getServiceInfo("name");
                 ServiceCatalogImpl serviceCatalog = new ServiceCatalogImpl();
-                ServiceEntry service = serviceCatalog.getServiceByNameAndVersion(serviceName, serviceVersion, tenantId);
+                service = serviceCatalog.getServiceByNameAndVersion(serviceName, serviceVersion, tenantId);
+            }
+            if (StringUtils.isNotEmpty(serviceVersion) && !serviceVersion.equals(existingAPI.getServiceInfo("version"))) {
                 APIDTO apidto = createAPIDTO(existingAPI, newVersion);
                 if (ServiceEntry.DefinitionType.OAS2.equals(service.getDefinitionType()) || ServiceEntry
                         .DefinitionType.OAS3.equals(service.getDefinitionType())) {
@@ -4005,7 +4008,7 @@ public class ApisApiServiceImpl implements ApisApiService {
     private APIDTO createAPIDTO(API existingAPI, String newVersion) {
         APIDTO apidto = new APIDTO();
         apidto.setName(existingAPI.getId().getApiName());
-        apidto.setContext(existingAPI.getContext());
+        apidto.setContext(existingAPI.getContextTemplate());
         apidto.setVersion(newVersion);
         return apidto;
     }


### PR DESCRIPTION
### Purpose
Fixes: https://github.com/wso2/product-apim/issues/11043

### Description
This PR addresses three issues.
- When creating new API version with service which has different version than the existing service's version, API version is appended to the newly created API's context.
- In sub tenant, when creating new version of API from different version of the service, the newly created API's context get appended by tenant-domain each time.
- Create new API is only needed when the new version uses another version of service than the existing API has used. Otherwise it will directly call to `createNewAPIVersion()` method in APIProviderImpl.

### Goals
- To prevent appending API version to the context in new version of API created from other version of service
- To prevent appending tenant domain each time to the context in new version of API created from other version of service in tenants

### Approach
- Added missing validations to check whether the selected service version is similar to the existing API's service version
- Replaced using `getContext()` to `getContextTemplate()`
- Added missing validation to check whether there any appended tenant domain to the context

Actions: https://github.com/YasasRangika/carbon-apimgt/actions/runs/771080952