### PR TITLE
Support for role names with white spaces for API visibility

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5094,7 +5094,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         }
 
         if (publisherAccessControlRoles != null && !publisherAccessControlRoles.trim().isEmpty()) {
-            String[] accessControlRoleList = publisherAccessControlRoles.replaceAll("\\s+", "").split(",");
+            String[] accessControlRoleList = publisherAccessControlRoles.split(",");
             if (log.isDebugEnabled()) {
                 log.debug("API has restricted access to creators and publishers with the roles : "
                         + Arrays.toString(accessControlRoleList));

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -7450,6 +7450,8 @@ public final class APIUtil {
 
         if (role.contains("&")) {
             return role.replaceAll("&", "%26");
+        } else if (role.contains(" ")) {
+            return role.replaceAll(" ", "%20");
         } else {
             return role;
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilTest.java
@@ -1680,6 +1680,7 @@ public class APIUtilTest {
         Assert.assertEquals("Test%26123", APIUtil.sanitizeUserRole("Test&123"));
         Assert.assertEquals("Test%26123%26test", APIUtil.sanitizeUserRole("Test&123&test"));
         Assert.assertEquals("Test123", APIUtil.sanitizeUserRole("Test123"));
+        Assert.assertEquals("Role%20A", APIUtil.sanitizeUserRole("Role A"));
     }
 
     @Test


### PR DESCRIPTION
This provides support for role names with white spaces (eg: Role A) for role restricted API visibility in publisher portal.

Fix for - https://github.com/wso2/api-manager/issues/553