### PR TITLE
Upgrade json-smart dependency to 2.4.7

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -426,6 +426,10 @@
             <groupId>com.damnhandy.wso2</groupId>
             <artifactId>handy-uri-templates</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -2035,7 +2035,7 @@
         <httpcomponents.version>4.5.10</httpcomponents.version>
         <commons-codec.version>1.14</commons-codec.version>
         <com.nimbusds.wso2.version>7.3.0.wso2v1</com.nimbusds.wso2.version>
-        <json-smart.version>2.3</json-smart.version>
+        <json-smart.version>2.4.7</json-smart.version>
         <org.apache.velocity.version>1.7</org.apache.velocity.version>
         <org.slf4j.version>1.7.0</org.slf4j.version>
         <slf4j.api.version>1.7.29</slf4j.api.version>


### PR DESCRIPTION
This PR upgrades `json-smart` dependency to `2.4.7`.