### PR TITLE
Handling query:empty and query:false situations

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
@@ -911,7 +911,7 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
                     }
                 }
                 apiRevisionListDTO = APIMappingUtil.fromListAPIRevisiontoDTO(apiDeployedRevisions);
-            } else {
+            } else if (StringUtils.equalsIgnoreCase(query, "deployed:false")) {
                 List<APIRevision> apiProductNotDeployedRevisions = new ArrayList<>();
                 for (APIRevision apiRevision : apiRevisions) {
                     if (apiRevision.getApiRevisionDeploymentList().isEmpty()) {
@@ -919,6 +919,8 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
                     }
                 }
                 apiRevisionListDTO = APIMappingUtil.fromListAPIRevisiontoDTO(apiProductNotDeployedRevisions);
+            } else {
+                apiRevisionListDTO = APIMappingUtil.fromListAPIRevisiontoDTO(apiRevisions);
             }
             return Response.ok().entity(apiRevisionListDTO).build();
         } catch (APIManagementException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -4252,7 +4252,7 @@ public class ApisApiServiceImpl implements ApisApiService {
                     }
                 }
                 apiRevisionListDTO = APIMappingUtil.fromListAPIRevisiontoDTO(apiDeployedRevisions);
-            } else {
+            } else if (StringUtils.equalsIgnoreCase(query, "deployed:false")) {
                 List<APIRevision> apiNotDeployedRevisions = new ArrayList<>();
                 for (APIRevision apiRevision : apiRevisions) {
                     if (apiRevision.getApiRevisionDeploymentList().isEmpty()) {
@@ -4260,6 +4260,8 @@ public class ApisApiServiceImpl implements ApisApiService {
                     }
                 }
                 apiRevisionListDTO = APIMappingUtil.fromListAPIRevisiontoDTO(apiNotDeployedRevisions);
+            } else {
+                apiRevisionListDTO = APIMappingUtil.fromListAPIRevisiontoDTO(apiRevisions);
             }
             return Response.ok().entity(apiRevisionListDTO).build();
         } catch (APIManagementException e) {


### PR DESCRIPTION
### Purpose
Solve inconsistency in deployment page after the fix: https://github.com/wso2/carbon-apimgt/pull/10452
Fixes: https://github.com/wso2/product-apim/issues/11211

### Approach
- Added else if check for `query:false` state
- Added else body to return all the revisions when `query: `

Actions: https://github.com/YasasRangika/carbon-apimgt/actions/runs/833773590