### PR TITLE
Reverting the synapse version to 2.1.7-wso2v289

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2021,7 +2021,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>2.1.7-wso2v290</synapse.version>
+        <synapse.version>2.1.7-wso2v289</synapse.version>
 
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 


### PR DESCRIPTION
## Purpose
Revert the synapse version to 2.1.7-wso2v289 to omit the test failure due to [1].
The synapse version was initially bumped to reflect the changes via [2]. But that bumped version had changes of [1] too, which fails some integration tests in product-apim. Hence, downgrading the synapse version for now.

## Goals
Omit the test failure due to https://github.com/wso2/wso2-synapse/pull/1970

[1] https://github.com/wso2/wso2-synapse/pull/1970
[2] https://github.com/wso2/carbon-apimgt/pull/11295