### PR TITLE
Add implementation to validate the origin header only if it's present in the request

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
@@ -279,6 +279,10 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
             return;
         }
         String requestOrigin = req.headers().get(HttpHeaderNames.ORIGIN);
+        // Don't validate the 'origin' header if it's not present in the request
+        if (requestOrigin == null) {
+            return;
+        }
         String allowedOrigin = assessAndGetAllowedOrigin(requestOrigin);
         if (allowedOrigin == null) {
             FullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.FORBIDDEN);


### PR DESCRIPTION
## Purpose
$subject. Fixes https://github.com/wso2/api-manager/issues/612