### PR TITLE
Refactor aggregator modules with proper names

### DIFF
--- a/components/apimgt/pom.xml
+++ b/components/apimgt/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>apimgt</artifactId>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
-    <name>API Management</name>
+    <name>WSO2 Carbon - API Management Component Aggregator Module</name>
 
     <modules>
         <module>org.wso2.carbon.apimgt.eventing</module>

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.rest.api.admin.feature</artifactId>
     <packaging>pom</packaging>
-    <name>WSO2 Carbon - API Manager Admin Rest API Feature</name>
+    <name>WSO2 Carbon - API Admin Rest API Feature</name>
     <url>http://wso2.org</url>
     <description>This feature contains required bundles for API Manager Rest API for API Admin Portal functionality
     </description>

--- a/features/apimgt/pom.xml
+++ b/features/apimgt/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apimgt-feature</artifactId>
     <packaging>pom</packaging>
-    <name>WSO2 Carbon - API management Feature Aggregator Module</name>
+    <name>WSO2 Carbon - API Management Feature Aggregator Module</name>
     <url>http://wso2.org</url>
 
     <modules>

--- a/service-stubs/apimgt/pom.xml
+++ b/service-stubs/apimgt/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>apimgt-stubs</artifactId>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
-    <name>API Management</name>
+    <name>WSO2 Carbon - API Management Service Stub Aggregator Module</name>
     <modules>
         <module>org.wso2.carbon.apimgt.keymgt.stub</module>
     </modules>


### PR DESCRIPTION
This PR renames aggregator module names with `Aggregator Module` suffix for better understanding.