### PR TITLE
Fix Issue of Token Type Changing from Opaque to JWT When Updating a Migrated Application

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -556,6 +556,7 @@ public final class APIConstants {
     public static final String ORGANIZATION_CLAIM_ATTRIBUTE = "OrganizationClaimAttribute";
     public static final String DEFAULT_ORGANIZATION_CLAIM_NAME = "http://wso2.org/claims/organization";
     public static final String DEFAULT_TOKEN_TYPE = "DEFAULT";
+    public static final String TOKEN_TYPE_OAUTH = "OAUTH";
     public static final String TOKEN_TYPE_JWT = "JWT";
 
     public static final String PASSWORD_RESOLVER_IMPL_CLASS = "PasswordResolverImpl";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -3593,6 +3593,20 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                     "A duplicate application already exists by the name - " + application.getName());
         }
 
+        // Retain the 'DEFAULT' token type of migrated applications unless the token type is changed to 'JWT'.
+        if (APIConstants.DEFAULT_TOKEN_TYPE.equals(existingApp.getTokenType()) &&
+                APIConstants.TOKEN_TYPE_OAUTH.equals(application.getTokenType())) {
+            application.setTokenType(APIConstants.DEFAULT_TOKEN_TYPE);
+        }
+
+        // Prevent the change of token type of applications having 'JWT' token type.
+        if (APIConstants.TOKEN_TYPE_JWT.equals(existingApp.getTokenType()) &&
+                !APIConstants.TOKEN_TYPE_JWT.equals(application.getTokenType())) {
+            throw new APIManagementException(
+                    "Cannot change application token type from " + APIConstants.TOKEN_TYPE_JWT + " to " +
+                            application.getTokenType());
+        }
+
         Subscriber subscriber = application.getSubscriber();
 
         JSONArray applicationAttributesFromConfig = getAppAttributesFromConfig(subscriber.getName());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIConsumerImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIConsumerImplTest.java
@@ -1079,6 +1079,84 @@ public class APIConsumerImplTest {
     }
 
     @Test
+    public void testTokenTypeChangeWhenUpdatingApplications() throws APIManagementException {
+
+        Application oldApplication = new Application("app1", new Subscriber("sub1"));
+        Application newApplication = new Application("app1", new Subscriber("sub1"));
+        Mockito.when(apiMgtDAO.getApplicationById(Mockito.anyInt())).thenReturn(oldApplication);
+        Mockito.when(apiMgtDAO.getApplicationByUUID(Mockito.anyString())).thenReturn(oldApplication);
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO);
+
+        // When token type of existing application is 'JWT' and request body contains 'OAUTH' as the token type.
+        oldApplication.setTokenType(APIConstants.TOKEN_TYPE_JWT);
+        newApplication.setTokenType(APIConstants.TOKEN_TYPE_OAUTH);
+        try {
+            // An exception will be thrown during this operation.
+            apiConsumer.updateApplication(newApplication);
+            Assert.fail("API management exception not thrown for error scenario");
+        } catch (APIManagementException e) {
+            Assert.assertTrue(e.getMessage().contains(
+                    "Cannot change application token type from " + APIConstants.TOKEN_TYPE_JWT + " to " +
+                            newApplication.getTokenType()));
+        }
+
+        // When token type of existing application is 'JWT' and request body contains 'JWT' as the token type.
+        oldApplication.setTokenType(APIConstants.TOKEN_TYPE_JWT);
+        newApplication.setTokenType(APIConstants.TOKEN_TYPE_JWT);
+        try {
+            // Token type of newApplication will not change during this operation.
+            apiConsumer.updateApplication(newApplication);
+            Assert.assertEquals(APIConstants.TOKEN_TYPE_JWT, newApplication.getTokenType());
+        } catch (APIManagementException e) {
+            Assert.fail("API management exception is thrown due to an error");
+        }
+
+        // When token type of existing application is 'OAUTH' and request body contains 'OAUTH' as the token type.
+        oldApplication.setTokenType(APIConstants.TOKEN_TYPE_OAUTH);
+        newApplication.setTokenType(APIConstants.TOKEN_TYPE_OAUTH);
+        try {
+            // Token type of newApplication will not change during this operation.
+            apiConsumer.updateApplication(newApplication);
+            Assert.assertEquals(APIConstants.TOKEN_TYPE_OAUTH, newApplication.getTokenType());
+        } catch (APIManagementException e) {
+            Assert.fail("API management exception is thrown due to an error");
+        }
+
+        // When token type of existing application is 'OAUTH' and request body contains 'JWT' as the token type.
+        oldApplication.setTokenType(APIConstants.TOKEN_TYPE_OAUTH);
+        newApplication.setTokenType(APIConstants.TOKEN_TYPE_JWT);
+        try {
+            // Token type of newApplication will not change during this operation.
+            apiConsumer.updateApplication(newApplication);
+            Assert.assertEquals(APIConstants.TOKEN_TYPE_JWT, newApplication.getTokenType());
+        } catch (APIManagementException e) {
+            Assert.fail("API management exception is thrown due to an error");
+        }
+
+        // When token type of existing application is 'DEFAULT' and request body contains 'OAUTH' as the token type.
+        oldApplication.setTokenType(APIConstants.DEFAULT_TOKEN_TYPE);
+        newApplication.setTokenType(APIConstants.TOKEN_TYPE_OAUTH);
+        try {
+            // Token type of newApplication will change to 'DEFAULT' during this operation.
+            apiConsumer.updateApplication(newApplication);
+            Assert.assertEquals(APIConstants.DEFAULT_TOKEN_TYPE, newApplication.getTokenType());
+        } catch (APIManagementException e) {
+            Assert.fail("API management exception is thrown due to an error");
+        }
+
+        // When token type of existing application is 'DEFAULT' and request body contains 'JWT' as the token type.
+        oldApplication.setTokenType(APIConstants.DEFAULT_TOKEN_TYPE);
+        newApplication.setTokenType(APIConstants.TOKEN_TYPE_JWT);
+        try {
+            // Token type of newApplication will not change during this operation.
+            apiConsumer.updateApplication(newApplication);
+            Assert.assertEquals(APIConstants.TOKEN_TYPE_JWT, newApplication.getTokenType());
+        } catch (APIManagementException e) {
+            Assert.fail("API management exception is thrown due to an error");
+        }
+    }
+
+    @Test
     public void testGetComments() throws APIManagementException {
         Comment comment = new Comment();
         Comment[] comments = new Comment[] { comment };

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
@@ -472,12 +472,6 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
             applicationDto.setAttributes(applicationAttributes);
         }
 
