### PR TITLE
Use persistsnce layer method for async api getDefinition

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConsumer.java
@@ -971,17 +971,6 @@ public interface APIConsumer extends APIManager {
     void changeUserPassword(String currentPassword, String newPassword) throws APIManagementException;
 
     /**
-     * Returns the AsyncAPI definition of the API for the given gateway environment as a string
-     *
-     * @param apiId id of the APIIdentifier
-     * @param environmentName API Gateway environment name
-     * @return AsyncAPI definition string
-     * @throws APIManagementException if error occurred while obtaining the AsyncAPI definition
-     */
-    String getAsyncAPIDefinitionForEnvironment(Identifier apiId, String environmentName)
-            throws APIManagementException;
-
-    /**
      * Returns the AsyncAPI definition of the API for the given microgateway gateway label as a string
      *
      * @param apiId id of the APIIdentifier

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
@@ -912,9 +912,10 @@ public interface APIManager {
     /**
      * Returns the AsyncAPI definition as a string
      *
-     * @param apiId id of the APIIdentifier
+     * @param apiId         id of the APIIdentifier
+     * @param organization  identifier of the organization
      * @return AsyncAPI string
      * @throws APIManagementException
      */
-    String getAsyncAPIDefinition(Identifier apiId) throws APIManagementException;
+    String getAsyncAPIDefinition(Identifier apiId, String organization) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
@@ -908,14 +908,4 @@ public interface APIManager {
      */
     Map<String, Object> searchPaginatedContent(String searchQuery, String orgId, int start, int end)
             throws APIManagementException;
-
-    /**
-     * Returns the AsyncAPI definition as a string
-     *
-     * @param apiId         id of the APIIdentifier
-     * @param organization  identifier of the organization
-     * @return AsyncAPI string
-     * @throws APIManagementException
-     */
-    String getAsyncAPIDefinition(Identifier apiId, String organization) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5897,11 +5897,6 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
     }
 
     @Override
-    public String getAsyncAPIDefinitionForEnvironment(Identifier apiId, String environmentName) throws APIManagementException {
-        return getAsyncAPIDefinitionForDeployment(apiId, environmentName);
-    }
-
-    @Override
     public String getAsyncAPIDefinitionForLabel(Identifier apiId, String labelName) throws APIManagementException {
         List<Label> gatewayLabels;
         String updatedDefinition = null;
@@ -5920,37 +5915,13 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
     }
 
     @Override
-    public String getAsyncAPIDefinition(Identifier apiId) throws APIManagementException {
-        return super.getAsyncAPIDefinition(apiId);
+    public String getAsyncAPIDefinition(Identifier apiId, String organization) throws APIManagementException {
+        return super.getAsyncAPIDefinition(apiId, organization);
     }
 
     @Override
     public List<APIRevisionDeployment> getAPIRevisionDeploymentListOfAPI(String apiUUID) throws APIManagementException {
         return apiMgtDAO.getAPIRevisionDeploymentByApiUUID(apiUUID);
-    }
-
-    /**
-     * Get server URL updated AsyncAPI definition for given synapse gateway environment
-     * @param apiId Id of the API
-     * @param environmentName Name of the synapse gateway environment
-     * @return Updated AsyncAPI definition
-     * @throws APIManagementException
-     */
-    private String getAsyncAPIDefinitionForDeployment(Identifier apiId, String environmentName)
-            throws APIManagementException {
-        String apiTenantDomain;
-        String updatedDefinition = null;
-        Map<String,String> hostsWithSchemes;
-        String definition = super.getAsyncAPIDefinition(apiId);
-        AsyncApiParser asyncAPIParser = new AsyncApiParser();
-        if (apiId instanceof APIIdentifier) {
-            API api = getLightweightAPI((APIIdentifier) apiId);
-            apiTenantDomain = MultitenantUtils.getTenantDomain(
-                    APIUtil.replaceEmailDomainBack(api.getId().getProviderName()));
-            hostsWithSchemes = getHostWithSchemeMappingForEnvironmentWS(apiTenantDomain, environmentName);
-            updatedDefinition = asyncAPIParser.getAsyncApiDefinitionForStore(api, definition, hostsWithSchemes);
-        }
-        return updatedDefinition;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5915,11 +5915,6 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
     }
 
     @Override
-    public String getAsyncAPIDefinition(Identifier apiId, String organization) throws APIManagementException {
-        return super.getAsyncAPIDefinition(apiId, organization);
-    }
-
-    @Override
     public List<APIRevisionDeployment> getAPIRevisionDeploymentListOfAPI(String apiUUID) throws APIManagementException {
         return apiMgtDAO.getAPIRevisionDeploymentByApiUUID(apiUUID);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -4132,42 +4132,20 @@ public abstract class AbstractAPIManager implements APIManager {
     /**
      * Returns the AsyncAPI definition of the given API
      *
-     * @param apiId id of the APIIdentifier
+     * @param apiId         id of the APIIdentifier
+     * @param organization  identifier of the organization
      * @return A String containing the AsyncAPI definition
      * @throws APIManagementException
      */
     @Override
-    public String getAsyncAPIDefinition(Identifier apiId) throws APIManagementException {
+    public String getAsyncAPIDefinition(Identifier apiId, String organization) throws APIManagementException {
 
-        String apiTenantDomain = getTenantDomain(apiId);
-        String asyncApiDoc = null;
-        boolean tenantFlowStarted = false;
+        String asyncApiDoc;
         try {
-            Registry registryType;
-            //Tenant store anonymous mode if current tenant and the required tenant is not matching
-            if (this.tenantDomain == null || isTenantDomainNotMatching(apiTenantDomain)) {
-                if (apiTenantDomain != null) {
-                    startTenantFlow(apiTenantDomain);
-                    tenantFlowStarted = true;
-                }
-                int tenantId = getTenantManager().getTenantId(apiTenantDomain);
-                registryType = getRegistryService().getGovernanceUserRegistry(
-                        CarbonConstants.REGISTRY_ANONNYMOUS_USERNAME, tenantId
-                );
-            } else {
-                registryType = registry;
-            }
-            asyncApiDoc = AsyncApiParserUtil.getAPIDefinition(apiId, registryType);
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            asyncApiDoc = apiPersistenceInstance.getAsyncDefinition(new Organization(organization), apiId.getUUID());
+        } catch (AsyncSpecPersistenceException e) {
             String msg = "Failed to get AsyncAPI documentation of API : " + apiId;
             throw new APIManagementException(msg, e);
-        } catch (RegistryException e) {
-            String msg = "Failed to get AsyncAPI documentation of API : " + apiId;
-            throw new APIManagementException(msg, e);
-        } finally {
-            if (tenantFlowStarted) {
-                endTenantFlow();
-            }
         }
         return asyncApiDoc;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -4129,27 +4129,6 @@ public abstract class AbstractAPIManager implements APIManager {
         return null;
     }
 
-    /**
-     * Returns the AsyncAPI definition of the given API
-     *
-     * @param apiId         id of the APIIdentifier
-     * @param organization  identifier of the organization
-     * @return A String containing the AsyncAPI definition
-     * @throws APIManagementException
-     */
-    @Override
-    public String getAsyncAPIDefinition(Identifier apiId, String organization) throws APIManagementException {
-
-        String asyncApiDoc;
-        try {
-            asyncApiDoc = apiPersistenceInstance.getAsyncDefinition(new Organization(organization), apiId.getUUID());
-        } catch (AsyncSpecPersistenceException e) {
-            String msg = "Failed to get AsyncAPI documentation of API : " + apiId;
-            throw new APIManagementException(msg, e);
-        }
-        return asyncApiDoc;
-    }
-
     protected boolean isOauthAppValidation() {
 
         String oauthAppValidation = getAPIManagerConfiguration()

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/UserAwareAPIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/UserAwareAPIProvider.java
@@ -26,10 +26,8 @@ import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIStateChangeResponse;
-import org.wso2.carbon.apimgt.api.model.APIStatus;
 import org.wso2.carbon.apimgt.api.model.APIStore;
 import org.wso2.carbon.apimgt.api.model.Documentation;
-import org.wso2.carbon.apimgt.api.model.DuplicateAPIException;
 import org.wso2.carbon.apimgt.api.model.Identifier;
 import org.wso2.carbon.apimgt.api.model.LifeCycleEvent;
 import org.wso2.carbon.apimgt.api.model.Mediation;
@@ -44,7 +42,6 @@ import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -444,8 +441,8 @@ public class UserAwareAPIProvider extends APIProviderImpl {
     }
 
     @Override
-    public String getAsyncAPIDefinition(Identifier apiId) throws APIManagementException {
+    public String getAsyncAPIDefinition(Identifier apiId, String organization) throws APIManagementException {
         checkAccessControlPermission(apiId);
-        return super.getAsyncAPIDefinition(apiId);
+        return super.getAsyncAPIDefinition(apiId, organization);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/UserAwareAPIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/UserAwareAPIProvider.java
@@ -439,10 +439,4 @@ public class UserAwareAPIProvider extends APIProviderImpl {
     public void deleteWorkflowTask(String uuid) throws APIManagementException {
         super.deleteWorkflowTask(uuid);
     }
-
-    @Override
-    public String getAsyncAPIDefinition(Identifier apiId, String organization) throws APIManagementException {
-        checkAccessControlPermission(apiId);
-        return super.getAsyncAPIDefinition(apiId, organization);
-    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiCommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiCommonUtil.java
@@ -462,7 +462,7 @@ public class RestApiCommonUtil {
     public static String retrieveAsyncAPIDefinition(API api, APIProvider apiProvider)
             throws APIManagementException {
 
-        return apiProvider.getAsyncAPIDefinition(api.getId());
+        return apiProvider.getAsyncAPIDefinition(api.getId(), api.getOrganization());
     }
 
     public static String getValidateTenantDomain(String xWSO2Tenant) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiCommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiCommonUtil.java
@@ -462,7 +462,7 @@ public class RestApiCommonUtil {
     public static String retrieveAsyncAPIDefinition(API api, APIProvider apiProvider)
             throws APIManagementException {
 
-        return apiProvider.getAsyncAPIDefinition(api.getId(), api.getOrganization());
+        return apiProvider.getAsyncAPIDefinition(api.getId().getUUID(), api.getOrganization());
     }
 
     public static String getValidateTenantDomain(String xWSO2Tenant) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/ImportExportAPIServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/ImportExportAPIServiceImpl.java
@@ -107,6 +107,7 @@ public class ImportExportAPIServiceImpl implements ImportExportAPI {
         APIIdentifier apiIdentifier = APIMappingUtil.getAPIIdentifierFromUUID(apiId);
         API api = apiProvider.getAPIbyUUID(revisionUUID, organization);
         api.setUuid(apiId);
+        apiIdentifier.setUuid(apiId);
         APIDTO apiDtoToReturn = APIMappingUtil.fromAPItoDTO(api, preserveCredentials, apiProvider);
         return ExportUtils.exportApi(apiProvider, apiIdentifier, apiDtoToReturn, api, userName, format, preserveStatus,
                 preserveDocs, StringUtils.EMPTY, organization);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -865,6 +865,7 @@ public class ExportUtils {
             String apiType = apiDtoToReturn.getType().toString();
             API api = APIMappingUtil.fromDTOtoAPI(apiDtoToReturn, apiDtoToReturn.getProvider());
             api.setOrganization(organization);
+            api.setId(apiIdentifier);
             if (!PublisherCommonUtils.isStreamingAPI(apiDtoToReturn)) {
                 // For Graphql APIs, the graphql schema definition should be exported.
                 if (StringUtils.equals(apiType, APIConstants.APITransportType.GRAPHQL.toString())) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -1043,7 +1043,7 @@ public class PublisherCommonUtils {
         apiProvider.saveAsyncApiDefinition(existingAPI, apiDefinition);
         apiProvider.updateAPI(existingAPI);
         //retrieves the updated AsyncAPI definition
-        return apiProvider.getAsyncAPIDefinition(existingAPI.getId(), organization);
+        return apiProvider.getAsyncAPIDefinition(existingAPI.getId().getUUID(), organization);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -1043,7 +1043,7 @@ public class PublisherCommonUtils {
         apiProvider.saveAsyncApiDefinition(existingAPI, apiDefinition);
         apiProvider.updateAPI(existingAPI);
         //retrieves the updated AsyncAPI definition
-        return apiProvider.getAsyncAPIDefinition(existingAPI.getId());
+        return apiProvider.getAsyncAPIDefinition(existingAPI.getId(), organization);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -4649,6 +4649,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             //APIIdentifier apiIdentifier = APIMappingUtil.getAPIIdentifierFromUUID(apiId, tenantDomain);
             //String asyncAPIString = apiProvider.getAsyncAPIDefinition(apiIdentifier);
             API api = apiProvider.getAPIbyUUID(apiId, organization);
+            api.setOrganization(organization);
             String updatedDefinition = RestApiCommonUtil.retrieveAsyncAPIDefinition(api, apiProvider);
             return Response.ok().entity(updatedDefinition).header("Content-Disposition",
                     "attachment; fileNme=\"" + "asyncapi.json" + "\"").build();


### PR DESCRIPTION
Goals
To provide async API creation support for Choreo APIM core.[1]

Objective
Change the code to use getAsyncDefinition (registry) method in the persistence layer

[1]: Issue: https://github.com/wso2-enterprise/choreo/issues/5567

Git Actions: https://github.com/YasasRangika/carbon-apimgt/actions/runs/971542548
