### PR TITLE
Fix duplicate context template allowed issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistrySearchUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistrySearchUtil.java
@@ -65,6 +65,7 @@ public class RegistrySearchUtil {
     private static final String PROVIDER_SEARCH_TYPE_PREFIX = "provider";
     private static final String VERSION_SEARCH_TYPE_PREFIX = "version";
     private static final String CONTEXT_SEARCH_TYPE_PREFIX = "context";
+    public static final String CONTEXT_TEMPLATE_SEARCH_TYPE_PREFIX = "contextTemplate";
     public static final String API_DESCRIPTION = "Description";
     public static final String TYPE_SEARCH_TYPE_PREFIX = "type";
     public static final String CATEGORY_SEARCH_TYPE_PREFIX = "api-category";
@@ -74,9 +75,10 @@ public class RegistrySearchUtil {
     public static final String GET_API_PRODUCT_QUERY  = "type=APIProduct";
     public static final String[] API_SEARCH_PREFIXES = { DOCUMENTATION_SEARCH_TYPE_PREFIX, TAGS_SEARCH_TYPE_PREFIX,
             NAME_TYPE_PREFIX, PROVIDER_SEARCH_TYPE_PREFIX, CONTEXT_SEARCH_TYPE_PREFIX,
-            VERSION_SEARCH_TYPE_PREFIX, LCSTATE_SEARCH_KEY.toLowerCase(), API_DESCRIPTION.toLowerCase(),
-            API_STATUS.toLowerCase(), CONTENT_SEARCH_TYPE_PREFIX, TYPE_SEARCH_TYPE_PREFIX, LABEL_SEARCH_TYPE_PREFIX,
-            CATEGORY_SEARCH_TYPE_PREFIX, ENABLE_STORE.toLowerCase() };
+            CONTEXT_TEMPLATE_SEARCH_TYPE_PREFIX.toLowerCase(), VERSION_SEARCH_TYPE_PREFIX,
+            LCSTATE_SEARCH_KEY.toLowerCase(), API_DESCRIPTION.toLowerCase(), API_STATUS.toLowerCase(),
+            CONTENT_SEARCH_TYPE_PREFIX, TYPE_SEARCH_TYPE_PREFIX, LABEL_SEARCH_TYPE_PREFIX, CATEGORY_SEARCH_TYPE_PREFIX,
+            ENABLE_STORE.toLowerCase() };
     
 
     private static final Log log = LogFactory.getLog(RegistryPersistenceImpl.class);
@@ -246,7 +248,7 @@ public class RegistrySearchUtil {
                 filteredQuery.append(query);
                 break;
             }
-            // If the query does not contains "=" then it is an errornous scenario.
+            // If the query does not contain "=" then it is an erroneous scenario.
             if (query.contains("=")) {
                 String[] searchKeys = query.split("=");
 
@@ -415,7 +417,16 @@ public class RegistrySearchUtil {
     }
 
     public static String getPublisherSearchQuery(String searchQuery, UserContext ctx) throws APIPersistenceException {
+
+        // If the context is dynamic, modify the searchQuery to use the templated context instead of plain context
+        if (searchQuery.contains("context") && searchQuery.contains("{")) {
+            searchQuery = searchQuery.replace(CONTEXT_SEARCH_TYPE_PREFIX, CONTEXT_TEMPLATE_SEARCH_TYPE_PREFIX);
+            searchQuery = searchQuery.replace("{", ClientUtils.escapeQueryChars("{"));
+            searchQuery = searchQuery.replace("}", ClientUtils.escapeQueryChars("}"));
+        }
+
         String newSearchQuery = constructNewSearchQuery(searchQuery);
+
         if (!newSearchQuery.contains(APIConstants.TYPE)) {
             String typeCriteria = APIConstants.TYPE_SEARCH_TYPE_KEY
                     + getORBasedSearchCriteria(APIConstants.API_SUPPORTED_TYPE_LIST);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APISearchResultAllOfDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APISearchResultAllOfDTO.java
@@ -22,6 +22,7 @@ public class APISearchResultAllOfDTO   {
   
     private String description = null;
     private String context = null;
+    private String contextTemplate = null;
     private String version = null;
     private String provider = null;
     private String status = null;
@@ -61,6 +62,24 @@ public class APISearchResultAllOfDTO   {
   }
   public void setContext(String context) {
     this.context = context;
+  }
+
+  /**
+   * The templated context of the API
+   **/
+  public APISearchResultAllOfDTO contextTemplate(String contextTemplate) {
+    this.contextTemplate = contextTemplate;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "CalculatorAPI/{version}", value = "The templated context of the API")
+  @JsonProperty("contextTemplate")
+  public String getContextTemplate() {
+    return contextTemplate;
+  }
+  public void setContextTemplate(String contextTemplate) {
+    this.contextTemplate = contextTemplate;
   }
 
   /**
@@ -146,6 +165,7 @@ public class APISearchResultAllOfDTO   {
     APISearchResultAllOfDTO apISearchResultAllOf = (APISearchResultAllOfDTO) o;
     return Objects.equals(description, apISearchResultAllOf.description) &&
         Objects.equals(context, apISearchResultAllOf.context) &&
+        Objects.equals(contextTemplate, apISearchResultAllOf.contextTemplate) &&
         Objects.equals(version, apISearchResultAllOf.version) &&
         Objects.equals(provider, apISearchResultAllOf.provider) &&
         Objects.equals(status, apISearchResultAllOf.status) &&
@@ -154,7 +174,7 @@ public class APISearchResultAllOfDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, version, provider, status, thumbnailUri);
+    return Objects.hash(description, context, contextTemplate, version, provider, status, thumbnailUri);
   }
 
   @Override
@@ -164,6 +184,7 @@ public class APISearchResultAllOfDTO   {
     
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
     sb.append("    context: ").append(toIndentedString(context)).append("\n");
+    sb.append("    contextTemplate: ").append(toIndentedString(contextTemplate)).append("\n");
     sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APISearchResultDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APISearchResultDTO.java
@@ -24,6 +24,7 @@ public class APISearchResultDTO extends SearchResultDTO  {
   
     private String description = null;
     private String context = null;
+    private String contextTemplate = null;
     private String version = null;
     private String provider = null;
     private String status = null;
@@ -63,6 +64,24 @@ public class APISearchResultDTO extends SearchResultDTO  {
   }
   public void setContext(String context) {
     this.context = context;
+  }
+
+  /**
+   * The templated context of the API
+   **/
+  public APISearchResultDTO contextTemplate(String contextTemplate) {
+    this.contextTemplate = contextTemplate;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "CalculatorAPI/{version}", value = "The templated context of the API")
+  @JsonProperty("contextTemplate")
+  public String getContextTemplate() {
+    return contextTemplate;
+  }
+  public void setContextTemplate(String contextTemplate) {
+    this.contextTemplate = contextTemplate;
   }
 
   /**
@@ -148,6 +167,7 @@ public class APISearchResultDTO extends SearchResultDTO  {
     APISearchResultDTO apISearchResult = (APISearchResultDTO) o;
     return Objects.equals(description, apISearchResult.description) &&
         Objects.equals(context, apISearchResult.context) &&
+        Objects.equals(contextTemplate, apISearchResult.contextTemplate) &&
         Objects.equals(version, apISearchResult.version) &&
         Objects.equals(provider, apISearchResult.provider) &&
         Objects.equals(status, apISearchResult.status) &&
@@ -156,7 +176,7 @@ public class APISearchResultDTO extends SearchResultDTO  {
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, version, provider, status, thumbnailUri);
+    return Objects.hash(description, context, contextTemplate, version, provider, status, thumbnailUri);
   }
 
   @Override
@@ -166,6 +186,7 @@ public class APISearchResultDTO extends SearchResultDTO  {
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
     sb.append("    context: ").append(toIndentedString(context)).append("\n");
+    sb.append("    contextTemplate: ").append(toIndentedString(contextTemplate)).append("\n");
     sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/SearchResultMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/SearchResultMappingUtil.java
@@ -66,6 +66,7 @@ public class SearchResultMappingUtil {
             context = context.replace("/" + RestApiConstants.API_VERSION_PARAM, "");
         }
         apiResultDTO.setContext(context);
+        apiResultDTO.setContextTemplate(api.getContextTemplate());
         apiResultDTO.setType(SearchResultDTO.TypeEnum.API);
         apiResultDTO.setTransportType(api.getType());
         apiResultDTO.setDescription(api.getDescription());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -10701,6 +10701,10 @@ components:
               type: string
               description: A string that represents the context of the user's request
               example: CalculatorAPI
+            contextTemplate:
+              type: string
+              description: The templated context of the API
+              example: CalculatorAPI/{version}
             version:
               type: string
               description: The version of the API


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/product-apim/issues/11841

As of now, when the context consists of a template (i.e. a dynamic context) the validation on whether or not the provided context is unique, fails. This PR fixes this duplicate templated context being allowed issue. This is done by taking into consideration the template of the context, rather than the plain context. Please refer to the below screenshot to see the modified error message shown in the Publisher when this validation happens.

This PR also fixes the Solr exception that gets thrown due to the presence of special characters (i.e. `{` and `}`) when a template is provided under the context.

<img width="805" alt="Screenshot 2021-10-20 at 20 58 50" src="https://user-images.githubusercontent.com/30475839/138470488-84d2a68a-969c-4d7b-b198-446386426a8d.png">

## Related PRs

- https://github.com/wso2/apim-apps/pull/89 (frontend fix PR)
- https://github.com/wso2/product-apim/pull/11899 (test PR)