### PR TITLE
Adding a missing fix for WSDL import on Windows

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIMWSDLReader.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIMWSDLReader.java
@@ -166,6 +166,10 @@ public class APIMWSDLReader {
                 + APIConstants.WSDL_ARCHIVES_TEMP_FOLDER + File.separator + UUID.randomUUID().toString();
         String wsdlFilePath = path + File.separator + APIConstants.WSDL_FILE
                 + APIConstants.WSDL_FILE_EXTENSION;
+        // Append an additional '/' if not found before the prefix
+        if (!wsdlFilePath.startsWith("/")) {
+            wsdlFilePath = "/" + wsdlFilePath;
+        }
 
         APIFileUtil.extractSingleWSDLFile(inputStream, path, wsdlFilePath);
         String finalPath = APIConstants.FILE_URI_PREFIX + wsdlFilePath;


### PR DESCRIPTION
## Purpose
Related to [1].

## Goals
- Adding a missing if statement which is related to WSDL import issues in Windows.

## Approach
- Added a missing if statement which is related to WSDL import issues in Windows.

## Test environment
- OS: Ubuntu 20.04.2 LTS, Windows 10
- JDK 1.8.0_251
 
[1] https://github.com/wso2/product-apim/issues/11448
