### PR TITLE
Adding the null check when retrieving total count

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence.mongodb/src/main/java/org/wso2/carbon/apimgt/persistence/mongodb/MongoDBPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence.mongodb/src/main/java/org/wso2/carbon/apimgt/persistence/mongodb/MongoDBPersistenceImpl.java
@@ -355,11 +355,11 @@ public class MongoDBPersistenceImpl implements APIPersistence {
     private long countTotalApi(Organization org){
         MongoCollection<Document> genericCollection = MongoDBConnectionUtil.getGenericCollection(org.getName());
         Document doc = genericCollection.aggregate(Arrays.asList(match(exists("revision", false)), count("totalApis"))).first();
-        long totCount = 0;
-        if(doc != null){
-            totCount = Long.parseLong(doc.get("totalApis").toString());
+        long totalCount = 0;
+        if (doc != null) {
+            totalCount = Long.parseLong(doc.get("totalApis").toString());
         }
-        return totCount;
+        return totalCount;
     }
 
     private Document buildSearchAggregate(String query) {

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence.mongodb/src/main/java/org/wso2/carbon/apimgt/persistence/mongodb/MongoDBPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence.mongodb/src/main/java/org/wso2/carbon/apimgt/persistence/mongodb/MongoDBPersistenceImpl.java
@@ -355,7 +355,10 @@ public class MongoDBPersistenceImpl implements APIPersistence {
     private long countTotalApi(Organization org){
         MongoCollection<Document> genericCollection = MongoDBConnectionUtil.getGenericCollection(org.getName());
         Document doc = genericCollection.aggregate(Arrays.asList(match(exists("revision", false)), count("totalApis"))).first();
-        long totCount = Long.parseLong(doc.get("totalApis").toString());
+        long totCount = 0;
+        if(doc != null){
+            totCount = Long.parseLong(doc.get("totalApis").toString());
+        }
         return totCount;
     }
 


### PR DESCRIPTION
### Purpose
Adding nulll check in order to retrieve the total when there are no apis created.

Please refer the discussion [#4000](https://github.com/wso2-enterprise/choreo/issues/4000)