### PR TITLE
Validating IdP type if the token type is EXCHANGED

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -192,11 +192,12 @@ public enum ExceptionCodes implements ErrorHandler {
     MULTIPLE_USERS_EXIST(900609, "Multiple users with the same username exist in the system", 500, "Multiple " +
             "users with the same username exist in the system"),
     INVALID_USER_ROLES(900610, "Invalid user roles found", 400, "Invalid user roles found"),
-    IDP_ADDING_FAILED(900611, "Unable to add the identity provider", 400, "Error while adding the identity provider"),
+    IDP_ADDING_FAILED(900611, "Unable to add the identity provider", 400, "Error while adding the identity provider."),
     IDP_RETRIEVAL_FAILED(900612, "Unable to retrieve the identity provider", 400, "Error while retrieving the "
             + "identity provider details"),
     IDP_DELETION_FAILED(900613, "Unable to delete the identity provider", 400, "Error while deleting the "
             + "identity provider"),
+    INVALID_IDP_TYPE(900614, "Unsupported identity provider type", 400, "Invalid identity provider type. %s"),
 
 
     // Labels related codes

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -192,7 +192,7 @@ public enum ExceptionCodes implements ErrorHandler {
     MULTIPLE_USERS_EXIST(900609, "Multiple users with the same username exist in the system", 500, "Multiple " +
             "users with the same username exist in the system"),
     INVALID_USER_ROLES(900610, "Invalid user roles found", 400, "Invalid user roles found"),
-    IDP_ADDING_FAILED(900611, "Unable to add the identity provider", 400, "Error while adding the identity provider."),
+    IDP_ADDING_FAILED(900611, "Unable to add the identity provider", 400, "Error while adding the identity provider"),
     IDP_RETRIEVAL_FAILED(900612, "Unable to retrieve the identity provider", 400, "Error while retrieving the "
             + "identity provider details"),
     IDP_DELETION_FAILED(900613, "Unable to delete the identity provider", 400, "Error while deleting the "

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/KeyManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/KeyManagerConfiguration.java
@@ -38,6 +38,10 @@ public class KeyManagerConfiguration {
         EXCHANGED, ORIGINAL
     }
 
+    public enum IdpTypeOfExchangedTokens {
+        Okta, KeyCloak, Auth0, PingFederate, ForgeRock, AzureAD
+    }
+
     private TokenType tokenType = TokenType.ORIGINAL;
 
     private Map<String, Object> configuration = new HashMap<>();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -395,7 +395,10 @@ public class APIAdminImpl implements APIAdmin {
                 APIConstants.KeyManager.DEFAULT_KEY_MANAGER.equals(keyManagerConfigurationDTO.getName())) {
             APIUtil.getAndSetDefaultKeyManagerConfiguration(keyManagerConfigurationDTO);
         }
-        maskValues(keyManagerConfigurationDTO);
+        if (!KeyManagerConfiguration.TokenType.valueOf(keyManagerConfigurationDTO.getTokenType().toUpperCase())
+                .equals(KeyManagerConfiguration.TokenType.EXCHANGED)) {
+            maskValues(keyManagerConfigurationDTO);
+        }
         return keyManagerConfigurationDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
@@ -237,8 +237,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
             throws APIManagementException {
         String tokenType = keyManagerConfigurationDTO.getTokenType();
         String keyManagerType = keyManagerConfigurationDTO.getType();
-        if (StringUtils.equals(tokenType.toLowerCase(),
-                KeyManagerConfiguration.TokenType.EXCHANGED.toString().toLowerCase())) {
+        if (StringUtils.equalsIgnoreCase(tokenType, KeyManagerConfiguration.TokenType.EXCHANGED.toString())) {
             Stream<KeyManagerConfiguration.IdpTypeOfExchangedTokens> streamIdpType = Stream
                     .of(KeyManagerConfiguration.IdpTypeOfExchangedTokens.values());
             boolean isAllowedIdP = streamIdpType

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
@@ -43,7 +43,6 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.UUID;
 
 import javax.ws.rs.core.Response;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import javax.ws.rs.core.Response;
 
@@ -238,15 +239,11 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
         String keyManagerType = keyManagerConfigurationDTO.getType();
         if (StringUtils.equals(tokenType.toLowerCase(),
                 KeyManagerConfiguration.TokenType.EXCHANGED.toString().toLowerCase())) {
-            boolean validIdp = Boolean.FALSE;
-            for (KeyManagerConfiguration.IdpTypeOfExchangedTokens idpType :
-                    KeyManagerConfiguration.IdpTypeOfExchangedTokens.values()) {
-                if (idpType.name().equals(keyManagerType)) {
-                    validIdp = Boolean.TRUE;
-                    break;
-                }
-            }
-            if (!validIdp) {
+            Stream<KeyManagerConfiguration.IdpTypeOfExchangedTokens> streamIdpType = Stream
+                    .of(KeyManagerConfiguration.IdpTypeOfExchangedTokens.values());
+            boolean isAllowedIdP = streamIdpType
+                    .anyMatch(idpType -> StringUtils.equalsIgnoreCase(idpType.toString(), keyManagerType));
+            if (!isAllowedIdP) {
                 String errMsg = "Identity Provider type: " + keyManagerType + " not allowed for the token type "
                         + KeyManagerConfiguration.TokenType.EXCHANGED + ". Should be a value from " + Arrays
                         .asList(KeyManagerConfiguration.IdpTypeOfExchangedTokens.values());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
@@ -235,6 +235,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
 
     private void validateIdpTypeFromTokenType(KeyManagerConfigurationDTO keyManagerConfigurationDTO)
             throws APIManagementException {
+        
         String tokenType = keyManagerConfigurationDTO.getTokenType();
         String keyManagerType = keyManagerConfigurationDTO.getType();
         if (StringUtils.equalsIgnoreCase(tokenType, KeyManagerConfiguration.TokenType.EXCHANGED.toString())) {


### PR DESCRIPTION
## Purpose
When adding/updating an IdP/Key Manager a user can enter any type as they wish. But this may cause issues in the scenario explained in [1]. Hence a validation will be done.

## Approach
- When adding/updating an IdP/Key Manager if the token type is EXCHANGED, the **type** will be validated against a set of allowed enum values.
- Remove the masking values if the token type is EXCHANGED during the retrieval of an IdP because the connector configs will not be used when the token type is EXCHANGED.

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.2 LTS

## Related PRs
[1] https://github.com/wso2-enterprise/choreo/issues/4200