### PR TITLE
Refactor module names of features with Api Management prefix

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.core.feature</artifactId>
     <packaging>pom</packaging>
-    <name>WSO2 Carbon - Api management Core Feature</name>
+    <name>WSO2 Carbon - Api Management Core Feature</name>
     <url>http://wso2.org</url>
 
     <description>

--- a/features/apimgt/org.wso2.carbon.apimgt.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.feature/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.feature</artifactId>
     <packaging>pom</packaging>
-    <name>WSO2 Carbon - Api management Feature</name>
+    <name>WSO2 Carbon - Api Management Feature</name>
     <url>http://wso2.org</url>
     <description>This feature contains the bundles required for API management</description>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.gateway.feature</artifactId>
     <packaging>pom</packaging>
-    <name>WSO2 Carbon - Api management Gateway Feature</name>
+    <name>WSO2 Carbon - Api Management Gateway Feature</name>
     <url>http://wso2.org</url>
     <description>This feature contains the core bundles required for API management Gateway
     </description>

--- a/features/apimgt/org.wso2.carbon.apimgt.internal.service.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.internal.service.feature/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.internal.service.feature</artifactId>
     <packaging>pom</packaging>
-    <name>WSO2 Carbon - Api management Internal Data Service Feature</name>
+    <name>WSO2 Carbon - Api Management Internal Data Service Feature</name>
     <url>http://wso2.org</url>
 
     <description>

--- a/features/apimgt/org.wso2.carbon.apimgt.keymanager.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.keymanager.feature/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.keymanager.feature</artifactId>
     <packaging>pom</packaging>
-    <name>WSO2 Carbon - Api management Key Manager Feature</name>
+    <name>WSO2 Carbon - Api Management Key Manager Feature</name>
     <url>http://wso2.org</url>
 
     <description>

--- a/features/apimgt/org.wso2.carbon.apimgt.persistence.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.persistence.feature/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.persistence.feature</artifactId>
     <packaging>pom</packaging>
-    <name>WSO2 Carbon - Api management Persistence Feature</name>
+    <name>WSO2 Carbon - Api Management Persistence Feature</name>
     <url>http://wso2.org</url>
 
     <description>

--- a/features/apimgt/org.wso2.carbon.apimgt.tokenmgt.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.tokenmgt.feature/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.tokenmgt.feature</artifactId>
     <packaging>pom</packaging>
-    <name>WSO2 Carbon - Api management Token management Feature</name>
+    <name>WSO2 Carbon - Api Management Token management Feature</name>
     <url>http://wso2.org</url>
 
     <description>

--- a/features/apimgt/org.wso2.carbon.apimgt.tracing.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.tracing.feature/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>org.wso2.carbon.apimgt.tracing.feature</artifactId>
     <packaging>pom</packaging>
-    <name>WSO2 Carbon - Api management Tracing Feature</name>
+    <name>WSO2 Carbon - Api Management Tracing Feature</name>
     <url>http://wso2.org</url>
 
     <description>


### PR DESCRIPTION
Changed module names to be consistent with other module names. Other modules in apimgt features contain proper title case module names. Following change is done.

before: `Api management ...`
after: `Api Management ...`