### PR TITLE
Making the Header validations of Swagger Schema Validator Case Insensitive

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
@@ -163,7 +163,9 @@ public class APIMgtLatencyStatsHandler extends AbstractHandler {
             if (pathItem != null) {
                 List<Operation> operations = pathItem.readOperations();
                 for (Operation operation : operations) {
-                    operation.setParameters(getLowercaseHeaderParameters(operation.getParameters()));
+                    if (operation.getParameters() != null) {
+                        operation.setParameters(getLowercaseHeaderParameters(operation.getParameters()));
+                    }
                 }
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
@@ -17,8 +17,14 @@
 */
 package org.wso2.carbon.apimgt.gateway.handlers.common;
 
+import com.atlassian.oai.validator.model.Headers;
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.parameters.HeaderParameter;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.parser.core.models.ParseOptions;
 import org.apache.axis2.Constants;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -26,9 +32,9 @@ import org.apache.synapse.MessageContext;
 import org.apache.synapse.config.Entry;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.AbstractHandler;
+import org.jetbrains.annotations.NotNull;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
-import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.tracing.TracingSpan;
 import org.wso2.carbon.apimgt.tracing.TracingTracer;
@@ -36,6 +42,11 @@ import org.wso2.carbon.apimgt.tracing.Util;
 import org.wso2.carbon.apimgt.tracing.telemetry.TelemetrySpan;
 import org.wso2.carbon.apimgt.tracing.telemetry.TelemetryTracer;
 import org.wso2.carbon.apimgt.tracing.telemetry.TelemetryUtil;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class APIMgtLatencyStatsHandler extends AbstractHandler {
     private static final Log log = LogFactory.getLog(APIMgtLatencyStatsHandler.class);
@@ -118,8 +129,12 @@ public class APIMgtLatencyStatsHandler extends AbstractHandler {
                     if (localEntryObj != null) {
                         swagger = localEntryObj.getValue().toString();
                         OpenAPIParser parser = new OpenAPIParser();
-                        openAPI = parser.readContents(swagger,
-                                null, null).getOpenAPI();
+                        ParseOptions parseOptions = new ParseOptions();
+                        parseOptions.setResolveFully(true);
+                        openAPI = parser.readContents(swagger, null, parseOptions).getOpenAPI();
+                        // HTTP headers should be case insensitive as for HTTP 1.1 RFC
+                        // Thus converting headers to lowercase for schema validation.
+                        convertHeadersToLowercase(openAPI);
                     }
                     long endTime = System.currentTimeMillis();
                     if (log.isDebugEnabled()) {
@@ -132,6 +147,57 @@ public class APIMgtLatencyStatsHandler extends AbstractHandler {
         messageContext.setProperty(APIMgtGatewayConstants.OPEN_API_OBJECT, openAPI);
         // Add swagger String to message context
         messageContext.setProperty(APIMgtGatewayConstants.OPEN_API_STRING, swagger);
+    }
+
+    /**
+     * This method iterate through openAPI paths and convert header parameter names to lowercase for each operation
+     *
+     * @param openAPI openAPI object
+     */
+    private void convertHeadersToLowercase(OpenAPI openAPI) {
+
+        // Iterate each path
+        for (Map.Entry<String, PathItem> entry : openAPI.getPaths().entrySet()) {
+            // Iterate each operation
+            PathItem pathItem = entry.getValue();
+            if (pathItem != null) {
+                List<Operation> operations = pathItem.readOperations();
+                for (Operation operation : operations) {
+                    operation.setParameters(getLowercaseHeaderParameters(operation.getParameters()));
+                }
+            }
+        }
+    }
+
+    /**
+     * This method read the parameter list and convert header parameter's name to lowercase
+     * @param parameters list of params
+     * @return
+     */
+    @NotNull
+    private List<Parameter> getLowercaseHeaderParameters(List<Parameter> parameters) {
+
+        List<Parameter> headerParameters = parameters.stream()
+                .filter(param -> param instanceof HeaderParameter)
+                .filter(param -> !param.getName().equalsIgnoreCase(Headers.CONTENT_TYPE)) // Ignore content-type header
+                .collect(Collectors.toList());
+        List<Parameter> modifiedHeaderParameters = headerParameters.stream()
+                .map(APIMgtLatencyStatsHandler::replaceLowerCaseHeaderName).collect(Collectors.toList());
+        List<Parameter> nonHeaderParameters = parameters.stream()
+                .filter(param -> !(param instanceof HeaderParameter)).collect(Collectors.toList());
+        nonHeaderParameters.addAll(modifiedHeaderParameters);
+        return nonHeaderParameters;
+    }
+
+    /**
+     * This method convert parameter name to lowercase.
+     * @param parameter param
+     * @return
+     */
+    private static Parameter replaceLowerCaseHeaderName(Parameter parameter) {
+
+        parameter.setName(parameter.getName().toLowerCase(Locale.ROOT));
+        return parameter;
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/model/OpenAPIRequest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/model/OpenAPIRequest.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -76,7 +77,7 @@ public class OpenAPIRequest implements Request {
             SwaggerParseResult swaggerParseResult =
                     openAPIParser.readContents(swagger, new ArrayList<>(), new ParseOptions());
             OpenAPI openAPI = swaggerParseResult.getOpenAPI();
-            validatePath(openAPI);;
+            validatePath(openAPI);
         }
         //extract transport headers
         Map<String, String> transportHeaders = (Map<String, String>)
@@ -91,7 +92,8 @@ public class OpenAPIRequest implements Request {
         for (Map.Entry<String, Collection<String>> header : headerMap.entrySet()) {
             String headerKey = header.getKey();
             String value =  header.getValue().iterator().next();
-            headerKey = headerKey.equalsIgnoreCase(contentTypeHeader) ? "Content-Type" : headerKey;
+            headerKey = headerKey.equalsIgnoreCase(contentTypeHeader) ?
+                    "Content-Type" : headerKey.toLowerCase(Locale.ROOT);
             headers.put(headerKey, value);
         }
         String apiResource = messageContext.getProperty(APIMgtGatewayConstants.RESOURCE).toString();

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/TestSchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/TestSchemaValidator.java
@@ -16,6 +16,9 @@
 
 package org.wso2.carbon.apimgt.gateway.handlers.security;
 
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.core.models.ParseOptions;
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
@@ -209,6 +212,11 @@ public class TestSchemaValidator {
                 getResource("swaggerEntry/swagger.json").getFile());
         String swaggerValue = FileUtils.readFileToString(swaggerJsonFile);
 
+        OpenAPIParser parser = new OpenAPIParser();
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolveFully(true);
+        OpenAPI openAPI = parser.readContents(swaggerValue, null, parseOptions).getOpenAPI();
+
         Mockito.doReturn(env).when(messageContext).getEnvelope();
         // Mockito.when()
 
@@ -234,6 +242,8 @@ public class TestSchemaValidator {
                 thenReturn(httpMethod);
         Mockito.when((String) messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_STRING))
                 .thenReturn(swaggerValue);
+        Mockito.when((OpenAPI) messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_OBJECT))
+                .thenReturn(openAPI);
         Map<String, String> headers = new HashMap<>();
         headers.put(CONTENT_TYPE_HEADER, contentType);
         Mockito.when(axis2MsgContext.getProperty(TRANSPORT_HEADERS)).thenReturn(headers);


### PR DESCRIPTION
### Purpose

Making the Header validations of Swagger Schema Validator Case Insensitive
Related Issue: https://github.com/wso2/api-manager/issues/559

### Approach

Feed the lower cased headers to the schema validation library and pick the lower cased headers from the swagger for header validations.