### PR TITLE
Adding a new WebsocketHandler constructor

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
@@ -43,10 +43,7 @@ public class WebsocketHandler extends CombinedChannelDuplexHandler<WebsocketInbo
     private WebSocketAnalyticsMetricsHandler metricsHandler;
 
     public WebsocketHandler() {
-        super(new WebsocketInboundHandler(), new WebsocketOutboundHandler());
-        if (APIUtil.isAnalyticsEnabled()) {
-            metricsHandler = new WebSocketAnalyticsMetricsHandler();
-        }
+        this(new WebsocketInboundHandler(), new WebsocketOutboundHandler());
     }
 
     public WebsocketHandler(WebsocketInboundHandler websocketInboundHandler,

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
@@ -49,6 +49,14 @@ public class WebsocketHandler extends CombinedChannelDuplexHandler<WebsocketInbo
         }
     }
 
+    public WebsocketHandler(WebsocketInboundHandler websocketInboundHandler,
+            WebsocketOutboundHandler websocketOutboundHandler) {
+        super(websocketInboundHandler, websocketOutboundHandler);
+        if (APIUtil.isAnalyticsEnabled()) {
+            metricsHandler = new WebSocketAnalyticsMetricsHandler();
+        }
+    }
+
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/12481

## Approach
Added WebsocketHandler constructor accepting the WebsocketInboundHandler and WebsocketOutboundHandler, so that these classes can be customized