### PR TITLE
Fix analytics events getting dropped when User-Agent header is missing

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/SuccessRequestDataCollector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/SuccessRequestDataCollector.java
@@ -74,6 +74,9 @@ public class SuccessRequestDataCollector extends CommonRequestDataCollector impl
         if (userIp == null) {
             userIp = Constants.UNKNOWN_VALUE;
         }
+        if (userAgent == null) {
+            userAgent = Constants.UNKNOWN_VALUE;
+        }
 
         event.setApi(api);
         event.setOperation(operation);


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/api-manager/issues/157