### PR TITLE
Bumping the identity, identity inbound and synapse versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1942,7 +1942,7 @@
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 
         <!-- Carbon Identity versions -->
-        <carbon.identity.version>5.18.250</carbon.identity.version>
+        <carbon.identity.version>5.18.251</carbon.identity.version>
         <carbon.identity.governance.version>1.4.100</carbon.identity.governance.version>
         <carbon.identity-inbound-auth-oauth.version>6.4.176</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-oauth2-grant-jwt.version>1.1.0</carbon.identity-oauth2-grant-jwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1944,7 +1944,7 @@
         <!-- Carbon Identity versions -->
         <carbon.identity.version>5.18.251</carbon.identity.version>
         <carbon.identity.governance.version>1.4.100</carbon.identity.governance.version>
-        <carbon.identity-inbound-auth-oauth.version>6.4.176</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version>6.4.177</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-oauth2-grant-jwt.version>1.1.0</carbon.identity-oauth2-grant-jwt.version>
         <carbon.identity-user-ws.version>5.4.6</carbon.identity-user-ws.version>
         <carbon.identity-inbound-auth-saml2.version>5.5.9</carbon.identity-inbound-auth-saml2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2021,7 +2021,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>2.1.7-wso2v287</synapse.version>
+        <synapse.version>2.1.7-wso2v290</synapse.version>
 
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 


### PR DESCRIPTION
## Purpose
Bumping the identity, identity inbound and synapse versions with regard to the changes done in [1], [2] and [3] accordingly.

## Goals
Bumping the identity, identity inbound and synapse versions.

## Approach
- Bumped the carbon identity version to reflect the change in [1].
- Bumped the identity inbound version to reflect the change in [2].
- Bumped the synapse version to reflect the change in [3].

## Related PRs
- https://github.com/wso2/product-apim/pull/12918

[1] https://github.com/wso2/carbon-identity-framework/pull/4066
[2] https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1858
[3] https://github.com/wso2/wso2-synapse/pull/1966
