### PR TITLE
Adding a meaningful message when importing the OpenAPI specification/Swagger definition during an API import via apictl

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -463,6 +463,9 @@ public enum ExceptionCodes implements ErrorHandler {
     ERROR_UPLOADING_THUMBNAIL(900914,
             "Error while updating thumbnail of API/API Product", 500,
             "Error while updating thumbnail of API/API Product: %s-%s"),
+    APICTL_OPENAPI_PARSE_EXCEPTION(
+            OPENAPI_PARSE_EXCEPTION.getErrorCode(), OPENAPI_PARSE_EXCEPTION.getErrorMessage(),
+            OPENAPI_PARSE_EXCEPTION.getHttpStatusCode(), "%s"),
 
     //AsyncApi related error codes
     ASYNCAPI_URL_MALFORMED(900756, "AsyncAPI specification retrieval from URL failed", 400, "Exception occurred while retrieving the AsyncAPI Specification from URL"),


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/115

## Goals
Adding a meaningful message when importing the OpenAPI specification/Swagger definition during an API import via apictl

## Approach
- If the Open API/Swagger definition has errors, a message like the below will be displayed.

wasura@wasura:~/Desktop/apictl$ apictl import api -f API410API/ -e production
Error importing API.
Status: 400
Response: {"code":900754,"message":"Error while parsing OpenAPI definition","description":"attribute paths.'/test/{val_1}_{val_2}/abc'. Declared path parameter val_1}_{val_2 needs to be defined as a path parameter in path or operation level. attribute paths.'/test/{val_1}_{val_2}/xyz'. Declared path parameter val_1}_{val_2 needs to be defined as a path parameter in path or operation level","moreInfo":"","error":[]}
apictl: Error importing API Reason: 400
Exit status 1

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.3 LTS