### PR TITLE
Upgrade openapi-generator Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1994,7 +1994,7 @@
         <swagger-jaxrs.version>1.6.1</swagger-jaxrs.version>
         <junit.version>4.12</junit.version>
         <opensaml3.version>3.3.1</opensaml3.version>
-        <openapi.generator.version>4.3.1.wso2v2</openapi.generator.version>
+        <openapi.generator.version>4.3.1.wso2v3</openapi.generator.version>
         <caffeine.version>2.8.1</caffeine.version>
         <cal10n.version>0.8.1</cal10n.version>
         <commons-lang.version>2.4</commons-lang.version>


### PR DESCRIPTION
## Purpose
Upgrading openapi-generator version from 4.3.1.wso2v2 to 4.3.1.wso2v3
Related wso2/orbit PR: https://github.com/wso2/orbit/pull/461