### PR TITLE
Optimise solace notification flow to reduce db calls

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/notifiers/SolaceApplicationNotifier.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/notifiers/SolaceApplicationNotifier.java
@@ -65,13 +65,16 @@ public class SolaceApplicationNotifier extends ApplicationNotifier {
      * @throws NotifierException if error occurs when casting event
      */
     private void process(Event event) throws NotifierException {
-        ApplicationEvent applicationEvent;
-        applicationEvent = (ApplicationEvent) event;
 
-        if (APIConstants.EventType.APPLICATION_DELETE.name().equals(event.getType())) {
-            removeSolaceApplication(applicationEvent);
-        } else if (APIConstants.EventType.APPLICATION_UPDATE.name().equals(event.getType())) {
-            renameSolaceApplication(applicationEvent);
+        if (SolaceNotifierUtils.isSolaceEnvironmentDefined()) {
+            ApplicationEvent applicationEvent;
+            applicationEvent = (ApplicationEvent) event;
+
+            if (APIConstants.EventType.APPLICATION_DELETE.name().equals(event.getType())) {
+                removeSolaceApplication(applicationEvent);
+            } else if (APIConstants.EventType.APPLICATION_UPDATE.name().equals(event.getType())) {
+                renameSolaceApplication(applicationEvent);
+            }
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/notifiers/SolaceKeyGenNotifier.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/notifiers/SolaceKeyGenNotifier.java
@@ -59,11 +59,14 @@ public class SolaceKeyGenNotifier extends ApplicationRegistrationNotifier {
      * @throws NotifierException if error occurs when casting event
      */
     private void process(Event event) throws NotifierException {
-        ApplicationRegistrationEvent applicationRegistrationEvent;
-        applicationRegistrationEvent = (ApplicationRegistrationEvent) event;
 
-        if (APIConstants.EventType.APPLICATION_REGISTRATION_CREATE.name().equals(event.getType())) {
-            syncSolaceApplicationClientId(applicationRegistrationEvent);
+        if (SolaceNotifierUtils.isSolaceEnvironmentDefined()) {
+            ApplicationRegistrationEvent applicationRegistrationEvent;
+            applicationRegistrationEvent = (ApplicationRegistrationEvent) event;
+
+            if (APIConstants.EventType.APPLICATION_REGISTRATION_CREATE.name().equals(event.getType())) {
+                syncSolaceApplicationClientId(applicationRegistrationEvent);
+            }
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/notifiers/SolaceSubscriptionsNotifier.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/notifiers/SolaceSubscriptionsNotifier.java
@@ -60,16 +60,18 @@ public class SolaceSubscriptionsNotifier extends SubscriptionsNotifier {
      * @throws NotifierException if error occurs when casting event
      */
     private void process(Event event) throws NotifierException {
-        SubscriptionEvent subscriptionEvent;
-        subscriptionEvent = (SubscriptionEvent) event;
 
+        if (SolaceNotifierUtils.isSolaceEnvironmentDefined()) {
+            SubscriptionEvent subscriptionEvent;
+            subscriptionEvent = (SubscriptionEvent) event;
 
-        if (APIConstants.EventType.SUBSCRIPTIONS_CREATE.name().equals(event.getType())) {
-            crateSubscription(subscriptionEvent);
-        } else if (APIConstants.EventType.SUBSCRIPTIONS_UPDATE.name().equals(event.getType())) {
-            updateSubscription(subscriptionEvent);
-        } else if (APIConstants.EventType.SUBSCRIPTIONS_DELETE.name().equals(event.getType())) {
-            removeSubscription(subscriptionEvent);
+            if (APIConstants.EventType.SUBSCRIPTIONS_CREATE.name().equals(event.getType())) {
+                crateSubscription(subscriptionEvent);
+            } else if (APIConstants.EventType.SUBSCRIPTIONS_UPDATE.name().equals(event.getType())) {
+                updateSubscription(subscriptionEvent);
+            } else if (APIConstants.EventType.SUBSCRIPTIONS_DELETE.name().equals(event.getType())) {
+                removeSubscription(subscriptionEvent);
+            }
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/utils/SolaceNotifierUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/utils/SolaceNotifierUtils.java
@@ -583,4 +583,17 @@ public class SolaceNotifierUtils {
         }
     }
 
+    public static boolean isSolaceEnvironmentDefined() {
+
+        Map<String, Environment> gatewayEnvironments = APIUtil.getReadOnlyGatewayEnvironments();
+        boolean isSolaceEnvironmentIncluded = false;
+        for (Map.Entry<String, Environment> entry : gatewayEnvironments.entrySet()) {
+            if (SolaceConstants.SOLACE_ENVIRONMENT.equals(entry.getValue().getProvider())) {
+                isSolaceEnvironmentIncluded = true;
+                break;
+            }
+        }
+        return isSolaceEnvironmentIncluded;
+    }
+
 }


### PR DESCRIPTION
Without this check, the solace notifiers will always retrieve API objects from the DB even though solace environments are not configured.