### PR TITLE
Revert API change

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/EventPublisherEvent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing/src/main/java/org/wso2/carbon/apimgt/eventing/EventPublisherEvent.java
@@ -32,6 +32,11 @@ public class EventPublisherEvent extends Event {
      */
     private String loggingEvent;
 
+    public EventPublisherEvent(java.lang.String streamId, long timeStamp, java.lang.Object[] metaDataArray,
+                               java.lang.Object[] correlationDataArray, java.lang.Object[] payloadDataArray) {
+        super(streamId, timeStamp, metaDataArray, correlationDataArray, payloadDataArray);
+    }
+
     public EventPublisherEvent(String streamId, long timeStamp, Object[] payloadDataArray) {
         super(streamId, timeStamp, null, null, payloadDataArray);
     }


### PR DESCRIPTION
This PR adds the removed constructor of EventPublisherEvent https://github.com/wso2/carbon-apimgt/pull/10883 since it can be used anywhere.