### PR TITLE
Fix issue when globally disabling cors

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidator.java
@@ -411,7 +411,11 @@ public class APIKeyValidator {
             }
 
             resourceString = selectedResource.getDispatcherHelper().getString();
+            resourceArray = new ArrayList<>(Arrays.asList(resourceString));
             resourceCacheKey = APIUtil.getResourceInfoDTOCacheKey(apiContext, apiVersion, resourceString, httpMethod);
+            synCtx.setProperty(APIConstants.API_ELECTED_RESOURCE, resourceString);
+            synCtx.setProperty(APIConstants.API_RESOURCE_CACHE_KEY, resourceCacheKey);
+            synCtx.setProperty(APIConstants.REST_METHOD, httpMethod);
 
             if (log.isDebugEnabled()) {
                 log.debug("Selected Resource: " + resourceString);


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/309. Setting following properties to message context from Authentication flow if it's not set in CORS handler:

```
APIConstants.API_ELECTED_RESOURCE
APIConstants.API_RESOURCE_CACHE_KEY
APIConstants.REST_METHOD
```