### PR TITLE
Add a new resource to Admin rest API to query application details by providing the app id

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -309,6 +309,10 @@
       {
         "Name": "apim:comment_write",
         "Roles": "admin,Internal/creator,Internal/publisher"
+      },
+      {
+        "Name": "apim:admin_application_view",
+        "Roles": "admin"
       }
     ]
   },

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/tenant-conf.json
@@ -277,6 +277,10 @@
       {
         "Name": "apim:role_manage",
         "Roles": "admin"
+      },
+      {
+        "Name": "apim:admin_application_view",
+        "Roles": "admin"
       }
     ]
   },

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/swagger.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/swagger.json
@@ -1078,8 +1078,8 @@
           "type" : "string",
           "example" : "EXCHANGED",
           "description" : "The type of the tokens to be used (exchanged or without exchanged). Accepted values are EXCHANGED and ORIGINAL.",
-          "enum" : [ "EXCHANGED", "ORIGINAL" ],
-          "default" : "ORIGINAL"
+          "default" : "ORIGINAL",
+          "enum" : [ "EXCHANGED", "ORIGINAL" ]
         }
       }
     },

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/ApplicationsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/ApplicationsApi.java
@@ -1,5 +1,6 @@
 package org.wso2.carbon.apimgt.rest.api.admin.v1;
 
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ApplicationDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ApplicationListDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ErrorDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.WorkflowResponseDTO;
@@ -74,6 +75,26 @@ ApplicationsApiService delegate = new ApplicationsApiServiceImpl();
     }
 
     @GET
+    @Path("/{applicationId}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get the details of an Application ", notes = "This operation can be used to get the details of an application by specifying its id. ", response = ApplicationDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:app_import_export", description = "Import and export applications related operations"),
+            @AuthorizationScope(scope = "apim:admin_application_view", description = "View Applications")
+        })
+    }, tags={ "Applications",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Application details returned. ", response = ApplicationDTO.class),
+        @ApiResponse(code = 400, message = "Bad Request. Invalid request or validation error.", response = ErrorDTO.class),
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
+        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class) })
+    public Response applicationsApplicationIdGet(@ApiParam(value = "Application UUID ",required=true) @PathParam("applicationId") String applicationId) throws APIManagementException{
+        return delegate.applicationsApplicationIdGet(applicationId, securityContext);
+    }
+
+    @GET
     
     
     @Produces({ "application/json" })
@@ -81,7 +102,8 @@ ApplicationsApiService delegate = new ApplicationsApiServiceImpl();
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
             @AuthorizationScope(scope = "apim:app_owner_change", description = "Retrieve and manage applications"),
