### PR TITLE
fix REST PUT API /apis/{apiId}/swagger error 500

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiConstants.java
@@ -46,9 +46,11 @@ public final class RestApiConstants {
     public static final String USER_REST_API_SCOPES = "user_rest_api_scopes";
 
     public static final String API_IMPORT_EXPORT_SCOPE = "apim:api_import_export";
+    public static final String API_MANAGE_SCOPE = "apim:api_manage";
     public static final String CREATOR_SCOPE = "apim:api_create";
     public static final String ADMIN_SCOPE = "apim:admin";
     public static final String PUBLISHER_SCOPE = "apim:api_publish";
+
 
     public static final String DEFAULT_RESPONSE_CONTENT_TYPE = APPLICATION_JSON;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -831,6 +831,7 @@ public class ApisApiServiceImpl implements ApisApiService {
         for (String scope : tokenScopes) {
             if (RestApiConstants.PUBLISHER_SCOPE.equals(scope)
                     || RestApiConstants.API_IMPORT_EXPORT_SCOPE.equals(scope)
+                    || RestApiConstants.API_MANAGE_SCOPE.equals(scope)
                     || RestApiConstants.ADMIN_SCOPE.equals(scope)) {
                 updatePermittedForPublishedDeprecated = true;
                 break;


### PR DESCRIPTION
when using scopes => apim:api_create apim:api_manage
{
    "access_token": "c10a2418-aaa1-34e7-bbd0-8f7ecfe95c83",
    "refresh_token": "332a10a2-5263-3930-a1db-d4b939cb19d6",
    "scope": "apim:api_create apim:api_manage",
    "token_type": "Bearer",
    "expires_in": 3600
}

the APIM gives this error:

{"code":500,"message":"Internal server error","description":"Error while updating the swagger definition of the API: 83a20a71-5000-40fa-9f7c-aa168b3cdc88 - 900380:Insufficient permission to update the API::Updating the API is restricted as as it is PUBLISHED.","moreInfo":"","error":[]}


while using scopes =>  apim:api_create apim:api_publish
{
    "access_token": "dcbaa7d1-fdd7-37bb-87f5-6dee7e5a43c1",
    "refresh_token": "baa74507-56af-3c08-a55a-106a892437a4",
    "scope": "apim:api_create apim:api_publish",
    "token_type": "Bearer",
    "expires_in": 3017
}

then it is OK / 200 HTTP code

the docs here https://apim.docs.wso2.com/en/latest/reference/product-apis/publisher-apis/publisher-v2/publisher-v2/#operation/getAPISwagger should be updated specially here (scope apim:api_create alone also gives 500 error):

<img width="1386" alt="image" src="https://user-images.githubusercontent.com/908425/130091856-caa0f7b6-d2a3-4ea9-aa76-b0c9d62674d8.png">

It should be  apim:api_create AND apim:api_publish Together