### PR TITLE
Skipping scope validation for GraphQL subscription when security disabled for subscription operation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/request/GraphQLRequestProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/request/GraphQLRequestProcessor.java
@@ -22,6 +22,7 @@ import graphql.language.Document;
 import graphql.language.OperationDefinition;
 import graphql.parser.Parser;
 import graphql.validation.Validator;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONObject;
@@ -86,27 +87,29 @@ public class GraphQLRequestProcessor extends RequestProcessor {
                             // subscription operation name
                             String subscriptionOperation = GraphQLProcessorUtil.getOperationList(operation,
                                     inboundMessageContext.getGraphQLSchemaDTO().getTypeDefinitionRegistry());
-                            // validate scopes based on subscription payload
-                            responseDTO = InboundWebsocketProcessorUtil
-                                    .validateScopes(inboundMessageContext, subscriptionOperation, operationId);
+                            // extract verb info dto with throttle policy for matching verb
+                            VerbInfoDTO verbInfoDTO = InboundWebsocketProcessorUtil
+                                    .findMatchingVerb(subscriptionOperation, inboundMessageContext);
+                            String authType = verbInfoDTO.getAuthType();
+                            // validate scopes based on subscription payload when security is enabled
+                            if (!StringUtils.capitalize(APIConstants.AUTH_TYPE_NONE.toLowerCase()).equals(authType)) {
+                                responseDTO = InboundWebsocketProcessorUtil
+                                        .validateScopes(inboundMessageContext, subscriptionOperation, operationId);
+                            }
                             if (!responseDTO.isError()) {
-                                // extract verb info dto with throttle policy for matching verb
-                                VerbInfoDTO verbInfoDTO = InboundWebsocketProcessorUtil.findMatchingVerb(
-                                        subscriptionOperation, inboundMessageContext);
-                                SubscriptionAnalyzer subscriptionAnalyzer =
-                                        new SubscriptionAnalyzer(inboundMessageContext.getGraphQLSchemaDTO()
-                                                .getGraphQLSchema());
+                                SubscriptionAnalyzer subscriptionAnalyzer = new SubscriptionAnalyzer(
+                                        inboundMessageContext.getGraphQLSchemaDTO().getGraphQLSchema());
                                 // analyze query depth and complexity
                                 responseDTO = validateQueryDepthAndComplexity(subscriptionAnalyzer,
                                         inboundMessageContext, graphQLSubscriptionPayload, operationId);
                                 if (!responseDTO.isError()) {
                                     //throttle for matching resource
-                                    responseDTO = InboundWebsocketProcessorUtil.doThrottleForGraphQL(msgSize, verbInfoDTO,
-                                            inboundMessageContext, operationId);
+                                    responseDTO = InboundWebsocketProcessorUtil
+                                            .doThrottleForGraphQL(msgSize, verbInfoDTO, inboundMessageContext,
+                                                    operationId);
                                     // add verb info dto for the successful invoking subscription operation request
-                                    inboundMessageContext.addVerbInfoForGraphQLMsgId(
-                                            graphQLMsg.getString(
-                                                    GraphQLConstants.SubscriptionConstants.PAYLOAD_FIELD_NAME_ID),
+                                    inboundMessageContext.addVerbInfoForGraphQLMsgId(graphQLMsg
+                                                    .getString(GraphQLConstants.SubscriptionConstants.PAYLOAD_FIELD_NAME_ID),
                                             new GraphQLOperationDTO(verbInfoDTO, subscriptionOperation));
                                 }
                             }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/response/GraphQLResponseProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/response/GraphQLResponseProcessor.java
@@ -17,12 +17,14 @@
  */
 package org.wso2.carbon.apimgt.gateway.inbound.websocket.response;
 
+import org.apache.commons.lang.StringUtils;
 import org.json.JSONObject;
 import org.wso2.carbon.apimgt.gateway.handlers.graphQL.GraphQLConstants;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.dto.GraphQLOperationDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.utils.InboundWebsocketProcessorUtil;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 
 /**
  * A GraphQL subscriptions specific extension of ResponseProcessor. This class intercepts the inbound websocket
@@ -54,9 +56,12 @@ public class GraphQLResponseProcessor extends ResponseProcessor {
                 GraphQLOperationDTO graphQLOperationDTO =
                         inboundMessageContext.getVerbInfoForGraphQLMsgId(
                                 graphQLMsg.getString(GraphQLConstants.SubscriptionConstants.PAYLOAD_FIELD_NAME_ID));
-                // validate scopes based on subscription payload
-                responseDTO = InboundWebsocketProcessorUtil
-                        .validateScopes(inboundMessageContext, graphQLOperationDTO.getOperation(), operationId);
+                // validate scopes based on subscription payload when security is enabled
+                String authType = graphQLOperationDTO.getVerbInfoDTO().getAuthType();
+                if (!StringUtils.capitalize(APIConstants.AUTH_TYPE_NONE.toLowerCase()).equals(authType)) {
+                    responseDTO = InboundWebsocketProcessorUtil
+                            .validateScopes(inboundMessageContext, graphQLOperationDTO.getOperation(), operationId);
+                }
                 if (!responseDTO.isError()) {
                     //throttle for matching resource
                     return InboundWebsocketProcessorUtil.doThrottleForGraphQL(msgSize,


### PR DESCRIPTION
Fix: https://github.com/wso2/product-apim/issues/12334