### PR TITLE
Improve parameter masking for JMS configs in error logs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.jms/src/main/java/org/wso2/carbon/apimgt/common/jms/utils/JMSUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.jms/src/main/java/org/wso2/carbon/apimgt/common/jms/utils/JMSUtils.java
@@ -23,8 +23,10 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.common.jms.JMSConstants;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -642,17 +644,22 @@ public class JMSUtils extends BaseUtils {
             } else {
                 // user info = user:pass
                 int colonIndex = userInfo.indexOf(':');
+                String decodedConnectionString = java.net.URLDecoder.decode(connectionString,
+                        StandardCharsets.UTF_8.name());
                 if (colonIndex == -1) {
                     // password is not in the url.
-                    return connectionString.replace(userInfo, maskString);
+                    return decodedConnectionString.replace(userInfo, maskString);
                 } else {
-                    return connectionString.replace(userInfo, maskString + ":" + maskString);
+                    return decodedConnectionString.replace(userInfo, maskString + ":" + maskString);
                 }
             }
         } catch (URISyntaxException ignore) {
             // If the provided url cannot be parsed, then a custom message will
             // be printed instead of the invalid url.
             log.error("Error while parsing the JMS connection url");
+            maskedConnectionString = "Invalid connection url";
+        } catch (UnsupportedEncodingException e) {
+            log.error("Error while decoding the JMS connection url");
             maskedConnectionString = "Invalid connection url";
         }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/test/java/org/wso2/carbon/apimgt/jms/listener/utils/JMSUtilsTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/test/java/org/wso2/carbon/apimgt/jms/listener/utils/JMSUtilsTestCase.java
@@ -35,5 +35,12 @@ public class JMSUtilsTestCase {
 		Hashtable<String, String> maskedParamTable = JMSUtils.maskAxis2ConfigSensitiveParameters(sensitiveParamsTable);
 		Assert.assertEquals("amqp://***:***@clientid/carbon?brokerlist='tcp://localhost:5672'",
 				maskedParamTable.get("connectionfactory.TopicConnectionFactory"));
+
+		sensitiveParamsTable = new Hashtable<String, String>();
+		sensitiveParamsTable.put("connectionfactory.TopicConnectionFactory",
+				"amqp://admin:%23admin@clientid/carbon?brokerlist='tcp://localhost:5672'");
+		maskedParamTable = JMSUtils.maskAxis2ConfigSensitiveParameters(sensitiveParamsTable);
+		Assert.assertEquals("amqp://***:***@clientid/carbon?brokerlist='tcp://localhost:5672'",
+				maskedParamTable.get("connectionfactory.TopicConnectionFactory"));
 	}
 }


### PR DESCRIPTION
## Issues
need to mask the credentials in JMS error logs