### PR TITLE
Fix backend jwt's incorrect `iat` and `exp` claims

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/jwtgenerator/AbstractAPIMgtGatewayJWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/jwtgenerator/AbstractAPIMgtGatewayJWTGenerator.java
@@ -37,6 +37,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Abstract class for jwt generation.
@@ -184,13 +185,16 @@ public abstract class AbstractAPIMgtGatewayJWTGenerator {
                     log.error("Error while reading claim values", e);
                 }
             } else if (JWTConstants.EXPIRY_TIME.equals(claimEntry.getKey())) {
-                jwtClaimSetBuilder.claim(claimEntry.getKey(), new Date(Long.parseLong((String) claimEntry.getValue())));
+                long exp = TimeUnit.SECONDS.toMillis(Long.parseLong((String) claimEntry.getValue()));
+                jwtClaimSetBuilder.claim(claimEntry.getKey(), new Date(exp));
             } else if (JWTConstants.ISSUED_TIME.equals(claimEntry.getKey())) {
-                jwtClaimSetBuilder.claim(claimEntry.getKey(), new Date(Long.parseLong((String) claimEntry.getValue())));
+                long iat = TimeUnit.SECONDS.toMillis(Long.parseLong((String) claimEntry.getValue()));
+                jwtClaimSetBuilder.claim(claimEntry.getKey(), new Date(iat));
             } else {
                 jwtClaimSetBuilder.claim(claimEntry.getKey(), claimEntry.getValue());
             }
         }
+
         //Adding JWT standard claim
         jwtClaimSetBuilder.jwtID(UUID.randomUUID().toString());
         JWTClaimsSet jwtClaimsSet = jwtClaimSetBuilder.build();


### PR DESCRIPTION
Fix wso2/product-microgateway#2687

jwtClaimSetBuilder expect the `iat` and `exp` claim values to be in milliseconds and internally converts the values to seconds when generating the jwt string. hense we need to provide milliseconds value to the builder.