### PR TITLE
Upgrading the jaeger client, okhttp and okio versions

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/Util.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/Util.java
@@ -22,8 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
-import io.opentracing.propagation.TextMapExtractAdapter;
-import io.opentracing.propagation.TextMapInjectAdapter;
+import io.opentracing.propagation.TextMapAdapter;
 import io.opentracing.util.GlobalTracer;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.tracing.internal.ServiceReferenceHolder;
@@ -137,10 +136,10 @@ public class Util {
         Object sp = span.getSpan();
         if (sp instanceof Span) {
             tracer.getTracingTracer().inject(((Span) sp).context(), Format.Builtin.HTTP_HEADERS,
-                    new TextMapInjectAdapter(tracerSpecificCarrier));
+                    new TextMapAdapter(tracerSpecificCarrier));
         } else if (sp instanceof SpanContext) {
             tracer.getTracingTracer().inject((SpanContext) sp, Format.Builtin.HTTP_HEADERS,
-                    new TextMapInjectAdapter(tracerSpecificCarrier));
+                    new TextMapAdapter(tracerSpecificCarrier));
         }
     }
 
@@ -154,7 +153,7 @@ public class Util {
     public static TracingSpan extract(TracingTracer tracer, Map<String, String> headerMap) {
 
         return new TracingSpan(tracer.getTracingTracer().extract(Format.Builtin.HTTP_HEADERS,
-                new TextMapExtractAdapter(headerMap)));
+                new TextMapAdapter(headerMap)));
     }
 
     public static TracingTracer getGlobalTracer() {

--- a/pom.xml
+++ b/pom.xml
@@ -2138,7 +2138,7 @@
         <swagger3-codegen-maven-plugin.version>3.0.19</swagger3-codegen-maven-plugin.version>
         <swagger3.core.version>2.1.12</swagger3.core.version>
         <javax.enterprise.version>2.0</javax.enterprise.version>
-        <jaeger.client.version>0.32.0.wso2v4</jaeger.client.version>
+        <jaeger.client.version>1.8.0.wso2v1</jaeger.client.version>
         <zipkin.sender.okhttp3.version>2.16.3</zipkin.sender.okhttp3.version>
         <zipkin.reporter.version>2.16.3</zipkin.reporter.version>
         <brave.opentracing.version>0.32.0</brave.opentracing.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2144,7 +2144,7 @@
         <brave.opentracing.version>0.32.0</brave.opentracing.version>
         <opentracing.api.version>0.31.0</opentracing.api.version>
         <opentracing.mock.version>0.31.0</opentracing.mock.version>
-        <opentelemetry.all.version>1.11.0.wso2v1</opentelemetry.all.version>
+        <opentelemetry.all.version>1.11.0.wso2v2</opentelemetry.all.version>
         <aspectj.version>1.9.5</aspectj.version>
         <everit.version>1.5.0.wso2.v2</everit.version>
         <json.orbit.version>3.0.0.wso2v1</json.orbit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1937,7 +1937,7 @@
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 
         <!-- Carbon Identity versions -->
-        <carbon.identity.version>5.18.248</carbon.identity.version>
+        <carbon.identity.version>5.18.250</carbon.identity.version>
         <carbon.identity.governance.version>1.4.100</carbon.identity.governance.version>
         <carbon.identity-inbound-auth-oauth.version>6.4.176</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-oauth2-grant-jwt.version>1.1.0</carbon.identity-oauth2-grant-jwt.version>
@@ -2016,7 +2016,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-	    <synapse.version>2.1.7-wso2v271</synapse.version>
+        <synapse.version>2.1.7-wso2v287</synapse.version>
 
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2165,8 +2165,8 @@
         <org.wso2.orbit.com.amazonaws.version>1.11.1034.wso2v1</org.wso2.orbit.com.amazonaws.version>
 
         <zipkin.version>2.23.2</zipkin.version>
-        <okhttp.wso2.version>4.2.0.wso2v1</okhttp.wso2.version>
-        <okio.wso2.version>2.4.0.wso2v1</okio.wso2.version>
+        <okhttp.wso2.version>4.9.3.wso2v1</okhttp.wso2.version>
+        <okio.wso2.version>2.8.0.wso2v1</okio.wso2.version>
 
         <openfeign.version>11.0</openfeign.version>
         <maven.spotbugsplugin.version>3.1.10</maven.spotbugsplugin.version>


### PR DESCRIPTION
## Purpose
Upgrading the jaeger client version to 1.8.0 which contains libthrift 0.16.0 and upgrading the okhttp and okio versions to 4.9.3 and 2.8.0 accordingly.

## Goals
Upgrading libthrift version to 0.16.0 and okhttp and okio versions to 4.9.3 and 2.8.0 accordingly.

## Approach
- After bumping the jaeger client version, there were some interface changes related to TextMapAdapter. Those changes had to be properly modified in the code.
- Updated the pom with the correct versions.

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.3 LTS

