### PR TITLE
[9.22.x] Add support for both /v2 and /v3 endpoints

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/webapp/WEB-INF/beans.xml
@@ -66,7 +66,8 @@
 
     <bean id="URLValidationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.URLValidationInterceptor">
         <property name="majorVersion" value="v3" />
-        <property name="latestVersion" value="v3.0" />
+        <!--This latestVersion is set to v2 temporarily to make both /v2 and /v3 endpoints work for APIM Upgrade testing-->
+        <property name="latestVersion" value="v2" />
     </bean>
     <bean id="PreAuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.PreAuthenticationInterceptor" />
     <bean id="TokenMergeInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.auth.TokenMergeInterceptor" />

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
@@ -51,7 +51,8 @@
 
     <bean id="URLValidationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.URLValidationInterceptor">
         <property name="majorVersion" value="v3" />
-        <property name="latestVersion" value="v3.0" />
+        <!--This latestVersion is set to v2 temporarily to make both /v2 and /v3 endpoints work for APIM Upgrade testing-->
+        <property name="latestVersion" value="v2" />
     </bean>
     <bean id="PreAuthenticationInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.PreAuthenticationInterceptor" />
     <bean id="TokenMergeInterceptor" class="org.wso2.carbon.apimgt.rest.api.util.interceptors.auth.TokenMergeInterceptor" />


### PR DESCRIPTION
## Purpose

This PR adds support for both /v2 and /v3 endpoints to make both of those endpoints work temporarily for APIM upgrade testing. 

Related Issue: https://github.com/wso2-enterprise/choreo/issues/9668