### PR TITLE
Fixing the issue when importing Blocked API/API Products with import update

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -2002,9 +2002,11 @@ public class ImportUtils {
             if (StringUtils.equals(targetStatus, APIStatus.BLOCKED.toString()) || StringUtils.equals(targetStatus,
                     APIStatus.DEPRECATED.toString()) || StringUtils.equals(targetStatus,
                     APIStatus.RETIRED.toString())) {
-                lifeCycleActions.put(APIStatus.PUBLISHED.toString(),
-                        lcManager.getTransitionAction(currentStatus.toUpperCase(), APIStatus.PUBLISHED.toString()));
-                currentStatus = APIStatus.PUBLISHED.toString();
+                if (StringUtils.equals(currentStatus, APIStatus.CREATED.toString())) {
+                    lifeCycleActions.put(APIStatus.PUBLISHED.toString(),
+                            lcManager.getTransitionAction(currentStatus.toUpperCase(), APIStatus.PUBLISHED.toString()));
+                    currentStatus = APIStatus.PUBLISHED.toString();
+                }
                 if (StringUtils.equals(targetStatus, APIStatus.RETIRED.toString())) {
                     // The API should be Deprecated prior Retiring the API
                     lifeCycleActions.put(APIStatus.DEPRECATED.toString(),


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/713

## Approach
Perform a validation: if the API/API Product is in BLOCKED/RETIRED/DEPRECATED state, then only if the current state was set to CREATED, then Publish the API/API Product before Blocking, Retiring, or Deprecating 

