### PR TITLE
Make max revision count configurable in APIM

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -103,6 +103,8 @@ public final class APIConstants {
     public static final String API_TENANT_CONF_MEDIA_TYPE = "tenant-config";
     public static final String TENANT_CONFIG_CACHE_NAME = "tenantConfigCache";
 
+    public static final String API_MAX_REVISION_COUNT_PROPERTY_NAME = "ApiMaxRevisionCount";
+
     public static final String RESOURCE_FOLDER_LOCATION = "repository" + File.separator + "resources";
 
     public static final String API_TENANT_CONF_ENABLE_MONITZATION_KEY = "EnableMonetization";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -8676,7 +8676,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     @Override
     public String addAPIRevision(APIRevision apiRevision, String organization) throws APIManagementException {
         int revisionCountPerAPI = apiMgtDAO.getRevisionCountByAPI(apiRevision.getApiUUID());
-        if (revisionCountPerAPI > 4) {
+        int maxRevisionCount = getMaxRevisionCount(organization);
+        if (revisionCountPerAPI >= maxRevisionCount) {
             String errorMessage = "Maximum number of revisions per API has reached. " +
                     "Need to remove stale revision to create a new Revision for API with API UUID:"
                     + apiRevision.getApiUUID();
@@ -8731,6 +8732,22 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             }
         }
         return revisionUUID;
+    }
+
+    /**
+     * Util method to read and return the max revision count per API, using the tenant configs
+     *
+     * @param organization organization name
+     * @return max revision count per API
+     * @throws APIManagementException
+     */
+    private int getMaxRevisionCount(String organization) throws APIManagementException {
+        JSONObject jsonObject = APIUtil.getTenantConfig(organization);
+        if (jsonObject.containsKey(APIConstants.API_MAX_REVISION_COUNT_PROPERTY_NAME)){
+            return Integer.valueOf(jsonObject.get(APIConstants.API_MAX_REVISION_COUNT_PROPERTY_NAME).toString());
+        } else {
+            return 5;
+        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
@@ -3859,6 +3859,7 @@ public class APIProviderImplTest {
         Mockito.when(APIUtil.getAPIPath(apiId)).thenReturn(apiPath);
         PowerMockito.when(apiPersistenceInstance.addAPIRevision(any(Organization.class), Mockito.anyString(), Mockito.anyInt()))
                 .thenReturn("b55e0fc3-9829-4432-b99e-02056dc91838");
+        Mockito.when(APIUtil.getTenantConfig(Mockito.anyString())).thenReturn(new JSONObject());
         try {
             apiProvider.addAPIRevision(apiRevision, superTenantDomain);
         } catch (Exception e) {
@@ -3895,6 +3896,7 @@ public class APIProviderImplTest {
 
         PowerMockito.when(apiPersistenceInstance.addAPIRevision(any(Organization.class), Mockito.anyString(), Mockito.anyInt()))
                 .thenReturn("b55e0fc3-9829-4432-b99e-02056dc91838");
+        Mockito.when(APIUtil.getTenantConfig(Mockito.anyString())).thenReturn(new JSONObject());
         try {
             apiProvider.addAPIRevision(apiRevision, superTenantDomain);
             apiProvider.getAPIRevision("b55e0fc3-9829-4432-b99e-02056dc91838");
@@ -3930,6 +3932,7 @@ public class APIProviderImplTest {
         Mockito.when(apimgtDAO.getMostRecentRevisionId(Mockito.anyString())).thenReturn(0);
         Mockito.when(APIUtil.getAPIIdentifierFromUUID(Mockito.anyString())).thenReturn(apiId);
         Mockito.when(APIUtil.getAPIPath(apiId)).thenReturn(apiPath);
+        Mockito.when(APIUtil.getTenantConfig(Mockito.anyString())).thenReturn(new JSONObject());
         PowerMockito.when(apiPersistenceInstance.addAPIRevision(any(Organization.class), Mockito.anyString(), Mockito.anyInt()))
                 .thenReturn("b55e0fc3-9829-4432-b99e-02056dc91838");
         try {
@@ -3968,6 +3971,7 @@ public class APIProviderImplTest {
         Mockito.when(apimgtDAO.getMostRecentRevisionId(Mockito.anyString())).thenReturn(0);
         Mockito.when(APIUtil.getAPIIdentifierFromUUID(Mockito.anyString())).thenReturn(apiId);
         Mockito.when(APIUtil.getAPIPath(apiId)).thenReturn(apiPath);
+        Mockito.when(APIUtil.getTenantConfig(Mockito.anyString())).thenReturn(new JSONObject());
         PowerMockito.when(apiPersistenceInstance.addAPIRevision(any(Organization.class), Mockito.anyString(), Mockito.anyInt()))
                 .thenReturn("b55e0fc3-9829-4432-b99e-02056dc91838");
         try {
@@ -4012,6 +4016,7 @@ public class APIProviderImplTest {
         Mockito.when(apimgtDAO.getMostRecentRevisionId(Mockito.anyString())).thenReturn(0);
         Mockito.when(APIUtil.getAPIIdentifierFromUUID(Mockito.anyString())).thenReturn(apiId);
         Mockito.when(APIUtil.getAPIPath(apiId)).thenReturn(apiPath);
+        Mockito.when(APIUtil.getTenantConfig(Mockito.anyString())).thenReturn(new JSONObject());
         PowerMockito.when(apiPersistenceInstance.addAPIRevision(any(Organization.class), Mockito.anyString(), Mockito.anyInt()))
                 .thenReturn("b55e0fc3-9829-4432-b99e-02056dc91838");
         try {


### PR DESCRIPTION
### Purpose
This PR introduces the relevant changes for $subject. 
Fixes for : https://github.com/wso2-enterprise/choreo/issues/9537

### Approach
Configurations for max revision count can be added to the `tenant-conf.json` file as follows.
```JSON
{
  "EnableMonetization" : false,
  "EnableRecommendation" : false,
  "IsUnlimitedTierPaid" : false,
  "ApiMaxRevisionCount" : 34,
  "ExtensionHandlerPosition": "bottom",
  "RESTAPIScopes": {
```