### PR TITLE
Fixes https://github.com/wso2-enterprise/choreo/issues/4039

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -5310,7 +5310,7 @@ public class ApiMgtDAO {
         if (!isProduct) {
             identifier = apiTypeWrapper.getApi().getId();
             apiUUID = apiTypeWrapper.getApi().getUuid();
-            id = getAPIIDFromIdentifierMatchingOrganization((APIIdentifier) identifier, apiUUID);
+            id = getAPIIDFromIdentifierMatchingOrganization((APIIdentifier) identifier, getOrganizationIDByAPIUUID(apiUUID));
         } else {
             identifier = apiTypeWrapper.getApiProduct().getId();
             id = apiTypeWrapper.getApiProduct().getProductId();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -5309,8 +5309,8 @@ public class ApiMgtDAO {
         String checkDuplicateQuery = SQLConstants.CHECK_EXISTING_SUBSCRIPTION_API_SQL;
         if (!isProduct) {
             identifier = apiTypeWrapper.getApi().getId();
-            id = identifier.getId();
             apiUUID = apiTypeWrapper.getApi().getUuid();
+            id = getAPIIDFromIdentifierMatchingOrganization((APIIdentifier) identifier, apiUUID);
         } else {
             identifier = apiTypeWrapper.getApiProduct().getId();
             id = apiTypeWrapper.getApiProduct().getProductId();


### PR DESCRIPTION
**Purpose**

https://github.com/wso2-enterprise/choreo/issues/4039

**Issue**

The auto-incrementing APIID retried from APIIdentifier is giving the first entry of the DB.

**Approach**

Retrieve the autoincrementing API correctly from APIIdentifier.

- Created APIs with name **test** and version **1.0**  in **org1** and **org2**.
- Create an application in **org2** and subscribe to the **test** api.

![Screenshot from 2021-05-14 22-45-57](https://user-images.githubusercontent.com/60866295/118305977-5bd44000-b506-11eb-9188-cff6f32e7dc8.png)

Subscription for the API **test**  in **org2** was correctly populated in **AM_SUBSCRIPTION** table.
