### PR TITLE
Retrieving IdP alias in key-managers GET Devportal V2 REST API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -369,7 +369,7 @@ public class APIAdminImpl implements APIAdmin {
     private void setAliasForTokenExchangeKeyManagers(List<KeyManagerConfigurationDTO> keyManagerConfigurationsByTenant,
             String tenantDomain) throws APIManagementException {
         for (KeyManagerConfigurationDTO keyManagerConfigurationDTO : keyManagerConfigurationsByTenant) {
-            if (org.apache.commons.lang3.StringUtils.equals(KeyManagerConfiguration.TokenType.EXCHANGED.toString(),
+            if (StringUtils.equals(KeyManagerConfiguration.TokenType.EXCHANGED.toString(),
                     keyManagerConfigurationDTO.getTokenType())) {
                 if (keyManagerConfigurationDTO.getExternalReferenceId() != null) {
                     IdentityProvider identityProvider;
@@ -378,7 +378,7 @@ public class APIAdminImpl implements APIAdmin {
                                 .getIdPByResourceId(keyManagerConfigurationDTO.getExternalReferenceId(), tenantDomain,
                                         Boolean.FALSE);
                     } catch (IdentityProviderManagementException e) {
-                        throw new APIManagementException("IdP retrieval failed. " + e.getMessage(),
+                        throw new APIManagementException("IdP retrieval failed. " + e.getMessage(), e,
                                 ExceptionCodes.IDP_RETRIEVAL_FAILED);
                     }
                     // Set alias value since this will be used from the Devportal side.

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -57,6 +57,9 @@ import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.core.util.CryptoUtil;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -355,10 +358,34 @@ public class APIAdminImpl implements APIAdmin {
             keyManagerConfigurationsByTenant.addAll(keyManagerConfigurationsByOrganization);
         }
 
+        setAliasForTokenExchangeKeyManagers(keyManagerConfigurationsByTenant, tenantDomain);
+
         for (KeyManagerConfigurationDTO keyManagerConfigurationDTO : keyManagerConfigurationsByTenant) {
             decryptKeyManagerConfigurationValues(keyManagerConfigurationDTO);
         }
         return keyManagerConfigurationsByTenant;
+    }
+
+    private void setAliasForTokenExchangeKeyManagers(List<KeyManagerConfigurationDTO> keyManagerConfigurationsByTenant,
+            String tenantDomain) throws APIManagementException {
+        for (KeyManagerConfigurationDTO keyManagerConfigurationDTO : keyManagerConfigurationsByTenant) {
+            if (org.apache.commons.lang3.StringUtils.equals(KeyManagerConfiguration.TokenType.EXCHANGED.toString(),
+                    keyManagerConfigurationDTO.getTokenType())) {
+                if (keyManagerConfigurationDTO.getExternalReferenceId() != null) {
+                    IdentityProvider identityProvider;
+                    try {
+                        identityProvider = IdentityProviderManager.getInstance()
+                                .getIdPByResourceId(keyManagerConfigurationDTO.getExternalReferenceId(), tenantDomain,
+                                        Boolean.FALSE);
+                    } catch (IdentityProviderManagementException e) {
+                        throw new APIManagementException("IdP retrieval failed. " + e.getMessage(),
+                                ExceptionCodes.IDP_RETRIEVAL_FAILED);
+                    }
+                    // Set alias value since this will be used from the Devportal side.
+                    keyManagerConfigurationDTO.setAlias(identityProvider.getAlias());
+                }
+            }
+        }
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/KeyManagerDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/KeyManagerDTO.java
@@ -331,7 +331,7 @@ return null;
   }
 
   /**
-   * The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token 
+   * The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be inclusive in the audience values of the JWT token 
    **/
   public KeyManagerDTO alias(String alias) {
     this.alias = alias;
@@ -339,7 +339,7 @@ return null;
   }
 
   
-  @ApiModelProperty(example = "https://localhost:8243/token", value = "The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token ")
+  @ApiModelProperty(example = "https://localhost:9443/oauth2/token", value = "The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be inclusive in the audience values of the JWT token ")
   @JsonProperty("alias")
   public String getAlias() {
     return alias;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/KeyManagerDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/KeyManagerDTO.java
@@ -339,7 +339,7 @@ return null;
   }
 
   
-  @ApiModelProperty(example = "ZyxWExFdfe4fAZ7sc1W8bkX2r80a", value = "The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token ")
+  @ApiModelProperty(example = "https://localhost:8243/token", value = "The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token ")
   @JsonProperty("alias")
   public String getAlias() {
     return alias;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
@@ -97,7 +97,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
                         keyManagerConfigurationDTO.setEnabled(identityProvider.isEnable());
                     }
                 } catch (IdentityProviderManagementException e) {
-                    throw new APIManagementException("IdP retrieval failed. " + e.getMessage(),
+                    throw new APIManagementException("IdP retrieval failed. " + e.getMessage(), e,
                             ExceptionCodes.IDP_RETRIEVAL_FAILED);
                 }
             }
@@ -124,7 +124,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
                                     APIUtil.getInternalOrganizationDomain(organization));
                 }
             } catch (IdentityProviderManagementException e) {
-                throw new APIManagementException("IdP deletion failed. " + e.getMessage(),
+                throw new APIManagementException("IdP deletion failed. " + e.getMessage(), e,
                         ExceptionCodes.IDP_DELETION_FAILED);
             }
         }
@@ -152,7 +152,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
                         mergeIdpWithKeyManagerConfiguration(identityProvider, keyManagerDTO);
                     }
                 } catch (IdentityProviderManagementException e) {
-                    throw new APIManagementException("IdP retrieval failed. " + e.getMessage(),
+                    throw new APIManagementException("IdP retrieval failed. " + e.getMessage(), e,
                             ExceptionCodes.IDP_RETRIEVAL_FAILED);
                 }
             }
@@ -198,7 +198,8 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
                             organization;
             RestApiUtil.handleInternalServerError(error, e, log);
         } catch (IdentityProviderManagementException e) {
-            throw new APIManagementException("IdP adding failed. " + e.getMessage(), ExceptionCodes.IDP_ADDING_FAILED);
+            throw new APIManagementException("IdP adding failed. " + e.getMessage(), e,
+                    ExceptionCodes.IDP_ADDING_FAILED);
         }
         return null;
     }
