### PR TITLE
Fix JWT scope validation failure

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
@@ -145,9 +145,6 @@ public class OAuthJwtAuthenticatorImpl extends AbstractOAuthAuthenticator {
         if (scopeClaim != null) {
             String orgId = RestApiUtil.resolveOrganization(message);
             String[] scopes = scopeClaim.split(JwtTokenConstants.SCOPE_DELIMITER);
-            scopes = java.util.Arrays.stream(scopes).filter(s -> s.contains(orgId))
-                    .map(s -> s.replace(APIConstants.URN_CHOREO + orgId + ":", ""))
-                    .toArray(size -> new String[size]);
             oauthTokenInfo.setScopes(scopes);
             Map<String, Object> authContext = RestApiUtil.addToJWTAuthenticationContext(message);
             String basePath = (String) message.get(RestApiConstants.BASE_PATH);


### PR DESCRIPTION
As per the previous logic, the scope array is getting set to an empty array when the `urn:choreo:<ORG_ID>:` is not included in the JWT claim set. This PR will fix that issue.

9.22.x branch PR: https://github.com/wso2/carbon-apimgt/pull/11470