### PR TITLE
Revert "Add endpoint validation"

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -440,11 +440,6 @@
             <artifactId>apicurio-data-models</artifactId>
             <version>1.1.5</version>
         </dependency>
-        <dependency>
-            <groupId>commons-validator</groupId>
-            <artifactId>commons-validator</artifactId>
-            <version>${commons-validator.version}</version>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -50,7 +50,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
@@ -265,8 +264,6 @@ import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.NetworkInterface;
 import java.net.SocketException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.UnknownHostException;
@@ -11811,39 +11808,6 @@ public final class APIUtil {
         return APIConstants.APITransportType.WS.toString().equalsIgnoreCase(apiProduct.getType()) ||
                 APIConstants.APITransportType.SSE.toString().equalsIgnoreCase(apiProduct.getType()) ||
                 APIConstants.APITransportType.WEBSUB.toString().equalsIgnoreCase(apiProduct.getType());
-    }
-
-    /**
-     * Validate sandbox and production endpoint URLs.
-     *
-     * @param endpoints sandbox and production endpoint URLs inclusive list
-     * @return validity of given URLs
-     */
-    public static boolean validateEndpointURLs(ArrayList<String> endpoints) {
-        UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_ALL_SCHEMES +
-                UrlValidator.ALLOW_LOCAL_URLS);
-
-        for (String endpoint : endpoints) {
-            // If url is a JMS connection url, validation is skipped. If not, validity is checked.
-            if (!endpoint.startsWith("jms:") && !urlValidator.isValid(endpoint)) {
-                try {
-                    // If the url is not identified as valid from the above check,
-                    // next step is determine the validity of the encoded url (done through the URI constructor).
-                    URL endpointUrl = new URL(endpoint);
-                    URI endpointUri = new URI(endpointUrl.getProtocol(), endpointUrl.getAuthority(),
-                            endpointUrl.getPath(), endpointUrl.getQuery(), null);
-
-                    if (!urlValidator.isValid(endpointUri.toString())) {
-                        log.error("Invalid endpoint url " + endpointUrl);
-                        return false;
-                    }
-                } catch (URISyntaxException | MalformedURLException e) {
-                    log.error("Error while parsing the endpoint url " + endpoint);
-                    return false;
-                }
-            }
-        }
-        return true;
     }
     
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -754,12 +754,6 @@ public class PublisherCommonUtils {
                     ExceptionCodes.INVALID_ENDPOINT_URL);
         }
 
-        // validate sandbox and production endpoints
-        if (!PublisherCommonUtils.validateEndpoints(apiDto)) {
-            throw new APIManagementException("Invalid/Malformed endpoint URL(s) detected",
-                    ExceptionCodes.INVALID_ENDPOINT_URL);
-        }
-
         Map endpointConfig = (Map) apiDto.getEndpointConfig();
         CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
 
@@ -854,30 +848,6 @@ public class PublisherCommonUtils {
         }
 
         return isValid;
