### PR TITLE
Remove un-deployed revision entries from the db

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -1694,7 +1694,7 @@ public interface APIProvider extends APIManager {
      *
      * @param apiId API UUID
      * @param apiRevisionUUID API Revision UUID
-     * @param environment -
+     * @param environment - Un-deployed environment
      * @throws APIManagementException if failed to add APIRevision
      */
     void removeUnDeployedAPIRevision(String apiId, String apiRevisionUUID, String environment) throws APIManagementException;

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -1690,6 +1690,16 @@ public interface APIProvider extends APIManager {
             deployedAPIRevisions) throws APIManagementException;
 
     /**
+     * Adds a new DeployedAPIRevision to an existing API
+     *
+     * @param apiId API UUID
+     * @param apiRevisionUUID API Revision UUID
+     * @param environment -
+     * @throws APIManagementException if failed to add APIRevision
+     */
+    void removeUnDeployedAPIRevision(String apiId, String apiRevisionUUID, String environment) throws APIManagementException;
+
+    /**
      * Update the displayOnDevportal field in an existing deployments of an API
      *
      * @param apiId API UUID

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/DeployedAPIRevision.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/DeployedAPIRevision.java
@@ -28,6 +28,14 @@ public class DeployedAPIRevision implements Serializable {
     private String vhost;
     private String deployedTime;
 
+    public DeployedAPIRevision() {
+    }
+
+    public DeployedAPIRevision(String revisionUUID, String deployment) {
+        this.revisionUUID = revisionUUID;
+        this.deployment = deployment;
+    }
+
     public int getId() {
         return id;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/UnDeployedAPIRevision.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/UnDeployedAPIRevision.java
@@ -1,0 +1,32 @@
+package org.wso2.carbon.apimgt.api.model;
+
+public class UnDeployedAPIRevision {
+    private static final long serialVersionUID = 1L;
+    private String apiUUID;
+    private String revisionUUID;
+    private String environment;
+
+    public String getApiUUID() {
+        return apiUUID;
+    }
+
+    public void setApiUUID(String apiUUID) {
+        this.apiUUID = apiUUID;
+    }
+
+    public String getRevisionUUID() {
+        return revisionUUID;
+    }
+
+    public void setRevisionUUID(String revisionUUID) {
+        this.revisionUUID = revisionUUID;
+    }
+
+    public String getEnvironment() {
+        return environment;
+    }
+
+    public void setEnvironment(String environment) {
+        this.environment = environment;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -8722,6 +8722,15 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     }
 
     @Override
+    public void removeUnDeployedAPIRevision(String apiId, String apiRevisionUUID,
+                                            String environment)
+            throws APIManagementException {
+        Set<DeployedAPIRevision> environmentsToRemove = new HashSet<>();
+        environmentsToRemove.add(new DeployedAPIRevision(apiRevisionUUID, environment));
+        apiMgtDAO.removeDeployedAPIRevision(apiId, environmentsToRemove);
+    }
+
+    @Override
     public void updateAPIDisplayOnDevportal(String apiId, String apiRevisionId, APIRevisionDeployment apiRevisionDeployment)
             throws APIManagementException {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/ApisApi.java
@@ -64,10 +64,10 @@ ApisApiService delegate = new ApisApiServiceImpl();
     }
 
     @POST
-    @Path("/un-deploy-revision")
+    @Path("/undeployed-revision")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Un-deploy Revision", notes = "Un-deploy a revision", response = Void.class, tags={ "Un-Deployed API Revisions" })
+    @ApiOperation(value = "Remove undeployed revision", notes = "Remove undeployed Revision entry from the database", response = Void.class, tags={ "UnDeployed API Revision" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "Fetch un-deployed revision", response = Void.class),
         @ApiResponse(code = 200, message = "", response = Void.class) })

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/ApisApi.java
@@ -4,6 +4,7 @@ import org.wso2.carbon.apimgt.internal.service.dto.APIListDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.DeployedAPIRevisionDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.ErrorDTO;
 import java.util.List;
+import org.wso2.carbon.apimgt.internal.service.dto.UnDeployedAPIRevisionDTO;
 import org.wso2.carbon.apimgt.internal.service.ApisApiService;
 import org.wso2.carbon.apimgt.internal.service.impl.ApisApiServiceImpl;
 import org.wso2.carbon.apimgt.api.APIManagementException;
@@ -54,11 +55,23 @@ ApisApiService delegate = new ApisApiServiceImpl();
     @Path("/deployed-revisions")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Deploy Revision", notes = "Deploy a revision ", response = Void.class, tags={ "API Revisions" })
+    @ApiOperation(value = "Deploy Revision", notes = "Deploy a revision ", response = Void.class, tags={ "API Revisions",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "Created. ", response = Void.class),
         @ApiResponse(code = 200, message = "", response = Void.class) })
     public Response deployedAPIRevision(@ApiParam(value = "Notification event payload" ) List<DeployedAPIRevisionDTO> deployedAPIRevisionDTOList) throws APIManagementException{
         return delegate.deployedAPIRevision(deployedAPIRevisionDTOList, securityContext);
+    }
+
+    @POST
+    @Path("/un-deploy-revision")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Un-deploy Revision", notes = "Un-deploy a revision", response = Void.class, tags={ "Un-Deployed API Revisions" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Fetch un-deployed revision", response = Void.class),
+        @ApiResponse(code = 200, message = "", response = Void.class) })
+    public Response unDeployedAPIRevision(@ApiParam(value = "Notification event payload" ) UnDeployedAPIRevisionDTO unDeployedAPIRevisionDTO) throws APIManagementException{
+        return delegate.unDeployedAPIRevision(unDeployedAPIRevisionDTO, securityContext);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/ApisApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/ApisApiService.java
@@ -13,6 +13,7 @@ import org.wso2.carbon.apimgt.internal.service.dto.APIListDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.DeployedAPIRevisionDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.ErrorDTO;
 import java.util.List;
+import org.wso2.carbon.apimgt.internal.service.dto.UnDeployedAPIRevisionDTO;
 
 import java.util.List;
 
@@ -25,4 +26,5 @@ import javax.ws.rs.core.SecurityContext;
 public interface ApisApiService {
       public Response apisGet(String xWSO2Tenant, String apiId, String context, String version, String gatewayLabel, String accept, MessageContext messageContext) throws APIManagementException;
       public Response deployedAPIRevision(List<DeployedAPIRevisionDTO> deployedAPIRevisionDTOList, MessageContext messageContext) throws APIManagementException;
+      public Response unDeployedAPIRevision(UnDeployedAPIRevisionDTO unDeployedAPIRevisionDTO, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/dto/UnDeployedAPIRevisionDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/dto/UnDeployedAPIRevisionDTO.java
@@ -62,7 +62,7 @@ public class UnDeployedAPIRevisionDTO   {
   }
 
   
-  @ApiModelProperty(example = "default", value = "")
+  @ApiModelProperty(example = "Default", value = "")
   @JsonProperty("environment")
  @Size(min=0,max=255)  public String getEnvironment() {
     return environment;

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/dto/UnDeployedAPIRevisionDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/dto/UnDeployedAPIRevisionDTO.java
@@ -1,0 +1,117 @@
+package org.wso2.carbon.apimgt.internal.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+
+
+public class UnDeployedAPIRevisionDTO   {
+  
+    private String apiUUID = null;
+    private String revisionUUID = null;
+    private String environment = null;
+
+  /**
+   **/
+  public UnDeployedAPIRevisionDTO apiUUID(String apiUUID) {
+    this.apiUUID = apiUUID;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "c26b2b9b-4632-4ca4-b6f3-521c8863990c", value = "")
+  @JsonProperty("apiUUID")
+ @Size(min=0,max=255)  public String getApiUUID() {
+    return apiUUID;
+  }
+  public void setApiUUID(String apiUUID) {
+    this.apiUUID = apiUUID;
+  }
+
+  /**
+   **/
+  public UnDeployedAPIRevisionDTO revisionUUID(String revisionUUID) {
+    this.revisionUUID = revisionUUID;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "c26b2b9b-4632-4ca4-b6f3-521c8863990c", value = "")
+  @JsonProperty("revisionUUID")
+ @Size(min=0,max=255)  public String getRevisionUUID() {
+    return revisionUUID;
+  }
+  public void setRevisionUUID(String revisionUUID) {
+    this.revisionUUID = revisionUUID;
+  }
+
+  /**
+   **/
+  public UnDeployedAPIRevisionDTO environment(String environment) {
+    this.environment = environment;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "default", value = "")
+  @JsonProperty("environment")
+ @Size(min=0,max=255)  public String getEnvironment() {
+    return environment;
+  }
+  public void setEnvironment(String environment) {
+    this.environment = environment;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UnDeployedAPIRevisionDTO unDeployedAPIRevision = (UnDeployedAPIRevisionDTO) o;
+    return Objects.equals(apiUUID, unDeployedAPIRevision.apiUUID) &&
+        Objects.equals(revisionUUID, unDeployedAPIRevision.revisionUUID) &&
+        Objects.equals(environment, unDeployedAPIRevision.environment);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(apiUUID, revisionUUID, environment);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class UnDeployedAPIRevisionDTO {\n");
+    
+    sb.append("    apiUUID: ").append(toIndentedString(apiUUID)).append("\n");
+    sb.append("    revisionUUID: ").append(toIndentedString(revisionUUID)).append("\n");
+    sb.append("    environment: ").append(toIndentedString(environment)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/ApisApiServiceImpl.java
@@ -133,6 +133,6 @@ public class ApisApiServiceImpl implements ApisApiService {
         APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
         apiProvider.removeUnDeployedAPIRevision(unDeployedAPIRevisionDTO.getApiUUID(), unDeployedAPIRevisionDTO.getRevisionUUID(),
                 unDeployedAPIRevisionDTO.getEnvironment());
-        return null;
+        return Response.ok().build();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/ApisApiServiceImpl.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.apimgt.internal.service.ApisApiService;
 import org.wso2.carbon.apimgt.internal.service.dto.APIListDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.DeployedAPIRevisionDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.DeployedEnvInfoDTO;
+import org.wso2.carbon.apimgt.internal.service.dto.UnDeployedAPIRevisionDTO;
 import org.wso2.carbon.apimgt.internal.service.utils.SubscriptionValidationDataUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
@@ -125,5 +126,13 @@ public class ApisApiServiceImpl implements ApisApiService {
         }
 
         return Response.ok().build();
+    }
+
+    @Override
+    public Response unDeployedAPIRevision(UnDeployedAPIRevisionDTO unDeployedAPIRevisionDTO, MessageContext messageContext) throws APIManagementException {
+        APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
+        apiProvider.removeUnDeployedAPIRevision(unDeployedAPIRevisionDTO.getApiUUID(), unDeployedAPIRevisionDTO.getRevisionUUID(),
+                unDeployedAPIRevisionDTO.getEnvironment());
+        return null;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/resources/api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/resources/api.yaml
@@ -584,14 +584,14 @@ paths:
         default:
           $ref: '#/definitions/Error'
   #--------------------------------------------
-  # Un-Deployed revision information
+  # UnDeployed revision information
   #--------------------------------------------
-  /apis/un-deploy-revision:
+  /apis/undeployed-revision:
     post:
       tags:
-        - Un-Deployed API Revisions
-      summary: Un-deploy Revision
-      description: Un-deploy a revision
+        - UnDeployed API Revision
+      summary: Remove undeployed revision
+      description: Remove undeployed Revision entry from the database
       operationId: unDeployedAPIRevision
       parameters:
         - name: unDeployedAPIRevisionDTO
@@ -852,7 +852,7 @@ definitions:
         items:
           $ref: '#/definitions/DeployedEnvInfo'
   UnDeployedAPIRevision:
-    title: Un-Deployed revision information
+    title: UnDeployed revision information
     properties:
       apiUUID:
         maxLength: 255
@@ -868,7 +868,7 @@ definitions:
         maxLength: 255
         minLength: 0
         type: string
-        example: default
+        example: Default
   DeployedEnvInfo:
     title: Environment information
     properties:

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/resources/api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/resources/api.yaml
@@ -583,6 +583,27 @@ paths:
             Created.
         default:
           $ref: '#/definitions/Error'
+  #--------------------------------------------
+  # Un-Deployed revision information
+  #--------------------------------------------
+  /apis/un-deploy-revision:
+    post:
+      tags:
+        - Un-Deployed API Revisions
+      summary: Un-deploy Revision
+      description: Un-deploy a revision
+      operationId: unDeployedAPIRevision
+      parameters:
+        - name: unDeployedAPIRevisionDTO
+          in: body
+          description: 'Notification event payload'
+          schema:
+            $ref: '#/definitions/UnDeployedAPIRevision'
+      responses:
+        200:
+          description: Fetch un-deployed revision
+        default:
+          $ref: '#/definitions/Error'
   /ga-config:
     get:
       summary: Get Google analytics config related to tenant.
@@ -830,6 +851,24 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/DeployedEnvInfo'
+  UnDeployedAPIRevision:
+    title: Un-Deployed revision information
+    properties:
+      apiUUID:
+        maxLength: 255
+        minLength: 0
+        type: string
+        example: c26b2b9b-4632-4ca4-b6f3-521c8863990c
+      revisionUUID:
+        maxLength: 255
+        minLength: 0
+        type: string
+        example: c26b2b9b-4632-4ca4-b6f3-521c8863990c
+      environment:
+        maxLength: 255
+        minLength: 0
+        type: string
+        example: default
   DeployedEnvInfo:
     title: Environment information
     properties:


### PR DESCRIPTION
## Purpose
> API provider throws exceptions when un-deploy a revision , but those exceptions doesn't catch from API service implementation.Purpose of this PR is to catching those exceptions.
FIX : https://github.com/wso2-enterprise/choreo/issues/9175