### PR TITLE
Fix scope validation issue in JWT token validation path

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
@@ -151,12 +151,9 @@ public class OAuthJwtAuthenticatorImpl extends AbstractOAuthAuthenticator {
             if (log.isDebugEnabled()) {
                 log.debug("scopes after spliting from scope delimiter: " + Arrays.toString(scopes));
             }
-
             Stream<String> stream = java.util.Arrays.stream(scopes).filter(s -> s.contains(orgId))
                     .map(s -> s.replace(APIConstants.URN_CHOREO + orgId + ":", ""));
-
             scopes = stream.toArray(size -> new String[size]);
-
             if (log.isDebugEnabled()) {
                 log.debug("scopes after filtering: " + Arrays.toString(scopes));
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
@@ -54,6 +54,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.wso2.carbon.apimgt.rest.api.common.APIMConfigUtil.getRestApiJWTAuthAudiences;
 
@@ -150,9 +151,12 @@ public class OAuthJwtAuthenticatorImpl extends AbstractOAuthAuthenticator {
             if (log.isDebugEnabled()) {
                 log.debug("scopes after spliting from scope delimiter: " + Arrays.toString(scopes));
             }
-            scopes = java.util.Arrays.stream(scopes).filter(s -> s.contains(orgId))
-                    .map(s -> s.replace(APIConstants.URN_CHOREO + orgId + ":", ""))
-                    .toArray(size -> new String[size]);
+
+            Stream<String> stream = java.util.Arrays.stream(scopes).filter(s -> s.contains(orgId))
+                    .map(s -> s.replace(APIConstants.URN_CHOREO + orgId + ":", ""));
+
+            scopes = stream.toArray(size -> new String[size]);
+
             if (log.isDebugEnabled()) {
                 log.debug("scopes after filtering: " + Arrays.toString(scopes));
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
@@ -54,7 +54,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.wso2.carbon.apimgt.rest.api.common.APIMConfigUtil.getRestApiJWTAuthAudiences;
 
@@ -150,12 +149,6 @@ public class OAuthJwtAuthenticatorImpl extends AbstractOAuthAuthenticator {
             String[] scopes = scopeClaim.split(JwtTokenConstants.SCOPE_DELIMITER);
             if (log.isDebugEnabled()) {
                 log.debug("scopes after spliting from scope delimiter: " + Arrays.toString(scopes));
-            }
-            Stream<String> stream = java.util.Arrays.stream(scopes).filter(s -> s.contains(orgId))
-                    .map(s -> s.replace(APIConstants.URN_CHOREO + orgId + ":", ""));
-            scopes = stream.toArray(size -> new String[size]);
-            if (log.isDebugEnabled()) {
-                log.debug("scopes after filtering: " + Arrays.toString(scopes));
             }
             oauthTokenInfo.setScopes(scopes);
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
As per the previous logic, the scope array is getting set to an empty array when the `urn:choreo:<ORG_ID>:` is not included in the JWT claim set. This PR will fix that issue.

#### Debug logs:
```
[2022-09-16 07:35:23,010] DEBUG ecb3f583-5606-4ffc-8824-9644af004a7c - OAuthJwtAuthenticatorImpl Starting JWT token validation ...XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXB9mu3T6Y
[2022-09-16 07:35:23,113] DEBUG ecb3f583-5606-4ffc-8824-9644af004a7c - OAuthJwtAuthenticatorImpl scopeClaim in the signedJWTInfo: apim:admin apim:api_manage apim:dcr:app_manage apim:publisher_settings apim:subscription_manage apim:tier_manage choreo:role_manage choreo:user_manage environments:view_dev environments:view_prod
[2022-09-16 07:35:23,113] DEBUG ecb3f583-5606-4ffc-8824-9644af004a7c - OAuthJwtAuthenticatorImpl scopes after spliting from scope delimiter: [apim:admin, apim:api_manage, apim:dcr:app_manage, apim:publisher_settings, apim:subscription_manage, apim:tier_manage, choreo:role_manage, choreo:user_manage, environments:view_dev, environments:view_prod]
[2022-09-16 07:35:23,122] DEBUG ecb3f583-5606-4ffc-8824-9644af004a7c - OAuthJwtAuthenticatorImpl scopes after filtering: []
[2022-09-16 07:35:23,122] DEBUG ecb3f583-5606-4ffc-8824-9644af004a7c - OAuthJwtAuthenticatorImpl scopes available in oauthTokenInfo: []
```

Related task: https://github.com/wso2-enterprise/choreo/issues/9668