### PR TITLE
Fixing WS close code missing issue and adding the missing master fix of setting API_PROPERTIES to WS channelctx 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
@@ -30,6 +30,7 @@ import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.apache.commons.lang3.StringUtils;
@@ -41,6 +42,7 @@ import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityException;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityUtils;
+import org.wso2.carbon.apimgt.gateway.handlers.security.AuthenticationContext;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketAnalyticsMetricsHandler;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketApiConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketUtils;
@@ -53,6 +55,7 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
 import java.net.InetSocketAddress;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -66,6 +69,7 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
     private static final Log log = LogFactory.getLog(WebsocketInboundHandler.class);
     private WebSocketAnalyticsMetricsHandler metricsHandler;
     private InboundWebSocketProcessor webSocketProcessor;
+    private final String API_PROPERTIES = "API_PROPERTIES";
 
     public WebsocketInboundHandler() {
         webSocketProcessor = initializeWebSocketProcessor();
@@ -128,6 +132,7 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
                     webSocketProcessor.handleHandshake(req, ctx, inboundMessageContext);
             if (!responseDTO.isError()) {
                 setApiAuthPropertiesToChannel(ctx, inboundMessageContext);
+                setApiPropertiesMapToChannel(ctx, inboundMessageContext);
                 if (StringUtils.isNotEmpty(inboundMessageContext.getToken())) {
                     req.headers().set(APIMgtGatewayConstants.WS_JWT_TOKEN_HEADER, inboundMessageContext.getToken());
                 }
@@ -308,5 +313,33 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
             }
         }
         return null;
+    }
+
+    private void setApiPropertiesMapToChannel(ChannelHandlerContext ctx, InboundMessageContext inboundMessageContext) {
+
+        ctx.channel().attr(AttributeKey.valueOf(API_PROPERTIES)).set(createApiPropertiesMap(inboundMessageContext));
+    }
+
+    private Map<String, Object> createApiPropertiesMap(InboundMessageContext inboundMessageContext) {
+
+        Map<String, Object> apiPropertiesMap = new HashMap<>();
+        AuthenticationContext authenticationContext = inboundMessageContext.getAuthContext();
+        if (authenticationContext != null) {
+            String apiName = authenticationContext.getApiName();
+            String apiVersion = authenticationContext.getApiVersion();
+            apiPropertiesMap.put(APIMgtGatewayConstants.CONSUMER_KEY, authenticationContext.getConsumerKey());
+            apiPropertiesMap.put(APIMgtGatewayConstants.USER_ID, authenticationContext.getUsername());
+            apiPropertiesMap.put(APIMgtGatewayConstants.CONTEXT, inboundMessageContext.getApiContext());
+            apiPropertiesMap.put(APIMgtGatewayConstants.API, apiName);
+            apiPropertiesMap.put(APIMgtGatewayConstants.VERSION, apiVersion);
+            apiPropertiesMap.put(APIMgtGatewayConstants.API_TYPE, String.valueOf(APIConstants.ApiTypes.API));
+            apiPropertiesMap.put(APIMgtGatewayConstants.HOST_NAME, APIUtil.getHostAddress());
+            apiPropertiesMap.put(APIMgtGatewayConstants.API_PUBLISHER, authenticationContext.getApiPublisher());
+            apiPropertiesMap.put(APIMgtGatewayConstants.END_USER_NAME, authenticationContext.getUsername());
+            apiPropertiesMap.put(APIMgtGatewayConstants.APPLICATION_NAME, authenticationContext.getApplicationName());
+            apiPropertiesMap.put(APIMgtGatewayConstants.APPLICATION_ID, authenticationContext.getApplicationId());
+            apiPropertiesMap.put(APIMgtGatewayConstants.API_VERSION, apiName + ":v" + apiVersion);
+        }
+        return apiPropertiesMap;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandlerTestCase.java
@@ -36,6 +36,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.gateway.dto.GraphQLOperationDTO;
 import org.wso2.carbon.apimgt.gateway.handlers.graphQL.GraphQLConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketApiConstants;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContextDataHolder;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
@@ -131,6 +132,7 @@ public class WebsocketHandlerTestCase {
         InboundProcessorResponseDTO responseDTO = new InboundProcessorResponseDTO();
         responseDTO.setError(true);
         responseDTO.setCloseConnection(true);
+        responseDTO.setErrorCode(WebSocketApiConstants.FrameErrorConstants.INTERNAL_SERVER_ERROR);
         PowerMockito.when(InboundWebsocketProcessorUtil.doThrottle(Mockito.anyInt(), Mockito.anyObject(),
                 Mockito.anyObject(), Mockito.anyObject())).thenReturn(responseDTO);
         websocketHandler.write(channelHandlerContext, msg, channelPromise);
@@ -178,6 +180,7 @@ public class WebsocketHandlerTestCase {
         //close connection error
         responseDTO.setError(true);
         responseDTO.setCloseConnection(true);
+        responseDTO.setErrorCode(WebSocketApiConstants.FrameErrorConstants.INTERNAL_SERVER_ERROR);
         websocketHandler.write(channelHandlerContext, msg.retain(), channelPromise);
         Assert.assertFalse(InboundMessageContextDataHolder.getInstance().getInboundMessageContextMap()
                 .containsKey(channelIdString));  // Closing connection error has occurred

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandlerTestCase.java
@@ -40,6 +40,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketApiConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketUtils;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContextDataHolder;
@@ -75,7 +76,9 @@ public class WebsocketInboundHandlerTestCase {
         inboundWebSocketProcessor = Mockito.mock(InboundWebSocketProcessor.class);
         channelHandlerContext = Mockito.mock(ChannelHandlerContext.class);
         Channel channel = Mockito.mock(Channel.class);
+        Attribute attribute = Mockito.mock(Attribute.class);
         ChannelId channelId = Mockito.mock(ChannelId.class);
+        Mockito.when(channel.attr(AttributeKey.valueOf("API_PROPERTIES"))).thenReturn(attribute);
         Mockito.when(channelHandlerContext.channel()).thenReturn(channel);
         Mockito.when(channel.id()).thenReturn(channelId);
         Mockito.when(channelId.asLongText()).thenReturn(channelIdString);
@@ -182,6 +185,7 @@ public class WebsocketInboundHandlerTestCase {
 
         //close connection error response
         responseDTO.setCloseConnection(true);
+        responseDTO.setErrorCode(WebSocketApiConstants.FrameErrorConstants.INTERNAL_SERVER_ERROR);
         websocketInboundHandler.channelRead(channelHandlerContext, msg);
         Assert.assertFalse((InboundMessageContextDataHolder.getInstance().getInboundMessageContextMap()
                 .containsKey(channelIdString)));

--- a/pom.xml
+++ b/pom.xml
@@ -2040,7 +2040,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>2.1.7-wso2v306</synapse.version>
+        <synapse.version>2.1.7-wso2v307</synapse.version>
 
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/661

## Goals
Fixing WS close code missing issue and adding the missing master fix of setting API_PROPERTIES to WS channelctx 

## Approach
- Adding the missing master fixes of [1].
- Bumping the synapse version to reflect the netty version upgrade that is required for compile time [2]
- By setting the property _api.ut.WS_SC_ inside exceptionCaught.

[1] https://github.com/wso2/product-apim/issues/12541
[2] https://github.com/wso2/wso2-synapse/pull/1999