### PR TITLE
Remove feature flag check and additional check on JWT's org claim

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/utils/JWTUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/utils/JWTUtil.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import org.wso2.uri.template.URITemplateException;
 import java.text.ParseException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,16 +76,13 @@ public class JWTUtil {
                 if (log.isDebugEnabled()) {
                     log.debug("$" + ENV_ORG_BASED_TOKEN_FEATURE + " is enabled.");
                 }
-                // check organization claim and orgId
-                String orgClaim = signedJWTInfo.getJwtClaimsSet().getStringClaim("organization");
-                if (!orgId.equals(orgClaim)) {
-                    log.error("OrgId and organization claim mismatch!");
-                    return false;
-                }
             } else {
                 scopes = java.util.Arrays.stream(scopes).filter(s -> s.contains(orgId))
                         .map(s -> s.replace(APIConstants.URN_CHOREO + orgId + ":", ""))
                         .toArray(size -> new String[size]);
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Scopes received from JWT: $" + Arrays.toString(scopes));
             }
             oauthTokenInfo.setScopes(scopes);
             if (validateScopes(message, oauthTokenInfo)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/utils/JWTUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/utils/JWTUtil.java
@@ -50,7 +50,6 @@ import java.util.Set;
 public class JWTUtil {
 
     private static final Log log = LogFactory.getLog(JWTUtil.class);
-    private static final String ENV_ORG_BASED_TOKEN_FEATURE = "FEATURE_FLAG_ORG_BASED_TOKEN_ENABLED";
     private static final String SUPER_TENANT_SUFFIX =
             APIConstants.EMAIL_DOMAIN_SEPARATOR + MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 
@@ -72,9 +71,9 @@ public class JWTUtil {
         if (scopeClaim != null) {
             String orgId = (String) message.get(RestApiConstants.ORG_ID);
             String[] scopes = scopeClaim.split(APIConstants.JwtTokenConstants.SCOPE_DELIMITER);
-            if (isOrgBasedTokenFeatureEnabled()) {
+            if (!isOrgIdAppendedInScopes(scopes, orgId)) {
                 if (log.isDebugEnabled()) {
-                    log.debug("$" + ENV_ORG_BASED_TOKEN_FEATURE + " is enabled.");
+                    log.debug("Org ID: $" + orgId + " not appended in scopes.");
                 }
             } else {
                 scopes = java.util.Arrays.stream(scopes).filter(s -> s.contains(orgId))
@@ -207,11 +206,13 @@ public class JWTUtil {
         return false;
     }
 
-    private static boolean isOrgBasedTokenFeatureEnabled() {
-        String featureEnabled = System.getenv(ENV_ORG_BASED_TOKEN_FEATURE);
-        if (featureEnabled == null) {
-            return false;
+    public static boolean isOrgIdAppendedInScopes(String[] scopes, String orgId) {
+        boolean containsOrgId = false;
+        for (String scope : scopes) {
+            if (scope.contains(APIConstants.URN_CHOREO + orgId)) {
+                containsOrgId = true;
+            }
         }
-        return Boolean.parseBoolean(featureEnabled);
+        return containsOrgId;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
@@ -49,6 +49,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.ParseException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -146,16 +147,13 @@ public class OAuthJwtAuthenticatorImpl extends AbstractOAuthAuthenticator {
                 if (log.isDebugEnabled()) {
                     log.debug("$" + ENV_ORG_BASED_TOKEN_FEATURE + " is enabled.");
                 }
-                // check organization claim and orgId
-                String orgClaim = signedJWTInfo.getJwtClaimsSet().getStringClaim("organization");
-                if (!orgId.equals(orgClaim)) {
-                    log.error("OrgId and organization claim mismatch!");
-                    return false;
-                }
             } else {
                 scopes = java.util.Arrays.stream(scopes).filter(s -> s.contains(orgId))
                         .map(s -> s.replace(APIConstants.URN_CHOREO + orgId + ":", ""))
                         .toArray(size -> new String[size]);
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Scopes received in JWT: $" + Arrays.toString(scopes));
             }
             oauthTokenInfo.setScopes(scopes);
 


### PR DESCRIPTION
### Description
This PR contains following changes:

1. Remove additional check on JWT's org claim. This is done since now in the JWT we receive org handle instead of org UUID.
2. To push this as non breaking change, removed feature flag check and added a check to verify whether scope contains org ID to get the similar behaviour. 

Sample JWT payload
```
{
  "sub": "e9fe9002-6623-4d63-acfe-e07c5d8bcf76",
  "aut": "APPLICATION_USER",
  "aud": "Wxqy0liCfLBsdpXOhkcxZz6uLPka",
  "nbf": 1639120199,
  "azp": "Wxqy0liCfLBsdpXOhkcxZz6uLPka",
  "scope": "apim:admin apim:api_manage apim:subscription_manage apim:tier_manage",
  "organization": "erandiganepola",
  "iss": "https://apim.preview-dv.choreo.dev:443/oauth2/token",
  "organizations": [
    "19bfb6f6-13db-44bb-99a5-ccfd478f4301",
    "f79950b4-f28b-4dc7-a41a-5e50fac6a9fe"
  ],
  "exp": 1639292999,
  "iat": 1639120199,
  "jti": "d85b0636-f871-4eab-813c-687d06c5a92e"
}
```

Relevant master branch PR - https://github.com/wso2/carbon-apimgt/pull/10881