### PR TITLE
Refactor apimgt component module names

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.api</artifactId>
     <packaging>bundle</packaging>
-    <name>WSO2 Carbon - Api for API Management</name>
+    <name>WSO2 Carbon - API Management API</name>
 
     <dependencies>
         <dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.internal.service</artifactId>
     <packaging>war</packaging>
-    <name>WSO2 API Manager Internal Data Service</name>
+    <name>WSO2 API Manager Internal Data Service - v1</name>
     <description>WSO2 API Manager Internal Data Service</description>
 
 

--- a/components/apimgt/org.wso2.carbon.apimgt.output.adapter.http/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.output.adapter.http/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>org.wso2.carbon.apimgt.output.adapter.http</artifactId>
 
     <packaging>bundle</packaging>
-    <name>WSO2 Carbon - Event Output Extended HTTP adapter Module</name>
+    <name>WSO2 Carbon - Event Output Extended HTTP Adapter Module</name>
     <description>org.wso2.carbon.output.adapter.http provides the back-end functionality of http event adapter
     </description>
     <url>http://wso2.org</url>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
@@ -27,7 +27,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.rest.api.dcr</artifactId>
-    <name>WSO2 Carbon API Manager- Dynamic Client Registration Web Service</name>
+    <name>WSO2 Carbon - Dynamic Client Registration Web Service</name>
     <description>WSO2 Carbon API Manager- Dynamic Client Registration Web</description>
     <packaging>war</packaging>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.devops/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.devops/pom.xml
@@ -27,7 +27,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.rest.api.devops</artifactId>
-    <name>WSO2 API Manager control plane API</name>
+    <name>WSO2 API Manager Devops REST API - v0</name>
     <description>WSO2 API Manager REST API for control plane</description>
     <packaging>war</packaging>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.rest.api.service.catalog</artifactId>
     <packaging>war</packaging>
-    <name>WSO2 API Manager Service Catalog REST API</name>
+    <name>WSO2 API Manager Service Catalog REST API - v1</name>
     <description>WSO2 API Manager REST API for Service Catalog</description>
 
 

--- a/components/apimgt/samples/org.wso2.carbon.apimgt.samples.calculator/pom.xml
+++ b/components/apimgt/samples/org.wso2.carbon.apimgt.samples.calculator/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.samples.calculator</artifactId>
     <packaging>war</packaging>
-    <name>WSO2 Carbon - Sample API</name>
+    <name>WSO2 Carbon - Sample Calculator API</name>
     <url>http://wso2.org</url>
     <description>This feature contains the sample calculator api</description>
 

--- a/components/apimgt/samples/org.wso2.carbon.apimgt.samples.pizzashack/pom.xml
+++ b/components/apimgt/samples/org.wso2.carbon.apimgt.samples.pizzashack/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.samples.pizzashack</artifactId>
     <packaging>war</packaging>
-    <name>WSO2 Carbon - Sample API</name>
+    <name>WSO2 Carbon - Sample PizzaShack API</name>
     <url>http://wso2.org</url>
     <description>This feature contains the sample pizza shack api</description>
 


### PR DESCRIPTION
* Added missing version for REST API module names
  * org.wso2.carbon.apimgt.internal.service/pom.xml
  * org.wso2.carbon.apimgt.rest.api.devops/pom.xml 
  * org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
* Added name of APIs for sample API module names
  * org.wso2.carbon.apimgt.samples.calculator/pom.xml
  * org.wso2.carbon.apimgt.samples.pizzashack/pom.xml
* Renamed module names with title case and consistency
  * org.wso2.carbon.apimgt.api/pom.xml
  * org.wso2.carbon.apimgt.output.adapter.http/pom.xml
  * org.wso2.carbon.apimgt.rest.api.dcr/pom.xml