### PR TITLE
Improve the existing DevPortal REST API to generate token using token-exchange grant type

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
@@ -785,8 +785,8 @@ public interface APIConsumer extends APIManager {
      * @throws APIManagementException
      */
     AccessTokenInfo renewAccessToken(String oldAccessToken, String clientId, String clientSecret, String validityTime,
-                                     String[] requestedScopes, String jsonInput,String keyManagerName) throws
-            APIManagementException;
+                                     String[] requestedScopes, String jsonInput, String keyManagerName,
+                                     String grantType) throws APIManagementException;
 
     /**
      * Generates a new api key

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
@@ -776,13 +776,16 @@ public interface APIConsumer extends APIManager {
     /**
      * Revokes the oldAccessToken generating a new one.
      *
-     * @param oldAccessToken          Token to be revoked
-     * @param clientId                Consumer Key for the Application
-     * @param clientSecret            Consumer Secret for the Application
-     * @param validityTime            Desired Validity time for the token
-     * @param jsonInput               Additional parameters if Authorization server needs any.
-     * @return Details of the newly generated Access Token.
-     * @throws APIManagementException
+     * @param oldAccessToken  Token to be revoked
+     * @param clientId        Consumer Key for the Application
+     * @param clientSecret    Consumer Secret for the Application
+     * @param validityTime    Desired Validity time for the token
+     * @param requestedScopes Requested Scopes
+     * @param jsonInput       Additional parameters if Authorization server needs any.
+     * @param keyManagerName  Configured Key Manager
+     * @param grantType       Grant Type
+     * @return AccessTokenInfo
+     * @throws APIManagementException Error when renewing access token
      */
     AccessTokenInfo renewAccessToken(String oldAccessToken, String clientId, String clientSecret, String validityTime,
                                      String[] requestedScopes, String jsonInput, String keyManagerName,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -407,13 +407,13 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
         TokenInfo tokenResponse;
 
         try {
-            if (GRANT_TYPE_VALUE.equals(tokenRequest.getGrantType())) {
-                tokenResponse = authClient.generate(tokenRequest.getClientId(), tokenRequest.getClientSecret(),
-                        tokenRequest.getGrantType(), scopes);
-            } else {
+            if (APIConstants.OAuthConstants.TOKEN_EXCHANGE.equals(tokenRequest.getGrantType())) {
                 tokenResponse = authClient.generate(tokenRequest.getClientId(), tokenRequest.getClientSecret(),
                         tokenRequest.getGrantType(), scopes, (String) tokenRequest.getRequestParam(APIConstants
                                 .OAuthConstants.SUBJECT_TOKEN), APIConstants.OAuthConstants.JWT_TOKEN_TYPE);
+            } else {
+                tokenResponse = authClient.generate(tokenRequest.getClientId(), tokenRequest.getClientSecret(),
+                        GRANT_TYPE_VALUE, scopes);
             }
         } catch (KeyManagerClientException e) {
             throw new APIManagementException("Error occurred while calling token endpoint!", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -407,8 +407,14 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
         TokenInfo tokenResponse;
 
         try {
-            tokenResponse = authClient.generate(tokenRequest.getClientId(), tokenRequest.getClientSecret(),
-                    GRANT_TYPE_VALUE, scopes);
+            if (GRANT_TYPE_VALUE.equals(tokenRequest.getGrantType())) {
+                tokenResponse = authClient.generate(tokenRequest.getClientId(), tokenRequest.getClientSecret(),
+                        tokenRequest.getGrantType(), scopes);
+            } else {
+                tokenResponse = authClient.generate(tokenRequest.getClientId(), tokenRequest.getClientSecret(),
+                        tokenRequest.getGrantType(), scopes, (String) tokenRequest.getRequestParam(APIConstants
+                                .OAuthConstants.SUBJECT_TOKEN), APIConstants.OAuthConstants.JWT_TOKEN_TYPE);
+            }
         } catch (KeyManagerClientException e) {
             throw new APIManagementException("Error occurred while calling token endpoint!", e);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1337,6 +1337,10 @@ public final class APIConstants {
         public static final String OAUTH_CUSTOM_PARAMETERS = "customParameters";
         public static final String CLIENT_CREDENTIALS = "CLIENT_CREDENTIALS";
         public static final String PASSWORD = "PASSWORD";
+        public static final String TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange";
+        public static final String SUBJECT_TOKEN = "subject_token";
+        public static final String SUBJECT_TOKEN_TYPE = "subject_token_type";
+        public static final String JWT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt";
 
         public static final String AUTHORIZATION_HEADER = "Authorization";
         public static final String CONTENT_TYPE_HEADER = "Content-Type";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -1243,7 +1243,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
     @Override
     public AccessTokenInfo renewAccessToken(String oldAccessToken, String clientId, String clientSecret,
                                             String validityTime, String[] requestedScopes, String jsonInput,
-                                            String keyManagerName) throws APIManagementException {
+                                            String keyManagerName, String grantType) throws APIManagementException {
         // Create Token Request with parameters provided from UI.
         AccessTokenRequest tokenRequest = new AccessTokenRequest();
         tokenRequest.setClientId(clientId);
@@ -1251,6 +1251,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         tokenRequest.setValidityPeriod(Long.parseLong(validityTime));
         tokenRequest.setTokenToRevoke(oldAccessToken);
         tokenRequest.setScope(requestedScopes);
+        tokenRequest.setGrantType(grantType);
 
         try {
             // Populating additional parameters.

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -1232,12 +1232,16 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
 
     /**
      * Re-generates the access token.
-     * @param oldAccessToken          Token to be revoked
-     * @param clientId                Consumer Key for the Application
-     * @param clientSecret            Consumer Secret for the Application
-     * @param validityTime            Desired Validity time for the token
-     * @param jsonInput               Additional parameters if Authorization server needs any.
-     * @return Renewed Access Token.
+     *
+     * @param oldAccessToken  Token to be revoked
+     * @param clientId        Consumer Key for the Application
+     * @param clientSecret    Consumer Secret for the Application
+     * @param validityTime    Desired Validity time for the token
+     * @param requestedScopes Requested Scopes
+     * @param jsonInput       Additional parameters if Authorization server needs any.
+     * @param keyManagerName  Configured Key Manager
+     * @param grantType       Grant Type
+     * @return
      * @throws APIManagementException
      */
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractKeyManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractKeyManager.java
@@ -95,6 +95,12 @@ public abstract class AbstractKeyManager implements KeyManager {
                     tokenRequest.setValidityPeriod(Long.parseLong((String) params.get(ApplicationConstants.VALIDITY_PERIOD)));
                 }
 
+                if (null != tokenRequest.getGrantType() && APIConstants.OAuthConstants.TOKEN_EXCHANGE
+                        .equals(tokenRequest.getGrantType())) {
+                    tokenRequest.addRequestParam(APIConstants.OAuthConstants.SUBJECT_TOKEN, params.get(APIConstants
+                            .OAuthConstants.SUBJECT_TOKEN));
+                }
+
                 return tokenRequest;
             }
         } catch (ParseException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractKeyManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractKeyManager.java
@@ -95,8 +95,7 @@ public abstract class AbstractKeyManager implements KeyManager {
                     tokenRequest.setValidityPeriod(Long.parseLong((String) params.get(ApplicationConstants.VALIDITY_PERIOD)));
                 }
 
-                if (null != tokenRequest.getGrantType() && APIConstants.OAuthConstants.TOKEN_EXCHANGE
-                        .equals(tokenRequest.getGrantType())) {
+                if (APIConstants.OAuthConstants.TOKEN_EXCHANGE.equals(tokenRequest.getGrantType())) {
                     tokenRequest.addRequestParam(APIConstants.OAuthConstants.SUBJECT_TOKEN, params.get(APIConstants
                             .OAuthConstants.SUBJECT_TOKEN));
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/kmclient/model/AuthClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/kmclient/model/AuthClient.java
@@ -36,6 +36,13 @@ public interface AuthClient {
 
     @RequestLine("POST ")
     @Headers("Content-type:application/x-www-form-urlencoded")
+    TokenInfo generate(@Param("client_id") String clientId, @Param("client_secret") String clientSecret,
+                       @Param("grant_type") String grantType, @Param("scope") String scope, @Param("subject_token")
+                               String subjectToken, @Param("subject_token_type") String subjectTokenType)
+            throws KeyManagerClientException;
+
+    @RequestLine("POST ")
+    @Headers("Content-type:application/x-www-form-urlencoded")
     TokenInfo generateWithValidityPeriod(@Param("client_id") String clientId,
                                          @Param("client_secret") String clientSecret,
                                          @Param("grant_type") String grantType,

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/ApplicationTokenGenerateRequestDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/ApplicationTokenGenerateRequestDTO.java
@@ -26,6 +26,38 @@ public class ApplicationTokenGenerateRequestDTO   {
     private Long validityPeriod = null;
     private List<String> scopes = new ArrayList<String>();
     private String revokeToken = null;
+
+    @XmlType(name="GrantTypeEnum")
+    @XmlEnum(String.class)
+    public enum GrantTypeEnum {
+        CLIENT_CREDENTIALS("CLIENT_CREDENTIALS"),
+        TOKEN_EXCHANGE("TOKEN_EXCHANGE");
+        private String value;
+
+        GrantTypeEnum (String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @JsonCreator
+        public static GrantTypeEnum fromValue(String v) {
+            for (GrantTypeEnum b : GrantTypeEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+return null;
+        }
+    }
+    private GrantTypeEnum grantType = GrantTypeEnum.CLIENT_CREDENTIALS;
     private Object additionalProperties = null;
 
   /**
@@ -101,6 +133,23 @@ public class ApplicationTokenGenerateRequestDTO   {
   }
 
   /**
+   **/
+  public ApplicationTokenGenerateRequestDTO grantType(GrantTypeEnum grantType) {
+    this.grantType = grantType;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("grantType")
+  public GrantTypeEnum getGrantType() {
+    return grantType;
+  }
+  public void setGrantType(GrantTypeEnum grantType) {
+    this.grantType = grantType;
+  }
+
+  /**
    * Additional parameters if Authorization server needs any
    **/
   public ApplicationTokenGenerateRequestDTO additionalProperties(Object additionalProperties) {
@@ -133,12 +182,13 @@ public class ApplicationTokenGenerateRequestDTO   {
         Objects.equals(validityPeriod, applicationTokenGenerateRequest.validityPeriod) &&
         Objects.equals(scopes, applicationTokenGenerateRequest.scopes) &&
         Objects.equals(revokeToken, applicationTokenGenerateRequest.revokeToken) &&
+        Objects.equals(grantType, applicationTokenGenerateRequest.grantType) &&
         Objects.equals(additionalProperties, applicationTokenGenerateRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(consumerSecret, validityPeriod, scopes, revokeToken, additionalProperties);
+    return Objects.hash(consumerSecret, validityPeriod, scopes, revokeToken, grantType, additionalProperties);
   }
 
   @Override
@@ -150,6 +200,7 @@ public class ApplicationTokenGenerateRequestDTO   {
     sb.append("    validityPeriod: ").append(toIndentedString(validityPeriod)).append("\n");
     sb.append("    scopes: ").append(toIndentedString(scopes)).append("\n");
     sb.append("    revokeToken: ").append(toIndentedString(revokeToken)).append("\n");
+    sb.append("    grantType: ").append(toIndentedString(grantType)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -4546,6 +4546,12 @@ components:
           type: string
           description: Token to be revoked, if any
           example: ""
+        grantType:
+          type: string
+          default: CLIENT_CREDENTIALS
+          enum:
+            - CLIENT_CREDENTIALS
+            - TOKEN_EXCHANGE
         additionalProperties:
           type: object
           properties: {}


### PR DESCRIPTION
This PR adds changes to improve the `POST /applications/{applicationId}/oauth-keys/{keyMappingId}/generate-token` Devportal REST API to generate token using token exchange grant type.

Request format:
```curl
curl --location --request POST 'https://localhost:9443/api/am/devportal/v2/applications/91e162e8-576b-402e-bff7-0c40c6a7d1e7/oauth-keys/a5eb6431-8c1b-4d97-976b-81aba133681e/generate-token' \
--header 'authorization: Bearer ${accessToken}' \
--data-raw '{
    "consumerSecret": "v2ZSpVrFSKo5sUlK9K1R6BZScdka",
    "validityPeriod": 3600,
    "revokeToken": null,
    "scopes": [],
    "grantType": "TOKEN_EXCHANGE",
    "additionalProperties": {
        "id_token_expiry_time": 3600,
        "application_access_token_expiry_time": 3600,
        "user_access_token_expiry_time": 3600,
        "refresh_token_expiry_time": 86400,
        "subject_token": "${externalIdPToken}"
    }
}'
```

Fixes https://github.com/wso2-enterprise/choreo/issues/5515