### PR TITLE
Improving the error messages from the backend when deleting an Advanced Throttling Policy that is already assigned to an API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -310,6 +310,7 @@ public enum ExceptionCodes implements ErrorHandler {
             "Cannot add client certificates to this server"),
     THROTTLING_POLICY_CANNOT_BE_NULL(900989,
             "Throttling Policy cannot be empty or null", 400, "Throttling Policy cannot be empty or null"),
+    POLICY_DELETE_ERROR(900971, "Cannot delete the policy", 403, "%s"),
 
     //Throttle related codes
     THROTTLE_TEMPLATE_EXCEPTION(900969, "Policy Generating Error", 500, " Error while generate policy configuration"),

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -310,7 +310,8 @@ public enum ExceptionCodes implements ErrorHandler {
             "Cannot add client certificates to this server"),
     THROTTLING_POLICY_CANNOT_BE_NULL(900989,
             "Throttling Policy cannot be empty or null", 400, "Throttling Policy cannot be empty or null"),
-    POLICY_DELETE_ERROR(900971, "Cannot delete the policy", 403, "%s"),
+    ALREADY_ASSIGNED_ADVANCED_POLICY_DELETE_ERROR(900971, "Cannot delete the advanced throttling policy", 403,
+            "Cannot delete the advanced policy with the name %s because it is already assigned to an API/Resource"),
 
     //Throttle related codes
     THROTTLE_TEMPLATE_EXCEPTION(900969, "Policy Generating Error", 500, " Error while generate policy configuration"),

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ThrottlingApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ThrottlingApiServiceImpl.java
@@ -237,9 +237,11 @@ public class ThrottlingApiServiceImpl implements ThrottlingApiService {
             RestApiUtil.handleAuthorizationFailure(RestApiConstants.RESOURCE_ADVANCED_POLICY, policyId, log);
         }
         if (apiProvider.hasAttachments(username, existingPolicy.getPolicyName(), PolicyConstants.POLICY_LEVEL_API)) {
-            String message =
-                    "Policy " + existingPolicy.getPolicyName() + ": " + policyId + " already attached to API/Resource";
-            throw new APIManagementException(message, ExceptionCodes.from(ExceptionCodes.POLICY_DELETE_ERROR, message));
+            String message = "Advanced Throttling Policy " + existingPolicy.getPolicyName() + ": " + policyId
+                    + " already attached to API/Resource";
+            throw new APIManagementException(message, ExceptionCodes
+                    .from(ExceptionCodes.ALREADY_ASSIGNED_ADVANCED_POLICY_DELETE_ERROR,
+                            existingPolicy.getPolicyName()));
         }
         apiProvider.deletePolicy(username, PolicyConstants.POLICY_LEVEL_API, existingPolicy.getPolicyName());
         return Response.ok().build();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ThrottlingApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ThrottlingApiServiceImpl.java
@@ -221,33 +221,28 @@ public class ThrottlingApiServiceImpl implements ThrottlingApiService {
      * @return 200 OK response if successfully deleted the policy
      */
     @Override
-    public Response throttlingPoliciesAdvancedPolicyIdDelete(String policyId, MessageContext messageContext) {
-        try {
-            APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
-            String username = RestApiCommonUtil.getLoggedInUsername();
+    public Response throttlingPoliciesAdvancedPolicyIdDelete(String policyId, MessageContext messageContext)
+            throws APIManagementException {
+        APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
+        String username = RestApiCommonUtil.getLoggedInUsername();
 
-            //This will give PolicyNotFoundException if there's no policy exists with UUID
-            APIPolicy existingPolicy = apiProvider.getAPIPolicyByUUID(policyId);
-            if (!RestApiAdminUtils.isPolicyAccessibleToUser(username, existingPolicy)) {
-                RestApiUtil.handleAuthorizationFailure(RestApiConstants.RESOURCE_ADVANCED_POLICY, policyId, log);
-            }
-            if (apiProvider.hasAttachments(username, existingPolicy.getPolicyName(),
-                    PolicyConstants.POLICY_LEVEL_API)) {
-                String message = "Policy " + policyId + " already attached to API/Resource";
-                log.error(message);
-                throw new APIManagementException(message);
-            }
-            apiProvider.deletePolicy(username, PolicyConstants.POLICY_LEVEL_API, existingPolicy.getPolicyName());
-            return Response.ok().build();
+        //This will give PolicyNotFoundException if there's no policy exists with UUID
+        APIPolicy existingPolicy = null;
+        try {
+            existingPolicy = apiProvider.getAPIPolicyByUUID(policyId);
         } catch (APIManagementException e) {
-            if (RestApiUtil.isDueToResourceNotFound(e)) {
-                RestApiUtil.handleResourceNotFoundError(RestApiConstants.RESOURCE_ADVANCED_POLICY, policyId, e, log);
-            } else {
-                String errorMessage = "Error while deleting Advanced level policy : " + policyId;
-                RestApiUtil.handleInternalServerError(errorMessage, e, log);
-            }
+            RestApiUtil.handleResourceNotFoundError(RestApiConstants.RESOURCE_ADVANCED_POLICY, policyId, e, log);
         }
-        return null;
+        if (!RestApiAdminUtils.isPolicyAccessibleToUser(username, existingPolicy)) {
+            RestApiUtil.handleAuthorizationFailure(RestApiConstants.RESOURCE_ADVANCED_POLICY, policyId, log);
+        }
+        if (apiProvider.hasAttachments(username, existingPolicy.getPolicyName(), PolicyConstants.POLICY_LEVEL_API)) {
+            String message =
+                    "Policy " + existingPolicy.getPolicyName() + ": " + policyId + " already attached to API/Resource";
+            throw new APIManagementException(message, ExceptionCodes.from(ExceptionCodes.POLICY_DELETE_ERROR, message));
+        }
+        apiProvider.deletePolicy(username, PolicyConstants.POLICY_LEVEL_API, existingPolicy.getPolicyName());
+        return Response.ok().build();
     }
 
     /**


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11401

## Goals
Improve the error messages from the backend when deleting an Advanced Throttling Policy that is already assigned to an API.

## Approach
- Introduced a new error code
- Throw the errors as APIManagement Exceptions with a meaningful message

## Related PRs
https://github.com/wso2/product-apim/pull/11403

## Test environment
- JDK 1.8.0_251
- OS: Ubuntu 20.04.2 LTS
