### PR TITLE
Remove the WSDL FileInputStream Reset Logic

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3337,22 +3337,6 @@ public class ApisApiServiceImpl implements ApisApiService {
             // Validation failure
             RestApiUtil.handleBadRequest(validationResponse.getError(), log);
         }
-
-        if (fileInputStream != null) {
-            if (fileInputStream.markSupported()) {
-                // For uploading the WSDL below will require re-reading from the input stream hence resetting
-                try {
-                    fileInputStream.reset();
-                } catch (IOException e) {
-                    throw new APIManagementException("Error occurred while trying to reset the content stream of the " +
-                            "WSDL", e);
-                }
-            } else {
-                log.warn("Marking is not supported in 'fileInputStream' InputStream type: "
-                        + fileInputStream.getClass() + ". Skipping validating WSDL to avoid re-reading from the " +
-                        "input stream.");
-            }
-        }
         return validationResponse;
     }
 


### PR DESCRIPTION
## Purpose
Remove the WSDL FileInputStream Reset Logic
Related Github Issue: https://github.com/wso2/product-apim/issues/12149

## Approach
When creating a SOAP API or generating SOAP to REST, since the WSDL content retrieved after validating the content is used  instead of directly using the FileInputStream, there is no need of the FileInputStream reset logic. Hence, removed the FileInputStream reset logic.