### PR TITLE
Add event publisher parameters

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1869,6 +1869,7 @@ public final class APIConstants {
 
         public static final String DATA_PUBLISHER_CONFIGURATION = "DataPublisher";
         public static final String DATA_PUBLISHER_CONFIGURAION_TYPE = "Type";
+        public static final String PROPERTIES_CONFIGURATION = "Properties";
         public static final String DATA_PUBLISHER_CONFIGURAION_REVEIVER_URL_GROUP = "ReceiverUrlGroup";
         public static final String DATA_PUBLISHER_CONFIGURAION_AUTH_URL_GROUP = "AuthUrlGroup";
         public static final String USERNAME = "Username";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/EventHubConfigurationDto.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/EventHubConfigurationDto.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.apimgt.impl.dto;
 
+import java.util.Map;
 import java.util.Properties;
 
 public class EventHubConfigurationDto {
@@ -120,6 +121,7 @@ public class EventHubConfigurationDto {
         private String type = "Binary";
         private String receiverUrlGroup = "tcp://localhost:9611";
         private String authUrlGroup = "ssl://localhost:9711";
+        private Map<String, String> properties;
 
         public String getType() {
 
@@ -149,6 +151,14 @@ public class EventHubConfigurationDto {
         public void setAuthUrlGroup(String authUrlGroup) {
 
             this.authUrlGroup = authUrlGroup;
+        }
+
+        public void setProperties(Map properties){
+            this.properties = properties;
+        }
+
+        public Map<String, String> getProperties() {
+            return properties;
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIManagerConfigurationTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIManagerConfigurationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.junit.Test;
+import org.testng.Assert;
+
+import javax.xml.stream.XMLStreamException;
+
+import java.util.Map;
+
+public class APIManagerConfigurationTest {
+
+    @Test
+    public void testPublisherProperties() throws XMLStreamException {
+        String publisherConfig = "<EventPublisherConfiguration>"
+                                 + "<Properties>\n"
+                                 + "<Property name=\"testProp\">testVal</Property>\n"
+                                 + "</Properties>\n"
+                                 + "</EventPublisherConfiguration>";
+        OMElement element = AXIOMUtil.stringToOM(publisherConfig);
+        APIManagerConfiguration config = new APIManagerConfiguration();
+        Map<String, String> extractedProperties = config.extractPublisherProperties(element);
+        Assert.assertTrue(extractedProperties.containsKey("testProp"));
+    }
+
+    @Test
+    public void testPublisherPropertiesUndefined() throws XMLStreamException {
+        String publisherConfig = "<EventPublisherConfiguration>"
+                                 + "<Properties>\n"
+                                 + "</Properties>\n"
+                                 + "</EventPublisherConfiguration>";
+        OMElement element = AXIOMUtil.stringToOM(publisherConfig);
+        APIManagerConfiguration config = new APIManagerConfiguration();
+        Map<String, String> extractedProperties = config.extractPublisherProperties(element);
+        Assert.assertTrue(extractedProperties.isEmpty());
+
+    }
+}

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1238,6 +1238,11 @@
                     <AuthUrlGroup>ssl://${carbon.local.ip}:${auth.url.port}</AuthUrlGroup>
                 {% endif %}
             {% endif %}
+        <Properties>
+            {% for key,value in apim.event_hub.publish.properties.items() %}
+            <Property name="{{key}}">{{value}}</Property>
+            {% endfor %}
+        </Properties>
         </EventPublisherConfiguration>
          <EventReceiverConfiguration>
              <transport.jms.ConnectionFactoryJNDIName>TopicConnectionFactory</transport.jms.ConnectionFactoryJNDIName>


### PR DESCRIPTION
Supports passing parameters in the for event hub publishers in the format of:
```
<EventPublisherConfiguration>
   <Properties>
      <Property name="connectionString">connection_string_value</Property>
   </Properties>
</EventPublisherConfiguration>
```
Supported deployment.toml configuration would be:
```
[apim.event_hub.publish.properties]
'connectionString'="sampleConnectionString"
'testParam2'="sampleTestParam2"
```