### PR TITLE
Move override.sp.name system property functionality to DCRMService

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -186,12 +186,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
             clientInfo.setRedirectUris(Arrays.asList(callbackURLs));
         }
 
-        String overrideSpName = System.getProperty(APIConstants.APPLICATION.OVERRIDE_SP_NAME);
-        if (StringUtils.isNotEmpty(overrideSpName) && !Boolean.parseBoolean(overrideSpName)) {
-            clientInfo.setClientName(info.getClientName());
-        } else {
-            clientInfo.setClientName(oauthClientName);
-        }
+        clientInfo.setClientName(oauthClientName);
 
         //todo: run tests by commenting the type
         if (StringUtils.isEmpty(info.getTokenType())) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2682,10 +2682,6 @@ public final class APIConstants {
     public static final String PASSWORD_POLICY_PATTERN_PROPERTY = "passwordPolicy.pattern";
     public static final String PASSWORD_JAVA_REGEX_PROPERTY = "PasswordJavaRegEx";
 
-    public static class APPLICATION {
-        public static final String OVERRIDE_SP_NAME = "override.sp.name";
-    }
-
     public class SkipListConstants {
 
         public static final String SKIP_LIST_CONFIG = "SkipList";


### PR DESCRIPTION
Related PR https://github.com/wso2-extensions/apim-km-wso2is/pull/61

Revert wso2/carbon-apimgt#9389 and handle wso2/product-apim#9455 with https://github.com/wso2-extensions/apim-km-wso2is/pull/61 in DCRMService of wso2is.keymanager.operations.endpoint.