### PR TITLE
Bump Rest API versions

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/interceptors/URLValidationInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/interceptors/URLValidationInterceptor.java
@@ -35,7 +35,7 @@ public class URLValidationInterceptor extends AbstractPhaseInterceptor<Message> 
     private static final Log log = LogFactory.getLog(URLValidationInterceptor.class);
     private static String majorVersion = "v2";
     //TODO: Get latest version from swagger
-    private static String latestVersion = "v2";
+    private static String latestVersion = "v2.1";
     private String pathSeparator = "/";
     private final String BASE_PATH = "org.apache.cxf.message.Message.BASE_PATH";
     private final String PATH_INFO = "org.apache.cxf.message.Message.PATH_INFO";


### PR DESCRIPTION
This PR will bump publisher, devportal, admin, gateway rest API version to v2.1 version and the rest APIs are still supported with relevant major version (v2)