### PR TITLE
Add publishing docker-compose logs step to contract tests

### DIFF
--- a/.azure/masterBranchPRValidation.yaml
+++ b/.azure/masterBranchPRValidation.yaml
@@ -107,8 +107,6 @@ stages:
         REPOSITORY: $(REPOSITORY_APIM)
         CONTAINER_REGISTRY: $(CONTAINER_REGISTRY_APIM)
     
-    - template: .azure/templates/run-contract-tests.yml@choreo-product-apim
-
     - template: .azure/templates/trivy-docker-scan.yml@choreo-product-apim
       parameters:
         registry: $(CONTAINER_REGISTRY_APIM)


### PR DESCRIPTION
Add publishing docker-compose logs step to contract tests

Related PR:
https://github.com/wso2-enterprise/choreo-product-apim/pull/275