### PR TITLE
Encrypting the endpoint secret during import OAS REST API call

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -342,7 +342,7 @@ public class PublisherCommonUtils {
      * @throws CryptoException        if an error occurs while encrypting and base64 encode
      * @throws APIManagementException if an error occurs due to a problem in the endpointConfig payload
      */
-    private static void encryptEndpointSecurityOAuthCredentials(Map endpointConfig, CryptoUtil cryptoUtil,
+    public static void encryptEndpointSecurityOAuthCredentials(Map endpointConfig, CryptoUtil cryptoUtil,
             String oldProductionApiSecret, String oldSandboxApiSecret, APIDTO apidto)
             throws CryptoException, APIManagementException {
         // OAuth 2.0 backend protection: API Key and API Secret encryption


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11454

## Goals
Fixing the issue of endpoint security when using an OAS definition to create an API

## Approach
Encrypted the OAuth credentials in the  **POST apis/import-openapi** as previously done for POST apis: and PUT apis/{apiId}.

## Related PRs
- https://github.com/wso2/product-apim/pull/11727

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.2 LTS