### PR TITLE
Add unit test for getAsyncDefinition method

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/test/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImplTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/test/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImplTestCase.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.apimgt.persistence.dto.PublisherAPI;
 import org.wso2.carbon.apimgt.persistence.dto.PublisherAPIProduct;
 import org.wso2.carbon.apimgt.persistence.dto.UserContext;
 import org.wso2.carbon.apimgt.persistence.exceptions.APIPersistenceException;
+import org.wso2.carbon.apimgt.persistence.exceptions.AsyncSpecPersistenceException;
 import org.wso2.carbon.apimgt.persistence.exceptions.GraphQLPersistenceException;
 import org.wso2.carbon.apimgt.persistence.exceptions.OASPersistenceException;
 import org.wso2.carbon.apimgt.persistence.internal.ServiceReferenceHolder;
@@ -517,6 +518,47 @@ public class RegistryPersistenceImplTestCase {
         Assert.assertEquals("API oas definition does not match", definition, def);
         
     }
+
+    @Test
+    public void testGetAsyncDefinition()
+            throws AsyncSpecPersistenceException, RegistryException, APIPersistenceException, APIManagementException {
+        Registry registry = Mockito.mock(UserRegistry.class);
+        GenericArtifact artifact = PersistenceHelper.getSampleAPIArtifact();
+        String apiUUID = artifact.getId();
+
+        PowerMockito.mockStatic(RegistryPersistenceUtil.class);
+        GenericArtifactManager manager = Mockito.mock(GenericArtifactManager.class);
+        PowerMockito.when(RegistryPersistenceUtil.getArtifactManager(registry, APIConstants.API_KEY))
+                .thenReturn(manager);
+        Mockito.when(manager.getGenericArtifact(apiUUID)).thenReturn(artifact);
+        Mockito.doNothing().when(manager).updateGenericArtifact(artifact);
+
+        String apiProviderName = artifact.getAttribute(APIConstants.API_OVERVIEW_PROVIDER);
+        apiProviderName = RegistryPersistenceUtil.replaceEmailDomain(apiProviderName);
+        String apiName = artifact.getAttribute(APIConstants.API_OVERVIEW_NAME);
+        String apiVersion = artifact.getAttribute(APIConstants.API_OVERVIEW_VERSION);
+        String definitionPath = APIConstants.API_ROOT_LOCATION + RegistryConstants.PATH_SEPARATOR
+                + RegistryPersistenceUtil.replaceEmailDomain(apiProviderName) + RegistryConstants.PATH_SEPARATOR
+                + apiName + RegistryConstants.PATH_SEPARATOR + apiVersion + RegistryConstants.PATH_SEPARATOR
+                + APIConstants.API_ASYNC_API_DEFINITION_RESOURCE_NAME;
+
+        String apiPath = APIConstants.API_ROOT_LOCATION + RegistryConstants.PATH_SEPARATOR + apiProviderName
+                + RegistryConstants.PATH_SEPARATOR + apiName + RegistryConstants.PATH_SEPARATOR + apiVersion
+                + RegistryConstants.PATH_SEPARATOR + "api";
+
+        PowerMockito.when(GovernanceUtils.getArtifactPath(registry, apiUUID)).thenReturn(apiPath);
+        String definition = "{\"asyncapi\":\"2.0.0\",\"info\":{\"description\":\"This is a sample Async API\"}}";
+        Organization org = new Organization(SUPER_TENANT_DOMAIN);
+        APIPersistence apiPersistenceInstance = new RegistryPersistenceImplWrapper(registry, artifact);
+        Mockito.when(registry.resourceExists(definitionPath)).thenReturn(true);
+        Resource asyncResource = new ResourceImpl();
+        asyncResource.setContent(definition.getBytes());
+        Mockito.when(registry.get(definitionPath)).thenReturn(asyncResource);
+
+        String def = apiPersistenceInstance.getAsyncDefinition(org, apiUUID);
+        Assert.assertEquals("API Async definition does not match", definition, def);
+
+    }
     
     @Test
     public void testAddAPI() throws RegistryException, APIPersistenceException, APIManagementException {
@@ -533,7 +575,7 @@ public class RegistryPersistenceImplTestCase {
         Mockito.when(registry.get(anyString())).thenReturn(resource);
         Tag[] tags = new Tag[0];
         Mockito.when(registry.getTags(anyString())).thenReturn(tags);
-        
+
         PowerMockito.mockStatic(RegistryPersistenceUtil.class);
         GenericArtifactManager manager = Mockito.mock(GenericArtifactManager.class);
         PowerMockito.when(RegistryPersistenceUtil.getArtifactManager(registry, APIConstants.API_KEY))


### PR DESCRIPTION
### Goals
To provide async API creation support for Choreo APIM core.[1]

### Objective
Add unit test for getAsyncDefinition() method.

[1]: Issue: https://github.com/wso2-enterprise/choreo/issues/5567

Git Actions: https://github.com/YasasRangika/carbon-apimgt/actions/runs/982683451