### PR TITLE
Add null check to swagger and asyncAPI json strings

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -894,9 +894,14 @@ public class ExportUtils {
                 if (!APIConstants.APITransportType.GRAPHQL.toString().equalsIgnoreCase(apiType)) {
                     String formattedSwaggerJson = RestApiCommonUtil.retrieveSwaggerDefinition(currentApiUuid, api,
                             apiProvider);
-                    CommonUtil.writeToYamlOrJson(archivePath + ImportExportConstants.SWAGGER_DEFINITION_LOCATION,
-                            exportFormat,
-                            formattedSwaggerJson);
+                    if (formattedSwaggerJson != null) {
+                        CommonUtil.writeToYamlOrJson(archivePath + ImportExportConstants.SWAGGER_DEFINITION_LOCATION,
+                                exportFormat, formattedSwaggerJson);
+                    } else {
+                        throw new APIImportExportException("Error while retrieving Swagger definition for API: "
+                                + apiDtoToReturn.getName() + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": "
+                                + apiDtoToReturn.getVersion());
+                    }
                 }
                 if (log.isDebugEnabled()) {
                     log.debug("Meta information retrieved successfully for API: " + apiDtoToReturn.getName()
@@ -933,8 +938,14 @@ public class ExportUtils {
                         apiDtoToReturn.setEndpointConfig(endpointConfig);
                     }
                 }
-                CommonUtil.writeToYamlOrJson(archivePath + ImportExportConstants.ASYNCAPI_DEFINITION_LOCATION,
-                        exportFormat, asyncApiJson);
+                if (asyncApiJson != null) {
+                    CommonUtil.writeToYamlOrJson(archivePath + ImportExportConstants.ASYNCAPI_DEFINITION_LOCATION,
+                            exportFormat, asyncApiJson);
+                } else {
+                    throw new APIImportExportException("Error while retrieving AsyncAPI definition for API: "
+                            + apiDtoToReturn.getName() + StringUtils.SPACE + APIConstants.API_DATA_VERSION + ": "
+                            + apiDtoToReturn.getVersion());
+                }
             }
             Gson gson = new GsonBuilder().setPrettyPrinting().create();
             JsonElement apiObj = gson.toJsonTree(apiDtoToReturn);
@@ -1050,8 +1061,13 @@ public class ExportUtils {
 
         try {
             String formattedSwaggerJson = apiProvider.getOpenAPIDefinition(apiProductDtoToReturn.getId(), organization);
-            CommonUtil.writeToYamlOrJson(archivePath + ImportExportConstants.SWAGGER_DEFINITION_LOCATION, exportFormat,
-                    formattedSwaggerJson);
+            if (formattedSwaggerJson != null) {
+                CommonUtil.writeToYamlOrJson(archivePath + ImportExportConstants.SWAGGER_DEFINITION_LOCATION,
+                        exportFormat, formattedSwaggerJson);
+            } else {
+                throw new APIImportExportException("Error while retrieving Swagger definition for API Product: "
+                        + apiProductDtoToReturn.getName());
+            }
 
             if (log.isDebugEnabled()) {
                 log.debug(


### PR DESCRIPTION
This PR adds null checks to swagger and asyncAPI json strings in the ExportUtils.

Fixes https://github.com/wso2/api-manager/issues/634