### PR TITLE
[9.22.x] Fix null pointer exception when generating token with empty additional Properties field

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
@@ -98,6 +98,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import javax.ws.rs.core.Response;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
@@ -92,13 +92,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.cert.Certificate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import javax.ws.rs.core.Response;
 
 public class ApplicationsApiServiceImpl implements ApplicationsApiService {
@@ -1185,7 +1179,8 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
                     try {
                         // verify that the provided jsonInput is a valid json
                         if (body.getAdditionalProperties() != null
-                                && !body.getAdditionalProperties().toString().isEmpty()) {
+                                && !body.getAdditionalProperties().toString().isEmpty()
+                                && !Objects.equals(body.getAdditionalProperties().toString(), "{}")) {
                             jsonInput = validateAdditionalParameters(grantType, body);
                         }
                     } catch (JsonProcessingException | ParseException | ClassCastException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
@@ -92,7 +92,13 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.cert.Certificate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import javax.ws.rs.core.Response;
 
 public class ApplicationsApiServiceImpl implements ApplicationsApiService {


### PR DESCRIPTION
## Purpose

- This PR fixes https://github.com/wso2-enterprise/choreo/issues/15253
- This PR fixes occurring a null pointer exception when generating application token with empty additional Properties field as follows:

```
{
  "consumerSecret": "ppB2JamZ0df3QNEnIs_xHHS9vpMa",
  "validityPeriod": 3600,
  "scopes": [
    "apim:subscribe"
  ],
  "revokeToken": "",
  "grantType": "client_credentials",
  "additionalProperties": {}
}
```


Now Generating token call works for all 3 scenarios

1. With Additional Properties field values
```
{
  "consumerSecret": "ppB2JamZ0df3QNEnIs_xHHS9vpMa",
  "validityPeriod": 3600,
  "scopes": [
    "apim:subscribe"
  ],
  "revokeToken": "",
  "grantType": "client_credentials",
  "additionalProperties": {
    "id_token_expiry_time": 3600,
    "application_access_token_expiry_time": 3600,
    "user_access_token_expiry_time": 3600,
    "bypassClientCredentials": false,
    "pkceMandatory": false,
    "pkceSupportPlain": false,
    "refresh_token_expiry_time": 86400
  }
}
```

2. With an empty additional properties field
```
{
  "consumerSecret": "ppB2JamZ0df3QNEnIs_xHHS9vpMa",
  "validityPeriod": 3600,
  "scopes": [
    "apim:subscribe"
  ],
  "revokeToken": "",
  "grantType": "client_credentials",
  "additionalProperties": {}
}
```

3. Without additional properties field
```
{
  "consumerSecret": "ppB2JamZ0df3QNEnIs_xHHS9vpMa",
  "validityPeriod": 3600,
  "scopes": [
    "apim:subscribe"
  ],
  "revokeToken": "",
  "grantType": "client_credentials"
}
```