### PR TITLE
Fix backend JWT padding issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/jwtgenerator/AbstractAPIMgtGatewayJWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/jwtgenerator/AbstractAPIMgtGatewayJWTGenerator.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.common.gateway.jwtgenerator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.JWTClaimsSet;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.common.gateway.constants.JWTConstants;
@@ -31,6 +32,7 @@ import org.wso2.carbon.apimgt.common.gateway.util.JWTUtil;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.util.Date;
@@ -202,7 +204,8 @@ public abstract class AbstractAPIMgtGatewayJWTGenerator {
     }
 
     public String encode(byte[] stringToBeEncoded) throws JWTGeneratorException {
-        return java.util.Base64.getUrlEncoder().encodeToString(stringToBeEncoded);
+        return new String(new Base64(0, null, true).
+                encode(stringToBeEncoded), StandardCharsets.UTF_8);
     }
 
     public String getDialectURI() {

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/JWTUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/JWTUtil.java
@@ -30,7 +30,6 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.common.gateway.exception.JWTGeneratorException;
 import org.wso2.carbon.apimgt.common.gateway.jwtgenerator.JWTSignatureAlg;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
@@ -91,8 +90,8 @@ public final class JWTUtil {
             byte[] digestInBytes = digestValue.digest();
             String publicCertThumbprint = hexify(digestInBytes);
             String base64UrlEncodedThumbPrint;
-            base64UrlEncodedThumbPrint = java.util.Base64.getUrlEncoder()
-                    .encodeToString(publicCertThumbprint.getBytes("UTF-8"));
+            base64UrlEncodedThumbPrint = new String(new Base64(0, null, true).
+                    encode(publicCertThumbprint.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
             StringBuilder jwtHeader = new StringBuilder();
             /*
              * Sample header
@@ -110,7 +109,7 @@ public final class JWTUtil {
             jwtHeader.append("\"}");
             return jwtHeader.toString();
 
-        } catch (NoSuchAlgorithmException | CertificateEncodingException | UnsupportedEncodingException e) {
+        } catch (NoSuchAlgorithmException | CertificateEncodingException e) {
             throw new JWTGeneratorException("Error in generating public certificate thumbprint", e);
         }
     }


### PR DESCRIPTION
This PR fixes the issue of generated backend JWTs are identified as invalid JWTs due to the padding applied in the token.

Fixes https://github.com/wso2/product-apim/issues/12655