### PR TITLE
Add apim-grant-type-token-tests to workflow ymls

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include:
           - id: 1
-            segment: apim-integration-tests-api-common, apim-integration-tests-api-change-endpoint, apim-integration-tests-api-product, apim-integration-tests-api-lifecycle, apim-integration-tests-api-lifecycle-2, apim-email-secondary-userstore-tests, apim-CORS-tests, apim-integration-tests-samples, apim-publisher-tests, apim-store-tests, apim-integration-tests-graphql, admin-rest-api-tests, rest-api-tests, apim-mediation-tests, apim-websocket-tests
+            segment: apim-integration-tests-api-common, apim-integration-tests-api-change-endpoint, apim-integration-tests-api-product, apim-integration-tests-api-lifecycle, apim-integration-tests-api-lifecycle-2, apim-email-secondary-userstore-tests, apim-CORS-tests, apim-integration-tests-samples, apim-publisher-tests, apim-store-tests, apim-grant-type-token-tests, apim-integration-tests-graphql, admin-rest-api-tests, rest-api-tests, apim-mediation-tests, apim-websocket-tests
           - id: 2
             segment: apim-integration-tests-without-restarts, apim-integration-tests-without-advance-throttling, apim-integration-tests-application-sharing, apim-JWT-integration-tests, apim-urlsafe-JWT-integration-tests, apim-integration-tests-endpoint-security, apim-integration-tests-external-idp, apim-integration-emailusername-login, apim-integration-tests-workflow,apim-streaming-api-tests
       fail-fast: false

--- a/.github/workflows/main-forks.yml
+++ b/.github/workflows/main-forks.yml
@@ -50,7 +50,7 @@ jobs:
           - id: 2
             segment: apim-email-secondary-userstore-tests,apim-CORS-tests,apim-publisher-tests
           - id: 3
-            segment: apim-integration-tests-samples,apim-store-tests,apim-integration-tests-graphql,admin-rest-api-tests,rest-api-tests,apim-mediation-tests,apim-integration-tests-without-restarts,apim-integration-tests-without-advance-throttling,apim-urlsafe-JWT-integration-tests
+            segment: apim-integration-tests-samples,apim-store-tests,apim-grant-type-token-tests,apim-integration-tests-graphql,admin-rest-api-tests,rest-api-tests,apim-mediation-tests,apim-integration-tests-without-restarts,apim-integration-tests-without-advance-throttling,apim-urlsafe-JWT-integration-tests
           - id: 4
             segment: apim-streaming-api-tests,apim-JWT-integration-tests,apim-integration-tests-external-idp,apim-integration-tests-workflow
           - id: 5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         include:
           - id: 1
-            segment: apim-integration-tests-api-common, apim-integration-tests-api-change-endpoint, apim-integration-tests-api-product, apim-integration-tests-api-lifecycle, apim-integration-tests-api-lifecycle-2, apim-email-secondary-userstore-tests, apim-CORS-tests, apim-integration-tests-samples, apim-publisher-tests, apim-store-tests, apim-integration-tests-graphql, admin-rest-api-tests, rest-api-tests, apim-mediation-tests, apim-websocket-tests
+            segment: apim-integration-tests-api-common, apim-integration-tests-api-change-endpoint, apim-integration-tests-api-product, apim-integration-tests-api-lifecycle, apim-integration-tests-api-lifecycle-2, apim-email-secondary-userstore-tests, apim-CORS-tests, apim-integration-tests-samples, apim-publisher-tests, apim-store-tests, apim-grant-type-token-tests, apim-integration-tests-graphql, admin-rest-api-tests, rest-api-tests, apim-mediation-tests, apim-websocket-tests
           - id: 2
             segment: apim-integration-tests-without-restarts, apim-integration-tests-without-advance-throttling, apim-integration-tests-application-sharing, apim-JWT-integration-tests, apim-urlsafe-JWT-integration-tests, apim-integration-tests-endpoint-security, apim-integration-tests-external-idp, apim-integration-emailusername-login, apim-integration-tests-workflow,apim-streaming-api-tests
       fail-fast: false


### PR DESCRIPTION
This PR adds `apim-grant-type-token-tests` to workflow yamls. 

Note:
With [1], the exisiting `GrantTypeTokenGenerateTestCase` was moved to a separate test tag with the name, `apim-grant-type-token-tests`. 

1. https://github.com/wso2/product-apim/pull/11716