### PR TITLE
Start ExpiredJWTCleaner thread to clean AM_REVOKED_JWT table

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -15048,7 +15048,7 @@ public class ApiMgtDAO {
         try (Connection connection = APIMgtDBUtil.getConnection(); PreparedStatement ps =
                 connection.prepareStatement(deleteQuery)) {
             connection.setAutoCommit(false);
-            ps.setLong(1, System.currentTimeMillis() / 1000);
+            ps.setLong(1, System.currentTimeMillis());
             ps.executeUpdate();
             connection.commit();
         } catch (SQLException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.notification/src/main/java/org/wso2/carbon/apimgt/notification/AbstractKeyManagerEventHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.notification/src/main/java/org/wso2/carbon/apimgt/notification/AbstractKeyManagerEventHandler.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.apimgt.notification;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.keymgt.ExpiredJWTCleaner;
 import org.wso2.carbon.apimgt.impl.keymgt.KeyManagerEventHandler;
 import org.wso2.carbon.apimgt.impl.publishers.RevocationRequestPublisher;
 import org.wso2.carbon.apimgt.notification.event.TokenRevocationEvent;
@@ -52,6 +53,11 @@ public abstract class AbstractKeyManagerEventHandler implements KeyManagerEventH
                 tokenRevocationEvent.getExpiryTime(), tokenRevocationEvent.getTenantId());
         revocationRequestPublisher.publishRevocationEvents(tokenRevocationEvent.getAccessToken(),
                 tokenRevocationEvent.getExpiryTime(), properties);
+
+        // Cleanup expired revoked tokens from db.
+        Runnable expiredJWTCleaner = new ExpiredJWTCleaner();
+        Thread cleanupThread = new Thread(expiredJWTCleaner);
+        cleanupThread.start();
         return true;
     }
 }


### PR DESCRIPTION
### Purpose
To fix AM_REVOKED_JWT table clean up process is not working as expected in APIM 3.2.0.

### Goal
Fixes: https://github.com/wso2/product-apim/issues/11541

### Approach
Invoke `ExpiredJWTCleaner` thread that is already there in the code from the `AbstractKeyManagerEventHandler.java` class.

**Git Actions:** https://github.com/YasasRangika/carbon-apimgt/actions/runs/1158197405