### PR TITLE
Fix monetization label being null in API response error

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -839,6 +839,7 @@ public class APIMappingUtil {
                 subscriptionAllowedTenants));
         int free = 0, commercial = 0;
         for (Tier tier : throttlingPolicies) {
+            tier = APIUtil.getTierFromCache(tier.getName(), apiTenant);
             if (RestApiConstants.FREE.equalsIgnoreCase(tier.getTierPlan())) {
                 free = free + 1;
             } else if (RestApiConstants.COMMERCIAL.equalsIgnoreCase(tier.getTierPlan())) {


### PR DESCRIPTION
This fixes the monetization label being null in the API response returned for devportal listing. 
Issue: wso2/product-apim#6760