### PR TITLE
Fix issues in /undeploy-revision path

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIGatewayManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIGatewayManager.java
@@ -155,7 +155,7 @@ public class APIGatewayManager {
             GatewayArtifactsMgtDAO.getInstance().deleteGatewayArtifact(apiProductUuid,
                     APIConstants.API_PRODUCT_REVISION);
             GatewayArtifactsMgtDAO.getInstance()
-                    .removePublishedGatewayLabels(apiProductUuid, APIConstants.API_PRODUCT_REVISION);
+                    .removePublishedGatewayLabels(apiProductUuid, APIConstants.API_PRODUCT_REVISION, gatewaysToRemove);
         } catch (ArtifactSynchronizerException e) {
             throw new APIManagementException("API " + apiProductIdentifier + "couldn't get unDeployed", e);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -8830,9 +8830,13 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     + apiRevisionId, ExceptionCodes.from(ExceptionCodes.API_REVISION_NOT_FOUND, apiRevisionId));
         }
         API api = getAPIbyUUID(apiId, apiRevision, organization);
+        Set<String> environmentsToRemove = new HashSet<>();
+        for (APIRevisionDeployment apiRevisionDeployment : apiRevisionDeployments) {
+            environmentsToRemove.add(apiRevisionDeployment.getDeployment());
+        }
         removeFromGateway(api, new HashSet<>(apiRevisionDeployments), Collections.emptySet());
         apiMgtDAO.removeAPIRevisionDeployment(apiRevisionId, apiRevisionDeployments);
-        GatewayArtifactsMgtDAO.getInstance().removePublishedGatewayLabels(apiId, apiRevisionId);
+        GatewayArtifactsMgtDAO.getInstance().removePublishedGatewayLabels(apiId, apiRevisionId, environmentsToRemove);
     }
 
     /**
@@ -9073,7 +9077,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         product.setEnvironments(environmentsToRemove);
         removeFromGateway(product, tenantDomain, new HashSet<>(apiRevisionDeployments),Collections.emptySet());
         apiMgtDAO.removeAPIRevisionDeployment(apiRevisionId, apiRevisionDeployments);
-        GatewayArtifactsMgtDAO.getInstance().removePublishedGatewayLabels(apiProductId, apiRevisionId);
+        GatewayArtifactsMgtDAO.getInstance().removePublishedGatewayLabels(apiProductId, apiRevisionId,
+                environmentsToRemove);
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/GatewayArtifactsMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/GatewayArtifactsMgtDAO.java
@@ -588,12 +588,12 @@ public class GatewayArtifactsMgtDAO {
         return apiRuntimeArtifactDtoList;
     }
 
-    public void removePublishedGatewayLabels(String apiId, String apiRevisionId, Set<String> label) throws APIManagementException {
+    public void removePublishedGatewayLabels(String apiId, String apiRevisionId, Set<String> gatewayLabels) throws APIManagementException {
 
         try (Connection connection = GatewayArtifactsMgtDBUtil.getArtifactSynchronizerConnection()) {
             try {
                 connection.setAutoCommit(false);
-                removePublishedGatewayLabels(connection, apiId, apiRevisionId, label);
+                removePublishedGatewayLabels(connection, apiId, apiRevisionId, gatewayLabels);
                 connection.commit();
             } catch (SQLException e) {
                 connection.rollback();
@@ -627,7 +627,6 @@ public class GatewayArtifactsMgtDAO {
                 preparedStatement.addBatch();
             }
             preparedStatement.executeBatch();
-            connection.commit();
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/GatewayArtifactsMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/GatewayArtifactsMgtDAO.java
@@ -588,12 +588,12 @@ public class GatewayArtifactsMgtDAO {
         return apiRuntimeArtifactDtoList;
     }
 
-    public void removePublishedGatewayLabels(String apiId, String apiRevisionId) throws APIManagementException {
+    public void removePublishedGatewayLabels(String apiId, String apiRevisionId, Set<String> label) throws APIManagementException {
 
         try (Connection connection = GatewayArtifactsMgtDBUtil.getArtifactSynchronizerConnection()) {
             try {
                 connection.setAutoCommit(false);
-                removePublishedGatewayLabels(connection, apiId, apiRevisionId);
+                removePublishedGatewayLabels(connection, apiId, apiRevisionId, label);
                 connection.commit();
             } catch (SQLException e) {
                 connection.rollback();
@@ -615,6 +615,22 @@ public class GatewayArtifactsMgtDAO {
         }
     }
 
+    private void removePublishedGatewayLabels(Connection connection, String apiId, String revision,
+        Set<String> labels) throws SQLException {
+
+        try (PreparedStatement preparedStatement = connection
+                .prepareStatement(SQLConstants.DELETE_GW_PUBLISHED_LABELS_BY_API_ID_REVISION_ID_DEPLOYMENT)) {
+            for (String label : labels) {
+                preparedStatement.setString(1, apiId);
+                preparedStatement.setString(2, revision);
+                preparedStatement.setString(3, label);
+                preparedStatement.addBatch();
+            }
+            preparedStatement.executeBatch();
+            connection.commit();
+        }
+    }
+
     public void addAndRemovePublishedGatewayLabels(String apiId, String revision, Set<String> gateways,
                                                    Map<String, String> gatewayVhosts)
             throws APIManagementException {
@@ -622,7 +638,7 @@ public class GatewayArtifactsMgtDAO {
         try (Connection connection = GatewayArtifactsMgtDBUtil.getArtifactSynchronizerConnection()) {
             try {
                 connection.setAutoCommit(false);
-                removePublishedGatewayLabels(connection, apiId, revision);
+                removePublishedGatewayLabels(connection, apiId, revision, gateways);
                 addPublishedGatewayLabels(connection, apiId, revision, gateways, gatewayVhosts);
                 connection.commit();
             } catch (SQLException | APIManagementException e) {


### PR DESCRIPTION
Fixes: https://github.com/wso2-enterprise/choreo/issues/12586

#### Tested steps:
Deployed the same revision in two gateways. Following is the `deployment.json` file returned by `/runtime-metadata` endpoint.
```
{
  "type": "deployments",
  "version": "v4.1.0",
  "data": {
    "deployments": [
      {
        "apiFile": "6271d4fe543df9406cf9e355-6271e18d3451604807f7fca1",
        "environments": [
          {
            "name": "Production",
            "vhost": "prod.e1-us-east-azure.choreoapis.dev"
          },
          {
            "name": "Default",
            "vhost": "prod.e1-us-east-azure.choreoapis.dev"
          }
        ],
        "organizationId": "WSO2",
        "version": "1.0.0",
        "apiContext": "/shalkiwenushika/cp-test-api4/1.0.0"
      }
    ]
  }

```
Deleted the deployment for `Default` gateway. After the fix, /runtime-metadata endpoint returned the correct deployment details:
```
{ 
  "type": "deployments",
  "version": "v4.1.0",
  "data": {
    "deployments": [
      {
        "apiFile": "6271d4fe543df9406cf9e355-6271e18d3451604807f7fca1",
        "environments": [
          {
            "name": "Production",
            "vhost": "prod.e1-us-east-azure.choreoapis.dev"
          }
        ],
        "organizationId": "WSO2",
        "version": "1.0.0",
        "apiContext": "/shalkiwenushika/cp-test-api4/1.0.0"
      }
    ]
  }
}
```