### PR TITLE
Improve external gateway and solace notifiers to reduce db queries

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/notifier/ExternalGatewayNotifier.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/notifier/ExternalGatewayNotifier.java
@@ -43,8 +43,10 @@ public class ExternalGatewayNotifier extends DeployAPIInGatewayNotifier{
 
     @Override
     public boolean publishEvent(Event event) throws NotifierException {
-        apiMgtDAO = ApiMgtDAO.getInstance();
-        process(event);
+        if (APIUtil.isAnyExternalGateWayProviderExists()) {
+            apiMgtDAO = ApiMgtDAO.getInstance();
+            process(event);
+        }
         return true;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -11369,4 +11369,18 @@ public final class APIUtil {
     public static Map<String, org.wso2.carbon.apimgt.api.APIDefinition> getApiDefinitionParsersMap() {
         return ServiceReferenceHolder.getInstance().getApiDefinitionMap();
     }
+
+    /**
+     * Check whether there are external environments registered
+     */
+    public static boolean isAnyExternalGateWayProviderExists() {
+
+        Map<String, Environment> gatewayEnvironments = APIUtil.getReadOnlyGatewayEnvironments();
+        for (Environment environment : gatewayEnvironments.values()) {
+            if (!APIConstants.WSO2_GATEWAY_ENVIRONMENT.equals(environment.getProvider())) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/notifiers/SolaceApplicationNotifier.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/notifiers/SolaceApplicationNotifier.java
@@ -53,8 +53,10 @@ public class SolaceApplicationNotifier extends ApplicationNotifier {
 
     @Override
     public boolean publishEvent(Event event) throws NotifierException {
-        apiMgtDAO = ApiMgtDAO.getInstance();
-        process(event);
+        if (SolaceNotifierUtils.isSolaceEnvironmentDefined()) {
+            apiMgtDAO = ApiMgtDAO.getInstance();
+            process(event);
+        }
         return true;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/notifiers/SolaceKeyGenNotifier.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/notifiers/SolaceKeyGenNotifier.java
@@ -47,8 +47,10 @@ public class SolaceKeyGenNotifier extends ApplicationRegistrationNotifier {
 
     @Override
     public boolean publishEvent(Event event) throws NotifierException {
-        apiMgtDAO = ApiMgtDAO.getInstance();
-        process(event);
+        if (SolaceNotifierUtils.isSolaceEnvironmentDefined()) {
+            apiMgtDAO = ApiMgtDAO.getInstance();
+            process(event);
+        }
         return true;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/notifiers/SolaceSubscriptionsNotifier.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/notifiers/SolaceSubscriptionsNotifier.java
@@ -48,8 +48,10 @@ public class SolaceSubscriptionsNotifier extends SubscriptionsNotifier {
 
     @Override
     public boolean publishEvent(Event event) throws NotifierException {
-        apiMgtDAO = ApiMgtDAO.getInstance();
-        process(event);
+        if (SolaceNotifierUtils.isSolaceEnvironmentDefined()) {
+            apiMgtDAO = ApiMgtDAO.getInstance();
+            process(event);
+        }
         return true;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/utils/SolaceNotifierUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.solace/src/main/java/org/wso2/carbon/apimgt/solace/utils/SolaceNotifierUtils.java
@@ -583,4 +583,17 @@ public class SolaceNotifierUtils {
         }
     }
 
+    /**
+     * Check whether there are solace environments registered
+     */
+    public static boolean isSolaceEnvironmentDefined() {
+
+        Map<String, Environment> gatewayEnvironments = APIUtil.getReadOnlyGatewayEnvironments();
+        for (Environment environment : gatewayEnvironments.values()) {
+            if (SolaceConstants.SOLACE_ENVIRONMENT.equals(environment.getProvider())) {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Without this check, the solace notifiers will always retrieve API objects from the DB even though solace environments are not configured.