### PR TITLE
Adding the changes related to https://github.com/wso2/wso2-synapse/pull/1996

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/RequestContextDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/RequestContextDTO.java
@@ -42,9 +42,6 @@ public class RequestContextDTO {
     private APIRequestInfoDTO apiRequestInfo;
     // client certificate from transport level
     private Certificate[] clientCerts;
-    @Deprecated
-    // X509Certificate client certificate from transport level
-    private X509Certificate[] x509clientCerts;
     // custom property map used to populate customProperty key template value
     private Map<String, Object> customProperty;
 
@@ -68,17 +65,8 @@ public class RequestContextDTO {
         this.apiRequestInfo = apiRequestInfo;
     }
 
-    public Certificate[] getClientCerts() {
-
-        return (Certificate[]) SerializationUtils.clone(clientCerts);
-    }
-
-    public void setClientCerts(Certificate[] clientCerts) {
-
-        this.clientCerts = (Certificate[]) SerializationUtils.clone(clientCerts);
-    }
-
-    public X509Certificate[] getX509ClientCerts() {
+    @Deprecated
+    public X509Certificate[] getClientCerts() {
         X509Certificate[] x509Certificates = new X509Certificate[clientCerts.length];
         for (int i = 0; i < clientCerts.length; i++) {
             try {
@@ -87,11 +75,11 @@ public class RequestContextDTO {
                 log.error("Error while converting client certificate", e);
             }
         }
-        return x509Certificates;
+        return (X509Certificate[]) SerializationUtils.clone(x509Certificates);
     }
 
-    public void setX509ClientCerts(X509Certificate[] x509ClientCerts) {
-
+    @Deprecated
+    public void setClientCerts(X509Certificate[] x509ClientCerts) {
         Certificate[] certificates = new Certificate[x509ClientCerts.length];
         for (int i = 0; i < x509ClientCerts.length; i++) {
             try {
@@ -102,7 +90,15 @@ public class RequestContextDTO {
                 log.error("Error while converting client certificate", e);
             }
         }
-        this.x509clientCerts = (X509Certificate[]) SerializationUtils.clone(certificates);
+        this.clientCerts = (Certificate[]) SerializationUtils.clone(certificates);
+    }
+
+    public Certificate[] getClientCertsLatest() {
+        return (Certificate[]) SerializationUtils.clone(clientCerts);
+    }
+
+    public void setClientCertsLatest(Certificate[] clientCerts) {
+        this.clientCerts = (Certificate[]) SerializationUtils.clone(clientCerts);
     }
 
     public Map<String, Object> getCustomProperty() {

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/RequestContextDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/RequestContextDTO.java
@@ -18,24 +18,35 @@
 package org.wso2.carbon.apimgt.common.gateway.dto;
 
 import org.apache.commons.lang.SerializationUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
+import java.io.ByteArrayInputStream;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateFactory;
 import java.util.Map;
 
+import javax.security.cert.CertificateException;
 import javax.security.cert.X509Certificate;
 
 /**
  * Representation of Request Information.
  */
 public class RequestContextDTO {
+    private static final Log log = LogFactory.getLog(RequestContextDTO.class);
 
     // request message information
-    MsgInfoDTO msgInfo;
+    private MsgInfoDTO msgInfo;
     // invoked API request information
-    APIRequestInfoDTO apiRequestInfo;
+    private APIRequestInfoDTO apiRequestInfo;
     // client certificate from transport level
-    javax.security.cert.X509Certificate[] clientCerts;
+    private Certificate[] clientCerts;
+    @Deprecated
+    // X509Certificate client certificate from transport level
+    private X509Certificate[] x509clientCerts;
     // custom property map used to populate customProperty key template value
-    Map<String, Object> customProperty;
+    private Map<String, Object> customProperty;
 
     public MsgInfoDTO getMsgInfo() {
 
@@ -57,14 +68,41 @@ public class RequestContextDTO {
         this.apiRequestInfo = apiRequestInfo;
     }
 
-    public X509Certificate[] getClientCerts() {
+    public Certificate[] getClientCerts() {
 
-        return (X509Certificate[]) SerializationUtils.clone(clientCerts);
+        return (Certificate[]) SerializationUtils.clone(clientCerts);
     }
 
-    public void setClientCerts(javax.security.cert.X509Certificate[] clientCerts) {
+    public void setClientCerts(Certificate[] clientCerts) {
 
-        this.clientCerts = (X509Certificate[]) SerializationUtils.clone(clientCerts);
+        this.clientCerts = (Certificate[]) SerializationUtils.clone(clientCerts);
+    }
+
+    public X509Certificate[] getX509ClientCerts() {
+        X509Certificate[] x509Certificates = new X509Certificate[clientCerts.length];
+        for (int i = 0; i < clientCerts.length; i++) {
+            try {
+                x509Certificates[i] = X509Certificate.getInstance(clientCerts[i].getEncoded());
+            } catch (CertificateException | CertificateEncodingException e) {
+                log.error("Error while converting client certificate", e);
+            }
+        }
+        return x509Certificates;
+    }
+
+    public void setX509ClientCerts(X509Certificate[] x509ClientCerts) {
+
+        Certificate[] certificates = new Certificate[x509ClientCerts.length];
+        for (int i = 0; i < x509ClientCerts.length; i++) {
+            try {
+                ByteArrayInputStream inputStream = new ByteArrayInputStream(x509ClientCerts[i].getEncoded());
+                CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                certificates[i] = cf.generateCertificate(inputStream);
+            } catch (CertificateException | java.security.cert.CertificateException e) {
+                log.error("Error while converting client certificate", e);
+            }
+        }
+        this.x509clientCerts = (X509Certificate[]) SerializationUtils.clone(certificates);
     }
 
     public Map<String, Object> getCustomProperty() {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
@@ -432,7 +432,7 @@ public class Utils {
         } else {
             Map headers =
                     (Map) axis2MessageContext.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
-            Object sslCertObject = axis2MessageContext.getProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT_X509);
+            Object sslCertObject = axis2MessageContext.getProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT);
             Certificate certificateFromMessageContext = null;
             if (sslCertObject != null) {
                 Certificate[] certs = (Certificate[]) sslCertObject;

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/MutualSSLCertificateHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/MutualSSLCertificateHandler.java
@@ -26,14 +26,12 @@ import org.apache.synapse.MessageContext;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.AbstractHandler;
 import org.wso2.carbon.apimgt.api.APIManagementException;
-import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.Utils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
 import java.util.Map;
-
-import javax.security.cert.CertificateEncodingException;
-import javax.security.cert.X509Certificate;
 
 public class MutualSSLCertificateHandler extends AbstractHandler {
 
@@ -47,7 +45,7 @@ public class MutualSSLCertificateHandler extends AbstractHandler {
         Map headers =
                 (Map) axis2MsgContext.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
         try {
-            X509Certificate clientCertificate = Utils.getClientCertificate(axis2MsgContext);
+            Certificate clientCertificate = Utils.getClientCertificate(axis2MsgContext);
             headers.remove(Utils.getClientCertificateHeader());
             if (clientCertificate != null) {
                 byte[] encoded = Base64.encodeBase64(clientCertificate.getEncoded());

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/listener/ExtensionListenerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/listener/ExtensionListenerUtil.java
@@ -177,7 +177,7 @@ public class ExtensionListenerUtil {
         } catch (APIManagementException e) {
             log.error("Error when getting client certificate", e);
         }
-        requestDTO.setClientCerts(clientCerts);
+        requestDTO.setClientCertsLatest(clientCerts);
         return requestDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/listener/ExtensionListenerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/listener/ExtensionListenerUtil.java
@@ -54,10 +54,10 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 
 import java.io.IOException;
+import java.security.cert.Certificate;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.security.cert.X509Certificate;
 import javax.xml.stream.XMLStreamException;
 
 /**
@@ -165,14 +165,14 @@ public class ExtensionListenerUtil {
         requestDTO.setMsgInfo(msgInfoDTO);
         requestDTO.setCustomProperty(getCustomPropertyMapFromMsgContext(messageContext));
 
-        javax.security.cert.X509Certificate[] clientCerts = null;
+        Certificate[] clientCerts = null;
 
         try {
-            X509Certificate clientCertificate = Utils.getClientCertificate(
+            Certificate clientCertificate = Utils.getClientCertificate(
                     ((Axis2MessageContext) messageContext).getAxis2MessageContext());
 
             if (clientCertificate != null) {
-                clientCerts = new X509Certificate[]{clientCertificate};
+                clientCerts = new Certificate[]{clientCertificate};
             }
         } catch (APIManagementException e) {
             log.error("Error when getting client certificate", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/MutualSSLAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/MutualSSLAuthenticator.java
@@ -38,13 +38,14 @@ import org.wso2.carbon.apimgt.impl.dto.VerbInfoDTO;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.keymgt.model.entity.API;
 
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
-import javax.security.cert.X509Certificate;
 
 /**
  * Authenticator responsible for handle API requests with mutual SSL.
@@ -98,7 +99,7 @@ public class MutualSSLAuthenticator implements Authenticator {
         org.apache.axis2.context.MessageContext axis2MessageContext = ((Axis2MessageContext) messageContext)
                 .getAxis2MessageContext();
         // try to retrieve the certificate
-        X509Certificate sslCertObject;
+        Certificate sslCertObject;
         try {
             sslCertObject = Utils.getClientCertificate(axis2MessageContext);
             if (!APIUtil.isCertificateExistsInListenerTrustStore(sslCertObject)) {
@@ -136,11 +137,12 @@ public class MutualSSLAuthenticator implements Authenticator {
      * To set the authentication context in current message context.
      *
      * @param messageContext Relevant message context.
-     * @param x509Certificate  SSL certificate.
+     * @param certificate    SSL certificate.
      * @throws APISecurityException API Security Exception.
      */
-    private void setAuthContext(MessageContext messageContext, X509Certificate x509Certificate) throws APISecurityException {
+    private void setAuthContext(MessageContext messageContext, Certificate certificate) throws APISecurityException {
 
+        X509Certificate x509Certificate = Utils.convertCertificateToX509Certificate(certificate);
         String subjectDN = x509Certificate.getSubjectDN().getName();
         String uniqueIdentifier = (x509Certificate.getSerialNumber() + "_" + x509Certificate.getIssuerDN()).replaceAll(",",
                         "#").replaceAll("\"", "'").trim();

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidator.java
@@ -60,6 +60,7 @@ import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 
+import java.security.cert.Certificate;
 import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
@@ -67,7 +68,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.cache.Cache;
-import javax.security.cert.X509Certificate;
 
 /**
  * A Validator class to validate JWT tokens in an API request.
@@ -154,8 +154,8 @@ public class JWTValidator {
         String jwtHeader = signedJWTInfo.getSignedJWT().getHeader().toString();
 
         try {
-            X509Certificate clientCertificate = Utils.getClientCertificate(axis2MsgContext);
-            signedJWTInfo.setX509ClientCertificate(clientCertificate);
+            Certificate clientCertificate = Utils.getClientCertificate(axis2MsgContext);
+            signedJWTInfo.setClientCertificate(clientCertificate);
         } catch (APIManagementException e) {
             log.error("Error while obtaining client certificate. " + GatewayUtils.getMaskedToken(jwtHeader));
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/jwt/JWTValidatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/jwt/JWTValidatorImpl.java
@@ -41,7 +41,6 @@ import org.wso2.carbon.apimgt.impl.utils.JWTUtil;
 import java.io.IOException;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -96,11 +95,11 @@ public class JWTValidatorImpl implements JWTValidator {
     private boolean isValidCertificateBoundAccessToken(SignedJWTInfo signedJWTInfo) { //Holder of Key token
 
         if (isCertificateBoundAccessTokenEnabled()) {
-            if (signedJWTInfo.getX509ClientCertificate() == null ||
-                    StringUtils.isEmpty(signedJWTInfo.getX509ClientCertificateHash())) {
+            if (signedJWTInfo.getClientCertificate() == null ||
+                    StringUtils.isEmpty(signedJWTInfo.getClientCertificateHash())) {
                 return true; // If cnf is not available - 200 success
             }
-            if (signedJWTInfo.getX509ClientCertificateHash().equals(signedJWTInfo.getCertificateThumbprint())) {
+            if (signedJWTInfo.getClientCertificateHash().equals(signedJWTInfo.getCertificateThumbprint())) {
                 return true; // if cnf matches with truststore cert - 200 success
             }
             return false; // if cert is not in truststore or thumbprint does not match with the cert

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/jwt/SignedJWTInfo.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/jwt/SignedJWTInfo.java
@@ -27,7 +27,7 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.utils.CertificateMgtUtils;
 
 import java.io.Serializable;
-import javax.security.cert.X509Certificate;
+import java.security.cert.Certificate;
 
 /**
  * JWT internal Representation
@@ -39,8 +39,8 @@ public class SignedJWTInfo implements Serializable {
     private JWTClaimsSet jwtClaimsSet;
     private ValidationStatus validationStatus = ValidationStatus.NOT_VALIDATED;
     private String certificateThumbprint; //holder of key certificate bound access token
-    private X509Certificate x509ClientCertificate; //holder of key certificate cnf
-    private String x509ClientCertificateHash; //holder of key certificate cnf
+    private Certificate clientCertificate; //holder of key certificate cnf
+    private String clientCertificateHash; //holder of key certificate cnf
     private static final Log log = LogFactory.getLog(JWTValidator.class);
 
     public enum ValidationStatus {
@@ -96,12 +96,12 @@ public class SignedJWTInfo implements Serializable {
         this.validationStatus = validationStatus;
     }
 
-    public void setX509ClientCertificate(X509Certificate x509ClientCertificate) {
+    public void setClientCertificate(Certificate clientCertificate) {
 
-        this.x509ClientCertificate = x509ClientCertificate;
-        if (x509ClientCertificate != null) {
-            CertificateMgtUtils.convert(x509ClientCertificate).ifPresent(x509Certificate ->
-                    x509ClientCertificateHash = X509CertUtils.computeSHA256Thumbprint(x509Certificate).toString());
+        this.clientCertificate = clientCertificate;
+        if (clientCertificate != null) {
+            CertificateMgtUtils.convert(clientCertificate).ifPresent(x509Certificate ->
+                    clientCertificateHash = X509CertUtils.computeSHA256Thumbprint(x509Certificate).toString());
         }
     }
 
@@ -116,13 +116,13 @@ public class SignedJWTInfo implements Serializable {
         return null;
     }
 
-    public String getX509ClientCertificateHash() {
+    public String getClientCertificateHash() {
 
-        return x509ClientCertificateHash;
+        return clientCertificateHash;
     }
 
-    public X509Certificate getX509ClientCertificate() {
+    public Certificate getClientCertificate() {
 
-        return x509ClientCertificate;
+        return clientCertificate;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -310,7 +310,6 @@ import javax.cache.CacheConfiguration;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
 import javax.net.ssl.SSLContext;
-import javax.security.cert.CertificateEncodingException;
 import javax.security.cert.X509Certificate;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -8369,7 +8368,7 @@ public final class APIUtil {
      * @return true if certificate exist in truststore
      * @throws APIManagementException
      */
-    public static boolean isCertificateExistsInListenerTrustStore(X509Certificate certificate) throws APIManagementException {
+    public static boolean isCertificateExistsInListenerTrustStore(Certificate certificate) throws APIManagementException {
 
         if (certificate != null) {
             try {
@@ -8386,7 +8385,7 @@ public final class APIUtil {
                         }
                     }
                 }
-            } catch (KeyStoreException | CertificateException | CertificateEncodingException | IOException e) {
+            } catch (KeyStoreException | CertificateException | IOException e) {
                 String msg = "Error in validating certificate existence";
                 log.error(msg, e);
                 throw new APIManagementException(msg, e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/CertificateMgtUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/CertificateMgtUtils.java
@@ -907,7 +907,7 @@ public class CertificateMgtUtils {
      * @param cert the certificate to be converted
      * @return java.security.cert.X509Certificate type certificate
      */
-    public static Optional<X509Certificate> convert(javax.security.cert.X509Certificate cert) {
+    public static Optional<X509Certificate> convert(Certificate cert) {
 
         if (cert != null) {
             try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(cert.getEncoded())) {
@@ -916,8 +916,6 @@ public class CertificateMgtUtils {
                         = java.security.cert.CertificateFactory.getInstance("X.509");
                 return Optional.of((java.security.cert.X509Certificate) certificateFactory.generateCertificate(
                         byteArrayInputStream));
-            } catch (javax.security.cert.CertificateEncodingException e) {
-                log.error("Error while decoding the certificate ", e);
             } catch (java.security.cert.CertificateException e) {
                 log.error("Error while generating the certificate", e);
             } catch (IOException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/jwt/JWTValidatorImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/jwt/JWTValidatorImplTest.java
@@ -223,7 +223,7 @@ public class JWTValidatorImplTest {
         PowerMockito.when(CertificateMgtUtils.convert(x509Certificate)).thenReturn(Optional.of(x509CertificateJava));
 
         Certificate[] sslCertObject = new java.security.cert.Certificate[]{x509Certificate};
-        Mockito.when(axis2MsgCntxt.getProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT_X509)).thenReturn(sslCertObject);
+        Mockito.when(axis2MsgCntxt.getProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT)).thenReturn(sslCertObject);
 
         Map<String, String> headers = new HashMap<>();
         Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
@@ -273,7 +273,7 @@ public class JWTValidatorImplTest {
 
         Map headers =
                 (Map) axis2MessageContext.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
-        Object sslCertObject = axis2MessageContext.getProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT_X509);
+        Object sslCertObject = axis2MessageContext.getProperty(NhttpConstants.SSL_CLIENT_AUTH_CERT);
         Certificate certificateFromMessageContext = null;
         if (sslCertObject != null) {
             Certificate[] certs = (Certificate[]) sslCertObject;

--- a/pom.xml
+++ b/pom.xml
@@ -2040,7 +2040,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>2.1.7-wso2v310</synapse.version>
+        <synapse.version>2.1.7-wso2v313</synapse.version>
 
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/636
**This should be merged after merging [1] and [2] while bumping the Synapse version of carbon-apimgt. After that, need to bump the Synapse version in product-apim too.**

## Approach
- Remove the usage of javax.security.cert.X509Certificate when using the implementations related to getPeerCertificates()
- Use  java.security.cert.Certificate in the above use cases

## Test environment
- OpenJDK 11.0.16+8
- OpenJDK 17.0.4+8

[1] https://github.com/wso2/wso2-synapse/pull/1965
[2] https://github.com/wso2/wso2-synapse/pull/1996