### PR TITLE
Add OrganizationId for API events and refactor remove subscription flow

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -3154,15 +3154,10 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             workflowDTO.setSubscriber(userId);
             workflowDTO.setCallbackUrl(removeSubscriptionWFExecutor.getCallbackURL());
             workflowDTO.setApplicationId(applicationId);
-            workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.API_ID, String.valueOf(apiIdentifier.getId()));
+            workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.API_ID, String.valueOf(identifier.getId()));
             workflowDTO.setApiUUID(identifier.getUUID());
 
-            String status = null;
-            if (apiIdentifier != null) {
-                status = apiMgtDAO.getSubscriptionStatus(apiIdentifier.getUUID(), applicationId);
-            } else if (apiProdIdentifier != null) {
-                status = apiMgtDAO.getSubscriptionStatus(apiProdIdentifier.getUUID(), applicationId);
-            }
+            String status = apiMgtDAO.getSubscriptionStatus(identifier.getUUID(), applicationId);
 
             if (APIConstants.SubscriptionStatus.ON_HOLD.equals(status)) {
                 try {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -3155,6 +3155,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             workflowDTO.setCallbackUrl(removeSubscriptionWFExecutor.getCallbackURL());
             workflowDTO.setApplicationId(applicationId);
             workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.API_ID, String.valueOf(apiIdentifier.getId()));
+            workflowDTO.setApiUUID(identifier.getUUID());
 
             String status = null;
             if (apiIdentifier != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -3154,6 +3154,8 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             workflowDTO.setSubscriber(userId);
             workflowDTO.setCallbackUrl(removeSubscriptionWFExecutor.getCallbackURL());
             workflowDTO.setApplicationId(applicationId);
+            workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.API_ID, String.valueOf(apiIdentifier.getId()));
+
             String status = null;
             if (apiIdentifier != null) {
                 status = apiMgtDAO.getSubscriptionStatus(apiIdentifier.getUUID(), applicationId);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIGatewayManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIGatewayManager.java
@@ -75,7 +75,7 @@ public class APIGatewayManager {
         APIIdentifier apiIdentifier = api.getId();
         DeployAPIInGatewayEvent
                 deployAPIInGatewayEvent = new DeployAPIInGatewayEvent(UUID.randomUUID().toString(),
-                System.currentTimeMillis(), APIConstants.EventType.DEPLOY_API_IN_GATEWAY.name(), tenantDomain,
+                System.currentTimeMillis(), APIConstants.EventType.DEPLOY_API_IN_GATEWAY.name(), api.getOrganization(),
                 api.getId().getId(), api.getUuid(), publishedGateways, apiIdentifier.getName(), apiIdentifier.getVersion(),
                 apiIdentifier.getProviderName(),api.getType(),api.getContext());
         APIUtil.sendNotification(deployAPIInGatewayEvent, APIConstants.NotifierType.GATEWAY_PUBLISHED_API.name());
@@ -105,9 +105,9 @@ public class APIGatewayManager {
 
         DeployAPIInGatewayEvent
                 deployAPIInGatewayEvent = new DeployAPIInGatewayEvent(UUID.randomUUID().toString(),
-                System.currentTimeMillis(), APIConstants.EventType.REMOVE_API_FROM_GATEWAY.name(), tenantDomain,
-                api.getId().getId(),api.getUuid(), removedGateways,apiIdentifier.getName(),apiIdentifier.getVersion(),
-                apiIdentifier.getProviderName(), api.getType(),api.getContext());
+                System.currentTimeMillis(), APIConstants.EventType.REMOVE_API_FROM_GATEWAY.name(),
+                api.getOrganization(), api.getId().getId(), api.getUuid(), removedGateways, apiIdentifier.getName(),
+                apiIdentifier.getVersion(), apiIdentifier.getProviderName(), api.getType(), api.getContext());
         APIUtil.sendNotification(deployAPIInGatewayEvent,
                 APIConstants.NotifierType.GATEWAY_PUBLISHED_API.name());
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -8702,6 +8702,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         api.setRevisionId(apiRevision.getId());
         api.setUuid(apiId);
         api.getId().setUuid(apiId);
+        api.setOrganization(organization);
         Set<String> environmentsToAdd = new HashSet<>();
         Map<String, String> gatewayVhosts = new HashMap<>();
         Set<APIRevisionDeployment> environmentsToRemove = new HashSet<>();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -749,7 +749,9 @@ public class ApiMgtDAO {
             conn = APIMgtDBUtil.getConnection();
             conn.setAutoCommit(false);
             String subscriptionUUIDQuery = SQLConstants.GET_SUBSCRIPTION_UUID_SQL;
-            if (identifier instanceof APIIdentifier) {
+            if (identifier.getId() > 0) {
+                id = identifier.getId();
+            } else if (identifier instanceof APIIdentifier) {
                 String apiUuid;
                 if (identifier.getUUID() != null) {
                     apiUuid = identifier.getUUID();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -272,6 +272,16 @@ public class SQLConstants {
             "   API_ID = ? " +
             "   AND APPLICATION_ID = ?";
 
+    public static final String GET_SUBSCRIPTION_UUID_BY_API_UUID_SQL =
+            " SELECT SUBS.UUID " +
+            " FROM " +
+            " AM_SUBSCRIPTION SUBS, " +
+            " AM_API APIS " +
+            " WHERE " +
+            " SUBS.API_ID = APIS.API_ID" +
+            " AND APIS.API_UUID = ? " +
+            " AND SUBS.APPLICATION_ID = ?";
+
     public static final String GET_SUBSCRIBER_ID_BY_SUBSCRIPTION_UUID_SQL =
             " SELECT APPS.SUBSCRIBER_ID  AS SUBSCRIBER_ID " +
             " FROM " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/SubscriptionWorkflowDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/SubscriptionWorkflowDTO.java
@@ -30,6 +30,8 @@ public class SubscriptionWorkflowDTO extends WorkflowDTO{
 
     private String apiProvider;
 
+    private String apiUUID;
+
     private String subscriber;
 
     private String applicationName;
@@ -111,4 +113,8 @@ public class SubscriptionWorkflowDTO extends WorkflowDTO{
     public void setRequestedTierName(String requestedTierName) {
         this.requestedTierName = requestedTierName;
     }
+
+    public String getApiUUID() { return apiUUID; }
+
+    public void setApiUUID(String apiUUID) { this.apiUUID = apiUUID; }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionSimpleWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionSimpleWorkflowExecutor.java
@@ -83,6 +83,7 @@ public class SubscriptionDeletionSimpleWorkflowExecutor extends WorkflowExecutor
         try {
             APIIdentifier identifier = new APIIdentifier(subWorkflowDTO.getApiProvider(),
                     subWorkflowDTO.getApiName(), subWorkflowDTO.getApiVersion());
+            identifier.setId(Integer.parseInt(subWorkflowDTO.getMetadata(WorkflowConstants.PayloadConstants.API_ID)));
             apiMgtDAO.removeSubscription(identifier, ((SubscriptionWorkflowDTO) workflowDTO).getApplicationId());
         } catch (APIManagementException e) {
             errorMsg = "Could not complete subscription deletion workflow for api: " + subWorkflowDTO.getApiName();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionSimpleWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionSimpleWorkflowExecutor.java
@@ -84,7 +84,7 @@ public class SubscriptionDeletionSimpleWorkflowExecutor extends WorkflowExecutor
             APIIdentifier identifier = new APIIdentifier(subWorkflowDTO.getApiProvider(),
                     subWorkflowDTO.getApiName(), subWorkflowDTO.getApiVersion());
             identifier.setId(Integer.parseInt(subWorkflowDTO.getMetadata(WorkflowConstants.PayloadConstants.API_ID)));
-            apiMgtDAO.removeSubscription(identifier, ((SubscriptionWorkflowDTO) workflowDTO).getApplicationId());
+            apiMgtDAO.removeSubscriptionByUUID(subWorkflowDTO.getApiUUID(), ((SubscriptionWorkflowDTO) workflowDTO).getApplicationId());
         } catch (APIManagementException e) {
             errorMsg = "Could not complete subscription deletion workflow for api: " + subWorkflowDTO.getApiName();
             throw new WorkflowException(errorMsg, e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/WorkflowConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/WorkflowConstants.java
@@ -128,6 +128,8 @@ public class WorkflowConstants {
         public static final String VARIABLE_CALLBACKURL = "callbackUrl";
         public static final String VARIABLE_WFREF = "wfReference";
         public static final String VARIABLE_INVOKER = "invoker";
+
+        public static final String API_ID = "apiId";
         
         public static final String DATA = "data";
         public static final String ID = "id";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionSimpleWorkflowExecutorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionSimpleWorkflowExecutorTest.java
@@ -50,6 +50,7 @@ public class SubscriptionDeletionSimpleWorkflowExecutorTest {
         subscriptionWorkflowDTO.setApiProvider("testUser");
         subscriptionWorkflowDTO.setApiName("weatherAPI");
         subscriptionWorkflowDTO.setApiVersion("v1");
+        subscriptionWorkflowDTO.setMetadata("apiId", String.valueOf(1));
         subscriptionDeletionSimpleWorkflowExecutor = new SubscriptionDeletionSimpleWorkflowExecutor();
     }
 


### PR DESCRIPTION
### Purpose
To add https://github.com/wso2/carbon-apimgt/pull/10551 changes to master

This PR,

1. Set organizationID as the tenant domain of the api events.
2. Fix subscription deletion issue when api and application names are equal in different organizations as mentioned in PR: https://github.com/wso2/carbon-apimgt/pull/10551
3. Refactor removeSubscription method as removeSubscriptionByUUID to directly work with UUIDs

Git Actions: https://github.com/YasasRangika/carbon-apimgt/actions/runs/956251757