### PR TITLE
Add EventPublisherException to EventPublisherFactory.configure method

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/EventPublisherFactory.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/EventPublisherFactory.java
@@ -29,7 +29,7 @@ public interface EventPublisherFactory {
      *
      * @param configuration event publisher configuration
      */
-    void configure(Map<String, String> configuration);
+    void configure(Map<String, String> configuration) throws EventPublisherException;
 
     /**
      * Get event publisher.


### PR DESCRIPTION
This PR changes the interface to throw an exception so that the server startup can be interrupted upon an exception that is thrown while configuring the even publisher factory.