### PR TITLE
Remove throwing the 409 when detect duplicate entry while deploying revision

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -486,9 +486,8 @@ public enum ExceptionCodes implements ErrorHandler {
     INVALID_ENDPOINT_CREDENTIALS(902000, "Invalid Endpoint Security credentials", 400,
             "Invalid Endpoint Security credentials. %s", false),
     INVALID_TENANT_CONFIG(9020001, "Invalid tenant-config found", 400, "Invalid tenant-config found with error %s", false),
-    INVALID_API_ID(9020002, "Invalid API ID", 404, "The provided API ID is not found %s", false),
-    REVISION_ALREADY_DEPLOYED(9020003, "Revision deployment state conflicted", 409,
-            "Revision deployment request conflicted with the current deployment state of the revision %s. Please try again later", false);
+    INVALID_API_ID(9020002, "Invalid API ID", 404, "The provided API ID is not found %s", false);
+
     private final long errorCode;
     private final String errorMessage;
     private final int httpStatusCode;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -16573,10 +16573,8 @@ public class ApiMgtDAO {
                     if (e.getMessage().toLowerCase().contains("primary key violation") ||
                             e.getMessage().toLowerCase().contains("duplicate entry") ||
                             e.getMessage().contains("Violation of PRIMARY KEY constraint")) {
-                        log.warn("Duplicate entries detected for Revision UUID " + apiRevisionId +
+                        log.debug("Duplicate entries detected for Revision UUID " + apiRevisionId +
                                 " while adding deployed API revisions", e);
-                        throw new APIManagementException("Failed to add deployed API Revision for Revision UUID "
-                                + apiRevisionId,  e, ExceptionCodes.REVISION_ALREADY_DEPLOYED);
                     } else {
                         handleException("Failed to add deployed API Revision for Revision UUID "
                                 + apiRevisionId, e);


### PR DESCRIPTION
## Purpose
Following PR[1]  has bee raised in order to solve the issue[2]. But , after a clarification regarding the issue we identify that returns a 200 HTTP status code for duplicate entry exception was a expected behavior.Since raise this PR to revert that change.

[1] https://github.com/wso2/carbon-apimgt/pull/11301
[2] https://github.com/wso2-enterprise/choreo/issues/13035 