### PR TITLE
Send a custom error code when an API with no DB record is requested

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -114,7 +114,7 @@ public enum ExceptionCodes implements ErrorHandler {
             "Environment specific api property config is not valid. %s", false),
     API_IS_NOT_FOUND_IN_DATABASE(900359, "API is not consistently stored", 500,
             "API is not consistently stored"),
-    API_IS_NOT_FOUND_IN_REGISTRY(900360, "API is not consistently stored", 404,
+    API_IS_NOT_FOUND_IN_REGISTRY(900360, "API Not Found", 404, "Requested API with id '%s' not found")
             "API is not consistently stored"),
 
     //Lifecycle related codes

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -114,8 +114,7 @@ public enum ExceptionCodes implements ErrorHandler {
             "Environment specific api property config is not valid. %s", false),
     API_IS_NOT_FOUND_IN_DATABASE(900359, "API is not consistently stored", 500,
             "API is not consistently stored"),
-    API_IS_NOT_FOUND_IN_REGISTRY(900360, "API Not Found", 404, "Requested API with id '%s' not found")
-            "API is not consistently stored"),
+    API_IS_NOT_FOUND_IN_REGISTRY(900360, "API Not Found", 404, "Requested API with id '%s' not found"),
 
     //Lifecycle related codes
     API_UPDATE_FORBIDDEN_PER_LC(900380, "Insufficient permission to update the API", 403,

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -112,6 +112,10 @@ public enum ExceptionCodes implements ErrorHandler {
     ORGANIZATION_NOT_FOUND(900357, "Organization Not Found", 400, "Organization is not found in the request"),
     INVALID_ENV_API_PROP_CONFIG(900358, "Invalid environment specific api property config", 400,
             "Environment specific api property config is not valid. %s", false),
+    API_IS_NOT_FOUND_IN_DATABASE(900359, "API is not consistently stored", 500,
+            "API is not consistently stored"),
+    API_IS_NOT_FOUND_IN_REGISTRY(900360, "API is not consistently stored", 404,
+            "API is not consistently stored"),
 
     //Lifecycle related codes
     API_UPDATE_FORBIDDEN_PER_LC(900380, "Insufficient permission to update the API", 403,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -7910,7 +7910,13 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 throw new APIMgtResourceNotFoundException(msg);
             }
         } catch (APIPersistenceException e) {
-            throw new APIManagementException("Failed to get API", e);
+            if (e.getErrorHandler().getErrorCode() == ExceptionCodes.INTERNAL_ERROR.getErrorCode()){
+                String msg = e.getMessage();
+                log.error(msg);
+                throw new APIManagementException(msg, ExceptionCodes.from(ExceptionCodes.API_IS_NOT_FOUND_IN_REGISTRY, uuid));
+            } else {
+                throw new APIManagementException("Failed to get API", e);
+            }
         } catch (OASPersistenceException e) {
             throw new APIManagementException("Error while retrieving the OAS definition", e);
         } catch (ParseException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -7910,13 +7910,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 throw new APIMgtResourceNotFoundException(msg);
             }
         } catch (APIPersistenceException e) {
-            if (e.getErrorHandler().getErrorCode() == ExceptionCodes.INTERNAL_ERROR.getErrorCode()){
-                String msg = e.getMessage();
-                log.error(msg);
-                throw new APIManagementException(msg, ExceptionCodes.from(ExceptionCodes.API_IS_NOT_FOUND_IN_REGISTRY, uuid));
-            } else {
-                throw new APIManagementException("Failed to get API", e);
-            }
+            throw new APIManagementException(e.getMessage(), e.getErrorHandler());
         } catch (OASPersistenceException e) {
             throw new APIManagementException("Error while retrieving the OAS definition", e);
         } catch (ParseException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -6999,7 +6999,7 @@ public class ApiMgtDAO {
                 if (id == -1) {
                     String msg = "Unable to find the API with UUID : " + uuid + " in the database";
                     log.error(msg);
-                    throw new APIManagementException(msg);
+                    throw new APIManagementException(msg, ExceptionCodes.from(ExceptionCodes.API_IS_NOT_FOUND_IN_DATABASE, uuid));
                 }
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -4087,7 +4087,7 @@ public class ApisApiServiceImpl implements ApisApiService {
         return null;
     }
 
-    private APIDTO getAPIByID(String apiId, APIProvider apiProvider, String organization) {
+    private APIDTO getAPIByID(String apiId, APIProvider apiProvider, String organization) throws APIManagementException{
         try {
             API api = apiProvider.getAPIbyUUID(apiId, organization);
             api.setOrganization(organization);
@@ -4100,8 +4100,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             } else if (isAuthorizationFailure(e)) {
                 RestApiUtil.handleAuthorizationFailure("User is not authorized to access the API", e, log);
             } else {
-                String errorMessage = "Error while retrieving API : " + apiId;
-                RestApiUtil.handleInternalServerError(errorMessage, e, log);
+                throw e;
             }
         }
         return null;


### PR DESCRIPTION
Resolves: https://github.com/wso2-enterprise/choreo/issues/14755

Send custom error codes when an API is partially saved in DBs.

In this change, 
- When an API is not preserved in the SQL DB, APIM will throw an specific exception with the error code (900359). (since the existence of the API in mongoDB is checked before SQL)
- When an API is not preserved in the mongoDB, the APIM will send a 404 response.