### PR TITLE
Refactoring codebase to fit with latest graphql-java version

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandler.java
@@ -103,7 +103,7 @@ public class GraphQLAPIHandler extends AbstractHandler {
                 } else {
                     RelayUtils.buildMessage(axis2MC);
                     OMElement body = axis2MC.getEnvelope().getBody().getFirstElement();
-                    if (body != null && body.getChildrenWithName(QName.valueOf(QUERY_PAYLOAD_STRING)) != null){
+                    if (body != null && body.getFirstChildWithName(QName.valueOf(QUERY_PAYLOAD_STRING)) != null){
                         payload = body.getFirstChildWithName(QName.valueOf(QUERY_PAYLOAD_STRING)).getText();
                     } else {
                         if (log.isDebugEnabled()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandler.java
@@ -22,6 +22,8 @@ import graphql.language.Document;
 import graphql.language.OperationDefinition;
 import graphql.parser.InvalidSyntaxException;
 import graphql.parser.Parser;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLType;
 import graphql.validation.Validator;
 import org.apache.axiom.om.OMElement;
@@ -164,7 +166,6 @@ public class GraphQLAPIHandler extends AbstractHandler {
      * @param messageContext message context of the request
      */
     private void supportForBasicAndAuthentication(MessageContext messageContext) {
-        ArrayList<String> roleArrayList = new ArrayList<>();
         @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
         HashMap<String, String> operationThrottlingMappingList = new HashMap<>();
         @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
@@ -175,56 +176,37 @@ public class GraphQLAPIHandler extends AbstractHandler {
 
         if (graphQLSchemaDTO.getGraphQLSchema() != null) {
             Set<GraphQLType> additionalTypes = graphQLSchemaDTO.getGraphQLSchema().getAdditionalTypes();
-            for (GraphQLType additionalType : additionalTypes) {
-                if (additionalType.getName().startsWith(APIConstants.GRAPHQL_ADDITIONAL_TYPE_PREFIX)) {
-                    String[] additionalTypeNameArray = additionalType.getName().split("_", 2);
-                    String additionalTypeName;
-                    if (additionalTypeNameArray.length > 1) {
-                        additionalTypeName = additionalTypeNameArray[1];
-                    } else {
-                        additionalTypeName = additionalTypeNameArray[0];
-                    }
-                    String base64DecodedAdditionalType = new String(Base64.getUrlDecoder().decode(additionalTypeName));
-                    for (GraphQLType type : additionalType.getChildren()) {
-                        if (additionalType.getName().contains(APIConstants.SCOPE_ROLE_MAPPING)) {
-                            String base64DecodedURLRole = new String(Base64.getUrlDecoder().decode(type.getName()));
-                            roleArrayList = new ArrayList<>();
-                            roleArrayList.add(base64DecodedURLRole);
-                        } else if (additionalType.getName().contains(APIConstants.SCOPE_OPERATION_MAPPING)) {
-                            String base64DecodedURLScope = new String(Base64.getUrlDecoder().decode(type.getName()));
-                            operationScopeMappingList.put(base64DecodedAdditionalType, base64DecodedURLScope);
-                            if (log.isDebugEnabled()) {
-                                log.debug("Added operation " + base64DecodedAdditionalType + "with scope "
-                                        + base64DecodedURLScope);
-                            }
-                        } else if (additionalType.getName().contains(APIConstants.OPERATION_THROTTLING_MAPPING)) {
-                            String base64DecodedURLThrottlingTier = new String(Base64.getUrlDecoder().decode(type.getName()));
-                            operationThrottlingMappingList.put(base64DecodedAdditionalType, base64DecodedURLThrottlingTier);
-                            if (log.isDebugEnabled()) {
-                                log.debug("Added operation " + base64DecodedAdditionalType + "with throttling "
-                                        + base64DecodedURLThrottlingTier);
-                            }
-
-                        } else if (additionalType.getName().contains(APIConstants.OPERATION_AUTH_SCHEME_MAPPING)) {
-                            boolean isSecurityEnabled = true;
-                            if (APIConstants.OPERATION_SECURITY_DISABLED.equalsIgnoreCase(type.getName())) {
-                                isSecurityEnabled = false;
-                            }
-                            operationAuthSchemeMappingList.put(base64DecodedAdditionalType, isSecurityEnabled);
-                            if (log.isDebugEnabled()) {
-                                log.debug("Added operation " + base64DecodedAdditionalType + "with security "
-                                        + isSecurityEnabled);
-                            }
-
-                        } else if (additionalType.getName().contains(APIConstants.GRAPHQL_ACCESS_CONTROL_POLICY)) {
-                            graphQLAccessControlPolicy = new String(Base64.getUrlDecoder().decode(type.getName()));
+            for (Object additionalType : additionalTypes.toArray()) {
+                if (additionalType instanceof GraphQLObjectType) {
+                    String additionalTypeName = ((GraphQLObjectType) additionalType).getName();
+                    if (additionalTypeName.startsWith(APIConstants.GRAPHQL_ADDITIONAL_TYPE_PREFIX)) {
+                        ArrayList<String> roleArrayList = new ArrayList<>();
+                        String[] additionalTypeNameArray = additionalTypeName.split("_", 2);
+                        String typeValue;
+                        if (additionalTypeNameArray.length > 1) {
+                            typeValue = additionalTypeNameArray[1];
+                        } else {
+                            typeValue = additionalTypeNameArray[0];
                         }
-                    }
-                    if (!roleArrayList.isEmpty()) {
-                        scopeRoleMappingList.put(base64DecodedAdditionalType, roleArrayList);
-                        if (log.isDebugEnabled()) {
-                            log.debug("Added scope " + base64DecodedAdditionalType + "with role list "
-                                    + String.join(",", roleArrayList));
+
+                        String base64DecodedTypeValue = new String(Base64.getUrlDecoder().decode(typeValue));
+                        for (GraphQLFieldDefinition fieldDefinition : ((GraphQLObjectType) additionalType)
+                                .getFieldDefinitions()) {
+                            if (additionalTypeName.contains(APIConstants.GRAPHQL_ACCESS_CONTROL_POLICY)) {
+                                graphQLAccessControlPolicy = new String(
+                                        Base64.getUrlDecoder().decode(fieldDefinition.getName()));
+                            }
+                            // Fill in each list according to the relevant field definition
+                            setMappingList(additionalTypeName, base64DecodedTypeValue, fieldDefinition,
+                                    operationThrottlingMappingList, operationAuthSchemeMappingList,
+                                    operationScopeMappingList, roleArrayList);
+                        }
+                        if (!roleArrayList.isEmpty()) {
+                            scopeRoleMappingList.put(base64DecodedTypeValue, roleArrayList);
+                            if (log.isDebugEnabled()) {
+                                log.debug("Added scope " + base64DecodedTypeValue + "with role list " + String
+                                        .join(",", roleArrayList));
+                            }
                         }
                     }
                 }
@@ -238,6 +220,39 @@ public class GraphQLAPIHandler extends AbstractHandler {
         messageContext.setProperty(APIConstants.GRAPHQL_ACCESS_CONTROL_POLICY, graphQLAccessControlPolicy);
         messageContext.setProperty(APIConstants.API_TYPE, GRAPHQL_API);
         messageContext.setProperty(APIConstants.GRAPHQL_SCHEMA, graphQLSchemaDTO.getGraphQLSchema());
+    }
+
+    private void setMappingList(String additionalTypeName, String base64DecodedTypeValue,
+            GraphQLFieldDefinition fieldDefinition, HashMap<String, String> operationThrottlingMappingList,
+            HashMap<String, Boolean> operationAuthSchemeMappingList, HashMap<String, String> operationScopeMappingList,
+            ArrayList<String> roleArrayList) {
+
+        String base64DecodedURLTypeName = new String(Base64.getUrlDecoder().decode(fieldDefinition.getName()));
+        if (additionalTypeName.contains(APIConstants.SCOPE_ROLE_MAPPING)) {
+            roleArrayList.add(base64DecodedURLTypeName);
+            if (log.isDebugEnabled()) {
+                log.debug("Added scope " + base64DecodedTypeValue + "with role " + base64DecodedURLTypeName);
+            }
+        } else if (additionalTypeName.contains(APIConstants.SCOPE_OPERATION_MAPPING)) {
+            operationScopeMappingList.put(base64DecodedTypeValue, base64DecodedURLTypeName);
+            if (log.isDebugEnabled()) {
+                log.debug("Added operation " + base64DecodedTypeValue + "with scope " + base64DecodedURLTypeName);
+            }
+        } else if (additionalTypeName.contains(APIConstants.OPERATION_THROTTLING_MAPPING)) {
+            operationThrottlingMappingList.put(base64DecodedTypeValue, base64DecodedURLTypeName);
+            if (log.isDebugEnabled()) {
+                log.debug("Added operation " + base64DecodedTypeValue + "with throttling " + base64DecodedURLTypeName);
+            }
+        } else if (additionalTypeName.contains(APIConstants.OPERATION_AUTH_SCHEME_MAPPING)) {
+            boolean isSecurityEnabled = true;
+            if (APIConstants.OPERATION_SECURITY_DISABLED.equalsIgnoreCase(fieldDefinition.getName())) {
+                isSecurityEnabled = false;
+            }
+            operationAuthSchemeMappingList.put(base64DecodedTypeValue, isSecurityEnabled);
+            if (log.isDebugEnabled()) {
+                log.debug("Added operation " + base64DecodedTypeValue + "with security " + isSecurityEnabled);
+            }
+        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/analyzer/SubscriptionAnalyzer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/analyzer/SubscriptionAnalyzer.java
@@ -18,6 +18,8 @@
 package org.wso2.carbon.apimgt.gateway.handlers.graphQL.analyzer;
 
 import graphql.analysis.FieldComplexityCalculator;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import org.apache.commons.logging.Log;
@@ -120,12 +122,12 @@ public class SubscriptionAnalyzer extends QueryAnalyzer {
         String graphQLAccessControlPolicy;
         Set<GraphQLType> additionalTypes = getSchema().getAdditionalTypes();
         for (GraphQLType additionalType : additionalTypes) {
-            if (additionalType.getName().startsWith(APIConstants.GRAPHQL_ADDITIONAL_TYPE_PREFIX)) {
-                for (GraphQLType type : additionalType.getChildren()) {
-                    if (additionalType.getName().contains(APIConstants.GRAPHQL_ACCESS_CONTROL_POLICY)) {
-                        graphQLAccessControlPolicy = new String(Base64.getUrlDecoder().decode(type.getName()));
-                        return graphQLAccessControlPolicy;
-                    }
+            String additionalTypeName = ((GraphQLObjectType) additionalType).getName();
+            if (additionalTypeName.startsWith(APIConstants.GRAPHQL_ADDITIONAL_TYPE_PREFIX) &&
+                    additionalTypeName.contains(APIConstants.GRAPHQL_ACCESS_CONTROL_POLICY)) {
+                for (GraphQLFieldDefinition type : ((GraphQLObjectType) additionalType).getFieldDefinitions()) {
+                    graphQLAccessControlPolicy = new String(Base64.getUrlDecoder().decode(type.getName()));
+                    return graphQLAccessControlPolicy;
                 }
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandlerTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandlerTest.java
@@ -38,6 +38,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.api.gateway.GraphQLSchemaDTO;
 import org.wso2.carbon.apimgt.gateway.internal.DataHolder;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+
 import javax.xml.namespace.QName;
 import java.io.File;
 import java.io.IOException;
@@ -51,7 +52,7 @@ import static org.apache.synapse.rest.RESTConstants.REST_SUB_REQUEST_PATH;
  * Unit test cases related GraphQLAPIHandler.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ DataHolder.class})
+@PrepareForTest({ DataHolder.class })
 public class GraphQLAPIHandlerTest {
 
     Axis2MessageContext messageContext;
@@ -115,6 +116,9 @@ public class GraphQLAPIHandlerTest {
         Assert.assertTrue(graphQLAPIHandler.handleRequest(messageContext));
     }
 
+    /**
+     * This method will test Graphql Query request flow.
+     */
     @Test
     public void testHandleRequestForGraphQLQueries() {
         Mockito.when(messageContext.getProperty(APIConstants.GRAPHQL_SUBSCRIPTION_REQUEST)).thenReturn(false);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandlerTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/graphQL/GraphQLAPIHandlerTest.java
@@ -18,16 +18,90 @@
 
 package org.wso2.carbon.apimgt.gateway.handlers.graphQL;
 
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.schema.idl.UnExecutableSchemaGenerator;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.soap.SOAPBody;
+import org.apache.axiom.soap.SOAPEnvelope;
+import org.apache.commons.io.IOUtils;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.gateway.GraphQLSchemaDTO;
+import org.wso2.carbon.apimgt.gateway.internal.DataHolder;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import javax.xml.namespace.QName;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.axis2.Constants.Configuration.HTTP_METHOD;
+import static org.apache.synapse.rest.RESTConstants.REST_SUB_REQUEST_PATH;
 
 /**
  * Unit test cases related GraphQLAPIHandler.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ DataHolder.class})
 public class GraphQLAPIHandlerTest {
+
+    Axis2MessageContext messageContext;
+    org.apache.axis2.context.MessageContext axis2MessageContext;
+    Map<String, GraphQLSchemaDTO> schemaDTOMap;
+    OMElement omElement;
+    DataHolder dataHolder;
+
+    @Before
+    public void setup() throws IOException {
+
+        messageContext = Mockito.mock(Axis2MessageContext.class);
+        axis2MessageContext = Mockito.mock(org.apache.axis2.context.MessageContext.class);
+        omElement = Mockito.mock(OMElement.class);
+        dataHolder = Mockito.mock(DataHolder.class);
+        SOAPEnvelope soapEnvelope = Mockito.mock(SOAPEnvelope.class);
+        SOAPBody soapBody = Mockito.mock(SOAPBody.class);
+        PowerMockito.mockStatic(DataHolder.class);
+        OMElement body = Mockito.mock(OMElement.class);
+        Map propertyList = Mockito.mock(Map.class);
+
+        Mockito.when(messageContext.getAxis2MessageContext()).thenReturn(axis2MessageContext);
+        Mockito.when(axis2MessageContext.getIncomingTransportName()).thenReturn("ws");
+        Mockito.when(messageContext.getProperty(APIConstants.GRAPHQL_SUBSCRIPTION_REQUEST)).thenReturn(true);
+        Mockito.when(axis2MessageContext.getIncomingTransportName()).thenReturn("wss");
+        Mockito.when(axis2MessageContext.getEnvelope()).thenReturn(soapEnvelope);
+        Mockito.when(soapEnvelope.getBody()).thenReturn(soapBody);
+        Mockito.when(soapBody.getFirstElement()).thenReturn(body);
+        Mockito.when(body.getFirstChildWithName(QName.valueOf("query"))).thenReturn(omElement);
+
+        Mockito.when(messageContext.getProperties()).thenReturn(propertyList);
+        Mockito.when(messageContext.getProperty(REST_SUB_REQUEST_PATH)).thenReturn("/");
+        Mockito.when(propertyList.get(REST_SUB_REQUEST_PATH)).thenReturn("/");
+        Mockito.when(propertyList.get(REST_SUB_REQUEST_PATH).toString().split("/?query=")).
+                thenReturn(new String[0]);
+        Mockito.when(DataHolder.getInstance()).thenReturn(dataHolder);
+
+        // Get schema and parse
+        schemaDTOMap = new HashMap<>();
+        String graphqlDirPath = "graphQL" + File.separator;
+        String relativePath = graphqlDirPath + "schema_with_additional_props.graphql";
+        String schemaString = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(relativePath));
+        SchemaParser schemaParser = new SchemaParser();
+        TypeDefinitionRegistry registry = schemaParser.parse(schemaString);
+        GraphQLSchema schema = UnExecutableSchemaGenerator.makeUnExecutableSchema(registry);
+        GraphQLSchemaDTO schemaDTO = new GraphQLSchemaDTO(schema, registry);
+        schemaDTOMap.put("12345", schemaDTO);
+
+        Mockito.when(dataHolder.getApiToGraphQLSchemaDTOMap()).thenReturn(schemaDTOMap);
+    }
 
     /**
      * This method will test request flow when "isGraphqlSubscriptionRequest" property is set in axis2 message context
@@ -35,16 +109,19 @@ public class GraphQLAPIHandlerTest {
      */
     @Test
     public void testHandleRequestForGraphQLSubscriptions() {
-        Axis2MessageContext messageContext = Mockito.mock(Axis2MessageContext.class);
-        org.apache.axis2.context.MessageContext axis2MessageContext =
-                Mockito.mock(org.apache.axis2.context.MessageContext.class);
-        Mockito.when(messageContext.getAxis2MessageContext()).thenReturn(axis2MessageContext);
-        Mockito.when(axis2MessageContext.getIncomingTransportName()).thenReturn("ws");
         Mockito.when(messageContext.getProperty(APIConstants.GRAPHQL_SUBSCRIPTION_REQUEST)).thenReturn(true);
         GraphQLAPIHandler graphQLAPIHandler = new GraphQLAPIHandler();
         Assert.assertTrue(graphQLAPIHandler.handleRequest(messageContext));
+        Assert.assertTrue(graphQLAPIHandler.handleRequest(messageContext));
+    }
 
-        Mockito.when(axis2MessageContext.getIncomingTransportName()).thenReturn("wss");
+    @Test
+    public void testHandleRequestForGraphQLQueries() {
+        Mockito.when(messageContext.getProperty(APIConstants.GRAPHQL_SUBSCRIPTION_REQUEST)).thenReturn(false);
+        Mockito.when(axis2MessageContext.getProperty(HTTP_METHOD)).thenReturn("QUERY");
+        Mockito.when(omElement.getText()).thenReturn(("{allLifts{name}}"));
+        GraphQLAPIHandler graphQLAPIHandler = new GraphQLAPIHandler();
+        graphQLAPIHandler.setApiUUID("12345");
         Assert.assertTrue(graphQLAPIHandler.handleRequest(messageContext));
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/GraphQLSchemaDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/GraphQLSchemaDefinition.java
@@ -236,15 +236,14 @@ public class GraphQLSchemaDefinition {
             }
 
             if (scopeRoleMap.size() > 0) {
-                List<String> scopeRoles = new ArrayList<>();
                 String[] roleList;
                 String scopeType;
                 String base64EncodedURLScopeKey;
                 String scopeRoleMappingType;
                 String base64EncodedURLRole;
                 String roleField;
-
                 for (Map.Entry<String, String> entry : scopeRoleMap.entrySet()) {
+                    List<String> scopeRoles = new ArrayList<>();
                     base64EncodedURLScopeKey = Base64.getUrlEncoder().withoutPadding().
                             encodeToString(entry.getKey().getBytes(Charset.defaultCharset()));
                     scopeType = "type " + APIConstants.SCOPE_ROLE_MAPPING + "_" + base64EncodedURLScopeKey + "{\n";

--- a/pom.xml
+++ b/pom.xml
@@ -1946,7 +1946,7 @@
         <saml.common.util.version>1.0.4</saml.common.util.version>
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
 
-        <graphql.java.version>13.0.wso2v2</graphql.java.version>
+        <graphql.java.version>17.3.wso2v1</graphql.java.version>
 
         <carbon.governance.version>4.8.27</carbon.governance.version>
         <carbon.deployment.version>4.11.1</carbon.deployment.version>


### PR DESCRIPTION
GraphQL version upgrades from 13.0 to 17.3 to fix [1] [2]. The Codebase had to be refactored to fit with latest graphql version.  Related Orbit PR [3] is merged and bundle is deployed.
Also Added fix for [4]

[1] https://github.com/wso2/product-apim/issues/12025
[2] https://github.com/wso2/product-apim/issues/12044
[3] https://github.com/wso2/orbit/pull/552/files
[4] https://github.com/wso2/product-apim/issues/12301