### PR TITLE
Add support to display application name in consent page

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -135,7 +135,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
         String[] tokenScopes = new String[1];
         tokenScopes[0] = tokenScope;
 
-        ClientInfo request = createClientInfo(oAuthApplicationInfo, oauthClientName, applicationName, false);
+        ClientInfo request = createClientInfo(oAuthApplicationInfo, oauthClientName, false);
         ClientInfo createdClient;
 
         try {
@@ -160,14 +160,13 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
      *
      * @param info            The OAuthApplicationInfo object
      * @param oauthClientName The name of the OAuth application to be created
-     * @param applicationName Application display name
      * @param isUpdate        To determine whether the ClientInfo object is related to application update call
      * @return constructed ClientInfo object
      * @throws JSONException          for errors in parsing the OAuthApplicationInfo json string
      * @throws APIManagementException if an error occurs while constructing the ClientInfo object
      */
-    private ClientInfo createClientInfo(OAuthApplicationInfo info, String oauthClientName, String applicationName,
-            boolean isUpdate) throws JSONException, APIManagementException {
+    private ClientInfo createClientInfo(OAuthApplicationInfo info, String oauthClientName, boolean isUpdate)
+            throws JSONException, APIManagementException {
 
         ClientInfo clientInfo = new ClientInfo();
         JSONObject infoJson = new JSONObject(info.getJsonString());
@@ -237,7 +236,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                         long expiry = Long.parseLong((String) expiryTimeObject);
                         if (expiry < 0) {
                             throw new APIManagementException("Invalid application access token expiry time given for "
-                                    + applicationName, ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
+                                    + oauthClientName, ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
                         }
                         clientInfo.setApplicationAccessTokenLifeTime(expiry);
                     } catch (NumberFormatException e) {
@@ -255,7 +254,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                         long expiry = Long.parseLong((String) expiryTimeObject);
                         if (expiry < 0) {
                             throw new APIManagementException("Invalid user access token expiry time given for "
-                                    + applicationName, ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
+                                    + oauthClientName, ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
                         }
                         clientInfo.setUserAccessTokenLifeTime(expiry);
                     } catch (NumberFormatException e) {
@@ -339,7 +338,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
         }
 
         // Set the display name of the application. This name would appear in the consent page of the app.
-        clientInfo.setApplicationDisplayName(applicationName);
+        clientInfo.setApplicationDisplayName(info.getClientName());
 
         return clientInfo;
     }
@@ -378,7 +377,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
             log.debug("Client Name : " + oauthClientName);
         }
 
-        ClientInfo request = createClientInfo(oAuthApplicationInfo, oauthClientName, applicationName, true);
+        ClientInfo request = createClientInfo(oAuthApplicationInfo, oauthClientName, true);
         ClientInfo createdClient;
         try {
             createdClient = dcrClient.updateApplication(oAuthApplicationInfo.getClientId(), request);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -161,11 +161,13 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
      * @param info            The OAuthApplicationInfo object
      * @param oauthClientName The name of the OAuth application to be created
      * @param applicationName Application display name
+     * @param isUpdate        To determine whether the ClientInfo object is related to application update call
      * @return constructed ClientInfo object
-     * @throws JSONException for errors in parsing the OAuthApplicationInfo json string
+     * @throws JSONException          for errors in parsing the OAuthApplicationInfo json string
+     * @throws APIManagementException if an error occurs while constructing the ClientInfo object
      */
     private ClientInfo createClientInfo(OAuthApplicationInfo info, String oauthClientName, String applicationName,
-                                        boolean isUpdate) throws JSONException, APIManagementException {
+            boolean isUpdate) throws JSONException, APIManagementException {
 
         ClientInfo clientInfo = new ClientInfo();
         JSONObject infoJson = new JSONObject(info.getJsonString());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -135,7 +135,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
         String[] tokenScopes = new String[1];
         tokenScopes[0] = tokenScope;
 
-        ClientInfo request = createClientInfo(oAuthApplicationInfo, oauthClientName, false);
+        ClientInfo request = createClientInfo(oAuthApplicationInfo, oauthClientName, applicationName, false);
         ClientInfo createdClient;
 
         try {
@@ -159,13 +159,13 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
      * Construct ClientInfo object for application create request
      *
      * @param info            The OAuthApplicationInfo object
-     * @param applicationName The name of the application to be created. We specifically request for this value as this
-     *                        should be formatted properly prior to calling this method
+     * @param oauthClientName The name of the OAuth application to be created
+     * @param applicationName Application display name
      * @return constructed ClientInfo object
      * @throws JSONException for errors in parsing the OAuthApplicationInfo json string
      */
-    private ClientInfo createClientInfo(OAuthApplicationInfo info, String applicationName, boolean isUpdate)
-            throws JSONException, APIManagementException {
+    private ClientInfo createClientInfo(OAuthApplicationInfo info, String oauthClientName, String applicationName,
+                                        boolean isUpdate) throws JSONException, APIManagementException {
 
         ClientInfo clientInfo = new ClientInfo();
         JSONObject infoJson = new JSONObject(info.getJsonString());
@@ -189,7 +189,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
         if (StringUtils.isNotEmpty(overrideSpName) && !Boolean.parseBoolean(overrideSpName)) {
             clientInfo.setClientName(info.getClientName());
         } else {
-            clientInfo.setClientName(applicationName);
+            clientInfo.setClientName(oauthClientName);
         }
 
         //todo: run tests by commenting the type
@@ -336,6 +336,9 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
             }
         }
 
+        // Set the display name of the application. This name would appear in the consent page of the app.
+        clientInfo.setApplicationDisplayName(applicationName);
+
         return clientInfo;
     }
 
@@ -373,7 +376,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
             log.debug("Client Name : " + oauthClientName);
         }
 
-        ClientInfo request = createClientInfo(oAuthApplicationInfo, oauthClientName, true);
+        ClientInfo request = createClientInfo(oAuthApplicationInfo, oauthClientName, applicationName, true);
         ClientInfo createdClient;
         try {
             createdClient = dcrClient.updateApplication(oAuthApplicationInfo.getClientId(), request);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/kmclient/model/ClientInfo.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/kmclient/model/ClientInfo.java
@@ -52,6 +52,8 @@ public class ClientInfo {
     private Long refreshTokenLifeTime;
     @SerializedName("ext_id_token_lifetime")
     private Long idTokenLifeTime;
+    @SerializedName("application_display_name")
+    private String applicationDisplayName;
     @SerializedName("pkceMandatory")
     private Boolean pkceMandatory;
     @SerializedName("pkceSupportPlain")
@@ -197,6 +199,16 @@ public class ClientInfo {
     public void setIdTokenLifeTime(Long idTokenLifeTime) {
 
         this.idTokenLifeTime = idTokenLifeTime;
+    }
+
+    public String getApplicationDisplayName() {
+
+        return applicationDisplayName;
+    }
+
+    public void setApplicationDisplayName(String applicationDisplayName) {
+
+        this.applicationDisplayName = applicationDisplayName;
     }
 
     public Boolean getPkceMandatory() {


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/product-apim/issues/11620

This PR introduces the support to display the application name on the consent page. By default, the consent page follows the format: **\<tenant\>\_\<application uuid\>\_\<key type\>**. With the proposed changes, the application name would appear in the consent page, so as to make the user-facing interface more meaningful. To achieve this, the following config should be set to true in `deployment.toml`:

```
[oauth]
show_display_name_in_consent_page = true
```
Thus improved consent page is as follows:

<img width="694" alt="Screenshot 2021-09-20 at 19 08 28" src="https://user-images.githubusercontent.com/30475839/134015793-0ebbb979-9153-440e-ac4b-418ec7fcaafe.png">

## Related PRs

- https://github.com/wso2-extensions/apim-km-wso2is/pull/57
- https://github.com/wso2/carbon-identity-framework/pull/3740
- https://github.com/wso2/product-apim/pull/11716