### PR TITLE
Fix Websocket APIs are not working when correlation logs are enabled

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/LogsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/LogsHandler.java
@@ -97,18 +97,21 @@ public class LogsHandler extends AbstractSynapseHandler {
             try {
                 requestSize = getContentLength(messageContext);
                 Map headers = LogUtils.getTransportHeaders(messageContext);
-                Set<String> key = headers.keySet();
-                String authHeader = LogUtils.getAuthorizationHeader(headers);
-                String orgIdHeader = LogUtils.getOrganizationIdHeader(headers);
-                String SrcIdHeader = LogUtils.getSourceIdHeader(headers);
-                String applIdHeader = LogUtils.getApplicationIdHeader(headers);
-                String uuIdHeader = LogUtils.getUuidHeader(headers);
-                String correlationIdHeader = LogUtils.getCorrelationHeader(headers);
-                messageContext.setProperty(AUTH_HEADER, authHeader);
-                messageContext.setProperty(ORG_ID_HEADER, orgIdHeader);
-                messageContext.setProperty(SRC_ID_HEADER, SrcIdHeader);
-                messageContext.setProperty(APP_ID_HEADER, applIdHeader);
-                messageContext.setProperty(UUID_HEADER, uuIdHeader);
+                String correlationIdHeader = null;
+                if (headers != null) {
+                    Set<String> key = headers.keySet();
+                    String authHeader = LogUtils.getAuthorizationHeader(headers);
+                    String orgIdHeader = LogUtils.getOrganizationIdHeader(headers);
+                    String SrcIdHeader = LogUtils.getSourceIdHeader(headers);
+                    String applIdHeader = LogUtils.getApplicationIdHeader(headers);
+                    String uuIdHeader = LogUtils.getUuidHeader(headers);
+                    correlationIdHeader = LogUtils.getCorrelationHeader(headers);
+                    messageContext.setProperty(AUTH_HEADER, authHeader);
+                    messageContext.setProperty(ORG_ID_HEADER, orgIdHeader);
+                    messageContext.setProperty(SRC_ID_HEADER, SrcIdHeader);
+                    messageContext.setProperty(APP_ID_HEADER, applIdHeader);
+                    messageContext.setProperty(UUID_HEADER, uuIdHeader);
+                }
 
                 if (MDC.get(APIConstants.CORRELATION_ID) != null) {
                     correlationIdHeader = (String) MDC.get(APIConstants.CORRELATION_ID);
@@ -225,7 +228,10 @@ public class LogsHandler extends AbstractSynapseHandler {
         org.apache.axis2.context.MessageContext axis2MC = ((Axis2MessageContext) messageContext)
                 .getAxis2MessageContext();
         Map headers = (Map) axis2MC.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
-        String contentLength = (String) headers.get(HttpHeaders.CONTENT_LENGTH);
+        String contentLength = null;
+        if (headers != null) {
+            contentLength = (String) headers.get(HttpHeaders.CONTENT_LENGTH);
+        }
         if (contentLength != null) {
             requestSize = Integer.parseInt(contentLength);
             // request size is left as -1 if chunking is enabled. this is to avoid building the message

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/LogsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/LogsHandler.java
@@ -44,18 +44,7 @@ public class LogsHandler extends AbstractSynapseHandler {
     private static final Log log = LogFactory.getLog(APIConstants.CORRELATION_LOGGER);
     private static boolean isEnabled = false;
     private static boolean isSet = false;
-    private String apiName = null;
-    private String apiCTX = null;
-    private String apiMethod = null;
     private String apiTo = null;
-    private long requestSize = 0;
-    private String apiElectedRsrc = null;
-    private String apiRestReqFullPath = null;
-    private String apiResponseSC = null;
-    private String apiMsgUUID = null;
-    private String apiRsrcCacheKey = null;
-    private String applicationName = null;
-    private String apiConsumerKey = null;
 
     private static final String AUTH_HEADER = "AUTH_HEADER";
     private static final String ORG_ID_HEADER = "ORG_ID_HEADER";
@@ -95,7 +84,6 @@ public class LogsHandler extends AbstractSynapseHandler {
     public boolean handleRequestOutFlow(MessageContext messageContext) {
         if (isEnabled()) {
             try {
-                requestSize = getContentLength(messageContext);
                 Map headers = LogUtils.getTransportHeaders(messageContext);
                 String correlationIdHeader = null;
                 if (headers != null) {
@@ -117,14 +105,7 @@ public class LogsHandler extends AbstractSynapseHandler {
                     correlationIdHeader = (String) MDC.get(APIConstants.CORRELATION_ID);
                 }
                 messageContext.setProperty(CORRELATION_ID_HEADER, correlationIdHeader);
-                apiName = LogUtils.getAPIName(messageContext);
-                apiCTX = LogUtils.getAPICtx(messageContext);
-                apiMethod = LogUtils.getRestMethod(messageContext);
                 // apiTo = LogUtils.getTo(messageContext);
-                apiElectedRsrc = LogUtils.getElectedResource(messageContext);
-                apiRestReqFullPath = LogUtils.getRestReqFullPath(messageContext);
-                apiMsgUUID = (String) messageContext.getMessageID();
-                apiRsrcCacheKey = LogUtils.getResourceCacheKey(messageContext);
             } catch (Exception e) {
                 log.error(REQUEST_EVENT_PUBLICATION_ERROR + e.getMessage(), e);
                 return false;
@@ -144,9 +125,6 @@ public class LogsHandler extends AbstractSynapseHandler {
                     long responseTime = getResponseTime(messageContext);
                     long beTotalLatency = getBackendLatency(messageContext);
                     long responseSize = getContentLength(messageContext);
-                    apiResponseSC = LogUtils.getRestHttpResponseStatusCode(messageContext);
-                    applicationName = LogUtils.getApplicationName(messageContext);
-                    apiConsumerKey = LogUtils.getConsumerKey(messageContext);
                     String authHeader = (String) messageContext.getProperty(AUTH_HEADER);
                     String orgIdHeader = (String) messageContext.getProperty(ORG_ID_HEADER);
                     String SrcIdHeader = (String) messageContext.getProperty(SRC_ID_HEADER);
@@ -154,11 +132,14 @@ public class LogsHandler extends AbstractSynapseHandler {
                     String uuIdHeader = (String) messageContext.getProperty(UUID_HEADER);
                     String correlationIdHeader = (String) messageContext.getProperty(CORRELATION_ID_HEADER);
                     MDC.put(APIConstants.CORRELATION_ID, correlationIdHeader);
-                    log.info(beTotalLatency + "|HTTP|" + apiName + "|" + apiMethod + "|" + apiCTX + apiElectedRsrc
-                            + "|" + apiTo + "|" + authHeader + "|" + orgIdHeader + "|" + SrcIdHeader
-                            + "|" + applIdHeader + "|" + uuIdHeader + "|" + requestSize
-                            + "|" + responseSize + "|" + apiResponseSC + "|"
-                            + applicationName + "|" + apiConsumerKey + "|" + responseTime);
+                    log.info(beTotalLatency + "|HTTP|" + LogUtils.getAPIName(messageContext) + "|"
+                            + LogUtils.getRestMethod(messageContext) + "|" + LogUtils.getAPICtx(messageContext)
+                            + LogUtils.getElectedResource(messageContext) + "|" + apiTo + "|" + authHeader + "|"
+                            + orgIdHeader + "|" + SrcIdHeader + "|" + applIdHeader + "|" + uuIdHeader + "|"
+                            + getContentLength(messageContext) + "|" + responseSize + "|"
+                            + LogUtils.getRestHttpResponseStatusCode(messageContext) + "|"
+                            + LogUtils.getApplicationName(messageContext) + "|"
+                            + LogUtils.getConsumerKey(messageContext) + "|" + responseTime);
                 } catch (Exception e) {
                     log.error(RESPONSE_EVENT_PUBLICATION_ERROR + e.getMessage(), e);
                     return false;

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/LogsHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/LogsHandlerTestCase.java
@@ -1,3 +1,21 @@
+/*
+ *   Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 package org.wso2.carbon.apimgt.gateway.handlers;
 
 import org.apache.log4j.MDC;

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/LogsHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/LogsHandlerTestCase.java
@@ -1,0 +1,73 @@
+package org.wso2.carbon.apimgt.gateway.handlers;
+
+import org.apache.log4j.MDC;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+
+import java.util.TreeMap;
+import java.util.UUID;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({LogUtils.class, MDC.class, System.class})
+public class LogsHandlerTestCase {
+
+    @Before
+    public void init() {
+        PowerMockito.mockStatic(LogUtils.class);
+        PowerMockito.mockStatic(MDC.class);
+        PowerMockito.mockStatic(System.class);
+        PowerMockito.when(System.getProperty("enableCorrelationLogs")).thenReturn("true");
+    }
+
+    @Test
+    public void testHandleRequestOutFlow() {
+        MessageContext messageContext = Mockito.mock(Axis2MessageContext.class);
+        org.apache.axis2.context.MessageContext axis2MC =
+                Mockito.mock(org.apache.axis2.context.MessageContext.class);
+        Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MC);
+
+        // For websocket APIs
+        Mockito.when(axis2MC.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS)).thenReturn(null);
+        PowerMockito.when(LogUtils.getTransportHeaders(messageContext)).thenReturn(null);
+        PowerMockito.when(MDC.get(APIConstants.CORRELATION_ID)).thenReturn(null);
+        PowerMockito.when(LogUtils.getAPIName(messageContext)).thenReturn("Chats:v1.0.0");
+        PowerMockito.when(LogUtils.getAPICtx(messageContext)).thenReturn("/chats/1.0.0");
+        PowerMockito.when(LogUtils.getRestMethod(messageContext)).thenReturn(null);
+        PowerMockito.when(LogUtils.getElectedResource(messageContext)).thenReturn(null);
+        PowerMockito.when(LogUtils.getRestReqFullPath(messageContext)).thenReturn("/chats/1.0.0/notifications");
+        PowerMockito.when(messageContext.getMessageID()).thenReturn("urn:uuid:"+ UUID.randomUUID().toString());
+        PowerMockito.when(LogUtils.getResourceCacheKey(messageContext)).thenReturn(null);
+
+        LogsHandler logsHandler = new LogsHandler();
+        Assert.assertTrue(logsHandler.handleResponseOutFlow(messageContext));
+
+        // For normal APIs
+        TreeMap<String, String> treeMap = new TreeMap<>();
+        // since the all requested header values in the code was not available in normal rest API header object,
+        // did not add any values to the map
+
+        PowerMockito.when(axis2MC.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
+                .thenReturn(treeMap);
+        PowerMockito.when(LogUtils.getTransportHeaders(messageContext)).thenReturn(treeMap);
+        String uuid = UUID.randomUUID().toString();
+        PowerMockito.when(MDC.get(APIConstants.CORRELATION_ID)).thenReturn(uuid);
+        PowerMockito.when(LogUtils.getAPIName(messageContext)).thenReturn("PizzaShackAPI:v1.0.0");
+        PowerMockito.when(LogUtils.getAPICtx(messageContext)).thenReturn("/pizzashack/1.0.0");
+        PowerMockito.when(LogUtils.getRestMethod(messageContext)).thenReturn("GET");
+        PowerMockito.when(LogUtils.getElectedResource(messageContext)).thenReturn("/menu");
+        PowerMockito.when(LogUtils.getRestReqFullPath(messageContext)).thenReturn("/pizzashack/1.0.0/menu");
+        PowerMockito.when(messageContext.getMessageID()).thenReturn("urn:uuid:"+uuid);
+        PowerMockito.when(LogUtils.getResourceCacheKey(messageContext)).thenReturn("/pizzashack/1.0.0/1.0.0/menu:GET");
+
+        Assert.assertTrue(logsHandler.handleResponseOutFlow(messageContext));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/LogsHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/LogsHandlerTestCase.java
@@ -25,7 +25,7 @@ public class LogsHandlerTestCase {
         PowerMockito.mockStatic(LogUtils.class);
         PowerMockito.mockStatic(MDC.class);
         PowerMockito.mockStatic(System.class);
-        PowerMockito.when(System.getProperty("enableCorrelationLogs")).thenReturn("true");
+        System.setProperty(APIConstants.ENABLE_CORRELATION_LOGS, "true");
     }
 
     @Test


### PR DESCRIPTION
## Purpose
To fix Websocket APIs are not working when correlation logs are enabled

## Goals
fixes: https://github.com/wso2/product-apim/issues/11836

## Approach
Added validation to check whether the headers are not available.

Git actions: https://github.com/YasasRangika/carbon-apimgt/actions/runs/1529688729