### PR TITLE
Fixing the NPE error for the migrated applications

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -861,7 +861,7 @@ public final class APIConstants {
     public static final String SELF_SIGN_UP_REG_ENABLED = "EnableSignup";
     public static final String SELF_SIGN_UP_REG_ROLE_NAME_ELEMENT = "RoleName";
     public static final String SELF_SIGN_UP_REG_ROLE_IS_EXTERNAL = "IsExternalRole";
-    
+
     public static final String ORG_RESOLVER = "OrganizationResolver";
 
     public static final String STATUS_OBSERVERS = "StatusObservers.";
@@ -2672,6 +2672,7 @@ public final class APIConstants {
         public static final String EVENT_ID = "eventId";
         public static final String TENANT_ID = "tenantId";
         public static final String TENANT_DOMAIN = "tenant_domain";
+        public static final String APPLICATION_TOKEN_TYPE_OAUTH2 = "Default";
     }
 
     //Constants related to user password

--- a/components/apimgt/org.wso2.carbon.apimgt.notification/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.notification/pom.xml
@@ -103,6 +103,21 @@
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>org.wso2.carbon.apimgt.eventing</artifactId>
     </dependency>
+    <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-all</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <scope>test</scope>
+    </dependency>
 </dependencies>
 
 </project>

--- a/components/apimgt/org.wso2.carbon.apimgt.notification/src/main/java/org/wso2/carbon/apimgt/notification/AbstractKeyManagerEventHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.notification/src/main/java/org/wso2/carbon/apimgt/notification/AbstractKeyManagerEventHandler.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.apimgt.notification;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
@@ -45,6 +46,9 @@ public abstract class AbstractKeyManagerEventHandler implements KeyManagerEventH
         Properties properties = new Properties();
         properties.setProperty(APIConstants.NotificationEvent.EVENT_ID, tokenRevocationEvent.getEventId());
         properties.put(APIConstants.NotificationEvent.CONSUMER_KEY, tokenRevocationEvent.getConsumerKey());
+        if (StringUtils.isBlank(tokenRevocationEvent.getTokenType())) {
+            tokenRevocationEvent.setTokenType(APIConstants.NotificationEvent.APPLICATION_TOKEN_TYPE_OAUTH2);
+        }
         properties.put(APIConstants.NotificationEvent.TOKEN_TYPE, tokenRevocationEvent.getTokenType());
         properties.put(APIConstants.NotificationEvent.TENANT_ID, tokenRevocationEvent.getTenantId());
         properties.put(APIConstants.NotificationEvent.TENANT_DOMAIN, tokenRevocationEvent.getTenantDomain());

--- a/components/apimgt/org.wso2.carbon.apimgt.notification/src/test/java/org/wso2/carbon/apimgt/notification/AbstractKeyManagerEventHandlerTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.notification/src/test/java/org/wso2/carbon/apimgt/notification/AbstractKeyManagerEventHandlerTest.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.notification;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.publishers.RevocationRequestPublisher;
+import org.wso2.carbon.apimgt.notification.event.TokenRevocationEvent;
+
+import java.util.Properties;
+
+import static org.mockito.Mockito.doNothing;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ AbstractKeyManagerEventHandler.class, ApiMgtDAO.class, RevocationRequestPublisher.class })
+public class AbstractKeyManagerEventHandlerTest {
+
+    @Test
+    public void handleTokenRevocationEventTest() throws Exception {
+
+        TokenRevocationEvent tokenRevocationEvent = new TokenRevocationEvent();
+        Assert.assertTrue(StringUtils.isBlank(tokenRevocationEvent.getTokenType()));
+
+        RevocationRequestPublisher revocationRequestPublisher = Mockito.mock(RevocationRequestPublisher.class);
+        PowerMockito.mockStatic(RevocationRequestPublisher.class);
+        PowerMockito.when(RevocationRequestPublisher.getInstance()).thenReturn(revocationRequestPublisher);
+        doNothing().when(revocationRequestPublisher)
+                .publishRevocationEvents(Mockito.anyString(), Mockito.anyLong(), Mockito.anyObject());
+
+        Properties properties = Mockito.mock(Properties.class);
+        whenNew(Properties.class).withNoArguments().thenReturn(properties);
+
+        ApiMgtDAO apiMgtDAO = Mockito.mock(ApiMgtDAO.class);
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+
+        DefaultKeyManagerEventHandlerImpl defaultKeyManagerEventHandler = new DefaultKeyManagerEventHandlerImpl();
+        Boolean result = defaultKeyManagerEventHandler.handleTokenRevocationEvent(tokenRevocationEvent);
+
+        Assert.assertTrue(result);
+        Assert.assertEquals("Default", tokenRevocationEvent.getTokenType());
+    }
+}


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11642

## Goals
Fixing the NPE arisen due to the missing tokenType in the IDN_OIDC_PROPERTY table.

## Approach
- Since the IDN_OIDC_PROPERTY table is not populated with the data after migration, added an if block to assign `Default` to the tokenType if it is null when accessing the tokenType.
- Wrote a unit test for the function **handleTokenRevocationEvent**

## Automation tests
 - Unit tests
   Provided a unit test for **handleTokenRevocationEvent** function

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.2 LTS
