### PR TITLE
Change the regex matcher to match the whole string

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractKeyManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractKeyManager.java
@@ -214,7 +214,7 @@ public abstract class AbstractKeyManager implements KeyManager {
                                 StringUtils.isNotEmpty(String.valueOf(tokenHandler.getValue()))) {
                             Pattern pattern = Pattern.compile((String) tokenHandler.getValue());
                             Matcher matcher = pattern.matcher(accessToken);
-                            canHandle = matcher.find();
+                            canHandle = matcher.matches();
                         }
                     } else if (TokenHandlingDto.TypeEnum.JWT.equals(tokenHandler.getType()) &&
                             accessToken.contains(APIConstants.DOT)) {


### PR DESCRIPTION
When checking whether a key manager can handle an access token pattern, it will only return true if the whole string matches the given pattern for the key manager.

Fix : https://github.com/wso2/api-manager/issues/749