### PR TITLE
Skip the API that is not stored in APIM DB in devportal API search

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5637,8 +5637,14 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 List<Object> apiList = new ArrayList<>();
                 for (DevPortalAPIInfo devPortalAPIInfo : list) {
                     API mappedAPI = APIMapper.INSTANCE.toApi(devPortalAPIInfo);
-                    mappedAPI.setRating(APIUtil.getAverageRating(mappedAPI.getUuid()));
-                    apiList.add(mappedAPI);
+                    try {
+                        mappedAPI.setRating(APIUtil.getAverageRating(mappedAPI.getUuid()));
+                        apiList.add(mappedAPI);
+                    } catch (APIManagementException e) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Getting Average rating failed for API: " + mappedAPI.getUuid());
+                        }
+                    }
                 }
                 apiSet.addAll(apiList);
                 result.put("apis", apiSet);


### PR DESCRIPTION
Resolves https://github.com/wso2-enterprise/choreo/issues/14546

If an API present in the mongoDB search result is not persisted in the APIM DB, APIM DB retrival call will fail for that API. And will give a 500 status code to devportal API search call (`devportal/v2/apis`). This fix will skip such an APIs so that remaining search results will be sent with a 200 status code.