### PR TITLE
Add REST API impl to fetch IdPs configured for the API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5774,7 +5774,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             }
         } catch (APIPersistenceException e) {
             String msg = "Failed to get API. API artifact corresponding to artifactId " + uuid + " does not exist";
-            throw new APIMgtResourceNotFoundException(msg);
+            throw new APIManagementException(msg, ExceptionCodes.from(e.getErrorHandler(), uuid));
         } catch (OASPersistenceException | ParseException e) {
             String msg = "Failed to get API";
             throw new APIManagementException(msg, e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5772,7 +5772,10 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 String msg = "Failed to get API. API artifact corresponding to artifactId " + uuid + " does not exist";
                 throw new APIMgtResourceNotFoundException(msg);
             }
-        } catch (APIPersistenceException | OASPersistenceException | ParseException e) {
+        } catch (APIPersistenceException e) {
+            String msg = "Failed to get API. API artifact corresponding to artifactId " + uuid + " does not exist";
+            throw new APIMgtResourceNotFoundException(msg);
+        } catch (OASPersistenceException | ParseException e) {
             String msg = "Failed to get API";
             throw new APIManagementException(msg, e);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1773,7 +1773,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     private void validateKeyManagers(API api) throws APIManagementException {
 
         List<KeyManagerConfigurationDTO> keyManagerConfigurationsByTenant =
-                apiMgtDAO.getKeyManagerConfigurationsByTenant(tenantDomain);
+                apiMgtDAO.getKeyManagerConfigurationsByTenant(api.getOrganizationId());
         List<String> configuredMissingKeyManagers = new ArrayList<>();
         for (String keyManager : api.getKeyManagers()) {
             if (!APIConstants.KeyManager.API_LEVEL_ALL_KEY_MANAGERS.equals(keyManager)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence.mongodb/src/main/java/org/wso2/carbon/apimgt/persistence/mongodb/MongoDBPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence.mongodb/src/main/java/org/wso2/carbon/apimgt/persistence/mongodb/MongoDBPersistenceImpl.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APICategory;
 import org.wso2.carbon.apimgt.api.model.Tag;
@@ -269,7 +270,7 @@ public class MongoDBPersistenceImpl implements APIPersistence {
         MongoDBDevPortalAPI mongoDBAPIDocument = collection.find(eq("_id", new ObjectId(apiId))).first();
         if (mongoDBAPIDocument == null) {
             String msg = "Failed to get API. " + apiId + " does not exist in mongodb database";
-            throw new APIPersistenceException(msg);
+            throw new APIPersistenceException(msg, ExceptionCodes.from(ExceptionCodes.API_NOT_FOUND, apiId));
         }
         return MongoAPIMapper.INSTANCE.toDevPortalApi(mongoDBAPIDocument);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
@@ -64,7 +64,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
 
     public Response keyManagersGet(MessageContext messageContext) throws APIManagementException {
 
-        String organization = RestApiAdminUtils.getOrganization(messageContext);
+        String organization = RestApiUtil.getOrganization(messageContext);
         APIAdmin apiAdmin = new APIAdminImpl();
         List<KeyManagerConfigurationDTO> keyManagerConfigurationsByOrganization =
                 apiAdmin.getKeyManagerConfigurationsByTenant(organization);
@@ -76,7 +76,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
     public Response keyManagersKeyManagerIdDelete(String keyManagerId, MessageContext messageContext)
             throws APIManagementException {
 
-        String organization = RestApiAdminUtils.getOrganization(messageContext);
+        String organization = RestApiUtil.getOrganization(messageContext);
         APIAdmin apiAdmin = new APIAdminImpl();
         apiAdmin.deleteKeyManagerConfigurationById(organization, keyManagerId);
         return Response.ok().build();
@@ -85,7 +85,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
     public Response keyManagersKeyManagerIdGet(String keyManagerId, MessageContext messageContext)
             throws APIManagementException {
 
-        String organization = RestApiAdminUtils.getOrganization(messageContext);
+        String organization = RestApiUtil.getOrganization(messageContext);
         APIAdmin apiAdmin = new APIAdminImpl();
         KeyManagerConfigurationDTO keyManagerConfigurationDTO =
                 apiAdmin.getKeyManagerConfigurationById(organization, keyManagerId);
@@ -99,7 +99,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
 
     public Response keyManagersKeyManagerIdPut(String keyManagerId, KeyManagerDTO body, MessageContext messageContext) {
 
-        String organization = RestApiAdminUtils.getOrganization(messageContext);
+        String organization = RestApiUtil.getOrganization(messageContext);
         APIAdmin apiAdmin = new APIAdminImpl();
         try {
             KeyManagerConfigurationDTO keyManagerConfigurationDTO =
@@ -128,7 +128,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
 
     public Response keyManagersPost(KeyManagerDTO body, MessageContext messageContext) throws APIManagementException {
 
-        String organization = RestApiAdminUtils.getOrganization(messageContext);
+        String organization = RestApiUtil.getOrganization(messageContext);
         APIAdmin apiAdmin = new APIAdminImpl();
         try {
             KeyManagerConfigurationDTO keyManagerConfigurationDTO =

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/RestApiAdminUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/RestApiAdminUtils.java
@@ -382,14 +382,4 @@ public class RestApiAdminUtils {
         FileUtils.deleteDirectory(backupDirectory);
         apiAdmin.updateTenantTheme(tenantId, existingTenantTheme);
     }
-
-    /**
-     * Retrieve organization from msg ctx.
-     *
-     * @param messageContext msg ctx
-     * @return organization
-     */
-    public static String getOrganization(MessageContext messageContext) {
-        return (String) messageContext.get(RestApiConstants.ORGANIZATION);
-    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/KeyManagersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/KeyManagersApiServiceImpl.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.apimgt.impl.APIAdminImpl;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.KeyManagersApiService;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings.KeyManagerMappingUtil;
+import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
 import java.util.List;
 
@@ -36,10 +37,10 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
     @Override
     public Response getAllKeyManagers(MessageContext messageContext) throws APIManagementException {
 
-        String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
+        String organization = RestApiUtil.getOrganization(messageContext);
         APIAdmin apiAdmin = new APIAdminImpl();
         List<KeyManagerConfigurationDTO> keyManagerConfigurations =
-                apiAdmin.getKeyManagerConfigurationsByTenant(tenantDomain);
+                apiAdmin.getKeyManagerConfigurationsByTenant(organization);
         return Response.ok(KeyManagerMappingUtil.toKeyManagerListDto(keyManagerConfigurations)).build();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
@@ -59,6 +59,7 @@
     <bean id="BasicAuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.auth.BasicAuthenticationInterceptor" />
     <bean id="PostAuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.PostAuthenticationInterceptor" />
     <bean id="ValidationInInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.validation.ValidationInInterceptor"/>
+    <bean id="OrganizationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.OrganizationInterceptor"/>
     <bean id="cors-filter" class="org.apache.cxf.rs.security.cors.CrossOriginResourceSharingFilter">
         <property name="allowHeaders">
             <list>
@@ -91,6 +92,7 @@
             <ref bean="BasicAuthenticationInterceptor"/>
             <ref bean="PostAuthenticationInterceptor"/>
             <ref bean="ValidationInInterceptor"/>
+            <ref bean="OrganizationInterceptor"/>
         </cxf:inInterceptors>
         <cxf:outInterceptors>
             <ref bean="gZipInterceptor"/>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApisApi.java
@@ -9,6 +9,7 @@ import org.wso2.carbon.apimgt.rest.api.store.v1.dto.DocumentListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ErrorDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.GraphQLQueryComplexityInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.GraphQLSchemaTypeListDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.KeyManagerListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.PatchRequestBodyDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.PostRequestBodyDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.RatingDTO;
@@ -439,6 +440,24 @@ ApisApiService delegate = new ApisApiServiceImpl();
         @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
     public Response getCommentOfAPI(@ApiParam(value = "Comment Id ",required=true) @PathParam("commentId") String commentId, @ApiParam(value = "**API ID** consisting of the **UUID** of the API. ",required=true) @PathParam("apiId") String apiId,  @ApiParam(value = "The Organization which the API belongs to. ")  @QueryParam("organizationId") String organizationId,  @ApiParam(value = "For cross-tenant invocations, this is used to specify the tenant domain, where the resource need to be   retrieved from. " )@HeaderParam("X-WSO2-Tenant") String xWSO2Tenant,  @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved variant of the resourec. " )@HeaderParam("If-None-Match") String ifNoneMatch,  @ApiParam(value = "Whether we need to display commentor details. ", defaultValue="false") @DefaultValue("false") @QueryParam("includeCommenterInfo") Boolean includeCommenterInfo,  @ApiParam(value = "Maximum size of replies array to return. ", defaultValue="25") @DefaultValue("25") @QueryParam("replyLimit") Integer replyLimit,  @ApiParam(value = "Starting point within the complete list of replies. ", defaultValue="0") @DefaultValue("0") @QueryParam("replyOffset") Integer replyOffset) throws APIManagementException{
         return delegate.getCommentOfAPI(commentId, apiId, organizationId, xWSO2Tenant, ifNoneMatch, includeCommenterInfo, replyLimit, replyOffset, securityContext);
+    }
+
+    @GET
+    @Path("/{apiId}/idps")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Retrieve the Identity Providers associated with the API", notes = "This operation can be used to retrieve the all Identity Providers associated with the API ", response = KeyManagerListDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:subscribe", description = "Subscribe API")
+        })
+    }, tags={ "Identity Providers",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Identity Providers list returned ", response = KeyManagerListDTO.class),
+        @ApiResponse(code = 401, message = "Unauthorized. The user is not authorized.", response = ErrorDTO.class),
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
+    public Response getIdpsOfAPI(@ApiParam(value = "**API ID** consisting of the **UUID** of the API. ",required=true) @PathParam("apiId") String apiId) throws APIManagementException{
+        return delegate.getIdpsOfAPI(apiId, securityContext);
     }
 
     @GET

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApisApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApisApiService.java
@@ -18,6 +18,7 @@ import org.wso2.carbon.apimgt.rest.api.store.v1.dto.DocumentListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ErrorDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.GraphQLQueryComplexityInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.GraphQLSchemaTypeListDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.KeyManagerListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.PatchRequestBodyDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.PostRequestBodyDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.RatingDTO;
@@ -56,6 +57,7 @@ public interface ApisApiService {
       public Response editCommentOfAPI(String commentId, String apiId, PatchRequestBodyDTO patchRequestBodyDTO, String organizationId, MessageContext messageContext) throws APIManagementException;
       public Response getAllCommentsOfAPI(String apiId, String organizationId, String xWSO2Tenant, Integer limit, Integer offset, Boolean includeCommenterInfo, MessageContext messageContext) throws APIManagementException;
       public Response getCommentOfAPI(String commentId, String apiId, String organizationId, String xWSO2Tenant, String ifNoneMatch, Boolean includeCommenterInfo, Integer replyLimit, Integer replyOffset, MessageContext messageContext) throws APIManagementException;
+      public Response getIdpsOfAPI(String apiId, MessageContext messageContext) throws APIManagementException;
       public Response getRepliesOfComment(String commentId, String apiId, String organizationId, String xWSO2Tenant, Integer limit, Integer offset, String ifNoneMatch, Boolean includeCommenterInfo, MessageContext messageContext) throws APIManagementException;
       public Response getWSDLOfAPI(String apiId, String organizationId, String environmentName, String ifNoneMatch, String xWSO2Tenant, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApisApiServiceImpl.java
@@ -1016,34 +1016,26 @@ public class ApisApiServiceImpl implements ApisApiService {
     }
 
     @Override
-    public Response getIdpsOfAPI(String apiId, MessageContext messageContext) {
-        try {
-            APIConsumer apiConsumer = RestApiCommonUtil.getLoggedInUserConsumer();
-            String organization = APIUtils.getOrganization(messageContext);
-            ApiTypeWrapper apiTypeWrapper = apiConsumer.getAPIorAPIProductByUUID(apiId, organization);
-            List<String> configuredIDPs = new ArrayList<>();
-            if (!apiTypeWrapper.isAPIProduct()) {
-                API api = apiTypeWrapper.getApi();
-                configuredIDPs = api.getKeyManagers();
-            }
-            APIAdmin apiAdmin = new APIAdminImpl();
-            List<KeyManagerConfigurationDTO> idpConfigurations = new ArrayList<>();
-            if (!configuredIDPs.isEmpty() && configuredIDPs.contains(APIConstants.KeyManager
-                    .API_LEVEL_ALL_KEY_MANAGERS)) {
-                idpConfigurations = apiAdmin.getKeyManagerConfigurationsByTenant(organization);
-            } else {
-                for (String idp : configuredIDPs) {
-                    idpConfigurations.add(apiAdmin.getKeyManagerConfigurationByName(organization, idp));
-                }
-            }
-            return Response.ok(KeyManagerMappingUtil.toKeyManagerListDto(idpConfigurations)).build();
-        } catch (APIMgtResourceNotFoundException e) {
-            RestApiUtil.handleResourceNotFoundError(RestApiConstants.RESOURCE_API, apiId, e, log);
-        } catch (APIManagementException e) {
-            RestApiUtil.handleInternalServerError("Error while retrieving IDP configurations associated " +
-                    "with API with ID " + apiId, log);
+    public Response getIdpsOfAPI(String apiId, MessageContext messageContext) throws APIManagementException {
+        APIConsumer apiConsumer = RestApiCommonUtil.getLoggedInUserConsumer();
+        String organization = RestApiUtil.getOrganization(messageContext);
+        ApiTypeWrapper apiTypeWrapper = apiConsumer.getAPIorAPIProductByUUID(apiId, organization);
+        List<String> configuredIDPs = new ArrayList<>();
+        if (!apiTypeWrapper.isAPIProduct()) {
+            API api = apiTypeWrapper.getApi();
+            configuredIDPs = api.getKeyManagers();
         }
-        return null;
+        APIAdmin apiAdmin = new APIAdminImpl();
+        List<KeyManagerConfigurationDTO> idpConfigurations = new ArrayList<>();
+        if (!configuredIDPs.isEmpty() && configuredIDPs.contains(APIConstants.KeyManager
+                .API_LEVEL_ALL_KEY_MANAGERS)) {
+            idpConfigurations = apiAdmin.getKeyManagerConfigurationsByTenant(organization);
+        } else {
+            for (String idp : configuredIDPs) {
+                idpConfigurations.add(apiAdmin.getKeyManagerConfigurationByName(organization, idp));
+            }
+        }
+        return Response.ok(KeyManagerMappingUtil.toKeyManagerListDto(idpConfigurations)).build();
     }
 
     private APIDTO getAPIByAPIId(String apiId, String organizationId, String tenantDomain) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -348,6 +348,39 @@ paths:
         - lang: Curl
           source: curl -k "https://localhost:9443/api/am/devportal/v2/apis/c43a325c-260b-4302-81cb-768eafaa3aed/graphql-schema"
 
+  /apis/{apiId}/idps:
+    get:
+      tags:
+        - Identity Providers
+      summary: Retrieve the Identity Providers associated with the API
+      description: |
+        This operation can be used to retrieve the all Identity Providers associated with the API
+      operationId: getIdpsOfAPI
+      parameters:
+        - $ref: '#/components/parameters/apiId'
+      responses:
+        200:
+          description: |
+            OK.
+            Identity Providers list returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeyManagerList'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:subscribe
+      x-code-samples:
+        - lang: Curl
+          source: curl -k -H "Authorization:Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://localhost:9443/api/am/devportal/v2/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/idps"
+
   /apis/{apiId}/sdks/{language}:
     get:
       tags:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/webapp/WEB-INF/beans.xml
@@ -52,6 +52,7 @@
     <bean id="PostAuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.PostAuthenticationInterceptor" />
     <bean id="SubscriberRegistrationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.SubscriberRegistrationInterceptor" />
     <bean id="ValidationInInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.validation.ValidationInInterceptor"/>
+    <bean id="OrganizationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.OrganizationInterceptor"/>
     <bean id="TokenMergeInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.auth.TokenMergeInterceptor"/>
     <bean id="cors-filter" class="org.apache.cxf.rs.security.cors.CrossOriginResourceSharingFilter">
         <property name="allowHeaders">
@@ -86,6 +87,7 @@
             <ref bean="PostAuthenticationInterceptor"/>
             <ref bean="SubscriberRegistrationInterceptor"/>
             <ref bean="ValidationInInterceptor"/>
+            <ref bean="OrganizationInterceptor"/>
         </cxf:inInterceptors>
         <cxf:outInterceptors>
             <ref bean="gZipInterceptor"/>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.apache.cxf.message.Message;
 import org.json.simple.JSONObject;
 import org.wso2.carbon.apimgt.api.APIDefinition;
@@ -1388,5 +1389,15 @@ public class RestApiUtil {
             log.error("Error while retrieving Anonymous config from registry", e);
         }
         return true;
+    }
+
+    /**
+     * Retrieve organization from msg ctx.
+     *
+     * @param messageContext msg ctx
+     * @return organization
+     */
+    public static String getOrganization(MessageContext messageContext) {
+        return (String) messageContext.get(RestApiConstants.ORGANIZATION);
     }
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1392,5 +1392,7 @@
     {% endif %}
     {% if apim.organization_resolver.resolver is defined %}
      <OrganizationResolver>{{apim.organization_resolver.resolver}}</OrganizationResolver>
+    {% else %}
+     <OrganizationResolver>org.wso2.carbon.apimgt.rest.api.util.resolver.ChoreoResolver</OrganizationResolver>
     {% endif %}
 </APIManager>


### PR DESCRIPTION
This PR adds 
- new REST API resource `GET /apis/{apiId}/idps` to fetch IdPs configured for the API. 
- fixes the issue in updating IdPs configured for an API with org support
- add org support to `GET /key-managers` in Publisher REST API

Fixes https://github.com/wso2-enterprise/choreo/issues/4204
Fixes https://github.com/wso2-enterprise/choreo/issues/4202