### PR TITLE
Changing the backend regular expression for throttling policy name

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/RestApiAdminUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/RestApiAdminUtils.java
@@ -124,7 +124,7 @@ public class RestApiAdminUtils {
     public static void validateThrottlePolicyNameProperty(String policyName)
             throws APIManagementException {
         String propertyName = "policyName";
-        Pattern pattern = Pattern.compile("[^A-Za-z0-9]");//. represents single character
+        Pattern pattern = Pattern.compile("[^A-Za-z0-9_]");//. represents single character
         Matcher matcher = pattern.matcher(policyName);
         if (StringUtils.isBlank(policyName)) {
             throw new APIManagementException(propertyName + " property value of payload cannot be blank",


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11410

## Goals
Underscores should be allowed in throttling policy names since they are quite common in naming conventions.

## Approach
Changed the backend regular expression for throttling policy name.

## Related PRs
- https://github.com/wso2/apim-apps/pull/37

## Test environment
- JDK 1.8.0_251
- OS: Ubuntu 20.04.2 LTS