### PR TITLE
Improve logging when API with invalid throttling tier is invoked

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyValidationService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyValidationService.java
@@ -355,9 +355,14 @@ public class APIKeyValidationService {
                     apiPolicy = new SubscriptionDataLoaderImpl().getAPIPolicy(urlMapping.getThrottlingPolicy(),
                             tenantDomain);
                     if (apiPolicy != null) {
-                        store.addOrUpdateApiPolicy(apiPolicy);
-                        if (log.isDebugEnabled()) {
-                            log.debug("Update SubscriptionDataStore API Policy for " + apiPolicy.getCacheKey());
+                        if (apiPolicy.getName() != null) {
+                            store.addOrUpdateApiPolicy(apiPolicy);
+                            if (log.isDebugEnabled()) {
+                                log.debug("Update SubscriptionDataStore API Policy for " + apiPolicy.getCacheKey());
+                            }
+                        } else {
+                            throw new APIManagementException("Exception while loading api policy for " +
+                                    urlMapping.getThrottlingPolicy() + " for domain " + tenantDomain);
                         }
                     }
 
@@ -367,9 +372,14 @@ public class APIKeyValidationService {
                 apiPolicy = new SubscriptionDataLoaderImpl().getAPIPolicy(urlMapping.getThrottlingPolicy(),
                         tenantDomain);
                 if (apiPolicy != null) {
-                    store.addOrUpdateApiPolicy(apiPolicy);
-                    if (log.isDebugEnabled()) {
-                        log.debug("Update SubscriptionDataStore API Policu for " + apiPolicy.getCacheKey());
+                    if (apiPolicy.getName() != null) {
+                        store.addOrUpdateApiPolicy(apiPolicy);
+                        if (log.isDebugEnabled()) {
+                            log.debug("Update SubscriptionDataStore API Policy for " + apiPolicy.getCacheKey());
+                        }
+                    } else {
+                        throw new APIManagementException("Exception while loading api policy for " +
+                                urlMapping.getThrottlingPolicy() + " for domain " + tenantDomain);
                     }
                 }
             }


### PR DESCRIPTION
This PR improves logging when API with invalid throttling tier is invoked.

Fixes https://github.com/wso2/product-apim/issues/11314