@@ -228,7 +229,8 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
             String error = "Error while Creating Key Manager configuration in organization " + organization;
             RestApiUtil.handleInternalServerError(error, e, log);
         } catch (IdentityProviderManagementException e) {
-            throw new APIManagementException("IdP adding failed. " + e.getMessage(), ExceptionCodes.IDP_ADDING_FAILED);
+            throw new APIManagementException("IdP adding failed. " + e.getMessage(), e,
+                    ExceptionCodes.IDP_ADDING_FAILED);
         }
         return null;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -4167,7 +4167,7 @@ components:
           description: |
             The alias of Identity Provider.
             If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token
-          example: ZyxWExFdfe4fAZ7sc1W8bkX2r80a
+          example: https://localhost:8243/token
         scopeManagementEndpoint:
           type: string
           example: https://wso2is.com:9444/api/identity/oauth2/v1.0/scopes

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -4166,8 +4166,8 @@ components:
           type: string
           description: |
             The alias of Identity Provider.
-            If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token
-          example: https://localhost:8243/token
+            If the tokenType is EXCHANGED, the alias value should be inclusive in the audience values of the JWT token
+          example: https://localhost:9443/oauth2/token
         scopeManagementEndpoint:
           type: string
           example: https://wso2is.com:9444/api/identity/oauth2/v1.0/scopes

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/KeyManagerInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/KeyManagerInfoDTO.java
@@ -319,7 +319,7 @@ public class KeyManagerInfoDTO   {
   }
 
   /**
-   * The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token 
+   * The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be inclusive in the audience values of the JWT token 
    **/
   public KeyManagerInfoDTO alias(String alias) {
     this.alias = alias;
@@ -327,7 +327,7 @@ public class KeyManagerInfoDTO   {
   }
 
   
-  @ApiModelProperty(example = "https://localhost:8243/token", value = "The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token ")
+  @ApiModelProperty(example = "https://localhost:9443/oauth2/token", value = "The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be inclusive in the audience values of the JWT token ")
   @JsonProperty("alias")
   public String getAlias() {
     return alias;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/KeyManagerInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/KeyManagerInfoDTO.java
@@ -327,7 +327,7 @@ public class KeyManagerInfoDTO   {
   }
 
   
-  @ApiModelProperty(example = "ZyxWExFdfe4fAZ7sc1W8bkX2r80a", value = "The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token ")
+  @ApiModelProperty(example = "https://localhost:8243/token", value = "The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token ")
   @JsonProperty("alias")
   public String getAlias() {
     return alias;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/KeyManagerInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/KeyManagerInfoDTO.java
@@ -39,6 +39,7 @@ public class KeyManagerInfoDTO   {
     private Boolean enableOAuthAppCreation = true;
     private Boolean enableMapOAuthConsumerApps = false;
     private List<KeyManagerApplicationConfigurationDTO> applicationConfiguration = new ArrayList<KeyManagerApplicationConfigurationDTO>();
+    private String alias = null;
     private Object additionalProperties = null;
 
   /**
@@ -318,6 +319,24 @@ public class KeyManagerInfoDTO   {
   }
 
   /**
+   * The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token 
+   **/
+  public KeyManagerInfoDTO alias(String alias) {
+    this.alias = alias;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "ZyxWExFdfe4fAZ7sc1W8bkX2r80a", value = "The alias of Identity Provider. If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token ")
+  @JsonProperty("alias")
+  public String getAlias() {
+    return alias;
+  }
+  public void setAlias(String alias) {
+    this.alias = alias;
+  }
+
+  /**
    **/
   public KeyManagerInfoDTO additionalProperties(Object additionalProperties) {
     this.additionalProperties = additionalProperties;
@@ -361,12 +380,13 @@ public class KeyManagerInfoDTO   {
         Objects.equals(enableOAuthAppCreation, keyManagerInfo.enableOAuthAppCreation) &&
         Objects.equals(enableMapOAuthConsumerApps, keyManagerInfo.enableMapOAuthConsumerApps) &&
         Objects.equals(applicationConfiguration, keyManagerInfo.applicationConfiguration) &&
+        Objects.equals(alias, keyManagerInfo.alias) &&
         Objects.equals(additionalProperties, keyManagerInfo.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, type, displayName, description, enabled, availableGrantTypes, tokenEndpoint, revokeEndpoint, userInfoEndpoint, enableTokenGeneration, enableTokenEncryption, enableTokenHashing, enableOAuthAppCreation, enableMapOAuthConsumerApps, applicationConfiguration, additionalProperties);
+    return Objects.hash(id, name, type, displayName, description, enabled, availableGrantTypes, tokenEndpoint, revokeEndpoint, userInfoEndpoint, enableTokenGeneration, enableTokenEncryption, enableTokenHashing, enableOAuthAppCreation, enableMapOAuthConsumerApps, applicationConfiguration, alias, additionalProperties);
   }
 
   @Override
@@ -390,6 +410,7 @@ public class KeyManagerInfoDTO   {
     sb.append("    enableOAuthAppCreation: ").append(toIndentedString(enableOAuthAppCreation)).append("\n");
     sb.append("    enableMapOAuthConsumerApps: ").append(toIndentedString(enableMapOAuthConsumerApps)).append("\n");
     sb.append("    applicationConfiguration: ").append(toIndentedString(applicationConfiguration)).append("\n");
+    sb.append("    alias: ").append(toIndentedString(alias)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/KeyManagerMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/KeyManagerMappingUtil.java
@@ -31,6 +31,7 @@ public class KeyManagerMappingUtil {
         keyManagerInfoDTO.setDisplayName(keyManagerConfigurationDTO.getDisplayName());
         keyManagerInfoDTO.setEnabled(keyManagerConfigurationDTO.isEnabled());
         keyManagerInfoDTO.setType(keyManagerConfigurationDTO.getType());
+        keyManagerInfoDTO.setAlias(keyManagerConfigurationDTO.getAlias());
         JsonObject jsonObject = fromConfigurationMapToJson(keyManagerConfigurationDTO.getAdditionalProperties());
         JsonElement grantTypesElement = jsonObject.get(APIConstants.KeyManager.AVAILABLE_GRANT_TYPE);
         if (grantTypesElement instanceof JsonArray) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -5156,7 +5156,7 @@ components:
           description: |
             The alias of Identity Provider.
             If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token
-          example: ZyxWExFdfe4fAZ7sc1W8bkX2r80a
+          example: https://localhost:8243/token
         additionalProperties:
           type: object
           properties: {}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -5155,8 +5155,8 @@ components:
           type: string
           description: |
             The alias of Identity Provider.
-            If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token
-          example: https://localhost:8243/token
+            If the tokenType is EXCHANGED, the alias value should be inclusive in the audience values of the JWT token
+          example: https://localhost:9443/oauth2/token
         additionalProperties:
           type: object
           properties: {}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -5151,6 +5151,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/KeyManagerApplicationConfiguration'
+        alias:
+          type: string
+          description: |
+            The alias of Identity Provider.
+            If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token
+          example: ZyxWExFdfe4fAZ7sc1W8bkX2r80a
         additionalProperties:
           type: object
           properties: {}


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2-enterprise/choreo/issues/4200

## Goals
There is a requirement to retrieve the alias (audience) value stored in the IdP tables from the GET key-managers call from Devportal V2 REST API to show it in the Choreo Devportal UI User Keys tab. Hence the backend has been improved.

## Approach
- A new property as alias has been added to KeyManagerInfoDTO as shown below
```
        alias:
          type: string
          description: |
            The alias of Identity Provider.
            If the tokenType is EXCHANGED, the alias value should be equal to the audience value of the JWT token
          example: https://localhost:8243/token
```
- If the token type is EXCHANGED the IS components will be called to get data from the IDP tables
- Set the alias in the KeyManagerConfigurationDTO from the above-retrieved data
- Set that alias value to the KeyManagerInfo DTO which will be used when sending the response from the REST API

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.2 LTS
