### PR TITLE
Fixing basic auth missing credential issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticatorTest.java
@@ -52,27 +52,6 @@ public class OAuthAuthenticatorTest {
     public void authenticate() throws Exception {
     }
 
-    @Test
-    public void extractCustomerKeyFromAuthHeader() throws Exception {
-        PowerMockito.mockStatic(ServiceReferenceHolder.class);
-
-        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
-        APIManagerConfigurationService apiManagerConfigurationService = Mockito.mock(APIManagerConfigurationService.class);
-        Mockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
-        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService()).thenReturn(apiManagerConfigurationService);
-
-        APIManagerConfiguration apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
-        Mockito.when(apiManagerConfigurationService.getAPIManagerConfiguration()).thenReturn(apiManagerConfiguration);
-        OAuthAuthenticator oauthAuthenticator = new OauthAuthenticatorWrapper(apiManagerConfiguration);
-
-        Map map = new HashMap();
-        Assert.assertNull("Assertion failure due to not null", oauthAuthenticator.extractCustomerKeyFromAuthHeader
-                (map));
-        map.put(HttpHeaders.AUTHORIZATION, "Bearer abcde-fghij");
-        Assert.assertNotNull(oauthAuthenticator.extractCustomerKeyFromAuthHeader(map), "Assertion failure due to null");
-
-    }
-
 
     @Test
     public void getRequestOrigin() throws Exception {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11745

## Goals
This PR fixes the issue where Basic Authentication drops the Authorization header at the gateway level when a load test is run. This happens due to the remainingAuthHeader variable in OAuthAuthenticator when both OAuth and Basic security are enabled for the testing API.