### PR TITLE
Modifying the apictl artifacts version and fixing error messages related apictl export

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -195,7 +195,7 @@ public final class ImportExportConstants {
 
     public static final String TYPE_DEPLOYMENT_ENVIRONMENTS = "deployment_environments";
 
-    public static final String APIM_VERSION = "v4.0.0";
+    public static final String APIM_VERSION = "v4.1.0";
 
     public static final String ENDPOINT_CONFIG = "endpointConfig";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/ImportExportAPIServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/ImportExportAPIServiceImpl.java
@@ -22,7 +22,9 @@ package org.wso2.carbon.apimgt.rest.api.publisher.v1.common;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.APIMgtResourceNotFoundException;
 import org.wso2.carbon.apimgt.api.APIProvider;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIProduct;
@@ -88,8 +90,13 @@ public class ImportExportAPIServiceImpl implements ImportExportAPI {
             //if a revision number is not provided, working copy's id is used
             exportAPIUUID = apiId;
         }
-        //If an incorrect revision num provided or revision does not exists, working copy will be exported
-        exportAPIUUID = (exportAPIUUID == null) ? apiId : exportAPIUUID;
+
+        // If an incorrect revision num provided (revision does not exist)
+        if (StringUtils.isBlank(exportAPIUUID)) {
+            throw new APIMgtResourceNotFoundException("Incorrect revision number provided: " + revisionNum,
+                    ExceptionCodes.from(ExceptionCodes.API_REVISION_NOT_FOUND, revisionNum));
+        }
+
         api = apiProvider.getAPIbyUUID(exportAPIUUID, organization);
         apiDtoToReturn = APIMappingUtil.fromAPItoDTO(api, preserveCredentials, apiProvider);
         apiIdentifier.setUuid(exportAPIUUID);
@@ -162,7 +169,12 @@ public class ImportExportAPIServiceImpl implements ImportExportAPI {
             exportAPIProductUUID = apiId;
         }
 
-        exportAPIProductUUID = (exportAPIProductUUID == null) ? apiId : exportAPIProductUUID;
+        // If an incorrect revision num provided (revision does not exist)
+        if (StringUtils.isBlank(exportAPIProductUUID)) {
+            throw new APIMgtResourceNotFoundException("Incorrect revision number provided: " + revisionNum,
+                    ExceptionCodes.from(ExceptionCodes.API_REVISION_NOT_FOUND, revisionNum));
+        }
+
         apiProduct = apiProvider.getAPIProductbyUUID(exportAPIProductUUID, tenantDomain);
         apiProductIdentifier.setUUID(exportAPIProductUUID);
         if (apiProduct != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
@@ -650,11 +650,9 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
                     .header(RestApiConstants.HEADER_CONTENT_DISPOSITION, "attachment; filename=\""
                             + file.getName() + "\"")
                     .build();
-        } catch (APIManagementException | APIImportExportException e) {
-            RestApiUtil.handleInternalServerError("Error while exporting " +
-                    RestApiConstants.RESOURCE_API_PRODUCT, e, log);
+        } catch (APIImportExportException e) {
+            throw new APIManagementException("Error while exporting " + RestApiConstants.RESOURCE_API_PRODUCT, e);
         }
-        return null;
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3858,7 +3858,8 @@ public class ApisApiServiceImpl implements ApisApiService {
      */
     @Override public Response exportAPI(String apiId, String name, String version, String revisionNum,
                                         String providerName, String format, Boolean preserveStatus,
-                                        Boolean exportLatestRevision, MessageContext messageContext) {
+                                        Boolean exportLatestRevision, MessageContext messageContext)
+            throws APIManagementException {
 
         //If not specified status is preserved by default
         preserveStatus = preserveStatus == null || preserveStatus;
@@ -3875,10 +3876,9 @@ public class ApisApiServiceImpl implements ApisApiService {
                             Boolean.TRUE, Boolean.FALSE, exportLatestRevision, StringUtils.EMPTY, organization);
             return Response.ok(file).header(RestApiConstants.HEADER_CONTENT_DISPOSITION,
                     "attachment; filename=\"" + file.getName() + "\"").build();
-        } catch (APIManagementException | APIImportExportException e) {
-            RestApiUtil.handleInternalServerError("Error while exporting " + RestApiConstants.RESOURCE_API, e, log);
+        } catch (APIImportExportException e) {
+            throw new APIManagementException("Error while exporting " + RestApiConstants.RESOURCE_API, e);
         }
-        return null;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/810
Fixes: https://github.com/wso2/product-apim-tooling/issues/742
Fixes: https://github.com/wso2/product-apim/issues/11212

## Goals
Modifying the apictl artifacts version and fixing error messages related apictl export

## Approach
- Updated the apictl artifacts version to 4.1.0
- Validated the revision ID when exporting an API/API Product and provided a meaningful error message
- Improved the error responses of Publisher V2 apis/export and api-products/export

## Automation tests
 - Integration tests
   - https://github.com/wso2/product-apim-tooling/pull/817

## Related PRs
- https://github.com/wso2/product-apim-tooling/pull/817

## Test environment

 

