### PR TITLE
Make expires_in time configurable if not specified in Token Response

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/client/OAuthClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/client/OAuthClient.java
@@ -153,8 +153,8 @@ public class OAuthClient {
                 tokenResponse.setRefreshToken((String) jsonResponse.get("refresh_token"));
             }
             if (jsonResponse.containsKey("scope")) {
-                Set<String> scopeSet = Stream.of( jsonResponse.get("scope").toString().trim()
-                        .split("\\s*,\\s*") ).collect(Collectors.toSet());
+                Set<String> scopeSet = Stream.of(jsonResponse.get("scope").toString().trim()
+                        .split("\\s*,\\s*")).collect(Collectors.toSet());
                 tokenResponse.setScope(scopeSet);
             }
             if (jsonResponse.containsKey("token_type")) {
@@ -162,6 +162,12 @@ public class OAuthClient {
             }
             if (jsonResponse.containsKey("expires_in")) {
                 tokenResponse.setExpiresIn(jsonResponse.get("expires_in").toString());
+            } else if (null != APIUtil.getMediationConfigurationFromAPIMConfig(
+                    APIConstants.OAuthConstants.OAUTH_MEDIATION_CONFIG +
+                            APIConstants.OAuthConstants.EXPIRES_IN_CONFIG)) {
+                tokenResponse.setExpiresIn(APIUtil.getMediationConfigurationFromAPIMConfig(
+                        APIConstants.OAuthConstants.OAUTH_MEDIATION_CONFIG +
+                                APIConstants.OAuthConstants.EXPIRES_IN_CONFIG));
                 long currentTimeInSeconds = System.currentTimeMillis() / 1000;
                 long expiryTimeInSeconds = currentTimeInSeconds + Long.parseLong(tokenResponse.getExpiresIn());
                 tokenResponse.setValidTill(expiryTimeInSeconds);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -440,6 +440,7 @@ public final class APIConstants {
     public static final String GATEWAY_JWT_GENERATOR_CLAIM = "Claim";
     public static final String CONVERT_CLAIMS_TO_CONSUMER_DIALECT = JWT_CONFIGS + ".ConvertClaimsToConsumerDialect";
 
+    public static final String MEDIATOR_CONFIG = "MediatorConfigs.";
     public static final String OAUTH_CONFIGS = "OAuthConfigurations.";
     public static final String AUTHORIZATION_HEADER = "AuthorizationHeader";
     public static final String API_SECURITY = "APISecurity";
@@ -1349,11 +1350,13 @@ public final class APIConstants {
         public static final String PASSWORD_GRANT_TYPE = "grant_type=password";
         public static final String REFRESH_TOKEN_GRANT_TYPE = "grant_type=refresh_token";
 
+        public static final String OAUTH_MEDIATION_CONFIG = "OAuth.";
         public static final String ACCESS_TOKEN = "access_token";
         public static final String REFRESH_TOKEN = "refresh_token";
         public static final String SCOPE = "scope";
         public static final String TOKEN_TYPE = "token_type";
         public static final String EXPIRES_IN = "expires_in";
+        public static final String EXPIRES_IN_CONFIG = "ExpiresIn";
 
         // Properties in Endpoint Config
         public static final String ENDPOINT_SECURITY_PRODUCTION = "production";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8795,6 +8795,17 @@ public final class APIUtil {
         return null;
     }
 
+    public static String getMediationConfigurationFromAPIMConfig(String property) {
+        APIManagerConfiguration apimConfig = ServiceReferenceHolder.getInstance()
+                .getAPIManagerConfigurationService().getAPIManagerConfiguration();
+
+        String mediatorConfiguration = apimConfig.getFirstProperty(APIConstants.MEDIATOR_CONFIG + property);
+        if (!StringUtils.isBlank(mediatorConfiguration)) {
+            return mediatorConfiguration;
+        }
+        return null;
+    }
+
     public static List<ConditionDto> extractConditionDto(String base64EncodedString) throws ParseException {
 
         List<ConditionDto> conditionDtoList = new ArrayList<>();

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -67,6 +67,7 @@
   ],
   "apim.oauth_config.token_endpoint_context": "/token",
   "apim.oauth_config.revoke_endpoint_context":"/revoke",
+  "apim.oauth_config.expires_in": "3600",
   "apim.devportal.login_username_case_insensitive": true,
   "apim.devportal.url": "https://localhost:${mgt.transport.https.port}/devportal",
   "apim.devportal.display_url": false,

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1392,4 +1392,13 @@
         </Properties>
      </PersistenceConfigs>
      {% endif %}
+
+     {% if apim.mediator_config.oauth is defined %}
+      <MediatorConfigs>
+        <OAuth>
+        <!-- If the access token expires, the server should reply with the duration of time the access token is granted for. -->
+                 <ExpiresIn>{{apim.mediator_config.oauth.expires_in}}</ExpiresIn>
+             </OAuth>
+          </MediatorConfigs>
+      {% endif %}
 </APIManager>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
@@ -730,6 +730,12 @@
         <EnableClientCertificateValidation>true</EnableClientCertificateValidation>
     </MutualSSL>
 
+    <MediatorConfigs>
+        <OAuth>
+            <!-- If the access token expires, the server should reply with the duration of time the access token is granted for. -->
+            <ExpiresIn>3600</ExpiresIn>
+        </OAuth>
+    </MediatorConfigs>
     <!--This parameter is used to Enable the password changing feature in devportal. When this is enabled, a user can
      change his/her password via devportal. By default this feature is enabled.-->
     <EnableChangePassword>true</EnableChangePassword>


### PR DESCRIPTION
## Purpose
This PR will improve the behavior when invoking endpoint secured by OAuth2.0, when expires_in is not present in the token response by allowing to configure a value to expire the token by default.
Related Issue: wso2/product-apim#11366

The default value can be provided in **deployment.toml** under the **[apim.mediator_configs.oauth]**

```
[apim.mediator_configs.oauth]
expires_in = "3600"
```

The default value will be 3600 seconds. 
