### PR TITLE
Fix the null pointer issue when adding the same local scope.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
@@ -494,13 +494,13 @@ public interface APIManager {
      * Check whether the given scope key is already assigned to an API as local scope under given tenant.
      * This will return false if those APIs are different versions of the same API.
      *
-     * @param uuid API uuid
+     * @param apiName API name
      * @param scopeKey   candidate scope key
      * @param organization   organization
      * @return true if the scope key is already attached as a local scope in any API
      * @throws APIManagementException if failed to check the local scope availability
      */
-    boolean isScopeKeyAssignedLocally(String uuid, String scopeKey, String organization) throws APIManagementException;
+    boolean isScopeKeyAssignedLocally(String apiName, String scopeKey, String organization) throws APIManagementException;
 
     /**
      * Check if a given context template already exists in an organization

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -1674,13 +1674,13 @@ public abstract class AbstractAPIManager implements APIManager {
      * Check whether the given scope key is already assigned to an API as local scope under given tenant.
      * The different versions of the same API will not be take into consideration.
      *
-     * @param uuid API UUID
+     * @param apiName API name
      * @param scopeKey      candidate scope key
      * @param organization   organization
      * @return true if the scope key is already attached as a local scope in any API
      * @throws APIManagementException if failed to check the local scope availability
      */
-    public boolean isScopeKeyAssignedLocally(String uuid, String scopeKey, String organization)
+    public boolean isScopeKeyAssignedLocally(String apiName, String scopeKey, String organization)
             throws APIManagementException {
 
         if (log.isDebugEnabled()) {
@@ -1688,7 +1688,7 @@ public abstract class AbstractAPIManager implements APIManager {
                     + " in organization: " + organization);
         }
         int tenantId = APIUtil.getInternalOrganizationId(organization);
-        return apiMgtDAO.isScopeKeyAssignedLocally(uuid, scopeKey, tenantId, organization);
+        return apiMgtDAO.isScopeKeyAssignedLocally(apiName, scopeKey, tenantId, organization);
     }
 
     public boolean isApiNameExist(String apiName) throws APIManagementException {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -10164,9 +10164,8 @@ public class ApiMgtDAO {
      * @return true if the scope key is already available
      * @throws APIManagementException if failed to check the context availability
      */
-    public boolean isScopeKeyAssignedLocally(String uuid, String scopeKey, int tenantId, String organization)
+    public boolean isScopeKeyAssignedLocally(String apiName, String scopeKey, int tenantId, String organization)
             throws APIManagementException {
-        APIIdentifier identifier = getAPIIdentifierFromUUID(uuid);
         try (Connection connection = APIMgtDBUtil.getConnection();
                 PreparedStatement statement = connection.prepareStatement(SQLConstants.IS_SCOPE_ATTACHED_LOCALLY)) {
             statement.setString(1, scopeKey);
@@ -10176,11 +10175,10 @@ public class ApiMgtDAO {
             try (ResultSet rs = statement.executeQuery()) {
                 if (rs.next()) {
                     String provider = rs.getString("API_PROVIDER");
-                    String apiName = rs.getString("API_NAME");
-                    // Check if the provider name and api name is same.
+                    String existingApiName = rs.getString("API_NAME");
+                    // Check if the api name is same.
                     // Return false if we're attaching the scope to another version of the API.
-                    return !(provider.equals(APIUtil.replaceEmailDomainBack(identifier.getProviderName()))
-                            && apiName.equals(identifier.getApiName()));
+                    return !(existingApiName.equals(apiName));
                 }
             }
         } catch (SQLException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AbstractAPIManagerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AbstractAPIManagerTestCase.java
@@ -971,8 +971,8 @@ public class AbstractAPIManagerTestCase {
         AbstractAPIManager abstractAPIManager = new AbstractAPIManagerWrapper(apiMgtDAO);
         PowerMockito.mockStatic(APIUtil.class);
         PowerMockito.when(APIUtil.getInternalOrganizationId(organization)).thenReturn(-1234);
-        Assert.assertFalse(abstractAPIManager.isScopeKeyAssignedLocally(uuid, "sample", "carbon.super"));
-        Assert.assertTrue(abstractAPIManager.isScopeKeyAssignedLocally(uuid, "sample1", "carbon.super"));
+        Assert.assertFalse(abstractAPIManager.isScopeKeyAssignedLocally(SAMPLE_API_NAME, "sample", "carbon.super"));
+        Assert.assertTrue(abstractAPIManager.isScopeKeyAssignedLocally(SAMPLE_API_NAME, "sample1", "carbon.super"));
     }
 
     @Test

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -690,7 +690,7 @@ public class PublisherCommonUtils {
                 // If false, check if the scope key is already defined as a shared scope. If so, do not honor the
                 // other scope attributes (description, role bindings) in the request payload, replace them with
                 // already defined values for the existing shared scope.
-                if (apiProvider.isScopeKeyAssignedLocally(api.getUuid(), scopeName, api.getOrganization())) {
+                if (apiProvider.isScopeKeyAssignedLocally(api.getId().getApiName(), scopeName, api.getOrganization())) {
                     throw new APIManagementException(
                             "Scope " + scopeName + " is already assigned locally by another API",
                             ExceptionCodes.SCOPE_ALREADY_ASSIGNED);


### PR DESCRIPTION
Related issue: https://github.com/wso2-enterprise/choreo/issues/8890

After the fix, it will give the following error when trying to add the same local scope to another API
`{"code":500,"message":"Internal server error","description":"Error while adding new API : null-SwaggerPetstore2-1.0.5 - Scope read:pets is already assigned locally by another API","moreInfo":"","error":[]}`