### PR TITLE
Update AWS SDK to 1.11.1034

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2152,9 +2152,9 @@
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <import.package.version.commons.io>[2.4.0,2.5.0)</import.package.version.commons.io>
 
-        <com.amazonaws.version>1.11.253</com.amazonaws.version>
+        <com.amazonaws.version>1.11.1034</com.amazonaws.version>
         <software.amazon.ion.version>1.0.2</software.amazon.ion.version>
-        <org.wso2.orbit.com.amazonaws.version>1.11.253.wso2v1</org.wso2.orbit.com.amazonaws.version>
+        <org.wso2.orbit.com.amazonaws.version>1.11.1034.wso2v1</org.wso2.orbit.com.amazonaws.version>
 
         <zipkin.version>2.20.1</zipkin.version>
         <okhttp.wso2.version>4.2.0.wso2v1</okhttp.wso2.version>


### PR DESCRIPTION
This PR adds the support for af-south-1 Cape town AWS region for lambda functions.

Fixes https://github.com/wso2/product-apim/issues/12225