### PR TITLE
Display subscription operation as the resource path in analytics graphs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
@@ -64,6 +64,7 @@ public class WebsocketHandler extends CombinedChannelDuplexHandler<WebsocketInbo
                     .getInboundMessageContextForConnectionId(channelId);
         } else {
             inboundMessageContext = new InboundMessageContext();
+            inboundMessageContext.setCtx(ctx);
             InboundMessageContextDataHolder.getInstance()
                     .addInboundMessageContextForConnection(channelId, inboundMessageContext);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
@@ -101,6 +101,7 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
                     .getInboundMessageContextForConnectionId(channelId);
         } else {
             inboundMessageContext = new InboundMessageContext();
+            inboundMessageContext.setCtx(ctx);
             InboundMessageContextDataHolder.getInstance()
                     .addInboundMessageContextForConnection(channelId, inboundMessageContext);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/InboundMessageContext.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/InboundMessageContext.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.apimgt.gateway.inbound;
 
+import io.netty.channel.ChannelHandlerContext;
 import org.apache.axis2.context.MessageContext;
 import org.apache.synapse.api.API;
 import org.wso2.carbon.apimgt.api.gateway.GraphQLSchemaDTO;
@@ -57,6 +58,7 @@ public class InboundMessageContext {
     private Map<String, ResourceInfoDTO> resourcesMap = new HashMap<>(); //elected API resources
     private String userIP;
     private String matchingResource; //invoking API resource
+    private ChannelHandlerContext ctx;
 
     //Graphql Subscription specific connection context information
     private GraphQLSchemaDTO graphQLSchemaDTO;
@@ -232,5 +234,13 @@ public class InboundMessageContext {
 
     public void setMatchingResource(String matchingResource) {
         this.matchingResource = matchingResource;
+    }
+
+    public ChannelHandlerContext getCtx() {
+        return ctx;
+    }
+
+    public void setCtx(ChannelHandlerContext ctx) {
+        this.ctx = ctx;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/request/GraphQLRequestProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/request/GraphQLRequestProcessor.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.apimgt.gateway.handlers.graphQL.GraphQLConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.graphQL.analyzer.SubscriptionAnalyzer;
 import org.wso2.carbon.apimgt.gateway.handlers.graphQL.utils.GraphQLProcessorUtil;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketApiConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketUtils;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.GraphQLProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
@@ -87,6 +88,8 @@ public class GraphQLRequestProcessor extends RequestProcessor {
                             // subscription operation name
                             String subscriptionOperation = GraphQLProcessorUtil.getOperationList(operation,
                                     inboundMessageContext.getGraphQLSchemaDTO().getTypeDefinitionRegistry());
+                            WebSocketUtils.setApiPropertyToChannel(inboundMessageContext.getCtx(),
+                                    APIConstants.API_ELECTED_RESOURCE, subscriptionOperation);
                             // extract verb info dto with throttle policy for matching verb
                             VerbInfoDTO verbInfoDTO = InboundWebsocketProcessorUtil
                                     .findMatchingVerb(subscriptionOperation, inboundMessageContext);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/response/GraphQLResponseProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/response/GraphQLResponseProcessor.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.gateway.inbound.websocket.response;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONObject;
 import org.wso2.carbon.apimgt.gateway.handlers.graphQL.GraphQLConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketUtils;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.dto.GraphQLOperationDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
@@ -56,6 +57,8 @@ public class GraphQLResponseProcessor extends ResponseProcessor {
                 GraphQLOperationDTO graphQLOperationDTO =
                         inboundMessageContext.getVerbInfoForGraphQLMsgId(
                                 graphQLMsg.getString(GraphQLConstants.SubscriptionConstants.PAYLOAD_FIELD_NAME_ID));
+                WebSocketUtils.setApiPropertyToChannel(inboundMessageContext.getCtx(),
+                        APIConstants.API_ELECTED_RESOURCE, graphQLOperationDTO.getOperation());
                 // validate scopes based on subscription payload when security is enabled
                 String authType = graphQLOperationDTO.getVerbInfoDTO().getAuthType();
                 if (!StringUtils.capitalize(APIConstants.AUTH_TYPE_NONE.toLowerCase()).equals(authType)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/request/GraphQLRequestProcessorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/request/GraphQLRequestProcessorTest.java
@@ -21,18 +21,24 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.schema.idl.UnExecutableSchemaGenerator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
 import org.apache.commons.io.IOUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.api.gateway.GraphQLSchemaDTO;
 import org.wso2.carbon.apimgt.gateway.handlers.graphQL.GraphQLConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketApiConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketUtils;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.GraphQLProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
@@ -41,12 +47,14 @@ import org.wso2.carbon.apimgt.impl.dto.APIKeyValidationInfoDTO;
 import org.wso2.carbon.apimgt.impl.dto.VerbInfoDTO;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Test class for GraphQLRequestProcessor.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({InboundWebsocketProcessorUtil.class})
+@PrepareForTest({InboundWebsocketProcessorUtil.class, WebSocketUtils.class})
 public class GraphQLRequestProcessorTest {
 
     @Test
@@ -87,6 +95,13 @@ public class GraphQLRequestProcessorTest {
         PowerMockito.when(InboundWebsocketProcessorUtil.doThrottleForGraphQL(msgSize, verbInfoDTO,
                 inboundMessageContext, "1")).thenReturn(responseDTO);
         GraphQLRequestProcessor graphQLRequestProcessor = new GraphQLRequestProcessor();
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        inboundMessageContext.setCtx(ctx);
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(ctx.channel()).thenReturn(channel);
+        PowerMockito.mockStatic(WebSocketUtils.class);
+        Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
+        PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
         InboundProcessorResponseDTO processorResponseDTO =
                 graphQLRequestProcessor.handleRequest(msgSize, msgText, inboundMessageContext);
         Assert.assertFalse(processorResponseDTO.isError());
@@ -301,6 +316,13 @@ public class GraphQLRequestProcessorTest {
                 .thenReturn(graphQLProcessorResponseDTO);
 
         GraphQLRequestProcessor graphQLRequestProcessor = new GraphQLRequestProcessor();
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        inboundMessageContext.setCtx(ctx);
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(ctx.channel()).thenReturn(channel);
+        PowerMockito.mockStatic(WebSocketUtils.class);
+        Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
+        PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
         InboundProcessorResponseDTO processorResponseDTO =
                 graphQLRequestProcessor.handleRequest(msgSize, msgText, inboundMessageContext);
         Assert.assertTrue(processorResponseDTO.isError());
@@ -367,6 +389,13 @@ public class GraphQLRequestProcessorTest {
                 inboundMessageContext, "1")).thenReturn(responseDTO);
 
         GraphQLRequestProcessor graphQLRequestProcessor = new GraphQLRequestProcessor();
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        inboundMessageContext.setCtx(ctx);
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(ctx.channel()).thenReturn(channel);
+        PowerMockito.mockStatic(WebSocketUtils.class);
+        Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
+        PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
         InboundProcessorResponseDTO processorResponseDTO =
                 graphQLRequestProcessor.handleRequest(msgSize, msgText, inboundMessageContext);
         Assert.assertFalse(processorResponseDTO.isError());
@@ -411,6 +440,13 @@ public class GraphQLRequestProcessorTest {
         inboundMessageContext.setInfoDTO(infoDTO);
 
         GraphQLRequestProcessor graphQLRequestProcessor = new GraphQLRequestProcessor();
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        inboundMessageContext.setCtx(ctx);
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(ctx.channel()).thenReturn(channel);
+        PowerMockito.mockStatic(WebSocketUtils.class);
+        Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
+        PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
         InboundProcessorResponseDTO processorResponseDTO =
                 graphQLRequestProcessor.handleRequest(msgSize, msgText, inboundMessageContext);
         Assert.assertTrue(processorResponseDTO.isError());
@@ -477,6 +513,13 @@ public class GraphQLRequestProcessorTest {
         PowerMockito.when(InboundWebsocketProcessorUtil.doThrottleForGraphQL(msgSize, verbInfoDTO,
                 inboundMessageContext, "1")).thenReturn(throttleResponseDTO);
         GraphQLRequestProcessor graphQLRequestProcessor = new GraphQLRequestProcessor();
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        inboundMessageContext.setCtx(ctx);
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(ctx.channel()).thenReturn(channel);
+        PowerMockito.mockStatic(WebSocketUtils.class);
+        Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
+        PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
         InboundProcessorResponseDTO processorResponseDTO =
                 graphQLRequestProcessor.handleRequest(msgSize, msgText, inboundMessageContext);
         Assert.assertTrue(processorResponseDTO.isError());
@@ -497,5 +540,49 @@ public class GraphQLRequestProcessorTest {
         Assert.assertEquals(String.valueOf(payload.get(WebSocketApiConstants.FrameErrorConstants.ERROR_CODE)),
                 String.valueOf(WebSocketApiConstants.FrameErrorConstants.THROTTLED_OUT_ERROR));
         Assert.assertFalse(processorResponseDTO.isCloseConnection());
+    }
+
+    private Attribute<Map<String, Object>> getChannelAttributeMap() {
+        return new Attribute<Map<String, Object>>() {
+            @Override
+            public AttributeKey<Map<String, Object>> key() {
+                return null;
+            }
+
+            @Override
+            public Map<String, Object> get() {
+                return null;
+            }
+
+            @Override
+            public void set(Map<String, Object> stringObjectMap) {
+
+            }
+
+            @Override
+            public Map<String, Object> getAndSet(Map<String, Object> stringObjectMap) {
+                return null;
+            }
+
+            @Override
+            public Map<String, Object> setIfAbsent(Map<String, Object> stringObjectMap) {
+                return null;
+            }
+
+            @Override
+            public Map<String, Object> getAndRemove() {
+                return null;
+            }
+
+            @Override
+            public boolean compareAndSet(Map<String, Object> stringObjectMap, Map<String, Object> t1) {
+                return false;
+            }
+
+            @Override
+            public void remove() {
+
+            }
+        };
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/response/GraphQLResponseProcessorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/response/GraphQLResponseProcessorTest.java
@@ -17,6 +17,10 @@
  */
 package org.wso2.carbon.apimgt.gateway.inbound.websocket.response;
 
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,17 +30,21 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.gateway.dto.GraphQLOperationDTO;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketApiConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketUtils;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.GraphQLProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.utils.InboundWebsocketProcessorUtil;
 import org.wso2.carbon.apimgt.impl.dto.VerbInfoDTO;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Test class for GraphQLResponseProcessor.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({InboundWebsocketProcessorUtil.class})
+@PrepareForTest({InboundWebsocketProcessorUtil.class, WebSocketUtils.class})
 public class GraphQLResponseProcessorTest {
 
     @Test
@@ -60,6 +68,13 @@ public class GraphQLResponseProcessorTest {
         PowerMockito.when(InboundWebsocketProcessorUtil.doThrottleForGraphQL(msgSize, verbInfoDTO,
                 inboundMessageContext, "1")).thenReturn(responseDTO);
         GraphQLResponseProcessor responseProcessor = new GraphQLResponseProcessor();
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        inboundMessageContext.setCtx(ctx);
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(ctx.channel()).thenReturn(channel);
+        PowerMockito.mockStatic(WebSocketUtils.class);
+        Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
+        PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
         InboundProcessorResponseDTO processorResponseDTO =
                 responseProcessor.handleResponse(msgSize, msgText, inboundMessageContext);
         Assert.assertFalse(processorResponseDTO.isError());
@@ -142,6 +157,13 @@ public class GraphQLResponseProcessorTest {
         PowerMockito.when(InboundWebsocketProcessorUtil.doThrottleForGraphQL(msgSize, verbInfoDTO,
                 inboundMessageContext, "1")).thenReturn(throttleResponseDTO);
         GraphQLResponseProcessor responseProcessor = new GraphQLResponseProcessor();
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        inboundMessageContext.setCtx(ctx);
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(ctx.channel()).thenReturn(channel);
+        PowerMockito.mockStatic(WebSocketUtils.class);
+        Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
+        PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
         InboundProcessorResponseDTO processorResponseDTO =
                 responseProcessor.handleResponse(msgSize, msgText, inboundMessageContext);
         Assert.assertTrue(processorResponseDTO.isError());
@@ -182,6 +204,13 @@ public class GraphQLResponseProcessorTest {
         PowerMockito.when(InboundWebsocketProcessorUtil.doThrottleForGraphQL(msgSize, verbInfoDTO,
                 inboundMessageContext, "1")).thenReturn(responseDTO);
         GraphQLResponseProcessor responseProcessor = new GraphQLResponseProcessor();
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        inboundMessageContext.setCtx(ctx);
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(ctx.channel()).thenReturn(channel);
+        PowerMockito.mockStatic(WebSocketUtils.class);
+        Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
+        PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
         InboundProcessorResponseDTO processorResponseDTO =
                 responseProcessor.handleResponse(msgSize, msgText, inboundMessageContext);
         Assert.assertTrue(processorResponseDTO.isError());
@@ -229,11 +258,62 @@ public class GraphQLResponseProcessorTest {
                 .thenReturn(responseDTO);
 
         GraphQLResponseProcessor responseProcessor = new GraphQLResponseProcessor();
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        inboundMessageContext.setCtx(ctx);
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(ctx.channel()).thenReturn(channel);
+        PowerMockito.mockStatic(WebSocketUtils.class);
+        Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
+        PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
         InboundProcessorResponseDTO processorResponseDTO = responseProcessor
                 .handleResponse(msgSize, msgText, inboundMessageContext);
         Assert.assertFalse(processorResponseDTO.isError());
         Assert.assertNull(processorResponseDTO.getErrorMessage());
         Assert.assertNotEquals(processorResponseDTO.getErrorMessage(),
                 "User is NOT authorized to access the Resource");
+    }
+
+    private Attribute<Map<String, Object>> getChannelAttributeMap() {
+        return new Attribute<Map<String, Object>>() {
+            @Override
+            public AttributeKey<Map<String, Object>> key() {
+                return null;
+            }
+
+            @Override
+            public Map<String, Object> get() {
+                return null;
+            }
+
+            @Override
+            public void set(Map<String, Object> stringObjectMap) {
+
+            }
+
+            @Override
+            public Map<String, Object> getAndSet(Map<String, Object> stringObjectMap) {
+                return null;
+            }
+
+            @Override
+            public Map<String, Object> setIfAbsent(Map<String, Object> stringObjectMap) {
+                return null;
+            }
+
+            @Override
+            public Map<String, Object> getAndRemove() {
+                return null;
+            }
+
+            @Override
+            public boolean compareAndSet(Map<String, Object> stringObjectMap, Map<String, Object> t1) {
+                return false;
+            }
+
+            @Override
+            public void remove() {
+
+            }
+        };
     }
 }


### PR DESCRIPTION
<img width="1365" alt="Screenshot 2022-03-16 at 17 30 40" src="https://user-images.githubusercontent.com/28379317/158617972-37590433-20be-4c51-96b1-0603b4446908.png">

**Approach**
* A new field ctx was introduced to the  inboundMessageContext to hold ChannelHandlerContext
* API_ELECTED_RESOURCE is set as a property to ctx

Related Issue : https://github.com/wso2/product-apim/issues/12197

Note : The wildcard entries in the screenshot are from invocations before applying this fix.
