### PR TITLE
Remove tier permissions record when deleting subscription policies

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -604,6 +604,11 @@ public class SQLConstants {
                     " FROM AM_THROTTLE_TIER_PERMISSIONS " +
                     " WHERE TIER = ? AND TENANT_ID = ?";
 
+    public static final String DELETE_THROTTLE_TIER_BY_NAME_PERMISSION_SQL =
+            " DELETE FROM " +
+            " AM_THROTTLE_TIER_PERMISSIONS " +
+            " WHERE TIER = ? AND TENANT_ID = ?";
+
   //--------------------
 
     public static final String GET_TIER_PERMISSION_ID_SQL =


### PR DESCRIPTION
Fixes wso2/product-apim#11527

**Note** : This error log is not reproducible in master/4.0.0 as we have added a null check at [1] to fix [2]. However the issue with role permissions not getting deleted is still there in master hence fixed it with this PR. 

[1]. https://github.com/wso2/carbon-apimgt/pull/9234
[2]. https://github.com/wso2/product-apim/issues/8921
