### PR TITLE
Added proper error message for Search API admin call when an empty context is set

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -4900,7 +4900,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 result.put("isMore", false);
             }
         } catch (APIPersistenceException e) {
-            throw new APIManagementException("Error while searching the api ", e);
+            String errorMsg = (e.getMessage() == null || e.getMessage().isEmpty()) ? "Error while searching the api" : e.getMessage();
+            throw new APIManagementException(errorMsg, e);
         }
         return result ;
     }


### PR DESCRIPTION
## Purpose
When search operation with URL pattern `{{basepath}}/search?limit=25&offset=0&query=context:` is performed, 500 error response with below response was observed. 
```
{
"code": 900967,
"message": "General Error",
"description": "Server Error Occurred",
"moreInfo": "",
"error": []
}
```
Therefore to handle that, added proper error message for Search API admin call when an empty context is set. Public git issue is https://github.com/wso2/api-manager/issues/745.

## Approach
- Parsed error message from `APIPersistenceException` and thrown to `SearchAPIServiceImpl` level if there is a error message parsed or otherwise default to `"Error while searching the api"`.
- Catched the `APIManagementException` in `SearchAPIServiceImpl`.
