### PR TITLE
Handle Exception when creating new version of API from invalid service version

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -463,7 +463,7 @@ public enum ExceptionCodes implements ErrorHandler {
                "Definition", 400, "Unsupported protocol specified in Async API Definition"),
 
     //Service Catalog related error codes
-    SERVICE_VERSION_IS_NOT_FOUND(901900, "Cannot find the service version", 404, "Cannot find a service that matches the given version");
+    SERVICE_VERSION_NOT_FOUND(901900, "Cannot find the service version", 404, "Cannot find a service that matches the given version");
 
     private final long errorCode;
     private final String errorMessage;

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -460,7 +460,10 @@ public enum ExceptionCodes implements ErrorHandler {
     MISSING_PROTOCOL_IN_ASYNC_API_DEFINITION(900911, "Missing protocol in Async API Definition", 400,
             "Missing protocol in Async API Definition"),
     UNSUPPORTED_PROTOCOL_SPECIFIED_IN_ASYNC_API_DEFINITION(900912, "Unsupported protocol specified in Async API " +
-               "Definition", 400, "Unsupported protocol specified in Async API Definition");
+               "Definition", 400, "Unsupported protocol specified in Async API Definition"),
+
+    //Service Catalog related error codes
+    SERVICE_VERSION_IS_NOT_FOUND(901900, "Cannot find the service version", 404, "Cannot find a service that matches the given version");
 
     private final long errorCode;
     private final String errorMessage;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3731,6 +3731,9 @@ public class ApisApiServiceImpl implements ApisApiService {
                 String serviceName = existingAPI.getServiceInfo("name");
                 ServiceCatalogImpl serviceCatalog = new ServiceCatalogImpl();
                 ServiceEntry service = serviceCatalog.getServiceByNameAndVersion(serviceName, serviceVersion, tenantId);
+                if (service == null) {
+                    throw new APIManagementException(ExceptionCodes.from(ExceptionCodes.ERROR_WHILE_TRYING_TO_DISCOVER_SERVICES));
+                }
                 APIDTO apidto = createAPIDTO(existingAPI, newVersion);
                 if (ServiceEntry.DefinitionType.OAS2.equals(service.getDefinitionType()) || ServiceEntry
                         .DefinitionType.OAS3.equals(service.getDefinitionType())) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3732,7 +3732,7 @@ public class ApisApiServiceImpl implements ApisApiService {
                 ServiceCatalogImpl serviceCatalog = new ServiceCatalogImpl();
                 ServiceEntry service = serviceCatalog.getServiceByNameAndVersion(serviceName, serviceVersion, tenantId);
                 if (service == null) {
-                    throw new APIManagementException(ExceptionCodes.from(ExceptionCodes.ERROR_WHILE_TRYING_TO_DISCOVER_SERVICES));
+                    throw new APIManagementException("No matching service version found", ExceptionCodes.SERVICE_VERSION_IS_NOT_FOUND);
                 }
                 APIDTO apidto = createAPIDTO(existingAPI, newVersion);
                 if (ServiceEntry.DefinitionType.OAS2.equals(service.getDefinitionType()) || ServiceEntry

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3733,7 +3733,7 @@ public class ApisApiServiceImpl implements ApisApiService {
                 ServiceCatalogImpl serviceCatalog = new ServiceCatalogImpl();
                 service = serviceCatalog.getServiceByNameAndVersion(serviceName, serviceVersion, tenantId);
                 if (service == null) {
-                    throw new APIManagementException("No matching service version found", ExceptionCodes.SERVICE_VERSION_IS_NOT_FOUND);
+                    throw new APIManagementException("No matching service version found", ExceptionCodes.SERVICE_VERSION_NOT_FOUND);
                 }
             }
             if (StringUtils.isNotEmpty(serviceVersion) && !serviceVersion


### PR DESCRIPTION
### Purpose
Fixes: https://github.com/wso2/product-apim/issues/11100

### Goals
Handle throwing NullPointer Exception when use invalid service version to create new version of API

### Approach
Added null check to `ServiceEntry` value after searching service from `getServiceByNameAndVersion()`

Actions: https://github.com/YasasRangika/carbon-apimgt/actions/runs/771578866