### PR TITLE
Add validation for token expiry

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -392,6 +392,8 @@ public enum ExceptionCodes implements ErrorHandler {
             "Required application properties are missing"),
     KEY_MAPPING_ALREADY_EXIST(901408, "Application already Registered", 409, "Application already Registered"),
     TENANT_MISMATCH(901409,"Tenant mismatch", 400, "Tenant mismatch"),
+    INVALID_APPLICATION_PROPERTIES(901410, "Invalid additional properties", 400,
+            "Invalid additional properties given for application"),
 
     //Scope related
     SCOPE_NOT_FOUND_FOR_USER(901500, "Scope does not belong to this user", 404, "Scope not found"),

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -229,8 +229,8 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                     try {
                         long expiry = Long.parseLong((String) expiryTimeObject);
                         if (expiry < 0) {
-                            throw new APIManagementException("Invalid application access token expiry time.",
-                                    ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
+                            throw new APIManagementException("Invalid application access token expiry time given for "
+                                    + applicationName, ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
                         }
                         clientInfo.setApplicationAccessTokenLifeTime(expiry);
                     } catch (NumberFormatException e) {
@@ -247,8 +247,8 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                     try {
                         long expiry = Long.parseLong((String) expiryTimeObject);
                         if (expiry < 0) {
-                            throw new APIManagementException("Invalid user access token expiry time.",
-                                    ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
+                            throw new APIManagementException("Invalid user access token expiry time given for "
+                                    + applicationName, ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
                         }
                         clientInfo.setUserAccessTokenLifeTime(expiry);
                     } catch (NumberFormatException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -159,7 +159,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
      * @throws JSONException for errors in parsing the OAuthApplicationInfo json string
      */
     private ClientInfo createClientInfo(OAuthApplicationInfo info, String applicationName, boolean isUpdate)
-            throws JSONException {
+            throws JSONException, APIManagementException {
 
         ClientInfo clientInfo = new ClientInfo();
         JSONObject infoJson = new JSONObject(info.getJsonString());
@@ -227,6 +227,9 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                 if (!APIConstants.KeyManager.NOT_APPLICABLE_VALUE.equals(expiryTimeObject)) {
                     try {
                         long expiry = Long.parseLong((String) expiryTimeObject);
+                        if (expiry < 0) {
+                            throw new APIManagementException("Invalid application access token expiry time.");
+                        }
                         clientInfo.setApplicationAccessTokenLifeTime(expiry);
                     } catch (NumberFormatException e) {
                         // No need to throw as its due to not a number sent.
@@ -241,6 +244,9 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                 if (!APIConstants.KeyManager.NOT_APPLICABLE_VALUE.equals(expiryTimeObject)) {
                     try {
                         long expiry = Long.parseLong((String) expiryTimeObject);
+                        if (expiry < 0) {
+                            throw new APIManagementException("Invalid user access token expiry time.");
+                        }
                         clientInfo.setUserAccessTokenLifeTime(expiry);
                     } catch (NumberFormatException e) {
                         // No need to throw as its due to not a number sent.

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -34,6 +34,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
 import org.wso2.carbon.apimgt.api.model.AccessTokenRequest;
@@ -228,7 +229,8 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                     try {
                         long expiry = Long.parseLong((String) expiryTimeObject);
                         if (expiry < 0) {
-                            throw new APIManagementException("Invalid application access token expiry time.");
+                            throw new APIManagementException("Invalid application access token expiry time.",
+                                    ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
                         }
                         clientInfo.setApplicationAccessTokenLifeTime(expiry);
                     } catch (NumberFormatException e) {
@@ -245,7 +247,8 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                     try {
                         long expiry = Long.parseLong((String) expiryTimeObject);
                         if (expiry < 0) {
-                            throw new APIManagementException("Invalid user access token expiry time.");
+                            throw new APIManagementException("Invalid user access token expiry time.",
+                                    ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
                         }
                         clientInfo.setUserAccessTokenLifeTime(expiry);
                     } catch (NumberFormatException e) {


### PR DESCRIPTION
Fix https://github.com/wso2-enterprise/choreo/issues/4027

The following error will be received upon an negative expiry time 
{"code":901410,"message":"Invalid additional properties","description":"Invalid additional properties given for application","moreInfo":"","error":[]}