### PR TITLE
Add Logic to Support UnknownExtensibilityElement in WSDL

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11ProcessorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11ProcessorImpl.java
@@ -23,6 +23,8 @@ import com.ibm.wsdl.extensions.soap.SOAPAddressImpl;
 import com.ibm.wsdl.extensions.soap12.SOAP12AddressImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ErrorHandler;
 import org.wso2.carbon.apimgt.api.ErrorItem;
@@ -53,6 +55,7 @@ import javax.wsdl.Port;
 import javax.wsdl.Service;
 import javax.wsdl.WSDLException;
 import javax.wsdl.extensions.ExtensibilityElement;
+import javax.wsdl.extensions.UnknownExtensibilityElement;
 import javax.wsdl.factory.WSDLFactory;
 import javax.wsdl.xml.WSDLReader;
 import javax.wsdl.xml.WSDLWriter;
@@ -434,9 +437,25 @@ public class WSDL11ProcessorImpl extends AbstractWSDLProcessor {
             return ((SOAPAddressImpl) exElement).getLocationURI();
         } else if (exElement instanceof HTTPAddressImpl) {
             return ((HTTPAddressImpl) exElement).getLocationURI();
+        } else if (exElement instanceof UnknownExtensibilityElement) {
+            Element unknownExtensibilityElement = ((UnknownExtensibilityElement) exElement).getElement();
+            if (unknownExtensibilityElement != null) {
+                NodeList nodeList = unknownExtensibilityElement.getElementsByTagNameNS(APIConstants.WSDL_NAMESPACE_URI,
+                        APIConstants.WSDL_ELEMENT_LOCAL_NAME);
+                String url = "";
+                if (nodeList != null && nodeList.getLength() > 0) {
+                    url = nodeList.item(0).getTextContent();
+                }
+                return url;
+            } else {
+                String msg = "WSDL errors! Extensibility Element is null";
+                log.error(msg);
+                throw new APIMgtWSDLException(msg);
+            }
         } else {
-            throw new APIMgtWSDLException("Unsupported WSDL Extensibility element",
-                    ExceptionCodes.UNSUPPORTED_WSDL_EXTENSIBILITY_ELEMENT);
+            String msg = "Unsupported WSDL errors!";
+            log.error(msg);
+            throw new APIMgtWSDLException(msg);
         }
     }
 
@@ -476,6 +495,15 @@ public class WSDL11ProcessorImpl extends AbstractWSDLProcessor {
             if (log.isDebugEnabled()) {
                 log.debug("Gateway endpoint for environment:" + environmentName + " is: "
                         + ((HTTPAddressImpl) exElement).getLocationURI());
+            }
+        } else if (exElement instanceof UnknownExtensibilityElement) {
+            Element unknownExtensibilityElement = ((UnknownExtensibilityElement) exElement).getElement();
+            if (unknownExtensibilityElement != null) {
+                NodeList nodeList = unknownExtensibilityElement.getElementsByTagNameNS(APIConstants.WSDL_NAMESPACE_URI,
+                        APIConstants.WSDL_ELEMENT_LOCAL_NAME);
+                if (nodeList != null && nodeList.getLength() > 0) {
+                    nodeList.item(0).setTextContent(APIUtil.getGatewayendpoint(transports, organization) + context);
+                }
             }
         } else {
             if (log.isDebugEnabled()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3422,22 +3422,6 @@ public class ApisApiServiceImpl implements ApisApiService {
             // Validation failure
             RestApiUtil.handleBadRequest(validationResponse.getError(), log);
         }
-
-        if (fileInputStream != null) {
-            if (fileInputStream.markSupported()) {
-                // For uploading the WSDL below will require re-reading from the input stream hence resetting
-                try {
-                    fileInputStream.reset();
-                } catch (IOException e) {
-                    throw new APIManagementException("Error occurred while trying to reset the content stream of the " +
-                            "WSDL", e);
-                }
-            } else {
-                log.warn("Marking is not supported in 'fileInputStream' InputStream type: "
-                        + fileInputStream.getClass() + ". Skipping validating WSDL to avoid re-reading from the " +
-                        "input stream.");
-            }
-        }
         return validationResponse;
     }
 


### PR DESCRIPTION
## Purpose
This PR add the logic to support UnknownExtensibilityElement in WSDL
Related Github Issue: https://github.com/wso2/product-apim/issues/12149

## Approach
- Added logic to support UnknownExtensibilityElement in `getAddressUrl` and `setAddressUrl` methods of `WSDL11ProcessorImpl` class.
- Removed the WSDL filestream reset related functionality