### PR TITLE
Add waiting time config for event hub events

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayJMSMessageListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayJMSMessageListener.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIConstants.EventType;
 import org.wso2.carbon.apimgt.impl.APIConstants.PolicyType;
 import org.wso2.carbon.apimgt.impl.certificatemgt.CertificateManagerImpl;
+import org.wso2.carbon.apimgt.impl.dto.EventHubConfigurationDto;
 import org.wso2.carbon.apimgt.impl.dto.GatewayArtifactSynchronizerProperties;
 import org.wso2.carbon.apimgt.impl.dto.WebhooksDTO;
 import org.wso2.carbon.apimgt.impl.gatewayartifactsynchronizer.exception.ArtifactSynchronizerException;
@@ -68,12 +69,24 @@ public class GatewayJMSMessageListener implements MessageListener {
     private static final Log log = LogFactory.getLog(GatewayJMSMessageListener.class);
     private boolean debugEnabled = log.isDebugEnabled();
     private InMemoryAPIDeployer inMemoryApiDeployer = new InMemoryAPIDeployer();
+    private EventHubConfigurationDto eventHubConfigurationDto = ServiceReferenceHolder.getInstance()
+            .getAPIManagerConfiguration().getEventHubConfigurationDto();
     private GatewayArtifactSynchronizerProperties gatewayArtifactSynchronizerProperties = ServiceReferenceHolder
             .getInstance().getAPIManagerConfiguration().getGatewayArtifactSynchronizerProperties();
 
     public void onMessage(Message message) {
 
         try {
+            if (eventHubConfigurationDto.hasEventWaitingTime()) {
+                long timeLeft = message.getJMSTimestamp() + eventHubConfigurationDto.getEventWaitingTime()
+                        - System.currentTimeMillis();
+                if (log.isDebugEnabled()) {
+                    log.debug("Event Hub waiting time: " + timeLeft);
+                }
+                if (timeLeft > 0) {
+                    Thread.sleep(timeLeft);
+                }
+            }
             if (message != null) {
                 if (log.isDebugEnabled()) {
                     log.debug("Event received in JMS Event Receiver - " + message);
@@ -117,6 +130,8 @@ public class GatewayJMSMessageListener implements MessageListener {
             }
         } catch (JMSException | JsonProcessingException e) {
             log.error("JMSException occurred when processing the received message ", e);
+        } catch (InterruptedException e) {
+            log.error("Error occurred while waiting to retrieve artifacts from event hub", e);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1846,6 +1846,7 @@ public final class APIConstants {
     public static final String REVOKED_TOKEN_KEY = "revokedToken";
     public static final String REVOKED_TOKEN_EXPIRY_TIME = "expiryTime";
     public static final String EVENT_TYPE = "eventType";
+    public static final String EVENT_WAITING_TIME_CONFIG = "EventWaitingTime";
     public static final String EVENT_TIMESTAMP = "timestamp";
     public static final String EVENT_PAYLOAD = "event";
     public static final String EVENT_PAYLOAD_DATA = "payloadData";
@@ -2613,7 +2614,6 @@ public final class APIConstants {
         public static final String RETRY_DUARTION = "RetryDuration";
         public static final String PUBLISH_DIRECTLY_TO_GW_CONFIG = "PublishDirectlyToGW";
         public static final String GATEWAY_LABELS_CONFIG = "GatewayLabels";
-        public static final String EVENT_WAITING_TIME_CONFIG = "EventWaitingTime";
         public static final String LABEL_CONFIG = "Label";
         public static final String DB_SAVER_NAME = "DBSaver";
         public static final String DB_RETRIEVER_NAME = "DBRetriever";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -1857,6 +1857,16 @@ public class APIManagerConfiguration {
                 String password = MiscellaneousUtil.resolve(passwordElement, secretResolver);
                 eventHubConfigurationDto.setPassword(APIUtil.replaceSystemProperty(password).toCharArray());
             }
+            OMElement eventWaitingTimeElement = omElement
+                    .getFirstChildWithName(new QName(APIConstants.EVENT_WAITING_TIME_CONFIG));
+            if (eventWaitingTimeElement != null) {
+                long eventWaitingTime = Long.valueOf(eventWaitingTimeElement.getText());
+                eventHubConfigurationDto.setEventWaitingTime(eventWaitingTime);
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Event hub event waiting time not set.");
+                }
+            }
 
             OMElement configurationRetrieverElement =
                     omElement.getFirstChildWithName(new QName(APIConstants.KeyManager.EVENT_RECEIVER_CONFIGURATION));
@@ -2026,12 +2036,12 @@ public class APIManagerConfiguration {
         }
 
         OMElement eventWaitingTimeElement = omElement
-                .getFirstChildWithName(new QName(APIConstants.GatewayArtifactSynchronizer.EVENT_WAITING_TIME_CONFIG));
+                .getFirstChildWithName(new QName(APIConstants.EVENT_WAITING_TIME_CONFIG));
         if (eventWaitingTimeElement != null) {
             long eventWaitingTime = Long.valueOf(eventWaitingTimeElement.getText());
             gatewayArtifactSynchronizerProperties.setEventWaitingTime(eventWaitingTime);
         } else {
-            log.debug("Gateway Startup mode is not set. Set to Sync Mode");
+            log.debug("Gateway artifact synchronizer Event waiting time not set.");
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/EventHubConfigurationDto.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/EventHubConfigurationDto.java
@@ -28,6 +28,8 @@ public class EventHubConfigurationDto {
     private char[] password;
     private EventHubReceiverConfiguration eventHubReceiverConfiguration;
     private EventHubPublisherConfiguration eventHubPublisherConfiguration ;
+    private long eventWaitingTime = 0;
+
     public boolean isEnabled() {
 
         return enabled;
@@ -69,7 +71,20 @@ public class EventHubConfigurationDto {
         this.eventHubReceiverConfiguration = eventHubReceiverConfiguration;
     }
 
+    public long getEventWaitingTime() {
 
+        return eventWaitingTime;
+    }
+
+    public void setEventWaitingTime(long eventWaitingTime) {
+
+        this.eventWaitingTime = eventWaitingTime;
+    }
+
+    public boolean hasEventWaitingTime() {
+
+        return eventWaitingTime > 0;
+    }
 
     public String getUsername() {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/GatewayArtifactSynchronizerProperties.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/GatewayArtifactSynchronizerProperties.java
@@ -28,6 +28,11 @@ public class GatewayArtifactSynchronizerProperties {
         return eventWaitingTime;
     }
 
+    public boolean hasEventWaitingTime() {
+
+        return eventWaitingTime > 1;
+    }
+
     public void setEventWaitingTime(long eventWaitingTime) {
 
         this.eventWaitingTime = eventWaitingTime;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/DBRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/DBRetriever.java
@@ -68,10 +68,12 @@ public class DBRetriever implements ArtifactRetriever {
             throws ArtifactSynchronizerException {
 
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        try {
-            Thread.sleep(gatewayArtifactSynchronizerProperties.getEventWaitingTime());
-        } catch (InterruptedException e) {
-            log.error("Error occurred while waiting to retrieve artifacts from event hub");
+        if (gatewayArtifactSynchronizerProperties.hasEventWaitingTime()) {
+            try {
+                Thread.sleep(gatewayArtifactSynchronizerProperties.getEventWaitingTime());
+            } catch (InterruptedException e) {
+                log.error("Error occurred while waiting to retrieve artifacts from event hub");
+            }
         }
         try {
             String encodedGatewayLabel = URLEncoder.encode(gatewayLabel, APIConstants.DigestAuthConstants.CHARSET);

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1260,6 +1260,9 @@
         {% else %}
          <ServiceURL>{{apim.throttling.service_url}}</ServiceURL>
         {% endif %}
+        {% if apim.event_hub.event_waiting_time is defined %}
+        <EventWaitingTime>{{apim.event_hub.event_waiting_time}}</EventWaitingTime>
+        {% endif %}
          {% if apim.event_hub.init_delay is defined %}
         <InitDelay>{{apim.event_hub.init_delay}}</InitDelay>
           {% endif %}
@@ -1371,7 +1374,7 @@
         {% if apim.sync_runtime_artifacts.gateway.data_retrieval_mode is defined %}
         <DataRetrievalMode>{{apim.sync_runtime_artifacts.gateway.data_retrieval_mode}}</DataRetrievalMode>
         {% endif %}
-        {% if apim.sync_runtime_artifacts.gateway.event_waiting_time is defined %}
+        {% if  apim.event_hub.event_waiting_time is not defined and apim.sync_runtime_artifacts.gateway.event_waiting_time is defined %}
         <EventWaitingTime>{{apim.sync_runtime_artifacts.gateway.event_waiting_time}}</EventWaitingTime>
         {% endif %}
         <SkipList>


### PR DESCRIPTION
This PR adds support to a new config which will add an event waiting time for all event hub events.

```
[apim.event_hub]
event_waiting_time = 5000
```

This config will not be added to the default.json, as it is intended not to be applied by default. If anyone is experiencing DB slowness, this can help with overcoming inconsistencies.

Fixes: https://github.com/wso2/api-manager/issues/702