### PR TITLE
Add REST APIs for APICTL Common API Policy Operations

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -512,10 +512,6 @@ public enum ExceptionCodes implements ErrorHandler {
 
     OPERATION_POLICY_WITH_NAME_NOT_FOUND(903002, "Operation Policy Not Found", 404,
             "Requested operation policy with name '%s' and version '%s' not found"),
-
-    THROTTLING_POLICY_NOT_FOUND(903005, "Throttling Policy Not Found", 404,
-            "Requested throttling policy with name '%s' and type '%s' not found"),
-
     OPERATION_POLICY_NOT_FOUND_WITH_NAME_AND_VERSION(903004, "Operation Policy Not Found", 404,
             "Requested operation policy with name '%s' and version '%s not found"),
 

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -310,7 +310,7 @@ public enum ExceptionCodes implements ErrorHandler {
     ACCESS_TOKEN_REVOKE_FAILED(900966, "Key Management Error", 500, "Error while revoking the access token."),
     INTERNAL_ERROR(900967, "General Error", 500, "Server Error Occurred"),
     INTERNAL_ERROR_WITH_SPECIFIC_MESSAGE(903006, "%s", 500, "Server Error Occurred"),
-    POLICY_SPECIFICATION_CONTENT_ERROR(903007, "Policy Specification file cannot be empty", 500, "Server Error Occurred"),
+
     POLICY_LEVEL_NOT_SUPPORTED(900968, "Throttle Policy level invalid", 400, "Specified Throttle policy level is not "
             + "valid"),
     INVALID_APPLICATION_ADDITIONAL_PROPERTIES(900970, "Invalid application additional properties", 400,
@@ -515,6 +515,10 @@ public enum ExceptionCodes implements ErrorHandler {
             "Requested operation policy with name '%s' and version '%s' not found"),
     OPERATION_POLICY_NOT_FOUND_WITH_NAME_AND_VERSION(903004, "Operation Policy Not Found", 404,
             "Requested operation policy with name '%s' and version '%s not found"),
+
+    OPERATION_POLICY_GATEWAY_ERROR(903008,
+            "Either Synapse or Choreo Gateway Definition files or both should be present", 400,
+            "Operation Policy cannot be imported due to the missing Gateway files."),
 
     SUBSCRIPTION_TIER_NOT_ALLOWED(902002, "Subscription Tier is not allowed for user", 403, "Subscription Tier %s is" +
             " not allowed for user %s ", false),

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -507,6 +507,8 @@ public enum ExceptionCodes implements ErrorHandler {
     OPERATION_POLICY_NOT_FOUND(902010, "Operation Policy Not Found", 404,
             "Requested operation policy with id '%s' not found"),
 
+    OPERATION_POLICY_ALREADY_EXISTS(900999, "The Operation Policy already exists.", 409, "An Operation Policy with name '%s' and version '%s' already exists"),
+
     SUBSCRIPTION_TIER_NOT_ALLOWED(902002, "Subscription Tier is not allowed for user", 403, "Subscription Tier %s is" +
             " not allowed for user %s ", false),
     INVALID_KEY_MANAGER_REQUEST(902003, "Invalid Request sent to Key Manager.", 400, "Invalid Request sent to Key Manager.Error from Backend : %s", false),

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -512,6 +512,12 @@ public enum ExceptionCodes implements ErrorHandler {
     OPERATION_POLICY_WITH_NAME_NOT_FOUND(903002, "Operation Policy Not Found", 404,
             "Requested operation policy with name '%s' and version '%s' not found"),
 
+    THROTTLING_POLICY_NOT_FOUND(903005, "Throttling Policy Not Found", 404,
+            "Requested throttling policy with name '%s' and type '%s' not found"),
+
+    OPERATION_POLICY_NOT_FOUND_WITH_NAME_AND_VERSION(903004, "Operation Policy Not Found", 404,
+            "Requested operation policy with name '%s' and version '%s not found"),
+
     SUBSCRIPTION_TIER_NOT_ALLOWED(902002, "Subscription Tier is not allowed for user", 403, "Subscription Tier %s is" +
             " not allowed for user %s ", false),
     INVALID_KEY_MANAGER_REQUEST(902003, "Invalid Request sent to Key Manager.", 400, "Invalid Request sent to Key Manager.Error from Backend : %s", false),

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -507,7 +507,10 @@ public enum ExceptionCodes implements ErrorHandler {
     OPERATION_POLICY_NOT_FOUND(902010, "Operation Policy Not Found", 404,
             "Requested operation policy with id '%s' not found"),
 
-    OPERATION_POLICY_ALREADY_EXISTS(900999, "The Operation Policy already exists.", 409, "An Operation Policy with name '%s' and version '%s' already exists"),
+    OPERATION_POLICY_ALREADY_EXISTS(903001, "The Operation Policy already exists.", 409, "An Operation Policy with name '%s' and version '%s' already exists"),
+
+    OPERATION_POLICY_WITH_NAME_NOT_FOUND(903002, "Operation Policy Not Found", 404,
+            "Requested operation policy with name '%s' and version '%s' not found"),
 
     SUBSCRIPTION_TIER_NOT_ALLOWED(902002, "Subscription Tier is not allowed for user", 403, "Subscription Tier %s is" +
             " not allowed for user %s ", false),

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -309,6 +309,7 @@ public enum ExceptionCodes implements ErrorHandler {
     INVALID_TOKEN_REQUEST(900965, "Key Management Error", 400, "Invalid access token request."),
     ACCESS_TOKEN_REVOKE_FAILED(900966, "Key Management Error", 500, "Error while revoking the access token."),
     INTERNAL_ERROR(900967, "General Error", 500, "Server Error Occurred"),
+    INTERNAL_ERROR_WITH_SPECIFIC_MESSAGE(903006, "%s", 500, "Server Error Occurred"),
     POLICY_LEVEL_NOT_SUPPORTED(900968, "Throttle Policy level invalid", 400, "Specified Throttle policy level is not "
             + "valid"),
     INVALID_APPLICATION_ADDITIONAL_PROPERTIES(900970, "Invalid application additional properties", 400,

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -310,6 +310,7 @@ public enum ExceptionCodes implements ErrorHandler {
     ACCESS_TOKEN_REVOKE_FAILED(900966, "Key Management Error", 500, "Error while revoking the access token."),
     INTERNAL_ERROR(900967, "General Error", 500, "Server Error Occurred"),
     INTERNAL_ERROR_WITH_SPECIFIC_MESSAGE(903006, "%s", 500, "Server Error Occurred"),
+    POLICY_SPECIFICATION_CONTENT_ERROR(903007, "Policy Specification file cannot be empty", 500, "Server Error Occurred"),
     POLICY_LEVEL_NOT_SUPPORTED(900968, "Throttle Policy level invalid", 400, "Specified Throttle policy level is not "
             + "valid"),
     INVALID_APPLICATION_ADDITIONAL_PROPERTIES(900970, "Invalid application additional properties", 400,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -19239,9 +19239,7 @@ public class ApiMgtDAO {
         statement.close();
 
         if (isWithPolicyDefinition && policyData != null) {
-            if (isWithPolicyDefinition && policyData != null) {
-                populatePolicyDefinitions(connection, policyData.getPolicyId(), policyData);
-            }
+            populatePolicyDefinitions(connection, policyData.getPolicyId(), policyData);
         }
         return policyData;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -68,6 +68,10 @@ public final class ImportExportConstants {
     public static final String JSON_EXTENSION = ".json";
     public static final String YAML_EXTENSION = ".yaml";
 
+    public static final String SYNAPSE_EXTENSION = ".j2";
+
+    public static final String CHOREO_CONNECT_EXTENSION = ".gotmpl";
+
     // Image resource
     public static final String IMAGE_RESOURCE = "Image";
 
@@ -94,6 +98,8 @@ public final class ImportExportConstants {
 
     public static final String UPLOAD_API_FILE_NAME = "APIArchive.zip";
 
+    public static final String UPLOAD_POLICY_FILE_NAME = "PolicyArchive.zip";
+
     // Location of the API swagger definition file
     public static final String JSON_SWAGGER_DEFINITION_LOCATION =
             File.separator + DEFINITIONS_DIRECTORY + File.separator + "swagger.json";
@@ -115,6 +121,10 @@ public final class ImportExportConstants {
 
     // Name of the API name element tag of the api.json file
     public static final String API_NAME_ELEMENT = "name";
+
+    public static final String OPERATION_POLICY_TYPE = "type";
+
+    public static final String DEFAULT_OPERATION_POLICY_TYPE = "operation_policy_specification";
 
     // Name of the API version element tag of the api.json file
     public static final String VERSION_ELEMENT = "version";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -308,4 +308,6 @@ public final class ImportExportConstants {
 
     public static final String EXPORT_POLICY_TYPE_YAML = "YAML";
     public static final String EXPORT_POLICY_TYPE_JSON = "JSON";
+
+    public static final String POLICY_NAME = "name";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -68,9 +68,9 @@ public final class ImportExportConstants {
     public static final String JSON_EXTENSION = ".json";
     public static final String YAML_EXTENSION = ".yaml";
 
-    public static final String SYNAPSE_EXTENSION = ".j2";
+    public static final String SYNAPSE_POLICY_EXTENSION = ".j2";
 
-    public static final String CHOREO_CONNECT_EXTENSION = ".gotmpl";
+    public static final String CHOREO_CONNECT_POLICY_EXTENSION = ".gotmpl";
 
     // Image resource
     public static final String IMAGE_RESOURCE = "Image";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -68,10 +68,6 @@ public final class ImportExportConstants {
     public static final String JSON_EXTENSION = ".json";
     public static final String YAML_EXTENSION = ".yaml";
 
-    public static final String SYNAPSE_POLICY_EXTENSION = ".j2";
-
-    public static final String CHOREO_CONNECT_POLICY_EXTENSION = ".gotmpl";
-
     // Image resource
     public static final String IMAGE_RESOURCE = "Image";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -122,10 +122,6 @@ public final class ImportExportConstants {
     // Name of the API name element tag of the api.json file
     public static final String API_NAME_ELEMENT = "name";
 
-    public static final String OPERATION_POLICY_TYPE = "type";
-
-    public static final String DEFAULT_OPERATION_POLICY_TYPE = "operation_policy_specification";
-
     // Name of the API version element tag of the api.json file
     public static final String VERSION_ELEMENT = "version";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/operationPolicy/operation-policy-specification-schema.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/operationPolicy/operation-policy-specification-schema.json
@@ -29,7 +29,8 @@
           "response",
           "fault"
         ]
-      }
+      },
+      "minItems": 1
     },
     "supportedGateways": {
       "type": "array",
@@ -39,7 +40,8 @@
           "Synapse",
           "ChoreoConnect"
         ]
-      }
+      },
+      "minItems": 1
     },
     "supportedApiTypes": {
       "type": "array",
@@ -48,7 +50,8 @@
         "enum": [
           "HTTP"
         ]
-      }
+      },
+      "minItems": 1
     },
     "policyAttributes": {
       "type": "array",

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -336,6 +336,10 @@
       {
         "Name": "apim:common_operation_policy_manage",
         "Roles": "admin,Internal/creator"
+      },
+      {
+        "Name": "apim:policies_import_export",
+        "Roles": "admin,Internal/devops"
       }
     ]
   },

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/EnvironmentsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/EnvironmentsApi.java
@@ -92,7 +92,7 @@ EnvironmentsApiService delegate = new EnvironmentsApiServiceImpl();
     
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Add an Environment", notes = "Add a new geteway environment ", response = EnvironmentDTO.class, authorizations = {
+    @ApiOperation(value = "Add an Environment", notes = "Add a new gateway environment ", response = EnvironmentDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
             @AuthorizationScope(scope = "apim:environment_manage", description = "Manage gateway environments")

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/KeyManagerConfigurationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/KeyManagerConfigurationDTO.java
@@ -142,7 +142,7 @@ public class KeyManagerConfigurationDTO   {
   }
 
   
-  @ApiModelProperty(example = "Entet username to connect to key manager", value = "")
+  @ApiModelProperty(example = "Enter username to connect to key manager", value = "")
   @JsonProperty("tooltip")
   public String getTooltip() {
     return tooltip;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/OperationPolicyDataDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/OperationPolicyDataDTO.java
@@ -26,7 +26,7 @@ public class OperationPolicyDataDTO   {
     private String category = null;
     private String id = null;
     private String name = null;
-    private String version = null;
+    private String version = "v1";
     private String displayName = null;
     private String description = null;
     private List<String> applicableFlows = new ArrayList<String>();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/OperationPolicyDataDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/OperationPolicyDataDTO.java
@@ -26,6 +26,7 @@ public class OperationPolicyDataDTO   {
     private String category = null;
     private String id = null;
     private String name = null;
+    private String version = null;
     private String displayName = null;
     private String description = null;
     private List<String> applicableFlows = new ArrayList<String>();
@@ -84,6 +85,23 @@ public class OperationPolicyDataDTO   {
   }
   public void setName(String name) {
     this.name = name;
+  }
+
+  /**
+   **/
+  public OperationPolicyDataDTO version(String version) {
+    this.version = version;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "v1", value = "")
+  @JsonProperty("version")
+  public String getVersion() {
+    return version;
+  }
+  public void setVersion(String version) {
+    this.version = version;
   }
 
   /**
@@ -236,6 +254,7 @@ public class OperationPolicyDataDTO   {
     return Objects.equals(category, operationPolicyData.category) &&
         Objects.equals(id, operationPolicyData.id) &&
         Objects.equals(name, operationPolicyData.name) &&
+        Objects.equals(version, operationPolicyData.version) &&
         Objects.equals(displayName, operationPolicyData.displayName) &&
         Objects.equals(description, operationPolicyData.description) &&
         Objects.equals(applicableFlows, operationPolicyData.applicableFlows) &&
@@ -248,7 +267,7 @@ public class OperationPolicyDataDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(category, id, name, displayName, description, applicableFlows, supportedGateways, supportedApiTypes, isAPISpecific, md5, policyAttributes);
+    return Objects.hash(category, id, name, version, displayName, description, applicableFlows, supportedGateways, supportedApiTypes, isAPISpecific, md5, policyAttributes);
   }
 
   @Override
@@ -259,6 +278,7 @@ public class OperationPolicyDataDTO   {
     sb.append("    category: ").append(toIndentedString(category)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
     sb.append("    applicableFlows: ").append(toIndentedString(applicableFlows)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -87,6 +87,7 @@ import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIProductDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DocumentDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.GraphQLQueryComplexityInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.GraphQLValidationResponseDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.OperationPolicyDataDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ProductAPIDTO;
 import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.registry.core.Registry;
@@ -95,7 +96,6 @@ import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -137,7 +137,7 @@ public class ImportUtils {
      * @param dependentAPIParamsConfigObject Params configuration of an API (this will not be null if a dependent API
      *                                       of an
      *                                       API product wants to override the parameters)
-     * @param organization  Identifier of an Organization
+     * @param organization                   Identifier of an Organization
      * @throws APIImportExportException If there is an error in importing an API
      * @@return Imported API
      */
@@ -175,8 +175,8 @@ public class ImportUtils {
                 importedApiDTO = APIControllerUtil.injectEnvParamsToAPI(importedApiDTO, paramsConfigObject,
                         extractedFolderPath);
                 if (!isAdvertiseOnlyAPI(importedApiDTO)) {
-                    JsonElement deploymentsParam = paramsConfigObject
-                            .get(ImportExportConstants.DEPLOYMENT_ENVIRONMENTS);
+                    JsonElement deploymentsParam = paramsConfigObject.get(
+                            ImportExportConstants.DEPLOYMENT_ENVIRONMENTS);
                     if (deploymentsParam != null && !deploymentsParam.isJsonNull()) {
                         deploymentInfoArray = deploymentsParam.getAsJsonArray();
                     }
@@ -217,8 +217,8 @@ public class ImportUtils {
                 processAdvertiseOnlyPropertiesInDTO(importedApiDTO, tokenScopes);
             }
 
-            Map<String, List<OperationPolicy>> extractedPoliciesMap =
-                    extractAndDropOperationPoliciesFromURITemplate(importedApiDTO.getOperations());
+            Map<String, List<OperationPolicy>> extractedPoliciesMap = extractAndDropOperationPoliciesFromURITemplate(
+                    importedApiDTO.getOperations());
 
             // If the overwrite is set to true (which means an update), retrieve the existing API
             if (Boolean.TRUE.equals(overwrite) && targetApi != null) {
@@ -234,8 +234,8 @@ public class ImportUtils {
                     setOperationsToDTO(importedApiDTO, validationResponse);
                 }
                 targetApi.setOrganization(organization);
-                importedApi = PublisherCommonUtils
-                        .updateApi(targetApi, importedApiDTO, RestApiCommonUtil.getLoggedInUserProvider(), tokenScopes);
+                importedApi = PublisherCommonUtils.updateApi(targetApi, importedApiDTO,
+                        RestApiCommonUtil.getLoggedInUserProvider(), tokenScopes);
             } else {
                 if (targetApi == null && Boolean.TRUE.equals(overwrite)) {
                     log.info("Cannot find : " + importedApiDTO.getName() + "-" + importedApiDTO.getVersion()
@@ -245,9 +245,8 @@ public class ImportUtils {
                 currentStatus = APIStatus.CREATED.toString();
                 importedApiDTO.setLifeCycleStatus(currentStatus);
                 if (!PublisherCommonUtils.isThirdPartyAsyncAPI(importedApiDTO)) {
-                    importedApi = PublisherCommonUtils
-                            .addAPIWithGeneratedSwaggerDefinition(importedApiDTO, ImportExportConstants.OAS_VERSION_3,
-                                    importedApiDTO.getProvider(), organization);
+                    importedApi = PublisherCommonUtils.addAPIWithGeneratedSwaggerDefinition(importedApiDTO,
+                            ImportExportConstants.OAS_VERSION_3, importedApiDTO.getProvider(), organization);
                 } else {
                     importedApi = PublisherCommonUtils.importAsyncAPIWithDefinition(validationResponse, Boolean.FALSE,
                             importedApiDTO, null, currentTenantDomain, apiProvider);
@@ -261,8 +260,9 @@ public class ImportUtils {
             }
 
             if (!extractedPoliciesMap.isEmpty()) {
-                importedApi.setUriTemplates(validateOperationPolicies(importedApi, apiProvider, extractedFolderPath,
-                        extractedPoliciesMap, currentTenantDomain));
+                importedApi.setUriTemplates(
+                        validateOperationPolicies(importedApi, apiProvider, extractedFolderPath, extractedPoliciesMap,
+                                currentTenantDomain));
                 API oldAPI = apiProvider.getAPIbyUUID(importedApi.getUuid(), importedApi.getOrganization());
                 apiProvider.updateAPI(importedApi, oldAPI);
             }
@@ -275,7 +275,7 @@ public class ImportUtils {
                     && !APIConstants.APITransportType.GRAPHQL.toString().equalsIgnoreCase(apiType)) {
                 // Add the validated swagger separately since the UI does the same procedure
                 PublisherCommonUtils.updateSwagger(importedApi.getUuid(), validationResponse, false, organization);
-                importedApi =  apiProvider.getAPIbyUUID(importedApi.getUuid(), currentTenantDomain);
+                importedApi = apiProvider.getAPIbyUUID(importedApi.getUuid(), currentTenantDomain);
             }
             // Add the GraphQL schema
             if (APIConstants.APITransportType.GRAPHQL.toString().equalsIgnoreCase(apiType)) {
@@ -300,8 +300,8 @@ public class ImportUtils {
             addThumbnailImage(extractedFolderPath, apiTypeWrapperWithUpdatedApi, apiProvider);
             addDocumentation(extractedFolderPath, apiTypeWrapperWithUpdatedApi, apiProvider, organization);
             addAPIWsdl(extractedFolderPath, importedApi, apiProvider);
-            if (StringUtils
-                    .equals(importedApi.getType().toLowerCase(), APIConstants.API_TYPE_SOAPTOREST.toLowerCase())) {
+            if (StringUtils.equals(importedApi.getType().toLowerCase(),
+                    APIConstants.API_TYPE_SOAPTOREST.toLowerCase())) {
                 addSOAPToREST(importedApi, validationResponse.getContent(), apiProvider);
             }
 
@@ -350,28 +350,27 @@ public class ImportUtils {
                 } catch (APIManagementException e) {
                     //if the revision count is more than 5, addAPIRevision will throw an exception. If rotateRevision
                     //enabled, earliest revision will be deleted before creating a revision again
-                    if (e.getErrorHandler().getErrorCode() ==
-                            ExceptionCodes.from(ExceptionCodes.MAXIMUM_REVISIONS_REACHED).getErrorCode() &&
-                            rotateRevision) {
+                    if (e.getErrorHandler().getErrorCode() == ExceptionCodes.from(
+                            ExceptionCodes.MAXIMUM_REVISIONS_REACHED).getErrorCode() && rotateRevision) {
                         String earliestRevisionUuid = apiProvider.getEarliestRevisionUUID(importedAPIUuid);
-                        List<APIRevisionDeployment> deploymentsList =
-                                apiProvider.getAPIRevisionDeploymentList(earliestRevisionUuid);
+                        List<APIRevisionDeployment> deploymentsList = apiProvider.getAPIRevisionDeploymentList(
+                                earliestRevisionUuid);
                         //if the earliest revision is already deployed in gateway environments, it will be undeployed
                         //before deleting
-                        apiProvider
-                                .undeployAPIRevisionDeployment(importedAPIUuid, earliestRevisionUuid, deploymentsList,
-                                        organization);
+                        apiProvider.undeployAPIRevisionDeployment(importedAPIUuid, earliestRevisionUuid,
+                                deploymentsList, organization);
                         apiProvider.deleteAPIRevision(importedAPIUuid, earliestRevisionUuid, tenantDomain);
                         revisionId = apiProvider.addAPIRevision(apiRevision, tenantDomain);
                         if (log.isDebugEnabled()) {
-                            log.debug("Revision ID: " + earliestRevisionUuid + " has been undeployed from " +
-                                    deploymentsList.size() + " gateway environments and created a new revision ID: " +
-                                    revisionId + " for API " + importedApi.getId().getApiName() + "_" +
-                                    importedApi.getId().getVersion());
+                            log.debug("Revision ID: " + earliestRevisionUuid + " has been undeployed from "
+                                    + deploymentsList.size() + " gateway environments and created a new revision ID: "
+                                    + revisionId + " for API " + importedApi.getId().getApiName() + "_"
+                                    + importedApi.getId().getVersion());
                         }
                     } else {
-                        throw new APIManagementException("Error occurred while creating a new revision for the API: " +
-                                importedApi.getId().getApiName(), e);
+                        throw new APIManagementException(
+                                "Error occurred while creating a new revision for the API: " + importedApi.getId()
+                                        .getApiName(), e);
                     }
                 }
 
@@ -379,12 +378,12 @@ public class ImportUtils {
                 //environments
                 apiProvider.deployAPIRevision(importedAPIUuid, revisionId, apiRevisionDeployments, organization);
                 if (log.isDebugEnabled()) {
-                    log.debug("API: " + importedApi.getId().getApiName() + "_" + importedApi.getId().getVersion() +
-                            " was deployed in " + apiRevisionDeployments.size() + " gateway environments.");
+                    log.debug("API: " + importedApi.getId().getApiName() + "_" + importedApi.getId().getVersion()
+                            + " was deployed in " + apiRevisionDeployments.size() + " gateway environments.");
                 }
             } else {
-                log.info("Valid deployment environments were not found for the imported artifact. Only working copy " +
-                        "was updated and not deployed in any of the gateway environments.");
+                log.info("Valid deployment environments were not found for the imported artifact. Only working copy "
+                        + "was updated and not deployed in any of the gateway environments.");
             }
             return importedApi;
         } catch (CryptoException | IOException e) {
@@ -410,13 +409,13 @@ public class ImportUtils {
         }
     }
 
-    public static Map<String, List<OperationPolicy>> extractAndDropOperationPoliciesFromURITemplate
-            (List<APIOperationsDTO> operationsDTO) {
+    public static Map<String, List<OperationPolicy>> extractAndDropOperationPoliciesFromURITemplate(
+            List<APIOperationsDTO> operationsDTO) {
         Map<String, List<OperationPolicy>> operationPoliciesMap = new HashMap<>();
         for (APIOperationsDTO dto : operationsDTO) {
             String key = dto.getVerb() + ":" + dto.getTarget();
-            List<OperationPolicy> operationPolicies =
-                    OperationPolicyMappingUtil.fromDTOToAPIOperationPoliciesList(dto.getOperationPolicies());
+            List<OperationPolicy> operationPolicies = OperationPolicyMappingUtil.fromDTOToAPIOperationPoliciesList(
+                    dto.getOperationPolicies());
             if (!operationPolicies.isEmpty()) {
                 operationPoliciesMap.put(key, operationPolicies);
             }
@@ -426,8 +425,7 @@ public class ImportUtils {
     }
 
     public static Set<URITemplate> validateOperationPolicies(API api, APIProvider provider, String extractedFolderPath,
-                                                             Map<String, List<OperationPolicy>> extractedPoliciesMap,
-                                                             String tenantDomain) {
+            Map<String, List<OperationPolicy>> extractedPoliciesMap, String tenantDomain) {
 
         String policyDirectory = extractedFolderPath + File.separator + ImportExportConstants.POLICIES_DIRECTORY;
         Map<String, String> importedPolicies = new HashMap<>();
@@ -445,10 +443,10 @@ public class ImportUtils {
                                     policy.getPolicyVersion());
                             String policyID = null;
                             if (!importedPolicies.containsKey(policyFileName)) {
-                                OperationPolicySpecification policySpec =
-                                        getOperationPolicySpecificationFromFile(policyDirectory, policyFileName);
-                                if (policySpec == null
-                                        && APIConstants.DEFAULT_POLICY_VERSION.equals(policy.getPolicyVersion())) {
+                                OperationPolicySpecification policySpec = getOperationPolicySpecificationFromFile(
+                                        policyDirectory, policyFileName);
+                                if (policySpec == null && APIConstants.DEFAULT_POLICY_VERSION.equals(
+                                        policy.getPolicyVersion())) {
                                     // this is to handle if the version is populated default, we disregard the version
                                     policySpec = getOperationPolicySpecificationFromFile(policyDirectory,
                                             policy.getPolicyName());
@@ -463,12 +461,11 @@ public class ImportUtils {
                                     OperationPolicyDefinition synapseDefinition =
                                             APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
                                                     policyFileName, APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
-                                    if (synapseDefinition == null
-                                            && APIConstants.DEFAULT_POLICY_VERSION.equals(policy.getPolicyVersion())) {
-                                        synapseDefinition =
-                                                APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
-                                                        policy.getPolicyName(),
-                                                        APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
+                                    if (synapseDefinition == null && APIConstants.DEFAULT_POLICY_VERSION.equals(
+                                            policy.getPolicyVersion())) {
+                                        synapseDefinition = APIUtil.getOperationPolicyDefinitionFromFile(
+                                                policyDirectory, policy.getPolicyName(),
+                                                APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
                                     }
                                     if (synapseDefinition != null) {
                                         synapseDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.Synapse);
@@ -477,19 +474,19 @@ public class ImportUtils {
                                     OperationPolicyDefinition ccDefinition =
                                             APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
                                                     policyFileName, APIConstants.CC_POLICY_DEFINITION_EXTENSION);
-                                    if (ccDefinition == null
-                                            && APIConstants.DEFAULT_POLICY_VERSION.equals(policy.getPolicyVersion())) {
+                                    if (ccDefinition == null && APIConstants.DEFAULT_POLICY_VERSION.equals(
+                                            policy.getPolicyVersion())) {
                                         ccDefinition = APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
                                                 policy.getPolicyName(), APIConstants.CC_POLICY_DEFINITION_EXTENSION);
                                     }
 
                                     if (ccDefinition != null) {
-                                        ccDefinition
-                                                .setGatewayType(OperationPolicyDefinition.GatewayType.ChoreoConnect);
+                                        ccDefinition.setGatewayType(
+                                                OperationPolicyDefinition.GatewayType.ChoreoConnect);
                                         operationPolicyData.setCcPolicyDefinition(ccDefinition);
                                     }
-                                    operationPolicyData
-                                            .setMd5Hash(APIUtil.getMd5OfOperationPolicy(operationPolicyData));
+                                    operationPolicyData.setMd5Hash(
+                                            APIUtil.getMd5OfOperationPolicy(operationPolicyData));
                                     policyID = provider.importOperationPolicy(operationPolicyData, tenantDomain);
                                     importedPolicies.put(policyFileName, policyID);
                                     policyImported = true;
@@ -503,8 +500,8 @@ public class ImportUtils {
                                 validatedOperationPolicies.add(policy);
                             }
                         } catch (APIManagementException e) {
-                            log.error("An error occurred when validating the operation policy "
-                                    + policy.getPolicyName() + "_" + policy.getPolicyVersion() + " for url template "
+                            log.error("An error occurred when validating the operation policy " + policy.getPolicyName()
+                                    + "_" + policy.getPolicyVersion() + " for url template "
                                     + uriTemplate.getUriTemplate() + ". Hence skipped.", e);
                         }
                     }
@@ -516,10 +513,9 @@ public class ImportUtils {
     }
 
     public static OperationPolicySpecification getOperationPolicySpecificationFromFile(String extractedFolderPath,
-                                                                                       String policyName)
-            throws APIManagementException {
+            String policyName) throws APIManagementException {
         try {
-            String jsonContent =  getFileContentAsJson(extractedFolderPath + File.separator + policyName);
+            String jsonContent = getFileContentAsJson(extractedFolderPath + File.separator + policyName);
             if (jsonContent == null) {
                 return null;
             }
@@ -527,8 +523,9 @@ public class ImportUtils {
             JsonElement configElement = new JsonParser().parse(jsonContent).getAsJsonObject().get(APIConstants.DATA);
             return APIUtil.getValidatedOperationPolicySpecification(configElement.toString());
         } catch (IOException e) {
-            throw new APIManagementException("Error while reading policy specification info from path: "
-                    + extractedFolderPath, e, ExceptionCodes.ERROR_READING_META_DATA);
+            throw new APIManagementException(
+                    "Error while reading policy specification info from path: " + extractedFolderPath, e,
+                    ExceptionCodes.ERROR_READING_META_DATA);
         }
     }
 
@@ -543,12 +540,12 @@ public class ImportUtils {
         }
         return importedApiDTO.getAdvertiseInfo() != null && importedApiDTO.getAdvertiseInfo().isAdvertised();
     }
-    
+
     /**
      * Process the properties specific to advertise only APIs
      *
-     * @param importedApiDTO               API DTO to import
-     * @param tokenScopes Scopes of the token
+     * @param importedApiDTO API DTO to import
+     * @param tokenScopes    Scopes of the token
      */
     private static void processAdvertiseOnlyPropertiesInDTO(APIDTO importedApiDTO, String[] tokenScopes) {
         // Only the users who has admin privileges (apim:admin scope) are allowed to set the original devportal URL.
@@ -575,9 +572,7 @@ public class ImportUtils {
      * @throws APIManagementException If an error occurs when validating the deployments list
      */
     private static List<APIRevisionDeployment> getValidatedDeploymentsList(JsonArray deploymentInfoArray,
-                                                                           String tenantDomain, APIProvider apiProvider,
-                                                                           String organization)
-            throws APIManagementException {
+            String tenantDomain, APIProvider apiProvider, String organization) throws APIManagementException {
 
         List<APIRevisionDeployment> apiRevisionDeployments = new ArrayList<>();
         if (deploymentInfoArray != null && deploymentInfoArray.size() > 0) {
@@ -597,15 +592,15 @@ public class ImportUtils {
                         } else {
                             // set the default vhost of the given environment
                             if (gatewayEnvironment.getVhosts().isEmpty()) {
-                                throw new APIManagementException("No VHosts defined for the environment: "
-                                        + deploymentName);
+                                throw new APIManagementException(
+                                        "No VHosts defined for the environment: " + deploymentName);
                             }
                             deploymentVhost = gatewayEnvironment.getVhosts().get(0).getHost();
                         }
                         // resolve vhost to null if it is the default vhost of read only environment
                         deploymentVhost = VHostUtils.resolveIfDefaultVhostToNull(deploymentName, deploymentVhost);
-                        JsonElement displayOnDevportalElement =
-                                deploymentJson.get(ImportExportConstants.DISPLAY_ON_DEVPORTAL_OPTION);
+                        JsonElement displayOnDevportalElement = deploymentJson.get(
+                                ImportExportConstants.DISPLAY_ON_DEVPORTAL_OPTION);
                         boolean displayOnDevportal =
                                 displayOnDevportalElement == null || displayOnDevportalElement.getAsBoolean();
                         APIRevisionDeployment apiRevisionDeployment = new APIRevisionDeployment();
@@ -616,8 +611,8 @@ public class ImportUtils {
                     } else {
                         throw new APIManagementException(
                                 "Label " + deploymentName + " is not a defined gateway environment. Hence "
-                                        + "skipped without deployment", ExceptionCodes
-                                .from(ExceptionCodes.GATEWAY_ENVIRONMENT_NOT_FOUND,
+                                        + "skipped without deployment",
+                                ExceptionCodes.from(ExceptionCodes.GATEWAY_ENVIRONMENT_NOT_FOUND,
                                         String.format("label '%s'", deploymentName)));
                     }
                 }
@@ -655,8 +650,7 @@ public class ImportUtils {
      * @throws APIManagementException If an error occurs when retrieving the API to overwrite
      */
     private static API retrieveApiToOverwrite(String apiName, String apiVersion, String currentTenantDomain,
-                                              APIProvider apiProvider, Boolean ignoreAndImport, String organization)
-            throws APIManagementException {
+            APIProvider apiProvider, Boolean ignoreAndImport, String organization) throws APIManagementException {
 
         String provider = APIUtil.getAPIProviderFromAPINameVersionTenant(apiName, apiVersion, currentTenantDomain);
         APIIdentifier apiIdentifier = new APIIdentifier(APIUtil.replaceEmailDomain(provider), apiName, apiVersion);
@@ -668,10 +662,11 @@ public class ImportUtils {
             }
             throw new APIMgtResourceNotFoundException(
                     "Error occurred while retrieving the API. API: " + apiName + StringUtils.SPACE
-                            + APIConstants.API_DATA_VERSION + ": " + apiVersion + " not found", ExceptionCodes
-                    .from(ExceptionCodes.API_NOT_FOUND, apiIdentifier.getApiName() + "-" + apiIdentifier.getVersion()));
+                            + APIConstants.API_DATA_VERSION + ": " + apiVersion + " not found",
+                    ExceptionCodes.from(ExceptionCodes.API_NOT_FOUND,
+                            apiIdentifier.getApiName() + "-" + apiIdentifier.getVersion()));
         }
-        
+
         String uuid = APIUtil.getUUIDFromIdentifier(apiIdentifier, organization);
         return apiProvider.getAPIbyUUID(uuid, currentTenantDomain);
     }
@@ -691,13 +686,13 @@ public class ImportUtils {
         String paramsFileName =
                 ImportExportConstants.INTERMEDIATE_PARAMS_FILE_LOCATION + ImportExportConstants.YAML_EXTENSION;
         boolean isParamsFileAvailable = CommonUtil.checkFileExistence(tempDirectoryAbsolutePath + paramsFileName);
-        boolean isDeploymentDirectoryAvailable = CommonUtil
-                .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.DEPLOYMENT_DIRECTORY_NAME);
+        boolean isDeploymentDirectoryAvailable = CommonUtil.checkFileExistence(
+                tempDirectoryAbsolutePath + ImportExportConstants.DEPLOYMENT_DIRECTORY_NAME);
 
         // When API controller is provided with params file
         if (isParamsFileAvailable) {
-            if (!CommonUtil
-                    .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME)) {
+            if (!CommonUtil.checkFileExistence(
+                    tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME)) {
                 throw new APIImportExportException("The source artifact is not provided properly");
             } else {
                 String newExtractedFolderName = CommonUtil.extractArchive(
@@ -714,8 +709,8 @@ public class ImportUtils {
         }
         //When API controller is provided with the "Deployment" directory
         if (isDeploymentDirectoryAvailable) {
-            if (!CommonUtil
-                    .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME)) {
+            if (!CommonUtil.checkFileExistence(
+                    tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME)) {
                 throw new APIImportExportException("The source artifact is not provided properly");
             } else {
                 String newExtractedFolderName = CommonUtil.extractArchive(
@@ -773,6 +768,31 @@ public class ImportUtils {
     }
 
     /**
+     * Extract the imported archive to a temporary folder and return the folder path of it.
+     *
+     * @param uploadedInputStream Input stream from the REST request
+     * @return Path to the extracted directory
+     * @throws APIImportExportException If an error occurs while creating the directory, transferring files or
+     *                                  extracting the content
+     */
+    public static String getArchivePathOfPolicyExtractedDirectory(InputStream uploadedInputStream)
+            throws APIManagementException {
+        try {
+            // Temporary directory is used to create the required folders
+            File importFolder = CommonUtil.createTempDirectory(null);
+            String uploadFileName = ImportExportConstants.UPLOAD_POLICY_FILE_NAME;
+            String absolutePath = importFolder.getAbsolutePath() + File.separator;
+            CommonUtil.transferFile(uploadedInputStream, uploadFileName, absolutePath);
+            String extractedFolderName = CommonUtil.extractArchive(new File(absolutePath + uploadFileName),
+                    absolutePath);
+            return absolutePath + extractedFolderName;
+        } catch (APIImportExportException e) {
+            throw new APIManagementException(e.getMessage(), ExceptionCodes.from(ExceptionCodes.INTERNAL_ERROR));
+        }
+
+    }
+
+    /**
      * Validate API/API Product configuration (api/api_product.yaml or api/api_product.json) and return it.
      *
      * @param pathToArchive            Path to the extracted folder
@@ -781,8 +801,7 @@ public class ImportUtils {
      * @throws APIManagementException If an error occurs while authorizing the provider or retrieving the definition
      */
     private static JsonElement retrieveValidatedDTOObject(String pathToArchive, Boolean isDefaultProviderAllowed,
-                                                          String currentUser, String type)
-            throws IOException, APIManagementException {
+            String currentUser, String type) throws IOException, APIManagementException {
 
         JsonObject configObject = (StringUtils.equals(type, ImportExportConstants.TYPE_API)) ?
                 retrievedAPIDtoJson(pathToArchive) :
@@ -791,11 +810,96 @@ public class ImportUtils {
         return configObject;
     }
 
-    @NotNull
-    private static JsonObject retrievedAPIDtoJson(String pathToArchive) throws IOException, APIManagementException {
+    /**
+     * Import Operation Policy as a zip.
+     *
+     * @param pathToArchive            Path to the extracted folder
+     * @param organization             Organization
+     * @param apiProvider              API Provider
+     * @throws APIManagementException If an error occurs while processing the policy files
+     */
+    public static OperationPolicyDataDTO importPolicy(String pathToArchive, String organization,
+            APIProvider apiProvider) throws APIManagementException {
+
+        OperationPolicySpecification policySpecification = null;
+
+        try {
+            OperationPolicyDefinition ccPolicyDefinition = null;
+            OperationPolicyDefinition synapseDefinition = null;
+
+            String[] fileLocations = pathToArchive.split("/");
+            String fileName = File.separator + fileLocations[fileLocations.length - 1];
+            String policyDefinitionJsonContent = getPolicyFileContentAsJson(pathToArchive + fileName, "policy");
+            if (policyDefinitionJsonContent == null) {
+                throw new APIManagementException(
+                        "Cannot find Operation Policy definition. policyDefinition.yaml should present",
+                        ExceptionCodes.ERROR_FETCHING_DEFINITION_FILE);
+            }
+
+            policyDefinitionJsonContent = CommonUtil.yamlToJson(policyDefinitionJsonContent);
+            policySpecification = APIUtil.getValidatedOperationPolicySpecification(policyDefinitionJsonContent);
+
+            OperationPolicyData operationPolicyData = new OperationPolicyData();
+            operationPolicyData.setOrganization(organization);
+            operationPolicyData.setSpecification(policySpecification);
+
+            String synapsePolicyDefinitionJsonContent = getPolicyFileContentAsJson(pathToArchive +
+                    fileName, "synapse");
+
+            if (synapsePolicyDefinitionJsonContent != null) {
+                synapseDefinition = new OperationPolicyDefinition();
+                synapseDefinition.setContent(synapsePolicyDefinitionJsonContent);
+                synapseDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.Synapse);
+                synapseDefinition.setMd5Hash(APIUtil.getMd5OfOperationPolicyDefinition(synapseDefinition));
+                operationPolicyData.setSynapsePolicyDefinition(synapseDefinition);
+            }
+
+            String choreoConnectPolicyDefinitionJsonContent = getPolicyFileContentAsJson(pathToArchive +
+                    fileName, "choreo");
+
+            if (choreoConnectPolicyDefinitionJsonContent != null) {
+                ccPolicyDefinition = new OperationPolicyDefinition();
+                ccPolicyDefinition.setContent(choreoConnectPolicyDefinitionJsonContent);
+                ccPolicyDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.ChoreoConnect);
+                ccPolicyDefinition.setMd5Hash(APIUtil.getMd5OfOperationPolicyDefinition(ccPolicyDefinition));
+                operationPolicyData.setCcPolicyDefinition(ccPolicyDefinition);
+            }
+
+            operationPolicyData.setMd5Hash(APIUtil.getMd5OfOperationPolicy(operationPolicyData));
+
+            OperationPolicyData existingPolicy = apiProvider.getCommonOperationPolicyByPolicyName(
+                    policySpecification.getName(), policySpecification.getVersion(), organization,
+                    false);
+            String policyID = null;
+            if (existingPolicy == null) {
+                policyID = apiProvider.addCommonOperationPolicy(operationPolicyData, organization);
+                if (log.isDebugEnabled()) {
+                    log.debug("A common operation policy has been added with name " + policySpecification.getName());
+                }
+            } else {
+                throw new APIManagementException("Existing common operation policy found for the same name.");
+            }
+            operationPolicyData.setPolicyId(policyID);
+            OperationPolicyDataDTO createdPolicy = OperationPolicyMappingUtil.fromOperationPolicyDataToDTO(
+                    operationPolicyData);
+
+            return createdPolicy;
+        } catch (APIManagementException e) {
+            String errorMessage = "Error while adding a common operation policy." + e.getMessage();
+            throw new APIManagementException(errorMessage, ExceptionCodes.from(
+                    ExceptionCodes.OPERATION_POLICY_ALREADY_EXISTS,
+                    policySpecification.getName(), policySpecification.getVersion()));
+        } catch (Exception e) {
+            String errorMessage = "An Error has occurred while adding common operation policy. " + e.getMessage();
+            throw new APIManagementException(errorMessage, ExceptionCodes.from(ExceptionCodes.INTERNAL_ERROR,
+                    policySpecification.getName(), policySpecification.getVersion()));
+        }
+    }
+
+    @NotNull private static JsonObject retrievedAPIDtoJson(String pathToArchive)
+            throws IOException, APIManagementException {
         // Get API Definition as JSON
-        String jsonContent =
-                getFileContentAsJson(pathToArchive + ImportExportConstants.API_FILE_LOCATION);
+        String jsonContent = getFileContentAsJson(pathToArchive + ImportExportConstants.API_FILE_LOCATION);
         if (jsonContent == null) {
             throw new APIManagementException("Cannot find API definition. api.yaml or api.json should present",
                     ExceptionCodes.ERROR_FETCHING_DEFINITION_FILE);
@@ -803,8 +907,7 @@ public class ImportUtils {
         return processRetrievedDefinition(jsonContent);
     }
 
-    @NotNull
-    private static JsonObject retrievedAPIProductDtoJson(String pathToArchive)
+    @NotNull private static JsonObject retrievedAPIProductDtoJson(String pathToArchive)
             throws IOException, APIManagementException {
         // Get API Product Definition as JSON
         String jsonContent = getFileContentAsJson(pathToArchive + ImportExportConstants.API_PRODUCT_FILE_LOCATION);
@@ -886,34 +989,34 @@ public class ImportUtils {
                     JsonObject endpointSecuritySandbox = endpointSecurity.get(APIConstants.ENDPOINT_SECURITY_SANDBOX)
                             .getAsJsonObject();
                     if (endpointSecuritySandbox.has(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS)) {
-                        String customParameters = endpointSecuritySandbox
-                                .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS).toString();
+                        String customParameters = endpointSecuritySandbox.get(
+                                APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS).toString();
                         endpointSecuritySandbox.remove(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
-                        endpointSecuritySandbox
-                                .addProperty(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS, customParameters);
+                        endpointSecuritySandbox.addProperty(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS,
+                                customParameters);
                     }
                 }
                 if (endpointSecurity.has(APIConstants.ENDPOINT_SECURITY_PRODUCTION)) {
                     JsonObject endpointSecuritySandbox = endpointSecurity.get(APIConstants.ENDPOINT_SECURITY_PRODUCTION)
                             .getAsJsonObject();
                     if (endpointSecuritySandbox.has(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS)) {
-                        String customParameters = endpointSecuritySandbox
-                                .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS).toString();
+                        String customParameters = endpointSecuritySandbox.get(
+                                APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS).toString();
                         endpointSecuritySandbox.remove(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
-                        endpointSecuritySandbox
-                                .addProperty(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS, customParameters);
+                        endpointSecuritySandbox.addProperty(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS,
+                                customParameters);
                     }
                 }
             }
             if (endpointConfig.has(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS)) {
                 if (endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS).isJsonObject()) {
-                    JsonObject productionEndpoint = endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS).
-                            getAsJsonObject();
+                    JsonObject productionEndpoint = endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS)
+                            .getAsJsonObject();
                     endpointConfig.add(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS,
                             getUpdatedEndpointConfig(productionEndpoint));
                 } else if (endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS).isJsonArray()) {
-                    JsonArray productionEndpointArray = endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS).
-                            getAsJsonArray();
+                    JsonArray productionEndpointArray = endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS)
+                            .getAsJsonArray();
                     JsonArray updatedArray = new JsonArray();
                     for (JsonElement endpoint : productionEndpointArray) {
                         updatedArray.add(getUpdatedEndpointConfig(endpoint.getAsJsonObject()));
@@ -923,13 +1026,13 @@ public class ImportUtils {
             }
             if (endpointConfig.has(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS)) {
                 if (endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS).isJsonObject()) {
-                    JsonObject sandboxEndpoint = endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS).
-                            getAsJsonObject();
+                    JsonObject sandboxEndpoint = endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS)
+                            .getAsJsonObject();
                     endpointConfig.add(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS,
                             getUpdatedEndpointConfig(sandboxEndpoint));
                 } else if (endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS).isJsonArray()) {
-                    JsonArray sandboxEndpointArray = endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS).
-                            getAsJsonArray();
+                    JsonArray sandboxEndpointArray = endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS)
+                            .getAsJsonArray();
                     JsonArray updatedArray = new JsonArray();
                     for (JsonElement endpoint : sandboxEndpointArray) {
                         updatedArray.add(getUpdatedEndpointConfig(endpoint.getAsJsonObject()));
@@ -941,7 +1044,7 @@ public class ImportUtils {
         return configObject;
     }
 
-     /**
+    /**
      * This function will preprocess and get the updated Endpoint Config object from the API/API Product configuration
      *
      * @param endpointConfigObject Endpoint Config object from the API/API Product configuration
@@ -950,11 +1053,9 @@ public class ImportUtils {
     public static JsonObject getUpdatedEndpointConfig(JsonObject endpointConfigObject) {
 
         if (endpointConfigObject.has(APIConstants.ENDPOINT_SPECIFIC_CONFIG)) {
-            JsonObject config = endpointConfigObject.get(APIConstants.ENDPOINT_SPECIFIC_CONFIG).
-                    getAsJsonObject();
+            JsonObject config = endpointConfigObject.get(APIConstants.ENDPOINT_SPECIFIC_CONFIG).getAsJsonObject();
             if (config.has(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION)) {
-                Double actionDuration = config.get(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION).
-                        getAsDouble();
+                Double actionDuration = config.get(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION).getAsDouble();
                 Integer value = (int) Math.round(actionDuration);
                 config.remove(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION);
                 config.addProperty(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION, value.toString());
@@ -971,7 +1072,7 @@ public class ImportUtils {
      * @throws APIMgtAuthorizationFailedException If an error occurs while authorizing the provider
      */
     private static JsonObject validatePreserveProvider(JsonObject configObject, Boolean isDefaultProviderAllowed,
-                                                       String currentUser) throws APIMgtAuthorizationFailedException {
+            String currentUser) throws APIMgtAuthorizationFailedException {
 
         String prevProvider = configObject.get(ImportExportConstants.PROVIDER_ELEMENT).getAsString();
         String prevTenantDomain = MultitenantUtils.getTenantDomain(APIUtil.replaceEmailDomainBack(prevProvider));
@@ -1009,7 +1110,7 @@ public class ImportUtils {
      * @param previousDomain Original domain name
      */
     public static JsonObject setCurrentProviderToContext(JsonObject jsonObject, String currentDomain,
-                                                         String previousDomain) {
+            String previousDomain) {
 
         String context = jsonObject.get(APIConstants.API_DOMAIN_MAPPINGS_CONTEXT).getAsString();
         if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(currentDomain)
@@ -1060,6 +1161,69 @@ public class ImportUtils {
     }
 
     /**
+     * Retrieve Policy Definition as JSON.
+     *
+     * @param pathToArchive Path to Policy archive
+     * @throws IOException If an error occurs while reading the file
+     */
+    public static String getPolicyFileContentAsJson(String pathToArchive, String type) throws IOException {
+
+        String jsonContent = null;
+        String pathToYamlFile = pathToArchive + ImportExportConstants.YAML_EXTENSION;
+        String pathToJsonFile = pathToArchive + ImportExportConstants.JSON_EXTENSION;
+        String pathToJ2File = pathToArchive + ImportExportConstants.SYNAPSE_EXTENSION;
+        String pathToGoTmplFile = pathToArchive + ImportExportConstants.CHOREO_CONNECT_EXTENSION;
+
+        // Load yaml representation first if it is present
+        if (CommonUtil.checkFileExistence(pathToYamlFile) && type.equals("policy")) {
+            if (log.isDebugEnabled()) {
+                log.debug("Found policy definition file " + pathToYamlFile);
+            }
+            String yamlContent = FileUtils.readFileToString(new File(pathToYamlFile));
+
+            jsonContent = CommonUtil.yamlToJson(yamlContent);
+            JsonObject object = new JsonParser().parse(jsonContent).getAsJsonObject();
+            JsonElement data = object.get("data");
+            object.remove("data");
+
+            for (String key : data.getAsJsonObject().keySet()) {
+                object.add(key, data.getAsJsonObject().get(key));
+            }
+
+            jsonContent = object.toString();
+
+        } else if (CommonUtil.checkFileExistence(pathToJsonFile) && type.equals("policy")) {
+            // load as a json fallback
+            if (log.isDebugEnabled()) {
+                log.debug("Found policy definition file " + pathToJsonFile);
+            }
+            jsonContent = FileUtils.readFileToString(new File(pathToJsonFile));
+            JsonObject object = new JsonParser().parse(jsonContent).getAsJsonObject();
+            JsonElement data = object.get("data");
+            object.remove("data");
+
+            for (String key : data.getAsJsonObject().keySet()) {
+                object.add(key, data.getAsJsonObject().get(key));
+            }
+
+            jsonContent = object.toString();
+        } else if (CommonUtil.checkFileExistence(pathToJ2File) && type.equals("synapse")) {
+            // load as a j2 fallback
+            if (log.isDebugEnabled()) {
+                log.debug("Found synapse definition file " + pathToJ2File);
+            }
+            jsonContent = FileUtils.readFileToString(new File(pathToJ2File));
+        } else if (CommonUtil.checkFileExistence(pathToGoTmplFile) && type.equals("choreo")) {
+            // load as a gotmpl fallback
+            if (log.isDebugEnabled()) {
+                log.debug("Found choreo definition file " + pathToGoTmplFile);
+            }
+            jsonContent = FileUtils.readFileToString(new File(pathToGoTmplFile));
+        }
+        return jsonContent;
+    }
+
+    /**
      * Validate Aysnc API definition from the archive directory and return it.
      *
      * @param pathToArchive Path to API archive
@@ -1071,8 +1235,8 @@ public class ImportUtils {
 
         try {
             String asyncApiDefinition = loadAsyncApiDefinitionFromFile(pathToArchive);
-            APIDefinitionValidationResponse validationResponse =
-                    AsyncApiParserUtil.validateAsyncAPISpecification(asyncApiDefinition, true);
+            APIDefinitionValidationResponse validationResponse = AsyncApiParserUtil.validateAsyncAPISpecification(
+                    asyncApiDefinition, true);
             if (!validationResponse.isValid()) {
                 throw new APIManagementException(
                         "Error occurred while importing the API. Invalid AsyncAPI definition found. "
@@ -1092,10 +1256,10 @@ public class ImportUtils {
                 log.debug("Found AsyncAPI file " + pathToArchive
                         + ImportExportConstants.JSON_ASYNCAPI_DEFINITION_LOCATION);
             }
-            return FileUtils
-                    .readFileToString(new File(pathToArchive, ImportExportConstants.JSON_ASYNCAPI_DEFINITION_LOCATION));
-        } else if (CommonUtil
-                .checkFileExistence(pathToArchive + ImportExportConstants.YAML_ASYNCAPI_DEFINITION_LOCATION)) {
+            return FileUtils.readFileToString(
+                    new File(pathToArchive, ImportExportConstants.JSON_ASYNCAPI_DEFINITION_LOCATION));
+        } else if (CommonUtil.checkFileExistence(
+                pathToArchive + ImportExportConstants.YAML_ASYNCAPI_DEFINITION_LOCATION)) {
             if (log.isDebugEnabled()) {
                 log.debug("Found AsyncAPI file " + pathToArchive
                         + ImportExportConstants.YAML_ASYNCAPI_DEFINITION_LOCATION);
@@ -1112,14 +1276,13 @@ public class ImportUtils {
      * @param pathToArchive Path to API archive
      * @throws APIImportExportException If an error occurs while reading the file
      */
-    public static String retrieveValidatedGraphqlSchemaFromArchive(String pathToArchive)
-            throws APIManagementException {
+    public static String retrieveValidatedGraphqlSchemaFromArchive(String pathToArchive) throws APIManagementException {
 
         File file = new File(pathToArchive + ImportExportConstants.GRAPHQL_SCHEMA_DEFINITION_LOCATION);
         try {
             String schemaDefinition = loadGraphqlSDLFile(pathToArchive);
-            GraphQLValidationResponseDTO graphQLValidationResponseDTO = PublisherCommonUtils
-                    .validateGraphQLSchema(file.getName(), schemaDefinition);
+            GraphQLValidationResponseDTO graphQLValidationResponseDTO = PublisherCommonUtils.validateGraphQLSchema(
+                    file.getName(), schemaDefinition);
             if (!graphQLValidationResponseDTO.isIsValid()) {
                 throw new APIManagementException(
                         "Error occurred while importing the API. Invalid GraphQL schema definition found. "
@@ -1144,16 +1307,17 @@ public class ImportUtils {
             throws APIManagementException {
 
         try {
-            String jsonContent =
-                    getFileContentAsJson(pathToArchive + ImportExportConstants.GRAPHQL_COMPLEXITY_INFO_LOCATION);
+            String jsonContent = getFileContentAsJson(
+                    pathToArchive + ImportExportConstants.GRAPHQL_COMPLEXITY_INFO_LOCATION);
             if (jsonContent == null) {
                 return null;
             }
             JsonElement configElement = new JsonParser().parse(jsonContent).getAsJsonObject().get(APIConstants.DATA);
             GraphQLQueryComplexityInfoDTO complexityDTO = new Gson().fromJson(String.valueOf(configElement),
                     GraphQLQueryComplexityInfoDTO.class);
-            GraphqlComplexityInfo graphqlComplexityInfo =
-                    GraphqlQueryAnalysisMappingUtil.fromDTOtoValidatedGraphqlComplexityInfo(complexityDTO, schema);
+            GraphqlComplexityInfo graphqlComplexityInfo = GraphqlQueryAnalysisMappingUtil
+                    .fromDTOtoValidatedGraphqlComplexityInfo(
+                    complexityDTO, schema);
             return graphqlComplexityInfo;
         } catch (IOException e) {
             throw new APIManagementException("Error while reading graphql complexity info from path: " + pathToArchive,
@@ -1175,8 +1339,8 @@ public class ImportUtils {
             //If the artifact is a dependent API from a API Product, instead of the artifact's deployment environments,
             //products deployment environments are used.
             String jsonContent = (dependentAPIFromProduct) ?
-                    getFileContentAsJson(new File(pathToArchive).getParentFile().getParent()
-                            + File.separator + ImportExportConstants.DEPLOYMENT_INFO_LOCATION) :
+                    getFileContentAsJson(new File(pathToArchive).getParentFile().getParent() + File.separator
+                            + ImportExportConstants.DEPLOYMENT_INFO_LOCATION) :
                     getFileContentAsJson(pathToArchive + ImportExportConstants.DEPLOYMENT_INFO_LOCATION);
             if (jsonContent == null) {
                 return null;
@@ -1185,8 +1349,9 @@ public class ImportUtils {
             JsonElement configElement = new JsonParser().parse(jsonContent).getAsJsonObject().get(APIConstants.DATA);
             return configElement.getAsJsonArray();
         } catch (IOException e) {
-            throw new APIManagementException("Error while reading deployment environments info from path: "
-                    + pathToArchive, e, ExceptionCodes.ERROR_READING_META_DATA);
+            throw new APIManagementException(
+                    "Error while reading deployment environments info from path: " + pathToArchive, e,
+                    ExceptionCodes.ERROR_READING_META_DATA);
         }
     }
 
@@ -1200,8 +1365,8 @@ public class ImportUtils {
 
         try {
             byte[] wsdlDefinition = loadWsdlFile(pathToArchive, apiDto);
-            WSDLValidationResponse wsdlValidationResponse = APIMWSDLReader.
-                    getWsdlValidationResponse(APIMWSDLReader.getWSDLProcessor(wsdlDefinition));
+            WSDLValidationResponse wsdlValidationResponse = APIMWSDLReader.getWsdlValidationResponse(
+                    APIMWSDLReader.getWSDLProcessor(wsdlDefinition));
             if (!wsdlValidationResponse.isValid()) {
                 throw new APIManagementException(
                         "Error occurred while importing the API. Invalid WSDL definition found. "
@@ -1286,8 +1451,8 @@ public class ImportUtils {
 
         try {
             String swaggerContent = loadSwaggerFile(pathToArchive);
-            APIDefinitionValidationResponse validationResponse = OASParserUtil
-                    .validateAPIDefinition(swaggerContent, Boolean.TRUE);
+            APIDefinitionValidationResponse validationResponse = OASParserUtil.validateAPIDefinition(swaggerContent,
+                    Boolean.TRUE);
             if (!validationResponse.isValid()) {
                 String errorDescription = "";
                 if (validationResponse.getErrorItems().size() > 0) {
@@ -1302,9 +1467,8 @@ public class ImportUtils {
                         ExceptionCodes.from(ExceptionCodes.APICTL_OPENAPI_PARSE_EXCEPTION, errorDescription));
             }
             JsonObject swaggerContentJson = new JsonParser().parse(swaggerContent).getAsJsonObject();
-            if (swaggerContentJson.has(APIConstants.SWAGGER_INFO)
-                    && swaggerContentJson.getAsJsonObject(APIConstants.SWAGGER_INFO)
-                    .has(ImportExportConstants.SWAGGER_X_WSO2_APICTL_INIT)
+            if (swaggerContentJson.has(APIConstants.SWAGGER_INFO) && swaggerContentJson.getAsJsonObject(
+                    APIConstants.SWAGGER_INFO).has(ImportExportConstants.SWAGGER_X_WSO2_APICTL_INIT)
                     && swaggerContentJson.getAsJsonObject(APIConstants.SWAGGER_INFO)
                     .get(ImportExportConstants.SWAGGER_X_WSO2_APICTL_INIT).getAsBoolean()) {
                 validationResponse.setInit(true);
@@ -1330,17 +1494,17 @@ public class ImportUtils {
                 log.debug(
                         "Found swagger file " + pathToArchive + ImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION);
             }
-            String yamlContent = FileUtils
-                    .readFileToString(new File(pathToArchive + ImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION));
+            String yamlContent = FileUtils.readFileToString(
+                    new File(pathToArchive + ImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION));
             return CommonUtil.yamlToJson(yamlContent);
-        } else if (CommonUtil
-                .checkFileExistence(pathToArchive + ImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION)) {
+        } else if (CommonUtil.checkFileExistence(
+                pathToArchive + ImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION)) {
             if (log.isDebugEnabled()) {
                 log.debug(
                         "Found swagger file " + pathToArchive + ImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION);
             }
-            return FileUtils
-                    .readFileToString(new File(pathToArchive + ImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION));
+            return FileUtils.readFileToString(
+                    new File(pathToArchive + ImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION));
         }
         throw new IOException("Missing swagger file. Either swagger.json or swagger.yaml should present");
     }
@@ -1352,8 +1516,8 @@ public class ImportUtils {
      * @param apiTypeWrapper The imported API object
      * @throws APIManagementException If an error occurs when uploading the thumbnail of the API/API Product
      */
-    private static void addThumbnailImage(String pathToArchive, ApiTypeWrapper apiTypeWrapper,
-                                          APIProvider apiProvider) throws APIManagementException {
+    private static void addThumbnailImage(String pathToArchive, ApiTypeWrapper apiTypeWrapper, APIProvider apiProvider)
+            throws APIManagementException {
 
         //Adding image icon to the API if there is any
         File imageFolder = new File(pathToArchive + ImportExportConstants.IMAGE_FILE_LOCATION);
@@ -1411,8 +1575,8 @@ public class ImportUtils {
         } catch (IOException e) {
             throw new APIManagementException(
                     "Failed to read the image file of API/API Product: " + identifier.getName() + " from the archive.",
-                    e, ExceptionCodes
-                    .from(ExceptionCodes.ERROR_UPLOADING_THUMBNAIL, identifier.getName(), identifier.getVersion()));
+                    e, ExceptionCodes.from(ExceptionCodes.ERROR_UPLOADING_THUMBNAIL, identifier.getName(),
+                    identifier.getVersion()));
         }
     }
 
@@ -1421,10 +1585,10 @@ public class ImportUtils {
      *
      * @param pathToArchive  Location of the extracted folder of the API or API Product
      * @param apiTypeWrapper Imported API or API Product
-     * @param organization  Identifier of an Organization
+     * @param organization   Identifier of an Organization
      */
     private static void addDocumentation(String pathToArchive, ApiTypeWrapper apiTypeWrapper, APIProvider apiProvider,
-                                         String organization) {
+            String organization) {
 
         String jsonContent = null;
         Identifier identifier = apiTypeWrapper.getId();
@@ -1432,7 +1596,8 @@ public class ImportUtils {
 
         File documentsFolder = new File(docDirectoryPath);
         File[] fileArray = documentsFolder.listFiles();
-        String provider = (apiTypeWrapper.isAPIProduct()) ? apiTypeWrapper.getApiProduct().getId().getProviderName() :
+        String provider = (apiTypeWrapper.isAPIProduct()) ?
+                apiTypeWrapper.getApiProduct().getId().getProviderName() :
                 apiTypeWrapper.getApi().getId().getProviderName();
         String tenantDomain = MultitenantUtils.getTenantDomain(provider);
 
@@ -1478,9 +1643,8 @@ public class ImportUtils {
 
                     // Add the documentation DTO
                     Documentation documentation = apiTypeWrapper.isAPIProduct() ?
-                            PublisherCommonUtils
-                                    .addDocumentationToAPI(documentDTO, apiTypeWrapper.getApiProduct().getUuid(),
-                                            organization) :
+                            PublisherCommonUtils.addDocumentationToAPI(documentDTO,
+                                    apiTypeWrapper.getApiProduct().getUuid(), organization) :
                             PublisherCommonUtils.addDocumentationToAPI(documentDTO, apiTypeWrapper.getApi().getUuid(),
                                     organization);
 
@@ -1512,8 +1676,8 @@ public class ImportUtils {
                                     tenantDomain);
                         } catch (FileNotFoundException e) {
                             //this error is logged and ignored because documents are optional in an API
-                            log.error("Failed to locate the document files of the API/API Product: " + apiTypeWrapper
-                                    .getId().getName(), e);
+                            log.error("Failed to locate the document files of the API/API Product: "
+                                    + apiTypeWrapper.getId().getName(), e);
                             continue;
                         }
                     }
@@ -1530,20 +1694,17 @@ public class ImportUtils {
     }
 
     public static String retrieveSequenceContent(String pathToArchive, boolean specific, String type,
-                                                 String sequenceName) {
+            String sequenceName) {
 
         String sequenceFileName = sequenceName + APIConstants.XML_EXTENSION;
         String sequenceFileLocation = null;
         if (APIConstants.API_CUSTOM_SEQUENCE_TYPE_IN.equals(type)) {
-            sequenceFileLocation =
-                    pathToArchive + ImportExportConstants.IN_SEQUENCE_LOCATION;
+            sequenceFileLocation = pathToArchive + ImportExportConstants.IN_SEQUENCE_LOCATION;
         } else if (APIConstants.API_CUSTOM_SEQUENCE_TYPE_OUT.equals(type)) {
-            sequenceFileLocation =
-                    pathToArchive + ImportExportConstants.OUT_SEQUENCE_LOCATION;
+            sequenceFileLocation = pathToArchive + ImportExportConstants.OUT_SEQUENCE_LOCATION;
 
         } else if (APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT.equals(type)) {
-            sequenceFileLocation =
-                    pathToArchive + ImportExportConstants.FAULT_SEQUENCE_LOCATION;
+            sequenceFileLocation = pathToArchive + ImportExportConstants.FAULT_SEQUENCE_LOCATION;
         }
         if (sequenceFileLocation != null) {
             if (specific) {
@@ -1563,8 +1724,7 @@ public class ImportUtils {
         return null;
     }
 
-    private static String retrieveSequenceContentFromLocation(String sequenceFileLocation)
-            throws IOException {
+    private static String retrieveSequenceContentFromLocation(String sequenceFileLocation) throws IOException {
 
         if (CommonUtil.checkFileExistence(sequenceFileLocation)) {
             File sequenceFile = new File(sequenceFileLocation);
@@ -1615,7 +1775,7 @@ public class ImportUtils {
      * @throws APIImportExportException If an error occurs while importing endpoint certificates from file
      */
     private static void addEndpointCertificates(String pathToArchive, API importedApi, APIProvider apiProvider,
-                                                int tenantId) throws APIManagementException {
+            int tenantId) throws APIManagementException {
 
         String jsonContent = null;
         String pathToEndpointsCertificatesDirectory =
@@ -1720,7 +1880,7 @@ public class ImportUtils {
      * @param tenantId    Tenant Id
      */
     private static void updateAPIWithCertificate(JsonElement certificate, APIProvider apiProvider, API importedApi,
-                                                 int tenantId) throws APIManagementException {
+            int tenantId) throws APIManagementException {
 
         String certificateFileName = certificate.getAsJsonObject().get(ImportExportConstants.CERTIFICATE_FILE)
                 .getAsString();
@@ -1733,15 +1893,15 @@ public class ImportUtils {
         String endpoint = certificate.getAsJsonObject().get(ImportExportConstants.ENDPOINT_JSON_KEY).getAsString();
         try {
             if (apiProvider.isCertificatePresent(tenantId, alias) || (
-                    ResponseCode.ALIAS_EXISTS_IN_TRUST_STORE.getResponseCode() == (apiProvider
-                            .addCertificate(APIUtil.replaceEmailDomainBack(importedApi.getId().getProviderName()),
-                                    certificateContent, alias, endpoint)))) {
+                    ResponseCode.ALIAS_EXISTS_IN_TRUST_STORE.getResponseCode() == (apiProvider.addCertificate(
+                            APIUtil.replaceEmailDomainBack(importedApi.getId().getProviderName()), certificateContent,
+                            alias, endpoint)))) {
                 apiProvider.updateCertificate(certificateContent, alias);
             }
         } catch (APIManagementException e) {
-            log.error("Error while importing certificate endpoint [" + endpoint + " ]" + "alias [" + alias +
-                    " ] tenant user [" + APIUtil.replaceEmailDomainBack(importedApi.getId().getProviderName())
-                    + "]", e);
+            log.error("Error while importing certificate endpoint [" + endpoint + " ]" + "alias [" + alias
+                            + " ] tenant user [" + APIUtil.replaceEmailDomainBack(importedApi.getId().getProviderName())
+                            + "]", e);
         }
     }
 
@@ -1750,15 +1910,14 @@ public class ImportUtils {
      *
      * @param pathToArchive Location of the extracted folder of the API
      * @param apiProvider   API Provider
-     * @param organization Identifier of the organization
+     * @param organization  Identifier of the organization
      * @throws APIImportExportException
      */
     private static void addClientCertificates(String pathToArchive, APIProvider apiProvider,
-                                              ApiTypeWrapper apiTypeWrapper, String organization)
-            throws APIManagementException {
+            ApiTypeWrapper apiTypeWrapper, String organization) throws APIManagementException {
 
         try {
-            Identifier apiIdentifier  = apiTypeWrapper.getId();
+            Identifier apiIdentifier = apiTypeWrapper.getId();
             List<ClientCertificateDTO> certificateMetadataDTOS = retrieveClientCertificates(pathToArchive);
             for (ClientCertificateDTO certDTO : certificateMetadataDTOS) {
                 apiProvider.addClientCertificate(APIUtil.replaceEmailDomainBack(apiIdentifier.getProviderName()),
@@ -1819,8 +1978,8 @@ public class ImportUtils {
     private static void addSOAPToREST(API importedApi, String swaggerContent, APIProvider apiProvider)
             throws APIManagementException, FaultGatewaysException {
         String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
-        PublisherCommonUtils
-                .updateAPIBySettingGenerateSequencesFromSwagger(swaggerContent, importedApi, apiProvider, tenantDomain);
+        PublisherCommonUtils.updateAPIBySettingGenerateSequencesFromSwagger(swaggerContent, importedApi, apiProvider,
+                tenantDomain);
     }
 
     public static List<SoapToRestMediationDto> retrieveSoapToRestFlowMediations(String pathToArchive, String type)
@@ -1841,8 +2000,8 @@ public class ImportUtils {
                     String method = "";
                     String resource = "";
                     if (fileName.split(".xml").length != 0) {
-                        method =
-                                fileName.split(".xml")[0].substring(file.getFileName().toString().lastIndexOf("_") + 1);
+                        method = fileName.split(".xml")[0].substring(
+                                file.getFileName().toString().lastIndexOf("_") + 1);
                         resource = fileName.substring(0, fileName.indexOf("_"));
                     }
                     try (InputStream inputFlowStream = new FileInputStream(file.toFile())) {
@@ -1868,8 +2027,7 @@ public class ImportUtils {
      * @throws APIImportExportException If an error occurs while importing/storing SOAP to REST mediation logic
      */
     private static void importMediationLogic(SoapToRestMediationDto sequenceData, Registry registry,
-                                             String soapToRestLocation)
-            throws APIManagementException {
+            String soapToRestLocation) throws APIManagementException {
 
         String fileName = sequenceData.getResource().concat("_").concat(sequenceData.getMethod()).concat(".xml");
         try {
@@ -1916,7 +2074,7 @@ public class ImportUtils {
      * @param preserveProvider    Decision to keep or replace the provider
      * @param overwriteAPIProduct Whether to update the API Product or not
      * @param overwriteAPIs       Whether to update the dependent APIs or not
-     * @param organization  Organization Identifier
+     * @param organization        Organization Identifier
      * @param importAPIs          Whether to import the dependent APIs or not
      * @throws APIImportExportException If there is an error in importing an API
      */
@@ -1943,8 +2101,8 @@ public class ImportUtils {
             JsonObject paramsConfigObject = APIControllerUtil.resolveAPIControllerEnvParams(extractedFolderPath);
             // If above the params configurations are not null, then resolve those
             if (paramsConfigObject != null) {
-                importedApiProductDTO = APIControllerUtil
-                        .injectEnvParamsToAPIProduct(importedApiProductDTO, paramsConfigObject, extractedFolderPath);
+                importedApiProductDTO = APIControllerUtil.injectEnvParamsToAPIProduct(importedApiProductDTO,
+                        paramsConfigObject, extractedFolderPath);
                 JsonElement deploymentsParam = paramsConfigObject.get(ImportExportConstants.DEPLOYMENT_ENVIRONMENTS);
                 if (deploymentsParam != null && !deploymentsParam.isJsonNull()) {
                     deploymentInfoArray = deploymentsParam.getAsJsonArray();
@@ -1967,8 +2125,8 @@ public class ImportUtils {
             } else {
                 // Even we do not import APIs, the UUIDs of the dependent APIs should be updated if the APIs are
                 // already in the APIM
-                importedApiProductDTO = updateDependentApiUuids(importedApiProductDTO, apiProvider,
-                        currentTenantDomain, organization);
+                importedApiProductDTO = updateDependentApiUuids(importedApiProductDTO, apiProvider, currentTenantDomain,
+                        organization);
             }
 
             APIProduct targetApiProduct = retrieveApiProductToOverwrite(importedApiProductDTO.getName(),
@@ -1985,9 +2143,8 @@ public class ImportUtils {
                     log.info("Cannot find : " + importedApiProductDTO.getName() + ". Creating it.");
                 }
                 currentStatus = APIStatus.CREATED.toString();
-                importedApiProduct = PublisherCommonUtils
-                        .addAPIProductWithGeneratedSwaggerDefinition(importedApiProductDTO,
-                                importedApiProductDTO.getProvider(), organization);
+                importedApiProduct = PublisherCommonUtils.addAPIProductWithGeneratedSwaggerDefinition(
+                        importedApiProductDTO, importedApiProductDTO.getProvider(), organization);
             }
 
             // Retrieving the life cycle action to do the lifecycle state change explicitly later
@@ -2032,31 +2189,28 @@ public class ImportUtils {
                 try {
                     revisionId = apiProvider.addAPIProductRevision(apiProductRevision, organization);
                     if (log.isDebugEnabled()) {
-                        log.debug("A new revision has been created for API Product " +
-                                importedApiProduct.getId().getName() + "_"
-                                + importedApiProduct.getId().getVersion() + " with ID: " + revisionId);
+                        log.debug("A new revision has been created for API Product " + importedApiProduct.getId()
+                                .getName() + "_" + importedApiProduct.getId().getVersion() + " with ID: " + revisionId);
                     }
                 } catch (APIManagementException e) {
                     //if the revision count is more than 5, addAPIProductRevision will throw an exception. If
                     // rotateRevision enabled, earliest revision will be deleted before creating a revision again
-                    if (e.getErrorHandler().getErrorCode() ==
-                            ExceptionCodes.from(ExceptionCodes.MAXIMUM_REVISIONS_REACHED).getErrorCode() &&
-                            rotateRevision) {
+                    if (e.getErrorHandler().getErrorCode() == ExceptionCodes.from(
+                            ExceptionCodes.MAXIMUM_REVISIONS_REACHED).getErrorCode() && rotateRevision) {
                         String earliestRevisionUuid = apiProvider.getEarliestRevisionUUID(importedAPIUuid);
-                        List<APIRevisionDeployment> deploymentsList =
-                                apiProvider.getAPIRevisionDeploymentList(earliestRevisionUuid);
+                        List<APIRevisionDeployment> deploymentsList = apiProvider.getAPIRevisionDeploymentList(
+                                earliestRevisionUuid);
                         //if the earliest revision is already deployed in gateway environments, it will be undeployed
                         //before deleting
-                        apiProvider
-                                .undeployAPIProductRevisionDeployment(importedAPIUuid, earliestRevisionUuid,
-                                        deploymentsList);
+                        apiProvider.undeployAPIProductRevisionDeployment(importedAPIUuid, earliestRevisionUuid,
+                                deploymentsList);
                         apiProvider.deleteAPIProductRevision(importedAPIUuid, earliestRevisionUuid, organization);
                         revisionId = apiProvider.addAPIProductRevision(apiProductRevision, organization);
                         if (log.isDebugEnabled()) {
-                            log.debug("Revision ID: " + earliestRevisionUuid + " has been undeployed from " +
-                                    deploymentsList.size() + " gateway environments and created a new revision ID: " +
-                                    revisionId + " for API Product " + importedApiProduct.getId().getName() + "_" +
-                                    importedApiProduct.getId().getVersion());
+                            log.debug("Revision ID: " + earliestRevisionUuid + " has been undeployed from "
+                                    + deploymentsList.size() + " gateway environments and created a new revision ID: "
+                                    + revisionId + " for API Product " + importedApiProduct.getId().getName() + "_"
+                                    + importedApiProduct.getId().getVersion());
                         }
                     } else {
                         throw new APIManagementException(e);
@@ -2067,8 +2221,8 @@ public class ImportUtils {
                 //environments
                 apiProvider.deployAPIProductRevision(importedAPIUuid, revisionId, apiProductRevisionDeployments);
             } else {
-                log.info("Valid deployment environments were not found for the imported artifact. Hence not deployed" +
-                        " in any of the gateway environments.");
+                log.info("Valid deployment environments were not found for the imported artifact. Hence not deployed"
+                        + " in any of the gateway environments.");
             }
 
             return importedApiProduct;
@@ -2094,10 +2248,10 @@ public class ImportUtils {
     /**
      * This method checks whether the resources in the API Product are valid.
      *
-     * @param path          Location of the extracted folder of the API Product
-     * @param currentUser   The current logged in user
-     * @param apiProvider   API provider
-     * @param apiProductDto API Product DTO
+     * @param path             Location of the extracted folder of the API Product
+     * @param currentUser      The current logged in user
+     * @param apiProvider      API provider
+     * @param apiProductDto    API Product DTO
      * @param preserveProvider
      * @param organization
      * @throws IOException            If there is an error while reading an API file
@@ -2117,9 +2271,8 @@ public class ImportUtils {
 
         if (apisDirectoryListing != null) {
             for (File apiDirectory : apisDirectoryListing) {
-                String apiDirectoryPath =
-                        path + File.separator + ImportExportConstants.APIS_DIRECTORY + File.separator + apiDirectory
-                                .getName();
+                String apiDirectoryPath = path + File.separator + ImportExportConstants.APIS_DIRECTORY + File.separator
+                        + apiDirectory.getName();
                 JsonElement jsonObject = retrieveValidatedDTOObject(apiDirectoryPath, preserveProvider, currentUser,
                         ImportExportConstants.TYPE_API);
                 APIDTO apiDto = new Gson().fromJson(jsonObject, APIDTO.class);
@@ -2131,8 +2284,8 @@ public class ImportUtils {
                 Set<URITemplate> apiUriTemplates = apiDefinition.getURITemplates(swaggerContent);
 
                 for (ProductAPIDTO apiFromProduct : apis) {
-                    if (StringUtils.equals(apiFromProduct.getName(), apiName) && StringUtils
-                            .equals(apiFromProduct.getVersion(), apiVersion)) {
+                    if (StringUtils.equals(apiFromProduct.getName(), apiName) && StringUtils.equals(
+                            apiFromProduct.getVersion(), apiVersion)) {
                         List<APIOperationsDTO> invalidApiOperations = filterInvalidProductResources(
                                 apiFromProduct.getOperations(), apiUriTemplates);
 
@@ -2170,7 +2323,7 @@ public class ImportUtils {
      * @return Invalid API operations
      */
     private static List<APIOperationsDTO> filterInvalidProductResources(List<APIOperationsDTO> apiProductOperations,
-                                                                        Set<URITemplate> apiUriTemplates) {
+            Set<URITemplate> apiUriTemplates) {
 
         List<APIOperationsDTO> apiOperations = new ArrayList<>(apiProductOperations);
         for (URITemplate apiUriTemplate : apiUriTemplates) {
@@ -2192,7 +2345,7 @@ public class ImportUtils {
      * @param overwriteAPIs            Whether to overwrite the APIs or not
      * @param apiProductDto            API Product DTO
      * @param tokenScopes              Scopes of the token
-     * @param organization  Organization Identifier
+     * @param organization             Organization Identifier
      * @return Modified API Product DTO with the correct API UUIDs
      * @throws IOException              If there is an error while reading an API file
      * @throws APIImportExportException If there is an error in importing an API
@@ -2212,15 +2365,14 @@ public class ImportUtils {
 
         if (apisDirectoryListing != null) {
             for (File apiDirectory : apisDirectoryListing) {
-                String apiDirectoryPath =
-                        path + File.separator + ImportExportConstants.APIS_DIRECTORY + File.separator + apiDirectory
-                                .getName();
+                String apiDirectoryPath = path + File.separator + ImportExportConstants.APIS_DIRECTORY + File.separator
+                        + apiDirectory.getName();
 
                 // If the param configurations of the dependent APIs are available, the configurations of the current
                 // API in the API directory will be retrieved if available
                 if (dependentAPIsParams != null) {
-                    dependentAPIParamsConfigObject = APIControllerUtil
-                            .getDependentAPIParams(dependentAPIsParams, apiDirectory.getName());
+                    dependentAPIParamsConfigObject = APIControllerUtil.getDependentAPIParams(dependentAPIsParams,
+                            apiDirectory.getName());
                     // If the "certificates" directory is specified, copy it inside Deployment directory of the
                     // dependent API since there may be certificates required for APIs
                     String deploymentCertificatesDirectoryPath = path + ImportExportConstants.DEPLOYMENT_DIRECTORY
@@ -2265,12 +2417,12 @@ public class ImportUtils {
                     }
                 } else {
                     // Retrieve the current tenant domain of the logged in user
-                    String currentTenantDomain = MultitenantUtils
-                            .getTenantDomain(APIUtil.replaceEmailDomainBack(currentUser));
+                    String currentTenantDomain = MultitenantUtils.getTenantDomain(
+                            APIUtil.replaceEmailDomainBack(currentUser));
 
                     // Get the provider of the API if the API is in current user's tenant domain.
-                    String apiProviderInCurrentTenantDomain = APIUtil
-                            .getAPIProviderFromAPINameVersionTenant(apiName, apiVersion, currentTenantDomain);
+                    String apiProviderInCurrentTenantDomain = APIUtil.getAPIProviderFromAPINameVersionTenant(apiName,
+                            apiVersion, currentTenantDomain);
 
                     if (StringUtils.isBlank(apiProviderInCurrentTenantDomain)) {
                         // If there is no API in the current tenant domain (which means the provider name is blank)
@@ -2316,8 +2468,8 @@ public class ImportUtils {
         APIIdentifier importedApiIdentifier = importedApi.getId();
         List<ProductAPIDTO> apis = apiProductDto.getApis();
         for (ProductAPIDTO api : apis) {
-            if (StringUtils.equals(api.getName(), importedApiIdentifier.getName()) && StringUtils
-                    .equals(api.getVersion(), importedApiIdentifier.getVersion())) {
+            if (StringUtils.equals(api.getName(), importedApiIdentifier.getName()) && StringUtils.equals(
+                    api.getVersion(), importedApiIdentifier.getVersion())) {
                 api.setApiId(importedApi.getUuid());
                 break;
             }
@@ -2331,7 +2483,7 @@ public class ImportUtils {
      * @param importedApiProductDtO API Product DTO
      * @param apiProvider           API Provider
      * @param currentTenantDomain   Current tenant domain
-     * @param organization organization
+     * @param organization          organization
      * @throws APIManagementException If failed failed when checking the existence of an API
      */
     private static APIProductDTO updateDependentApiUuids(APIProductDTO importedApiProductDtO, APIProvider apiProvider,
@@ -2389,8 +2541,8 @@ public class ImportUtils {
      * @throws FaultGatewaysException If an error occurs when updating the API to overwrite
      * @throws IOException            If an error occurs when loading the swagger file
      */
-    private static APIProduct updateApiProductSwagger(String pathToArchive, String apiProductId, APIProduct
-            importedApiProduct, APIProvider apiProvider, String orgId)
+    private static APIProduct updateApiProductSwagger(String pathToArchive, String apiProductId,
+            APIProduct importedApiProduct, APIProvider apiProvider, String orgId)
             throws APIManagementException, FaultGatewaysException, IOException {
 
         String swaggerContent = loadSwaggerFile(pathToArchive);
@@ -2402,8 +2554,8 @@ public class ImportUtils {
         importedApiProduct.setOrganization(orgId);
 
         // This is required to make scopes get effected
-        Map<API, List<APIProductResource>> apiToProductResourceMapping = apiProvider
-                .updateAPIProduct(importedApiProduct);
+        Map<API, List<APIProductResource>> apiToProductResourceMapping = apiProvider.updateAPIProduct(
+                importedApiProduct);
         apiProvider.updateAPIProductSwagger(apiProductId, apiToProductResourceMapping, importedApiProduct, orgId);
         return importedApiProduct;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -841,7 +841,7 @@ public class ImportUtils {
                         "Cannot find Operation Policy definition. policyDefinition.yaml should present",
                         ExceptionCodes.ERROR_FETCHING_DEFINITION_FILE);
             }
-            
+
             policySpecification = APIUtil.getValidatedOperationPolicySpecification(policyDefinitionJsonContent);
 
             OperationPolicyData operationPolicyData = new OperationPolicyData();
@@ -1227,13 +1227,13 @@ public class ImportUtils {
      * @return
      * @throws IOException
      */
-    public static String readDefinitionFiles(String path) throws IOException {
-        String jsonContent = null;
+    private static String readDefinitionFiles(String path) throws IOException {
+        String content = null;
         if (CommonUtil.checkFileExistence(path)) {
-            jsonContent = FileUtils.readFileToString(new File(path));
+            content = FileUtils.readFileToString(new File(path));
         }
 
-        return jsonContent;
+        return content;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -1162,40 +1162,6 @@ public class ImportUtils {
     }
 
     /**
-     * Retrieving the File content.
-     *
-     * @param path File path.
-     * @return
-     * @throws IOException
-     */
-    private static String readDefinitionFiles(String path) throws IOException {
-        String content = null;
-        if (CommonUtil.checkFileExistence(path)) {
-            content = FileUtils.readFileToString(new File(path));
-        }
-        return content;
-    }
-
-    /**
-     * Break the data object into fields and append to the main object.
-     *
-     * @param jsonContent Json content of the file.
-     * @return String object which with data elements.
-     * @throws IOException if exists.
-     */
-    private static String getJsonContentWithData(String jsonContent) throws IOException {
-        JsonObject object = new JsonParser().parse(jsonContent).getAsJsonObject();
-        JsonElement data = object.get("data");
-        object.remove("data");
-
-        for (String key : data.getAsJsonObject().keySet()) {
-            object.add(key, data.getAsJsonObject().get(key));
-        }
-
-        return object.toString();
-    }
-
-    /**
      * Validate Aysnc API definition from the archive directory and return it.
      *
      * @param pathToArchive Path to API archive

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -819,9 +819,9 @@ public class ImportUtils {
     /**
      * Import Operation Policy as a zip.
      *
-     * @param pathToArchive            Path to the extracted folder
-     * @param organization             Organization
-     * @param apiProvider              API Provider
+     * @param pathToArchive Path to the extracted folder
+     * @param organization  Organization
+     * @param apiProvider   API Provider
      * @throws APIManagementException If an error occurs while processing the policy files
      */
     public static OperationPolicyDataDTO importPolicy(String pathToArchive, String organization,
@@ -855,7 +855,8 @@ public class ImportUtils {
             String synapsePolicyDefinitionJsonContent = readDefinitionFiles(pathToJ2File);
 
             if (synapsePolicyDefinitionJsonContent != null) {
-                gatewayDefinition = setPropertiesToGatewayDefinition(synapsePolicyDefinitionJsonContent, OperationPolicyDefinition.GatewayType.Synapse);
+                gatewayDefinition = setPropertiesToGatewayDefinition(synapsePolicyDefinitionJsonContent,
+                        OperationPolicyDefinition.GatewayType.Synapse);
                 operationPolicyData.setSynapsePolicyDefinition(gatewayDefinition);
             }
 
@@ -864,15 +865,15 @@ public class ImportUtils {
             String choreoConnectPolicyDefinitionJsonContent = readDefinitionFiles(pathToChoreoFile);
 
             if (choreoConnectPolicyDefinitionJsonContent != null) {
-                gatewayDefinition = setPropertiesToGatewayDefinition(choreoConnectPolicyDefinitionJsonContent, OperationPolicyDefinition.GatewayType.ChoreoConnect);
+                gatewayDefinition = setPropertiesToGatewayDefinition(choreoConnectPolicyDefinitionJsonContent,
+                        OperationPolicyDefinition.GatewayType.ChoreoConnect);
                 operationPolicyData.setCcPolicyDefinition(gatewayDefinition);
             }
 
             operationPolicyData.setMd5Hash(APIUtil.getMd5OfOperationPolicy(operationPolicyData));
 
             OperationPolicyData existingPolicy = apiProvider.getCommonOperationPolicyByPolicyName(
-                    policySpecification.getName(), policySpecification.getVersion(), organization,
-                    false);
+                    policySpecification.getName(), policySpecification.getVersion(), organization, false);
             String policyID = null;
             if (existingPolicy == null) {
                 policyID = apiProvider.addCommonOperationPolicy(operationPolicyData, organization);
@@ -889,13 +890,14 @@ public class ImportUtils {
             return createdPolicy;
         } catch (APIManagementException e) {
             String errorMessage = "Error while adding a common operation policy." + e.getMessage();
-            throw new APIManagementException(errorMessage, ExceptionCodes.from(
-                    ExceptionCodes.OPERATION_POLICY_ALREADY_EXISTS,
-                    policySpecification.getName(), policySpecification.getVersion()));
+            throw new APIManagementException(errorMessage,
+                    ExceptionCodes.from(ExceptionCodes.OPERATION_POLICY_ALREADY_EXISTS, policySpecification.getName(),
+                            policySpecification.getVersion()));
         } catch (IOException e) {
             String errorMessage = "An Error has occurred while adding common operation policy. " + e.getMessage();
-            throw new APIManagementException(errorMessage, ExceptionCodes.from(ExceptionCodes.INTERNAL_ERROR,
-                    policySpecification.getName(), policySpecification.getVersion()));
+            throw new APIManagementException(errorMessage,
+                    ExceptionCodes.from(ExceptionCodes.INTERNAL_ERROR, policySpecification.getName(),
+                            policySpecification.getVersion()));
         }
     }
 
@@ -903,10 +905,11 @@ public class ImportUtils {
      * Set Properties to Gateway Definition.
      *
      * @param gatewayDefinitionJsonContent Gateway Definition Content.
-     * @param type Gateway Type.
+     * @param type                         Gateway Type.
      * @return
      */
-    private static OperationPolicyDefinition setPropertiesToGatewayDefinition(String gatewayDefinitionJsonContent, OperationPolicyDefinition.GatewayType type) {
+    private static OperationPolicyDefinition setPropertiesToGatewayDefinition(String gatewayDefinitionJsonContent,
+            OperationPolicyDefinition.GatewayType type) {
         OperationPolicyDefinition gatewayDefinition = new OperationPolicyDefinition();
         gatewayDefinition.setContent(gatewayDefinitionJsonContent);
         gatewayDefinition.setGatewayType(type);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -827,41 +827,34 @@ public class ImportUtils {
             APIProvider apiProvider) throws APIManagementException {
 
         OperationPolicySpecification policySpecification = null;
-
         try {
             OperationPolicyDefinition gatewayDefinition = null;
-
             String[] fileLocations = pathToArchive.split("/");
 
             // File names of all types should be the same
             String fileName = File.separator + fileLocations[fileLocations.length - 1];
-            String policyDefinitionJsonContent = getPolicyFileContentAsJson(pathToArchive + fileName);
-            if (policyDefinitionJsonContent == null) {
+            String policySpecificationJsonContent = getPolicyFileContentAsJson(pathToArchive + fileName);
+            if (policySpecificationJsonContent == null) {
                 throw new APIManagementException(
-                        "Cannot find Operation Policy definition. policyDefinition.yaml or policyDefinition.json "
+                        "Cannot find Operation Policy Specification. policySpecification.yaml or "
+                                + "policySpecification.json "
                                 + "should present", ExceptionCodes.ERROR_FETCHING_DEFINITION_FILE);
             }
-
-            policySpecification = APIUtil.getValidatedOperationPolicySpecification(policyDefinitionJsonContent);
-
+            policySpecification = APIUtil.getValidatedOperationPolicySpecification(policySpecificationJsonContent);
             OperationPolicyData operationPolicyData = new OperationPolicyData();
             operationPolicyData.setOrganization(organization);
             operationPolicyData.setSpecification(policySpecification);
 
-            String pathToJ2File = pathToArchive + fileName + ImportExportConstants.SYNAPSE_EXTENSION;
-
+            String pathToJ2File = pathToArchive + fileName + ImportExportConstants.SYNAPSE_POLICY_EXTENSION;
             String synapsePolicyDefinitionJsonContent = readDefinitionFiles(pathToJ2File);
-
             if (synapsePolicyDefinitionJsonContent != null) {
                 gatewayDefinition = setPropertiesToGatewayDefinition(synapsePolicyDefinitionJsonContent,
                         OperationPolicyDefinition.GatewayType.Synapse);
                 operationPolicyData.setSynapsePolicyDefinition(gatewayDefinition);
             }
 
-            String pathToChoreoFile = pathToArchive + fileName + ImportExportConstants.CHOREO_CONNECT_EXTENSION;
-
+            String pathToChoreoFile = pathToArchive + fileName + ImportExportConstants.CHOREO_CONNECT_POLICY_EXTENSION;
             String choreoConnectPolicyDefinitionJsonContent = readDefinitionFiles(pathToChoreoFile);
-
             if (choreoConnectPolicyDefinitionJsonContent != null) {
                 gatewayDefinition = setPropertiesToGatewayDefinition(choreoConnectPolicyDefinitionJsonContent,
                         OperationPolicyDefinition.GatewayType.ChoreoConnect);
@@ -869,7 +862,6 @@ public class ImportUtils {
             }
 
             operationPolicyData.setMd5Hash(APIUtil.getMd5OfOperationPolicy(operationPolicyData));
-
             OperationPolicyData existingPolicy = apiProvider.getCommonOperationPolicyByPolicyName(
                     policySpecification.getName(), policySpecification.getVersion(), organization, false);
             String policyID = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -175,8 +175,8 @@ public class ImportUtils {
                 importedApiDTO = APIControllerUtil.injectEnvParamsToAPI(importedApiDTO, paramsConfigObject,
                         extractedFolderPath);
                 if (!isAdvertiseOnlyAPI(importedApiDTO)) {
-                    JsonElement deploymentsParam = paramsConfigObject.get(
-                            ImportExportConstants.DEPLOYMENT_ENVIRONMENTS);
+                    JsonElement deploymentsParam = paramsConfigObject
+                            .get(ImportExportConstants.DEPLOYMENT_ENVIRONMENTS);
                     if (deploymentsParam != null && !deploymentsParam.isJsonNull()) {
                         deploymentInfoArray = deploymentsParam.getAsJsonArray();
                     }
@@ -217,8 +217,8 @@ public class ImportUtils {
                 processAdvertiseOnlyPropertiesInDTO(importedApiDTO, tokenScopes);
             }
 
-            Map<String, List<OperationPolicy>> extractedPoliciesMap = extractAndDropOperationPoliciesFromURITemplate(
-                    importedApiDTO.getOperations());
+            Map<String, List<OperationPolicy>> extractedPoliciesMap =
+                    extractAndDropOperationPoliciesFromURITemplate(importedApiDTO.getOperations());
 
             // If the overwrite is set to true (which means an update), retrieve the existing API
             if (Boolean.TRUE.equals(overwrite) && targetApi != null) {
@@ -234,8 +234,8 @@ public class ImportUtils {
                     setOperationsToDTO(importedApiDTO, validationResponse);
                 }
                 targetApi.setOrganization(organization);
-                importedApi = PublisherCommonUtils.updateApi(targetApi, importedApiDTO,
-                        RestApiCommonUtil.getLoggedInUserProvider(), tokenScopes);
+                importedApi = PublisherCommonUtils
+                        .updateApi(targetApi, importedApiDTO, RestApiCommonUtil.getLoggedInUserProvider(), tokenScopes);
             } else {
                 if (targetApi == null && Boolean.TRUE.equals(overwrite)) {
                     log.info("Cannot find : " + importedApiDTO.getName() + "-" + importedApiDTO.getVersion()
@@ -245,8 +245,9 @@ public class ImportUtils {
                 currentStatus = APIStatus.CREATED.toString();
                 importedApiDTO.setLifeCycleStatus(currentStatus);
                 if (!PublisherCommonUtils.isThirdPartyAsyncAPI(importedApiDTO)) {
-                    importedApi = PublisherCommonUtils.addAPIWithGeneratedSwaggerDefinition(importedApiDTO,
-                            ImportExportConstants.OAS_VERSION_3, importedApiDTO.getProvider(), organization);
+                    importedApi = PublisherCommonUtils
+                            .addAPIWithGeneratedSwaggerDefinition(importedApiDTO, ImportExportConstants.OAS_VERSION_3,
+                                    importedApiDTO.getProvider(), organization);
                 } else {
                     importedApi = PublisherCommonUtils.importAsyncAPIWithDefinition(validationResponse, Boolean.FALSE,
                             importedApiDTO, null, currentTenantDomain, apiProvider);
@@ -260,9 +261,8 @@ public class ImportUtils {
             }
 
             if (!extractedPoliciesMap.isEmpty()) {
-                importedApi.setUriTemplates(
-                        validateOperationPolicies(importedApi, apiProvider, extractedFolderPath, extractedPoliciesMap,
-                                currentTenantDomain));
+                importedApi.setUriTemplates(validateOperationPolicies(importedApi, apiProvider, extractedFolderPath,
+                        extractedPoliciesMap, currentTenantDomain));
                 API oldAPI = apiProvider.getAPIbyUUID(importedApi.getUuid(), importedApi.getOrganization());
                 apiProvider.updateAPI(importedApi, oldAPI);
             }
@@ -275,7 +275,7 @@ public class ImportUtils {
                     && !APIConstants.APITransportType.GRAPHQL.toString().equalsIgnoreCase(apiType)) {
                 // Add the validated swagger separately since the UI does the same procedure
                 PublisherCommonUtils.updateSwagger(importedApi.getUuid(), validationResponse, false, organization);
-                importedApi = apiProvider.getAPIbyUUID(importedApi.getUuid(), currentTenantDomain);
+                importedApi =  apiProvider.getAPIbyUUID(importedApi.getUuid(), currentTenantDomain);
             }
             // Add the GraphQL schema
             if (APIConstants.APITransportType.GRAPHQL.toString().equalsIgnoreCase(apiType)) {
@@ -300,8 +300,8 @@ public class ImportUtils {
             addThumbnailImage(extractedFolderPath, apiTypeWrapperWithUpdatedApi, apiProvider);
             addDocumentation(extractedFolderPath, apiTypeWrapperWithUpdatedApi, apiProvider, organization);
             addAPIWsdl(extractedFolderPath, importedApi, apiProvider);
-            if (StringUtils.equals(importedApi.getType().toLowerCase(),
-                    APIConstants.API_TYPE_SOAPTOREST.toLowerCase())) {
+            if (StringUtils
+                    .equals(importedApi.getType().toLowerCase(), APIConstants.API_TYPE_SOAPTOREST.toLowerCase())) {
                 addSOAPToREST(importedApi, validationResponse.getContent(), apiProvider);
             }
 
@@ -350,27 +350,28 @@ public class ImportUtils {
                 } catch (APIManagementException e) {
                     //if the revision count is more than 5, addAPIRevision will throw an exception. If rotateRevision
                     //enabled, earliest revision will be deleted before creating a revision again
-                    if (e.getErrorHandler().getErrorCode() == ExceptionCodes.from(
-                            ExceptionCodes.MAXIMUM_REVISIONS_REACHED).getErrorCode() && rotateRevision) {
+                    if (e.getErrorHandler().getErrorCode() ==
+                            ExceptionCodes.from(ExceptionCodes.MAXIMUM_REVISIONS_REACHED).getErrorCode() &&
+                            rotateRevision) {
                         String earliestRevisionUuid = apiProvider.getEarliestRevisionUUID(importedAPIUuid);
-                        List<APIRevisionDeployment> deploymentsList = apiProvider.getAPIRevisionDeploymentList(
-                                earliestRevisionUuid);
+                        List<APIRevisionDeployment> deploymentsList =
+                                apiProvider.getAPIRevisionDeploymentList(earliestRevisionUuid);
                         //if the earliest revision is already deployed in gateway environments, it will be undeployed
                         //before deleting
-                        apiProvider.undeployAPIRevisionDeployment(importedAPIUuid, earliestRevisionUuid,
-                                deploymentsList, organization);
+                        apiProvider
+                                .undeployAPIRevisionDeployment(importedAPIUuid, earliestRevisionUuid, deploymentsList,
+                                        organization);
                         apiProvider.deleteAPIRevision(importedAPIUuid, earliestRevisionUuid, tenantDomain);
                         revisionId = apiProvider.addAPIRevision(apiRevision, tenantDomain);
                         if (log.isDebugEnabled()) {
-                            log.debug("Revision ID: " + earliestRevisionUuid + " has been undeployed from "
-                                    + deploymentsList.size() + " gateway environments and created a new revision ID: "
-                                    + revisionId + " for API " + importedApi.getId().getApiName() + "_"
-                                    + importedApi.getId().getVersion());
+                            log.debug("Revision ID: " + earliestRevisionUuid + " has been undeployed from " +
+                                    deploymentsList.size() + " gateway environments and created a new revision ID: " +
+                                    revisionId + " for API " + importedApi.getId().getApiName() + "_" +
+                                    importedApi.getId().getVersion());
                         }
                     } else {
-                        throw new APIManagementException(
-                                "Error occurred while creating a new revision for the API: " + importedApi.getId()
-                                        .getApiName(), e);
+                        throw new APIManagementException("Error occurred while creating a new revision for the API: " +
+                                importedApi.getId().getApiName(), e);
                     }
                 }
 
@@ -378,12 +379,12 @@ public class ImportUtils {
                 //environments
                 apiProvider.deployAPIRevision(importedAPIUuid, revisionId, apiRevisionDeployments, organization);
                 if (log.isDebugEnabled()) {
-                    log.debug("API: " + importedApi.getId().getApiName() + "_" + importedApi.getId().getVersion()
-                            + " was deployed in " + apiRevisionDeployments.size() + " gateway environments.");
+                    log.debug("API: " + importedApi.getId().getApiName() + "_" + importedApi.getId().getVersion() +
+                            " was deployed in " + apiRevisionDeployments.size() + " gateway environments.");
                 }
             } else {
-                log.info("Valid deployment environments were not found for the imported artifact. Only working copy "
-                        + "was updated and not deployed in any of the gateway environments.");
+                log.info("Valid deployment environments were not found for the imported artifact. Only working copy " +
+                        "was updated and not deployed in any of the gateway environments.");
             }
             return importedApi;
         } catch (CryptoException | IOException e) {
@@ -409,13 +410,13 @@ public class ImportUtils {
         }
     }
 
-    public static Map<String, List<OperationPolicy>> extractAndDropOperationPoliciesFromURITemplate(
-            List<APIOperationsDTO> operationsDTO) {
+    public static Map<String, List<OperationPolicy>> extractAndDropOperationPoliciesFromURITemplate
+            (List<APIOperationsDTO> operationsDTO) {
         Map<String, List<OperationPolicy>> operationPoliciesMap = new HashMap<>();
         for (APIOperationsDTO dto : operationsDTO) {
             String key = dto.getVerb() + ":" + dto.getTarget();
-            List<OperationPolicy> operationPolicies = OperationPolicyMappingUtil.fromDTOToAPIOperationPoliciesList(
-                    dto.getOperationPolicies());
+            List<OperationPolicy> operationPolicies =
+                    OperationPolicyMappingUtil.fromDTOToAPIOperationPoliciesList(dto.getOperationPolicies());
             if (!operationPolicies.isEmpty()) {
                 operationPoliciesMap.put(key, operationPolicies);
             }
@@ -425,7 +426,8 @@ public class ImportUtils {
     }
 
     public static Set<URITemplate> validateOperationPolicies(API api, APIProvider provider, String extractedFolderPath,
-            Map<String, List<OperationPolicy>> extractedPoliciesMap, String tenantDomain) {
+                                                             Map<String, List<OperationPolicy>> extractedPoliciesMap,
+                                                             String tenantDomain) {
 
         String policyDirectory = extractedFolderPath + File.separator + ImportExportConstants.POLICIES_DIRECTORY;
         Map<String, String> importedPolicies = new HashMap<>();
@@ -443,10 +445,10 @@ public class ImportUtils {
                                     policy.getPolicyVersion());
                             String policyID = null;
                             if (!importedPolicies.containsKey(policyFileName)) {
-                                OperationPolicySpecification policySpec = getOperationPolicySpecificationFromFile(
-                                        policyDirectory, policyFileName);
-                                if (policySpec == null && APIConstants.DEFAULT_POLICY_VERSION.equals(
-                                        policy.getPolicyVersion())) {
+                                OperationPolicySpecification policySpec =
+                                        getOperationPolicySpecificationFromFile(policyDirectory, policyFileName);
+                                if (policySpec == null
+                                        && APIConstants.DEFAULT_POLICY_VERSION.equals(policy.getPolicyVersion())) {
                                     // this is to handle if the version is populated default, we disregard the version
                                     policySpec = getOperationPolicySpecificationFromFile(policyDirectory,
                                             policy.getPolicyName());
@@ -461,11 +463,12 @@ public class ImportUtils {
                                     OperationPolicyDefinition synapseDefinition =
                                             APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
                                                     policyFileName, APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
-                                    if (synapseDefinition == null && APIConstants.DEFAULT_POLICY_VERSION.equals(
-                                            policy.getPolicyVersion())) {
-                                        synapseDefinition = APIUtil.getOperationPolicyDefinitionFromFile(
-                                                policyDirectory, policy.getPolicyName(),
-                                                APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
+                                    if (synapseDefinition == null
+                                            && APIConstants.DEFAULT_POLICY_VERSION.equals(policy.getPolicyVersion())) {
+                                        synapseDefinition =
+                                                APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
+                                                        policy.getPolicyName(),
+                                                        APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
                                     }
                                     if (synapseDefinition != null) {
                                         synapseDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.Synapse);
@@ -474,19 +477,19 @@ public class ImportUtils {
                                     OperationPolicyDefinition ccDefinition =
                                             APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
                                                     policyFileName, APIConstants.CC_POLICY_DEFINITION_EXTENSION);
-                                    if (ccDefinition == null && APIConstants.DEFAULT_POLICY_VERSION.equals(
-                                            policy.getPolicyVersion())) {
+                                    if (ccDefinition == null
+                                            && APIConstants.DEFAULT_POLICY_VERSION.equals(policy.getPolicyVersion())) {
                                         ccDefinition = APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
                                                 policy.getPolicyName(), APIConstants.CC_POLICY_DEFINITION_EXTENSION);
                                     }
 
                                     if (ccDefinition != null) {
-                                        ccDefinition.setGatewayType(
-                                                OperationPolicyDefinition.GatewayType.ChoreoConnect);
+                                        ccDefinition
+                                                .setGatewayType(OperationPolicyDefinition.GatewayType.ChoreoConnect);
                                         operationPolicyData.setCcPolicyDefinition(ccDefinition);
                                     }
-                                    operationPolicyData.setMd5Hash(
-                                            APIUtil.getMd5OfOperationPolicy(operationPolicyData));
+                                    operationPolicyData
+                                            .setMd5Hash(APIUtil.getMd5OfOperationPolicy(operationPolicyData));
                                     policyID = provider.importOperationPolicy(operationPolicyData, tenantDomain);
                                     importedPolicies.put(policyFileName, policyID);
                                     policyImported = true;
@@ -500,8 +503,8 @@ public class ImportUtils {
                                 validatedOperationPolicies.add(policy);
                             }
                         } catch (APIManagementException e) {
-                            log.error("An error occurred when validating the operation policy " + policy.getPolicyName()
-                                    + "_" + policy.getPolicyVersion() + " for url template "
+                            log.error("An error occurred when validating the operation policy "
+                                    + policy.getPolicyName() + "_" + policy.getPolicyVersion() + " for url template "
                                     + uriTemplate.getUriTemplate() + ". Hence skipped.", e);
                         }
                     }
@@ -513,9 +516,10 @@ public class ImportUtils {
     }
 
     public static OperationPolicySpecification getOperationPolicySpecificationFromFile(String extractedFolderPath,
-            String policyName) throws APIManagementException {
+                                                                                       String policyName)
+            throws APIManagementException {
         try {
-            String jsonContent = getFileContentAsJson(extractedFolderPath + File.separator + policyName);
+            String jsonContent =  getFileContentAsJson(extractedFolderPath + File.separator + policyName);
             if (jsonContent == null) {
                 return null;
             }
@@ -523,9 +527,8 @@ public class ImportUtils {
             JsonElement configElement = new JsonParser().parse(jsonContent).getAsJsonObject().get(APIConstants.DATA);
             return APIUtil.getValidatedOperationPolicySpecification(configElement.toString());
         } catch (IOException e) {
-            throw new APIManagementException(
-                    "Error while reading policy specification info from path: " + extractedFolderPath, e,
-                    ExceptionCodes.ERROR_READING_META_DATA);
+            throw new APIManagementException("Error while reading policy specification info from path: "
+                    + extractedFolderPath, e, ExceptionCodes.ERROR_READING_META_DATA);
         }
     }
 
@@ -544,8 +547,8 @@ public class ImportUtils {
     /**
      * Process the properties specific to advertise only APIs
      *
-     * @param importedApiDTO API DTO to import
-     * @param tokenScopes    Scopes of the token
+     * @param importedApiDTO               API DTO to import
+     * @param tokenScopes Scopes of the token
      */
     private static void processAdvertiseOnlyPropertiesInDTO(APIDTO importedApiDTO, String[] tokenScopes) {
         // Only the users who has admin privileges (apim:admin scope) are allowed to set the original devportal URL.
@@ -572,7 +575,9 @@ public class ImportUtils {
      * @throws APIManagementException If an error occurs when validating the deployments list
      */
     private static List<APIRevisionDeployment> getValidatedDeploymentsList(JsonArray deploymentInfoArray,
-            String tenantDomain, APIProvider apiProvider, String organization) throws APIManagementException {
+                                                                           String tenantDomain, APIProvider apiProvider,
+                                                                           String organization)
+            throws APIManagementException {
 
         List<APIRevisionDeployment> apiRevisionDeployments = new ArrayList<>();
         if (deploymentInfoArray != null && deploymentInfoArray.size() > 0) {
@@ -592,15 +597,15 @@ public class ImportUtils {
                         } else {
                             // set the default vhost of the given environment
                             if (gatewayEnvironment.getVhosts().isEmpty()) {
-                                throw new APIManagementException(
-                                        "No VHosts defined for the environment: " + deploymentName);
+                                throw new APIManagementException("No VHosts defined for the environment: "
+                                        + deploymentName);
                             }
                             deploymentVhost = gatewayEnvironment.getVhosts().get(0).getHost();
                         }
                         // resolve vhost to null if it is the default vhost of read only environment
                         deploymentVhost = VHostUtils.resolveIfDefaultVhostToNull(deploymentName, deploymentVhost);
-                        JsonElement displayOnDevportalElement = deploymentJson.get(
-                                ImportExportConstants.DISPLAY_ON_DEVPORTAL_OPTION);
+                        JsonElement displayOnDevportalElement =
+                                deploymentJson.get(ImportExportConstants.DISPLAY_ON_DEVPORTAL_OPTION);
                         boolean displayOnDevportal =
                                 displayOnDevportalElement == null || displayOnDevportalElement.getAsBoolean();
                         APIRevisionDeployment apiRevisionDeployment = new APIRevisionDeployment();
@@ -611,8 +616,8 @@ public class ImportUtils {
                     } else {
                         throw new APIManagementException(
                                 "Label " + deploymentName + " is not a defined gateway environment. Hence "
-                                        + "skipped without deployment",
-                                ExceptionCodes.from(ExceptionCodes.GATEWAY_ENVIRONMENT_NOT_FOUND,
+                                        + "skipped without deployment", ExceptionCodes
+                                .from(ExceptionCodes.GATEWAY_ENVIRONMENT_NOT_FOUND,
                                         String.format("label '%s'", deploymentName)));
                     }
                 }
@@ -650,7 +655,8 @@ public class ImportUtils {
      * @throws APIManagementException If an error occurs when retrieving the API to overwrite
      */
     private static API retrieveApiToOverwrite(String apiName, String apiVersion, String currentTenantDomain,
-            APIProvider apiProvider, Boolean ignoreAndImport, String organization) throws APIManagementException {
+                                              APIProvider apiProvider, Boolean ignoreAndImport, String organization)
+            throws APIManagementException {
 
         String provider = APIUtil.getAPIProviderFromAPINameVersionTenant(apiName, apiVersion, currentTenantDomain);
         APIIdentifier apiIdentifier = new APIIdentifier(APIUtil.replaceEmailDomain(provider), apiName, apiVersion);
@@ -662,9 +668,8 @@ public class ImportUtils {
             }
             throw new APIMgtResourceNotFoundException(
                     "Error occurred while retrieving the API. API: " + apiName + StringUtils.SPACE
-                            + APIConstants.API_DATA_VERSION + ": " + apiVersion + " not found",
-                    ExceptionCodes.from(ExceptionCodes.API_NOT_FOUND,
-                            apiIdentifier.getApiName() + "-" + apiIdentifier.getVersion()));
+                            + APIConstants.API_DATA_VERSION + ": " + apiVersion + " not found", ExceptionCodes
+                    .from(ExceptionCodes.API_NOT_FOUND, apiIdentifier.getApiName() + "-" + apiIdentifier.getVersion()));
         }
 
         String uuid = APIUtil.getUUIDFromIdentifier(apiIdentifier, organization);
@@ -686,13 +691,13 @@ public class ImportUtils {
         String paramsFileName =
                 ImportExportConstants.INTERMEDIATE_PARAMS_FILE_LOCATION + ImportExportConstants.YAML_EXTENSION;
         boolean isParamsFileAvailable = CommonUtil.checkFileExistence(tempDirectoryAbsolutePath + paramsFileName);
-        boolean isDeploymentDirectoryAvailable = CommonUtil.checkFileExistence(
-                tempDirectoryAbsolutePath + ImportExportConstants.DEPLOYMENT_DIRECTORY_NAME);
+        boolean isDeploymentDirectoryAvailable = CommonUtil
+                .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.DEPLOYMENT_DIRECTORY_NAME);
 
         // When API controller is provided with params file
         if (isParamsFileAvailable) {
-            if (!CommonUtil.checkFileExistence(
-                    tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME)) {
+            if (!CommonUtil
+                    .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME)) {
                 throw new APIImportExportException("The source artifact is not provided properly");
             } else {
                 String newExtractedFolderName = CommonUtil.extractArchive(
@@ -709,8 +714,8 @@ public class ImportUtils {
         }
         //When API controller is provided with the "Deployment" directory
         if (isDeploymentDirectoryAvailable) {
-            if (!CommonUtil.checkFileExistence(
-                    tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME)) {
+            if (!CommonUtil
+                    .checkFileExistence(tempDirectoryAbsolutePath + ImportExportConstants.SOURCE_ZIP_DIRECTORY_NAME)) {
                 throw new APIImportExportException("The source artifact is not provided properly");
             } else {
                 String newExtractedFolderName = CommonUtil.extractArchive(
@@ -801,7 +806,8 @@ public class ImportUtils {
      * @throws APIManagementException If an error occurs while authorizing the provider or retrieving the definition
      */
     private static JsonElement retrieveValidatedDTOObject(String pathToArchive, Boolean isDefaultProviderAllowed,
-            String currentUser, String type) throws IOException, APIManagementException {
+                                                          String currentUser, String type)
+            throws IOException, APIManagementException {
 
         JsonObject configObject = (StringUtils.equals(type, ImportExportConstants.TYPE_API)) ?
                 retrievedAPIDtoJson(pathToArchive) :
@@ -896,10 +902,11 @@ public class ImportUtils {
         }
     }
 
-    @NotNull private static JsonObject retrievedAPIDtoJson(String pathToArchive)
-            throws IOException, APIManagementException {
+    @NotNull
+    private static JsonObject retrievedAPIDtoJson(String pathToArchive) throws IOException, APIManagementException {
         // Get API Definition as JSON
-        String jsonContent = getFileContentAsJson(pathToArchive + ImportExportConstants.API_FILE_LOCATION);
+        String jsonContent =
+                getFileContentAsJson(pathToArchive + ImportExportConstants.API_FILE_LOCATION);
         if (jsonContent == null) {
             throw new APIManagementException("Cannot find API definition. api.yaml or api.json should present",
                     ExceptionCodes.ERROR_FETCHING_DEFINITION_FILE);
@@ -907,7 +914,8 @@ public class ImportUtils {
         return processRetrievedDefinition(jsonContent);
     }
 
-    @NotNull private static JsonObject retrievedAPIProductDtoJson(String pathToArchive)
+    @NotNull
+    private static JsonObject retrievedAPIProductDtoJson(String pathToArchive)
             throws IOException, APIManagementException {
         // Get API Product Definition as JSON
         String jsonContent = getFileContentAsJson(pathToArchive + ImportExportConstants.API_PRODUCT_FILE_LOCATION);
@@ -989,34 +997,34 @@ public class ImportUtils {
                     JsonObject endpointSecuritySandbox = endpointSecurity.get(APIConstants.ENDPOINT_SECURITY_SANDBOX)
                             .getAsJsonObject();
                     if (endpointSecuritySandbox.has(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS)) {
-                        String customParameters = endpointSecuritySandbox.get(
-                                APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS).toString();
+                        String customParameters = endpointSecuritySandbox
+                                .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS).toString();
                         endpointSecuritySandbox.remove(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
-                        endpointSecuritySandbox.addProperty(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS,
-                                customParameters);
+                        endpointSecuritySandbox
+                                .addProperty(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS, customParameters);
                     }
                 }
                 if (endpointSecurity.has(APIConstants.ENDPOINT_SECURITY_PRODUCTION)) {
                     JsonObject endpointSecuritySandbox = endpointSecurity.get(APIConstants.ENDPOINT_SECURITY_PRODUCTION)
                             .getAsJsonObject();
                     if (endpointSecuritySandbox.has(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS)) {
-                        String customParameters = endpointSecuritySandbox.get(
-                                APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS).toString();
+                        String customParameters = endpointSecuritySandbox
+                                .get(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS).toString();
                         endpointSecuritySandbox.remove(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
-                        endpointSecuritySandbox.addProperty(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS,
-                                customParameters);
+                        endpointSecuritySandbox
+                                .addProperty(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS, customParameters);
                     }
                 }
             }
             if (endpointConfig.has(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS)) {
                 if (endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS).isJsonObject()) {
-                    JsonObject productionEndpoint = endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS)
-                            .getAsJsonObject();
+                    JsonObject productionEndpoint = endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS).
+                            getAsJsonObject();
                     endpointConfig.add(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS,
                             getUpdatedEndpointConfig(productionEndpoint));
                 } else if (endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS).isJsonArray()) {
-                    JsonArray productionEndpointArray = endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS)
-                            .getAsJsonArray();
+                    JsonArray productionEndpointArray = endpointConfig.get(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS).
+                            getAsJsonArray();
                     JsonArray updatedArray = new JsonArray();
                     for (JsonElement endpoint : productionEndpointArray) {
                         updatedArray.add(getUpdatedEndpointConfig(endpoint.getAsJsonObject()));
@@ -1026,13 +1034,13 @@ public class ImportUtils {
             }
             if (endpointConfig.has(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS)) {
                 if (endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS).isJsonObject()) {
-                    JsonObject sandboxEndpoint = endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS)
-                            .getAsJsonObject();
+                    JsonObject sandboxEndpoint = endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS).
+                            getAsJsonObject();
                     endpointConfig.add(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS,
                             getUpdatedEndpointConfig(sandboxEndpoint));
                 } else if (endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS).isJsonArray()) {
-                    JsonArray sandboxEndpointArray = endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS)
-                            .getAsJsonArray();
+                    JsonArray sandboxEndpointArray = endpointConfig.get(APIConstants.ENDPOINT_SANDBOX_ENDPOINTS).
+                            getAsJsonArray();
                     JsonArray updatedArray = new JsonArray();
                     for (JsonElement endpoint : sandboxEndpointArray) {
                         updatedArray.add(getUpdatedEndpointConfig(endpoint.getAsJsonObject()));
@@ -1053,9 +1061,11 @@ public class ImportUtils {
     public static JsonObject getUpdatedEndpointConfig(JsonObject endpointConfigObject) {
 
         if (endpointConfigObject.has(APIConstants.ENDPOINT_SPECIFIC_CONFIG)) {
-            JsonObject config = endpointConfigObject.get(APIConstants.ENDPOINT_SPECIFIC_CONFIG).getAsJsonObject();
+            JsonObject config = endpointConfigObject.get(APIConstants.ENDPOINT_SPECIFIC_CONFIG).
+                    getAsJsonObject();
             if (config.has(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION)) {
-                Double actionDuration = config.get(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION).getAsDouble();
+                Double actionDuration = config.get(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION).
+                        getAsDouble();
                 Integer value = (int) Math.round(actionDuration);
                 config.remove(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION);
                 config.addProperty(APIConstants.ENDPOINT_CONFIG_ACTION_DURATION, value.toString());
@@ -1072,7 +1082,7 @@ public class ImportUtils {
      * @throws APIMgtAuthorizationFailedException If an error occurs while authorizing the provider
      */
     private static JsonObject validatePreserveProvider(JsonObject configObject, Boolean isDefaultProviderAllowed,
-            String currentUser) throws APIMgtAuthorizationFailedException {
+                                                       String currentUser) throws APIMgtAuthorizationFailedException {
 
         String prevProvider = configObject.get(ImportExportConstants.PROVIDER_ELEMENT).getAsString();
         String prevTenantDomain = MultitenantUtils.getTenantDomain(APIUtil.replaceEmailDomainBack(prevProvider));
@@ -1110,7 +1120,7 @@ public class ImportUtils {
      * @param previousDomain Original domain name
      */
     public static JsonObject setCurrentProviderToContext(JsonObject jsonObject, String currentDomain,
-            String previousDomain) {
+                                                         String previousDomain) {
 
         String context = jsonObject.get(APIConstants.API_DOMAIN_MAPPINGS_CONTEXT).getAsString();
         if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(currentDomain)
@@ -1235,8 +1245,8 @@ public class ImportUtils {
 
         try {
             String asyncApiDefinition = loadAsyncApiDefinitionFromFile(pathToArchive);
-            APIDefinitionValidationResponse validationResponse = AsyncApiParserUtil.validateAsyncAPISpecification(
-                    asyncApiDefinition, true);
+            APIDefinitionValidationResponse validationResponse =
+                    AsyncApiParserUtil.validateAsyncAPISpecification(asyncApiDefinition, true);
             if (!validationResponse.isValid()) {
                 throw new APIManagementException(
                         "Error occurred while importing the API. Invalid AsyncAPI definition found. "
@@ -1256,10 +1266,10 @@ public class ImportUtils {
                 log.debug("Found AsyncAPI file " + pathToArchive
                         + ImportExportConstants.JSON_ASYNCAPI_DEFINITION_LOCATION);
             }
-            return FileUtils.readFileToString(
-                    new File(pathToArchive, ImportExportConstants.JSON_ASYNCAPI_DEFINITION_LOCATION));
-        } else if (CommonUtil.checkFileExistence(
-                pathToArchive + ImportExportConstants.YAML_ASYNCAPI_DEFINITION_LOCATION)) {
+            return FileUtils
+                    .readFileToString(new File(pathToArchive, ImportExportConstants.JSON_ASYNCAPI_DEFINITION_LOCATION));
+        } else if (CommonUtil
+                .checkFileExistence(pathToArchive + ImportExportConstants.YAML_ASYNCAPI_DEFINITION_LOCATION)) {
             if (log.isDebugEnabled()) {
                 log.debug("Found AsyncAPI file " + pathToArchive
                         + ImportExportConstants.YAML_ASYNCAPI_DEFINITION_LOCATION);
@@ -1276,13 +1286,14 @@ public class ImportUtils {
      * @param pathToArchive Path to API archive
      * @throws APIImportExportException If an error occurs while reading the file
      */
-    public static String retrieveValidatedGraphqlSchemaFromArchive(String pathToArchive) throws APIManagementException {
+    public static String retrieveValidatedGraphqlSchemaFromArchive(String pathToArchive)
+            throws APIManagementException {
 
         File file = new File(pathToArchive + ImportExportConstants.GRAPHQL_SCHEMA_DEFINITION_LOCATION);
         try {
             String schemaDefinition = loadGraphqlSDLFile(pathToArchive);
-            GraphQLValidationResponseDTO graphQLValidationResponseDTO = PublisherCommonUtils.validateGraphQLSchema(
-                    file.getName(), schemaDefinition);
+            GraphQLValidationResponseDTO graphQLValidationResponseDTO = PublisherCommonUtils
+                    .validateGraphQLSchema(file.getName(), schemaDefinition);
             if (!graphQLValidationResponseDTO.isIsValid()) {
                 throw new APIManagementException(
                         "Error occurred while importing the API. Invalid GraphQL schema definition found. "
@@ -1307,17 +1318,16 @@ public class ImportUtils {
             throws APIManagementException {
 
         try {
-            String jsonContent = getFileContentAsJson(
-                    pathToArchive + ImportExportConstants.GRAPHQL_COMPLEXITY_INFO_LOCATION);
+            String jsonContent =
+                    getFileContentAsJson(pathToArchive + ImportExportConstants.GRAPHQL_COMPLEXITY_INFO_LOCATION);
             if (jsonContent == null) {
                 return null;
             }
             JsonElement configElement = new JsonParser().parse(jsonContent).getAsJsonObject().get(APIConstants.DATA);
             GraphQLQueryComplexityInfoDTO complexityDTO = new Gson().fromJson(String.valueOf(configElement),
                     GraphQLQueryComplexityInfoDTO.class);
-            GraphqlComplexityInfo graphqlComplexityInfo = GraphqlQueryAnalysisMappingUtil
-                    .fromDTOtoValidatedGraphqlComplexityInfo(
-                    complexityDTO, schema);
+            GraphqlComplexityInfo graphqlComplexityInfo =
+                    GraphqlQueryAnalysisMappingUtil.fromDTOtoValidatedGraphqlComplexityInfo(complexityDTO, schema);
             return graphqlComplexityInfo;
         } catch (IOException e) {
             throw new APIManagementException("Error while reading graphql complexity info from path: " + pathToArchive,
@@ -1339,8 +1349,8 @@ public class ImportUtils {
             //If the artifact is a dependent API from a API Product, instead of the artifact's deployment environments,
             //products deployment environments are used.
             String jsonContent = (dependentAPIFromProduct) ?
-                    getFileContentAsJson(new File(pathToArchive).getParentFile().getParent() + File.separator
-                            + ImportExportConstants.DEPLOYMENT_INFO_LOCATION) :
+                    getFileContentAsJson(new File(pathToArchive).getParentFile().getParent()
+                            + File.separator + ImportExportConstants.DEPLOYMENT_INFO_LOCATION) :
                     getFileContentAsJson(pathToArchive + ImportExportConstants.DEPLOYMENT_INFO_LOCATION);
             if (jsonContent == null) {
                 return null;
@@ -1349,9 +1359,8 @@ public class ImportUtils {
             JsonElement configElement = new JsonParser().parse(jsonContent).getAsJsonObject().get(APIConstants.DATA);
             return configElement.getAsJsonArray();
         } catch (IOException e) {
-            throw new APIManagementException(
-                    "Error while reading deployment environments info from path: " + pathToArchive, e,
-                    ExceptionCodes.ERROR_READING_META_DATA);
+            throw new APIManagementException("Error while reading deployment environments info from path: "
+                    + pathToArchive, e, ExceptionCodes.ERROR_READING_META_DATA);
         }
     }
 
@@ -1365,8 +1374,8 @@ public class ImportUtils {
 
         try {
             byte[] wsdlDefinition = loadWsdlFile(pathToArchive, apiDto);
-            WSDLValidationResponse wsdlValidationResponse = APIMWSDLReader.getWsdlValidationResponse(
-                    APIMWSDLReader.getWSDLProcessor(wsdlDefinition));
+            WSDLValidationResponse wsdlValidationResponse = APIMWSDLReader.
+                    getWsdlValidationResponse(APIMWSDLReader.getWSDLProcessor(wsdlDefinition));
             if (!wsdlValidationResponse.isValid()) {
                 throw new APIManagementException(
                         "Error occurred while importing the API. Invalid WSDL definition found. "
@@ -1451,8 +1460,8 @@ public class ImportUtils {
 
         try {
             String swaggerContent = loadSwaggerFile(pathToArchive);
-            APIDefinitionValidationResponse validationResponse = OASParserUtil.validateAPIDefinition(swaggerContent,
-                    Boolean.TRUE);
+            APIDefinitionValidationResponse validationResponse = OASParserUtil
+                    .validateAPIDefinition(swaggerContent, Boolean.TRUE);
             if (!validationResponse.isValid()) {
                 String errorDescription = "";
                 if (validationResponse.getErrorItems().size() > 0) {
@@ -1467,8 +1476,9 @@ public class ImportUtils {
                         ExceptionCodes.from(ExceptionCodes.APICTL_OPENAPI_PARSE_EXCEPTION, errorDescription));
             }
             JsonObject swaggerContentJson = new JsonParser().parse(swaggerContent).getAsJsonObject();
-            if (swaggerContentJson.has(APIConstants.SWAGGER_INFO) && swaggerContentJson.getAsJsonObject(
-                    APIConstants.SWAGGER_INFO).has(ImportExportConstants.SWAGGER_X_WSO2_APICTL_INIT)
+            if (swaggerContentJson.has(APIConstants.SWAGGER_INFO)
+                    && swaggerContentJson.getAsJsonObject(APIConstants.SWAGGER_INFO)
+                    .has(ImportExportConstants.SWAGGER_X_WSO2_APICTL_INIT)
                     && swaggerContentJson.getAsJsonObject(APIConstants.SWAGGER_INFO)
                     .get(ImportExportConstants.SWAGGER_X_WSO2_APICTL_INIT).getAsBoolean()) {
                 validationResponse.setInit(true);
@@ -1494,17 +1504,17 @@ public class ImportUtils {
                 log.debug(
                         "Found swagger file " + pathToArchive + ImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION);
             }
-            String yamlContent = FileUtils.readFileToString(
-                    new File(pathToArchive + ImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION));
+            String yamlContent = FileUtils
+                    .readFileToString(new File(pathToArchive + ImportExportConstants.YAML_SWAGGER_DEFINITION_LOCATION));
             return CommonUtil.yamlToJson(yamlContent);
-        } else if (CommonUtil.checkFileExistence(
-                pathToArchive + ImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION)) {
+        } else if (CommonUtil
+                .checkFileExistence(pathToArchive + ImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION)) {
             if (log.isDebugEnabled()) {
                 log.debug(
                         "Found swagger file " + pathToArchive + ImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION);
             }
-            return FileUtils.readFileToString(
-                    new File(pathToArchive + ImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION));
+            return FileUtils
+                    .readFileToString(new File(pathToArchive + ImportExportConstants.JSON_SWAGGER_DEFINITION_LOCATION));
         }
         throw new IOException("Missing swagger file. Either swagger.json or swagger.yaml should present");
     }
@@ -1516,8 +1526,8 @@ public class ImportUtils {
      * @param apiTypeWrapper The imported API object
      * @throws APIManagementException If an error occurs when uploading the thumbnail of the API/API Product
      */
-    private static void addThumbnailImage(String pathToArchive, ApiTypeWrapper apiTypeWrapper, APIProvider apiProvider)
-            throws APIManagementException {
+    private static void addThumbnailImage(String pathToArchive, ApiTypeWrapper apiTypeWrapper,
+                                          APIProvider apiProvider) throws APIManagementException {
 
         //Adding image icon to the API if there is any
         File imageFolder = new File(pathToArchive + ImportExportConstants.IMAGE_FILE_LOCATION);
@@ -1575,8 +1585,8 @@ public class ImportUtils {
         } catch (IOException e) {
             throw new APIManagementException(
                     "Failed to read the image file of API/API Product: " + identifier.getName() + " from the archive.",
-                    e, ExceptionCodes.from(ExceptionCodes.ERROR_UPLOADING_THUMBNAIL, identifier.getName(),
-                    identifier.getVersion()));
+                    e, ExceptionCodes
+                    .from(ExceptionCodes.ERROR_UPLOADING_THUMBNAIL, identifier.getName(), identifier.getVersion()));
         }
     }
 
@@ -1585,10 +1595,10 @@ public class ImportUtils {
      *
      * @param pathToArchive  Location of the extracted folder of the API or API Product
      * @param apiTypeWrapper Imported API or API Product
-     * @param organization   Identifier of an Organization
+     * @param organization  Identifier of an Organization
      */
     private static void addDocumentation(String pathToArchive, ApiTypeWrapper apiTypeWrapper, APIProvider apiProvider,
-            String organization) {
+                                         String organization) {
 
         String jsonContent = null;
         Identifier identifier = apiTypeWrapper.getId();
@@ -1596,8 +1606,7 @@ public class ImportUtils {
 
         File documentsFolder = new File(docDirectoryPath);
         File[] fileArray = documentsFolder.listFiles();
-        String provider = (apiTypeWrapper.isAPIProduct()) ?
-                apiTypeWrapper.getApiProduct().getId().getProviderName() :
+        String provider = (apiTypeWrapper.isAPIProduct()) ? apiTypeWrapper.getApiProduct().getId().getProviderName() :
                 apiTypeWrapper.getApi().getId().getProviderName();
         String tenantDomain = MultitenantUtils.getTenantDomain(provider);
 
@@ -1643,8 +1652,9 @@ public class ImportUtils {
 
                     // Add the documentation DTO
                     Documentation documentation = apiTypeWrapper.isAPIProduct() ?
-                            PublisherCommonUtils.addDocumentationToAPI(documentDTO,
-                                    apiTypeWrapper.getApiProduct().getUuid(), organization) :
+                            PublisherCommonUtils
+                                    .addDocumentationToAPI(documentDTO, apiTypeWrapper.getApiProduct().getUuid(),
+                                            organization) :
                             PublisherCommonUtils.addDocumentationToAPI(documentDTO, apiTypeWrapper.getApi().getUuid(),
                                     organization);
 
@@ -1676,8 +1686,8 @@ public class ImportUtils {
                                     tenantDomain);
                         } catch (FileNotFoundException e) {
                             //this error is logged and ignored because documents are optional in an API
-                            log.error("Failed to locate the document files of the API/API Product: "
-                                    + apiTypeWrapper.getId().getName(), e);
+                            log.error("Failed to locate the document files of the API/API Product: " + apiTypeWrapper
+                                    .getId().getName(), e);
                             continue;
                         }
                     }
@@ -1694,17 +1704,20 @@ public class ImportUtils {
     }
 
     public static String retrieveSequenceContent(String pathToArchive, boolean specific, String type,
-            String sequenceName) {
+                                                 String sequenceName) {
 
         String sequenceFileName = sequenceName + APIConstants.XML_EXTENSION;
         String sequenceFileLocation = null;
         if (APIConstants.API_CUSTOM_SEQUENCE_TYPE_IN.equals(type)) {
-            sequenceFileLocation = pathToArchive + ImportExportConstants.IN_SEQUENCE_LOCATION;
+            sequenceFileLocation =
+                    pathToArchive + ImportExportConstants.IN_SEQUENCE_LOCATION;
         } else if (APIConstants.API_CUSTOM_SEQUENCE_TYPE_OUT.equals(type)) {
-            sequenceFileLocation = pathToArchive + ImportExportConstants.OUT_SEQUENCE_LOCATION;
+            sequenceFileLocation =
+                    pathToArchive + ImportExportConstants.OUT_SEQUENCE_LOCATION;
 
         } else if (APIConstants.API_CUSTOM_SEQUENCE_TYPE_FAULT.equals(type)) {
-            sequenceFileLocation = pathToArchive + ImportExportConstants.FAULT_SEQUENCE_LOCATION;
+            sequenceFileLocation =
+                    pathToArchive + ImportExportConstants.FAULT_SEQUENCE_LOCATION;
         }
         if (sequenceFileLocation != null) {
             if (specific) {
@@ -1724,7 +1737,8 @@ public class ImportUtils {
         return null;
     }
 
-    private static String retrieveSequenceContentFromLocation(String sequenceFileLocation) throws IOException {
+    private static String retrieveSequenceContentFromLocation(String sequenceFileLocation)
+            throws IOException {
 
         if (CommonUtil.checkFileExistence(sequenceFileLocation)) {
             File sequenceFile = new File(sequenceFileLocation);
@@ -1775,7 +1789,7 @@ public class ImportUtils {
      * @throws APIImportExportException If an error occurs while importing endpoint certificates from file
      */
     private static void addEndpointCertificates(String pathToArchive, API importedApi, APIProvider apiProvider,
-            int tenantId) throws APIManagementException {
+                                                int tenantId) throws APIManagementException {
 
         String jsonContent = null;
         String pathToEndpointsCertificatesDirectory =
@@ -1880,7 +1894,7 @@ public class ImportUtils {
      * @param tenantId    Tenant Id
      */
     private static void updateAPIWithCertificate(JsonElement certificate, APIProvider apiProvider, API importedApi,
-            int tenantId) throws APIManagementException {
+                                                 int tenantId) throws APIManagementException {
 
         String certificateFileName = certificate.getAsJsonObject().get(ImportExportConstants.CERTIFICATE_FILE)
                 .getAsString();
@@ -1893,15 +1907,15 @@ public class ImportUtils {
         String endpoint = certificate.getAsJsonObject().get(ImportExportConstants.ENDPOINT_JSON_KEY).getAsString();
         try {
             if (apiProvider.isCertificatePresent(tenantId, alias) || (
-                    ResponseCode.ALIAS_EXISTS_IN_TRUST_STORE.getResponseCode() == (apiProvider.addCertificate(
-                            APIUtil.replaceEmailDomainBack(importedApi.getId().getProviderName()), certificateContent,
-                            alias, endpoint)))) {
+                    ResponseCode.ALIAS_EXISTS_IN_TRUST_STORE.getResponseCode() == (apiProvider
+                            .addCertificate(APIUtil.replaceEmailDomainBack(importedApi.getId().getProviderName()),
+                                    certificateContent, alias, endpoint)))) {
                 apiProvider.updateCertificate(certificateContent, alias);
             }
         } catch (APIManagementException e) {
-            log.error("Error while importing certificate endpoint [" + endpoint + " ]" + "alias [" + alias
-                            + " ] tenant user [" + APIUtil.replaceEmailDomainBack(importedApi.getId().getProviderName())
-                            + "]", e);
+            log.error("Error while importing certificate endpoint [" + endpoint + " ]" + "alias [" + alias +
+                    " ] tenant user [" + APIUtil.replaceEmailDomainBack(importedApi.getId().getProviderName())
+                    + "]", e);
         }
     }
 
@@ -1910,14 +1924,15 @@ public class ImportUtils {
      *
      * @param pathToArchive Location of the extracted folder of the API
      * @param apiProvider   API Provider
-     * @param organization  Identifier of the organization
+     * @param organization Identifier of the organization
      * @throws APIImportExportException
      */
     private static void addClientCertificates(String pathToArchive, APIProvider apiProvider,
-            ApiTypeWrapper apiTypeWrapper, String organization) throws APIManagementException {
+                                              ApiTypeWrapper apiTypeWrapper, String organization)
+            throws APIManagementException {
 
         try {
-            Identifier apiIdentifier = apiTypeWrapper.getId();
+            Identifier apiIdentifier  = apiTypeWrapper.getId();
             List<ClientCertificateDTO> certificateMetadataDTOS = retrieveClientCertificates(pathToArchive);
             for (ClientCertificateDTO certDTO : certificateMetadataDTOS) {
                 apiProvider.addClientCertificate(APIUtil.replaceEmailDomainBack(apiIdentifier.getProviderName()),
@@ -1978,8 +1993,8 @@ public class ImportUtils {
     private static void addSOAPToREST(API importedApi, String swaggerContent, APIProvider apiProvider)
             throws APIManagementException, FaultGatewaysException {
         String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
-        PublisherCommonUtils.updateAPIBySettingGenerateSequencesFromSwagger(swaggerContent, importedApi, apiProvider,
-                tenantDomain);
+        PublisherCommonUtils
+                .updateAPIBySettingGenerateSequencesFromSwagger(swaggerContent, importedApi, apiProvider, tenantDomain);
     }
 
     public static List<SoapToRestMediationDto> retrieveSoapToRestFlowMediations(String pathToArchive, String type)
@@ -2000,8 +2015,8 @@ public class ImportUtils {
                     String method = "";
                     String resource = "";
                     if (fileName.split(".xml").length != 0) {
-                        method = fileName.split(".xml")[0].substring(
-                                file.getFileName().toString().lastIndexOf("_") + 1);
+                        method =
+                                fileName.split(".xml")[0].substring(file.getFileName().toString().lastIndexOf("_") + 1);
                         resource = fileName.substring(0, fileName.indexOf("_"));
                     }
                     try (InputStream inputFlowStream = new FileInputStream(file.toFile())) {
@@ -2027,7 +2042,8 @@ public class ImportUtils {
      * @throws APIImportExportException If an error occurs while importing/storing SOAP to REST mediation logic
      */
     private static void importMediationLogic(SoapToRestMediationDto sequenceData, Registry registry,
-            String soapToRestLocation) throws APIManagementException {
+                                             String soapToRestLocation)
+            throws APIManagementException {
 
         String fileName = sequenceData.getResource().concat("_").concat(sequenceData.getMethod()).concat(".xml");
         try {
@@ -2074,7 +2090,7 @@ public class ImportUtils {
      * @param preserveProvider    Decision to keep or replace the provider
      * @param overwriteAPIProduct Whether to update the API Product or not
      * @param overwriteAPIs       Whether to update the dependent APIs or not
-     * @param organization        Organization Identifier
+     * @param organization  Organization Identifier
      * @param importAPIs          Whether to import the dependent APIs or not
      * @throws APIImportExportException If there is an error in importing an API
      */
@@ -2101,8 +2117,8 @@ public class ImportUtils {
             JsonObject paramsConfigObject = APIControllerUtil.resolveAPIControllerEnvParams(extractedFolderPath);
             // If above the params configurations are not null, then resolve those
             if (paramsConfigObject != null) {
-                importedApiProductDTO = APIControllerUtil.injectEnvParamsToAPIProduct(importedApiProductDTO,
-                        paramsConfigObject, extractedFolderPath);
+                importedApiProductDTO = APIControllerUtil
+                        .injectEnvParamsToAPIProduct(importedApiProductDTO, paramsConfigObject, extractedFolderPath);
                 JsonElement deploymentsParam = paramsConfigObject.get(ImportExportConstants.DEPLOYMENT_ENVIRONMENTS);
                 if (deploymentsParam != null && !deploymentsParam.isJsonNull()) {
                     deploymentInfoArray = deploymentsParam.getAsJsonArray();
@@ -2125,8 +2141,8 @@ public class ImportUtils {
             } else {
                 // Even we do not import APIs, the UUIDs of the dependent APIs should be updated if the APIs are
                 // already in the APIM
-                importedApiProductDTO = updateDependentApiUuids(importedApiProductDTO, apiProvider, currentTenantDomain,
-                        organization);
+                importedApiProductDTO = updateDependentApiUuids(importedApiProductDTO, apiProvider,
+                        currentTenantDomain, organization);
             }
 
             APIProduct targetApiProduct = retrieveApiProductToOverwrite(importedApiProductDTO.getName(),
@@ -2143,8 +2159,9 @@ public class ImportUtils {
                     log.info("Cannot find : " + importedApiProductDTO.getName() + ". Creating it.");
                 }
                 currentStatus = APIStatus.CREATED.toString();
-                importedApiProduct = PublisherCommonUtils.addAPIProductWithGeneratedSwaggerDefinition(
-                        importedApiProductDTO, importedApiProductDTO.getProvider(), organization);
+                importedApiProduct = PublisherCommonUtils
+                        .addAPIProductWithGeneratedSwaggerDefinition(importedApiProductDTO,
+                                importedApiProductDTO.getProvider(), organization);
             }
 
             // Retrieving the life cycle action to do the lifecycle state change explicitly later
@@ -2189,28 +2206,31 @@ public class ImportUtils {
                 try {
                     revisionId = apiProvider.addAPIProductRevision(apiProductRevision, organization);
                     if (log.isDebugEnabled()) {
-                        log.debug("A new revision has been created for API Product " + importedApiProduct.getId()
-                                .getName() + "_" + importedApiProduct.getId().getVersion() + " with ID: " + revisionId);
+                        log.debug("A new revision has been created for API Product " +
+                                importedApiProduct.getId().getName() + "_"
+                                + importedApiProduct.getId().getVersion() + " with ID: " + revisionId);
                     }
                 } catch (APIManagementException e) {
                     //if the revision count is more than 5, addAPIProductRevision will throw an exception. If
                     // rotateRevision enabled, earliest revision will be deleted before creating a revision again
-                    if (e.getErrorHandler().getErrorCode() == ExceptionCodes.from(
-                            ExceptionCodes.MAXIMUM_REVISIONS_REACHED).getErrorCode() && rotateRevision) {
+                    if (e.getErrorHandler().getErrorCode() ==
+                            ExceptionCodes.from(ExceptionCodes.MAXIMUM_REVISIONS_REACHED).getErrorCode() &&
+                            rotateRevision) {
                         String earliestRevisionUuid = apiProvider.getEarliestRevisionUUID(importedAPIUuid);
-                        List<APIRevisionDeployment> deploymentsList = apiProvider.getAPIRevisionDeploymentList(
-                                earliestRevisionUuid);
+                        List<APIRevisionDeployment> deploymentsList =
+                                apiProvider.getAPIRevisionDeploymentList(earliestRevisionUuid);
                         //if the earliest revision is already deployed in gateway environments, it will be undeployed
                         //before deleting
-                        apiProvider.undeployAPIProductRevisionDeployment(importedAPIUuid, earliestRevisionUuid,
-                                deploymentsList);
+                        apiProvider
+                                .undeployAPIProductRevisionDeployment(importedAPIUuid, earliestRevisionUuid,
+                                        deploymentsList);
                         apiProvider.deleteAPIProductRevision(importedAPIUuid, earliestRevisionUuid, organization);
                         revisionId = apiProvider.addAPIProductRevision(apiProductRevision, organization);
                         if (log.isDebugEnabled()) {
-                            log.debug("Revision ID: " + earliestRevisionUuid + " has been undeployed from "
-                                    + deploymentsList.size() + " gateway environments and created a new revision ID: "
-                                    + revisionId + " for API Product " + importedApiProduct.getId().getName() + "_"
-                                    + importedApiProduct.getId().getVersion());
+                            log.debug("Revision ID: " + earliestRevisionUuid + " has been undeployed from " +
+                                    deploymentsList.size() + " gateway environments and created a new revision ID: " +
+                                    revisionId + " for API Product " + importedApiProduct.getId().getName() + "_" +
+                                    importedApiProduct.getId().getVersion());
                         }
                     } else {
                         throw new APIManagementException(e);
@@ -2221,8 +2241,8 @@ public class ImportUtils {
                 //environments
                 apiProvider.deployAPIProductRevision(importedAPIUuid, revisionId, apiProductRevisionDeployments);
             } else {
-                log.info("Valid deployment environments were not found for the imported artifact. Hence not deployed"
-                        + " in any of the gateway environments.");
+                log.info("Valid deployment environments were not found for the imported artifact. Hence not deployed" +
+                        " in any of the gateway environments.");
             }
 
             return importedApiProduct;
@@ -2248,10 +2268,10 @@ public class ImportUtils {
     /**
      * This method checks whether the resources in the API Product are valid.
      *
-     * @param path             Location of the extracted folder of the API Product
-     * @param currentUser      The current logged in user
-     * @param apiProvider      API provider
-     * @param apiProductDto    API Product DTO
+     * @param path          Location of the extracted folder of the API Product
+     * @param currentUser   The current logged in user
+     * @param apiProvider   API provider
+     * @param apiProductDto API Product DTO
      * @param preserveProvider
      * @param organization
      * @throws IOException            If there is an error while reading an API file
@@ -2271,8 +2291,9 @@ public class ImportUtils {
 
         if (apisDirectoryListing != null) {
             for (File apiDirectory : apisDirectoryListing) {
-                String apiDirectoryPath = path + File.separator + ImportExportConstants.APIS_DIRECTORY + File.separator
-                        + apiDirectory.getName();
+                String apiDirectoryPath =
+                        path + File.separator + ImportExportConstants.APIS_DIRECTORY + File.separator + apiDirectory
+                                .getName();
                 JsonElement jsonObject = retrieveValidatedDTOObject(apiDirectoryPath, preserveProvider, currentUser,
                         ImportExportConstants.TYPE_API);
                 APIDTO apiDto = new Gson().fromJson(jsonObject, APIDTO.class);
@@ -2284,8 +2305,8 @@ public class ImportUtils {
                 Set<URITemplate> apiUriTemplates = apiDefinition.getURITemplates(swaggerContent);
 
                 for (ProductAPIDTO apiFromProduct : apis) {
-                    if (StringUtils.equals(apiFromProduct.getName(), apiName) && StringUtils.equals(
-                            apiFromProduct.getVersion(), apiVersion)) {
+                    if (StringUtils.equals(apiFromProduct.getName(), apiName) && StringUtils
+                            .equals(apiFromProduct.getVersion(), apiVersion)) {
                         List<APIOperationsDTO> invalidApiOperations = filterInvalidProductResources(
                                 apiFromProduct.getOperations(), apiUriTemplates);
 
@@ -2323,7 +2344,7 @@ public class ImportUtils {
      * @return Invalid API operations
      */
     private static List<APIOperationsDTO> filterInvalidProductResources(List<APIOperationsDTO> apiProductOperations,
-            Set<URITemplate> apiUriTemplates) {
+                                                                        Set<URITemplate> apiUriTemplates) {
 
         List<APIOperationsDTO> apiOperations = new ArrayList<>(apiProductOperations);
         for (URITemplate apiUriTemplate : apiUriTemplates) {
@@ -2345,7 +2366,7 @@ public class ImportUtils {
      * @param overwriteAPIs            Whether to overwrite the APIs or not
      * @param apiProductDto            API Product DTO
      * @param tokenScopes              Scopes of the token
-     * @param organization             Organization Identifier
+     * @param organization  Organization Identifier
      * @return Modified API Product DTO with the correct API UUIDs
      * @throws IOException              If there is an error while reading an API file
      * @throws APIImportExportException If there is an error in importing an API
@@ -2365,14 +2386,15 @@ public class ImportUtils {
 
         if (apisDirectoryListing != null) {
             for (File apiDirectory : apisDirectoryListing) {
-                String apiDirectoryPath = path + File.separator + ImportExportConstants.APIS_DIRECTORY + File.separator
-                        + apiDirectory.getName();
+                String apiDirectoryPath =
+                        path + File.separator + ImportExportConstants.APIS_DIRECTORY + File.separator + apiDirectory
+                                .getName();
 
                 // If the param configurations of the dependent APIs are available, the configurations of the current
                 // API in the API directory will be retrieved if available
                 if (dependentAPIsParams != null) {
-                    dependentAPIParamsConfigObject = APIControllerUtil.getDependentAPIParams(dependentAPIsParams,
-                            apiDirectory.getName());
+                    dependentAPIParamsConfigObject = APIControllerUtil
+                            .getDependentAPIParams(dependentAPIsParams, apiDirectory.getName());
                     // If the "certificates" directory is specified, copy it inside Deployment directory of the
                     // dependent API since there may be certificates required for APIs
                     String deploymentCertificatesDirectoryPath = path + ImportExportConstants.DEPLOYMENT_DIRECTORY
@@ -2417,12 +2439,12 @@ public class ImportUtils {
                     }
                 } else {
                     // Retrieve the current tenant domain of the logged in user
-                    String currentTenantDomain = MultitenantUtils.getTenantDomain(
-                            APIUtil.replaceEmailDomainBack(currentUser));
+                    String currentTenantDomain = MultitenantUtils
+                            .getTenantDomain(APIUtil.replaceEmailDomainBack(currentUser));
 
                     // Get the provider of the API if the API is in current user's tenant domain.
-                    String apiProviderInCurrentTenantDomain = APIUtil.getAPIProviderFromAPINameVersionTenant(apiName,
-                            apiVersion, currentTenantDomain);
+                    String apiProviderInCurrentTenantDomain = APIUtil
+                            .getAPIProviderFromAPINameVersionTenant(apiName, apiVersion, currentTenantDomain);
 
                     if (StringUtils.isBlank(apiProviderInCurrentTenantDomain)) {
                         // If there is no API in the current tenant domain (which means the provider name is blank)
@@ -2468,8 +2490,8 @@ public class ImportUtils {
         APIIdentifier importedApiIdentifier = importedApi.getId();
         List<ProductAPIDTO> apis = apiProductDto.getApis();
         for (ProductAPIDTO api : apis) {
-            if (StringUtils.equals(api.getName(), importedApiIdentifier.getName()) && StringUtils.equals(
-                    api.getVersion(), importedApiIdentifier.getVersion())) {
+            if (StringUtils.equals(api.getName(), importedApiIdentifier.getName()) && StringUtils
+                    .equals(api.getVersion(), importedApiIdentifier.getVersion())) {
                 api.setApiId(importedApi.getUuid());
                 break;
             }
@@ -2483,7 +2505,7 @@ public class ImportUtils {
      * @param importedApiProductDtO API Product DTO
      * @param apiProvider           API Provider
      * @param currentTenantDomain   Current tenant domain
-     * @param organization          organization
+     * @param organization organization
      * @throws APIManagementException If failed failed when checking the existence of an API
      */
     private static APIProductDTO updateDependentApiUuids(APIProductDTO importedApiProductDtO, APIProvider apiProvider,
@@ -2541,8 +2563,8 @@ public class ImportUtils {
      * @throws FaultGatewaysException If an error occurs when updating the API to overwrite
      * @throws IOException            If an error occurs when loading the swagger file
      */
-    private static APIProduct updateApiProductSwagger(String pathToArchive, String apiProductId,
-            APIProduct importedApiProduct, APIProvider apiProvider, String orgId)
+    private static APIProduct updateApiProductSwagger(String pathToArchive, String apiProductId, APIProduct
+            importedApiProduct, APIProvider apiProvider, String orgId)
             throws APIManagementException, FaultGatewaysException, IOException {
 
         String swaggerContent = loadSwaggerFile(pathToArchive);
@@ -2554,8 +2576,8 @@ public class ImportUtils {
         importedApiProduct.setOrganization(orgId);
 
         // This is required to make scopes get effected
-        Map<API, List<APIProductResource>> apiToProductResourceMapping = apiProvider.updateAPIProduct(
-                importedApiProduct);
+        Map<API, List<APIProductResource>> apiToProductResourceMapping = apiProvider
+                .updateAPIProduct(importedApiProduct);
         apiProvider.updateAPIProductSwagger(apiProductId, apiToProductResourceMapping, importedApiProduct, orgId);
         return importedApiProduct;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -841,8 +841,7 @@ public class ImportUtils {
                         "Cannot find Operation Policy definition. policyDefinition.yaml should present",
                         ExceptionCodes.ERROR_FETCHING_DEFINITION_FILE);
             }
-
-            policyDefinitionJsonContent = CommonUtil.yamlToJson(policyDefinitionJsonContent);
+            
             policySpecification = APIUtil.getValidatedOperationPolicySpecification(policyDefinitionJsonContent);
 
             OperationPolicyData operationPolicyData = new OperationPolicyData();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -838,8 +838,8 @@ public class ImportUtils {
             String policyDefinitionJsonContent = getPolicyFileContentAsJson(pathToArchive + fileName);
             if (policyDefinitionJsonContent == null) {
                 throw new APIManagementException(
-                        "Cannot find Operation Policy definition. policyDefinition.yaml should present",
-                        ExceptionCodes.ERROR_FETCHING_DEFINITION_FILE);
+                        "Cannot find Operation Policy definition. policyDefinition.yaml or policyDefinition.json "
+                                + "should present", ExceptionCodes.ERROR_FETCHING_DEFINITION_FILE);
             }
 
             policySpecification = APIUtil.getValidatedOperationPolicySpecification(policyDefinitionJsonContent);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/OperationPolicyMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/OperationPolicyMappingUtil.java
@@ -171,6 +171,7 @@ public class OperationPolicyMappingUtil {
         policyDataDTO.setMd5(policyData.getMd5Hash());
         policyDataDTO.setIsAPISpecific(policyData.isApiSpecificPolicy());
         policyDataDTO.setName(policySpecification.getName());
+        policyDataDTO.setVersion(policySpecification.getVersion());
         policyDataDTO.setDisplayName(policySpecification.getDisplayName());
         policyDataDTO.setDescription(policySpecification.getDescription());
         policyDataDTO.setSupportedGateways(policySpecification.getSupportedGateways());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtilsTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtilsTest.java
@@ -1,0 +1,156 @@
+/*
+ *
+ *   Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.APIProvider;
+import org.wso2.carbon.apimgt.api.model.OperationPolicyData;
+import org.wso2.carbon.apimgt.api.model.OperationPolicyDefinition;
+import org.wso2.carbon.apimgt.api.model.OperationPolicySpecification;
+import org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.OperationPolicyDataDTO;
+import java.io.File;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ APIProvider.class, CommonUtil.class, FileUtils.class, APIUtil.class })
+public class ImportUtilsTest {
+    private static final String ORGANIZATION = "carbon.super";
+    private APIProvider apiProvider;
+
+    private final String pathToArchive = "/tmp/test/customCommonLogPolicy";
+    private final String yamlFile = pathToArchive + "/customCommonLogPolicy.yaml";
+    private final String jsonFile = pathToArchive + "/customCommonLogPolicy.json";
+    private final String synapsePath = pathToArchive + "/customCommonLogPolicy.j2";
+    private final String synapseDefFileString = "<log level=\"full\">\n"
+            + "    <property name=\"MESSAGE\" value=\"MESSAGE\"/>\n" + "</log>";
+
+    private static final String POLICYNAME = "customCommonLogPolicy";
+
+    private static final String POLICYVERSION = "v1";
+
+    private static OperationPolicyData policyData;
+
+    @Before
+    public void init() throws Exception {
+        PowerMockito.mockStatic(CommonUtil.class);
+        PowerMockito.mockStatic(FileUtils.class);
+        apiProvider = Mockito.mock(APIProvider.class);
+        // PowerMockito.mockStatic(APIUtil.class);
+
+//        PowerMockito.stub(PowerMockito.method(APIUtil.class, "getMd5OfOperationPolicyDefinition"));
+//        PowerMockito.stub(PowerMockito.method(APIUtil.class, "getMd5OfOperationPolicy"));
+
+        // PowerMockito.mockStatic(RandomStringUtils.class);
+    }
+
+    @Test public void testImportAPIPolicy() throws Exception {
+
+        String policyDefContent = "{\"type\":\"operation_policy_specification\",\"version\":\"v4.1.0\",\"data\":"
+                + "{\"category\":\"Mediation\",\"name\":\"customCommonLogPolicy\",\"version\":\"v1\",\"displayName\""
+                + ":\"CustomCommonLogPolicy\",\"description\":\"Usingthispolicy,youcanaddacustomlogmessage\""
+                + ",\"applicableFlows\":[\"request\",\"response\",\"fault\"],\"supportedGateways\":[\"Synapse\"]"
+                + ",\"supportedApiTypes\":[\"HTTP\"],\"policyAttributes\":[]}}";
+
+        String policyDefContentModified =
+                "{\"type\":\"operation_policy_specification\",\"version\":\"v1\",\"category\"" + ":"
+                        + "\"Mediation\",\"name\":\"customCommonLogPolicy\",\"displayName\":\"CustomCommonLogPolicy\","
+                        + "\"description\":\"Usingthispolicy,youcanaddacustomlogmessage\",\"applicableFlows\":"
+                        + "[\"request\","
+                        + "\"response\",\"fault\"],\"supportedGateways\":[\"Synapse\"],\"supportedApiTypes\":"
+                        + "[\"HTTP\"],"
+                        + "\"policyAttributes\":[]}";
+
+        Mockito.when(CommonUtil.checkFileExistence(yamlFile)).thenReturn(false);
+        Mockito.when(CommonUtil.checkFileExistence(jsonFile)).thenReturn(true);
+        Mockito.when(FileUtils.readFileToString(new File(jsonFile))).thenReturn(policyDefContent);
+        Mockito.when(CommonUtil.checkFileExistence(synapsePath)).thenReturn(true);
+        Mockito.when(FileUtils.readFileToString(new File(synapsePath))).thenReturn(synapseDefFileString);
+
+        String policyId = RandomStringUtils.randomAlphanumeric(10);
+        String synapseMd5 = RandomStringUtils.randomAlphanumeric(30);
+        String policyMD5 = RandomStringUtils.randomAlphanumeric(30);
+        policyData = Mockito.mock(OperationPolicyData.class);
+
+        OperationPolicySpecification operationPolicySpecification = APIUtil.getValidatedOperationPolicySpecification(
+                policyDefContentModified);
+
+        OperationPolicyData operationPolicyData = new OperationPolicyData();
+        operationPolicyData.setOrganization(ORGANIZATION);
+        operationPolicyData.setSpecification(operationPolicySpecification);
+
+        OperationPolicyDefinition gatewayDefinition = new OperationPolicyDefinition();
+        gatewayDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.Synapse);
+        gatewayDefinition.setContent(synapseDefFileString);
+
+        PowerMockito.stub(PowerMockito.method(APIUtil.class, "getMd5OfOperationPolicyDefinition",
+                OperationPolicyDefinition.class)).toReturn(synapseMd5);
+
+        // Mockito.when(APIUtil.getMd5OfOperationPolicyDefinition(gatewayDefinition)).thenReturn(synapseMd5);
+
+        gatewayDefinition.setMd5Hash(synapseMd5);
+        operationPolicyData.setSynapsePolicyDefinition(gatewayDefinition);
+
+        PowerMockito.stub(PowerMockito.method(APIUtil.class, "getMd5OfOperationPolicy", OperationPolicyData.class))
+                .toReturn(policyMD5);
+
+        // Mockito.when(APIUtil.getMd5OfOperationPolicy(operationPolicyData)).thenReturn(policyMD5);
+        operationPolicyData.setMd5Hash(policyMD5);
+
+        Mockito.when(apiProvider.getCommonOperationPolicyByPolicyName(POLICYNAME, POLICYVERSION, ORGANIZATION, false))
+                .thenReturn(null);
+        Mockito.when(apiProvider.addCommonOperationPolicy(policyData, ORGANIZATION)).thenReturn(policyId);
+
+        try {
+            OperationPolicyDataDTO operationPolicyDataDTO = ImportUtils.importPolicy(pathToArchive, ORGANIZATION,
+                    apiProvider);
+            Assert.assertNotNull(operationPolicyDataDTO);
+        } catch (APIManagementException ex) {
+            Assert.fail("Import Policy failed due to an exception!");
+        }
+
+        Mockito.when(apiProvider.getCommonOperationPolicyByPolicyName(POLICYNAME, POLICYVERSION, ORGANIZATION, false))
+                .thenReturn(policyData);
+
+        String unauthenticatedResponse = "{\"code\":401,\"message\":\"\",\"description\":\"Unauthenticated request\","
+                + "\"moreInfo\":\"\",\"error\":[]}";
+        String errorMsg =
+                "Import API service call received unsuccessful response: " + unauthenticatedResponse + " status: "
+                        + HttpStatus.SC_UNAUTHORIZED;
+
+        try {
+            ImportUtils.importPolicy(pathToArchive, ORGANIZATION, apiProvider);
+            Assert.fail("Cannot create an existing API Policy!");
+        } catch (APIManagementException ex) {
+            Assert.assertEquals(errorMsg, ex.getMessage());
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApi.java
@@ -62,7 +62,8 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @Produces({ "application/json" })
     @ApiOperation(value = "Delete a common operation policy", notes = "This operation can be used to delete an existing common opreation policy by providing the Id of the policy. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies")
+            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies"),
+            @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
     }, tags={ "Operation Policies",  })
     @ApiResponses(value = { 
@@ -75,21 +76,41 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     }
 
     @GET
+    @Path("/export")
+    
+    @Produces({ "application/zip", "application/json" })
+    @ApiOperation(value = "Export common operation policies by their names and versions ", notes = "This operation provides you to export preferred common operation policies ", response = File.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:common_operation_policy_view", description = "View common operation policies"),
+            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies"),
+            @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
+        })
+    }, tags={ "Import Export",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Export Successful. ", response = File.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class),
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class) })
+    public Response exportOperationPolicy( @ApiParam(value = "Policy name")  @QueryParam("name") String name,  @ApiParam(value = "Version of the policy")  @QueryParam("version") String version) throws APIManagementException{
+        return delegate.exportOperationPolicy(name, version, securityContext);
+    }
+
+    @GET
     
     
     @Produces({ "application/json" })
     @ApiOperation(value = "Get all common operation policies to all the APIs ", notes = "This operation provides you a list of all common operation policies that can be used by any API ", response = OperationPolicyDataListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:common_operation_policy_view", description = "View common operation policies"),
-            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies")
+            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies"),
+            @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
     }, tags={ "Operation Policies",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "OK. List of qualifying policies is returned. ", response = OperationPolicyDataListDTO.class),
         @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class),
         @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
-    public Response getAllCommonOperationPolicies( @ApiParam(value = "Maximum size of resource array to return. ", defaultValue="25") @DefaultValue("25") @QueryParam("limit") Integer limit,  @ApiParam(value = "Starting point within the complete list of items qualified. ", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset,  @ApiParam(value = "-Not supported yet-")  @QueryParam("query") String query) throws APIManagementException{
-        return delegate.getAllCommonOperationPolicies(limit, offset, query, securityContext);
+    public Response getAllCommonOperationPolicies( @ApiParam(value = "Maximum size of resource array to return. ", defaultValue="25") @DefaultValue("25") @QueryParam("limit") Integer limit,  @ApiParam(value = "Starting point within the complete list of items qualified. ", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset,  @ApiParam(value = "-Not supported yet-")  @QueryParam("query") String query,  @ApiParam(value = "Policy Name to fetch ID")  @QueryParam("name") String name,  @ApiParam(value = "Policy Version to fetch ID")  @QueryParam("version") String version) throws APIManagementException{
+        return delegate.getAllCommonOperationPolicies(limit, offset, query, name, version, securityContext);
     }
 
     @GET
@@ -99,7 +120,8 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @ApiOperation(value = "Get the details of a common operation policy by providing policy ID", notes = "This operation can be used to retrieve a particular common operation policy. ", response = OperationPolicyDataDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:common_operation_policy_view", description = "View common operation policies"),
-            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies")
+            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies"),
+            @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
     }, tags={ "Operation Policies",  })
     @ApiResponses(value = { 
@@ -120,12 +142,32 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
             @AuthorizationScope(scope = "apim:common_operation_policy_view", description = "View common operation policies"),
             @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies")
         })
-    }, tags={ "Operation Policies" })
+    }, tags={ "Operation Policies",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "OK. Operation policy returned. ", response = File.class),
         @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
         @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
     public Response getCommonOperationPolicyContentByPolicyId(@ApiParam(value = "Operation policy Id ",required=true) @PathParam("operationPolicyId") String operationPolicyId) throws APIManagementException{
         return delegate.getCommonOperationPolicyContentByPolicyId(operationPolicyId, securityContext);
+    }
+
+    @POST
+    @Path("/import")
+    @Consumes({ "multipart/form-data" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Import a Policy", notes = "This operation can be used to import an Policy. ", response = Void.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
+        })
+    }, tags={ "Import Export" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Created. Policy Imported Successfully. ", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden. The request must be conditional but no condition has been specified.", response = ErrorDTO.class),
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
+        @ApiResponse(code = 409, message = "Conflict. Specified resource already exists.", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
+    public Response importOperationPolicy( @Multipart(value = "file") InputStream fileInputStream, @Multipart(value = "file" ) Attachment fileDetail) throws APIManagementException{
+        return delegate.importOperationPolicy(fileInputStream, fileDetail, securityContext);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApi.java
@@ -79,15 +79,14 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @Path("/export")
     
     @Produces({ "application/zip", "application/json" })
-    @ApiOperation(value = "Export common operation policies by their names and versions ", notes = "This operation provides you to export preferred common operation policies ", response = File.class, authorizations = {
+    @ApiOperation(value = "Export common operation policies by their names and versions ", notes = "This operation provides you to export preferred common API policies ", response = File.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:common_operation_policy_view", description = "View common operation policies"),
-            @AuthorizationScope(scope = "apim:common_operation_policy_manage", description = "Add, Update and Delete common operation policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
     }, tags={ "Import Export",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "OK. Export Successful. ", response = File.class),
+        @ApiResponse(code = 403, message = "Forbidden. The request must be conditional but no condition has been specified.", response = ErrorDTO.class),
         @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class),
         @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class) })
     public Response exportOperationPolicy( @ApiParam(value = "Policy name")  @QueryParam("name") String name,  @ApiParam(value = "Version of the policy")  @QueryParam("version") String version) throws APIManagementException{
@@ -109,7 +108,7 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
         @ApiResponse(code = 200, message = "OK. List of qualifying policies is returned. ", response = OperationPolicyDataListDTO.class),
         @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class),
         @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
-    public Response getAllCommonOperationPolicies( @ApiParam(value = "Maximum size of resource array to return. ", defaultValue="25") @DefaultValue("25") @QueryParam("limit") Integer limit,  @ApiParam(value = "Starting point within the complete list of items qualified. ", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset,  @ApiParam(value = "-Not supported yet-")  @QueryParam("query") String query,  @ApiParam(value = "Policy Name to fetch ID")  @QueryParam("name") String name,  @ApiParam(value = "Policy Version to fetch ID")  @QueryParam("version") String version) throws APIManagementException{
+    public Response getAllCommonOperationPolicies( @ApiParam(value = "Maximum size of resource array to return. ")  @QueryParam("limit") Integer limit,  @ApiParam(value = "Starting point within the complete list of items qualified. ", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset,  @ApiParam(value = "-Not supported yet-")  @QueryParam("query") String query,  @ApiParam(value = "Policy Name to fetch ID")  @QueryParam("name") String name,  @ApiParam(value = "Policy Version to fetch ID")  @QueryParam("version") String version) throws APIManagementException{
         return delegate.getAllCommonOperationPolicies(limit, offset, query, name, version, securityContext);
     }
 
@@ -155,16 +154,14 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @Path("/import")
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Import a Policy", notes = "This operation can be used to import an Policy. ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Import a Policy", notes = "This operation can be used to import a common API Policy. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
-            @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
     }, tags={ "Import Export" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "Created. Policy Imported Successfully. ", response = Void.class),
         @ApiResponse(code = 403, message = "Forbidden. The request must be conditional but no condition has been specified.", response = ErrorDTO.class),
-        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
         @ApiResponse(code = 409, message = "Conflict. Specified resource already exists.", response = ErrorDTO.class),
         @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
     public Response importOperationPolicy( @Multipart(value = "file") InputStream fileInputStream, @Multipart(value = "file" ) Attachment fileDetail) throws APIManagementException{

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApi.java
@@ -79,7 +79,7 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @Path("/export")
     
     @Produces({ "application/zip", "application/json" })
-    @ApiOperation(value = "Export common operation policies by their names and versions ", notes = "This operation provides you to export preferred common API policies ", response = File.class, authorizations = {
+    @ApiOperation(value = "Export an API Policy by its name and version ", notes = "This operation provides you to export a preferred common API policy ", response = File.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
@@ -108,8 +108,8 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
         @ApiResponse(code = 200, message = "OK. List of qualifying policies is returned. ", response = OperationPolicyDataListDTO.class),
         @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class),
         @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
-    public Response getAllCommonOperationPolicies( @ApiParam(value = "Maximum size of resource array to return. ")  @QueryParam("limit") Integer limit,  @ApiParam(value = "Starting point within the complete list of items qualified. ", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset,  @ApiParam(value = "-Not supported yet-")  @QueryParam("query") String query,  @ApiParam(value = "Policy Name to fetch ID")  @QueryParam("name") String name,  @ApiParam(value = "Policy Version to fetch ID")  @QueryParam("version") String version) throws APIManagementException{
-        return delegate.getAllCommonOperationPolicies(limit, offset, query, name, version, securityContext);
+    public Response getAllCommonOperationPolicies( @ApiParam(value = "Maximum size of policy array to return. ")  @QueryParam("limit") Integer limit,  @ApiParam(value = "Starting point within the complete list of items qualified. ", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset,  @ApiParam(value = "**Search condition**.  You can search in attributes by using an **\"<attribute>:\"** modifier.  Eg. \"name:addHeader\" will match an API Policy if the provider of the API Policy contains \"addHeader\". \"version:\"v1\"\" will match an API Policy if the provider of the API Policy contains \"v1\".  Also you can use combined modifiers Eg. name:addHeader&version:v1 will match an API Policy if the name of the API Policy is addHeader and version is v1.  Supported attribute modifiers are [**version, name**]  If query attributes are provided, this returns all API policies available under the given limit.  Please note that you need to use encoded URL (URL encoding) if you are using a client which does not support URL encoding (such as curl) ")  @QueryParam("query") String query) throws APIManagementException{
+        return delegate.getAllCommonOperationPolicies(limit, offset, query, securityContext);
     }
 
     @GET
@@ -154,7 +154,7 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
     @Path("/import")
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Import a Policy", notes = "This operation can be used to import a common API Policy. ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Import an API Policy", notes = "This operation can be used to import an API Policy. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApi.java
@@ -89,8 +89,8 @@ OperationPoliciesApiService delegate = new OperationPoliciesApiServiceImpl();
         @ApiResponse(code = 403, message = "Forbidden. The request must be conditional but no condition has been specified.", response = ErrorDTO.class),
         @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class),
         @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class) })
-    public Response exportOperationPolicy( @ApiParam(value = "Policy name")  @QueryParam("name") String name,  @ApiParam(value = "Version of the policy")  @QueryParam("version") String version) throws APIManagementException{
-        return delegate.exportOperationPolicy(name, version, securityContext);
+    public Response exportOperationPolicy( @ApiParam(value = "Policy name")  @QueryParam("name") String name,  @ApiParam(value = "Version of the policy")  @QueryParam("version") String version,  @ApiParam(value = "Format of the policy definition file")  @QueryParam("format") String format) throws APIManagementException{
+        return delegate.exportOperationPolicy(name, version, format, securityContext);
     }
 
     @GET

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApiService.java
@@ -26,7 +26,7 @@ public interface OperationPoliciesApiService {
       public Response addCommonOperationPolicy(InputStream policySpecFileInputStream, Attachment policySpecFileDetail, InputStream synapsePolicyDefinitionFileInputStream, Attachment synapsePolicyDefinitionFileDetail, InputStream ccPolicyDefinitionFileInputStream, Attachment ccPolicyDefinitionFileDetail, MessageContext messageContext) throws APIManagementException;
       public Response deleteCommonOperationPolicyByPolicyId(String operationPolicyId, MessageContext messageContext) throws APIManagementException;
       public Response exportOperationPolicy(String name, String version, MessageContext messageContext) throws APIManagementException;
-      public Response getAllCommonOperationPolicies(Integer limit, Integer offset, String query, String name, String version, MessageContext messageContext) throws APIManagementException;
+      public Response getAllCommonOperationPolicies(Integer limit, Integer offset, String query, MessageContext messageContext) throws APIManagementException;
       public Response getCommonOperationPolicyByPolicyId(String operationPolicyId, MessageContext messageContext) throws APIManagementException;
       public Response getCommonOperationPolicyContentByPolicyId(String operationPolicyId, MessageContext messageContext) throws APIManagementException;
       public Response importOperationPolicy(InputStream fileInputStream, Attachment fileDetail, MessageContext messageContext) throws APIManagementException;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApiService.java
@@ -25,7 +25,7 @@ import javax.ws.rs.core.SecurityContext;
 public interface OperationPoliciesApiService {
       public Response addCommonOperationPolicy(InputStream policySpecFileInputStream, Attachment policySpecFileDetail, InputStream synapsePolicyDefinitionFileInputStream, Attachment synapsePolicyDefinitionFileDetail, InputStream ccPolicyDefinitionFileInputStream, Attachment ccPolicyDefinitionFileDetail, MessageContext messageContext) throws APIManagementException;
       public Response deleteCommonOperationPolicyByPolicyId(String operationPolicyId, MessageContext messageContext) throws APIManagementException;
-      public Response exportOperationPolicy(String name, String version, MessageContext messageContext) throws APIManagementException;
+      public Response exportOperationPolicy(String name, String version, String format, MessageContext messageContext) throws APIManagementException;
       public Response getAllCommonOperationPolicies(Integer limit, Integer offset, String query, MessageContext messageContext) throws APIManagementException;
       public Response getCommonOperationPolicyByPolicyId(String operationPolicyId, MessageContext messageContext) throws APIManagementException;
       public Response getCommonOperationPolicyContentByPolicyId(String operationPolicyId, MessageContext messageContext) throws APIManagementException;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/OperationPoliciesApiService.java
@@ -25,7 +25,9 @@ import javax.ws.rs.core.SecurityContext;
 public interface OperationPoliciesApiService {
       public Response addCommonOperationPolicy(InputStream policySpecFileInputStream, Attachment policySpecFileDetail, InputStream synapsePolicyDefinitionFileInputStream, Attachment synapsePolicyDefinitionFileDetail, InputStream ccPolicyDefinitionFileInputStream, Attachment ccPolicyDefinitionFileDetail, MessageContext messageContext) throws APIManagementException;
       public Response deleteCommonOperationPolicyByPolicyId(String operationPolicyId, MessageContext messageContext) throws APIManagementException;
-      public Response getAllCommonOperationPolicies(Integer limit, Integer offset, String query, MessageContext messageContext) throws APIManagementException;
+      public Response exportOperationPolicy(String name, String version, MessageContext messageContext) throws APIManagementException;
+      public Response getAllCommonOperationPolicies(Integer limit, Integer offset, String query, String name, String version, MessageContext messageContext) throws APIManagementException;
       public Response getCommonOperationPolicyByPolicyId(String operationPolicyId, MessageContext messageContext) throws APIManagementException;
       public Response getCommonOperationPolicyContentByPolicyId(String operationPolicyId, MessageContext messageContext) throws APIManagementException;
+      public Response importOperationPolicy(InputStream fileInputStream, Attachment fileDetail, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -2429,7 +2429,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             OperationPolicyData policyData =
                     apiProvider.getAPISpecificOperationPolicyByPolicyId(operationPolicyId, apiId, organization, true);
             if (policyData != null) {
-                File file = RestApiPublisherUtils.exportOperationPolicyData(policyData);
+                File file = RestApiPublisherUtils.exportOperationPolicyData(policyData, ExportFormat.YAML.name());
                 return Response.ok(file).header(RestApiConstants.HEADER_CONTENT_DISPOSITION,
                         "attachment; filename=\"" + file.getName() + "\"").build();
             } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.apimgt.api.model.OperationPolicyDefinition;
 import org.wso2.carbon.apimgt.api.model.OperationPolicySpecification;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.importexport.APIImportExportException;
+import org.wso2.carbon.apimgt.impl.importexport.ExportFormat;
 import org.wso2.carbon.apimgt.impl.importexport.ImportExportAPI;
 import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
 import org.wso2.carbon.apimgt.impl.importexport.utils.APIImportExportUtil;
@@ -348,7 +349,7 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
             OperationPolicyData policyData =
                     apiProvider.getCommonOperationPolicyByPolicyId(operationPolicyId, organization, true);
             if (policyData != null) {
-                File file = RestApiPublisherUtils.exportOperationPolicyData(policyData);
+                File file = RestApiPublisherUtils.exportOperationPolicyData(policyData, ExportFormat.YAML.name());
                 return Response.ok(file).header(RestApiConstants.HEADER_CONTENT_DISPOSITION,
                         "attachment; filename=\"" + file.getName() + "\"").build();
             } else {
@@ -383,7 +384,7 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
      *                                extracting the content
      * @returnA zip file containing both (if exists) operation policy specification and policy definition
      */
-    public Response exportOperationPolicy(String name, String version, MessageContext messageContext)
+    public Response exportOperationPolicy(String name, String version, String format, MessageContext messageContext)
             throws APIManagementException {
 
         APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
@@ -392,7 +393,7 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
         OperationPolicyData policyData = apiProvider.getCommonOperationPolicyByPolicyName(name, version, organization,
                 true);
         if (policyData != null) {
-            File file = RestApiPublisherUtils.exportOperationPolicyData(policyData);
+            File file = RestApiPublisherUtils.exportOperationPolicyData(policyData, format);
             return Response.ok(file).header(RestApiConstants.HEADER_CONTENT_DISPOSITION,
                     "attachment; filename=\"" + file.getName() + "\"").build();
         } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.apimgt.rest.api.publisher.v1.impl;
 
+import com.github.jknack.handlebars.internal.lang3.StringUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -390,7 +391,10 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
         OperationPolicyData policyData = apiProvider.getCommonOperationPolicyByPolicyName(name, version, organization,
                 true);
         if (policyData != null) {
-            File file = RestApiPublisherUtils.exportOperationPolicyData(policyData, format);
+            ExportFormat exportFormat = StringUtils.isNotEmpty(format) ?
+                    ExportFormat.valueOf(format.toUpperCase()) :
+                    ExportFormat.YAML;
+            File file = RestApiPublisherUtils.exportOperationPolicyData(policyData, exportFormat.name());
             return Response.ok(file).header(RestApiConstants.HEADER_CONTENT_DISPOSITION,
                     "attachment; filename=\"" + file.getName() + "\"").build();
         } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.apimgt.rest.api.publisher.v1.impl;
 
-import com.github.jknack.handlebars.internal.lang3.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
@@ -220,7 +220,9 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
      * @param messageContext message context
      * @return A list of operation policies available for the API
      */
-    @Override public Response getAllCommonOperationPolicies(Integer limit, Integer offset, String query,MessageContext messageContext) throws APIManagementException {
+    @Override
+    public Response getAllCommonOperationPolicies(Integer limit, Integer offset, String query,
+            MessageContext messageContext) throws APIManagementException {
 
         String apiManagementExceptionErrorMessage = "";
         OperationPolicyDataListDTO policyListDTO = null;
@@ -239,13 +241,12 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
                     queryParamMap.put(keyVal[0], keyVal[1]);
                 }
 
-                name =  queryParamMap.get(ImportExportConstants.POLICY_NAME);
+                name = queryParamMap.get(ImportExportConstants.POLICY_NAME);
                 version = queryParamMap.get(ImportExportConstants.VERSION_ELEMENT);
 
                 apiManagementExceptionErrorMessage = "Error while retrieving the policy by name & version.";
-                OperationPolicyData policyData = apiProvider.getCommonOperationPolicyByPolicyName(
-                       name,
-                        version, organization, false);
+                OperationPolicyData policyData = apiProvider.getCommonOperationPolicyByPolicyName(name, version,
+                        organization, false);
 
                 // if not found, throw not found error
                 if (policyData != null) {
@@ -279,8 +280,7 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
         } catch (APIManagementException e) {
             if (RestApiUtil.isDueToResourceNotFound(e)) {
                 throw new APIManagementException(
-                        "Couldn't retrieve an existing API policy with Name: " + name + " and Version: "
-                                + version,
+                        "Couldn't retrieve an existing API policy with Name: " + name + " and Version: " + version,
                         ExceptionCodes.from(ExceptionCodes.OPERATION_POLICY_WITH_NAME_NOT_FOUND, name, version));
             } else {
                 apiManagementExceptionErrorMessage += e.getMessage();
@@ -384,6 +384,7 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
      *                                extracting the content
      * @returnA zip file containing both (if exists) operation policy specification and policy definition
      */
+    @Override
     public Response exportOperationPolicy(String name, String version, String format, MessageContext messageContext)
             throws APIManagementException {
 
@@ -412,6 +413,7 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
      * @throws APIManagementException If an error occurs while creating the directory, transferring files or
      *                                extracting the content
      */
+    @Override
     public Response importOperationPolicy(InputStream fileInputStream, Attachment fileDetail,
             MessageContext messageContext) throws APIManagementException {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
@@ -58,7 +58,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLConnection;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
@@ -228,11 +230,20 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
             APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
 
             // If name & version are given, it returns the policy data
-            if (name != null && version != null) {
+            if (query != null) {
+                Map<String, String> queryParamMap = new HashMap();
+
+                String[] queryParams = query.split("&");
+                for (String param : queryParams) {
+                    String[] keyVal = param.split(":");
+                    queryParamMap.put(keyVal[0], keyVal[1]);
+                }
+
                 apiManagementExceptionErrorMessage = "Error while retrieving the policy by name & version.";
                 exceptionErrorMessage = "An error has occurred while getting the operation policies by name & version";
-                OperationPolicyData policyData = apiProvider.getCommonOperationPolicyByPolicyName(name, version,
-                        organization, false);
+                OperationPolicyData policyData = apiProvider.getCommonOperationPolicyByPolicyName(
+                        queryParamMap.get(ImportExportConstants.POLICY_NAME),
+                        queryParamMap.get(ImportExportConstants.VERSION_ELEMENT), organization, false);
 
                 // if not found, throw not found error
                 if (policyData != null) {
@@ -247,7 +258,6 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
                             ExceptionCodes.from(ExceptionCodes.OPERATION_POLICY_NOT_FOUND, name, version));
                 }
             } else {
-                // limit = limit != null ? limit : RestApiConstants.PAGINATION_LIMIT_DEFAULT;
                 offset = offset != null ? offset : RestApiConstants.PAGINATION_OFFSET_DEFAULT;
 
                 apiManagementExceptionErrorMessage = "Error while retrieving the list of all common operation policies.";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
@@ -109,7 +109,6 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
                 if (APIConstants.YAML_CONTENT_TYPE.equals(fileContentType)) {
                     jsonContent = CommonUtil.yamlToJson(jsonContent);
                 }
-
                 policySpecification = APIUtil.getValidatedOperationPolicySpecification(jsonContent);
 
                 OperationPolicyData operationPolicyData = new OperationPolicyData();
@@ -234,13 +233,13 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
             // If name & version are given, it returns the policy data
             if (query != null) {
                 Map<String, String> queryParamMap = new HashMap();
-
                 String[] queryParams = query.split(" ");
                 for (String param : queryParams) {
                     String[] keyVal = param.split(":");
-                    queryParamMap.put(keyVal[0], keyVal[1]);
+                    if (keyVal.length == 2) {
+                        queryParamMap.put(keyVal[0], keyVal[1]);
+                    }
                 }
-
                 name = queryParamMap.get(ImportExportConstants.POLICY_NAME);
                 version = queryParamMap.get(ImportExportConstants.VERSION_ELEMENT);
 
@@ -262,7 +261,6 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
                 }
             } else {
                 offset = offset != null ? offset : RestApiConstants.PAGINATION_OFFSET_DEFAULT;
-
                 apiManagementExceptionErrorMessage = "Error while retrieving the list of all common operation policies.";
 
                 // Since policy definition is bit bulky, we don't query the definition unnecessarily.
@@ -274,7 +272,6 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
                 policyListDTO = OperationPolicyMappingUtil.fromOperationPolicyDataListToDTO(commonOperationPolicyLIst,
                         offset, limit);
             }
-
             return Response.ok().entity(policyListDTO).build();
 
         } catch (APIManagementException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
@@ -219,12 +219,12 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
      * @param messageContext message context
      * @return A list of operation policies available for the API
      */
-    @Override public Response getAllCommonOperationPolicies(Integer limit, Integer offset, String query, String name,
-            String version, MessageContext messageContext) throws APIManagementException {
+    @Override public Response getAllCommonOperationPolicies(Integer limit, Integer offset, String query,MessageContext messageContext) throws APIManagementException {
 
         String apiManagementExceptionErrorMessage = "";
         String exceptionErrorMessage = "";
         OperationPolicyDataListDTO policyListDTO = null;
+        String name = null, version = null;
         try {
             String organization = RestApiUtil.getValidatedOrganization(messageContext);
             APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
@@ -239,11 +239,14 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
                     queryParamMap.put(keyVal[0], keyVal[1]);
                 }
 
+                name =  queryParamMap.get(ImportExportConstants.POLICY_NAME);
+                version = queryParamMap.get(ImportExportConstants.VERSION_ELEMENT);
+
                 apiManagementExceptionErrorMessage = "Error while retrieving the policy by name & version.";
                 exceptionErrorMessage = "An error has occurred while getting the operation policies by name & version";
                 OperationPolicyData policyData = apiProvider.getCommonOperationPolicyByPolicyName(
-                        queryParamMap.get(ImportExportConstants.POLICY_NAME),
-                        queryParamMap.get(ImportExportConstants.VERSION_ELEMENT), organization, false);
+                       name,
+                        version, organization, false);
 
                 // if not found, throw not found error
                 if (policyData != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
@@ -101,7 +101,6 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
                 jsonContent = RestApiPublisherUtils.readInputStream(policySpecFileInputStream, policySpecFileDetail);
 
                 String fileName = policySpecFileDetail.getDataHandler().getName();
-
                 String fileContentType = URLConnection.guessContentTypeFromName(fileName);
                 if (org.apache.commons.lang3.StringUtils.isBlank(fileContentType)) {
                     fileContentType = policySpecFileDetail.getContentType().toString();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
@@ -400,7 +400,7 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
             // if not found, throw not found error
             throw new APIManagementException(
                     "Couldn't retrieve an existing common policy with Name: " + name + " and Version: " + version,
-                    ExceptionCodes.from(ExceptionCodes.OPERATION_POLICY_NOT_FOUND, name, version));
+                    ExceptionCodes.from(ExceptionCodes.OPERATION_POLICY_NOT_FOUND_WITH_NAME_AND_VERSION, name, version));
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -277,7 +277,7 @@ public class RestApiPublisherUtils {
             String policyName = archivePath + File.separator + policyData.getSpecification().getName();
             if (policyData.getSpecification() != null) {
                 if (format == null || format == "") {
-                    throw new APIImportExportException("Policy Definition file format should not be null or empty");
+                    throw new APIImportExportException("Policy Specification file format should not be null or empty");
                 }
                 if (format.equalsIgnoreCase(ExportFormat.YAML.name())) {
                     CommonUtil.writeDtoToFile(policyName, ExportFormat.YAML,

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -263,7 +263,7 @@ public class RestApiPublisherUtils {
         return fileContentType;
     }
 
-    public static File exportOperationPolicyData(OperationPolicyData policyData)
+    public static File exportOperationPolicyData(OperationPolicyData policyData, String format)
             throws APIManagementException {
 
         File exportFolder = null;
@@ -276,9 +276,18 @@ public class RestApiPublisherUtils {
             CommonUtil.createDirectory(archivePath);
             String policyName = archivePath + File.separator + policyData.getSpecification().getName();
             if (policyData.getSpecification() != null) {
-                CommonUtil.writeDtoToFile(policyName, ExportFormat.YAML,
-                        ImportExportConstants.TYPE_POLICY_SPECIFICATION,
-                        policyData.getSpecification());
+                if (format == null || format == "") {
+                    throw new APIImportExportException("Policy Definition file format should not be null or empty");
+                }
+                if (format.equalsIgnoreCase(ExportFormat.YAML.name())) {
+                    CommonUtil.writeDtoToFile(policyName, ExportFormat.YAML,
+                            ImportExportConstants.TYPE_POLICY_SPECIFICATION,
+                            policyData.getSpecification());
+                } else if (format.equalsIgnoreCase(ExportFormat.JSON.name())) {
+                    CommonUtil.writeDtoToFile(policyName, ExportFormat.JSON,
+                            ImportExportConstants.TYPE_POLICY_SPECIFICATION,
+                            policyData.getSpecification());
+                }
             }
             if (policyData.getSynapsePolicyDefinition() != null) {
                 CommonUtil.writeFile(policyName + APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION,

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -276,9 +276,6 @@ public class RestApiPublisherUtils {
             CommonUtil.createDirectory(archivePath);
             String policyName = archivePath + File.separator + policyData.getSpecification().getName();
             if (policyData.getSpecification() != null) {
-                if (format == null || format == "") {
-                    throw new APIImportExportException("Policy Specification file format should not be null or empty");
-                }
                 if (format.equalsIgnoreCase(ExportFormat.YAML.name())) {
                     CommonUtil.writeDtoToFile(policyName, ExportFormat.YAML,
                             ImportExportConstants.TYPE_POLICY_SPECIFICATION,

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -7722,21 +7722,28 @@ paths:
         This operation provides you a list of all common operation policies that can be used by any API
       operationId: getAllCommonOperationPolicies
       parameters:
-        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/policyLimit'
         - $ref: '#/components/parameters/offset'
         - name: query
           in: query
-          description: -Not supported yet-
-          schema:
-            type: string
-        - name: name
-          in: query
-          description: Policy Name to fetch ID
-          schema:
-            type: string
-        - name: version
-          in: query
-          description: Policy Version to fetch ID
+          description: |
+            **Search condition**.
+
+            You can search in attributes by using an **"<attribute>:"** modifier.
+
+            Eg.
+            "name:addHeader" will match an API Policy if the provider of the API Policy contains "addHeader".
+            "version:"v1"" will match an API Policy if the provider of the API Policy contains "v1".
+
+            Also you can use combined modifiers
+            Eg.
+            name:addHeader&version:v1 will match an API Policy if the name of the API Policy is addHeader and version is v1.
+
+            Supported attribute modifiers are [**version, name**]
+            
+            If query attributes are provided, this returns all API policies available under the given limit.
+
+            Please note that you need to use encoded URL (URL encoding) if you are using a client which does not support URL encoding (such as curl)
           schema:
             type: string
       responses:
@@ -7833,9 +7840,9 @@ paths:
       tags:
         - Import Export
       summary: |
-        Export common operation policies by their names and versions
+        Export an API Policy by its name and version
       description: |
-        This operation provides you to export preferred common API policies
+        This operation provides you to export a preferred common API policy
       operationId: exportOperationPolicy
       parameters:
         - name: name
@@ -7882,9 +7889,9 @@ paths:
     post:
       tags:
         - Import Export
-      summary: Import a Policy
+      summary: Import an API Policy
       description: |
-        This operation can be used to import a common API Policy.
+        This operation can be used to import an API Policy.
       requestBody:
         content:
           multipart/form-data:
@@ -12080,7 +12087,14 @@ components:
         Maximum size of resource array to return.
       schema:
         type: integer
-#        default: 25
+        default: 25
+    policyLimit:
+      name: limit
+      in: query
+      description: |
+        Maximum size of policy array to return.
+      schema:
+        type: integer
     Accept:
       name: Accept
       in: header

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -7855,6 +7855,11 @@ paths:
           description: Version of the policy
           schema:
             type: string
+        - name: format
+          in: query
+          description: Format of the policy definition file
+          schema:
+            type: string
       responses:
         200:
           description: |

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -7835,7 +7835,7 @@ paths:
       summary: |
         Export common operation policies by their names and versions
       description: |
-        This operation provides you to export preferred common operation policies
+        This operation provides you to export preferred common API policies
       operationId: exportOperationPolicy
       parameters:
         - name: name
@@ -7863,19 +7863,19 @@ paths:
               schema:
                 type: string
                 format: binary
+        403:
+          $ref: '#/components/responses/Forbidden'
         500:
           $ref: '#/components/responses/InternalServerError'
         404:
           $ref: '#/components/responses/NotFound'
       security:
         - OAuth2Security:
-            - apim:common_operation_policy_view
-            - apim:common_operation_policy_manage
             - apim:policies_import_export
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v2/operation-policies/export?name=addHeader&version=v1"
+            "https://127.0.0.1:9443/api/am/publisher/v3/operation-policies/export?name=addHeader&version=v1"
             > addHeader_v1.zip'
 
   /operation-policies/import:
@@ -7884,7 +7884,7 @@ paths:
         - Import Export
       summary: Import a Policy
       description: |
-        This operation can be used to import an Policy.
+        This operation can be used to import a common API Policy.
       requestBody:
         content:
           multipart/form-data:
@@ -7903,15 +7903,12 @@ paths:
             Policy Imported Successfully.
         403:
           $ref: '#/components/responses/Forbidden'
-        404:
-          $ref: '#/components/responses/NotFound'
         409:
           $ref: '#/components/responses/Conflict'
         500:
           $ref: '#/components/responses/InternalServerError'
       security:
         - OAuth2Security:
-            - apim:admin
             - apim:policies_import_export
       x-code-samples:
         - lang: Curl
@@ -12083,7 +12080,7 @@ components:
         Maximum size of resource array to return.
       schema:
         type: integer
-        default: 25
+#        default: 25
     Accept:
       name: Accept
       in: header

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -11658,6 +11658,7 @@ components:
         version:
           type: string
           example: v1
+          default: v1
         displayName:
           type: string
           example: Remove Header Policy

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -7729,6 +7729,16 @@ paths:
           description: -Not supported yet-
           schema:
             type: string
+        - name: name
+          in: query
+          description: Policy Name to fetch ID
+          schema:
+            type: string
+        - name: version
+          in: query
+          description: Policy Version to fetch ID
+          schema:
+            type: string
       responses:
         200:
           description: |
@@ -7751,11 +7761,11 @@ paths:
         - OAuth2Security:
             - apim:common_operation_policy_view
             - apim:common_operation_policy_manage
+            - apim:policies_import_export
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
             "https://127.0.0.1:9443/api/am/publisher/v3/operation-policies"'
-
     post:
       tags:
         - Operation Policies
@@ -7818,6 +7828,97 @@ paths:
             -H "Content-Type: multipart/form-data" -F policySpecFile=@setHeader.yaml -F policyDefinitionFile=@setHeader.j2
             "https://127.0.0.1:9443/api/am/publisher/v3/operation-policies"'
 
+  /operation-policies/export:
+    get:
+      tags:
+        - Import Export
+      summary: |
+        Export common operation policies by their names and versions
+      description: |
+        This operation provides you to export preferred common operation policies
+      operationId: exportOperationPolicy
+      parameters:
+        - name: name
+          in: query
+          description: Policy name
+          schema:
+            type: string
+        - name: version
+          in: query
+          description: Version of the policy
+          schema:
+            type: string
+      responses:
+        200:
+          description: |
+            OK.
+            Export Successful.
+          headers:
+            Content-Type:
+              description: The content type of the body.
+              schema:
+                type: string
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        500:
+          $ref: '#/components/responses/InternalServerError'
+        404:
+          $ref: '#/components/responses/NotFound'
+      security:
+        - OAuth2Security:
+            - apim:common_operation_policy_view
+            - apim:common_operation_policy_manage
+            - apim:policies_import_export
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://127.0.0.1:9443/api/am/publisher/v2/operation-policies/export?name=addHeader&version=v1"
+            > addHeader_v1.zip'
+
+  /operation-policies/import:
+    post:
+      tags:
+        - Import Export
+      summary: Import a Policy
+      description: |
+        This operation can be used to import an Policy.
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  description: Zip archive consisting on exported policy configuration
+                  format: binary
+      responses:
+        200:
+          description: |
+            Created.
+            Policy Imported Successfully.
+        403:
+          $ref: '#/components/responses/Forbidden'
+        404:
+          $ref: '#/components/responses/NotFound'
+        409:
+          $ref: '#/components/responses/Conflict'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:admin
+            - apim:policies_import_export
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          -F file=add_header_v1.zip "https://127.0.0.1:9443/api/am/publisher/v3/operation-policies/import"'
+      operationId: importOperationPolicy
+
   /operation-policies/{operationPolicyId}:
     get:
       tags:
@@ -7853,6 +7954,7 @@ paths:
         - OAuth2Security:
             - apim:common_operation_policy_view
             - apim:common_operation_policy_manage
+            - apim:policies_import_export
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -7882,6 +7984,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:common_operation_policy_manage
+            - apim:policies_import_export
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -11543,6 +11646,9 @@ components:
         name:
           type: string
           example: removeHeaderPolicy
+        version:
+          type: string
+          example: v1
         displayName:
           type: string
           example: Remove Header Policy
@@ -12149,6 +12255,7 @@ components:
           scopes:
             openid: Authorize access to user details
             apim:api_view: View API
+            apim:policies_import_export: Export and import policies related operations
             apim:api_create: Create API
             apim:api_delete: Delete API
             apim:api_publish: Publish API


### PR DESCRIPTION
**Purpose**
Fix: [wso2/api-manager#223](https://github.com/wso2/api-manager/issues/223) [wso2/api-manager#344](https://github.com/wso2/api-manager/issues/344) [wso2/api-manager#345](https://github.com/wso2/api-manager/issues/345)

**Approach**
- Add export operation policy API to export a policy by name and version.
- Add import operation policy API to accept an archive file.
- Add `policyName` and `policyVersion` query parameters support for `GET` operation polices API
- Adde Unit Test for `ImportAPIPolicy` function