### PR TITLE
Fix scope missing issue in migrated APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -437,6 +437,10 @@ public class OAS2Parser extends APIDefinition {
                 }
                 scopeSet.add(scope);
             }
+            if (oAuth2Definition.getScopes().isEmpty() && swagger.getVendorExtensions() != null
+                    && swagger.getVendorExtensions().containsKey(APIConstants.SWAGGER_X_WSO2_SECURITY)) {
+                return OASParserUtil.sortScopes(getScopesFromExtensions(swagger));
+            }
             return OASParserUtil.sortScopes(scopeSet);
         } else {
             return OASParserUtil.sortScopes(getScopesFromExtensions(swagger));

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -517,6 +517,9 @@ public class OAS3Parser extends APIDefinition {
                     Map<String, String> scopeBindings;
                     scopeSet.add(scope);
                 }
+            } else if (openAPI.getExtensions() != null
+                    && openAPI.getExtensions().containsKey(APIConstants.SWAGGER_X_WSO2_SECURITY)) {
+                return OASParserUtil.sortScopes(getScopesFromExtensions(openAPI));
             }
             return OASParserUtil.sortScopes(scopeSet);
         } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -484,7 +484,7 @@ public class OAS3Parser extends APIDefinition {
         if (openAPI.getComponents() != null && (securitySchemes = openAPI.getComponents().getSecuritySchemes())
                 != null) {
             Set<Scope> scopeSet = new HashSet<>();
-            if  ((securityScheme = securitySchemes.get(OPENAPI_SECURITY_SCHEMA_KEY)) != null &&
+            if ((securityScheme = securitySchemes.get(OPENAPI_SECURITY_SCHEMA_KEY)) != null &&
                     (oAuthFlows = securityScheme.getFlows()) != null && (oAuthFlow = oAuthFlows.getImplicit()) != null
                     && (scopes = oAuthFlow.getScopes()) != null) {
                 for (Map.Entry<String, String> entry : scopes.entrySet()) {
@@ -501,6 +501,10 @@ public class OAS3Parser extends APIDefinition {
                         }
                     }
                     scopeSet.add(scope);
+                }
+                if (scopes.isEmpty() && openAPI.getExtensions() != null
+                        && openAPI.getExtensions().containsKey(APIConstants.SWAGGER_X_WSO2_SECURITY)) {
+                    return OASParserUtil.sortScopes(getScopesFromExtensions(openAPI));
                 }
             } else if ((securityScheme = securitySchemes.get("OAuth2Security")) != null &&
                     (oAuthFlows = securityScheme.getFlows()) != null && (oAuthFlow = oAuthFlows.getPassword()) != null


### PR DESCRIPTION
This PR fixes an issue where the migrated APIs with scopes throw an error when deploying the API without saving it. This fix checks whether legacy scopes exist for the API and adds them to the definition if no scopes are already defined.

Fixes https://github.com/wso2/product-apim/issues/12783