### PR TITLE
Add action attrib to API_UPDATE event

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2593,6 +2593,10 @@ public final class APIConstants {
         UDATE_API_LOG_LEVEL
     }
 
+    public enum EventAction {
+        DEFAULT_VERSION
+    }
+
     public static class GatewayArtifactSynchronizer {
 
         public static final String SYNC_RUNTIME_ARTIFACTS_PUBLISHER_CONFIG = "SyncRuntimeArtifactsPublisher";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1223,6 +1223,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         }
 
         String publishedDefaultVersion = getPublishedDefaultVersion(api.getId());
+        String prevDefaultVersion = getDefaultVersion(api.getId());
 
         //Update WSDL in the registry
         if (api.getWsdlUrl() != null && api.getWsdlResource() == null) {
@@ -1310,11 +1311,15 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 sendUpdateEventToPreviousDefaultVersion(previousDefaultVersionIdentifier, organization);
             }
         }
+        APIConstants.EventAction action = null;
+        if (api.isDefaultVersion() ^ api.getId().getVersion().equals(prevDefaultVersion)) {
+            action = APIConstants.EventAction.DEFAULT_VERSION;
+        }
         APIEvent apiEvent = new APIEvent(UUID.randomUUID().toString(), System.currentTimeMillis(),
                 APIConstants.EventType.API_UPDATE.name(), tenantId, tenantDomain, api.getId().getApiName(), apiId,
                 api.getUuid(), api.getId().getVersion(), api.getType(), api.getContext(),
                 APIUtil.replaceEmailDomainBack(api.getId().getProviderName()),
-                api.getStatus());
+                api.getStatus(), action);
         APIUtil.sendNotification(apiEvent, APIConstants.NotifierType.API.name());
 
         // Extracting API details for the recommendation system
@@ -1332,7 +1337,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 APIConstants.EventType.API_UPDATE.name(), tenantId, tenantDomain, apiIdentifier.getApiName(),
                 api.getId().getId(), api.getUuid(), api.getId().getVersion(), api.getType(), api.getContext(),
                 APIUtil.replaceEmailDomainBack(api.getId().getProviderName()),
-                api.getStatus());
+                api.getStatus(), APIConstants.EventAction.DEFAULT_VERSION);
         APIUtil.sendNotification(apiEvent, APIConstants.NotifierType.API.name());
     }
 
@@ -1348,6 +1353,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         validateAndSetAPISecurity(api);
         validateKeyManagers(api);
         String publishedDefaultVersion = getPublishedDefaultVersion(api.getId());
+        String prevDefaultVersion = getDefaultVersion(api.getId());
 
         Gson gson = new Gson();
         String organization = api.getOrganization();
@@ -1433,10 +1439,15 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             }
         }
 
+        APIConstants.EventAction action = null;
+        if (api.isDefaultVersion() ^ api.getId().getVersion().equals(prevDefaultVersion)) {
+            action = APIConstants.EventAction.DEFAULT_VERSION;
+        }
+
         APIEvent apiEvent = new APIEvent(UUID.randomUUID().toString(), System.currentTimeMillis(),
                 APIConstants.EventType.API_UPDATE.name(), tenantId, tenantDomain, api.getId().getApiName(), apiId,
                 api.getUuid(), api.getId().getVersion(), api.getType(), api.getContext(),
-                APIUtil.replaceEmailDomainBack(api.getId().getProviderName()), api.getStatus());
+                APIUtil.replaceEmailDomainBack(api.getId().getProviderName()), api.getStatus(), action);
         APIUtil.sendNotification(apiEvent, APIConstants.NotifierType.API.name());
 
         // Extracting API details for the recommendation system

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/notifier/events/APIEvent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/notifier/events/APIEvent.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.apimgt.impl.notifier.events;
 
+import org.wso2.carbon.apimgt.impl.APIConstants;
+
 import java.util.Objects;
 
 /**
@@ -34,6 +36,7 @@ public class APIEvent extends Event {
     private String apiType;
     private String apiStatus;
     private String logLevel;
+    private APIConstants.EventAction action;
 
     public APIEvent(String uuid, String logLevel, String type, String apiContext) {
         this.uuid = uuid;
@@ -71,6 +74,25 @@ public class APIEvent extends Event {
         this.tenantDomain = tenantDomain;
     }
 
+    public APIEvent(String eventId, long timestamp, String type, int tenantId, String tenantDomain, String apiName,
+                    int apiId, String uuid, String apiVersion, String apiType, String apiContext, String apiProvider,
+                    String apiStatus, APIConstants.EventAction action) {
+        this.eventId = eventId;
+        this.timeStamp = timestamp;
+        this.type = type;
+        this.tenantId = tenantId;
+        this.apiId = apiId;
+        this.uuid = uuid;
+        this.apiVersion = apiVersion;
+        this.apiName = apiName;
+        this.apiType = apiType;
+        this.apiContext = apiContext;
+        this.apiProvider = apiProvider;
+        this.apiStatus = apiStatus;
+        this.tenantDomain = tenantDomain;
+        this.action = action;
+    }
+
     @Override
     public String toString() {
 
@@ -83,6 +105,7 @@ public class APIEvent extends Event {
                 ", apiProvider='" + apiProvider + '\'' +
                 ", apiType='" + apiType + '\'' +
                 ", apiStatus='" + apiStatus + '\'' +
+                ", action='" + action + '\'' +
                 '}';
     }
 
@@ -190,5 +213,13 @@ public class APIEvent extends Event {
 
     public String getLogLevel() {
         return logLevel;
+    }
+
+    public APIConstants.EventAction getAction() {
+        return action;
+    }
+
+    public void setAction(APIConstants.EventAction action) {
+        this.action = action;
     }
 }


### PR DESCRIPTION
CC only process deployment events. However, when default version is updated it needs to process the API_UPDATE event to redeploy the API. Redeploying API for all API_UPDATE events is not an option for CC. Therefore, to identify the purpose of API_UPDATE event we are adding this `action` attribute. With that we can inform event receiving parties what type of change has happened.