### PR TITLE
Retrieving correct search total in Devportal [8.x branch]

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -6011,15 +6011,17 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                         apiSet.add(api);
                     }
                 }
-            }
-            compoundResult.addAll(apiSet);
-            compoundResult.addAll(docMap.entrySet());
-            compoundResult.sort(new ContentSearchResultNameComparator());
+                compoundResult.addAll(apiSet);
+                compoundResult.addAll(docMap.entrySet());
+                compoundResult.sort(new ContentSearchResultNameComparator());
+                result.put("length", sResults.getTotalCount());
+            } else {
+                result.put("length", compoundResult.size());
+            }            
         } catch (APIPersistenceException e) {
             throw new APIManagementException("Error while searching content ", e);
         }
         result.put("apis", compoundResult);
-        result.put("length", totalLength);
         return result;
     }
 


### PR DESCRIPTION
This will retrieve the matching searched apis total with pagination & shows the correct total in network tab in Devportal.
Fixes: [#11393](https://github.com/wso2/product-apim/issues/11393)

![Screenshot from 2021-07-02 11-33-36](https://user-images.githubusercontent.com/30332391/124258081-a3606b00-db4a-11eb-9fa9-cda5dcbce284.png)
![Screenshot from 2021-07-02 11-33-47](https://user-images.githubusercontent.com/30332391/124258093-a6f3f200-db4a-11eb-9f59-4ca36a4e2878.png)
