### PR TITLE
Fix API get failure in Choreo Async API feature

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -7981,6 +7981,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             throw new APIManagementException("Error while retrieving the OAS definition", e);
         } catch (ParseException e) {
             throw new APIManagementException("Error while parsing the OAS definition", e);
+        } catch (AsyncSpecPersistenceException e) {
+            throw new APIManagementException("Error while retrieving the Async API definition", e);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -3711,7 +3711,7 @@ public abstract class AbstractAPIManager implements APIManager {
     }
 
     protected void populateAPIInformation(String uuid, String organization, API api)
-            throws APIManagementException, OASPersistenceException, ParseException {
+            throws APIManagementException, OASPersistenceException, ParseException, AsyncSpecPersistenceException {
         Organization org = new Organization(organization);
         //UUID
         if (api.getUuid() == null) {
@@ -3767,13 +3767,22 @@ public abstract class AbstractAPIManager implements APIManager {
         api.setScopes(new LinkedHashSet<>(scopeToKeyMapping.values()));
 
         //templates
-        String resourceConfigsString = null;
+        String resourceConfigsString;
         if (api.getSwaggerDefinition() != null) {
             resourceConfigsString = api.getSwaggerDefinition();
         } else {
             resourceConfigsString = apiPersistenceInstance.getOASDefinition(org, uuid);
         }
         api.setSwaggerDefinition(resourceConfigsString);
+
+        if (resourceConfigsString == null) {
+            if (api.getAsyncApiDefinition() != null) {
+                resourceConfigsString = api.getAsyncApiDefinition();
+            } else {
+                resourceConfigsString = apiPersistenceInstance.getAsyncDefinition(org, uuid);
+            }
+            api.setAsyncApiDefinition(resourceConfigsString);
+        }
 
         if (api.getType() != null && APIConstants.APITransportType.GRAPHQL.toString().equals(api.getType())) {
             api.setGraphQLSchema(getGraphqlSchemaDefinition(uuid, organization));

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/WebsubSubscriptionConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/WebsubSubscriptionConfiguration.java
@@ -23,6 +23,9 @@ public class WebsubSubscriptionConfiguration {
     private String signingAlgorithm;
     private String signatureHeader;
 
+    public WebsubSubscriptionConfiguration() {
+
+    }
     public WebsubSubscriptionConfiguration(
             boolean enable, String secret, String signingAlgorithm, String signatureHeader) {
         this.enable = enable;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -1122,7 +1122,7 @@ public class APIMappingUtil {
                 asyncAPIDefinition = model.getAsyncApiDefinition();
             } else {
                 asyncAPIDefinition = apiProvider
-                        .getAsyncAPIDefinition(model.getId().getUUID(), model.getOrganization());
+                        .getAsyncAPIDefinition(model.getId().getUUID(), tenantDomain);
             }
             if (asyncAPIDefinition != null) {
                 List<ScopeDTO> scopeDTOS = getScopesFromAsyncAPI(asyncAPIDefinition);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -1121,7 +1121,8 @@ public class APIMappingUtil {
             if (model.getAsyncApiDefinition() != null) {
                 asyncAPIDefinition = model.getAsyncApiDefinition();
             } else {
-                asyncAPIDefinition = apiProvider.getAsyncAPIDefinition(model.getId().getUUID(), tenantDomain);
+                asyncAPIDefinition = apiProvider
+                        .getAsyncAPIDefinition(model.getId().getUUID(), model.getOrganization());
             }
             if (asyncAPIDefinition != null) {
                 List<ScopeDTO> scopeDTOS = getScopesFromAsyncAPI(asyncAPIDefinition);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3983,7 +3983,7 @@ public class ApisApiServiceImpl implements ApisApiService {
     private APIDTO getAPIByID(String apiId, APIProvider apiProvider, String organization) {
         try {
             API api = apiProvider.getAPIbyUUID(apiId, organization);
-
+            api.setOrganization(organization);
             return APIMappingUtil.fromAPItoDTO(api, apiProvider);
         } catch (APIManagementException e) {
             //Auth failure occurs when cross tenant accessing APIs. Sends 404, since we don't need


### PR DESCRIPTION
### Goals
To provide async API creation support for Choreo APIM core.[1]

### Objective
Change the code to use getAsyncDefinition (registry) method in the persistence layer

[1]: Issue: https://github.com/wso2-enterprise/choreo/issues/5567

Git Actions: https://github.com/YasasRangika/carbon-apimgt/actions/runs/982064866
https://github.com/YasasRangika/carbon-apimgt/actions/runs/985304156(latest)
