### PR TITLE
Add reverted fix which was caused by token generation failure in devportal fix

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -464,7 +464,14 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
         try {
             String credentials = tokenRequest.getClientId() + ':' + tokenRequest.getClientSecret();
             String authToken = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
-            tokenResponse = authClient.generate(authToken, GRANT_TYPE_VALUE, scopes);
+            if (APIConstants.OAuthConstants.TOKEN_EXCHANGE.equals(tokenRequest.getGrantType())) {
+                tokenResponse = authClient.generate(tokenRequest.getClientId(), tokenRequest.getClientSecret(),
+                        tokenRequest.getGrantType(), scopes, (String) tokenRequest.getRequestParam(APIConstants
+                                .OAuthConstants.SUBJECT_TOKEN), APIConstants.OAuthConstants.JWT_TOKEN_TYPE);
+            } else {
+                tokenResponse = authClient.generate(authToken, GRANT_TYPE_VALUE, scopes);
+            }
+
         } catch (KeyManagerClientException e) {
             throw new APIManagementException("Error occurred while calling token endpoint - " + e.getReason(), e);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/kmclient/model/AuthClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/kmclient/model/AuthClient.java
@@ -36,6 +36,15 @@ public interface AuthClient {
             throws KeyManagerClientException;
 
     @RequestLine("POST ")
+    TokenInfo generate(@Param("client_id") String clientId,
+                       @Param("client_secret") String clientSecret,
+                       @Param("grant_type") String grantType,
+                       @Param("scope") String scope,
+                       @Param("subject_token") String subjectToken,
+                       @Param("subject_token_type") String subjectTokenType)
+            throws KeyManagerClientException;
+
+    @RequestLine("POST ")
     TokenInfo generateWithValidityPeriod(@Param("client_id") String clientId,
                                          @Param("client_secret") String clientSecret,
                                          @Param("grant_type") String grantType,


### PR DESCRIPTION
A Part of the fix that was included in https://github.com/wso2/carbon-apimgt/pull/10610 PR was reverted by the https://github.com/wso2/carbon-apimgt/pull/10860 PR. This PR adds back the reverted code change.