### PR TITLE
[Master] Fix for Endpoint timeout duration expected as a number but was not number

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1652,6 +1652,8 @@ public final class APIConstants {
     public static final String ENDPOINT_SECURITY_CLIENT_ID = "clientId";
     public static final String ENDPOINT_SECURITY_CLIENT_SECRET = "clientSecret";
     public static final String ENDPOINT_SECURITY_ENABLED = "enabled";
+    public static final String ENDPOINT_SPECIFIC_CONFIG = "config";
+    public static final String ENDPOINT_CONFIG_ACTION_DURATION = "actionDuration";
     public static final String ENDPOINT_TYPE_GRAPHQL = "graphql";
 
     public static final String API_ENDPOINT_CONFIG_TIMEOUT = "timeout";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -768,6 +768,34 @@ public class ImportUtils {
                     }
                 }
             }
+            if (endpointConfig.has(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS)) {
+                JsonObject productionEndpoint = endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS).
+                        getAsJsonObject();
+                if (productionEndpoint.has(APIConstants.ENDPOINT_SPECIFIC_CONFIG)) {
+                    JsonObject config = productionEndpoint.get(APIConstants.ENDPOINT_SPECIFIC_CONFIG).
+                            getAsJsonObject();
+                    if (config.has(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION)) {
+                        Double actionDuration = config.get(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION).getAsDouble();
+                        Integer value = (int) Math.round(actionDuration);
+                        config.remove(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION);
+                        config.addProperty(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION, value.toString());
+                    }
+                }
+            }
+            if (endpointConfig.has(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS)) {
+                JsonObject sandboxEndpoint = endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS).
+                        getAsJsonObject();
+                if (sandboxEndpoint.has(APIConstants.ENDPOINT_SPECIFIC_CONFIG)) {
+                    JsonObject config = sandboxEndpoint.get(APIConstants.ENDPOINT_SPECIFIC_CONFIG).
+                            getAsJsonObject();
+                    if (config.has(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION)) {
+                        Double actionDuration = config.get(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION).getAsDouble();
+                        Integer value = (int) Math.round(actionDuration);
+                        config.remove(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION);
+                        config.addProperty(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION, value.toString());
+                    }
+                }
+            }
         }
         return configObject;
     }


### PR DESCRIPTION
### Purpose 
This issue is related to APIM migration from 1.9.0 to 4.0.0. After the APIs are migrated from APIM 1.9.0 to 4.0.0, the endpoint deployment fails at the runtime with the below error. in APIM 1.9.0, the endpoint timeout value is maintained as an integer in the JSON configuration object which in turn is stored in the registry metadata file. When this JSON is deserialized into a DTO at the server startup a decimal point is added to the timeout value via GSON. This leads to a NumberFormatException during the endpoint deployment. This issue will be fixed from this PR and add the update for the Master branch.

### Goal
Fixes https://github.com/wso2/product-apim/issues/12030
Fixes https://github.com/wso2/product-apim/issues/12079

