### PR TITLE
Fix artifact retrieval issue when gateway worker node is started first

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
@@ -92,7 +92,8 @@ public class InMemoryAPIDeployer {
             GatewayAPIDTO gatewayAPIDTO = retrieveArtifact(apiId, gatewayLabels);
             if (gatewayAPIDTO != null) {
                 APIGatewayAdmin apiGatewayAdmin = new APIGatewayAdmin();
-                MessageContext.setCurrentMessageContext(org.wso2.carbon.apimgt.gateway.utils.GatewayUtils.createAxis2MessageContext());
+                MessageContext.setCurrentMessageContext(
+                        org.wso2.carbon.apimgt.gateway.utils.GatewayUtils.createAxis2MessageContext());
                 unDeployAPI(apiGatewayAdmin, gatewayEvent);
                 apiGatewayAdmin.deployAPI(gatewayAPIDTO);
                 addDeployedCertificatesToAPIAssociation(gatewayAPIDTO);
@@ -167,8 +168,8 @@ public class InMemoryAPIDeployer {
                     MessageContext.setCurrentMessageContext(org.wso2.carbon.apimgt.gateway.utils.GatewayUtils.createAxis2MessageContext());
                     PrivilegedCarbonContext.startTenantFlow();
                     PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
-                    List<String> gatewayRuntimeArtifacts =
-                            ServiceReferenceHolder.getInstance().getArtifactRetriever().retrieveAllArtifacts(encodedString, tenantDomain);
+                    List<String> gatewayRuntimeArtifacts = ServiceReferenceHolder.getInstance().getArtifactRetriever()
+                            .retrieveAllArtifacts(encodedString, tenantDomain);
                     if (gatewayRuntimeArtifacts.size() == 0) {
                         return true;
                     }
@@ -201,9 +202,9 @@ public class InMemoryAPIDeployer {
                         return false;
                     }
                 } catch (ArtifactSynchronizerException | AxisFault e) {
-                    String msg = "Error  deploying APIs to the Gateway ";
+                    String msg = "Error deploying APIs to the Gateway ";
                     log.error(msg, e);
-                    throw new ArtifactSynchronizerException(msg, e);
+                    return false;
                 } finally {
                     MessageContext.destroyCurrentMessageContext();
                     PrivilegedCarbonContext.endTenantFlow();


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/product-apim/issues/12126

This PR fixes the issue where the API invocations result in a 404 response when the `Gateway Profile` is started first.

## RCA

The artifact retrieval step fails with an artifact synchronization exception when the gateway profile is started first. This is encountered with the inability to retrieve the existing artifacts since the control plane is not up yet. In order to fix the aforementioned issue, a delaying factor is introduced to the thread that is trying to retrieve the artifacts