### PR TITLE
Fix API listing after export and import from APICTL in DevPortal

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -112,6 +112,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -308,7 +309,8 @@ public class ImportUtils {
                     apiProvider.changeAPILCCheckListItems(importedApi.getId(),
                             ImportExportConstants.REFER_REQUIRE_RE_SUBSCRIPTION_CHECK_ITEM, true);
                 }
-                apiProvider.changeLifeCycleStatus(importedApi.getId(), lifecycleAction, organization);
+                apiProvider.changeLifeCycleStatus(currentTenantDomain, importedApi.getUuid(), lifecycleAction,
+                        new HashMap<>());
             }
             importedApi.setStatus(targetStatus);
             String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();


### PR DESCRIPTION
## Purpose
To fix that the imported api is not searchable in the search bar on the subscription section but showing in the API list in the Dev portal UI.

## Goals
Fixes: https://github.com/wso2/product-apim/issues/11806

### Description
The Dev portal UI that imported api by apictl tool is not searchable in the search bar on the subscription section but showing in the API list.

## Approach
Used latest four parameter `changeLifeCycleStatus(tenantDomain, apiId, lifecycleAction, lifecycleMap)` method instead of two parameter method `changeLifeCycleStatus(apiId, lifecycleAction)`

**Git Actions:** https://github.com/YasasRangika/carbon-apimgt/actions/runs/1337479982