### PR TITLE
Fix duplicate data entry issue for deployed revision

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -16571,12 +16571,10 @@ public class ApiMgtDAO {
                     connection.rollback();
                     // handle concurrent db entry update. Fix duplicate primary key issue.
                     if (e.getMessage().toLowerCase().contains("primary key violation") ||
-                            e.getMessage().toLowerCase().contains("duplicate entry") ||
+                            e.getMessage().toLowerCase().contains("duplicate") ||
                             e.getMessage().contains("Violation of PRIMARY KEY constraint")) {
                         log.warn("Duplicate entries detected for Revision UUID " + apiRevisionId +
                                 " while adding deployed API revisions", e);
-                        throw new APIManagementException("Failed to add deployed API Revision for Revision UUID "
-                                + apiRevisionId,  e, ExceptionCodes.REVISION_ALREADY_DEPLOYED);
                     } else {
                         handleException("Failed to add deployed API Revision for Revision UUID "
                                 + apiRevisionId, e);


### PR DESCRIPTION
This is to handle duplicate API deployed status updates. If the same call (PATCH /deployed-revisions) was received by the apim, no need to consider it as an error scenario as multiple choreo connect local adapters can send the same acknowledgment due to the HA in choreo connect local adapter deployment.

This PR will update the existing condition to identify duplicate key error.

Existing code below is there to identify duplicate key errors. 
```
e.getMessage().toLowerCase().contains("duplicate entry")
```
However with mssql, the error will contain "duplicate key", and it does not contain "duplicate entry" . 
Therefore in order to fix it to be compatible with all DB types, we will change it to 
```
e.getMessage().toLowerCase().contains("duplicate")
```


