### PR TITLE
Fix the error response if the feign service call to token endpoint fails

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -416,7 +416,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                         GRANT_TYPE_VALUE, scopes);
             }
         } catch (KeyManagerClientException e) {
-            throw new APIManagementException("Error occurred while calling token endpoint!", e);
+            throw new APIManagementException("Error occurred while calling token endpoint - " + e.getReason(), e);
         }
 
         tokenInfo = new AccessTokenInfo();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/kmclient/KMClientErrorDecoder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/kmclient/KMClientErrorDecoder.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.apimgt.impl.kmclient;
 import feign.Response;
 import feign.codec.ErrorDecoder;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -33,25 +34,35 @@ public class KMClientErrorDecoder implements ErrorDecoder {
     @Override
     public Exception decode(String methodKey, Response response) {
 
-        String errorDescription;
-        try {
-            String responseStr = IOUtils.toString(response.body().asInputStream(), UTF_8);
-            JSONParser jsonParser = new JSONParser();
-            JSONObject responseJson = (JSONObject) jsonParser.parse(responseStr);
-            if (responseJson.get("error_description") != null) {
-                errorDescription = responseJson.get("error_description").toString();
-            } else {
-                errorDescription = response.reason();
-            }
-            if (response.status() >= 400 && response.status() <= 499) {
-                return new KeyManagerClientException(response.status(), errorDescription);
-            }
-            if (response.status() >= 500 && response.status() <= 599) {
-                return new KeyManagerClientException(response.status(), errorDescription);
-            }
-        } catch (IOException | ParseException e) {
-            e.printStackTrace();
+        String errorDescription = getErrorDescriptionFromStream(response);
+        if (StringUtils.isEmpty(errorDescription)) {
+            errorDescription = response.reason();
+        }
+        if (response.status() >= 400 && response.status() <= 499) {
+            return new KeyManagerClientException(response.status(), errorDescription);
+        }
+        if (response.status() >= 500 && response.status() <= 599) {
+            return new KeyManagerClientException(response.status(), errorDescription);
         }
         return errorStatus(methodKey, response);
+    }
+
+    private String getErrorDescriptionFromStream(Response response) {
+
+        String errorDescription = null;
+        if (response.body() != null) {
+            try {
+                String responseStr = IOUtils.toString(response.body().asInputStream(), UTF_8);
+                JSONParser jsonParser = new JSONParser();
+                JSONObject responseJson = (JSONObject) jsonParser.parse(responseStr);
+                Object errorObj = responseJson.get("error_description");
+                if (errorObj != null) {
+                    errorDescription = errorObj.toString();
+                }
+            } catch (IOException | ParseException ignore) {
+
+            }
+        }
+        return errorDescription;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
@@ -56,6 +56,7 @@ import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
 import org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.store.v1.ApplicationsApiService;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIInfoListDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIKeyDTO;
@@ -75,13 +76,11 @@ import org.wso2.carbon.apimgt.rest.api.store.v1.dto.ScopeInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.mappings.APIInfoMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.mappings.ApplicationKeyMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.store.v1.mappings.ApplicationMappingUtil;
-import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.store.v1.models.ExportedApplication;
 import org.wso2.carbon.apimgt.rest.api.store.v1.utils.ExportUtils;
 import org.wso2.carbon.apimgt.rest.api.store.v1.utils.ImportUtils;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestAPIStoreUtils;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
-import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -100,7 +99,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.ws.rs.core.Response;
 
 public class ApplicationsApiServiceImpl implements ApplicationsApiService {
@@ -1213,7 +1211,9 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
                         appToken.setValidityTime(response.getValidityPeriod());
                         return Response.ok().entity(appToken).build();
                     } catch (APIManagementException e) {
-                        RestApiUtil.handleBadRequest(e.getMessage(), e.getErrorHandler().getErrorCode(), log);
+                        Long errorCode = e.getErrorHandler() != null ? e.getErrorHandler().getErrorCode() :
+                                ExceptionCodes.INTERNAL_ERROR.getErrorCode();
+                        RestApiUtil.handleBadRequest(e.getMessage(), errorCode, log);
                     }
                 } else {
                     RestApiUtil

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
@@ -1213,7 +1213,7 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
                         appToken.setValidityTime(response.getValidityPeriod());
                         return Response.ok().entity(appToken).build();
                     } catch (APIManagementException e) {
-                        RestApiUtil.handleBadRequest(e.getErrorHandler(), log);
+                        RestApiUtil.handleBadRequest(e.getMessage(), e.getErrorHandler().getErrorCode(), log);
                     }
                 } else {
                     RestApiUtil


### PR DESCRIPTION
Currently the `POST /applications/{applicationId}/oauth-keys/{keyMappingId}/generate-token` REST API is used to generate token from Devportal UI. If any error occurred during the token generation it returns a general error response as follows:

```json
{
   "code":900967,
   "message":"General Error",
   "description":"Server Error Occurred",
   "moreInfo":"","error":[]
}
```

This PR fixes it as:

```json
{
    "code": 900967,
    "message": "Bad Request",
    "description": "Error occurred while calling token endpoint - No Registered IDP found for the JWT with issuer name : https://{okta-domain}/oauth2/default",
    "moreInfo": "",
    "error": []
}
```