### PR TITLE
Fix issue while invoking a new version of SOAP to REST API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3710,6 +3710,9 @@ public class ApisApiServiceImpl implements ApisApiService {
                 }
             } else {
                 API versionedAPI = apiProvider.createNewAPIVersion(apiId, newVersion, defaultVersion, organization);
+                if (APIConstants.API_TYPE_SOAPTOREST.equals(versionedAPI.getType())) {
+                    updateSwagger(versionedAPI.getUuid(), versionedAPI.getSwaggerDefinition(), organization);
+                }
                 newVersionedApi = APIMappingUtil.fromAPItoDTO(versionedAPI);
             }
             //This URI used to set the location header of the POST response
@@ -3722,7 +3725,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             } else {
                 throw e;
             }
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException | FaultGatewaysException e) {
             String errorMessage = "Error while retrieving API location of " + apiId;
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
         }


### PR DESCRIPTION
### Purpose
To fix returning an HTML page when invoking a new version of SOAP to REST API.

### Goal
Fixes: https://github.com/wso2/product-apim/issues/12150

### Approach
Added a conditional clause to update the swagger definition to get the sequences from swagger before deploying a new revision.

Git Actions: https://github.com/YasasRangika/carbon-apimgt/actions/runs/2075607917