### PR TITLE
Add endpoint validation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -444,6 +444,11 @@
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.eventing</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>${commons-validator.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -50,6 +50,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.commons.validator.routines.RegexValidator;
+import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
@@ -286,6 +288,8 @@ import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.UnknownHostException;
@@ -11869,6 +11873,40 @@ public final class APIUtil {
         return APIConstants.APITransportType.WS.toString().equalsIgnoreCase(apiProduct.getType()) ||
                 APIConstants.APITransportType.SSE.toString().equalsIgnoreCase(apiProduct.getType()) ||
                 APIConstants.APITransportType.WEBSUB.toString().equalsIgnoreCase(apiProduct.getType());
+    }
+
+    /**
+     * Validate sandbox and production endpoint URLs.
+     *
+     * @param endpoints sandbox and production endpoint URLs inclusive list
+     * @return validity of given URLs
+     */
+    public static boolean validateEndpointURLs(ArrayList<String> endpoints) {
+        long validatorOptions = UrlValidator.ALLOW_ALL_SCHEMES + UrlValidator.ALLOW_LOCAL_URLS;
+        RegexValidator authorityValidator = new RegexValidator(".*");
+        UrlValidator urlValidator = new UrlValidator(authorityValidator, validatorOptions);
+
+        for (String endpoint : endpoints) {
+            // If url is a JMS connection url, validation is skipped. If not, validity is checked.
+            if (!endpoint.startsWith("jms:") && !urlValidator.isValid(endpoint)) {
+                try {
+                    // If the url is not identified as valid from the above check,
+                    // next step is determine the validity of the encoded url (done through the URI constructor).
+                    URL endpointUrl = new URL(endpoint);
+                    URI endpointUri = new URI(endpointUrl.getProtocol(), endpointUrl.getAuthority(),
+                            endpointUrl.getPath(), endpointUrl.getQuery(), null);
+
+                    if (!urlValidator.isValid(endpointUri.toString())) {
+                        log.error("Invalid endpoint url " + endpointUrl);
+                        return false;
+                    }
+                } catch (URISyntaxException | MalformedURLException e) {
+                    log.error("Error while parsing the endpoint url " + endpoint);
+                    return false;
+                }
+            }
+        }
+        return true;
     }
     
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -755,7 +755,8 @@ public class PublisherCommonUtils {
         }
 
         // validate sandbox and production endpoints
-        if (!PublisherCommonUtils.validateEndpoints(apiDto)) {
+        if (Boolean.parseBoolean(System.getenv("FEATURE_FLAG_URL_VALIDATION")) &&
+                !PublisherCommonUtils.validateEndpoints(apiDto)) {
             throw new APIManagementException("Invalid/Malformed endpoint URL(s) detected",
                     ExceptionCodes.INVALID_ENDPOINT_URL);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -754,6 +754,12 @@ public class PublisherCommonUtils {
                     ExceptionCodes.INVALID_ENDPOINT_URL);
         }
 
+        // validate sandbox and production endpoints
+        if (!PublisherCommonUtils.validateEndpoints(apiDto)) {
+            throw new APIManagementException("Invalid/Malformed endpoint URL(s) detected",
+                    ExceptionCodes.INVALID_ENDPOINT_URL);
+        }
+
         Map endpointConfig = (Map) apiDto.getEndpointConfig();
         CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
 
@@ -848,6 +854,30 @@ public class PublisherCommonUtils {
         }
 
         return isValid;
+    }
+
+    /**
+     * Validate sandbox and production endpoint URLs.
+     *
+     * @param apiDto API DTO of the API
+     * @return validity of URLs found within the endpoint configurations of the DTO
+     */
+    public static boolean validateEndpoints(APIDTO apiDto) {
+
+        ArrayList<String> endpoints = new ArrayList<>();
+        org.json.JSONObject endpointConfiguration = new org.json.JSONObject((Map) apiDto.getEndpointConfig());
+
+        // extract sandbox endpoint URL
+        if (!endpointConfiguration.isNull(APIConstants.API_DATA_SANDBOX_ENDPOINTS)) {
+            endpoints.add(endpointConfiguration.getJSONObject(APIConstants.API_DATA_SANDBOX_ENDPOINTS)
+                    .getString(APIConstants.API_DATA_URL));
+        }
+        // extract production endpoint URL
+        if (!endpointConfiguration.isNull(APIConstants.API_DATA_PRODUCTION_ENDPOINTS)) {
+            endpoints.add(endpointConfiguration.getJSONObject(APIConstants.API_DATA_PRODUCTION_ENDPOINTS)
+                    .getString(APIConstants.API_DATA_URL));
+        }
+        return APIUtil.validateEndpointURLs(endpoints);
     }
 
     public static String constructEndpointConfigForService(String serviceUrl, String protocol) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -789,7 +789,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             validateAPIExistence(apiId);
 
             // validate sandbox and production endpoints
-            if (!PublisherCommonUtils.validateEndpoints(body)) {
+            if (Boolean.parseBoolean(System.getenv("FEATURE_FLAG_URL_VALIDATION")) &&
+                    !PublisherCommonUtils.validateEndpoints(body)) {
                 throw new APIManagementException("Invalid/Malformed endpoint URL(s) detected",
                         ExceptionCodes.INVALID_ENDPOINT_URL);
             }
@@ -3324,7 +3325,8 @@ public class ApisApiServiceImpl implements ApisApiService {
         }
 
         // validate sandbox and production endpoints
-        if (!PublisherCommonUtils.validateEndpoints(apiDTOFromProperties)) {
+        if (Boolean.parseBoolean(System.getenv("FEATURE_FLAG_URL_VALIDATION")) &&
+                !PublisherCommonUtils.validateEndpoints(apiDTOFromProperties)) {
             throw new APIManagementException("Invalid/Malformed endpoint URL(s) detected",
                     ExceptionCodes.INVALID_ENDPOINT_URL);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -787,6 +787,13 @@ public class ApisApiServiceImpl implements ApisApiService {
             String organization = RestApiUtil.getValidatedOrganization(messageContext);
             //validate if api exists
             validateAPIExistence(apiId);
+
+            // validate sandbox and production endpoints
+            if (!PublisherCommonUtils.validateEndpoints(body)) {
+                throw new APIManagementException("Invalid/Malformed endpoint URL(s) detected",
+                        ExceptionCodes.INVALID_ENDPOINT_URL);
+            }
+
             APIProvider apiProvider = RestApiCommonUtil.getProvider(username);
             API originalAPI = apiProvider.getAPIbyUUID(apiId, organization);
             originalAPI.setOrganization(organization);
@@ -3295,11 +3302,12 @@ public class ApisApiServiceImpl implements ApisApiService {
      * @param inlineApiDefinition Swagger API definition String
      * @param messageContext CXF message context
      * @return API Import using OpenAPI definition response
+     * @throws APIManagementException when error occurs while importing the OpenAPI definition
      */
     @Override
     public Response importOpenAPIDefinition(InputStream fileInputStream, Attachment fileDetail, String url,
                                             String additionalProperties, String inlineApiDefinition,
-                                            MessageContext messageContext) {
+                                            MessageContext messageContext) throws APIManagementException {
 
         // validate 'additionalProperties' json
         if (StringUtils.isBlank(additionalProperties)) {
@@ -3313,6 +3321,12 @@ public class ApisApiServiceImpl implements ApisApiService {
             apiDTOFromProperties = objectMapper.readValue(additionalProperties, APIDTO.class);
         } catch (IOException e) {
             throw RestApiUtil.buildBadRequestException("Error while parsing 'additionalProperties'", e);
+        }
+
+        // validate sandbox and production endpoints
+        if (!PublisherCommonUtils.validateEndpoints(apiDTOFromProperties)) {
+            throw new APIManagementException("Invalid/Malformed endpoint URL(s) detected",
+                    ExceptionCodes.INVALID_ENDPOINT_URL);
         }
 
         // Import the API and Definition

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
@@ -131,6 +131,11 @@
             <groupId>com.damnhandy.wso2</groupId>
             <artifactId>handy-uri-templates</artifactId>
         </dependency>
+       <dependency>
+           <groupId>commons-validator</groupId>
+           <artifactId>commons-validator</artifactId>
+           <version>${commons-validator.version}</version>
+       </dependency>
     </dependencies>
     <reporting>
         <plugins>
@@ -296,6 +301,7 @@
                                     org.wso2.orbit.com.amazonaws:awslambda:${org.wso2.orbit.com.amazonaws.version}
                                 </bundleDef>
                                 <bundleDef>com.damnhandy.wso2:handy-uri-templates</bundleDef>
+                                <bundleDef>commons-validator:commons-validator:${commons-validator.version}</bundleDef>
                             </bundles>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1838,11 +1838,16 @@
                 <artifactId>javax.jms-api</artifactId>
                 <version>${javax.jms.version}</version>
             </dependency>
-                <dependency>
-                    <groupId>com.damnhandy.wso2</groupId>
-                    <artifactId>handy-uri-templates</artifactId>
-                    <version>${damnhandy.version}</version>
-                </dependency>
+            <dependency>
+                <groupId>com.damnhandy.wso2</groupId>
+                <artifactId>handy-uri-templates</artifactId>
+                <version>${damnhandy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-validator</groupId>
+                <artifactId>commons-validator</artifactId>
+                <version>${commons-validator.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1998,6 +2003,7 @@
         <caffeine.version>2.8.1</caffeine.version>
         <cal10n.version>0.8.1</cal10n.version>
         <commons-lang.version>2.4</commons-lang.version>
+        <commons-validator.version>1.7</commons-validator.version>
 
         <!-- imp package version ranges -->
         <imp.pkg.version.axis2>[1.6.1, 1.7.0)</imp.pkg.version.axis2>


### PR DESCRIPTION
## Purpose
As of now, a user can send any invalid url as the backend url. With this fix, we do a validation on the user provided url in order to ensure its validity.

## Related PRs

- Initial PR that added this capability was https://github.com/wso2/carbon-apimgt/pull/10715
- This was temporarily reverted with https://github.com/wso2/carbon-apimgt/pull/10764 due to an issue that arose with API deploy step in Choreo Integrations and Services https://github.com/wso2-enterprise/choreo/issues/7934

### Deviation from initial PR
The [apache commons UrlValidator](https://commons.apache.org/proper/commons-validator/apidocs/org/apache/commons/validator/routines/UrlValidator.html) that was used to introduce the validation, failed to validate custom domains. And hence, was failing to identify the TLD of Choreo. It seems to only validate URLs with known TLDs (refer http://data.iana.org/TLD/tlds-alpha-by-domain.txt). To overcome this, the following constructor was used:

- `UrlValidator(RegexValidator authorityValidator, long options)`
