### PR TITLE
Fix failover endpoint certificate is not added to project and not working with choreo-connect backend

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1275,14 +1275,14 @@ public class OASParserUtil {
         }
 
         ArrayNode endpointsArray = objectMapper.createArrayNode();
+        if (primaryEndpoints != null && primaryEndpoints.has(APIConstants.ENDPOINT_URL)) {
+            endpointsArray.add(primaryEndpoints.getString(APIConstants.ENDPOINT_URL));
+        }
         if (endpointsURLs != null) {
             for (int i = 0; i < endpointsURLs.length(); i++) {
                 JSONObject obj = endpointsURLs.getJSONObject(i);
                 endpointsArray.add(obj.getString(APIConstants.ENDPOINT_URL));
             }
-        }
-        if (primaryEndpoints != null && primaryEndpoints.has(APIConstants.ENDPOINT_URL)) {
-            endpointsArray.add(primaryEndpoints.getString(APIConstants.ENDPOINT_URL));
         }
         if (endpointsArray.size() < 1) {
             return null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -662,6 +662,8 @@ public class ExportUtils {
 
         List<String> productionEndpoints;
         List<String> sandboxEndpoints;
+        List<String> productionFailovers;
+        List<String> sandboxFailovers;
         Set<String> uniqueEndpointURLs = new HashSet<>();
         JsonArray endpointCertificatesDetails = new JsonArray();
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -684,8 +686,14 @@ public class ExportUtils {
                     apiDto.getName());
             sandboxEndpoints = getEndpointURLs(endpointConfig, API_DATA_SANDBOX_ENDPOINTS,
                     apiDto.getName());
+            productionFailovers = getEndpointURLs(endpointConfig, APIConstants.ENDPOINT_PRODUCTION_FAILOVERS,
+                    apiDto.getName());
+            sandboxFailovers = getEndpointURLs(endpointConfig, APIConstants.ENDPOINT_SANDBOX_FAILOVERS,
+                    apiDto.getName());
             uniqueEndpointURLs.addAll(productionEndpoints); // Remove duplicate and append result
             uniqueEndpointURLs.addAll(sandboxEndpoints);
+            uniqueEndpointURLs.addAll(productionFailovers);
+            uniqueEndpointURLs.addAll(sandboxFailovers);
 
             for (String url : uniqueEndpointURLs) {
                 JsonArray certificateListOfUrl = getEndpointCertificateContentAndMetaData(tenantId, url,


### PR DESCRIPTION
## Purpose
To fix failover endpoint certificate is not added to the project and not working with the choreo-connect backend.

## Goals
fixes: https://github.com/wso2/product-apim/issues/11856
and
fixes: https://github.com/wso2/product-apim/issues/11982
and
fixes: https://github.com/wso2/product-apim/issues/11946

Git actions: https://github.com/YasasRangika/carbon-apimgt/actions/runs/1557500077