-        //we do not honor tokenType sent in the body and all the applications are considered of 'JWT' token type
-        //unless the current application is already of 'OAUTH' type
-        if (!ApplicationDTO.TokenTypeEnum.OAUTH.toString().equals(oldApplication.getTokenType())) {
-            applicationDto.setTokenType(ApplicationDTO.TokenTypeEnum.JWT);
-        }
-
         //we do not honor the subscriber coming from the request body as we can't change the subscriber of the application
         Application application = ApplicationMappingUtil.fromDTOtoApplication(applicationDto, username);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/ApplicationMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/ApplicationMappingUtil.java
@@ -80,7 +80,6 @@ public class ApplicationMappingUtil {
         application.setTier(applicationDTO.getThrottlingPolicy());
         application.setDescription(applicationDTO.getDescription());
         application.setUUID(applicationDTO.getApplicationId());
-        application.setTokenType(APIConstants.DEFAULT_TOKEN_TYPE);
 
         //Check if the token type is not set in the request.
         if (StringUtils.isEmpty(applicationDTO.getTokenType().toString())) {


### PR DESCRIPTION
## Purpose
Fix issue of token type changing from `Opaque` to `JWT` when updating a migrated application.
Fixes: https://github.com/wso2/product-apim/issues/11888

## Goals
Token type should not change when updating a migrated application

## Approach
- Implemented the logic to retain the `DEFAULT` token type of migrated applications unless the token type is changed to `JWT`.
- Added a condition to prevent the change of token type of applications having `JWT` token type.

## Behavior
| Existing App Token Type  | Token Type in Request | Action | Token Type Added to DB |
| ------------- | ------------- | ------------- | ------------- |
| DEFAULT  | OAUTH  | Allowed | DEFAULT |
| DEFAULT  | JWT  | Allowed | JWT |
| OAUTH  | OAUTH  | Allowed | OAUTH |
| OAUTH  | JWT  | Allowed | JWT |
| JWT  | OAUTH  | Not Allowed | - |
| JWT  | JWT  | Allowed | JWT |