-    }
-
-    /**
-     * Validate sandbox and production endpoint URLs.
-     *
-     * @param apiDto API DTO of the API
-     * @return validity of URLs found within the endpoint configurations of the DTO
-     */
-    public static boolean validateEndpoints(APIDTO apiDto) {
-
-        ArrayList<String> endpoints = new ArrayList<>();
-        org.json.JSONObject endpointConfiguration = new org.json.JSONObject((Map) apiDto.getEndpointConfig());
-
-        // extract sandbox endpoint URL
-        if (!endpointConfiguration.isNull(APIConstants.API_DATA_SANDBOX_ENDPOINTS)) {
-            endpoints.add(endpointConfiguration.getJSONObject(APIConstants.API_DATA_SANDBOX_ENDPOINTS)
-                    .getString(APIConstants.API_DATA_URL));
-        }
-        // extract production endpoint URL
-        if (!endpointConfiguration.isNull(APIConstants.API_DATA_PRODUCTION_ENDPOINTS)) {
-            endpoints.add(endpointConfiguration.getJSONObject(APIConstants.API_DATA_PRODUCTION_ENDPOINTS)
-                    .getString(APIConstants.API_DATA_URL));
-        }
-        return APIUtil.validateEndpointURLs(endpoints);
     }
 
     public static String constructEndpointConfigForService(String serviceUrl, String protocol) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -784,13 +784,6 @@ public class ApisApiServiceImpl implements ApisApiService {
             String organization = RestApiUtil.getValidatedOrganization(messageContext);
             //validate if api exists
             validateAPIExistence(apiId);
-
-            // validate sandbox and production endpoints
-            if (!PublisherCommonUtils.validateEndpoints(body)) {
-                throw new APIManagementException("Invalid/Malformed endpoint URL(s) detected",
-                        ExceptionCodes.INVALID_ENDPOINT_URL);
-            }
-
             APIProvider apiProvider = RestApiCommonUtil.getProvider(username);
             API originalAPI = apiProvider.getAPIbyUUID(apiId, organization);
             originalAPI.setOrganization(organization);
@@ -3299,12 +3292,11 @@ public class ApisApiServiceImpl implements ApisApiService {
      * @param inlineApiDefinition Swagger API definition String
      * @param messageContext CXF message context
      * @return API Import using OpenAPI definition response
-     * @throws APIManagementException when error occurs while importing the OpenAPI definition
      */
     @Override
     public Response importOpenAPIDefinition(InputStream fileInputStream, Attachment fileDetail, String url,
                                             String additionalProperties, String inlineApiDefinition,
-                                            MessageContext messageContext) throws APIManagementException {
+                                            MessageContext messageContext) {
 
         // validate 'additionalProperties' json
         if (StringUtils.isBlank(additionalProperties)) {
@@ -3318,12 +3310,6 @@ public class ApisApiServiceImpl implements ApisApiService {
             apiDTOFromProperties = objectMapper.readValue(additionalProperties, APIDTO.class);
         } catch (IOException e) {
             throw RestApiUtil.buildBadRequestException("Error while parsing 'additionalProperties'", e);
-        }
-
-        // validate sandbox and production endpoints
-        if (!PublisherCommonUtils.validateEndpoints(apiDTOFromProperties)) {
-            throw new APIManagementException("Invalid/Malformed endpoint URL(s) detected",
-                    ExceptionCodes.INVALID_ENDPOINT_URL);
         }
 
         // Import the API and Definition

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
@@ -131,11 +131,6 @@
             <groupId>com.damnhandy.wso2</groupId>
             <artifactId>handy-uri-templates</artifactId>
         </dependency>
-       <dependency>
-           <groupId>commons-validator</groupId>
-           <artifactId>commons-validator</artifactId>
-           <version>${commons-validator.version}</version>
-       </dependency>
     </dependencies>
     <reporting>
         <plugins>
@@ -301,7 +296,6 @@
                                     org.wso2.orbit.com.amazonaws:awslambda:${org.wso2.orbit.com.amazonaws.version}
                                 </bundleDef>
                                 <bundleDef>com.damnhandy.wso2:handy-uri-templates</bundleDef>
-                                <bundleDef>commons-validator:commons-validator:${commons-validator.version}</bundleDef>
                             </bundles>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1838,16 +1838,11 @@
                 <artifactId>javax.jms-api</artifactId>
                 <version>${javax.jms.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.damnhandy.wso2</groupId>
-                <artifactId>handy-uri-templates</artifactId>
-                <version>${damnhandy.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-validator</groupId>
-                <artifactId>commons-validator</artifactId>
-                <version>${commons-validator.version}</version>
-            </dependency>
+                <dependency>
+                    <groupId>com.damnhandy.wso2</groupId>
+                    <artifactId>handy-uri-templates</artifactId>
+                    <version>${damnhandy.version}</version>
+                </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -2003,7 +1998,6 @@
         <caffeine.version>2.8.1</caffeine.version>
         <cal10n.version>0.8.1</cal10n.version>
         <commons-lang.version>2.4</commons-lang.version>
-        <commons-validator.version>1.7</commons-validator.version>
 
         <!-- imp package version ranges -->
         <imp.pkg.version.axis2>[1.6.1, 1.7.0)</imp.pkg.version.axis2>


### PR DESCRIPTION
Reverts wso2/carbon-apimgt#10715

API creation and update fails due to invalid endpoint URL when creating an integration in Choreo. This PR will temporarily disable the validation till the proper fix is sent.

## Related Issue:

- https://github.com/wso2-enterprise/choreo/issues/7917