### PR TITLE
Add transport.receiver.session_timeout unit to unit-resolve.json

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.unit-resolve.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.unit-resolve.json
@@ -12,6 +12,7 @@
     "apim.throttling.blacklist_condition.period" : "ms",
     "apim.throttling.jms.start_delay" : "ms",
     "apim.jwt.expiry_time": "s",
-    "apim.certificate_reloader.period": "s"
+    "apim.certificate_reloader.period": "s",
+    "transport.receiver.session_timeout": "m"
   }
 }


### PR DESCRIPTION
## Purpose
Add transport.receiver.session_timeout unit to unit-resolve.json
Related Issue: https://github.com/wso2/product-apim/issues/11346

## Related PRs
[WUM][3.2.0] - https://github.com/wso2-support/carbon-apimgt/pull/3479
[U2][3.2.0] - https://github.com/wso2-support/carbon-apimgt/pull/3480