### PR TITLE
Encrypt OAuth Credentials in the endpoint security when adding an API (POST request)

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -473,7 +473,9 @@ public enum ExceptionCodes implements ErrorHandler {
                "Definition", 400, "Unsupported protocol specified in Async API Definition"),
 
     //Service Catalog related error codes
-    SERVICE_VERSION_NOT_FOUND(901900, "Cannot find the service version", 404, "Cannot find a service that matches the given version");
+    SERVICE_VERSION_NOT_FOUND(901900, "Cannot find the service version", 404, "Cannot find a service that matches the given version"),
+    INVALID_ENDPOINT_CREDENTIALS(902000, "Invalid Endpoint Security credentials", 400,
+            "Invalid Endpoint Security credentials. %s", false);
 
     private final long errorCode;
     private final String errorMessage;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -344,7 +344,7 @@ public class PublisherCommonUtils {
     private static void encryptEndpointSecurityOAuthCredentials(Map endpointConfig, CryptoUtil cryptoUtil,
             String oldProductionApiSecret, String oldSandboxApiSecret, APIDTO apidto) throws CryptoException {
         // OAuth 2.0 backend protection: API Key and API Secret encryption
-        String customParametersString = "{}";
+        String customParametersString;
         if (endpointConfig != null) {
             if ((endpointConfig.get(APIConstants.ENDPOINT_SECURITY) != null)) {
                 Map endpointSecurity = (Map) endpointConfig.get(APIConstants.ENDPOINT_SECURITY);
@@ -357,10 +357,15 @@ public class PublisherCommonUtils {
                     // Change default value of customParameters JSONObject to String
                     if (!(endpointSecurityProduction
                             .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS) instanceof String)) {
-                        LinkedHashMap<String, String> customParametersHashMap =
-                                (LinkedHashMap<String, String>) endpointSecurityProduction
-                                .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
+                        LinkedHashMap<String, String> customParametersHashMap = (LinkedHashMap<String, String>)
+                                endpointSecurityProduction.get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
                         customParametersString = JSONObject.toJSONString(customParametersHashMap);
+                    } else if (endpointSecurityProduction.get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS)
+                            != null) {
+                        customParametersString = (String) endpointSecurityProduction
+                                .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
+                    } else {
+                        customParametersString = "{}";
                     }
 
                     endpointSecurityProduction
@@ -401,6 +406,12 @@ public class PublisherCommonUtils {
                         Map<String, String> customParametersHashMap = (Map<String, String>) endpointSecuritySandbox
                                 .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
                         customParametersString = JSONObject.toJSONString(customParametersHashMap);
+                    } else if (endpointSecuritySandbox.get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS)
+                            != null) {
+                        customParametersString = (String) endpointSecuritySandbox
+                                .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
+                    } else {
+                        customParametersString = "{}";
                     }
                     endpointSecuritySandbox
                             .put(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS, customParametersString);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -174,83 +174,9 @@ public class PublisherCommonUtils {
         Map endpointConfig = (Map) apiDtoToUpdate.getEndpointConfig();
         CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
 
-        // OAuth 2.0 backend protection: Api Key and Api Secret encryption while updating the API
-        String customParametersString = "{}";
-        if (endpointConfig != null) {
-            if ((endpointConfig.get(APIConstants.ENDPOINT_SECURITY) != null)) {
-                Map endpointSecurity = (Map) endpointConfig.get(APIConstants.ENDPOINT_SECURITY);
-                if (endpointSecurity.get(APIConstants.OAuthConstants.ENDPOINT_SECURITY_PRODUCTION) != null) {
-                    Map endpointSecurityProduction = (Map) endpointSecurity
-                            .get(APIConstants.OAuthConstants.ENDPOINT_SECURITY_PRODUCTION);
-                    String productionEndpointType = (String) endpointSecurityProduction
-                            .get(APIConstants.OAuthConstants.ENDPOINT_SECURITY_TYPE);
-
-                    // Change default value of customParameters JSONObject to String
-                    if (!(endpointSecurityProduction
-                            .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS) instanceof String)) {
-                        LinkedHashMap<String, String> customParametersHashMap =
-                                (LinkedHashMap<String, String>) endpointSecurityProduction
-                                        .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
-                        customParametersString = JSONObject.toJSONString(customParametersHashMap);
-                    }
-
-                    endpointSecurityProduction
-                            .put(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS, customParametersString);
-
-                    if (APIConstants.OAuthConstants.OAUTH.equals(productionEndpointType)) {
-                        String apiSecret = endpointSecurityProduction
-                                .get(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET).toString();
-
-                        if (StringUtils.isNotEmpty(apiSecret)) {
-                            String encryptedApiSecret = cryptoUtil.encryptAndBase64Encode(apiSecret.getBytes());
-                            endpointSecurityProduction
-                                    .put(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET, encryptedApiSecret);
-                        } else {
-                            endpointSecurityProduction
-                                    .put(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET, oldProductionApiSecret);
-                        }
-                    }
-                    endpointSecurity
-                            .put(APIConstants.OAuthConstants.ENDPOINT_SECURITY_PRODUCTION, endpointSecurityProduction);
-                    endpointConfig.put(APIConstants.ENDPOINT_SECURITY, endpointSecurity);
-                    apiDtoToUpdate.setEndpointConfig(endpointConfig);
-                }
-                if (endpointSecurity.get(APIConstants.OAuthConstants.ENDPOINT_SECURITY_SANDBOX) != null) {
-                    Map endpointSecuritySandbox = (Map) endpointSecurity
-                            .get(APIConstants.OAuthConstants.ENDPOINT_SECURITY_SANDBOX);
-                    String sandboxEndpointType = (String) endpointSecuritySandbox
-                            .get(APIConstants.OAuthConstants.ENDPOINT_SECURITY_TYPE);
-
-                    // Change default value of customParameters JSONObject to String
-                    if (!(endpointSecuritySandbox
-                            .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS) instanceof String)) {
-                        Map<String, String> customParametersHashMap = (Map<String, String>) endpointSecuritySandbox
-                                .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
-                        customParametersString = JSONObject.toJSONString(customParametersHashMap);
-                    }
-                    endpointSecuritySandbox
-                            .put(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS, customParametersString);
-
-                    if (APIConstants.OAuthConstants.OAUTH.equals(sandboxEndpointType)) {
-                        String apiSecret = endpointSecuritySandbox.get(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET)
-                                .toString();
-
-                        if (StringUtils.isNotEmpty(apiSecret)) {
-                            String encryptedApiSecret = cryptoUtil.encryptAndBase64Encode(apiSecret.getBytes());
-                            endpointSecuritySandbox
-                                    .put(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET, encryptedApiSecret);
-                        } else {
-                            endpointSecuritySandbox
-                                    .put(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET, oldSandboxApiSecret);
-                        }
-                    }
-                    endpointSecurity
-                            .put(APIConstants.OAuthConstants.ENDPOINT_SECURITY_SANDBOX, endpointSecuritySandbox);
-                    endpointConfig.put(APIConstants.ENDPOINT_SECURITY, endpointSecurity);
-                    apiDtoToUpdate.setEndpointConfig(endpointConfig);
-                }
-            }
-        }
+        // OAuth 2.0 backend protection: API Key and API Secret encryption
+        encryptEndpointSecurityOAuthCredentials(endpointConfig, cryptoUtil, oldProductionApiSecret, oldSandboxApiSecret,
+                apiDtoToUpdate);
 
         // AWS Lambda: secret key encryption while updating the API
         if (apiDtoToUpdate.getEndpointConfig() != null) {
@@ -403,6 +329,107 @@ public class PublisherCommonUtils {
 
         return apiProvider.getAPIbyUUID(originalAPI.getUuid(), originalAPI.getOrganization());
         // TODO use returend api
+    }
+
+    /**
+     * This method will encrypt the OAuth 2.0 API Key and API Secret
+     *
+     * @param endpointConfig         endpoint configuration of API
+     * @param cryptoUtil             cryptography util
+     * @param oldProductionApiSecret existing production API secret
+     * @param oldSandboxApiSecret    existing sandbox API secret
+     * @param apidto                 API DTO
+     * @throws CryptoException if an error occurs while encrypting and base64 encode
+     */
+    private static void encryptEndpointSecurityOAuthCredentials(Map endpointConfig, CryptoUtil cryptoUtil,
+            String oldProductionApiSecret, String oldSandboxApiSecret, APIDTO apidto) throws CryptoException {
+        // OAuth 2.0 backend protection: API Key and API Secret encryption
+        String customParametersString = "{}";
+        if (endpointConfig != null) {
+            if ((endpointConfig.get(APIConstants.ENDPOINT_SECURITY) != null)) {
+                Map endpointSecurity = (Map) endpointConfig.get(APIConstants.ENDPOINT_SECURITY);
+                if (endpointSecurity.get(APIConstants.OAuthConstants.ENDPOINT_SECURITY_PRODUCTION) != null) {
+                    Map endpointSecurityProduction = (Map) endpointSecurity
+                            .get(APIConstants.OAuthConstants.ENDPOINT_SECURITY_PRODUCTION);
+                    String productionEndpointType = (String) endpointSecurityProduction
+                            .get(APIConstants.OAuthConstants.ENDPOINT_SECURITY_TYPE);
+
+                    // Change default value of customParameters JSONObject to String
+                    if (!(endpointSecurityProduction
+                            .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS) instanceof String)) {
+                        LinkedHashMap<String, String> customParametersHashMap =
+                                (LinkedHashMap<String, String>) endpointSecurityProduction
+                                .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
+                        customParametersString = JSONObject.toJSONString(customParametersHashMap);
+                    }
+
+                    endpointSecurityProduction
+                            .put(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS, customParametersString);
+
+                    if (APIConstants.OAuthConstants.OAUTH.equals(productionEndpointType)) {
+                        String apiSecret = endpointSecurityProduction
+                                .get(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET).toString();
+
+                        if (StringUtils.isNotEmpty(apiSecret)) {
+                            String encryptedApiSecret = cryptoUtil.encryptAndBase64Encode(apiSecret.getBytes());
+                            endpointSecurityProduction
+                                    .put(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET, encryptedApiSecret);
+                        } else {
+                            if (!oldProductionApiSecret.isEmpty()) {
+                                endpointSecurityProduction
+                                        .put(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET, oldProductionApiSecret);
+                            } else {
+                                endpointSecurityProduction
+                                        .put(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET, StringUtils.EMPTY);
+                            }
+                        }
+                    }
+                    endpointSecurity
+                            .put(APIConstants.OAuthConstants.ENDPOINT_SECURITY_PRODUCTION, endpointSecurityProduction);
+                    endpointConfig.put(APIConstants.ENDPOINT_SECURITY, endpointSecurity);
+                    apidto.setEndpointConfig(endpointConfig);
+                }
+                if (endpointSecurity.get(APIConstants.OAuthConstants.ENDPOINT_SECURITY_SANDBOX) != null) {
+                    Map endpointSecuritySandbox = (Map) endpointSecurity
+                            .get(APIConstants.OAuthConstants.ENDPOINT_SECURITY_SANDBOX);
+                    String sandboxEndpointType = (String) endpointSecuritySandbox
+                            .get(APIConstants.OAuthConstants.ENDPOINT_SECURITY_TYPE);
+
+                    // Change default value of customParameters JSONObject to String
+                    if (!(endpointSecuritySandbox
+                            .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS) instanceof String)) {
+                        Map<String, String> customParametersHashMap = (Map<String, String>) endpointSecuritySandbox
+                                .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
+                        customParametersString = JSONObject.toJSONString(customParametersHashMap);
+                    }
+                    endpointSecuritySandbox
+                            .put(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS, customParametersString);
+
+                    if (APIConstants.OAuthConstants.OAUTH.equals(sandboxEndpointType)) {
+                        String apiSecret = endpointSecuritySandbox.get(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET)
+                                .toString();
+
+                        if (StringUtils.isNotEmpty(apiSecret)) {
+                            String encryptedApiSecret = cryptoUtil.encryptAndBase64Encode(apiSecret.getBytes());
+                            endpointSecuritySandbox
+                                    .put(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET, encryptedApiSecret);
+                        } else {
+                            if (!oldSandboxApiSecret.isEmpty()) {
+                                endpointSecuritySandbox
+                                        .put(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET, oldSandboxApiSecret);
+                            } else {
+                                endpointSecuritySandbox
+                                        .put(APIConstants.OAuthConstants.OAUTH_CLIENT_SECRET, StringUtils.EMPTY);
+                            }
+                        }
+                    }
+                    endpointSecurity
+                            .put(APIConstants.OAuthConstants.ENDPOINT_SECURITY_SANDBOX, endpointSecuritySandbox);
+                    endpointConfig.put(APIConstants.ENDPOINT_SECURITY, endpointSecurity);
+                    apidto.setEndpointConfig(endpointConfig);
+                }
+            }
+        }
     }
 
     /**
@@ -712,13 +739,18 @@ public class PublisherCommonUtils {
                     ExceptionCodes.INVALID_ENDPOINT_URL);
         }
 
+        Map endpointConfig = (Map) apiDto.getEndpointConfig();
+        CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
+
+        // OAuth 2.0 backend protection: API Key and API Secret encryption
+        encryptEndpointSecurityOAuthCredentials(endpointConfig, cryptoUtil, StringUtils.EMPTY, StringUtils.EMPTY,
+                apiDto);
+
         // AWS Lambda: secret key encryption while creating the API
         if (apiDto.getEndpointConfig() != null) {
-            Map endpointConfig = (Map) apiDto.getEndpointConfig();
             if (endpointConfig.containsKey(APIConstants.AMZN_SECRET_KEY)) {
                 String secretKey = (String) endpointConfig.get(APIConstants.AMZN_SECRET_KEY);
                 if (!StringUtils.isEmpty(secretKey)) {
-                    CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
                     String encryptedSecretKey = cryptoUtil.encryptAndBase64Encode(secretKey.getBytes());
                     endpointConfig.put(APIConstants.AMZN_SECRET_KEY, encryptedSecretKey);
                     apiDto.setEndpointConfig(endpointConfig);


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11435

## Goals
Previously the endpoint security OAuth credentials have been encrypted only during an update of an API. Now it will be done when adding an API as well.

## Approach
- Refactored the existing code to encrypt OAuth Credentials, to a common place and called during the POST and PUT methods of APIs.
- Support both String and Object parameter for customParameters field in the endpoint security.

## Related PRs
- https://github.com/wso2/product-apim/pull/11444

## Test environment
- JDK 1.8.0_251
- OS: Ubuntu 20.04.2 LTS
