### PR TITLE
Fixing SOAP to REST API import issues with some WSDL definitions

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3410,8 +3410,8 @@ public class ApisApiServiceImpl implements ApisApiService {
                     wsdlArchiveExtractedPath = validationResponse.getWsdlArchiveInfo().getLocation()
                             + File.separator + APIConstants.API_WSDL_EXTRACTED_DIRECTORY;
                 }
-                createdApi = importSOAPToRESTAPI(fileInputStream, fileDetail, url, wsdlArchiveExtractedPath, apiToAdd,
-                        organization);
+                createdApi = importSOAPToRESTAPI(validationResponse.getWsdlProcessor().getWSDL(), fileDetail, url,
+                        wsdlArchiveExtractedPath, apiToAdd, organization);
             } else {
                 RestApiUtil.handleBadRequest("Invalid implementationType parameter", log);
             }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11534

## Goals
Fixes the issue when importing some WSDL definition files to create SOAP to REST APIs via the Publisher portal.

## Approach
Use the WSDL content retrieved after validating the content, instead of directly using the File Input Stream when importing/creating a SOAP to REST API.

##Related PRs
- https://github.com/wso2/product-apim/pull/10981

## Test environment
- OS: Ubuntu 20.04.2 LTS
- JDK 1.8.0_251
