### PR TITLE
Fix NPE coming when having the title in OAS definition as empty

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -750,12 +750,9 @@ public class OAS3Parser extends APIDefinition {
                     }
                 }
             }
-            String title = "";
-            String context = "";
-            if (StringUtils.isBlank(info.getTitle())) {
-                title = null;
-                context = null;
-            } else {
+            String title = null;
+            String context = null;
+            if (!StringUtils.isBlank(info.getTitle())) {
                 title = info.getTitle();
                 context = info.getTitle().replaceAll("\\s", "").toLowerCase();
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -752,7 +752,9 @@ public class OAS3Parser extends APIDefinition {
             }
             OASParserUtil.updateValidationResponseAsSuccess(
                     validationResponse, apiDefinition, openAPI.getOpenapi(),
-                    info.getTitle(), info.getVersion(), info.getTitle().replaceAll("\\s","").toLowerCase(),
+                    info.getTitle(), info.getVersion(),
+                    (info.getTitle() == null || info.getTitle().isEmpty() ? null :
+                            info.getTitle().replaceAll("\\s", "").toLowerCase()),
                     info.getDescription(), endpoints
             );
             validationResponse.setParser(this);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -750,11 +750,18 @@ public class OAS3Parser extends APIDefinition {
                     }
                 }
             }
+            String title = "";
+            String context = "";
+            if (StringUtils.isBlank(info.getTitle())) {
+                title = null;
+                context = null;
+            } else {
+                title = info.getTitle();
+                context = info.getTitle().replaceAll("\\s", "").toLowerCase();
+            }
             OASParserUtil.updateValidationResponseAsSuccess(
                     validationResponse, apiDefinition, openAPI.getOpenapi(),
-                    info.getTitle(), info.getVersion(),
-                    (info.getTitle() == null || info.getTitle().isEmpty() ? null :
-                            info.getTitle().replaceAll("\\s", "").toLowerCase()),
+                    title, info.getVersion(), context,
                     info.getDescription(), endpoints
             );
             validationResponse.setParser(this);


### PR DESCRIPTION
## Purpose 

- This PR fixes https://github.com/wso2-enterprise/choreo/issues/7298
- This PR includes a null check before getting the context from the title in OAS definition. If the title is empty it sets context as null. 