### PR TITLE
Add eventing component for externalizing event publishing

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.eventing/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ you may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>apimgt</artifactId>
+        <groupId>org.wso2.carbon.apimgt</groupId>
+        <version>9.0.278-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.apimgt.eventing</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - API Management Eventing</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.databridge.agent</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            org.wso2.carbon.apimgt.eventing.internal.*
+                        </Private-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.apimgt.eventing.internal.*,
+                            org.wso2.carbon.apimgt.eventing.*;version="${carbon.apimgt.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.osgi.service.*;version="${imp.package.version.osgi.service}",
+                            org.apache.commons.logging.*;version="${import.package.version.commons.logging}",
+                            org.wso2.carbon.base;version="${imp.pkg.version.org.wso2.carbon.base}",
+                            org.wso2.carbon.context;version="${carbon.platform.package.import.version.range}",
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/EventPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/EventPublisher.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.eventing;
+
+/**
+ * Interface for event publishers.
+ */
+public interface EventPublisher {
+
+    /**
+     * Initialize the event publisher.
+     */
+    void init();
+
+    /**
+     * Publish event to the message broker defined in configs.
+     *
+     * @param eventPublisherEvent event to be published
+     */
+    void publish(EventPublisherEvent eventPublisherEvent);
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/EventPublisherEvent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/EventPublisherEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.eventing;
+
+import org.wso2.carbon.databridge.commons.Event;
+
+/**
+ * Event class for eventing.
+ */
+public class EventPublisherEvent extends Event {
+
+    public EventPublisherEvent(java.lang.String streamId, long timeStamp, java.lang.Object[] metaDataArray,
+                 java.lang.Object[] correlationDataArray, java.lang.Object[] payloadDataArray) {
+        super(streamId, timeStamp, metaDataArray, correlationDataArray, payloadDataArray);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/EventPublisherFactory.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/EventPublisherFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.eventing;
+
+/**
+ * Interface for event publisher factories.
+ */
+public interface EventPublisherFactory {
+
+    /**
+     * Get event publisher.
+     *
+     * @return event publisher
+     */
+    EventPublisher getEventPublisher();
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/EventPublisherFactoryProducer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/EventPublisherFactoryProducer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.eventing;
+
+import org.wso2.carbon.apimgt.eventing.internal.ServiceReferenceHolder;
+
+/**
+ * Factory producer for getting an event publisher factory.
+ */
+public class EventPublisherFactoryProducer {
+
+    /**
+     * Private constructor.
+     */
+    private EventPublisherFactoryProducer() {
+
+    }
+
+    /**
+     * Get event publisher factory.
+     *
+     * @return event publisher factory
+     */
+    public static EventPublisherFactory getEventPublisherFactory() {
+        return ServiceReferenceHolder.getInstance().getEventPublisherFactory();
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/internal/ServiceComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/internal/ServiceComponent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.eventing.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * This class used to activate eventing bundle.
+ */
+@Component(name = "org.wso2.carbon.apimgt.eventing.internal.ServiceComponent", immediate = true)
+public class ServiceComponent {
+    private static final Log log = LogFactory.getLog(ServiceComponent.class);
+
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+        log.info("[TEST][FEATURE_FLAG_REPLACE_EVENT_HUB] ServiceComponent activated");
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext componentContext) {
+        log.info("[TEST][FEATURE_FLAG_REPLACE_EVENT_HUB] ServiceComponent deactivated");
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/internal/ServiceReferenceHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/internal/ServiceReferenceHolder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.eventing.internal;
+
+import org.wso2.carbon.apimgt.eventing.EventPublisherFactory;
+
+/**
+ * Service reference holder for event hub publishing.
+ */
+public class ServiceReferenceHolder {
+    private static final ServiceReferenceHolder instance = new ServiceReferenceHolder();
+    private EventPublisherFactory eventPublisherFactory;
+
+    private ServiceReferenceHolder() {
+
+    }
+
+    public static ServiceReferenceHolder getInstance() {
+        return instance;
+    }
+
+    public void setEventPublisherFactory(EventPublisherFactory eventPublisherFactory) {
+        this.eventPublisherFactory = eventPublisherFactory;
+    }
+
+    public EventPublisherFactory getEventPublisherFactory() {
+        return eventPublisherFactory;
+    }
+}

--- a/components/apimgt/pom.xml
+++ b/components/apimgt/pom.xml
@@ -29,6 +29,7 @@
     <name>API Management</name>
 
     <modules>
+        <module>org.wso2.carbon.apimgt.eventing</module>
         <module>org.wso2.carbon.apimgt.api</module>
         <module>org.wso2.carbon.apimgt.persistence</module>
         <module>org.wso2.carbon.apimgt.impl</module>


### PR DESCRIPTION
This PR adds an eventing component to be used instead of the current event publishers. However, the wiring of the written publisher will be done as a seperate PR.

Resolves: https://github.com/wso2/product-apim/issues/11513