### PR TITLE
Convert entityInfo into a JsonObject inside logAuditMessage

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -1289,7 +1289,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
 
                 JSONObject appLogObject = new JSONObject();
                 appLogObject.put("Re-Generated Keys for application with client Id", clientId);
-                APIUtil.logAuditMessage(APIConstants.AuditLogConstants.APPLICATION, appLogObject,
+                APIUtil.logAuditMessage(APIConstants.AuditLogConstants.APPLICATION, appLogObject.toString(),
                         APIConstants.AuditLogConstants.UPDATED, this.username);
 
                 return keyManager.getNewApplicationAccessToken(tokenRequest);
@@ -2854,7 +2854,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 subsLogObject.put(APIConstants.AuditLogConstants.APPLICATION_NAME, applicationName);
                 subsLogObject.put(APIConstants.AuditLogConstants.TIER, identifier.getTier());
 
-                APIUtil.logAuditMessage(APIConstants.AuditLogConstants.SUBSCRIPTION, subsLogObject,
+                APIUtil.logAuditMessage(APIConstants.AuditLogConstants.SUBSCRIPTION, subsLogObject.toString(),
                         APIConstants.AuditLogConstants.CREATED, this.username);
 
                 if (workflowResponse == null) {
@@ -3042,7 +3042,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 subsLogObject.put(APIConstants.AuditLogConstants.TIER, identifier.getTier());
                 subsLogObject.put(APIConstants.AuditLogConstants.REQUESTED_TIER, requestedThrottlingPolicy);
 
-                APIUtil.logAuditMessage(APIConstants.AuditLogConstants.SUBSCRIPTION, subsLogObject,
+                APIUtil.logAuditMessage(APIConstants.AuditLogConstants.SUBSCRIPTION, subsLogObject.toString(),
                         APIConstants.AuditLogConstants.UPDATED, this.username);
 
                 if (workflowResponse == null) {
@@ -3232,7 +3232,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             subsLogObject.put(APIConstants.AuditLogConstants.APPLICATION_ID, applicationId);
             subsLogObject.put(APIConstants.AuditLogConstants.APPLICATION_NAME, applicationName);
 
-            APIUtil.logAuditMessage(APIConstants.AuditLogConstants.SUBSCRIPTION, subsLogObject,
+            APIUtil.logAuditMessage(APIConstants.AuditLogConstants.SUBSCRIPTION, subsLogObject.toString(),
                     APIConstants.AuditLogConstants.DELETED, this.username);
 
         } catch (WorkflowException e) {
@@ -3472,7 +3472,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         appLogObject.put(APIConstants.AuditLogConstants.GROUPS, application.getGroupId());
         appLogObject.put(APIConstants.AuditLogConstants.OWNER, application.getSubscriber().getName());
 
-        APIUtil.logAuditMessage(APIConstants.AuditLogConstants.APPLICATION, appLogObject,
+        APIUtil.logAuditMessage(APIConstants.AuditLogConstants.APPLICATION, appLogObject.toString(),
                 APIConstants.AuditLogConstants.CREATED, this.username);
 
         boolean isTenantFlowStarted = false;
@@ -3692,7 +3692,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         appLogObject.put(APIConstants.AuditLogConstants.GROUPS, application.getGroupId());
         appLogObject.put(APIConstants.AuditLogConstants.OWNER, application.getSubscriber().getName());
 
-        APIUtil.logAuditMessage(APIConstants.AuditLogConstants.APPLICATION, appLogObject,
+        APIUtil.logAuditMessage(APIConstants.AuditLogConstants.APPLICATION, appLogObject.toString(),
                 APIConstants.AuditLogConstants.UPDATED, this.username);
 
 
@@ -3884,7 +3884,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             appLogObject.put(APIConstants.AuditLogConstants.GROUPS, application.getGroupId());
             appLogObject.put(APIConstants.AuditLogConstants.OWNER, application.getSubscriber().getName());
 
-            APIUtil.logAuditMessage(APIConstants.AuditLogConstants.APPLICATION, appLogObject,
+            APIUtil.logAuditMessage(APIConstants.AuditLogConstants.APPLICATION, appLogObject.toString(),
                     APIConstants.AuditLogConstants.DELETED, this.username);
 
         } catch (WorkflowException e) {
@@ -4150,7 +4150,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
 
             JSONObject appLogObject = new JSONObject();
             appLogObject.put("Generated keys for application", application.getName());
-            APIUtil.logAuditMessage(APIConstants.AuditLogConstants.APPLICATION, appLogObject,
+            APIUtil.logAuditMessage(APIConstants.AuditLogConstants.APPLICATION, appLogObject.toString(),
                     APIConstants.AuditLogConstants.UPDATED, this.username);
 
             String orgId = application.getOrganization();
@@ -4661,7 +4661,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             appLogObject.put("Updated Oauth app with Call back URL", callbackUrl);
             appLogObject.put("Updated Oauth app with grant types", jsonString);
 
-            APIUtil.logAuditMessage(APIConstants.AuditLogConstants.APPLICATION, appLogObject,
+            APIUtil.logAuditMessage(APIConstants.AuditLogConstants.APPLICATION, appLogObject.toString(),
                     APIConstants.AuditLogConstants.UPDATED, this.username);
             return updatedAppInfo;
         } finally {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -708,7 +708,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         apiLogObject.put(APIConstants.AuditLogConstants.VERSION, api.getId().getVersion());
         apiLogObject.put(APIConstants.AuditLogConstants.PROVIDER, api.getId().getProviderName());
 
-        APIUtil.logAuditMessage(APIConstants.AuditLogConstants.API, apiLogObject,
+        APIUtil.logAuditMessage(APIConstants.AuditLogConstants.API, apiLogObject.toString(),
                 APIConstants.AuditLogConstants.CREATED, this.username);
 
         if (log.isDebugEnabled()) {
@@ -1272,7 +1272,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         apiLogObject.put(APIConstants.AuditLogConstants.VERSION, api.getId().getVersion());
         apiLogObject.put(APIConstants.AuditLogConstants.PROVIDER, api.getId().getProviderName());
 
-        APIUtil.logAuditMessage(APIConstants.AuditLogConstants.API, apiLogObject,
+        APIUtil.logAuditMessage(APIConstants.AuditLogConstants.API, apiLogObject.toString(),
                 APIConstants.AuditLogConstants.UPDATED, this.username);
         //update doc visibility
         List<Documentation> docsList = getAllDocumentation(api.getId());
@@ -1390,7 +1390,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         } catch (APIPersistenceException e) {
             throw new APIManagementException("Error while updating API details", e);
         }
-        APIUtil.logAuditMessage(APIConstants.AuditLogConstants.API, apiLogObject,
+        APIUtil.logAuditMessage(APIConstants.AuditLogConstants.API, apiLogObject.toString(),
                 APIConstants.AuditLogConstants.UPDATED, this.username);
 
         //Validate Transports
@@ -3387,7 +3387,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             apiLogObject.put(APIConstants.AuditLogConstants.VERSION, api.getId().getVersion());
             apiLogObject.put(APIConstants.AuditLogConstants.PROVIDER, api.getId().getProviderName());
 
-            APIUtil.logAuditMessage(APIConstants.AuditLogConstants.API, apiLogObject,
+            APIUtil.logAuditMessage(APIConstants.AuditLogConstants.API, apiLogObject.toString(),
                     APIConstants.AuditLogConstants.DELETED, this.username);
         }
 
@@ -7010,7 +7010,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             apiLogObject.put(APIConstants.AuditLogConstants.VERSION, identifier.getVersion());
             apiLogObject.put(APIConstants.AuditLogConstants.PROVIDER, identifier.getProviderName());
 
-            APIUtil.logAuditMessage(APIConstants.AuditLogConstants.API_PRODUCT, apiLogObject,
+            APIUtil.logAuditMessage(APIConstants.AuditLogConstants.API_PRODUCT, apiLogObject.toString(),
                     APIConstants.AuditLogConstants.DELETED, this.username);
 
             GatewayArtifactsMgtDAO.getInstance().deleteGatewayArtifacts(apiProduct.getUuid());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8215,13 +8215,18 @@ public final class APIUtil {
      * @param action      - The type of action performed. Ex: Create, Update
      * @param performedBy - The user who performs the action.
      */
-    public static void logAuditMessage(String entityType, JSONObject entityInfo, String action, String performedBy) {
+    public static void logAuditMessage(String entityType, String entityInfo, String action, String performedBy) {
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("typ", entityType);
         jsonObject.put("action", action);
         jsonObject.put("performedBy", performedBy);
-        jsonObject.put("info", entityInfo);
+        try {
+            JSONObject entityInfoJson = (JSONObject) new JSONParser().parse(entityInfo);
+            jsonObject.put("info", entityInfoJson);
+        } catch (ParseException e) {
+            jsonObject.put("info", entityInfo);
+        }
         audit.info(StringEscapeUtils.unescapeJava(jsonObject.toString()));
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8224,7 +8224,7 @@ public final class APIUtil {
         try {
             JSONObject entityInfoJson = (JSONObject) new JSONParser().parse(entityInfo);
             jsonObject.put("info", entityInfoJson);
-        } catch (ParseException e) {
+        } catch (ParseException ignored) { // if entityInfo cannot be parsed as json, log as a simple string 
             jsonObject.put("info", entityInfo);
         }
         audit.info(StringEscapeUtils.unescapeJava(jsonObject.toString()));


### PR DESCRIPTION
Convert entityInfo into a JsonObject inside logAuditMessage. 

Will be able to close https://github.com/wso2/carbon-apimgt/pull/11333 with this PR.