### PR TITLE
Fix issue in passing headers, query/path params to lamda function from Gateway

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
@@ -28,6 +28,7 @@ import com.amazonaws.services.lambda.model.InvocationType;
 import com.amazonaws.services.lambda.model.InvokeRequest;
 import com.amazonaws.services.lambda.model.InvokeResult;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
@@ -57,6 +58,8 @@ public class AWSLambdaMediator extends AbstractMediator {
     private static final String PATH_PARAMETERS = "pathParameters";
     private static final String QUERY_STRING_PARAMETERS = "queryStringParameters";
     private static final String BODY_PARAMETER = "body";
+    private static final String PATH = "path";
+    private static final String HTTP_METHOD = "httpMethod";
 
     public AWSLambdaMediator() {
 
@@ -102,6 +105,8 @@ public class AWSLambdaMediator extends AbstractMediator {
         }
         payload.add(PATH_PARAMETERS, pathParameters);
         payload.add(QUERY_STRING_PARAMETERS, queryStringParameters);
+        payload.addProperty(HTTP_METHOD, (String) messageContext.getProperty(APIConstants.REST_METHOD));
+        payload.addProperty(PATH, (String) messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE));
 
         // Set lambda backend invocation start time for analytics
         messageContext.setProperty(Constants.BACKEND_START_TIME_PROPERTY, System.currentTimeMillis());
@@ -112,7 +117,7 @@ public class AWSLambdaMediator extends AbstractMediator {
         } else {
             body = "{}";
         }
-        payload.addProperty(BODY_PARAMETER, body);
+        payload.add(BODY_PARAMETER, new JsonParser().parse(body).getAsJsonObject());
 
         if (log.isDebugEnabled()) {
             log.debug("Passing the payload " + payload.toString() + " to AWS Lambda function with resource name "

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1241,6 +1241,7 @@ public final class APIConstants {
 
     public static final String API_RESOURCE_CACHE_KEY = "API_RESOURCE_CACHE_KEY";
     public static final String API_ELECTED_RESOURCE = "API_ELECTED_RESOURCE";
+    public static final String REST_METHOD = "REST_METHOD";
 
     // GraphQL related constants
     public static final String API_TYPE = "API_TYPE";


### PR DESCRIPTION
Fixes https://github.com/wso2/product-apim/issues/11430 and sends `httpMethod` and `path` to AWS Lambda function.

The sample payload send to Lambda function would look like:
```json
{
    "headers": {
        "Accept": "*/*",
        "Accept-Encoding": "gzip, deflate, br",
        "Accept-Language": "en,en-US;q=0.5",
        "activityid": "401688ab-a955-42ee-b16e-96ab26ff31ec"
    },
    "pathParameters": {
        "xxxx": "xxxxx"
    },
    "queryStringParameters": {
        "xxxx": "xxxxx"
    },
    "body": {
        "key1": "value1",
        "key2": "value2"
    },
    "httpMethod": "POST",
    "path": "/resource/{path}"
}
```