### PR TITLE
Updating the length of filtered multiple versioned APIs list

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -1729,7 +1729,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         } catch (APIPersistenceException e) {
             String msg = "Failed to get API tags";
             throw new APIManagementException(msg, e);
-        } 
+        }
         return tagSet;
     }
 
@@ -3671,7 +3671,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             Thread recommendationThread = new Thread(extractor);
             recommendationThread.start();
         }
-        
+
         String tenantDomain = APIUtil.getTenantDomainFromTenantId(tenantId);
         ApplicationEvent applicationEvent = new ApplicationEvent(UUID.randomUUID().toString(),
                 System.currentTimeMillis(), APIConstants.EventType.APPLICATION_UPDATE.name(), tenantId, tenantDomain,
@@ -3927,8 +3927,8 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             tenantDomain = MultitenantUtils.getTenantDomain(userId);
         } else {
             int tenantId = APIUtil.getInternalOrganizationId(tenantDomain);
-            
-            // To handle choreo scenario. 
+
+            // To handle choreo scenario.
             if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
                 tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
             }
@@ -5257,6 +5257,8 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         } else {
             apiSet = (ArrayList<Object>) apiObj;
         }
+        int apiSetLengthWithVersionedApis = apiSet.size(); // Store the length of the APIs list with the versioned APIs
+        int totalLength = Integer.parseInt(searchResults.get("length").toString());
 
         //filter store results if displayMultipleVersions is set to false
         Boolean displayMultipleVersions = APIUtil.isAllowDisplayMultipleVersions();
@@ -5321,6 +5323,10 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                     }
                 }
             }
+
+            // Store the length of the APIs list without the versioned APIs
+            int apiSetLengthWithoutVersionedApis = tempApiSet.size();
+
             apiSet = tempApiSet;
             ArrayList<Object> resultAPIandProductSet = new ArrayList<>();
             resultAPIandProductSet.addAll(apiSet);
@@ -5332,7 +5338,8 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             } else {
                 searchResults.put("apis", resultAPIandProductSet);
             }
-            searchResults.put("length", resultAPIandProductSet.size());
+            searchResults.put("length",
+                    totalLength - (apiSetLengthWithVersionedApis - apiSetLengthWithoutVersionedApis));
         }
         return searchResults;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5339,7 +5339,8 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 searchResults.put("apis", resultAPIandProductSet);
             }
             searchResults.put("length",
-                    totalLength - (apiSetLengthWithVersionedApis - apiSetLengthWithoutVersionedApis));
+                    totalLength - (apiSetLengthWithVersionedApis - (apiSetLengthWithoutVersionedApis + apiProductSet
+                            .size())));
         }
         return searchResults;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5332,6 +5332,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             } else {
                 searchResults.put("apis", resultAPIandProductSet);
             }
+            searchResults.put("length", resultAPIandProductSet.size());
         }
         return searchResults;
     }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11627

## Goals
When displaying the multiple version of APIs feature in the dev portal is disabled, we need to display the search count based on the default version of the API

## Approach
Changed the total length while filtering the APIs with multiple versions to display

## Related PRs
- https://github.com/wso2/product-apim/pull/11639

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.2 LTS
