### PR TITLE
Fixing the NPE when isAdvertised is not specified in api.yaml of apictl

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -402,6 +402,9 @@ public class ImportUtils {
      * @param importedApiDTO API DTO to import
      */
     public static boolean isAdvertiseOnlyAPI(APIDTO importedApiDTO) {
+        if (importedApiDTO.getAdvertiseInfo() != null && importedApiDTO.getAdvertiseInfo().isAdvertised() == null) {
+            importedApiDTO.getAdvertiseInfo().setAdvertised(Boolean.FALSE);
+        }
         return importedApiDTO.getAdvertiseInfo() != null && importedApiDTO.getAdvertiseInfo().isAdvertised();
     }
     


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/783

## Goals
Fising the NPE when isAdvertised property is not there in the api.yaml when the project is created using the apictl init with the definition flag.

## Approach
- Added a null check. If the isAdvertised value is null, set it to False

## User stories
The user story that broke in [1] is fixed now.

## Automation tests
 - Integration tests
   - https://github.com/wso2/product-apim-tooling/pull/814

## Related PRs
- https://github.com/wso2/product-apim-tooling/pull/814

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.4 LTS
 
[1] https://github.com/wso2/product-apim-tooling/issues/783
