### PR TITLE
Modify endpoint validation to allow consul endpoints

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -11197,8 +11197,9 @@ public final class APIUtil {
         UrlValidator urlValidator = new UrlValidator(authorityValidator, validatorOptions);
 
         for (String endpoint : endpoints) {
-            // If url is a JMS connection url, validation is skipped. If not, validity is checked.
-            if (!endpoint.startsWith("jms:") && !urlValidator.isValid(endpoint)) {
+            // If url is a JMS connection url or a Consul service discovery related url, validation is skipped.
+            // If not, validity is checked.
+            if (!endpoint.startsWith("jms:") && !endpoint.startsWith("consul(") && !urlValidator.isValid(endpoint)) {
                 try {
                     // If the url is not identified as valid from the above check,
                     // next step is determine the validity of the encoded url (done through the URI constructor).


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/product-apim/issues/12767

With this PR, the endpoint validation logic is bypassed for Consul endpoints like `consul(google,https://10.10.1.5:5000/)`

<img width="905" alt="image" src="https://user-images.githubusercontent.com/30475839/159994031-46d93a36-558c-4dea-9891-65b4cfae06d6.png">
