### PR TITLE
Use additionalPropertiesMap when updating API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -318,6 +318,18 @@ public class APIMappingUtil {
             }
         }
 
+        Map<String, APIInfoAdditionalPropertiesMapDTO> additionalPropertiesMap = dto.getAdditionalPropertiesMap();
+        if (additionalPropertiesMap != null && !additionalPropertiesMap.isEmpty()) {
+            for (Map.Entry<String, APIInfoAdditionalPropertiesMapDTO> entry : additionalPropertiesMap.entrySet()) {
+                if (entry.getValue().isDisplay()) {
+                    model.addProperty(entry.getKey() + APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX,
+                            entry.getValue().getValue());
+                } else {
+                    model.addProperty(entry.getKey(), entry.getValue().getValue());
+                }
+            }
+        }
+
         ObjectMapper objectMapper = new ObjectMapper();
         APIBusinessInformationDTO apiBusinessInformationDTO = objectMapper.convertValue(dto.getBusinessInformation(),
                 APIBusinessInformationDTO.class);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -4913,12 +4913,6 @@ public class ApisApiServiceImpl implements ApisApiService {
 
             // adding the API and definition
             apiToAdd.setSwaggerDefinition(definitionToAdd);
-            if (apiDTOFromProperties.getAdditionalPropertiesMap() != null) {
-                for (Map.Entry<String, APIInfoAdditionalPropertiesMapDTO> entry : apiDTOFromProperties
-                        .getAdditionalPropertiesMap().entrySet()) {
-                    apiToAdd.addProperty(entry.getKey(), entry.getValue().getValue());
-                }
-            }
             API addedAPI = apiProvider.addAPI(apiToAdd);
             //apiProvider.saveSwaggerDefinition(apiToAdd, definitionToAdd);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -4976,12 +4976,6 @@ public class ApisApiServiceImpl implements ApisApiService {
                     definitionToAdd, APIConstants.API_TYPE_WS.equals(apiToAdd.getType())));
             apiToAdd.setOrganization(organization);
             apiToAdd.setAsyncApiDefinition(definitionToAdd);
-            if (apiDTOFromProperties.getAdditionalPropertiesMap() != null) {
-                for (Map.Entry<String, APIInfoAdditionalPropertiesMapDTO> entry : apiDTOFromProperties
-                        .getAdditionalPropertiesMap().entrySet()) {
-                    apiToAdd.addProperty(entry.getKey(), entry.getValue().getValue());
-                }
-            }
 
             apiProvider.addAPI(apiToAdd);
             return APIMappingUtil.fromAPItoDTO(apiProvider.getAPIbyUUID(apiToAdd.getUuid(), organization));


### PR DESCRIPTION
This PR fixes an issue where the `additionalPropertiesMap` is not updated properly when updating an API (PUT). Earlier, the values in `additionalPropertiesMap` will be overridden by the values in `additionalProperties` array. This issue is fixed this PR.

Related issue: https://github.com/wso2-enterprise/choreo/issues/6888