### PR TITLE
Returning the existing json payload when building message from the context

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/listener/ExtensionListenerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/listener/ExtensionListenerUtil.java
@@ -292,7 +292,7 @@ public class ExtensionListenerUtil {
             try {
                 String payload = IOUtils.toString(extensionResponseDTO.getPayload());
                 // based on Content-Type header reset the payload
-                if (StringUtils.equals(contentType, APIConstants.APPLICATION_JSON_MEDIA_TYPE)) {
+                if (StringUtils.startsWith(contentType, APIConstants.APPLICATION_JSON_MEDIA_TYPE)) {
                     JsonUtil.removeJsonPayload(axis2MC);
                     JsonUtil.getNewJsonPayload(axis2MC, payload, true, true);
                     axis2MC.setProperty(Constants.Configuration.MESSAGE_TYPE, APIConstants.APPLICATION_JSON_MEDIA_TYPE);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/payloadhandler/SynapsePayloadHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/payloadhandler/SynapsePayloadHandler.java
@@ -22,6 +22,7 @@ import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
 import org.wso2.carbon.apimgt.api.APIManagementException;
@@ -92,12 +93,16 @@ public class SynapsePayloadHandler implements PayloadHandler {
             log.error(errorMessage, e);
             throw new APIManagementException(errorMessage, e);
         }
-        SOAPEnvelope env = ((Axis2MessageContext) this.messageContext).getAxis2MessageContext().getEnvelope();
-        if (env != null) {
-            SOAPBody body = env.getBody();
-            if (body != null) {
-                env.buildWithAttachments();
-                return body.toString();
+        if (JsonUtil.hasAJsonPayload(((Axis2MessageContext) this.messageContext).getAxis2MessageContext())) {
+            return JsonUtil.jsonPayloadToString(((Axis2MessageContext) this.messageContext).getAxis2MessageContext());
+        } else {
+            SOAPEnvelope env = ((Axis2MessageContext) this.messageContext).getAxis2MessageContext().getEnvelope();
+            if (env != null) {
+                SOAPBody body = env.getBody();
+                if (body != null) {
+                    env.buildWithAttachments();
+                    return body.toString();
+                }
             }
         }
         return null;


### PR DESCRIPTION
This PR includes two changes with regard to the gateway.
1. When building the message if a json payload already exists in the MessageContext it is returned as it is without rebuilding it. 
2. Allowing to pass the charset value as well in the Content-Type header.

Also note that these changes were prior added to the APIM 4.0.0 version using this [PR](https://github.com/wso2-support/carbon-apimgt/pull/4775). 