### PR TITLE
[9.22.x] Update carbon-spimgt version 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.broker.lifecycle/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.broker.lifecycle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.cache.invalidation/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.cache.invalidation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.cleanup.service/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.cleanup.service/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.jms/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.jms/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.core/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.devops.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.devops.impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.eventing.hub/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing.hub/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.eventing/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.eventing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.jms.listener/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.jms.listener/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt.client/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.notification/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.notification/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
     </parent>
     <artifactId>org.wso2.carbon.apimgt.notification</artifactId>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.output.adapter.http/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.output.adapter.http/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.devops/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.devops/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.gateway/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.solace/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.solace/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.tokenmgt/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.tokenmgt/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/pom.xml
+++ b/components/apimgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/samples/org.wso2.carbon.apimgt.samples.calculator/pom.xml
+++ b/components/apimgt/samples/org.wso2.carbon.apimgt.samples.calculator/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/apimgt/samples/org.wso2.carbon.apimgt.samples.pizzashack/pom.xml
+++ b/components/apimgt/samples/org.wso2.carbon.apimgt.samples.pizzashack/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.cache.invalidation.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.cache.invalidation.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.eventing.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.eventing.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt-feature</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.eventing.hub.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.eventing.hub.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apimgt-feature</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.internal.service.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.internal.service.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.jms.listener.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.jms.listener.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.keymanager.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.keymanager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.persistence.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.persistence.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.dcr.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.dcr.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.devops.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.devops.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.gateway.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.scxml.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.scxml.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.tokenmgt.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.tokenmgt.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-feature</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/apimgt/org.wso2.carbon.apimgt.tracing.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.tracing.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apimgt-feature</artifactId>
         <groupId>org.wso2.carbon.apimgt</groupId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/features/apimgt/pom.xml
+++ b/features/apimgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt</groupId>
     <artifactId>carbon-apimgt</artifactId>
     <packaging>pom</packaging>
-    <version>9.22.33-SNAPSHOT</version>
+    <version>9.22.35-SNAPSHOT</version>
     <name>WSO2 Carbon - API Management Aggregator POM</name>
     <url>https://wso2.org</url>
 
@@ -1926,7 +1926,7 @@
 
         <!-- APIM Component Version -->
         <hamcrest.version>1.3</hamcrest.version>
-        <carbon.apimgt.version>9.22.33-SNAPSHOT</carbon.apimgt.version>
+        <carbon.apimgt.version>9.22.35-SNAPSHOT</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
         <carbon.analytics.common.version>5.2.41</carbon.analytics.common.version>

--- a/service-stubs/apimgt/org.wso2.carbon.apimgt.keymgt.stub/pom.xml
+++ b/service-stubs/apimgt/org.wso2.carbon.apimgt.keymgt.stub/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>apimgt-stubs</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/apimgt/pom.xml
+++ b/service-stubs/apimgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt</groupId>
         <artifactId>carbon-apimgt</artifactId>
-        <version>9.22.33-SNAPSHOT</version>
+        <version>9.22.35-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Purpose

This PR updates the carbon-apimgt version to `9.22.35-SNAPSHOT` to prepare for the release build.