### PR TITLE
Update synapse, mediation for JDK 11 builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1956,7 +1956,7 @@
 
         <carbon.commons.version>4.7.49</carbon.commons.version>
         <carbon.registry.version>4.8.2</carbon.registry.version>
-        <carbon.mediation.version>4.7.138</carbon.mediation.version>
+        <carbon.mediation.version>4.7.141</carbon.mediation.version>
 
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 
@@ -2040,7 +2040,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>2.1.7-wso2v307</synapse.version>
+        <synapse.version>2.1.7-wso2v310</synapse.version>
 
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 


### PR DESCRIPTION
Update axiom, synapse, and carbon-mediation for build in JDK 11 and run on JDK 17