### PR TITLE
Remove APIIdentifier from getAPIContext

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -250,11 +250,11 @@ public interface APIProvider extends APIManager {
     /**
      * Get the context of API identified by the given APIIdentifier
      *
-     * @param apiId api identifier
+     * @param uuid api uuid
      * @return apiContext
      * @throws APIManagementException if failed to fetch the context for apiID
      */
-    String getAPIContext(APIIdentifier apiId) throws APIManagementException;
+    String getAPIContext(String uuid) throws APIManagementException;
 
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1121,14 +1121,14 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     }
 
     /**
-     * This method is used to get the context of API identified by the given APIIdentifier
+     * This method is used to get the context of API identified by the given uuid
      *
-     * @param apiId api identifier
+     * @param uuid api uuid
      * @return apiContext
-     * @throws APIManagementException if failed to fetch the context for apiID
+     * @throws APIManagementException if failed to fetch the context for api uuid
      */
-    public String getAPIContext(APIIdentifier apiId) throws APIManagementException {
-        return apiMgtDAO.getAPIContext(apiId);
+    public String getAPIContext(String uuid) throws APIManagementException {
+        return apiMgtDAO.getAPIContext(uuid);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -7978,19 +7978,18 @@ public class ApiMgtDAO {
     /**
      * Get API Context using a new DB connection.
      *
-     * @param identifier API Identifier
+     * @param uuid API uuid
      * @return API Context
      * @throws APIManagementException if an error occurs
      */
-    public String getAPIContext(APIIdentifier identifier) throws APIManagementException {
+    public String getAPIContext(String uuid) throws APIManagementException {
 
         String context = null;
         try (Connection connection = APIMgtDBUtil.getConnection()) {
-            context = getAPIContext(identifier, connection);
+            context = getAPIContext(uuid, connection);
         } catch (SQLException e) {
             log.error("Failed to retrieve the API Context", e);
-            handleException("Failed to retrieve connection while getting the API Context for "
-                    + identifier.getProviderName() + '-' + identifier.getApiName() + '-' + identifier.getVersion(), e);
+            handleException("Failed to retrieve connection while getting the API Context for API with UUID " + uuid, e);
         }
         return context;
     }
@@ -7998,19 +7997,17 @@ public class ApiMgtDAO {
     /**
      * Get API Context by passing an existing DB connection.
      *
-     * @param identifier API Identifier
+     * @param uuid API uuid
      * @param connection DB Connection
      * @return API Context
      * @throws APIManagementException if an error occurs
      */
-    public String getAPIContext(APIIdentifier identifier, Connection connection) throws APIManagementException {
+    public String getAPIContext(String uuid, Connection connection) throws APIManagementException {
 
         String context = null;
-        String sql = SQLConstants.GET_API_CONTEXT_BY_API_NAME_SQL;
+        String sql = SQLConstants.GET_API_CONTEXT_BY_API_UUID_SQL;
         try (PreparedStatement prepStmt = connection.prepareStatement(sql)) {
-            prepStmt.setString(1, APIUtil.replaceEmailDomainBack(identifier.getProviderName()));
-            prepStmt.setString(2, identifier.getApiName());
-            prepStmt.setString(3, identifier.getVersion());
+            prepStmt.setString(1, uuid);
             try (ResultSet resultSet = prepStmt.executeQuery()) {
                 while (resultSet.next()) {
                     context = resultSet.getString(1);
@@ -8018,8 +8015,7 @@ public class ApiMgtDAO {
             }
         } catch (SQLException e) {
             log.error("Failed to retrieve the API Context", e);
-            handleException("Failed to retrieve the API Context for " + identifier.getProviderName() + '-'
-                    + identifier.getApiName() + '-' + identifier.getVersion(), e);
+            handleException("Failed to retrieve the API Context for API with UUID " + uuid, e);
         }
         return context;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -1876,8 +1876,8 @@ public class SQLConstants {
     public static final String GET_API_TYPE_BY_UUID =
             "SELECT API_TYPE FROM AM_API WHERE API_UUID = ?";
 
-    public static final String GET_API_CONTEXT_BY_API_NAME_SQL =
-            "SELECT CONTEXT FROM AM_API WHERE API_PROVIDER = ? AND API_NAME = ? AND API_VERSION  = ?";
+    public static final String GET_API_CONTEXT_BY_API_UUID_SQL =
+            "SELECT CONTEXT FROM AM_API WHERE API_UUID = ?";
 
     public static final String GET_ALL_CONTEXT_SQL = "SELECT CONTEXT FROM AM_API ";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/APIMgtDAOTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/APIMgtDAOTest.java
@@ -867,7 +867,7 @@ public class APIMgtDAOTest {
         int subsId = apiMgtDAO.addSubscription(apiTypeWrapper1, application,
                 APIConstants.SubscriptionStatus.ON_HOLD, subscriber.getName());
         assertTrue(apiMgtDAO.isContextExist(api.getContext()));
-        assertTrue(api.getContext().equals(apiMgtDAO.getAPIContext(apiId)));
+        assertTrue(api.getContext().equals(apiMgtDAO.getAPIContext(api.getUuid())));
         apiMgtDAO.removeSubscription(apiId, application.getId());
         apiMgtDAO.removeSubscriptionById(subsId);
         apiMgtDAO.deleteAPI(api.getUuid());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SubscriptionsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SubscriptionsApiServiceImpl.java
@@ -91,8 +91,10 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
 
                 String apiContext = "";
                 String apiVersion = "";
+
                 if (apiId instanceof APIIdentifier) {
-                    apiContext = apiProvider.getAPIContext((APIIdentifier) apiId);
+                    String uuid = ApiMgtDAO.getInstance().getUUIDFromIdentifier((APIIdentifier) apiId);
+                    apiContext = apiProvider.getAPIContext(uuid);
                     apiVersion = apiId.getVersion();
                 } else if (apiId instanceof APIProductIdentifier) {
                     APIProduct product = apiProvider.getAPIProduct((APIProductIdentifier) apiId);
@@ -281,7 +283,8 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
                 String apiContext = "";
                 String apiVersion = "";
                 if (apiId instanceof APIIdentifier) {
-                    apiContext = apiProvider.getAPIContext((APIIdentifier) apiId);
+                    String uuid = ApiMgtDAO.getInstance().getUUIDFromIdentifier((APIIdentifier) apiId);
+                    apiContext = apiProvider.getAPIContext(uuid);
                     apiVersion = apiId.getVersion();
                 } else if (apiId instanceof  APIProductIdentifier) {
                     APIProduct product = apiProvider.getAPIProduct((APIProductIdentifier) apiId);


### PR DESCRIPTION
This PR removes APIIdentifier from getAPIContext.

Fixes https://github.com/wso2-enterprise/choreo/issues/4445