### PR TITLE
Add null Check When Retrieving APIs Against Gateway Labels

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/impl/SubscriptionDataLoaderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/impl/SubscriptionDataLoaderImpl.java
@@ -317,8 +317,9 @@ public class SubscriptionDataLoaderImpl implements SubscriptionDataLoader {
                         api = list.getList().get(0);
                     }
                 }
-                return api;
-
+                if (api != null) {
+                    return api;
+                }
             }
         }
         return null;


### PR DESCRIPTION
## Purpose
- Add null check when retrieving APIs against gateway labels
- Related Issue: https://github.com/wso2/api-manager/issues/103

## Approach
When fetching APIs against gateway labels array, the implementation returns the API even it is null and hence, the loop finishes with the first gateway label and does not search for the API with other gateway labels. This PR adds the null check so that no null API is returned.