### PR TITLE
Add display token endpoint and display revoke endpoint to admin key manager REST APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2411,7 +2411,9 @@ public final class APIConstants {
         public static final String KEY_MANAGER_OPERATIONS_DCR_ENDPOINT = "/keymanager-operations/dcr/register";
         public static final String KEY_MANAGER_OPERATIONS_USERINFO_ENDPOINT = "/keymanager-operations/user-info";
         public static final String TOKEN_ENDPOINT = "token_endpoint";
+        public static final String DISPLAY_TOKEN_ENDPOINT = "display_token_endpoint";
         public static final String REVOKE_ENDPOINT = "revoke_endpoint";
+        public static final String DISPLAY_REVOKE_ENDPOINT = "display_revoke_endpoint";
         public static final String WELL_KNOWN_ENDPOINT = "well_known_endpoint";
         public static final String SCOPE_MANAGEMENT_ENDPOINT = "scope_endpoint";
         public static final String AVAILABLE_GRANT_TYPE = "grant_types";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/KeyManagerDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/KeyManagerDTO.java
@@ -34,7 +34,9 @@ public class KeyManagerDTO   {
     private String introspectionEndpoint = null;
     private String clientRegistrationEndpoint = null;
     private String tokenEndpoint = null;
+    private String displayTokenEndpoint = null;
     private String revokeEndpoint = null;
+    private String displayRevokeEndpoint = null;
     private String userInfoEndpoint = null;
     private String authorizeEndpoint = null;
     private KeyManagerCertificatesDTO certificates = null;
@@ -246,6 +248,23 @@ return null;
 
   /**
    **/
+  public KeyManagerDTO displayTokenEndpoint(String displayTokenEndpoint) {
+    this.displayTokenEndpoint = displayTokenEndpoint;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "https://localhost:9444/oauth2/token", value = "")
+  @JsonProperty("displayTokenEndpoint")
+  public String getDisplayTokenEndpoint() {
+    return displayTokenEndpoint;
+  }
+  public void setDisplayTokenEndpoint(String displayTokenEndpoint) {
+    this.displayTokenEndpoint = displayTokenEndpoint;
+  }
+
+  /**
+   **/
   public KeyManagerDTO revokeEndpoint(String revokeEndpoint) {
     this.revokeEndpoint = revokeEndpoint;
     return this;
@@ -259,6 +278,23 @@ return null;
   }
   public void setRevokeEndpoint(String revokeEndpoint) {
     this.revokeEndpoint = revokeEndpoint;
+  }
+
+  /**
+   **/
+  public KeyManagerDTO displayRevokeEndpoint(String displayRevokeEndpoint) {
+    this.displayRevokeEndpoint = displayRevokeEndpoint;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "https://localhost:9444/oauth2/revoke", value = "")
+  @JsonProperty("displayRevokeEndpoint")
+  public String getDisplayRevokeEndpoint() {
+    return displayRevokeEndpoint;
+  }
+  public void setDisplayRevokeEndpoint(String displayRevokeEndpoint) {
+    this.displayRevokeEndpoint = displayRevokeEndpoint;
   }
 
   /**
@@ -626,7 +662,9 @@ return null;
         Objects.equals(introspectionEndpoint, keyManager.introspectionEndpoint) &&
         Objects.equals(clientRegistrationEndpoint, keyManager.clientRegistrationEndpoint) &&
         Objects.equals(tokenEndpoint, keyManager.tokenEndpoint) &&
+        Objects.equals(displayTokenEndpoint, keyManager.displayTokenEndpoint) &&
         Objects.equals(revokeEndpoint, keyManager.revokeEndpoint) &&
+        Objects.equals(displayRevokeEndpoint, keyManager.displayRevokeEndpoint) &&
         Objects.equals(userInfoEndpoint, keyManager.userInfoEndpoint) &&
         Objects.equals(authorizeEndpoint, keyManager.authorizeEndpoint) &&
         Objects.equals(certificates, keyManager.certificates) &&
@@ -651,7 +689,7 @@ return null;
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, displayName, type, description, wellKnownEndpoint, introspectionEndpoint, clientRegistrationEndpoint, tokenEndpoint, revokeEndpoint, userInfoEndpoint, authorizeEndpoint, certificates, issuer, alias, scopeManagementEndpoint, availableGrantTypes, enableTokenGeneration, enableTokenEncryption, enableTokenHashing, enableMapOAuthConsumerApps, enableOAuthAppCreation, enableSelfValidationJWT, claimMapping, consumerKeyClaim, scopesClaim, tokenValidation, enabled, additionalProperties, tokenType);
+    return Objects.hash(id, name, displayName, type, description, wellKnownEndpoint, introspectionEndpoint, clientRegistrationEndpoint, tokenEndpoint, displayTokenEndpoint, revokeEndpoint, displayRevokeEndpoint, userInfoEndpoint, authorizeEndpoint, certificates, issuer, alias, scopeManagementEndpoint, availableGrantTypes, enableTokenGeneration, enableTokenEncryption, enableTokenHashing, enableMapOAuthConsumerApps, enableOAuthAppCreation, enableSelfValidationJWT, claimMapping, consumerKeyClaim, scopesClaim, tokenValidation, enabled, additionalProperties, tokenType);
   }
 
   @Override
@@ -668,7 +706,9 @@ return null;
     sb.append("    introspectionEndpoint: ").append(toIndentedString(introspectionEndpoint)).append("\n");
     sb.append("    clientRegistrationEndpoint: ").append(toIndentedString(clientRegistrationEndpoint)).append("\n");
     sb.append("    tokenEndpoint: ").append(toIndentedString(tokenEndpoint)).append("\n");
+    sb.append("    displayTokenEndpoint: ").append(toIndentedString(displayTokenEndpoint)).append("\n");
     sb.append("    revokeEndpoint: ").append(toIndentedString(revokeEndpoint)).append("\n");
+    sb.append("    displayRevokeEndpoint: ").append(toIndentedString(displayRevokeEndpoint)).append("\n");
     sb.append("    userInfoEndpoint: ").append(toIndentedString(userInfoEndpoint)).append("\n");
     sb.append("    authorizeEndpoint: ").append(toIndentedString(authorizeEndpoint)).append("\n");
     sb.append("    certificates: ").append(toIndentedString(certificates)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/KeyManagerMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/KeyManagerMappingUtil.java
@@ -77,10 +77,21 @@ public class KeyManagerMappingUtil {
             keyManagerDTO.setTokenEndpoint(tokenEndpointElement.getAsString());
             jsonObject.remove(APIConstants.KeyManager.TOKEN_ENDPOINT);
         }
+        JsonElement displayTokenEndpointElement = jsonObject.get(APIConstants.KeyManager.DISPLAY_TOKEN_ENDPOINT);
+        if (displayTokenEndpointElement != null && !displayTokenEndpointElement.getAsString().trim().isEmpty()) {
+            keyManagerDTO.setDisplayTokenEndpoint(displayTokenEndpointElement.getAsString());
+            jsonObject.remove(APIConstants.KeyManager.DISPLAY_TOKEN_ENDPOINT);
+        }
         JsonElement revokeEndpointElement = jsonObject.get(APIConstants.KeyManager.REVOKE_ENDPOINT);
         if (revokeEndpointElement != null) {
             keyManagerDTO.setRevokeEndpoint(revokeEndpointElement.getAsString());
             jsonObject.remove(APIConstants.KeyManager.REVOKE_ENDPOINT);
+        }
+        JsonElement displayRevokeEndpointElement = jsonObject.get(APIConstants.KeyManager.DISPLAY_REVOKE_ENDPOINT);
+        if (displayRevokeEndpointElement != null &&
+                !displayRevokeEndpointElement.getAsString().trim().isEmpty()) {
+            keyManagerDTO.setDisplayRevokeEndpoint(displayRevokeEndpointElement.getAsString());
+            jsonObject.remove(APIConstants.KeyManager.DISPLAY_REVOKE_ENDPOINT);
         }
         JsonElement scopeEndpointElement = jsonObject.get(APIConstants.KeyManager.SCOPE_MANAGEMENT_ENDPOINT);
         if (scopeEndpointElement != null) {
@@ -208,8 +219,14 @@ public class KeyManagerMappingUtil {
         if (StringUtils.isNotEmpty(keyManagerDTO.getTokenEndpoint())) {
             additionalProperties.put(APIConstants.KeyManager.TOKEN_ENDPOINT, keyManagerDTO.getTokenEndpoint());
         }
+        if (StringUtils.isNotEmpty(keyManagerDTO.getDisplayTokenEndpoint())) {
+            additionalProperties.put(APIConstants.KeyManager.DISPLAY_TOKEN_ENDPOINT, keyManagerDTO.getDisplayTokenEndpoint());
+        }
         if (StringUtils.isNotEmpty(keyManagerDTO.getRevokeEndpoint())) {
             additionalProperties.put(APIConstants.KeyManager.REVOKE_ENDPOINT, keyManagerDTO.getRevokeEndpoint());
+        }
+        if (StringUtils.isNotEmpty(keyManagerDTO.getDisplayRevokeEndpoint())) {
+            additionalProperties.put(APIConstants.KeyManager.DISPLAY_REVOKE_ENDPOINT, keyManagerDTO.getDisplayRevokeEndpoint());
         }
         if (StringUtils.isNotEmpty(keyManagerDTO.getScopeManagementEndpoint())) {
             additionalProperties

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -4247,7 +4247,13 @@ components:
         tokenEndpoint:
           type: string
           example: https://localhost:9444/oauth2/token
+        displayTokenEndpoint:
+          type: string
+          example: https://localhost:9444/oauth2/token
         revokeEndpoint:
+          type: string
+          example: https://localhost:9444/oauth2/revoke
+        displayRevokeEndpoint:
           type: string
           example: https://localhost:9444/oauth2/revoke
         userInfoEndpoint:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/KeyManagerMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/KeyManagerMappingUtil.java
@@ -58,13 +58,27 @@ public class KeyManagerMappingUtil {
             keyManagerInfoDTO.setEnableTokenHashing(
                     jsonObject.get(APIConstants.KeyManager.ENABLE_TOKEN_HASH).getAsBoolean());
         }
-        if (jsonObject.has(APIConstants.KeyManager.TOKEN_ENDPOINT)){
+        if (jsonObject.has(APIConstants.KeyManager.DISPLAY_TOKEN_ENDPOINT) &&
+                !jsonObject.get(APIConstants.KeyManager.DISPLAY_TOKEN_ENDPOINT).isJsonNull() &&
+                !jsonObject.get(APIConstants.KeyManager.DISPLAY_TOKEN_ENDPOINT).getAsString().trim().isEmpty()) {
             keyManagerInfoDTO.setTokenEndpoint(
-                    jsonObject.get(APIConstants.KeyManager.TOKEN_ENDPOINT).getAsString());
+                    jsonObject.get(APIConstants.KeyManager.DISPLAY_TOKEN_ENDPOINT).getAsString());
+        } else {
+            if (jsonObject.has(APIConstants.KeyManager.TOKEN_ENDPOINT)){
+                keyManagerInfoDTO.setTokenEndpoint(
+                        jsonObject.get(APIConstants.KeyManager.TOKEN_ENDPOINT).getAsString());
+            }
         }
-        if (jsonObject.has(APIConstants.KeyManager.REVOKE_ENDPOINT)){
+        if (jsonObject.has(APIConstants.KeyManager.DISPLAY_REVOKE_ENDPOINT) &&
+                !jsonObject.get(APIConstants.KeyManager.DISPLAY_REVOKE_ENDPOINT).isJsonNull() &&
+                !jsonObject.get(APIConstants.KeyManager.DISPLAY_REVOKE_ENDPOINT).getAsString().trim().isEmpty()) {
             keyManagerInfoDTO.setRevokeEndpoint(
-                    jsonObject.get(APIConstants.KeyManager.REVOKE_ENDPOINT).getAsString());
+                    jsonObject.get(APIConstants.KeyManager.DISPLAY_REVOKE_ENDPOINT).getAsString());
+        } else {
+            if (jsonObject.has(APIConstants.KeyManager.REVOKE_ENDPOINT)) {
+                keyManagerInfoDTO.setRevokeEndpoint(
+                        jsonObject.get(APIConstants.KeyManager.REVOKE_ENDPOINT).getAsString());
+            }
         }
         Map<String,String> additionalProperties = new HashMap<>();
         if (keyManagerConfigurationDTO.getAdditionalProperties()


### PR DESCRIPTION
### Purpose
As $subject, this will add two new parameters called display token endpoint and display revoke endpoint to admin key manager REST APIs and set those values in dev portal REST API token endpoint and revoke endpoints.

### Fixes
1. https://github.com/wso2/product-apim/issues/11590