### PR TITLE
Move a Util method to rest.api.common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,9 @@ features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/src/main/resources
 features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/src/main/resources/api-docs/package.json
 features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/tenant/tenant-conf.json
 components/apimgt/org.wso2.carbon.apimgt.hybrid.gateway/org.wso2.carbon.apimgt.hybrid.gateway.usage.publisher/src/test/resources/carbon-home/api-usage-data/api-usage-data.dat
-components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
-components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/devportal-api.yaml
-components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/admin-api.yaml
+components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
+components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
+components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
 components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/swagger.json
 components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/swagger.json
 components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/swagger.json

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SystemScopesMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SystemScopesMappingUtil.java
@@ -29,13 +29,13 @@ import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.RoleAliasDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.RoleAliasListDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ScopeListDTO;
-import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
+import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SystemScopesMappingUtil {
@@ -71,7 +71,7 @@ public class SystemScopesMappingUtil {
         if (portalScopeList.isEmpty()) {
             synchronized (lock) {
                 if (portalScopeList.isEmpty()) {
-                    portalScopeList = RestApiUtil.getScopesInfoFromAPIYamlDefinitions();
+                    portalScopeList = RestApiCommonUtil.getScopesInfoFromAPIYamlDefinitions();
                 }
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiCommonUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiCommonUtil.java
@@ -323,6 +323,43 @@ public class RestApiCommonUtil {
     }
 
     /**
+     * This method is used to get the scope list from the yaml file.
+     *
+     * @return MAP of scope list for all portal
+     */
+    public static  Map<String, List<String>> getScopesInfoFromAPIYamlDefinitions() throws APIManagementException {
+
+        Map<String, List<String>>   portalScopeList = new HashMap<>();
+        String [] fileNameArray = {"/admin-api.yaml", "/publisher-api.yaml", "/devportal-api.yaml",
+                "/service-catalog-api.yaml"};
+        for (String fileName : fileNameArray) {
+            String definition = null;
+            try {
+                definition = IOUtils
+                        .toString(RestApiCommonUtil.class.getResourceAsStream(fileName), "UTF-8");
+            } catch (IOException  e) {
+                throw new APIManagementException("Error while reading the swagger definition ,",
+                        ExceptionCodes.DEFINITION_EXCEPTION);
+            }
+            APIDefinition oasParser = OASParserUtil.getOASParser(definition);
+            Set<Scope> scopeSet = oasParser.getScopes(definition);
+            for (Scope entry : scopeSet) {
+                List<String> list = new ArrayList<>();
+                list.add(entry.getDescription());
+                list.add((fileName.replaceAll("-api.yaml", "").replace("/", "")));
+                if (("/service-catalog-api.yaml".equals(fileName))) {
+                    if (!entry.getKey().contains("apim:api_view")) {
+                        portalScopeList.put(entry.getName(), list);
+                    }
+                } else {
+                    portalScopeList.put(entry.getName(), list);
+                }
+            }
+        }
+        return portalScopeList;
+    }
+
+    /**
      * Returns an APIConsumer which is corresponding to the current logged in user taken from the carbon context
      *
      * @return an APIConsumer which is corresponding to the current logged in user

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/utils/RestApiUtil.java
@@ -26,7 +26,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.apache.cxf.message.Message;
 import org.json.simple.JSONObject;
-import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIMgtAuthorizationFailedException;
 import org.wso2.carbon.apimgt.api.APIMgtResourceAlreadyExistsException;
@@ -39,13 +38,10 @@ import org.wso2.carbon.apimgt.api.model.DuplicateAPIException;
 import org.wso2.carbon.apimgt.api.model.OAuthAppRequest;
 import org.wso2.carbon.apimgt.api.model.OAuthApplicationInfo;
 import org.wso2.carbon.apimgt.api.model.ResourceFile;
-import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.Tier;
-import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.AMDefaultKeyManagerImpl;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
-import org.wso2.carbon.apimgt.impl.definitions.OASParserUtil;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
@@ -74,7 +70,6 @@ import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
@@ -1118,42 +1113,6 @@ public class RestApiUtil {
     public static boolean checkIfAnonymousAPI(Message inMessage) {
         return (inMessage.get(RestApiConstants.AUTHENTICATION_REQUIRED) != null &&
                 !((Boolean) inMessage.get(RestApiConstants.AUTHENTICATION_REQUIRED)));
-    }
-
-    /**
-     * This method is used to get the scope list from the yaml file
-     *
-     * @return MAP of scope list for all portal
-     */
-    public static  Map<String, List<String>> getScopesInfoFromAPIYamlDefinitions() throws APIManagementException {
-
-        Map<String, List<String>>   portalScopeList = new HashMap<>();
-        String [] fileNameArray = {"/admin-api.yaml", "/publisher-api.yaml", "/devportal-api.yaml", "/service-catalog-api.yaml"};
-        for (String fileName : fileNameArray) {
-            String definition = null;
-            try {
-                definition = IOUtils
-                        .toString(RestApiUtil.class.getResourceAsStream(fileName), "UTF-8");
-            } catch (IOException  e) {
-                throw new APIManagementException("Error while reading the swagger definition ,",
-                        ExceptionCodes.DEFINITION_EXCEPTION);
-            }
-            APIDefinition oasParser = OASParserUtil.getOASParser(definition);
-            Set<Scope> scopeSet = oasParser.getScopes(definition);
-            for (Scope entry : scopeSet) {
-                List<String> list = new ArrayList<>();
-                list.add(entry.getDescription());
-                list.add((fileName.replaceAll("-api.yaml", "").replace("/", "")));
-                if (("/service-catalog-api.yaml".equals(fileName))) {
-                    if (!entry.getKey().contains("apim:api_view")) {
-                        portalScopeList.put(entry.getName(), list);
-                    }
-                } else {
-                    portalScopeList.put(entry.getName(), list);
-                }
-            }
-        }
-        return portalScopeList;
     }
 
     /**


### PR DESCRIPTION
#### Description
Move getScopesInfoFromAPIYamlDefinitions method to rest.api.common from rest.api.util
Fix https://github.com/wso2/api-manager/issues/795

#### Related PRs

- wso2/carbon-apimgt/pull/11443