### PR TITLE
Add the policy versioning support and few bug fixes for Operation policies

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -1940,6 +1940,24 @@ public interface APIProvider extends APIManager {
      */
     void deleteOperationPolicyById(String policyId, String organization) throws APIManagementException;
 
+    /**
+     * Load the mediation policies if exists to the API. If a mediation policy is defined in the object under keys
+     * inSequence, outSequence or faultSequence, this method will search in the registry for a such sequence and
+     * populate the inSequenceMediation, outSequenceMediation or faultSequenceMediation attributes with a mediation
+     * object.
+     *
+     * @param api     API object
+     * @param organization Organization name
+     * @throws APIManagementException
+     */
     void loadMediationPoliciesToAPI(API api, String organization) throws APIManagementException;
+
+    /**
+     * Check whether the provided api uuid is a revisioned API's uuid or not.
+     *
+     * @param apiUUID    API UUID
+     * @throws APIManagementException
+     */
+    APIRevision checkAPIUUIDIsARevisionUUID(String apiUUID) throws APIManagementException;
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -1833,6 +1833,7 @@ public interface APIProvider extends APIManager {
      * or not.
      *
      * @param policyName             API specific policy name
+     * @param policyVersion          API specific policy version
      * @param apiUUID                Unique identifier for API
      * @param revisionUUID           Unique identifier for API revision
      * @param organization           Organization name
@@ -1841,7 +1842,7 @@ public interface APIProvider extends APIManager {
      * @return Operation Policy
      * @throws APIManagementException
      */
-    OperationPolicyData getAPISpecificOperationPolicyByPolicyName(String policyName, String apiUUID,
+    OperationPolicyData getAPISpecificOperationPolicyByPolicyName(String policyName, String policyVersion, String apiUUID,
                                                                   String revisionUUID,
                                                                   String organization,
                                                                   boolean isWithPolicyDefinition)
@@ -1852,13 +1853,14 @@ public interface APIProvider extends APIManager {
      * a matching policy created as a common policy. If not, it will return null
      *
      * @param policyName             Common Policy name
+     * @param policyVersion          Common Policy version
      * @param organization           Organization
      * @param isWithPolicyDefinition This will decide whether to return policy definition or not as policy definition
      *                               is bit bulky
      * @return Common Operation Policy
      * @throws APIManagementException
      */
-    OperationPolicyData getCommonOperationPolicyByPolicyName(String policyName, String organization,
+    OperationPolicyData getCommonOperationPolicyByPolicyName(String policyName, String policyVersion, String organization,
                                                              boolean isWithPolicyDefinition)
             throws APIManagementException;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OperationPolicy.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OperationPolicy.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 public class OperationPolicy implements Comparable<OperationPolicy> {
 
     private String policyName = "";
+    private String policyVersion = "v1";
     private String direction = null;
     private Map<String, Object> parameters = null;
     private String policyId = null;
@@ -37,6 +38,16 @@ public class OperationPolicy implements Comparable<OperationPolicy> {
     public void setPolicyName(String policyName) {
 
         this.policyName = policyName;
+    }
+
+    public String getPolicyVersion() {
+
+        return policyVersion;
+    }
+
+    public void setPolicyVersion(String policyVersion) {
+
+        this.policyVersion = policyVersion;
     }
 
     public Map<String, Object> getParameters() {
@@ -87,14 +98,14 @@ public class OperationPolicy implements Comparable<OperationPolicy> {
         if (o == null || getClass() != o.getClass())
             return false;
         OperationPolicy policyObj = (OperationPolicy) o;
-        return policyId == policyObj.policyId && policyName == policyObj.policyName && direction.equals(
-                policyObj.direction) && parameters.equals(policyObj.parameters);
+        return policyId == policyObj.policyId && policyName == policyObj.policyName && policyVersion == policyObj.policyVersion
+                && direction.equals(policyObj.direction) && parameters.equals(policyObj.parameters);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(policyName, direction, parameters, policyId);
+        return Objects.hash(policyName, policyVersion, direction, parameters, policyId);
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2878,6 +2878,7 @@ public final class APIConstants {
             + "resources" + File.separator + "operation_policies" + File.separator + "definitions";
     public static final String OPERATION_POLICY_SUPPORTED_GATEWAY_SYNAPSE = "Synapse";
     public static final String OPERATION_POLICY_SUPPORTED_API_TYPE_HTTP = "HTTP";
+    public static final String DEFAULT_POLICY_VERSION = "v1";
 
 
     public static final String WSO2_GATEWAY_ENVIRONMENT = "wso2";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -2716,6 +2716,14 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                                 throw new APIManagementException("Invalid policy selected. " + policyId
                                         + " policy is not found.", ExceptionCodes.INVALID_OPERATION_POLICY);
                             }
+
+                            if (!policyData.getSpecification().getName().equals(policy.getPolicyName()) ||
+                                    !policyData.getSpecification().getVersion().equals(policy.getPolicyVersion()) ) {
+                                throw new APIManagementException("Applied policy for uriTemplate "
+                                        + uriTemplate.getUriTemplate() + " : " + policy.getPolicyName()
+                                        + "_" + policy.getPolicyVersion() + " does not match the specification");
+                            }
+
                             OperationPolicySpecification policySpecification = policyData.getSpecification();
                             if (validateAppliedPolicyWithSpecification(policySpecification, policy, api)) {
                                 validatedPolicies.add(policy);
@@ -2730,6 +2738,14 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                                     log.debug(
                                             "A common policy is found for " + policyId + ". Validating the policy");
                                 }
+
+                                if (!commonPolicyData.getSpecification().getName().equals(policy.getPolicyName()) ||
+                                        !commonPolicyData.getSpecification().getVersion().equals(policy.getPolicyVersion()) ) {
+                                    throw new APIManagementException("Applied policy for uriTemplate "
+                                            + uriTemplate.getUriTemplate() + " : " + policy.getPolicyName()
+                                            + "_" + policy.getPolicyVersion() + " does not match the specification");
+                                }
+
                                 OperationPolicySpecification commonPolicySpec = commonPolicyData.getSpecification();
                                 if (validateAppliedPolicyWithSpecification(commonPolicySpec, policy, api)) {
                                     validatedPolicies.add(policy);
@@ -2742,8 +2758,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     } else {
                         // check the API specific operation policy list
                         OperationPolicyData policyData =
-                                getAPISpecificOperationPolicyByPolicyName(policy.getPolicyName(), api.getUuid(), null,
-                                        tenantDomain, false);
+                                getAPISpecificOperationPolicyByPolicyName(policy.getPolicyName(),
+                                policy.getPolicyVersion(), api.getUuid(), null, tenantDomain, false);
                         if (policyData != null) {
                             if (log.isDebugEnabled()) {
                                 log.debug("Policy Id is not defined and an API specific policy is found for "
@@ -2756,7 +2772,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                             }
                         } else {
                             OperationPolicyData commonPolicyData =
-                                    getCommonOperationPolicyByPolicyName(policy.getPolicyName(), tenantDomain, false);
+                                    getCommonOperationPolicyByPolicyName(policy.getPolicyName(),
+                                    policy.getPolicyVersion(), tenantDomain, false);
                             if (commonPolicyData != null) {
                                 // A common policy is found for specified policy. This will be validated according to the provided
                                 // attributes and added to API policy list
@@ -9554,8 +9571,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
 
         OperationPolicySpecification importedSpec = importedPolicyData.getSpecification();
         OperationPolicyData existingOperationPolicy =
-                getAPISpecificOperationPolicyByPolicyName(importedSpec.getName(), importedPolicyData.getApiUUID(),
-                        null, organization, false);
+                getAPISpecificOperationPolicyByPolicyName(importedSpec.getName(), importedSpec.getVersion(),
+                        importedPolicyData.getApiUUID(), null, organization, false);
         String policyId = null;
         if (existingOperationPolicy != null) {
             if (existingOperationPolicy.getMd5Hash().equals(importedPolicyData.getMd5Hash())) {
@@ -9572,7 +9589,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             }
             policyId = existingOperationPolicy.getPolicyId();
         } else {
-            existingOperationPolicy = getCommonOperationPolicyByPolicyName(importedSpec.getName(), organization, false);
+            existingOperationPolicy = getCommonOperationPolicyByPolicyName(importedSpec.getName(),
+                    importedSpec.getVersion(),organization, false);
             if (existingOperationPolicy != null) {
                 if (existingOperationPolicy.getMd5Hash().equals(importedPolicyData.getMd5Hash())) {
                     if (log.isDebugEnabled()) {
@@ -9622,21 +9640,23 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     }
 
     @Override
-    public OperationPolicyData getAPISpecificOperationPolicyByPolicyName(String policyName, String apiUUID,
-                                                                         String revisionUUID, String tenantDomain,
+    public OperationPolicyData getAPISpecificOperationPolicyByPolicyName(String policyName, String policyVersion,
+                                                                         String apiUUID, String revisionUUID,
+                                                                         String tenantDomain,
                                                                          boolean isWithPolicyDefinition)
             throws APIManagementException {
 
-        return apiMgtDAO.getAPISpecificOperationPolicyByPolicyName(policyName, apiUUID, revisionUUID, tenantDomain,
-                isWithPolicyDefinition);
+        return apiMgtDAO.getAPISpecificOperationPolicyByPolicyName(policyName, policyVersion, apiUUID, revisionUUID,
+                tenantDomain, isWithPolicyDefinition);
     }
 
     @Override
-    public OperationPolicyData getCommonOperationPolicyByPolicyName(String policyName, String tenantDomain,
+    public OperationPolicyData getCommonOperationPolicyByPolicyName(String policyName, String policyVersion,
+                                                                    String tenantDomain,
                                                                     boolean isWithPolicyDefinition)
             throws APIManagementException {
 
-        return apiMgtDAO.getCommonOperationPolicyByPolicyName(policyName, tenantDomain, isWithPolicyDefinition);
+        return apiMgtDAO.getCommonOperationPolicyByPolicyName(policyName, policyVersion, tenantDomain, isWithPolicyDefinition);
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -2083,7 +2083,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         // get all policies
         if (APIUtil.isSequenceDefined(api.getInSequence())) {
             OperationPolicyData existingPolicy = getAPISpecificOperationPolicyByPolicyName(api.getInSequence(),
-                    api.getUuid(), null, organization, false);
+                    APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             inFlowPolicy = new OperationPolicy();
             inFlowPolicy.setPolicyName(api.getInSequence());
             inFlowPolicy.setDirection(APIConstants.OPERATION_SEQUENCE_TYPE_REQUEST);
@@ -2095,7 +2095,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         }
         if (APIUtil.isSequenceDefined(api.getOutSequence())) {
             OperationPolicyData existingPolicy = getAPISpecificOperationPolicyByPolicyName(api.getOutSequence(),
-                    api.getUuid(), null, organization, false);
+                    APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             outFlowPolicy = new OperationPolicy();
             outFlowPolicy.setPolicyName(api.getOutSequence());
             outFlowPolicy.setDirection(APIConstants.OPERATION_SEQUENCE_TYPE_RESPONSE);
@@ -2107,7 +2107,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         }
         if (APIUtil.isSequenceDefined(api.getFaultSequence())) {
             OperationPolicyData existingPolicy = getAPISpecificOperationPolicyByPolicyName(api.getFaultSequence(),
-                    api.getUuid(), null, organization, false);
+                    APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             faultFlowPolicy = new OperationPolicy();
             faultFlowPolicy.setPolicyName(api.getFaultSequence());
             faultFlowPolicy.setDirection(APIConstants.OPERATION_SEQUENCE_TYPE_FAULT);
@@ -2161,8 +2161,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (APIUtil.isSequenceDefined(api.getInSequence())) {
             Mediation inSequenceMediation = api.getInSequenceMediation();
             OperationPolicyData existingPolicy =
-                    getAPISpecificOperationPolicyByPolicyName(inSequenceMediation.getName(), api.getUuid(),
-                            null, organization, false);
+                    getAPISpecificOperationPolicyByPolicyName(inSequenceMediation.getName(),
+                            APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             String inFlowPolicyId;
             if (existingPolicy == null) {
                 OperationPolicyData inSeqPolicyData =
@@ -2180,8 +2180,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (APIUtil.isSequenceDefined(api.getOutSequence())) {
             Mediation outSequenceMediation = api.getOutSequenceMediation();
             OperationPolicyData existingPolicy =
-                    getAPISpecificOperationPolicyByPolicyName(outSequenceMediation.getName(), api.getUuid(),
-                            null, organization, false);
+                    getAPISpecificOperationPolicyByPolicyName(outSequenceMediation.getName(),
+                            APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             String outFlowPolicyId;
             if (existingPolicy == null) {
                 OperationPolicyData outSeqPolicyData =
@@ -2199,8 +2199,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (APIUtil.isSequenceDefined(api.getFaultSequence())) {
             Mediation faultSequenceMediation = api.getFaultSequenceMediation();
             OperationPolicyData existingPolicy =
-                    getAPISpecificOperationPolicyByPolicyName(faultSequenceMediation.getName(), api.getUuid(),
-                            null, organization, false);
+                    getAPISpecificOperationPolicyByPolicyName(faultSequenceMediation.getName(),
+                            APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             String faultFlowPolicyId;
             if (existingPolicy == null) {
                 OperationPolicyData faultSeqPolicyData =
@@ -2773,7 +2773,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                         } else {
                             OperationPolicyData commonPolicyData =
                                     getCommonOperationPolicyByPolicyName(policy.getPolicyName(),
-                                    policy.getPolicyVersion(), tenantDomain, false);
+ policy.getPolicyVersion(), tenantDomain, false);
                             if (commonPolicyData != null) {
                                 // A common policy is found for specified policy. This will be validated according to the provided
                                 // attributes and added to API policy list

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -9717,4 +9717,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         }
         return operationPoliciesMap;
     }
+
+    public  APIRevision checkAPIUUIDIsARevisionUUID(String apiUUID) throws APIManagementException {
+        return apiMgtDAO.checkAPIUUIDIsARevisionUUID(apiUUID);
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -2773,8 +2773,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                         } else {
                             OperationPolicyData commonPolicyData =
                                     getCommonOperationPolicyByPolicyName(policy.getPolicyName(),
- policy.getPolicyVersion(), tenantDomain, false);
+                                            policy.getPolicyVersion(), tenantDomain, false);
                             if (commonPolicyData != null) {
+                                log.info(commonPolicyData.getPolicyId());
                                 // A common policy is found for specified policy. This will be validated according to the provided
                                 // attributes and added to API policy list
                                 if (log.isDebugEnabled()) {
@@ -2783,7 +2784,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                                 }
                                 OperationPolicySpecification commonPolicySpec = commonPolicyData.getSpecification();
                                 if (validateAppliedPolicyWithSpecification(commonPolicySpec, policy, api)) {
-                                    policy.setPolicyId(policyData.getPolicyId());
+                                    policy.setPolicyId(commonPolicyData.getPolicyId());
                                     validatedPolicies.add(policy);
                                 }
                             } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -3702,7 +3702,7 @@ public class SQLConstants {
 
         public static final String GET_OPERATION_POLICIES_BY_URI_TEMPLATE_ID =
                 "SELECT " +
-                        " OP.POLICY_NAME, OPM.DIRECTION, OPM.PARAMETERS, OPM.POLICY_ORDER, OPM.POLICY_UUID " +
+                        " OP.POLICY_NAME, OP.POLICY_VERSION, OPM.DIRECTION, OPM.PARAMETERS, OPM.POLICY_ORDER, OPM.POLICY_UUID " +
                         " FROM " +
                         " AM_API_URL_MAPPING AUM " +
                         " INNER JOIN AM_API_OPERATION_POLICY_MAPPING OPM ON AUM.URL_MAPPING_ID = OPM.URL_MAPPING_ID" +
@@ -3715,7 +3715,7 @@ public class SQLConstants {
         public static final String GET_OPERATION_POLICIES_OF_API_SQL =
                 " SELECT " +
                         " AUM.URL_MAPPING_ID, AUM.URL_PATTERN, AUM.HTTP_METHOD," +
-                        " OP.POLICY_NAME, OPM.PARAMETERS, OPM.DIRECTION, OPM.POLICY_ORDER, OPM.POLICY_UUID" +
+                        " OP.POLICY_NAME, OP.POLICY_VERSION, OPM.PARAMETERS, OPM.DIRECTION, OPM.POLICY_ORDER, OPM.POLICY_UUID" +
                         " FROM " +
                         " AM_API_URL_MAPPING AUM " +
                         " INNER JOIN AM_API API ON AUM.API_ID = API.API_ID " +
@@ -3731,7 +3731,7 @@ public class SQLConstants {
         public static final String GET_OPERATION_POLICIES_FOR_API_REVISION_SQL =
                 " SELECT " +
                         " AUM.URL_MAPPING_ID, AUM.URL_PATTERN, AUM.HTTP_METHOD," +
-                        " OP.POLICY_NAME, OPM.PARAMETERS, OPM.DIRECTION, OPM.POLICY_ORDER, OPM.POLICY_UUID" +
+                        " OP.POLICY_NAME, OP.POLICY_VERSION, OPM.PARAMETERS, OPM.DIRECTION, OPM.POLICY_ORDER, OPM.POLICY_UUID" +
                         " FROM " +
                         " AM_API_URL_MAPPING AUM " +
                         " INNER JOIN AM_API API ON AUM.API_ID = API.API_ID " +
@@ -3747,7 +3747,7 @@ public class SQLConstants {
         public static final String GET_OPERATION_POLICIES_PER_API_PRODUCT_SQL =
                 " SELECT " +
                         " AUM.URL_MAPPING_ID, AUM.URL_PATTERN, AUM.HTTP_METHOD, " +
-                        " OP.POLICY_NAME, OPM.PARAMETERS, OPM.DIRECTION, OPM.POLICY_ORDER, OPM.POLICY_UUID " +
+                        " OP.POLICY_NAME, OP.POLICY_VERSION, OPM.PARAMETERS, OPM.DIRECTION, OPM.POLICY_ORDER, OPM.POLICY_UUID " +
                         " FROM " +
                         " AM_API_URL_MAPPING AUM " +
                         " INNER JOIN AM_API_OPERATION_POLICY_MAPPING OPM ON AUM.URL_MAPPING_ID = OPM.URL_MAPPING_ID " +
@@ -3767,10 +3767,10 @@ public class SQLConstants {
 
         public static final String ADD_OPERATION_POLICY =
                 "INSERT INTO AM_OPERATION_POLICY " +
-                        " (POLICY_UUID, POLICY_NAME, DISPLAY_NAME, POLICY_DESCRIPTION, APPLICABLE_FLOWS, GATEWAY_TYPES, " +
+                        " (POLICY_UUID, POLICY_NAME, POLICY_VERSION, DISPLAY_NAME, POLICY_DESCRIPTION, APPLICABLE_FLOWS, GATEWAY_TYPES, " +
                         " API_TYPES, POLICY_PARAMETERS, ORGANIZATION, POLICY_CATEGORY, " +
                         " POLICY_MD5) " +
-                        " VALUES (?,?,?,?,?,?,?,?,?,?,?)";
+                        " VALUES (?,?,?,?,?,?,?,?,?,?,?,?)";
 
         public static final String UPDATE_API_OPERATION_POLICY_BY_POLICY_ID =
                 "UPDATE  AM_API_OPERATION_POLICY SET CLONED_POLICY_UUID = ?  WHERE  POLICY_UUID = ?";
@@ -3779,7 +3779,7 @@ public class SQLConstants {
                 "UPDATE " +
                         " AM_OPERATION_POLICY " +
                         " SET " +
-                        " POLICY_NAME = ?, DISPLAY_NAME = ?, POLICY_DESCRIPTION = ?, APPLICABLE_FLOWS = ?, GATEWAY_TYPES = ?, " +
+                        " POLICY_NAME = ?, POLICY_VERSION = ?, DISPLAY_NAME = ?, POLICY_DESCRIPTION = ?, APPLICABLE_FLOWS = ?, GATEWAY_TYPES = ?, " +
                         " API_TYPES = ?, POLICY_PARAMETERS = ?, ORGANIZATION = ?, POLICY_CATEGORY = ?, " +
                         " POLICY_MD5 = ? " +
                         " WHERE " +
@@ -3787,7 +3787,7 @@ public class SQLConstants {
 
         public static final String GET_OPERATION_POLICY_FROM_POLICY_ID =
                 "SELECT " +
-                        " POLICY_NAME, DISPLAY_NAME, POLICY_DESCRIPTION, APPLICABLE_FLOWS, GATEWAY_TYPES, API_TYPES, " +
+                        " POLICY_NAME, POLICY_VERSION, DISPLAY_NAME, POLICY_DESCRIPTION, APPLICABLE_FLOWS, GATEWAY_TYPES, API_TYPES, " +
                         " POLICY_PARAMETERS, POLICY_CATEGORY, POLICY_MD5, ORGANIZATION " +
                         " FROM " +
                         " AM_OPERATION_POLICY " +
@@ -3796,7 +3796,7 @@ public class SQLConstants {
 
         public static final String GET_API_SPECIFIC_OPERATION_POLICY_FROM_POLICY_ID =
                 "SELECT " +
-                        " OP.POLICY_UUID, OP.POLICY_NAME, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, OP.API_TYPES, " +
+                        " OP.POLICY_UUID, OP.POLICY_NAME, OP.POLICY_VERSION, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, OP.API_TYPES, " +
                         " OP.POLICY_PARAMETERS, OP.POLICY_CATEGORY, OP.POLICY_MD5, " +
                         " AOP.API_UUID, AOP.REVISION_UUID, AOP.CLONED_POLICY_UUID " +
                         " FROM " +
@@ -3806,7 +3806,7 @@ public class SQLConstants {
 
         public static final String GET_COMMON_OPERATION_POLICY_WITH_OUT_DEFINITION_FROM_POLICY_ID =
                 "SELECT " +
-                        " OP.POLICY_UUID, OP.POLICY_NAME, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, OP.API_TYPES, " +
+                        " OP.POLICY_UUID, OP.POLICY_NAME, OP.POLICY_VERSION, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, OP.API_TYPES, " +
                         " OP.POLICY_PARAMETERS, OP.POLICY_CATEGORY, OP.POLICY_MD5 " +
                         " FROM " +
                         " AM_OPERATION_POLICY OP INNER JOIN AM_COMMON_OPERATION_POLICY COP ON OP.POLICY_UUID = COP.POLICY_UUID " +
@@ -3816,26 +3816,26 @@ public class SQLConstants {
 
         public static final String GET_API_SPECIFIC_OPERATION_POLICY_FROM_POLICY_NAME =
                 "SELECT " +
-                        " OP.POLICY_UUID, OP.POLICY_NAME, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, OP.API_TYPES, " +
+                        " OP.POLICY_UUID, OP.POLICY_NAME, OP.POLICY_VERSION, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, OP.API_TYPES, " +
                         " OP.POLICY_PARAMETERS, OP.POLICY_CATEGORY, OP.POLICY_MD5, " +
                         " AOP.API_UUID, AOP.REVISION_UUID, AOP.CLONED_POLICY_UUID " +
                         " FROM " +
                         " AM_OPERATION_POLICY OP INNER JOIN AM_API_OPERATION_POLICY AOP ON OP.POLICY_UUID = AOP.POLICY_UUID " +
                         " WHERE " +
-                        " OP.POLICY_NAME = ? AND OP.ORGANIZATION = ? AND AOP.API_UUID = ? ";
+                        " OP.POLICY_NAME = ? AND OP.POLICY_VERSION = ? AND OP.ORGANIZATION = ? AND AOP.API_UUID = ? ";
 
         public static final String GET_COMMON_OPERATION_POLICY_FROM_POLICY_NAME =
                 "SELECT " +
-                        " OP.POLICY_UUID, OP.POLICY_NAME, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, OP.API_TYPES, " +
+                        " OP.POLICY_UUID, OP.POLICY_NAME, OP.POLICY_VERSION, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, OP.API_TYPES, " +
                         " OP.POLICY_PARAMETERS, OP.POLICY_CATEGORY, OP.POLICY_MD5 " +
                         " FROM " +
                         " AM_OPERATION_POLICY OP INNER JOIN AM_COMMON_OPERATION_POLICY COP ON OP.POLICY_UUID = COP.POLICY_UUID " +
                         " WHERE " +
-                        " OP.POLICY_NAME = ? AND OP.ORGANIZATION = ?";
+                        " OP.POLICY_NAME = ? AND OP.POLICY_VERSION = ? AND OP.ORGANIZATION = ?";
 
         public static final String GET_ALL_COMMON_OPERATION_POLICIES =
                 "SELECT " +
-                        " OP.POLICY_UUID, OP.POLICY_NAME, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, " +
+                        " OP.POLICY_UUID, OP.POLICY_NAME, OP.POLICY_VERSION, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, " +
                         " OP.API_TYPES, OP.POLICY_PARAMETERS, OP.POLICY_CATEGORY, OP.POLICY_MD5 " +
                         " FROM " +
                         " AM_OPERATION_POLICY OP INNER JOIN AM_COMMON_OPERATION_POLICY COP ON OP.POLICY_UUID = COP.POLICY_UUID " +
@@ -3844,7 +3844,7 @@ public class SQLConstants {
 
         public static final String GET_ALL_API_SPECIFIC_OPERATION_POLICIES_WITHOUT_CLONED_POLICIES =
                 "SELECT " +
-                        " OP.POLICY_UUID, OP.POLICY_NAME, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, " +
+                        " OP.POLICY_UUID, OP.POLICY_NAME, OP.POLICY_VERSION, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, " +
                         " OP.API_TYPES, OP.POLICY_PARAMETERS, OP.POLICY_CATEGORY, OP.POLICY_MD5 " +
                         " FROM " +
                         " AM_OPERATION_POLICY OP INNER JOIN AM_API_OPERATION_POLICY AOP ON OP.POLICY_UUID = AOP.POLICY_UUID " +
@@ -3888,7 +3888,7 @@ public class SQLConstants {
                         " WHERE POLICY_UUID = ? AND GATEWAY_TYPE = ?";
 
         public static final String GET_COMMON_OPERATION_POLICY_NAMES_FOR_ORGANIZATION =
-                "SELECT OP.POLICY_NAME FROM AM_OPERATION_POLICY OP INNER JOIN AM_COMMON_OPERATION_POLICY COP " +
+                "SELECT OP.POLICY_NAME, OP.POLICY_VERSION FROM AM_OPERATION_POLICY OP INNER JOIN AM_COMMON_OPERATION_POLICY COP " +
                         " ON OP.POLICY_UUID = COP.POLICY_UUID WHERE OP.ORGANIZATION = ?";
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -11346,17 +11346,18 @@ public final class APIUtil {
                                 OperationPolicyData policyData = new OperationPolicyData();
                                 policyData.setSpecification(policySpec);
                                 policyData.setOrganization(organization);
-
+                                String policyFileName = getOperationPolicyFileName(policySpec.getName(),
+                                        policySpec.getVersion());
                                 OperationPolicyDefinition synapsePolicyDefinition =
                                         getOperationPolicyDefinitionFromFile(policyDefinitionLocation,
-                                                policySpec.getName(), APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
+                                                policyFileName, APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
                                 if (synapsePolicyDefinition != null) {
                                     synapsePolicyDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.Synapse);
                                     policyData.setSynapsePolicyDefinition(synapsePolicyDefinition);
                                 }
                                 OperationPolicyDefinition ccPolicyDefinition =
                                         getOperationPolicyDefinitionFromFile(policyDefinitionLocation,
-                                                policySpec.getName(), APIConstants.CC_POLICY_DEFINITION_EXTENSION);
+                                                policyFileName, APIConstants.CC_POLICY_DEFINITION_EXTENSION);
                                 if (ccPolicyDefinition != null) {
                                     ccPolicyDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.ChoreoConnect);
                                     policyData.setCcPolicyDefinition(ccPolicyDefinition);
@@ -11384,19 +11385,19 @@ public final class APIUtil {
      * Read the operation policy definition from the provided path and return the definition object
      *
      * @param extractedFolderPath   Location of the policy definition
-     * @param policyName            Name of the policy
+     * @param definitionFileName    Name of the policy file
      * @param fileExtension         Since there can be both synapse and choreo connect definitons, fileExtension is used
      *
      * @return OperationPolicyDefinition
      */
     public static OperationPolicyDefinition getOperationPolicyDefinitionFromFile(String extractedFolderPath,
-                                                                                 String policyName,
+                                                                                 String definitionFileName,
                                                                                  String fileExtension)
             throws APIManagementException {
 
         OperationPolicyDefinition policyDefinition = null;
         try {
-            String fileName = extractedFolderPath + File.separator + policyName + fileExtension;
+            String fileName = extractedFolderPath + File.separator + definitionFileName + fileExtension;
             if (checkFileExistence(fileName)) {
                 if (log.isDebugEnabled()) {
                     log.debug("Found policy definition file " + fileName);
@@ -11597,6 +11598,13 @@ public final class APIUtil {
         return policyData;
     }
 
+
+    public static String getOperationPolicyFileName(String policyName, String policyVersion) {
+        if (StringUtils.isEmpty(policyVersion)) {
+            policyVersion = "v1";
+        }
+        return policyName + "_" + policyVersion;
+    }
 
     public static void initializeVelocityContext(VelocityEngine velocityEngine){
         velocityEngine.setProperty(RuntimeConstants.OLD_CHECK_EMPTY_OBJECTS, false);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -328,6 +328,14 @@
       {
         "Name": "apim:api_definition_view",
         "Roles": "Internal/integration_dev"
+      },
+      {
+        "Name": "apim:common_operation_policy_view",
+        "Roles": "admin,Internal/creator,Internal/publisher"
+      },
+      {
+        "Name": "apim:common_operation_policy_manage",
+        "Roles": "admin,Internal/creator"
       }
     ]
   },

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
@@ -4059,11 +4059,11 @@ public class APIProviderImplTest {
         api.setFaultSequence("test-sequence");
 
         Mockito.when(apiProvider.getAPISpecificOperationPolicyByPolicyName(api.getInSequence(),
-                api.getUuid(), null, superTenantDomain, false)).thenReturn(null);
+                APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, superTenantDomain, false)).thenReturn(null);
         Mockito.when(apiProvider.getAPISpecificOperationPolicyByPolicyName(api.getOutSequence(),
-                api.getUuid(), null, superTenantDomain, false)).thenReturn(null);
+                APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, superTenantDomain, false)).thenReturn(null);
         Mockito.when(apiProvider.getAPISpecificOperationPolicyByPolicyName(api.getFaultSequence(),
-                api.getUuid(), null, superTenantDomain, false)).thenReturn(null);
+                APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, superTenantDomain, false)).thenReturn(null);
 
         PowerMockito.when(APIUtil.isSequenceDefined(Mockito.anyString())).thenReturn(true);
         apiProvider.loadMediationPoliciesAsOperationPoliciesToAPI(api, superTenantDomain);
@@ -4111,11 +4111,11 @@ public class APIProviderImplTest {
         policyData.setPolicyId(policyId);
 
         Mockito.when(apiProvider.getAPISpecificOperationPolicyByPolicyName(api.getInSequence(),
-                api.getUuid(), null, superTenantDomain, false)).thenReturn(policyData);
+                APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, superTenantDomain, false)).thenReturn(policyData);
         Mockito.when(apiProvider.getAPISpecificOperationPolicyByPolicyName(api.getOutSequence(),
-                api.getUuid(), null, superTenantDomain, false)).thenReturn(null);
+                APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, superTenantDomain, false)).thenReturn(null);
         Mockito.when(apiProvider.getAPISpecificOperationPolicyByPolicyName(api.getFaultSequence(),
-                api.getUuid(), null, superTenantDomain, false)).thenReturn(policyData);
+                APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, superTenantDomain, false)).thenReturn(policyData);
 
         PowerMockito.when(APIUtil.isSequenceDefined(Mockito.anyString())).thenReturn(true);
         apiProvider.loadMediationPoliciesAsOperationPoliciesToAPI(api, superTenantDomain);
@@ -4195,7 +4195,7 @@ public class APIProviderImplTest {
         PowerMockito.when(APIUtil.isSequenceDefined(api.getInSequence())).thenReturn(true);
 
         Mockito.when(apiProvider.getAPISpecificOperationPolicyByPolicyName("in-policy",
-                api.getUuid(), null, superTenantDomain, false)).thenReturn(null);
+                APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, superTenantDomain, false)).thenReturn(null);
         PowerMockito.when(APIUtil.getPolicyDataForMediationFlow(api, APIConstants.OPERATION_SEQUENCE_TYPE_REQUEST,
                 superTenantDomain)).thenReturn(policyData);
         Mockito.when(apiProvider.addAPISpecificOperationPolicy(apiuuid, policyData, superTenantDomain)).thenReturn("11111");
@@ -4276,7 +4276,7 @@ public class APIProviderImplTest {
         PowerMockito.when(APIUtil.isSequenceDefined(api.getInSequence())).thenReturn(true);
 
         Mockito.when(apiProvider.getAPISpecificOperationPolicyByPolicyName("in-policy",
-                api.getUuid(), null, superTenantDomain, false)).thenReturn(policyData);
+                APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, superTenantDomain, false)).thenReturn(policyData);
 
         apiProvider.migrateMediationPoliciesOfAPI(api, superTenantDomain, false);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/OperationPolicyDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/OperationPolicyDTO.java
@@ -24,6 +24,7 @@ import javax.validation.Valid;
 public class OperationPolicyDTO   {
   
     private String policyName = null;
+    private String policyVersion = "v1";
     private String policyId = null;
     private Map<String, Object> parameters = new HashMap<String, Object>();
 
@@ -43,6 +44,23 @@ public class OperationPolicyDTO   {
   }
   public void setPolicyName(String policyName) {
     this.policyName = policyName;
+  }
+
+  /**
+   **/
+  public OperationPolicyDTO policyVersion(String policyVersion) {
+    this.policyVersion = policyVersion;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("policyVersion")
+  public String getPolicyVersion() {
+    return policyVersion;
+  }
+  public void setPolicyVersion(String policyVersion) {
+    this.policyVersion = policyVersion;
   }
 
   /**
@@ -90,13 +108,14 @@ public class OperationPolicyDTO   {
     }
     OperationPolicyDTO operationPolicy = (OperationPolicyDTO) o;
     return Objects.equals(policyName, operationPolicy.policyName) &&
+        Objects.equals(policyVersion, operationPolicy.policyVersion) &&
         Objects.equals(policyId, operationPolicy.policyId) &&
         Objects.equals(parameters, operationPolicy.parameters);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(policyName, policyId, parameters);
+    return Objects.hash(policyName, policyVersion, policyId, parameters);
   }
 
   @Override
@@ -105,6 +124,7 @@ public class OperationPolicyDTO   {
     sb.append("class OperationPolicyDTO {\n");
     
     sb.append("    policyName: ").append(toIndentedString(policyName)).append("\n");
+    sb.append("    policyVersion: ").append(toIndentedString(policyVersion)).append("\n");
     sb.append("    policyId: ").append(toIndentedString(policyId)).append("\n");
     sb.append("    parameters: ").append(toIndentedString(parameters)).append("\n");
     sb.append("}");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
@@ -98,12 +98,14 @@ public class SynapsePolicyAggregator {
         for (OperationPolicy policy : operationPolicies) {
             if (flow.equals(policy.getDirection())) {
                 Map<String, Object> policyParameters = policy.getParameters();
+                String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
+                        policy.getPolicyVersion());
                 OperationPolicySpecification policySpecification = ImportUtils
-                        .getOperationPolicySpecificationFromFile(policyDirectory, policy.getPolicyName());
+                        .getOperationPolicySpecificationFromFile(policyDirectory, policyFileName);
                 if (policySpecification.getSupportedGateways()
                         .contains(APIConstants.OPERATION_POLICY_SUPPORTED_GATEWAY_SYNAPSE)) {
                     OperationPolicyDefinition policyDefinition =
-                            APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory, policy.getPolicyName(),
+                            APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory, policyFileName,
                                     APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
                     if (policyDefinition != null) {
                         try {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.apimgt.api.dto.ClientCertificateDTO;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIProductIdentifier;
+import org.wso2.carbon.apimgt.api.model.APIRevision;
 import org.wso2.carbon.apimgt.api.model.APIRevisionDeployment;
 import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.api.model.DocumentationContent;
@@ -625,6 +626,15 @@ public class ExportUtils {
             throws APIManagementException {
 
         try {
+
+            String currentApiUuid;
+            APIRevision apiRevision = apiProvider.checkAPIUUIDIsARevisionUUID(apiID);
+            if (apiRevision != null && apiRevision.getApiUUID() != null) {
+                currentApiUuid = apiRevision.getApiUUID();
+            } else {
+                currentApiUuid = apiID;
+            }
+
             CommonUtil.createDirectory(archivePath + File.separator + ImportExportConstants.POLICIES_DIRECTORY);
             Set<URITemplate> uriTemplates = api.getUriTemplates();
             Set<String> exportedPolicies = new HashSet<>();
@@ -638,8 +648,8 @@ public class ExportUtils {
                                     policy.getPolicyVersion());
                             if (policy.getPolicyId() != null) {
                                 OperationPolicyData policyData =
-                                        apiProvider.getAPISpecificOperationPolicyByPolicyId(policy.getPolicyId(), apiID,
-                                                tenantDomain, true);
+                                        apiProvider.getAPISpecificOperationPolicyByPolicyId(policy.getPolicyId(),
+                                                currentApiUuid, tenantDomain, true);
                                 if (policyData != null) {
                                     exportPolicyData(policyFileName, policyData, archivePath, exportFormat);
                                     exportedPolicies.add(policy.getPolicyName());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -634,12 +634,14 @@ public class ExportUtils {
                 if (operationPolicies != null && !operationPolicies.isEmpty()) {
                     for (OperationPolicy policy : operationPolicies) {
                         if (!exportedPolicies.contains(policy.getPolicyName())) {
+                            String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
+                                    policy.getPolicyVersion());
                             if (policy.getPolicyId() != null) {
                                 OperationPolicyData policyData =
                                         apiProvider.getAPISpecificOperationPolicyByPolicyId(policy.getPolicyId(), apiID,
                                                 tenantDomain, true);
                                 if (policyData != null) {
-                                    exportPolicyData(policyData, archivePath, exportFormat);
+                                    exportPolicyData(policyFileName, policyData, archivePath, exportFormat);
                                     exportedPolicies.add(policy.getPolicyName());
                                 }
                             } else {
@@ -657,7 +659,7 @@ public class ExportUtils {
                                     OperationPolicyData policyData = APIUtil.getPolicyDataForMediationFlow(api,
                                             policy.getDirection(), tenantDomain);
                                     if (policyData != null) {
-                                        exportPolicyData(policyData, archivePath, exportFormat);
+                                        exportPolicyData(policyFileName, policyData, archivePath, exportFormat);
                                         exportedPolicies.add(policy.getPolicyName());
                                     }
                                 }
@@ -682,11 +684,11 @@ public class ExportUtils {
         }
     }
 
-    public static void exportPolicyData(OperationPolicyData policyData, String archivePath, ExportFormat exportFormat)
+    public static void exportPolicyData(String policyFileName, OperationPolicyData policyData, String archivePath, ExportFormat exportFormat)
             throws APIImportExportException, IOException {
 
         String policyName = archivePath + File.separator + ImportExportConstants.POLICIES_DIRECTORY + File.separator +
-                policyData.getSpecification().getName();
+                policyFileName;
         // Policy specification and definition will have the same name
         if (policyData.getSpecification() != null) {
             CommonUtil.writeDtoToFile(policyName, exportFormat, ImportExportConstants.TYPE_POLICY_SPECIFICATION,
@@ -928,7 +930,7 @@ public class ExportUtils {
             JsonElement apiObj = gson.toJsonTree(apiDtoToReturn);
             JsonObject apiJson = (JsonObject) apiObj;
             apiJson.addProperty("organizationId", organization);
-            
+
             CommonUtil.writeDtoToFile(archivePath + ImportExportConstants.API_FILE_LOCATION, exportFormat,
                     ImportExportConstants.TYPE_API, apiJson);
         } catch (APIManagementException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -684,8 +684,8 @@ public class ExportUtils {
         }
     }
 
-    public static void exportPolicyData(String policyFileName, OperationPolicyData policyData, String archivePath, ExportFormat exportFormat)
-            throws APIImportExportException, IOException {
+    public static void exportPolicyData(String policyFileName, OperationPolicyData policyData, String archivePath,
+                                        ExportFormat exportFormat) throws APIImportExportException, IOException {
 
         String policyName = archivePath + File.separator + ImportExportConstants.POLICIES_DIRECTORY + File.separator +
                 policyFileName;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -441,9 +441,10 @@ public class ImportUtils {
                 if (operationPolicies != null && !operationPolicies.isEmpty()) {
                     for (OperationPolicy policy : operationPolicies) {
                         try {
+                            String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
+                                    policy.getPolicyVersion());
                             OperationPolicySpecification policySpec =
-                                    getOperationPolicySpecificationFromFile(policyDirectory,
-                                            policy.getPolicyName());
+                                    getOperationPolicySpecificationFromFile(policyDirectory, policyFileName);
 
                             OperationPolicyData operationPolicyData = new OperationPolicyData();
                             operationPolicyData.setSpecification(policySpec);
@@ -452,14 +453,14 @@ public class ImportUtils {
 
                             OperationPolicyDefinition synapseDefinition =
                                     APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
-                                            policy.getPolicyName(), APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
+                                            policyFileName, APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
                             if (synapseDefinition != null) {
                                 synapseDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.Synapse);
                                 operationPolicyData.setSynapsePolicyDefinition(synapseDefinition);
                             }
                             OperationPolicyDefinition ccDefinition =
                                     APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
-                                            policy.getPolicyName(), APIConstants.CC_POLICY_DEFINITION_EXTENSION);
+                                            policyFileName, APIConstants.CC_POLICY_DEFINITION_EXTENSION);
                             if (ccDefinition != null) {
                                 ccDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.ChoreoConnect);
                                 operationPolicyData.setCcPolicyDefinition(ccDefinition);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -432,6 +432,7 @@ public class ImportUtils {
                                                              String tenantDomain) {
 
         String policyDirectory = extractedFolderPath + File.separator + ImportExportConstants.POLICIES_DIRECTORY;
+        Map<String, String> importedPolicies = new HashMap<>();
         Set<URITemplate> uriTemplates = api.getUriTemplates();
         for (URITemplate uriTemplate : uriTemplates) {
             String key = uriTemplate.getHTTPVerb() + ":" + uriTemplate.getUriTemplate();
@@ -443,34 +444,43 @@ public class ImportUtils {
                         try {
                             String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
                                     policy.getPolicyVersion());
-                            OperationPolicySpecification policySpec =
-                                    getOperationPolicySpecificationFromFile(policyDirectory, policyFileName);
+                            String policyID;
+                            if (!importedPolicies.containsKey(policyFileName)) {
+                                OperationPolicySpecification policySpec =
+                                        getOperationPolicySpecificationFromFile(policyDirectory, policyFileName);
 
-                            OperationPolicyData operationPolicyData = new OperationPolicyData();
-                            operationPolicyData.setSpecification(policySpec);
-                            operationPolicyData.setOrganization(tenantDomain);
-                            operationPolicyData.setApiUUID(api.getUuid());
+                                OperationPolicyData operationPolicyData = new OperationPolicyData();
+                                operationPolicyData.setSpecification(policySpec);
+                                operationPolicyData.setOrganization(tenantDomain);
+                                operationPolicyData.setApiUUID(api.getUuid());
 
-                            OperationPolicyDefinition synapseDefinition =
-                                    APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
-                                            policyFileName, APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
-                            if (synapseDefinition != null) {
-                                synapseDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.Synapse);
-                                operationPolicyData.setSynapsePolicyDefinition(synapseDefinition);
+                                OperationPolicyDefinition synapseDefinition =
+                                        APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
+                                                policyFileName, APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
+                                if (synapseDefinition != null) {
+                                    synapseDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.Synapse);
+                                    operationPolicyData.setSynapsePolicyDefinition(synapseDefinition);
+                                }
+                                OperationPolicyDefinition ccDefinition =
+                                        APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
+                                                policyFileName, APIConstants.CC_POLICY_DEFINITION_EXTENSION);
+                                if (ccDefinition != null) {
+                                    ccDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.ChoreoConnect);
+                                    operationPolicyData.setCcPolicyDefinition(ccDefinition);
+                                }
+                                operationPolicyData.setMd5Hash(APIUtil.getMd5OfOperationPolicy(operationPolicyData));
+                                policyID = provider.importOperationPolicy(operationPolicyData, tenantDomain);
+                                importedPolicies.put(policyFileName, policyID);
+                            } else {
+                                policyID = importedPolicies.get(policyFileName);
                             }
-                            OperationPolicyDefinition ccDefinition =
-                                    APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
-                                            policyFileName, APIConstants.CC_POLICY_DEFINITION_EXTENSION);
-                            if (ccDefinition != null) {
-                                ccDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.ChoreoConnect);
-                                operationPolicyData.setCcPolicyDefinition(ccDefinition);
-                            }
-                            operationPolicyData.setMd5Hash(APIUtil.getMd5OfOperationPolicy(operationPolicyData));
-                            String policyID = provider.importOperationPolicy(operationPolicyData, tenantDomain);
+
                             policy.setPolicyId(policyID);
                             validatedOperationPolicies.add(policy);
                         } catch (APIManagementException e) {
-                            log.error(e);
+                            log.error("An error occurred when validating the operation policy "
+                                    + policy.getPolicyName() + "_" + policy.getPolicyVersion() + " for url template "
+                                    + uriTemplate.getUriTemplate() + ". Hence skipped.", e);
                         }
                     }
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/OperationPolicyMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/OperationPolicyMappingUtil.java
@@ -56,6 +56,7 @@ public class OperationPolicyMappingUtil {
 
         OperationPolicy operationPolicy = new OperationPolicy();
         operationPolicy.setPolicyName(operationPolicyDTO.getPolicyName());
+        operationPolicy.setPolicyVersion(operationPolicyDTO.getPolicyVersion());
         operationPolicy.setPolicyId(operationPolicyDTO.getPolicyId());
         operationPolicy.setParameters(operationPolicyDTO.getParameters());
         return operationPolicy;
@@ -65,6 +66,7 @@ public class OperationPolicyMappingUtil {
 
         OperationPolicyDTO dto = new OperationPolicyDTO();
         dto.setPolicyName(operationPolicy.getPolicyName());
+        dto.setPolicyVersion(operationPolicy.getPolicyVersion());
         dto.setPolicyId(operationPolicy.getPolicyId());
         dto.setParameters(operationPolicy.getParameters());
         return dto;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/ApisApi.java
@@ -174,7 +174,8 @@ ApisApiService delegate = new ApisApiServiceImpl();
     @ApiResponses(value = { 
         @ApiResponse(code = 201, message = "OK. Operation policy uploaded ", response = OperationPolicyDataDTO.class),
         @ApiResponse(code = 400, message = "Bad Request. Invalid request or validation error.", response = ErrorDTO.class),
-        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class) })
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
     public Response addAPISpecificOperationPolicy(@ApiParam(value = "**API ID** consisting of the **UUID** of the API. ",required=true) @PathParam("apiId") String apiId,  @Multipart(value = "policySpecFile", required = false) InputStream policySpecFileInputStream, @Multipart(value = "policySpecFile" , required = false) Attachment policySpecFileDetail,  @Multipart(value = "synapsePolicyDefinitionFile", required = false) InputStream synapsePolicyDefinitionFileInputStream, @Multipart(value = "synapsePolicyDefinitionFile" , required = false) Attachment synapsePolicyDefinitionFileDetail,  @Multipart(value = "ccPolicyDefinitionFile", required = false) InputStream ccPolicyDefinitionFileInputStream, @Multipart(value = "ccPolicyDefinitionFile" , required = false) Attachment ccPolicyDefinitionFileDetail) throws APIManagementException{
         return delegate.addAPISpecificOperationPolicy(apiId, policySpecFileInputStream, policySpecFileDetail, synapsePolicyDefinitionFileInputStream, synapsePolicyDefinitionFileDetail, ccPolicyDefinitionFileInputStream, ccPolicyDefinitionFileDetail, securityContext);
     }
@@ -469,7 +470,8 @@ ApisApiService delegate = new ApisApiServiceImpl();
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "OK. Resource successfully deleted. ", response = Void.class),
         @ApiResponse(code = 403, message = "Forbidden. The request must be conditional but no condition has been specified.", response = ErrorDTO.class),
-        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class) })
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
     public Response deleteAPISpecificOperationPolicyByPolicyId(@ApiParam(value = "**API ID** consisting of the **UUID** of the API. ",required=true) @PathParam("apiId") String apiId, @ApiParam(value = "Operation policy Id ",required=true) @PathParam("operationPolicyId") String operationPolicyId) throws APIManagementException{
         return delegate.deleteAPISpecificOperationPolicyByPolicyId(apiId, operationPolicyId, securityContext);
     }
@@ -968,7 +970,8 @@ ApisApiService delegate = new ApisApiServiceImpl();
     }, tags={ "API Operation Policies",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "OK. Operation policy returned. ", response = File.class),
-        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class) })
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
     public Response getAPISpecificOperationPolicyContentByPolicyId(@ApiParam(value = "**API ID** consisting of the **UUID** of the API. ",required=true) @PathParam("apiId") String apiId, @ApiParam(value = "Operation policy Id ",required=true) @PathParam("operationPolicyId") String operationPolicyId) throws APIManagementException{
         return delegate.getAPISpecificOperationPolicyContentByPolicyId(apiId, operationPolicyId, securityContext);
     }
@@ -1046,7 +1049,8 @@ ApisApiService delegate = new ApisApiServiceImpl();
     }, tags={ "API Operation Policies",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "OK. List of qualifying policies is returned. ", response = OperationPolicyDataListDTO.class),
-        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class) })
+        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
     public Response getAllAPISpecificOperationPolicies(@ApiParam(value = "**API ID** consisting of the **UUID** of the API. ",required=true) @PathParam("apiId") String apiId,  @ApiParam(value = "Maximum size of resource array to return. ", defaultValue="25") @DefaultValue("25") @QueryParam("limit") Integer limit,  @ApiParam(value = "Starting point within the complete list of items qualified. ", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset,  @ApiParam(value = "-Not supported yet-")  @QueryParam("query") String query) throws APIManagementException{
         return delegate.getAllAPISpecificOperationPolicies(apiId, limit, offset, query, securityContext);
     }
@@ -1236,7 +1240,8 @@ ApisApiService delegate = new ApisApiServiceImpl();
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "OK. Operation policy returned. ", response = OperationPolicyDataDTO.class),
         @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
-        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class) })
+        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
     public Response getOperationPolicyForAPIByPolicyId(@ApiParam(value = "**API ID** consisting of the **UUID** of the API. ",required=true) @PathParam("apiId") String apiId, @ApiParam(value = "Operation policy Id ",required=true) @PathParam("operationPolicyId") String operationPolicyId) throws APIManagementException{
         return delegate.getOperationPolicyForAPIByPolicyId(apiId, operationPolicyId, securityContext);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/ApisApi.java
@@ -165,7 +165,6 @@ ApisApiService delegate = new ApisApiServiceImpl();
     @Produces({ "application/json" })
     @ApiOperation(value = "Add an API specific operation policy", notes = "This operation can be used to add an API specifc operation policy. This policy cannot be used in other APIs. ", response = OperationPolicyDataDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:api_create", description = "Create API"),
             @AuthorizationScope(scope = "apim:api_manage", description = "Manage all API related operations"),
             @AuthorizationScope(scope = "apim:mediation_policy_create", description = "Create mediation policies"),
             @AuthorizationScope(scope = "apim:mediation_policy_manage", description = "Update and delete mediation policies"),
@@ -461,8 +460,8 @@ ApisApiService delegate = new ApisApiServiceImpl();
     @Produces({ "application/json" })
     @ApiOperation(value = "Delete an API Specific Operation Policy", notes = "This operation can be used to delete an existing API specific opreation policy by providing the Id of the API and the Id of the policy. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:api_create", description = "Create API"),
             @AuthorizationScope(scope = "apim:api_manage", description = "Manage all API related operations"),
+            @AuthorizationScope(scope = "apim:mediation_policy_create", description = "Create mediation policies"),
             @AuthorizationScope(scope = "apim:mediation_policy_manage", description = "Update and delete mediation policies"),
             @AuthorizationScope(scope = "apim:api_mediation_policy_manage", description = "View, create, update and remove API specific mediation policies")
         })

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApi.java
@@ -44,11 +44,7 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @Produces({ "application/json" })
     @ApiOperation(value = "Add a new common operation policy", notes = "This operation can be used to add a new common operation policy. ", response = OperationPolicyDataDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:api_create", description = "Create API"),
-            @AuthorizationScope(scope = "apim:api_manage", description = "Manage all API related operations"),
-            @AuthorizationScope(scope = "apim:mediation_policy_create", description = "Create mediation policies"),
-            @AuthorizationScope(scope = "apim:mediation_policy_manage", description = "Update and delete mediation policies"),
-            @AuthorizationScope(scope = "apim:api_mediation_policy_manage", description = "View, create, update and remove API specific mediation policies")
+            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies")
         })
     }, tags={ "Operation Policies",  })
     @ApiResponses(value = { 
@@ -65,10 +61,7 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @Produces({ "application/json" })
     @ApiOperation(value = "Delete a common operation policy", notes = "This operation can be used to delete an existing common opreation policy by providing the Id of the policy. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:api_create", description = "Create API"),
-            @AuthorizationScope(scope = "apim:api_manage", description = "Manage all API related operations"),
-            @AuthorizationScope(scope = "apim:mediation_policy_manage", description = "Update and delete mediation policies"),
-            @AuthorizationScope(scope = "apim:api_mediation_policy_manage", description = "View, create, update and remove API specific mediation policies")
+            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies")
         })
     }, tags={ "Operation Policies",  })
     @ApiResponses(value = { 
@@ -86,10 +79,8 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @ApiOperation(value = "Export the operation policies specification schema.", notes = "This operation can be used to export the operation-policy-specification-schema.json used in deployment. ", response = String.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:api_view", description = "View API"),
-            @AuthorizationScope(scope = "apim:api_manage", description = "Manage all API related operations"),
             @AuthorizationScope(scope = "apim:mediation_policy_view", description = "View mediation policies"),
-            @AuthorizationScope(scope = "apim:mediation_policy_manage", description = "Update and delete mediation policies"),
-            @AuthorizationScope(scope = "apim:api_mediation_policy_manage", description = "View, create, update and remove API specific mediation policies")
+            @AuthorizationScope(scope = "apim:common_operation_policy_view", description = "View common operation policies")
         })
     }, tags={ "Operation Policies",  })
     @ApiResponses(value = { 
@@ -107,11 +98,8 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @Produces({ "application/json" })
     @ApiOperation(value = "Get all common operation policies to all the APIs ", notes = "This operation provides you a list of all common operation policies that can be used by any API ", response = OperationPolicyDataListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:api_view", description = "View API"),
-            @AuthorizationScope(scope = "apim:api_manage", description = "Manage all API related operations"),
-            @AuthorizationScope(scope = "apim:mediation_policy_view", description = "View mediation policies"),
-            @AuthorizationScope(scope = "apim:mediation_policy_manage", description = "Update and delete mediation policies"),
-            @AuthorizationScope(scope = "apim:api_mediation_policy_manage", description = "View, create, update and remove API specific mediation policies")
+            @AuthorizationScope(scope = "apim:common_operation_policy_view", description = "View common operation policies"),
+            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies")
         })
     }, tags={ "Operation Policies",  })
     @ApiResponses(value = { 
@@ -127,11 +115,8 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @Produces({ "application/json" })
     @ApiOperation(value = "Get the details of a common operation policy by providing policy ID", notes = "This operation can be used to retrieve a particular common operation policy. ", response = OperationPolicyDataDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:api_view", description = "View API"),
-            @AuthorizationScope(scope = "apim:api_manage", description = "Manage all API related operations"),
-            @AuthorizationScope(scope = "apim:mediation_policy_view", description = "View mediation policies"),
-            @AuthorizationScope(scope = "apim:mediation_policy_manage", description = "Update and delete mediation policies"),
-            @AuthorizationScope(scope = "apim:api_mediation_policy_manage", description = "View, create, update and remove API specific mediation policies")
+            @AuthorizationScope(scope = "apim:common_operation_policy_view", description = "View common operation policies"),
+            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies")
         })
     }, tags={ "Operation Policies",  })
     @ApiResponses(value = { 
@@ -148,11 +133,8 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @Produces({ "application/zip", "application/json" })
     @ApiOperation(value = "Download a common operation policy", notes = "This operation can be used to download a selected common operation policy. ", response = File.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:api_view", description = "View API"),
-            @AuthorizationScope(scope = "apim:api_manage", description = "Manage all API related operations"),
-            @AuthorizationScope(scope = "apim:mediation_policy_view", description = "View mediation policies"),
-            @AuthorizationScope(scope = "apim:mediation_policy_manage", description = "Update and delete mediation policies"),
-            @AuthorizationScope(scope = "apim:api_mediation_policy_manage", description = "View, create, update and remove API specific mediation policies")
+            @AuthorizationScope(scope = "apim:common_operation_policy_view", description = "View common operation policies"),
+            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies")
         })
     }, tags={ "Operation Policies" })
     @ApiResponses(value = { 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApi.java
@@ -50,7 +50,8 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @ApiResponses(value = { 
         @ApiResponse(code = 201, message = "OK. Shared operation policy uploaded ", response = OperationPolicyDataDTO.class),
         @ApiResponse(code = 400, message = "Bad Request. Invalid request or validation error.", response = ErrorDTO.class),
-        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class) })
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
     public Response addCommonOperationPolicy( @Multipart(value = "policySpecFile", required = false) InputStream policySpecFileInputStream, @Multipart(value = "policySpecFile" , required = false) Attachment policySpecFileDetail,  @Multipart(value = "synapsePolicyDefinitionFile", required = false) InputStream synapsePolicyDefinitionFileInputStream, @Multipart(value = "synapsePolicyDefinitionFile" , required = false) Attachment synapsePolicyDefinitionFileDetail,  @Multipart(value = "ccPolicyDefinitionFile", required = false) InputStream ccPolicyDefinitionFileInputStream, @Multipart(value = "ccPolicyDefinitionFile" , required = false) Attachment ccPolicyDefinitionFileDetail) throws APIManagementException{
         return delegate.addCommonOperationPolicy(policySpecFileInputStream, policySpecFileDetail, synapsePolicyDefinitionFileInputStream, synapsePolicyDefinitionFileDetail, ccPolicyDefinitionFileInputStream, ccPolicyDefinitionFileDetail, securityContext);
     }
@@ -67,29 +68,10 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "OK. Resource successfully deleted. ", response = Void.class),
         @ApiResponse(code = 403, message = "Forbidden. The request must be conditional but no condition has been specified.", response = ErrorDTO.class),
-        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class) })
-    public Response deleteCommonOperationPolicyByPolicyId(@ApiParam(value = "Operation policy Id ",required=true) @PathParam("operationPolicyId") String operationPolicyId) throws APIManagementException{
-        return delegate.deleteCommonOperationPolicyByPolicyId(operationPolicyId, securityContext);
-    }
-
-    @GET
-    @Path("/specification/schema")
-    
-    @Produces({ "application/json" })
-    @ApiOperation(value = "Export the operation policies specification schema.", notes = "This operation can be used to export the operation-policy-specification-schema.json used in deployment. ", response = String.class, authorizations = {
-        @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:api_view", description = "View API"),
-            @AuthorizationScope(scope = "apim:mediation_policy_view", description = "View mediation policies"),
-            @AuthorizationScope(scope = "apim:common_operation_policy_view", description = "View common operation policies")
-        })
-    }, tags={ "Operation Policies",  })
-    @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "OK. Operation policy specification schema exported successfully. ", response = String.class),
-        @ApiResponse(code = 403, message = "Forbidden. The request must be conditional but no condition has been specified.", response = ErrorDTO.class),
         @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
         @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
-    public Response exportOperationPolicySpecificationSchema() throws APIManagementException{
-        return delegate.exportOperationPolicySpecificationSchema(securityContext);
+    public Response deleteCommonOperationPolicyByPolicyId(@ApiParam(value = "Operation policy Id ",required=true) @PathParam("operationPolicyId") String operationPolicyId) throws APIManagementException{
+        return delegate.deleteCommonOperationPolicyByPolicyId(operationPolicyId, securityContext);
     }
 
     @GET
@@ -104,7 +86,8 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     }, tags={ "Operation Policies",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "OK. List of qualifying policies is returned. ", response = OperationPolicyDataListDTO.class),
-        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class) })
+        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
     public Response getAllCommonOperationPolicies( @ApiParam(value = "Maximum size of resource array to return. ", defaultValue="25") @DefaultValue("25") @QueryParam("limit") Integer limit,  @ApiParam(value = "Starting point within the complete list of items qualified. ", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset,  @ApiParam(value = "-Not supported yet-")  @QueryParam("query") String query) throws APIManagementException{
         return delegate.getAllCommonOperationPolicies(limit, offset, query, securityContext);
     }
@@ -122,7 +105,8 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "OK. Operation policy returned. ", response = OperationPolicyDataDTO.class),
         @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
-        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class) })
+        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
     public Response getCommonOperationPolicyByPolicyId(@ApiParam(value = "Operation policy Id ",required=true) @PathParam("operationPolicyId") String operationPolicyId) throws APIManagementException{
         return delegate.getCommonOperationPolicyByPolicyId(operationPolicyId, securityContext);
     }
@@ -139,7 +123,8 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     }, tags={ "Operation Policies" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "OK. Operation policy returned. ", response = File.class),
-        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class) })
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
     public Response getCommonOperationPolicyContentByPolicyId(@ApiParam(value = "Operation policy Id ",required=true) @PathParam("operationPolicyId") String operationPolicyId) throws APIManagementException{
         return delegate.getCommonOperationPolicyContentByPolicyId(operationPolicyId, securityContext);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApiService.java
@@ -25,7 +25,6 @@ import javax.ws.rs.core.SecurityContext;
 public interface OperationPoliciesApiService {
       public Response addCommonOperationPolicy(InputStream policySpecFileInputStream, Attachment policySpecFileDetail, InputStream synapsePolicyDefinitionFileInputStream, Attachment synapsePolicyDefinitionFileDetail, InputStream ccPolicyDefinitionFileInputStream, Attachment ccPolicyDefinitionFileDetail, MessageContext messageContext) throws APIManagementException;
       public Response deleteCommonOperationPolicyByPolicyId(String operationPolicyId, MessageContext messageContext) throws APIManagementException;
-      public Response exportOperationPolicySpecificationSchema(MessageContext messageContext) throws APIManagementException;
       public Response getAllCommonOperationPolicies(Integer limit, Integer offset, String query, MessageContext messageContext) throws APIManagementException;
       public Response getCommonOperationPolicyByPolicyId(String operationPolicyId, MessageContext messageContext) throws APIManagementException;
       public Response getCommonOperationPolicyContentByPolicyId(String operationPolicyId, MessageContext messageContext) throws APIManagementException;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -2378,8 +2378,8 @@ public class ApisApiServiceImpl implements ApisApiService {
                 operationPolicyData.setMd5Hash(APIUtil.getMd5OfOperationPolicy(operationPolicyData));
 
                 OperationPolicyData existingPolicy =
-                        apiProvider.getAPISpecificOperationPolicyByPolicyName(policySpecification.getName(), apiId,
-                                null, organization, false);
+                        apiProvider.getAPISpecificOperationPolicyByPolicyName(policySpecification.getName(),
+                                policySpecification.getVersion(), apiId, null, organization, false);
                 String policyID;
                 if (existingPolicy == null) {
                     policyID = apiProvider.addAPISpecificOperationPolicy(apiId, operationPolicyData, organization);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
@@ -122,8 +122,8 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
                 operationPolicyData.setMd5Hash(APIUtil.getMd5OfOperationPolicy(operationPolicyData));
 
                 OperationPolicyData existingPolicy =
-                        apiProvider.getCommonOperationPolicyByPolicyName(policySpecification.getName(), organization,
-                                false);
+                        apiProvider.getCommonOperationPolicyByPolicyName(policySpecification.getName(),
+                                policySpecification.getVersion(), organization, false);
                 String policyID;
                 if (existingPolicy == null) {
                     policyID = apiProvider.addCommonOperationPolicy(operationPolicyData, organization);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
@@ -194,15 +194,6 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
         return null;
     }
 
-    @Override
-    public Response exportOperationPolicySpecificationSchema(MessageContext messageContext)
-            throws APIManagementException {
-
-        String schema = APIUtil.retrieveOperationPolicySpecificationJsonSchema().toString();
-        return Response.ok().entity(schema)
-                .header(RestApiConstants.HEADER_CONTENT_TYPE, RestApiConstants.APPLICATION_JSON).build();
-    }
-
     /**
      * Get the list of all common operation policies for a given organization
      *

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -11513,6 +11513,9 @@ components:
       properties:
         policyName:
           type: string
+        policyVersion:
+          type: string
+          default: v1
         policyId:
           type: string
         parameters:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -7514,6 +7514,8 @@ paths:
                 $ref: '#/components/schemas/OperationPolicyDataList'
         406:
           $ref: '#/components/responses/NotAcceptable'
+        500:
+          $ref: '#/components/responses/InternalServerError'
       security:
         - OAuth2Security:
             - apim:api_view    #This scope was added as the publisher user needs to access this resource. Mediation_policy_view scope is not included in the Internal/Publisher user.
@@ -7579,6 +7581,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         404:
           $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
       security:
         - OAuth2Security:
             - apim:api_manage
@@ -7622,6 +7626,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         406:
           $ref: '#/components/responses/NotAcceptable'
+        500:
+          $ref: '#/components/responses/InternalServerError'
       security:
         - OAuth2Security:
             - apim:api_view   #This scope was added as the publisher user needs to access this resource. Mediation_policy_view scope is not included in the Internal/Publisher user.
@@ -7654,6 +7660,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         404:
           $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
       security:
         - OAuth2Security:
             - apim:api_manage
@@ -7694,6 +7702,8 @@ paths:
                 format: binary
         404:
           $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
       security:
         - OAuth2Security:
             - apim:api_view  #This scope was added as the publisher user needs to access this resource. Mediation_policy_view scope is not included in the Internal/Publisher user.
@@ -7739,6 +7749,8 @@ paths:
                 $ref: '#/components/schemas/OperationPolicyDataList'
         406:
           $ref: '#/components/responses/NotAcceptable'
+        500:
+          $ref: '#/components/responses/InternalServerError'
       security:
         - OAuth2Security:
             - apim:common_operation_policy_view
@@ -7799,6 +7811,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         404:
           $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
       security:
         - OAuth2Security:
             - apim:common_operation_policy_manage
@@ -7837,6 +7851,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         406:
           $ref: '#/components/responses/NotAcceptable'
+        500:
+          $ref: '#/components/responses/InternalServerError'
       security:
         - OAuth2Security:
             - apim:common_operation_policy_view
@@ -7865,6 +7881,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         404:
           $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
       security:
         - OAuth2Security:
             - apim:common_operation_policy_manage
@@ -7901,6 +7919,8 @@ paths:
                 format: binary
         404:
           $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
       security:
         - OAuth2Security:
             - apim:common_operation_policy_view
@@ -7909,46 +7929,6 @@ paths:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
           "https://127.0.0.1:9443/api/am/publisher/v2/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a/content"'
-
-  /operation-policies/specification/schema:
-    get:
-      tags:
-        - Operation Policies
-      summary: Export the operation policies specification schema.
-      description: |
-        This operation can be used to export the operation-policy-specification-schema.json used in deployment.
-      operationId: exportOperationPolicySpecificationSchema
-      responses:
-        200:
-          description: |
-            OK.
-            Operation policy specification schema exported successfully.
-          headers:
-            Content-Type:
-              description: |
-                The content type of the body.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                type: string
-        403:
-          $ref: '#/components/responses/Forbidden'
-        404:
-          $ref: '#/components/responses/NotFound'
-        500:
-          $ref: '#/components/responses/InternalServerError'
-      security:
-        - OAuth2Security:
-            - apim:api_view
-            - apim:mediation_policy_view
-            - apim:common_operation_policy_view
-      x-code-samples:
-        - lang: Shell
-          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/v2/operation-policies/specification/schema" > operation-policy-specification-schema.json'
-
 
   /api-products/change-lifecycle:
     post:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -12180,6 +12180,8 @@ components:
             apim:mediation_policy_view: View mediation policies
             apim:mediation_policy_create: Create mediation policies
             apim:mediation_policy_manage: Update and delete mediation policies
+            apim:common_operation_policy_view: View common operation policies
+            apim:common_operation_policy_manage: Add, Update and Delete common operation policies
             apim:client_certificates_view: View client certificates
             apim:client_certificates_add: Add client certificates
             apim:client_certificates_update: Update and delete client certificates

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -7516,7 +7516,7 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
       security:
         - OAuth2Security:
-            - apim:api_view
+            - apim:api_view    #This scope was added as the publisher user needs to access this resource. Mediation_policy_view scope is not included in the Internal/Publisher user.
             - apim:api_manage
             - apim:mediation_policy_view
             - apim:mediation_policy_manage
@@ -7581,7 +7581,6 @@ paths:
           $ref: '#/components/responses/NotFound'
       security:
         - OAuth2Security:
-            - apim:api_create #todo: consider removing this. There are some requirements to deny creating policies even though user has api_create scope.
             - apim:api_manage
             - apim:mediation_policy_create
             - apim:mediation_policy_manage
@@ -7625,7 +7624,7 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
       security:
         - OAuth2Security:
-            - apim:api_view
+            - apim:api_view   #This scope was added as the publisher user needs to access this resource. Mediation_policy_view scope is not included in the Internal/Publisher user.
             - apim:api_manage
             - apim:mediation_policy_view
             - apim:mediation_policy_manage
@@ -7657,8 +7656,8 @@ paths:
           $ref: '#/components/responses/NotFound'
       security:
         - OAuth2Security:
-            - apim:api_create
             - apim:api_manage
+            - apim:mediation_policy_create
             - apim:mediation_policy_manage
             - apim:api_mediation_policy_manage
       x-code-samples:
@@ -7697,7 +7696,7 @@ paths:
           $ref: '#/components/responses/NotFound'
       security:
         - OAuth2Security:
-            - apim:api_view
+            - apim:api_view  #This scope was added as the publisher user needs to access this resource. Mediation_policy_view scope is not included in the Internal/Publisher user.
             - apim:api_manage
             - apim:mediation_policy_view
             - apim:mediation_policy_manage
@@ -7742,11 +7741,8 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
       security:
         - OAuth2Security:
-            - apim:api_view
-            - apim:api_manage
-            - apim:mediation_policy_view
-            - apim:mediation_policy_manage
-            - apim:api_mediation_policy_manage
+            - apim:common_operation_policy_view
+            - apim:common_operation_policy_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -7805,11 +7801,7 @@ paths:
           $ref: '#/components/responses/NotFound'
       security:
         - OAuth2Security:
-            - apim:api_create #todo: consider removing this. There are some requirements to deny creating policies even though user has api_create scope.
-            - apim:api_manage
-            - apim:mediation_policy_create
-            - apim:mediation_policy_manage
-            - apim:api_mediation_policy_manage
+            - apim:common_operation_policy_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -7847,11 +7839,8 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
       security:
         - OAuth2Security:
-            - apim:api_view
-            - apim:api_manage
-            - apim:mediation_policy_view
-            - apim:mediation_policy_manage
-            - apim:api_mediation_policy_manage
+            - apim:common_operation_policy_view
+            - apim:common_operation_policy_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -7878,10 +7867,7 @@ paths:
           $ref: '#/components/responses/NotFound'
       security:
         - OAuth2Security:
-            - apim:api_create
-            - apim:api_manage
-            - apim:mediation_policy_manage
-            - apim:api_mediation_policy_manage
+            - apim:common_operation_policy_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -7917,11 +7903,8 @@ paths:
           $ref: '#/components/responses/NotFound'
       security:
         - OAuth2Security:
-            - apim:api_view
-            - apim:api_manage
-            - apim:mediation_policy_view
-            - apim:mediation_policy_manage
-            - apim:api_mediation_policy_manage
+            - apim:common_operation_policy_view
+            - apim:common_operation_policy_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -7959,10 +7942,8 @@ paths:
       security:
         - OAuth2Security:
             - apim:api_view
-            - apim:api_manage
             - apim:mediation_policy_view
-            - apim:mediation_policy_manage
-            - apim:api_mediation_policy_manage
+            - apim:common_operation_policy_view
       x-code-samples:
         - lang: Shell
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"


### PR DESCRIPTION
A new property is added as policy version to the API object. Policy specs are updated via https://github.com/wso2/product-apim/pull/12612.

Fixed https://github.com/wso2/product-apim/issues/12643
Added two new scopes for common operation policies.