### PR TITLE
Fixes for vulnerable third-party dependencies

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
@@ -73,7 +73,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/pom.xml
@@ -76,7 +76,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <exclusions>
                 <exclusion>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
@@ -84,7 +84,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <exclusions>
                 <exclusion>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.devops/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.devops/pom.xml
@@ -84,7 +84,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <exclusions>
                 <exclusion>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.gateway/pom.xml
@@ -89,7 +89,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <exclusions>
                 <exclusion>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
@@ -98,7 +98,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <exclusions>
                 <exclusion>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
@@ -88,7 +88,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <exclusions>
                 <exclusion>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/pom.xml
@@ -89,7 +89,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <exclusions>
                 <exclusion>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/pom.xml
@@ -98,7 +98,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1348,7 +1348,7 @@
                 <version>${reflection.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${hibernate-validator.version}</version>
             </dependency>
@@ -2081,7 +2081,7 @@
         <slf4j.api.version>1.7.29</slf4j.api.version>
         <slf4j.wso2.version>1.5.10.wso2v1</slf4j.wso2.version>
         <spring-web.version>5.1.13.RELEASE</spring-web.version>
-        <hibernate-validator.version>5.4.3.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.0.23.Final</hibernate-validator.version>
         <swagger-jaxrs.version>1.6.1</swagger-jaxrs.version>
         <junit.version>4.13.1</junit.version>
         <opensaml3.version>3.3.1</opensaml3.version>
@@ -2129,7 +2129,7 @@
         <fasterxml.jackson.version>2.13.1</fasterxml.jackson.version>
         <fasterxml.jackson.databind.version>2.13.1</fasterxml.jackson.databind.version>
         <fasterxml.jackson.core.version>2.13.1</fasterxml.jackson.core.version>
-        <javax.validation-api>1.1.0.Final</javax.validation-api>
+        <javax.validation-api>2.0.1.Final</javax.validation-api>
         <carbon.broker.version>3.3.26</carbon.broker.version>
         <andes.version>3.3.24</andes.version>
         <waffle-jna.version>1.6.wso2v7</waffle-jna.version>


### PR DESCRIPTION
- hibernate-validator has been updated from 5.4.3.Final to 6.0.23.Final
- validation-api has been updated from 1.1.0.Final to 2.0.1.Final

The following components will be updated from this PR

- ./repository/deployment/server/webapps/api#am#admin#v0.17/WEB-INF/lib/hibernate-validator-5.4.3.Final.jar
- ./repository/deployment/server/webapps/api#am#gateway/WEB-INF/lib/hibernate-validator-5.4.3.Final.jar
- ./repository/deployment/server/webapps/api#am#gateway#v0.9/WEB-INF/lib/hibernate-validator-5.4.3.Final.jar
- ./repository/deployment/server/webapps/api#am#publisher/WEB-INF/lib/hibernate-validator-5.4.3.Final.jar
- ./repository/deployment/server/webapps/api#am#store/WEB-INF/lib/hibernate-validator-5.4.3.Final.jar
- ./repository/deployment/server/webapps/client-registration#v0.17/WEB-INF/lib/hibernate-validator-5.4.3.Final.jar
- ./repository/deployment/server/webapps/api#am#admin/WEB-INF/lib/hibernate-validator-5.4.3.Final.jar
-------------------------------------------------------------------------------------------------------------------
- ./repository/deployment/server/webapps/api#am#admin#v0.17/WEB-INF/lib/validation-api-1.1.0.Final.jar
- ./repository/deployment/server/webapps/api#am#gateway/WEB-INF/lib/validation-api-1.1.0.Final.jar
- ./repository/deployment/server/webapps/api#am#gateway#v0.9/WEB-INF/lib/validation-api-1.1.0.Final.jar
- ./repository/deployment/server/webapps/api#am#publisher/WEB-INF/lib/validation-api-1.1.0.Final.jar
- ./repository/deployment/server/webapps/api#am#store/WEB-INF/lib/validation-api-1.1.0.Final.jar
- ./repository/deployment/server/webapps/client-registration#v0.17/WEB-INF/lib/validation-api-1.1.0.Final.jar
- ./repository/deployment/server/webapps/api#am#admin/WEB-INF/lib/validation-api-1.1.0.Final.jar