-            @AuthorizationScope(scope = "apim:app_import_export", description = "Import and export applications related operations")
+            @AuthorizationScope(scope = "apim:app_import_export", description = "Import and export applications related operations"),
+            @AuthorizationScope(scope = "apim:admin_application_view", description = "View Applications")
         })
     }, tags={ "Application (Collection)" })
     @ApiResponses(value = { 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/ApplicationsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/ApplicationsApiService.java
@@ -9,6 +9,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 
 import org.wso2.carbon.apimgt.api.APIManagementException;
 
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ApplicationDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ApplicationListDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ErrorDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.WorkflowResponseDTO;
@@ -24,5 +25,6 @@ import javax.ws.rs.core.SecurityContext;
 public interface ApplicationsApiService {
       public Response applicationsApplicationIdChangeOwnerPost(String owner, String applicationId, MessageContext messageContext) throws APIManagementException;
       public Response applicationsApplicationIdDelete(String applicationId, MessageContext messageContext) throws APIManagementException;
+      public Response applicationsApplicationIdGet(String applicationId, MessageContext messageContext) throws APIManagementException;
       public Response applicationsGet(String user, Integer limit, Integer offset, String accept, String name, String tenantDomain, String sortBy, String sortOrder, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/ApplicationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/ApplicationDTO.java
@@ -1,0 +1,320 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeInfoDTO;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class ApplicationDTO   {
+  
+    private String applicationId = null;
+    private String name = null;
+    private String throttlingPolicy = null;
+    private String description = null;
+
+    @XmlType(name="TokenTypeEnum")
+    @XmlEnum(String.class)
+    public enum TokenTypeEnum {
+        OAUTH("OAUTH"),
+        JWT("JWT");
+        private String value;
+
+        TokenTypeEnum (String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @JsonCreator
+        public static TokenTypeEnum fromValue(String v) {
+            for (TokenTypeEnum b : TokenTypeEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+return null;
+        }
+    }
+    private TokenTypeEnum tokenType = TokenTypeEnum.JWT;
+    private String status = "";
+    private List<String> groups = new ArrayList<String>();
+    private Integer subscriptionCount = null;
+    private Map<String, String> attributes = new HashMap<String, String>();
+    private List<ScopeInfoDTO> subscriptionScopes = new ArrayList<ScopeInfoDTO>();
+    private String owner = null;
+
+  /**
+   **/
+  public ApplicationDTO applicationId(String applicationId) {
+    this.applicationId = applicationId;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "01234567-0123-0123-0123-012345678901", value = "")
+  @JsonProperty("applicationId")
+  public String getApplicationId() {
+    return applicationId;
+  }
+  public void setApplicationId(String applicationId) {
+    this.applicationId = applicationId;
+  }
+
+  /**
+   **/
+  public ApplicationDTO name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "CalculatorApp", value = "")
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   **/
+  public ApplicationDTO throttlingPolicy(String throttlingPolicy) {
+    this.throttlingPolicy = throttlingPolicy;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Unlimited", value = "")
+  @JsonProperty("throttlingPolicy")
+  public String getThrottlingPolicy() {
+    return throttlingPolicy;
+  }
+  public void setThrottlingPolicy(String throttlingPolicy) {
+    this.throttlingPolicy = throttlingPolicy;
+  }
+
+  /**
+   **/
+  public ApplicationDTO description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Sample calculator application", value = "")
+  @JsonProperty("description")
+  public String getDescription() {
+    return description;
+  }
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  /**
+   * Type of the access token generated for this application. **OAUTH:** A UUID based access token which is issued by default. **JWT:** A self-contained, signed JWT based access token. **Note:** This can be only used in Microgateway environments. 
+   **/
+  public ApplicationDTO tokenType(TokenTypeEnum tokenType) {
+    this.tokenType = tokenType;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "JWT", value = "Type of the access token generated for this application. **OAUTH:** A UUID based access token which is issued by default. **JWT:** A self-contained, signed JWT based access token. **Note:** This can be only used in Microgateway environments. ")
+  @JsonProperty("tokenType")
+  public TokenTypeEnum getTokenType() {
+    return tokenType;
+  }
+  public void setTokenType(TokenTypeEnum tokenType) {
+    this.tokenType = tokenType;
+  }
+
+  /**
+   **/
+  public ApplicationDTO status(String status) {
+    this.status = status;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "APPROVED", value = "")
+  @JsonProperty("status")
+  public String getStatus() {
+    return status;
+  }
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  /**
+   **/
+  public ApplicationDTO groups(List<String> groups) {
+    this.groups = groups;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("groups")
+  public List<String> getGroups() {
+    return groups;
+  }
+  public void setGroups(List<String> groups) {
+    this.groups = groups;
+  }
+
+  /**
+   **/
+  public ApplicationDTO subscriptionCount(Integer subscriptionCount) {
+    this.subscriptionCount = subscriptionCount;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("subscriptionCount")
+  public Integer getSubscriptionCount() {
+    return subscriptionCount;
+  }
+  public void setSubscriptionCount(Integer subscriptionCount) {
+    this.subscriptionCount = subscriptionCount;
+  }
+
+  /**
+   **/
+  public ApplicationDTO attributes(Map<String, String> attributes) {
+    this.attributes = attributes;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "External Reference ID, Billing Tier", value = "")
+  @JsonProperty("attributes")
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+  public void setAttributes(Map<String, String> attributes) {
+    this.attributes = attributes;
+  }
+
+  /**
+   **/
+  public ApplicationDTO subscriptionScopes(List<ScopeInfoDTO> subscriptionScopes) {
+    this.subscriptionScopes = subscriptionScopes;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "[]", value = "")
+      @Valid
+  @JsonProperty("subscriptionScopes")
+  public List<ScopeInfoDTO> getSubscriptionScopes() {
+    return subscriptionScopes;
+  }
+  public void setSubscriptionScopes(List<ScopeInfoDTO> subscriptionScopes) {
+    this.subscriptionScopes = subscriptionScopes;
+  }
+
+  /**
+   * Application created user 
+   **/
+  public ApplicationDTO owner(String owner) {
+    this.owner = owner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "admin", value = "Application created user ")
+  @JsonProperty("owner")
+  public String getOwner() {
+    return owner;
+  }
+  public void setOwner(String owner) {
+    this.owner = owner;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ApplicationDTO application = (ApplicationDTO) o;
+    return Objects.equals(applicationId, application.applicationId) &&
+        Objects.equals(name, application.name) &&
+        Objects.equals(throttlingPolicy, application.throttlingPolicy) &&
+        Objects.equals(description, application.description) &&
+        Objects.equals(tokenType, application.tokenType) &&
+        Objects.equals(status, application.status) &&
+        Objects.equals(groups, application.groups) &&
+        Objects.equals(subscriptionCount, application.subscriptionCount) &&
+        Objects.equals(attributes, application.attributes) &&
+        Objects.equals(subscriptionScopes, application.subscriptionScopes) &&
+        Objects.equals(owner, application.owner);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(applicationId, name, throttlingPolicy, description, tokenType, status, groups, subscriptionCount, attributes, subscriptionScopes, owner);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ApplicationDTO {\n");
+    
+    sb.append("    applicationId: ").append(toIndentedString(applicationId)).append("\n");
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    throttlingPolicy: ").append(toIndentedString(throttlingPolicy)).append("\n");
+    sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("    tokenType: ").append(toIndentedString(tokenType)).append("\n");
+    sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
+    sb.append("    subscriptionCount: ").append(toIndentedString(subscriptionCount)).append("\n");
+    sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
+    sb.append("    subscriptionScopes: ").append(toIndentedString(subscriptionScopes)).append("\n");
+    sb.append("    owner: ").append(toIndentedString(owner)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/ScopeInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/ScopeInfoDTO.java
@@ -1,0 +1,145 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class ScopeInfoDTO   {
+  
+    private String key = null;
+    private String name = null;
+    private List<String> roles = new ArrayList<String>();
+    private String description = null;
+
+  /**
+   **/
+  public ScopeInfoDTO key(String key) {
+    this.key = key;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "admin_scope", value = "")
+  @JsonProperty("key")
+  public String getKey() {
+    return key;
+  }
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  /**
+   **/
+  public ScopeInfoDTO name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "admin scope", value = "")
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Allowed roles for the scope
+   **/
+  public ScopeInfoDTO roles(List<String> roles) {
+    this.roles = roles;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "[\"manager\",\"developer\"]", value = "Allowed roles for the scope")
+  @JsonProperty("roles")
+  public List<String> getRoles() {
+    return roles;
+  }
+  public void setRoles(List<String> roles) {
+    this.roles = roles;
+  }
+
+  /**
+   * Description of the scope
+   **/
+  public ScopeInfoDTO description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Description of the scope")
+  @JsonProperty("description")
+  public String getDescription() {
+    return description;
+  }
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ScopeInfoDTO scopeInfo = (ScopeInfoDTO) o;
+    return Objects.equals(key, scopeInfo.key) &&
+        Objects.equals(name, scopeInfo.name) &&
+        Objects.equals(roles, scopeInfo.roles) &&
+        Objects.equals(description, scopeInfo.description);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, name, roles, description);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ScopeInfoDTO {\n");
+    
+    sb.append("    key: ").append(toIndentedString(key)).append("\n");
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
+    sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ApplicationsApiServiceImpl.java
@@ -16,26 +16,38 @@
  */
 package org.wso2.carbon.apimgt.rest.api.admin.v1.impl;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.jaxrs.ext.MessageContext;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.wso2.carbon.apimgt.api.APIAdmin;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.Application;
+import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.Subscriber;
 import org.wso2.carbon.apimgt.impl.APIAdminImpl;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerFactory;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.ApplicationsApiService;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ApplicationDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ApplicationListDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.utils.mappings.ApplicationMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
+import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.ws.rs.core.Response;
 
@@ -147,5 +159,55 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
             updatedSortBy = "CREATED_BY";
         }
         return updatedSortBy;
+    }
+
+    @Override
+    public Response applicationsApplicationIdGet(String applicationId, MessageContext messageContext)
+            throws APIManagementException {
+
+        String username = RestApiCommonUtil.getLoggedInUsername();
+        String organization = RestApiUtil.getOrganization(messageContext);
+        try {
+            APIConsumer apiConsumer = APIManagerFactory.getInstance().getAPIConsumer(username);
+            String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+            Application application = apiConsumer.getApplicationByUUID(applicationId, organization);
+            if (application != null) {
+                String applicationTenantDomain = MultitenantUtils.getTenantDomain(application.getOwner());
+                //If we need to remove this validation due to cross tenant subscription feature, we have to further validate
+                //and verify that the invoking user's tenant domain has an API subscribed by this application
+                if (tenantDomain.equals(applicationTenantDomain)) {
+                    // Remove hidden attributes and set the rest of the attributes from config
+                    JSONArray applicationAttributesFromConfig = apiConsumer.getAppAttributesFromConfig(username);
+                    Map<String, String> existingApplicationAttributes = application.getApplicationAttributes();
+                    Map<String, String> applicationAttributes = new HashMap<>();
+                    if (existingApplicationAttributes != null && applicationAttributesFromConfig != null) {
+                        for (Object object : applicationAttributesFromConfig) {
+                            JSONObject attribute = (JSONObject) object;
+                            Boolean hidden = (Boolean) attribute.get(APIConstants.ApplicationAttributes.HIDDEN);
+                            String attributeName = (String) attribute.get(APIConstants.ApplicationAttributes.ATTRIBUTE);
+                            if (!BooleanUtils.isTrue(hidden)) {
+                                String attributeVal = existingApplicationAttributes.get(attributeName);
+                                if (attributeVal != null) {
+                                    applicationAttributes.put(attributeName, attributeVal);
+                                } else {
+                                    applicationAttributes.put(attributeName, "");
+                                }
+                            }
+                        }
+                    }
+                    application.setApplicationAttributes(applicationAttributes);
+                    ApplicationDTO applicationDTO = ApplicationMappingUtil.fromApplicationtoDTO(application);
+                    Set<Scope> scopes = apiConsumer
+                            .getScopesForApplicationSubscription(username, application.getId(), organization);
+                    List<ScopeInfoDTO> scopeInfoList = ApplicationMappingUtil.getScopeInfoDTO(scopes);
+                    applicationDTO.setSubscriptionScopes(scopeInfoList);
+                    return Response.ok().entity(applicationDTO).build();
+                }
+            }
+        } catch (APIManagementException e) {
+            RestApiUtil.handleInternalServerError("Error while retrieving application " + applicationId, e, log);
+        }
+        RestApiUtil.handleResourceNotFoundError(RestApiConstants.RESOURCE_APPLICATION, applicationId, log);
+        return null;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/ApplicationMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/ApplicationMappingUtil.java
@@ -17,16 +17,23 @@
 
 package org.wso2.carbon.apimgt.rest.api.admin.v1.utils.mappings;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.apimgt.api.model.Application;
+import org.wso2.carbon.apimgt.api.model.Scope;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ApplicationDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ApplicationInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ApplicationListDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.PaginationDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class ApplicationMappingUtil {
 
@@ -99,5 +106,43 @@ public class ApplicationMappingUtil {
         applicationInfoDTO.setGroupId(application.getGroupId());
         applicationInfoDTO.setOwner(application.getOwner());
         return applicationInfoDTO;
+    }
+
+    public static ApplicationDTO fromApplicationtoDTO(Application application) {
+        ApplicationDTO applicationDTO = new ApplicationDTO();
+        applicationDTO.setApplicationId(application.getUUID());
+        applicationDTO.setThrottlingPolicy(application.getTier());
+        applicationDTO.setDescription(application.getDescription());
+        Map<String,String> applicationAttributes = application.getApplicationAttributes();
+        applicationDTO.setAttributes(applicationAttributes);
+        applicationDTO.setName(application.getName());
+        applicationDTO.setStatus(application.getStatus());
+        applicationDTO.setOwner(application.getOwner());
+
+        if (StringUtils.isNotEmpty(application.getGroupId())) {
+            applicationDTO.setGroups(Arrays.asList(application.getGroupId().split(",")));
+        }
+        applicationDTO.setTokenType(ApplicationDTO.TokenTypeEnum.OAUTH);
+        applicationDTO.setSubscriptionCount(application.getSubscriptionCount());
+        if (StringUtils.isNotEmpty(application.getTokenType()) && !APIConstants.DEFAULT_TOKEN_TYPE
+                .equals(application.getTokenType())) {
+            applicationDTO.setTokenType(ApplicationDTO.TokenTypeEnum.valueOf(application.getTokenType()));
+        }
+        return applicationDTO;
+    }
+
+    public static List<ScopeInfoDTO> getScopeInfoDTO(Set<Scope> scopes) {
+        List<ScopeInfoDTO> scopeDto = new ArrayList<ScopeInfoDTO>();
+        for (Scope scope : scopes) {
+            ScopeInfoDTO scopeInfoDTO = new ScopeInfoDTO();
+            scopeInfoDTO.setKey(scope.getKey());
+            scopeInfoDTO.setName(scope.getName());
+            scopeInfoDTO.setDescription(scope.getDescription());
+            if (StringUtils.isNotBlank(scope.getRoles())) {
+                scopeInfoDTO.setRoles(Arrays.asList(scope.getRoles().trim().split(",")));
+            }
+            scopeDto.add(scopeInfoDTO);
+        }
+        return scopeDto;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -1580,6 +1580,7 @@ paths:
         - apim:admin
         - apim:app_owner_change
         - apim:app_import_export
+        - apim:admin_application_view
       x-code-samples:
       - lang: Shell
         source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -1589,6 +1590,40 @@ paths:
   # The "Individual Application" resource APIs
   ######################################################
   /applications/{applicationId}:
+    get:
+      tags:
+        - Applications
+      summary: |
+        Get the details of an Application
+      description: |
+        This operation can be used to get the details of an application by specifying its id.
+      parameters:
+        - $ref: '#/components/parameters/applicationId'
+      responses:
+        200:
+          description: |
+            OK.
+            Application details returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Application'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+      security:
+        - OAuth2Security:
+            - apim:admin
+            - apim:app_import_export
+            - apim:admin_application_view
+      x-code-samples:
+        - lang: Shell
+          source: 'curl -k -X GET -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/admin/v2/applications/0a043c2b-ee75-4ef3-9e1c-fc2610ccfa8b"'
+
     delete:
       tags:
       - Applications
@@ -3762,6 +3797,78 @@ components:
         groupId:
           type: string
           example: ""
+    Application:
+      title: Application object with all the application details
+      type: object
+      properties:
+        applicationId:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901
+        name:
+          type: string
+          example: CalculatorApp
+        throttlingPolicy:
+          type: string
+          example: Unlimited
+        description:
+          type: string
+          example: Sample calculator application
+        tokenType:
+          type: string
+          enum:
+            - OAUTH
+            - JWT
+          description: |
+            Type of the access token generated for this application.
+            **OAUTH:** A UUID based access token which is issued by default.
+            **JWT:** A self-contained, signed JWT based access token. **Note:** This can be only used in Microgateway environments.
+          default: JWT
+          example: JWT
+        status:
+          type: string
+          example: APPROVED
+          default: ""
+        groups:
+          type: array
+          items:
+            type: string
+          example: ""
+        subscriptionCount:
+          type: integer
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+          example: External Reference ID, Billing Tier
+        subscriptionScopes:
+          type: array
+          items:
+            $ref: '#/definitions/ScopeInfo'
+          example: []
+        owner:
+          description: |
+            Application created user
+          type: string
+          example: admin
+    ScopeInfo:
+      title: API Scope info object with scope details
+      type: object
+      properties:
+        key:
+          type: string
+          example: admin_scope
+        name:
+          type: string
+          example: admin scope
+        roles:
+          type: array
+          items:
+            type: string
+          description: Allowed roles for the scope
+          example: ["manager","developer"]
+        description:
+          type: string
+          description: Description of the scope
     APIInfoList:
       title: API Info List
       type: object
@@ -4895,3 +5002,4 @@ components:
             apim:api_workflow_view: Retrive workflow requests
             apim:scope_manage: Manage system scopes
             apim:role_manage: Manage system roles
+            apim:admin_application_view: View Applications


### PR DESCRIPTION
We have a similar resource is Devportal rest API. However, that resource only returns the applications created by the user. Since admin users should be able to view the other applications in a specific tenant, this new resource will provide that capability.

Fixes : wso2/product-apim#11324