### PR TITLE
Fix api revision export failure

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/CertificateMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/CertificateMgtDAO.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.dto.CertificateMetadataDTO;
 import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.APIRevision;
 import org.wso2.carbon.apimgt.impl.certificatemgt.exceptions.CertificateAliasExistsException;
 import org.wso2.carbon.apimgt.impl.certificatemgt.exceptions.CertificateManagementException;
 import org.wso2.carbon.apimgt.impl.dao.constants.SQLConstants;
@@ -268,6 +269,10 @@ public class CertificateMgtDAO {
                 String apiUuid;
                 if (apiIdentifier.getUUID() != null) {
                     apiUuid = apiIdentifier.getUUID();
+                    APIRevision apiRevision = ApiMgtDAO.getInstance().checkAPIUUIDIsARevisionUUID(apiUuid);
+                    if (apiRevision != null && apiRevision.getApiUUID() != null) {
+                        apiUuid = apiRevision.getApiUUID();
+                    }
                 } else {
                     apiUuid = ApiMgtDAO.getInstance().getUUIDFromIdentifier(apiIdentifier, organization);
                 }


### PR DESCRIPTION
By removing the API identifier from getting API ID, export revision scenario fails as per this issue https://github.com/wso2/product-apim-tooling/issues/794.  When we are exporting a revision, API UUID is set to revision ID and with this fix, it will be changed to the original API UUID when exporting the client certificates.


Fixes https://github.com/wso2/product-apim-tooling/issues/794