### PR TITLE
Support importing keys for KMs configured with 'no oauth apps'

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
@@ -489,7 +489,7 @@ public interface APIConsumer extends APIManager {
      * @param jsonString Callback URL for the Application.
      * @param keyManagerName key manager name
      * @param tenantDomain tenant domain for the app registration request
-     * @param isImported whether Application is being imported from controller or not
+     * @param isImportMode whether Application is being imported from controller or not
      * @throws APIManagementException if failed to applications for given subscriber
      */
     Map<String,Object> requestApprovalForApplicationRegistration(String userId, String applicationName,
@@ -498,27 +498,29 @@ public interface APIConsumer extends APIManager {
                                                                  String validityTime,
                                                                  String tokenScope, String groupingId,
                                                                  String jsonString, String keyManagerName,
-                                                                 String tenantDomain, boolean isImported)
+                                                                 String tenantDomain, boolean isImportMode)
             throws APIManagementException;
 
     /**
      * Creates a request for getting Approval for Application Registration.
      *
-     * @param userId Subscriber name.
+     * @param userId          Subscriber name.
      * @param applicationName of the Application.
-     * @param tokenType Token type (PRODUCTION | SANDBOX)
-     * @param callbackUrl callback URL
-     * @param allowedDomains allowedDomains for token.
-     * @param validityTime validity time period.
-     * @param tokenScope Scopes for the requested tokens.
-     *
-     * @param groupingId APIM application id.
-     * @param jsonString Callback URL for the Application.
-     * @param keyManagerName name of the key manager
-     * @param tenantDomain tenant domain for the app registration request
+     * @param tokenType       Token type (PRODUCTION | SANDBOX)
+     * @param callbackUrl     callback URL
+     * @param allowedDomains  allowedDomains for token.
+     * @param validityTime    validity time period.
+     * @param tokenScope      Scopes for the requested tokens.
+     * @param groupingId      APIM application id.
+     * @param jsonString      Callback URL for the Application.
+     * @param keyManagerName  name of the key manager
+     * @param tenantDomain    tenant domain for the app registration request
      * @throws APIManagementException if failed to applications for given subscriber
+     * @deprecated Use {@link #requestApprovalForApplicationRegistration(String, String, String, String, String[],
+     * String, String, String, String, String, String, boolean)} instead
      */
-    Map<String,Object> requestApprovalForApplicationRegistration(String userId, String applicationName,
+    @Deprecated
+    Map<String, Object> requestApprovalForApplicationRegistration(String userId, String applicationName,
                                                                  String tokenType,
                                                                  String callbackUrl, String[] allowedDomains,
                                                                  String validityTime,

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
@@ -477,7 +477,7 @@ public interface APIConsumer extends APIManager {
     /**
      * Creates a request for getting Approval for Application Registration.
      *
-     * @param userId Subsriber name.
+     * @param userId Subscriber name.
      * @param applicationName of the Application.
      * @param tokenType Token type (PRODUCTION | SANDBOX)
      * @param callbackUrl callback URL
@@ -487,7 +487,35 @@ public interface APIConsumer extends APIManager {
      *
      * @param groupingId APIM application id.
      * @param jsonString Callback URL for the Application.
-     * @param keyManagerName
+     * @param keyManagerName key manager name
+     * @param tenantDomain tenant domain for the app registration request
+     * @param isImported whether Application is being imported from controller or not
+     * @throws APIManagementException if failed to applications for given subscriber
+     */
+    Map<String,Object> requestApprovalForApplicationRegistration(String userId, String applicationName,
+                                                                 String tokenType,
+                                                                 String callbackUrl, String[] allowedDomains,
+                                                                 String validityTime,
+                                                                 String tokenScope, String groupingId,
+                                                                 String jsonString, String keyManagerName,
+                                                                 String tenantDomain, boolean isImported)
+            throws APIManagementException;
+
+    /**
+     * Creates a request for getting Approval for Application Registration.
+     *
+     * @param userId Subscriber name.
+     * @param applicationName of the Application.
+     * @param tokenType Token type (PRODUCTION | SANDBOX)
+     * @param callbackUrl callback URL
+     * @param allowedDomains allowedDomains for token.
+     * @param validityTime validity time period.
+     * @param tokenScope Scopes for the requested tokens.
+     *
+     * @param groupingId APIM application id.
+     * @param jsonString Callback URL for the Application.
+     * @param keyManagerName name of the key manager
+     * @param tenantDomain tenant domain for the app registration request
      * @throws APIManagementException if failed to applications for given subscriber
      */
     Map<String,Object> requestApprovalForApplicationRegistration(String userId, String applicationName,
@@ -502,7 +530,7 @@ public interface APIConsumer extends APIManager {
     /**
      * Creates a request for application update.
      *
-     * @param userId Subsriber name.
+     * @param userId Subscriber name.
      * @param applicationName of the Application.
      * @param tokenType Token type (PRODUCTION | SANDBOX)
      * @param callbackUrl callback URL

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2055,6 +2055,7 @@ public final class APIConstants {
     public static final String JSON_CLIENT_ID = "client_id";
     public static final String JSON_ADDITIONAL_PROPERTIES = "additionalProperties";
     public static final String JSON_CLIENT_SECRET = "client_secret";
+    public static final String JSON_CALLBACK_URL = "callbackUrl";
 
     /**
      * Publisher Access Control related registry properties and values.

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -4079,6 +4079,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
     }
 
     @Override
+    @Deprecated
     public Map<String, Object> requestApprovalForApplicationRegistration(String userId, String applicationName,
                                                                          String tokenType, String callbackUrl,
                                                                          String[] allowedDomains, String validityTime,
@@ -4086,8 +4087,8 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                                                                          String jsonString,
                                                                          String keyManagerName, String tenantDomain)
             throws APIManagementException {
-        return requestApprovalForApplicationRegistration(userId, applicationName,tokenType, callbackUrl, allowedDomains,
-                validityTime, tokenScope, groupingId, jsonString, keyManagerName, tenantDomain, false);
+        return requestApprovalForApplicationRegistration(userId, applicationName, tokenType, callbackUrl,
+                allowedDomains, validityTime, tokenScope, groupingId, jsonString, keyManagerName, tenantDomain, false);
     }
 
     /**
@@ -4103,7 +4104,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                                                                          String tokenScope, String groupingId,
                                                                          String jsonString,
                                                                          String keyManagerName, String tenantDomain,
-                                                                         boolean isImported)
+                                                                         boolean isImportMode)
     throws APIManagementException {
 
         boolean isTenantFlowStarted = false;
@@ -4139,7 +4140,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             Object enableOauthAppCreation =
                     keyManagerConfiguration.getProperty(APIConstants.KeyManager.ENABLE_OAUTH_APP_CREATION);
             if (enableOauthAppCreation != null && !(Boolean) enableOauthAppCreation) {
-                if (isImported) {
+                if (isImportMode) {
                     log.debug("Importing application when KM OAuth App creation is disabled. Trying to map keys");
                     // passing null `clientId` is ok here since the id/secret pair is included
                     // in the `jsonString` and ApplicationUtils#createOauthAppRequest logic handles it.

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -2644,6 +2644,10 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 .createOauthAppRequest(applicationName, clientId, callBackURL, "default", jsonString, tokenType,
                         tenantDomain, keyManagerName);
 
+        // if clientId is null in the argument `ApplicationUtils#createOauthAppRequest` will set it using
+        // the props in `jsonString`. Hence we are taking the updated `clientId` here
+        clientId = oauthAppRequest.getOAuthApplicationInfo().getClientId();
+
         KeyManager keyManager = KeyManagerHolder.getKeyManagerInstance(tenantDomain, keyManagerName);
         if (keyManager == null) {
             throw new APIManagementException(
@@ -3943,11 +3947,11 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             }
 
             // cleanup pending application registration tasks
-            Map<String,String> keyManagerWiseProductionKeyStatus = apiMgtDAO
+            Map<String, String> keyManagerWiseProductionKeyStatus = apiMgtDAO
                     .getRegistrationApprovalState(applicationId, APIConstants.API_KEY_TYPE_PRODUCTION);
-            Map<String,String> keyManagerWiseSandboxKeyStatus = apiMgtDAO
+            Map<String, String> keyManagerWiseSandboxKeyStatus = apiMgtDAO
                     .getRegistrationApprovalState(applicationId, APIConstants.API_KEY_TYPE_SANDBOX);
-            keyManagerWiseProductionKeyStatus.forEach((keyManagerName, state) ->{
+            keyManagerWiseProductionKeyStatus.forEach((keyManagerName, state) -> {
                 if (WorkflowStatus.CREATED.toString().equals(state)) {
                     try {
                         String applicationRegistrationExternalRef = apiMgtDAO
@@ -3966,8 +3970,8 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                     }
                 }
 
-            } );
-            keyManagerWiseSandboxKeyStatus.forEach((keyManagerName, state) ->{
+            });
+            keyManagerWiseSandboxKeyStatus.forEach((keyManagerName, state) -> {
                 if (WorkflowStatus.CREATED.toString().equals(state)) {
                     try {
                         String applicationRegistrationExternalRef = apiMgtDAO
@@ -4074,6 +4078,18 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         }
     }
 
+    @Override
+    public Map<String, Object> requestApprovalForApplicationRegistration(String userId, String applicationName,
+                                                                         String tokenType, String callbackUrl,
+                                                                         String[] allowedDomains, String validityTime,
+                                                                         String tokenScope, String groupingId,
+                                                                         String jsonString,
+                                                                         String keyManagerName, String tenantDomain)
+            throws APIManagementException {
+        return requestApprovalForApplicationRegistration(userId, applicationName,tokenType, callbackUrl, allowedDomains,
+                validityTime, tokenScope, groupingId, jsonString, keyManagerName, tenantDomain, false);
+    }
+
     /**
      * This method specifically implemented for REST API by removing application and data access logic
      * from host object layer. So as per new implementation we need to pass requested scopes to this method
@@ -4086,8 +4102,9 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                                                                          String[] allowedDomains, String validityTime,
                                                                          String tokenScope, String groupingId,
                                                                          String jsonString,
-                                                                         String keyManagerName, String tenantDomain)
-            throws APIManagementException {
+                                                                         String keyManagerName, String tenantDomain,
+                                                                         boolean isImported)
+    throws APIManagementException {
 
         boolean isTenantFlowStarted = false;
         if (StringUtils.isEmpty(tenantDomain)) {
@@ -4102,7 +4119,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         }
 
         String keyManagerId = null;
-        if (keyManagerName != null){
+        if (keyManagerName != null) {
             KeyManagerConfigurationDTO keyManagerConfiguration =
                     apiMgtDAO.getKeyManagerConfigurationByName(tenantDomain, keyManagerName);
             if (keyManagerConfiguration == null) {
@@ -4121,9 +4138,17 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             }
             Object enableOauthAppCreation =
                     keyManagerConfiguration.getProperty(APIConstants.KeyManager.ENABLE_OAUTH_APP_CREATION);
-            if (enableOauthAppCreation != null && !(Boolean) enableOauthAppCreation){
-                throw new APIManagementException("Key Manager " + keyManagerName + " doesn't support to generate " +
-                        "Client Application",ExceptionCodes.KEY_MANAGER_NOT_SUPPORT_OAUTH_APP_CREATION);
+            if (enableOauthAppCreation != null && !(Boolean) enableOauthAppCreation) {
+                if (isImported) {
+                    log.debug("Importing application when KM OAuth App creation is disabled. Trying to map keys");
+                    // passing null `clientId` is ok here since the id/secret pair is included
+                    // in the `jsonString` and ApplicationUtils#createOauthAppRequest logic handles it.
+                    return mapExistingOAuthClient(jsonString, userId, null, applicationName, tokenType,
+                            APIConstants.DEFAULT_TOKEN_TYPE, keyManagerName, tenantDomain);
+                } else {
+                    throw new APIManagementException("Key Manager " + keyManagerName + " doesn't support to generate" +
+                            " Client Application", ExceptionCodes.KEY_MANAGER_NOT_SUPPORT_OAUTH_APP_CREATION);
+                }
             }
         }
         try {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractKeyManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractKeyManager.java
@@ -129,6 +129,9 @@ public abstract class AbstractKeyManager implements KeyManager {
             if (jsonObject != null) {
                 //create a map to hold json parsed objects.
                 Map<String, Object> params = (Map) jsonObject;
+                if (params.get(APIConstants.JSON_CALLBACK_URL) != null) {
+                    oAuthApplicationInfo.setCallBackURL((String) params.get(APIConstants.JSON_CALLBACK_URL));
+                }
                 if(params.get(APIConstants.JSON_GRANT_TYPES) != null) {
                     String grantTypeString = params.get(APIConstants.JSON_GRANT_TYPES).toString();
                     if (StringUtils.isEmpty(oAuthApplicationInfo.getCallBackURL()) &&

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIConsumerImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIConsumerImplTest.java
@@ -1041,7 +1041,7 @@ public class APIConsumerImplTest {
         try {
             apiConsumer
                     .requestApprovalForApplicationRegistration("1", "app1", "access", "identity.com/auth", null, "3600",
-                            "api_view", "2", null, "default", null);
+                            "api_view", "2", null, "default", null, false);
             Assert.fail("User store exception not thrown for invalid token type");
         } catch (APIManagementException e) {
             Assert.assertTrue(e.getMessage().contains("Unable to retrieve the tenant information of the current user"));
@@ -1060,7 +1060,7 @@ public class APIConsumerImplTest {
         try {
             apiConsumer
                     .requestApprovalForApplicationRegistration("1", "app1", "access", "identity.com/auth", null, "3600",
-                            "api_view", "2", null, "default", null);
+                            "api_view", "2", null, "default", null, false);
             Assert.fail("API management exception not thrown for invalid token type");
         } catch (APIManagementException e) {
             Assert.assertTrue(e.getMessage().contains("Invalid Token Type"));
@@ -1080,13 +1080,13 @@ public class APIConsumerImplTest {
                 .thenReturn(application);
         Map<String, Object> result = apiConsumer
                 .requestApprovalForApplicationRegistration("1", "app1", APIConstants.API_KEY_TYPE_PRODUCTION,
-                        "identity.com/auth", null, "3600", "api_view", "2", null, "default", null);
+                        "identity.com/auth", null, "3600", "api_view", "2", null, "default", null, false);
         Assert.assertEquals(result.size(),10);
         Assert.assertEquals(result.get("keyState"), "APPROVED");
 
         result = apiConsumer
                 .requestApprovalForApplicationRegistration("1", "app1", APIConstants.API_KEY_TYPE_SANDBOX, "", null,
-                        "3600", "api_view", "2", null, "default", null);
+                        "3600", "api_view", "2", null, "default", null, false);
         Assert.assertEquals(result.size(), 10);
         Assert.assertEquals(result.get("keyState"), "APPROVED");
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/ApplicationImportExportManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/ApplicationImportExportManager.java
@@ -136,11 +136,14 @@ public class ApplicationImportExportManager {
                 jsonParamObj.put(APIConstants.JSON_CLIENT_SECRET, apiKey.getConsumerSecret());
             }
         }
+        if (!StringUtils.isEmpty(apiKey.getCallbackUrl())) {
+            jsonParamObj.put(APIConstants.JSON_CALLBACK_URL, apiKey.getCallbackUrl());
+        }
         String jsonParams = jsonParamObj.toString();
         String tokenScopes = apiKey.getTokenScope();
         apiConsumer.requestApprovalForApplicationRegistration(
                 username, application.getName(), apiKey.getType(), apiKey.getCallbackUrl(),
                 accessAllowDomainsArray, Long.toString(apiKey.getValidityPeriod()), tokenScopes, application.getGroupId(),
-                jsonParams,apiKey.getKeyManager(), null);
+                jsonParams,apiKey.getKeyManager(), null, true);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
@@ -740,7 +740,7 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
                     Map<String, Object> keyDetails = apiConsumer.requestApprovalForApplicationRegistration(
                             username, application.getName(), body.getKeyType().toString(), body.getCallbackUrl(),
                             accessAllowDomainsArray, body.getValidityTime(), tokenScopes, application.getGroupId(),
-                            jsonParams, keyManagerName, xWSO2Tenant);
+                            jsonParams, keyManagerName, xWSO2Tenant, false);
                     ApplicationKeyDTO applicationKeyDTO =
                             ApplicationKeyMappingUtil.fromApplicationKeyToDTO(keyDetails, body.getKeyType().toString());
                     applicationKeyDTO.setKeyManager(keyManagerName);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
@@ -125,8 +125,9 @@ public class ImportUtils {
         apiKey.setConsumerSecret(new String(Base64.decodeBase64(applicationKeyDto.getConsumerSecret())));
         apiKey.setKeyManager(applicationKeyDto.getKeyManager());
         apiKey.setGrantTypes(StringUtils.join(applicationKeyDto.getSupportedGrantTypes(), ", "));
-        if (apiKey.getGrantTypes() != null && apiKey.getGrantTypes().contains(GRANT_TYPE_IMPLICIT) && apiKey
-                .getGrantTypes().contains(GRANT_TYPE_CODE)) {
+
+        if (apiKey.getGrantTypes() != null && (apiKey.getGrantTypes().contains(GRANT_TYPE_IMPLICIT)
+                || apiKey.getGrantTypes().contains(GRANT_TYPE_CODE))) {
             apiKey.setCallbackUrl(applicationKeyDto.getCallbackUrl());
         }
         apiKey.setValidityPeriod(applicationKeyDto.getToken().getValidityTime());
@@ -292,10 +293,13 @@ public class ImportUtils {
                 jsonParamObj.put(APIConstants.JSON_CLIENT_SECRET, apiKey.getConsumerSecret());
             }
         }
+        if (!StringUtils.isEmpty(apiKey.getCallbackUrl())) {
+            jsonParamObj.put(APIConstants.JSON_CALLBACK_URL, apiKey.getCallbackUrl());
+        }
         String jsonParams = jsonParamObj.toString();
         String tokenScopes = apiKey.getTokenScope();
         apiConsumer.requestApprovalForApplicationRegistration(username, application.getName(), apiKey.getType(),
                 apiKey.getCallbackUrl(), accessAllowDomainsArray, Long.toString(apiKey.getValidityPeriod()),
-                tokenScopes, application.getGroupId(), jsonParams, apiKey.getKeyManager(), null);
+                tokenScopes, application.getGroupId(), jsonParams, apiKey.getKeyManager(), null, true);
     }
 }


### PR DESCRIPTION
Fixes wso2/product-apim#11125

if oauth app creation is disabled for the KM, we should treat it as an out of band app and use the mapped keys provided with the app.
implementation to avoid interface changes.
new overloaded method for `requestApprovalForApplicationRegistration` was introduced with `isImported` arg to identify if the request is coming from `import-app` API. This is then used to provide error msg when rest API is being used to generate keys for `create oauth apps` disabled KMs.