### PR TITLE
Remove responsesObject from swagger to fix swagger-editor issue for swagger2

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.google.gson.JsonObject;
 import io.swagger.inflector.examples.ExampleBuilder;
 import io.swagger.inflector.examples.models.Example;
 import io.swagger.inflector.processors.JsonNodeExampleSerializer;
@@ -1060,8 +1059,8 @@ public class OAS2Parser extends APIDefinition {
         mapper.addMixIn(Response.class, ResponseSchemaMixin.class);
         try {
             //this is to remove responesObject from swagger content
-            String modifiedSwagString = removeResponsesObject(swaggerObj, new String(mapper.writeValueAsBytes(swaggerObj)));
-            return modifiedSwagString;
+            String modifiedSwaggerString = removeResponsesObject(swaggerObj, new String(mapper.writeValueAsBytes(swaggerObj)));
+            return modifiedSwaggerString;
         } catch (JsonProcessingException e) {
             throw new APIManagementException("Error while generating Swagger json from model", e);
         }
@@ -1194,7 +1193,6 @@ public class OAS2Parser extends APIDefinition {
      * @param swagger Swagger model
      * @param swaggerString Swagger definition as string
      * @return Modified swagger string
-     * @throws APIManagementException
      */
     public String removeResponsesObject(Swagger swagger, String swaggerString) {
         JSONObject jsonObj = new JSONObject(swaggerString);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS2ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS2ParserTest.java
@@ -132,4 +132,19 @@ public class OAS2ParserTest extends OASTestBase {
         Set<URITemplate> uriTemplateSet = oas2Parser.getURITemplates(swagger);
         Assert.assertEquals(uriTemplateSet, uriTemplates);
     }
+
+    @Test
+    public void testRemoveResponsesObjectFromOpenAPI20Spec() throws Exception {
+        String relativePathSwagger1 = "definitions" + File.separator + "oas2" + File.separator +
+                "oas2_uri_template.json";
+        String relativePathSwagger2 = "definitions" + File.separator + "oas2" + File.separator +
+                "oas2_uri_template_with_responsesObject.json";
+        String swaggerWithoutResponsesObject = IOUtils.toString(getClass().getClassLoader().
+                getResourceAsStream(relativePathSwagger1), "UTF-8");
+        String swaggerWithResponsesObject = IOUtils.toString(getClass().getClassLoader().
+                getResourceAsStream(relativePathSwagger2), "UTF-8");
+        Swagger swagger = oas2Parser.getSwagger(swaggerWithResponsesObject);
+        Assert.assertEquals(oas2Parser.removeResponsesObject(swagger,swaggerWithoutResponsesObject),
+                oas2Parser.removeResponsesObject(swagger,swaggerWithResponsesObject));
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas2/oas2_uri_template_with_responsesObject.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas2/oas2_uri_template_with_responsesObject.json
@@ -1,0 +1,92 @@
+{
+  "paths": {
+    "/*": {
+      "get": {
+        "x-auth-type": "Application",
+        "x-throttling-tier": "Unlimited",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "responsesObject": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "x-auth-type": "Application User",
+        "x-throttling-tier": "Unlimited",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "responsesObject": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "x-auth-type": "None",
+        "x-throttling-tier": "Unlimited",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "responsesObject": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "delete": {
+        "x-throttling-tier": "Unlimited",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "responsesObject": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/abc": {
+      "get": {
+        "x-auth-type": "Application & Application User",
+        "x-throttling-tier": "Unlimited",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "responsesObject": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "x-wso2-security": {
+    "apim": {
+      "x-wso2-scopes": []
+    }
+  },
+  "swagger": "2.0",
+  "info": {
+    "title": "PhoneVerification",
+    "description": "Verify a phone number",
+    "contact": {
+      "email": "xx@ee.com",
+      "name": "xx"
+    },
+    "version": "1.0.0"
+  }
+}


### PR DESCRIPTION
## Purpose
As $subject, this will add a workaround for OASParser2 to remove reposnsesObject inorder to fix swagger-editor issue for swagger2.

### Fixes
- https://github.com/wso2/product-apim/issues/12561