### PR TITLE
Add missing query string for DB2

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsDB2.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsDB2.java
@@ -194,7 +194,41 @@ public class SQLConstantsDB2 extends SQLConstants{
                     " limit ? , ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
 
-
+    public static final String GET_APPLICATIONS_PREFIX_CASESENSITVE_WITH_MULTIGROUPID =
+            "select distinct x.*,bl.ENABLED from (" +
+                    " SELECT " +
+                    "   APPLICATION_ID, " +
+                    "   NAME," +
+                    "   APPLICATION_TIER," +
+                    "   APP.SUBSCRIBER_ID,  " +
+                    "   APP.CREATED_TIME AS APP_CREATED_TIME, " +
+                    "   APP.UPDATED_TIME AS APP_UPDATED_TIME, " +
+                    "   CALLBACK_URL,  " +
+                    "   DESCRIPTION, " +
+                    "   APPLICATION_STATUS, " +
+                    "   USER_ID, " +
+                    "   GROUP_ID, " +
+                    "   UUID, " +
+                    "   APP.CREATED_BY AS CREATED_BY " +
+                    " FROM" +
+                    "   AM_APPLICATION APP, " +
+                    "   AM_SUBSCRIBER SUB  " +
+                    " WHERE " +
+                    "   SUB.SUBSCRIBER_ID = APP.SUBSCRIBER_ID " +
+                    " AND (" +
+                    "    (APPLICATION_ID IN ( SELECT APPLICATION_ID FROM AM_APPLICATION_GROUP_MAPPING WHERE GROUP_ID " +
+                    " IN ($params) AND TENANT = ? ))" +
+                    "           OR " +
+                    "    (SUB.USER_ID = ?)" +
+                    "           OR " +
+                    "     (APP.APPLICATION_ID IN (SELECT APPLICATION_ID FROM AM_APPLICATION WHERE GROUP_ID = ?))" +
+                    " )" +
+                    " AND " +
+                    "   APP.ORGANIZATION = ? " +
+                    " And " +
+                    "    NAME like ?"+
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
+                    " ORDER BY $1 $2 limit ? , ?";
 
     public static final String GET_APPLICATIONS_BY_TENANT_ID =
             "(" +


### PR DESCRIPTION
### Description

Fix wso2/api-manager/issues/669 for master branch
Add the query string GET_APPLICATIONS_PREFIX_CASESENSITVE_WITH_MULTIGROUPID

### Related pull requests

wso2-support/carbon-apimgt/pull/5365