### PR TITLE
Adding WSDL definition and proxy service support for Service Catalog APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2701,11 +2701,13 @@ public final class APIConstants {
     public static final String METADATA_FILE_NAME = "metadata";
     public static final String METADATA_FILE = "metadata.yaml";
     public static final String DEFINITION_FILE = "definition.yaml";
+    public static final String DEFINITION_WSDL_FILE = "definition.wsdl";
     public static final String KEY_SEPARATOR = "-";
     public static final String MAP_KEY_ACCEPTED_NEW_SERVICE = "accepted";
     public static final String MAP_KEY_IGNORED_EXISTING_SERVICE = "ignored";
     public static final String MAP_KEY_VERIFIED_EXISTING_SERVICE = "verified";
     public static final String MAP_KEY_HASH_NOT_CHANGED_EXISTING_SERVICE = "notChanged";
+    public static final String PROXY_SERVICE_NAME_SUFFIX = "_proxy";
 
     public static final String ALLOW_MULTIPLE_STATUS = "allowMultipleStatus";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIMWSDLReader.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIMWSDLReader.java
@@ -226,6 +226,18 @@ public class APIMWSDLReader {
     }
 
     /**
+     * Extract the WSDL file and validates it
+     *
+     * @param wsdlContent file content as a byte array
+     * @return Validation information
+     * @throws APIManagementException Error occurred during validation
+     */
+    public static WSDLValidationResponse validateWSDLFile(byte[] wsdlContent) throws  APIManagementException {
+        WSDLProcessor processor = getWSDLProcessor(wsdlContent);
+        return getWsdlValidationResponse(processor);
+    }
+
+    /**
      * Gets WSDL processor WSDL 1.1/WSDL 2.0 based on the content {@code content}.
      *
      * @param content WSDL content

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3367,7 +3367,7 @@ public class ApisApiServiceImpl implements ApisApiService {
     @Override
     public Response validateWSDLDefinition(String url, InputStream fileInputStream, Attachment fileDetail,
                                            MessageContext messageContext) throws APIManagementException {
-        Map validationResponseMap = validateWSDL(url, fileInputStream, fileDetail);
+        Map validationResponseMap = validateWSDL(url, fileInputStream, fileDetail, false);
 
         WSDLValidationResponseDTO validationResponseDTO =
                 (WSDLValidationResponseDTO)validationResponseMap.get(RestApiConstants.RETURN_DTO);
@@ -3381,11 +3381,13 @@ public class ApisApiServiceImpl implements ApisApiService {
      * @param url WSDL url
      * @param fileInputStream file data stream
      * @param fileDetail file details
+     * @param isServiceAPI is service api condition
      * @return the validation response DTO (for REST API) and the intermediate model as a Map
      * @throws APIManagementException if error occurred during validation of the WSDL
      */
-    private Map validateWSDL(String url, InputStream fileInputStream, Attachment fileDetail) throws APIManagementException {
-        handleInvalidParams(fileInputStream, fileDetail, url, null, false);
+    private Map validateWSDL(String url, InputStream fileInputStream, Attachment fileDetail, Boolean isServiceAPI)
+            throws APIManagementException {
+        handleInvalidParams(fileInputStream, fileDetail, url, null, isServiceAPI);
         WSDLValidationResponseDTO responseDTO;
         WSDLValidationResponse validationResponse = new WSDLValidationResponse();
 
@@ -3396,7 +3398,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             } catch (MalformedURLException e) {
                 RestApiUtil.handleBadRequest("Invalid/Malformed URL : " + url, log);
             }
-        } else if (fileInputStream != null) {
+        } else if (fileInputStream != null && !isServiceAPI) {
             String filename = fileDetail.getContentDisposition().getFilename();
             try {
                 if (filename.endsWith(".zip")) {
@@ -3408,6 +3410,13 @@ public class ApisApiServiceImpl implements ApisApiService {
                 }
             } catch (APIManagementException e) {
                 String errorMessage = "Internal error while validating the WSDL from file:" + filename;
+                RestApiUtil.handleInternalServerError(errorMessage, e, log);
+            }
+        } else if (fileInputStream != null) {
+            try {
+                validationResponse = APIMWSDLReader.validateWSDLFile(fileInputStream);
+            } catch (APIManagementException e) {
+                String errorMessage = "Internal error while validating the WSDL definition input stream";
                 RestApiUtil.handleInternalServerError(errorMessage, e, log);
             }
         }
@@ -3465,7 +3474,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             API createdApi = null;
             if (isSoapAPI) {
                 createdApi = importSOAPAPI(validationResponse.getWsdlProcessor().getWSDL(), fileDetail, url,
-                        apiToAdd, organization);
+                        apiToAdd, organization, null);
             } else if (isSoapToRestConvertedAPI) {
                 String wsdlArchiveExtractedPath = null;
                 if (validationResponse.getWsdlArchiveInfo() != null) {
@@ -3497,7 +3506,7 @@ public class ApisApiServiceImpl implements ApisApiService {
      */
     private WSDLValidationResponse validateWSDLAndReset(InputStream fileInputStream, Attachment fileDetail, String url)
             throws APIManagementException {
-        Map validationResponseMap = validateWSDL(url, fileInputStream, fileDetail);
+        Map validationResponseMap = validateWSDL(url, fileInputStream, fileDetail, false);
         WSDLValidationResponse validationResponse =
                 (WSDLValidationResponse)validationResponseMap.get(RestApiConstants.RETURN_MODEL);
 
@@ -3532,10 +3541,11 @@ public class ApisApiServiceImpl implements ApisApiService {
      * @param url URL of the WSDL
      * @param apiToAdd API object to be added to the system (which is not added yet)
      * @param organization Organization
+     * @param service service
      * @return API added api
      */
     private API importSOAPAPI(InputStream fileInputStream, Attachment fileDetail, String url, API apiToAdd,
-                              String organization) {
+                              String organization, ServiceEntry service) {
         try {
             APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
 
@@ -3549,6 +3559,11 @@ public class ApisApiServiceImpl implements ApisApiService {
                 PublisherCommonUtils
                         .addWsdl(fileDetail.getContentType().toString(), fileInputStream, apiToAdd, apiProvider,
                                 organization);
+            } else if (service != null && fileInputStream == null) {
+                RestApiUtil.handleBadRequest("Error while importing WSDL to create a SOAP API", log);
+            } else if (service != null) {
+                PublisherCommonUtils.addWsdl(RestApiConstants.APPLICATION_OCTET_STREAM,
+                        fileInputStream, apiToAdd, apiProvider, organization);
             }
 
             //add the generated swagger definition to SOAP
@@ -4812,6 +4827,18 @@ public class ApisApiServiceImpl implements ApisApiService {
             } else if (ServiceEntry.DefinitionType.ASYNC_API.equals(service.getDefinitionType())) {
                 createdApiDTO = importAsyncAPISpecification(service.getEndpointDef(), null, apiDto, null, service,
                         organization);
+            } else if (ServiceEntry.DefinitionType.WSDL1.equals(service.getDefinitionType())) {
+                apiDto.setProvider(RestApiCommonUtil.getLoggedInUsername());
+                apiDto.setType(APIDTO.TypeEnum.fromValue("SOAP"));
+                API apiToAdd = PublisherCommonUtils.prepareToCreateAPIByDTO(apiDto,
+                        RestApiCommonUtil.getLoggedInUserProvider(), username, organization);
+                apiToAdd.setServiceInfo("key", service.getKey());
+                apiToAdd.setServiceInfo("md5", service.getMd5());
+                apiToAdd.setEndpointConfig(PublisherCommonUtils.constructEndpointConfigForService(service
+                        .getServiceUrl(), null));
+                API api = importSOAPAPI(service.getEndpointDef(), null, null,
+                        apiToAdd, organization, service);
+                createdApiDTO = APIMappingUtil.fromAPItoDTO(api);
             }
             if (createdApiDTO != null) {
                 URI createdApiUri = new URI(RestApiConstants.RESOURCE_PATH_APIS + "/" + createdApiDTO.getId());
@@ -4869,22 +4896,30 @@ public class ApisApiServiceImpl implements ApisApiService {
             } else if (ServiceEntry.DefinitionType.ASYNC_API.equals(service.getDefinitionType())) {
                 validationResponseMap = validateAsyncAPISpecification(null, service.getEndpointDef(),
                         null, true, true);
-            } else {
+            } else if (!ServiceEntry.DefinitionType.WSDL1.equals(service.getDefinitionType())) {
                 RestApiUtil.handleBadRequest("Unsupported definition type provided. Cannot re-import service to " +
                         "API using the service type " + service.getDefinitionType(), log);
             }
-            APIDefinitionValidationResponse validationResponse =
-                    (APIDefinitionValidationResponse) validationResponseMap.get(RestApiConstants.RETURN_MODEL);
-            if (!validationResponse.isValid()) {
-                RestApiUtil.handleBadRequest(validationResponse.getErrorItems(), log);
+            APIDefinitionValidationResponse validationAPIResponse = null;
+            if (ServiceEntry.DefinitionType.WSDL1.equals(service.getDefinitionType())) {
+                PublisherCommonUtils.addWsdl(RestApiConstants.APPLICATION_OCTET_STREAM,
+                        service.getEndpointDef(), api, apiProvider, organization);
+            } else {
+                validationAPIResponse =
+                        (APIDefinitionValidationResponse) validationResponseMap.get(RestApiConstants.RETURN_MODEL);
+                if (!validationAPIResponse.isValid()) {
+                    RestApiUtil.handleBadRequest(validationAPIResponse.getErrorItems(), log);
+                }
             }
-            String protocol = validationResponse.getProtocol();
+            String protocol = (validationAPIResponse != null ? validationAPIResponse.getProtocol() : "" );
             if (!APIConstants.API_TYPE_WEBSUB.equalsIgnoreCase(protocol)) {
                 api.setEndpointConfig(PublisherCommonUtils.constructEndpointConfigForService(service.getServiceUrl(),
                         protocol));
             }
             API updatedApi = apiProvider.updateAPI(api, originalAPI);
-            PublisherCommonUtils.updateAPIDefinition(apiId, validationResponse, service, organization);
+            if (validationAPIResponse != null) {
+                PublisherCommonUtils.updateAPIDefinition(apiId, validationAPIResponse, service, organization);
+            }
             return Response.ok().entity(APIMappingUtil.fromAPItoDTO(updatedApi)).build();
         } catch (APIManagementException e) {
             if (ExceptionCodes.MISSING_PROTOCOL_IN_ASYNC_API_DEFINITION.getErrorCode() == e.getErrorHandler()

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/utils/ServiceEntryMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/utils/ServiceEntryMappingUtil.java
@@ -104,7 +104,13 @@ public class ServiceEntryMappingUtil {
             if (file.isDirectory()) {
                 ServiceEntry serviceInfo = new ServiceEntry();
                 File metadataFile = getServiceFile(APIConstants.METADATA_FILE, file);
-                File definitionFile = getServiceFile(APIConstants.DEFINITION_FILE, file);
+                File definitionFile;
+                if (file.getName().contains(APIConstants.PROXY_SERVICE_NAME_SUFFIX)
+                        && new File(file.getAbsoluteFile(), APIConstants.DEFINITION_WSDL_FILE).exists()) {
+                    definitionFile = getServiceFile(APIConstants.DEFINITION_WSDL_FILE, file);
+                } else {
+                    definitionFile = getServiceFile(APIConstants.DEFINITION_FILE, file);
+                }
                 String key = null;
                 try {
                     serviceInfo = fromFileToServiceEntry(metadataFile, serviceInfo);


### PR DESCRIPTION
$subject. This PR includes following tasks.

- Refactoring Service Catalogue - getServiceDefinition Endpoint
- Refactoring Service Catalogue - importService Endpoint
- Refactoring Publisher - importServiceFromCatalog Endpoint
- Refactoring Publisher - reimportServiceFromCatalog Endpoint

Related Issue: https://github.com/wso2/product-apim/issues/11656
Related EPIC: https://github.com/wso2/micro-integrator/issues/2397


