### PR TITLE
Remove unused commons-compress and kubernetes-client

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -336,19 +336,9 @@
             <version>${graphql.java.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.io.fabric8</groupId>
-            <artifactId>kubernetes-client</artifactId>
-            <version>${org.wso2.orbit.io.fabric8.kubernetes.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.orbit.com.squareup.okio</groupId>
             <artifactId>okio</artifactId>
             <version>${okio.wso2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>${org.wso2.orbit.org.apache.commons.compress.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.com.squareup.okhttp</groupId>
@@ -621,12 +611,7 @@
                             org.wso2.carbon.um.ws.api.stub,
                             org.wso2.securevault.*,
                             org.wso2.carbon.registry.*;version="${carbon.registry.imp.pkg.version}",
-                            io.fabric8.kubernetes.client.*;version="${org.wso2.orbit.io.fabric8.kubernetes.version}",
-                            io.fabric8.kubernetes.api.*;version="${org.wso2.orbit.io.fabric8.kubernetes.version}",
-                            io.fabric8.kubernetes.internal.*;version="${org.wso2.orbit.io.fabric8.kubernetes.version}",
-                            io.fabric8.openshift.client.*;version="${org.wso2.orbit.io.fabric8.kubernetes.version}",
                             okio.*;version="${okio.wso2.version}",
-                            org.apache.commons.compress.*;version="${org.wso2.orbit.org.apache.commons.compress.version}",
                             okhttp3.*;version="${okhttp.wso2.version}"
                             *;resolution:=optional
                         </Import-Package>

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
@@ -281,9 +281,7 @@
                                 <bundleDef>org.wso2.orbit.io.swagger:swagger-inflector:${swagger.inflector.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.io.swagger:swagger-inflector-oas3:${swagger.inflector.oas3.version}</bundleDef>
 
-                                <bundleDef>org.wso2.orbit.io.fabric8:kubernetes-client:${org.wso2.orbit.io.fabric8.kubernetes.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.com.squareup.okio:okio:${okio.wso2.version}</bundleDef>
-                                <bundleDef>org.wso2.orbit.org.apache.commons:commons-compress:${org.wso2.orbit.org.apache.commons.compress.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.com.squareup.okhttp:okhttp:${okhttp.wso2.version}</bundleDef>
                                 <bundleDef>
                                     org.wso2.orbit.com.amazonaws:awslambda:${org.wso2.orbit.com.amazonaws.version}

--- a/pom.xml
+++ b/pom.xml
@@ -1754,16 +1754,6 @@
                 <version>${jaeger.client.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.orbit.io.fabric8</groupId>
-                <artifactId>kubernetes-client</artifactId>
-                <version>${org.wso2.orbit.io.fabric8.kubernetes.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.orbit.org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>${org.wso2.orbit.org.apache.commons.compress.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.claim.mgt</artifactId>
                 <version>${carbon.identity.version}</version>
@@ -2150,8 +2140,6 @@
         <okhttp.wso2.version>4.2.0.wso2v1</okhttp.wso2.version>
         <okio.wso2.version>2.4.0.wso2v1</okio.wso2.version>
 
-        <org.wso2.orbit.io.fabric8.kubernetes.version>4.6.4.wso2v1</org.wso2.orbit.io.fabric8.kubernetes.version>
-        <org.wso2.orbit.org.apache.commons.compress.version>1.18.0.wso2v1</org.wso2.orbit.org.apache.commons.compress.version>
         <openfeign.version>11.0</openfeign.version>
         <maven.spotbugsplugin.version>3.1.10</maven.spotbugsplugin.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>


### PR DESCRIPTION
This PR removes the following unused dependencies.
- commons-compress
- kubernetes-client