### PR TITLE
Adding the support to import third party Async APIs from apictl and fixing the update issue from Publisher portal for the same type of APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2078,6 +2078,7 @@ public final class APIConstants {
 
     public static final String API_TYPE_WEBSUB = "WEBSUB";
     public static final String API_TYPE_SSE = "SSE";
+    public static final String API_TYPE_ASYNC = "ASYNC";
 
     public static final String API_TYPE_SOAP = "SOAP";
     public static final String API_TYPE_SOAPTOREST = "SOAPTOREST";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/AsyncApiParser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/AsyncApiParser.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.SwaggerData;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
 import java.net.URI;
@@ -2042,11 +2043,14 @@ public class AsyncApiParser extends APIDefinition {
         oauth2SecurityScheme.flows.implicit.addExtension(APIConstants.SWAGGER_X_SCOPES_BINDINGS, xScopeBindings);
 
         document.components.securitySchemes.put(APIConstants.DEFAULT_API_SECURITY_OAUTH2, oauth2SecurityScheme);
-        Aai20Server server = (Aai20Server) document.createServer("production");
-        JSONObject endpointConfig = new JSONObject(apiToUpdate.getEndpointConfig());
-        server.url = endpointConfig.getJSONObject("production_endpoints").getString("url");
-        server.protocol = apiToUpdate.getType().toLowerCase();
-        document.addServer("production", server);
+        if (!StringUtils.equalsIgnoreCase(APIConstants.API_TYPE_ASYNC, apiToUpdate.getType())
+                || !apiToUpdate.isAdvertiseOnly()) {
+            Aai20Server server = (Aai20Server) document.createServer("production");
+            JSONObject endpointConfig = new JSONObject(apiToUpdate.getEndpointConfig());
+            server.url = endpointConfig.getJSONObject("production_endpoints").getString("url");
+            server.protocol = apiToUpdate.getType().toLowerCase();
+            document.addServer("production", server);
+        }
         return Library.writeDocumentToJSONString(document);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/AsyncApiParser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/AsyncApiParser.java
@@ -33,7 +33,6 @@ import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.SwaggerData;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.APIConstants;
-import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
 import java.net.URI;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -294,10 +294,8 @@ public class ImportUtils {
                     apiProvider.addOrUpdateComplexityDetails(importedApi.getUuid(), graphqlComplexityInfo);
                 }
             }
-            // Add/update Async API definition for streaming APIs (but for not third party ones,
-            // because it was already done in importAsyncAPIWithDefinition)
-            if (PublisherCommonUtils.isStreamingAPI(importedApiDTO) && !PublisherCommonUtils.isThirdPartyAsyncAPI(
-                    importedApiDTO)) {
+            // Add/update Async API definition for streaming APIs
+            if (PublisherCommonUtils.isStreamingAPI(importedApiDTO)) {
                 // Add the validated Async API definition separately since the UI does the same procedure
                 PublisherCommonUtils.updateAsyncAPIDefinition(importedApi.getUuid(), validationResponse, organization);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -253,9 +253,14 @@ public class ImportUtils {
                 // Initialize to CREATED when import
                 currentStatus = APIStatus.CREATED.toString();
                 importedApiDTO.setLifeCycleStatus(currentStatus);
-                importedApi = PublisherCommonUtils
-                        .addAPIWithGeneratedSwaggerDefinition(importedApiDTO, ImportExportConstants.OAS_VERSION_3,
-                                importedApiDTO.getProvider(), organization);
+                if (!PublisherCommonUtils.isThirdPartyAsyncAPI(importedApiDTO)) {
+                    importedApi = PublisherCommonUtils
+                            .addAPIWithGeneratedSwaggerDefinition(importedApiDTO, ImportExportConstants.OAS_VERSION_3,
+                                    importedApiDTO.getProvider(), organization);
+                } else {
+                    importedApi = PublisherCommonUtils.importAsyncAPIWithDefinition(validationResponse, Boolean.FALSE,
+                            importedApiDTO, null, currentTenantDomain, apiProvider);
+                }
 
                 // Set API definition to validationResponse if the API is imported with sample API definition
                 if (validationResponse != null && validationResponse.isInit()) {
@@ -289,8 +294,10 @@ public class ImportUtils {
                     apiProvider.addOrUpdateComplexityDetails(importedApi.getUuid(), graphqlComplexityInfo);
                 }
             }
-            // Add/update Async API definition for streaming APIs
-            if (PublisherCommonUtils.isStreamingAPI(importedApiDTO)) {
+            // Add/update Async API definition for streaming APIs (but for not third party ones,
+            // because it was already done in importAsyncAPIWithDefinition)
+            if (PublisherCommonUtils.isStreamingAPI(importedApiDTO) && !PublisherCommonUtils.isThirdPartyAsyncAPI(
+                    importedApiDTO)) {
                 // Add the validated Async API definition separately since the UI does the same procedure
                 PublisherCommonUtils.updateAsyncAPIDefinition(importedApi.getUuid(), validationResponse, organization);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -1819,21 +1819,29 @@ public class PublisherCommonUtils {
         }
     }
 
+    /**
+     * @param validationResponse Response of a Async API definition validation call
+     * @param isServiceAPI       Whether this is a service API
+     * @param apiDto             API DTO
+     * @param service            If this is a service API, the service entry should be passed here
+     * @param organization       Organization of logged-in user
+     * @param apiProvider        API Provider
+     * @return
+     * @throws APIManagementException If an error occurs while importing the Async API definition
+     */
     public static API importAsyncAPIWithDefinition(APIDefinitionValidationResponse validationResponse,
-            Boolean isServiceAPI, APIDTO apiDTOFromProperties, ServiceEntry service, String organization,
-            APIProvider apiProvider)
+            Boolean isServiceAPI, APIDTO apiDto, ServiceEntry service, String organization, APIProvider apiProvider)
             throws APIManagementException {
         String definitionToAdd = validationResponse.getJsonContent();
         String protocol = validationResponse.getProtocol();
         if (isServiceAPI) {
-            apiDTOFromProperties.setType(PublisherCommonUtils.getAPIType(service.getDefinitionType(), protocol));
+            apiDto.setType(PublisherCommonUtils.getAPIType(service.getDefinitionType(), protocol));
         }
-        if (!APIConstants.WSO2_GATEWAY_ENVIRONMENT.equals(apiDTOFromProperties.getGatewayVendor())) {
-            apiDTOFromProperties.getPolicies().add(APIConstants.DEFAULT_SUB_POLICY_ASYNC_UNLIMITED);
-            apiDTOFromProperties.setAsyncTransportProtocols(
-                    AsyncApiParser.getTransportProtocolsForAsyncAPI(definitionToAdd));
+        if (!APIConstants.WSO2_GATEWAY_ENVIRONMENT.equals(apiDto.getGatewayVendor())) {
+            apiDto.getPolicies().add(APIConstants.DEFAULT_SUB_POLICY_ASYNC_UNLIMITED);
+            apiDto.setAsyncTransportProtocols(AsyncApiParser.getTransportProtocolsForAsyncAPI(definitionToAdd));
         }
-        API apiToAdd = PublisherCommonUtils.prepareToCreateAPIByDTO(apiDTOFromProperties, apiProvider,
+        API apiToAdd = PublisherCommonUtils.prepareToCreateAPIByDTO(apiDto, apiProvider,
                 RestApiCommonUtil.getLoggedInUsername(), organization);
         if (isServiceAPI) {
             apiToAdd.setServiceInfo("key", service.getKey());
@@ -1845,7 +1853,7 @@ public class PublisherCommonUtils {
         }
         apiToAdd.setAsyncApiDefinition(definitionToAdd);
 
-        //load topics from AsyncAPI
+        // load topics from AsyncAPI
         apiToAdd.setUriTemplates(new AsyncApiParser().getURITemplates(definitionToAdd,
                 APIConstants.API_TYPE_WS.equals(apiToAdd.getType()) || !APIConstants.WSO2_GATEWAY_ENVIRONMENT.equals(
                         apiToAdd.getGatewayVendor())));

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -4876,37 +4876,9 @@ public class ApisApiServiceImpl implements ApisApiService {
         //Import the API and Definition
         try {
             APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
-            String definitionToAdd = validationResponse.getJsonContent();
-            String protocol = validationResponse.getProtocol();
-            if (isServiceAPI) {
-                apiDTOFromProperties.setType(PublisherCommonUtils.getAPIType(service.getDefinitionType(), protocol));
-            }
-            if (!APIConstants.WSO2_GATEWAY_ENVIRONMENT.equals(apiDTOFromProperties.getGatewayVendor())) {
-                apiDTOFromProperties.getPolicies().add(APIConstants.DEFAULT_SUB_POLICY_ASYNC_UNLIMITED);
-                apiDTOFromProperties.setAsyncTransportProtocols(AsyncApiParser.
-                        getTransportProtocolsForAsyncAPI(definitionToAdd));
-            }
-            API apiToAdd = PublisherCommonUtils.prepareToCreateAPIByDTO(apiDTOFromProperties, apiProvider,
-                    RestApiCommonUtil.getLoggedInUsername(), organization);
-            if (isServiceAPI) {
-                apiToAdd.setServiceInfo("key", service.getKey());
-                apiToAdd.setServiceInfo("md5", service.getMd5());
-                if (!APIConstants.API_TYPE_WEBSUB.equals(protocol.toUpperCase())) {
-                    apiToAdd.setEndpointConfig(PublisherCommonUtils.constructEndpointConfigForService(service
-                            .getServiceUrl(), protocol));
-                }
-            }
-            apiToAdd.setAsyncApiDefinition(definitionToAdd);
-
-            //load topics from AsyncAPI
-            apiToAdd.setUriTemplates(new AsyncApiParser().getURITemplates(
-                    definitionToAdd, APIConstants.API_TYPE_WS.equals(apiToAdd.getType())
-                            || !APIConstants.WSO2_GATEWAY_ENVIRONMENT.equals(apiToAdd.getGatewayVendor())));
-            apiToAdd.setOrganization(organization);
-            apiToAdd.setAsyncApiDefinition(definitionToAdd);
-
-            apiProvider.addAPI(apiToAdd);
-            return APIMappingUtil.fromAPItoDTO(apiProvider.getAPIbyUUID(apiToAdd.getUuid(), organization));
+            API api = PublisherCommonUtils.importAsyncAPIWithDefinition(validationResponse, isServiceAPI,
+                    apiDTOFromProperties, service, organization, apiProvider);
+            return APIMappingUtil.fromAPItoDTO(api);
         } catch (APIManagementException e) {
             String errorMessage = "Error while adding new API : " + apiDTOFromProperties.getProvider() + "-" +
                     apiDTOFromProperties.getName() + "-" + apiDTOFromProperties.getVersion() + " - " + e.getMessage();


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/900
Fixes: https://github.com/wso2/product-apim/issues/12693

## Goals
Adding the support to import thrid party Async APIs from apictl and fixing the update issue from Publisher portal for the same type of APIs

## Approach
- Skip retrieving endpoint config in third party Async API update in AsyncApiParser.java
- Refactored the common code in ApisApiServiceImpl.java by moving the necessary parts to PublisherCommonUtils.java
- Added the support to import thrid party Async APIs from apictl

## User stories
Users can export/import thrid party Async APIs from apictl

## Related PRs
-

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.4 LTS