### PR TITLE
Fixing the issue in generating a valid infinite access token

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -302,6 +302,8 @@ public enum ExceptionCodes implements ErrorHandler {
     INTERNAL_ERROR(900967, "General Error", 500, "Server Error Occurred"),
     POLICY_LEVEL_NOT_SUPPORTED(900968, "Throttle Policy level invalid", 400, "Specified Throttle policy level is not "
             + "valid"),
+    INVALID_APPLICATION_ADDITIONAL_PROPERTIES(900970, "Invalid application additional properties", 400,
+            "Invalid additional properties. %s"),
     JWT_PARSING_FAILED(900986, "Key Management Error", 500, "Error while parsing JWT. Invalid Jwt."),
     TOKEN_SCOPES_NOT_SET(
             900987, "The token information has not been correctly set internally", 400,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -1140,8 +1140,8 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                     if (StringUtils.isNotBlank(additionalProperty) && !StringUtils
                             .equals(additionalProperty, APIConstants.KeyManager.NOT_APPLICABLE_VALUE)) {
                         try {
-                            Double doubleValue = Double.parseDouble(additionalProperty);
-                            if (doubleValue < 0) {
+                            Long longValue = Long.parseLong(additionalProperty);
+                            if (longValue < 0) {
                                 String errMsg = "Application configuration values cannot have negative values.";
                                 throw new APIManagementException(errMsg, ExceptionCodes
                                         .from(ExceptionCodes.INVALID_APPLICATION_ADDITIONAL_PROPERTIES, errMsg));

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -19,6 +19,9 @@
 package org.wso2.carbon.apimgt.impl;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import feign.Feign;
 import feign.Response;
 import feign.auth.BasicAuthRequestInterceptor;
@@ -40,12 +43,14 @@ import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
 import org.wso2.carbon.apimgt.api.model.AccessTokenRequest;
 import org.wso2.carbon.apimgt.api.model.ApplicationConstants;
 import org.wso2.carbon.apimgt.api.model.KeyManagerConfiguration;
+import org.wso2.carbon.apimgt.api.model.KeyManagerConnectorConfiguration;
 import org.wso2.carbon.apimgt.api.model.OAuthAppRequest;
 import org.wso2.carbon.apimgt.api.model.OAuthApplicationInfo;
 import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.dto.ScopeDTO;
 import org.wso2.carbon.apimgt.impl.dto.UserInfoDTO;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.kmclient.ApacheFeignHttpClient;
 import org.wso2.carbon.apimgt.impl.kmclient.FormEncoder;
 import org.wso2.carbon.apimgt.impl.kmclient.KMClientErrorDecoder;
@@ -1115,5 +1120,40 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
             handleException("Error while getting user info", e);
         }
         return map;
+    }
+
+    @Override
+    protected void validateOAuthAppCreationProperties(OAuthApplicationInfo oAuthApplicationInfo)
+            throws APIManagementException {
+        super.validateOAuthAppCreationProperties(oAuthApplicationInfo);
+
+        String type = getType();
+        KeyManagerConnectorConfiguration keyManagerConnectorConfiguration = ServiceReferenceHolder.getInstance()
+                .getKeyManagerConnectorConfiguration(type);
+        if (keyManagerConnectorConfiguration != null) {
+            Object additionalProperties = oAuthApplicationInfo.getParameter(APIConstants.JSON_ADDITIONAL_PROPERTIES);
+            if (additionalProperties != null) {
+                JsonObject additionalPropertiesJson = (JsonObject) new JsonParser()
+                        .parse((String) additionalProperties);
+                for (Map.Entry<String, JsonElement> entry : additionalPropertiesJson.entrySet()) {
+                    String additionalProperty = entry.getValue().getAsString();
+                    if (StringUtils.isNotBlank(additionalProperty) && !StringUtils
+                            .equals(additionalProperty, APIConstants.KeyManager.NOT_APPLICABLE_VALUE)) {
+                        try {
+                            Double doubleValue = Double.parseDouble(additionalProperty);
+                            if (doubleValue < 0) {
+                                String errMsg = "Application configuration values cannot have negative values.";
+                                throw new APIManagementException(errMsg, ExceptionCodes
+                                        .from(ExceptionCodes.INVALID_APPLICATION_ADDITIONAL_PROPERTIES, errMsg));
+                            }
+                        } catch (NumberFormatException e) {
+                            String errMsg = "Application configuration values cannot have string values.";
+                            throw new APIManagementException(errMsg, ExceptionCodes
+                                    .from(ExceptionCodes.INVALID_APPLICATION_ADDITIONAL_PROPERTIES, errMsg));
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractKeyManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractKeyManager.java
@@ -278,37 +278,32 @@ public abstract class AbstractKeyManager implements KeyManager {
             throws APIManagementException {
 
         String type = getType();
-        if (!APIConstants.KeyManager.DEFAULT_KEY_MANAGER_TYPE.equals(type)) {
-
-            List<String> missedRequiredValues = new ArrayList<>();
-            KeyManagerConnectorConfiguration keyManagerConnectorConfiguration =
-                    ServiceReferenceHolder.getInstance().getKeyManagerConnectorConfiguration(type);
-            if (keyManagerConnectorConfiguration != null) {
-                List<ConfigurationDto> applicationConfigurationDtoList =
-                        keyManagerConnectorConfiguration.getApplicationConfigurations();
-                Object additionalProperties =
-                        oAuthApplicationInfo.getParameter(APIConstants.JSON_ADDITIONAL_PROPERTIES);
-                if (additionalProperties != null) {
-                    JsonObject additionalPropertiesJson =
-                            (JsonObject) new JsonParser().parse((String) additionalProperties);
-                    for (ConfigurationDto configurationDto : applicationConfigurationDtoList) {
-                        JsonElement value = additionalPropertiesJson.get(configurationDto.getName());
-                        if (value == null) {
-                            if (configurationDto.isRequired()) {
-                                missedRequiredValues.add(configurationDto.getName());
-                            }
+        List<String> missedRequiredValues = new ArrayList<>();
+        KeyManagerConnectorConfiguration keyManagerConnectorConfiguration = ServiceReferenceHolder.getInstance()
+                .getKeyManagerConnectorConfiguration(type);
+        if (keyManagerConnectorConfiguration != null) {
+            List<ConfigurationDto> applicationConfigurationDtoList = keyManagerConnectorConfiguration
+                    .getApplicationConfigurations();
+            Object additionalProperties = oAuthApplicationInfo.getParameter(APIConstants.JSON_ADDITIONAL_PROPERTIES);
+            if (additionalProperties != null) {
+                JsonObject additionalPropertiesJson = (JsonObject) new JsonParser()
+                        .parse((String) additionalProperties);
+                for (ConfigurationDto configurationDto : applicationConfigurationDtoList) {
+                    JsonElement value = additionalPropertiesJson.get(configurationDto.getName());
+                    if (value == null) {
+                        if (configurationDto.isRequired()) {
+                            missedRequiredValues.add(configurationDto.getName());
                         }
                     }
-                    if (!missedRequiredValues.isEmpty()) {
-                        throw new APIManagementException("Missing required properties to create/update oauth " +
-                                "application",
-                                ExceptionCodes.KEY_MANAGER_MISSING_REQUIRED_PROPERTIES_IN_APPLICATION);
-                    }
                 }
-            } else {
-                throw new APIManagementException("Invalid Key Manager Type " + type,
-                        ExceptionCodes.KEY_MANAGER_NOT_FOUND);
+                if (!missedRequiredValues.isEmpty()) {
+                    throw new APIManagementException(
+                            "Missing required properties to create/update oauth " + "application",
+                            ExceptionCodes.KEY_MANAGER_MISSING_REQUIRED_PROPERTIES_IN_APPLICATION);
+                }
             }
+        } else {
+            throw new APIManagementException("Invalid Key Manager Type " + type, ExceptionCodes.KEY_MANAGER_NOT_FOUND);
         }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AbstractKeyManagerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AbstractKeyManagerTestCase.java
@@ -20,12 +20,19 @@ package org.wso2.carbon.apimgt.impl;
 
 import org.compass.core.util.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.AccessTokenRequest;
 import org.wso2.carbon.apimgt.api.model.KeyManager;
 import org.wso2.carbon.apimgt.api.model.KeyManagerConfiguration;
+import org.wso2.carbon.apimgt.api.model.KeyManagerConnectorConfiguration;
 import org.wso2.carbon.apimgt.api.model.OAuthApplicationInfo;
 import org.wso2.carbon.apimgt.impl.factory.ModelKeyManagerForTest;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 
 import java.util.UUID;
 
@@ -35,6 +42,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ServiceReferenceHolder.class})
 public class AbstractKeyManagerTestCase {
 
     @Test
@@ -84,6 +93,15 @@ public class AbstractKeyManagerTestCase {
     @Test
     public void buildFromJSONTest() throws APIManagementException {
         AbstractKeyManager keyManager = new AMDefaultKeyManagerImpl();
+
+        KeyManagerConnectorConfiguration keyManagerConnectorConfiguration = Mockito
+                .mock(DefaultKeyManagerConnectorConfiguration.class);
+        ServiceReferenceHolder serviceReferenceHolder = PowerMockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        Mockito.when(serviceReferenceHolder
+                .getKeyManagerConnectorConfiguration(APIConstants.KeyManager.DEFAULT_KEY_MANAGER_TYPE))
+                .thenReturn(keyManagerConnectorConfiguration);
 
         // test with empty json payload
         assertNotNull(keyManager.buildFromJSON(new OAuthApplicationInfo(), "{}"));


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/9541
Fixes: https://github.com/wso2/product-apim/issues/11585

## Goals
Fix the issue in generating a valid infinite access token.

## Approach
- When a user provides application access token expiry time, user access token expiry time, refresh token expiry time, or id token expiry time with a negative value, it will be rejected with an error.
- To generate infinite tokens the user needs to provide long values not the negative values.

## Related PRs
- https://github.com/wso2/product-apim/pull/11591

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.2 LTS