### PR TITLE
 Refactor Web-Sub Subscription process

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
@@ -187,6 +187,11 @@ public class API implements Serializable {
      */
     private boolean enableSchemaValidation = false;
 
+    /**
+     * Property to enable/disable WebSub intent verification
+     */
+    private boolean enableSubscriberVerification = false;
+
     private List<APICategory> apiCategories;
 
     /**
@@ -1081,6 +1086,24 @@ public class API implements Serializable {
      */
     public void setEnableSchemaValidation(boolean enableSchemaValidation) {
         this.enableSchemaValidation = enableSchemaValidation;
+    }
+
+    /**
+     * Check the status of the enableSubscriberVerification property
+     *
+     * @return status of the property
+     */
+    public boolean isEnableSubscriberVerification() {
+        return enableSubscriberVerification;
+    }
+
+    /**
+     * To set enableSubscriberVerification property
+     *
+     * @param enableSubscriberVerification Given status
+     */
+    public void setEnableSubscriberVerification(boolean enableSubscriberVerification) {
+        this.enableSubscriberVerification = enableSubscriberVerification;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -167,5 +167,13 @@ public class APIMgtGatewayConstants {
     public static final String OAUTH_ENDPOINT_INSTANCE = "oauth.instance";
     public static final String VALIDATED_X509_CERT = "ValidatedX509Cert";
     public static final String RESOURCE_SPAN = "API:Resource";
+
+    /**
+     * Web-sub related properties
+     */
+    public static final String SUBSCRIBER_LINK_HEADER_HUB = "; rel=\"hub\", ";
+    public static final String SUBSCRIBER_LINK_HEADER_SELF = "; rel=\"self\" ";
+
+    public static final String SUBSCRIBER_LINK_HEADER_PROPERTY = "SUBSCRIBER_LINK_HEADER";
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/webhooks/SubscriberInfoLoader.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/webhooks/SubscriberInfoLoader.java
@@ -23,6 +23,7 @@ import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractMediator;
+import org.apache.synapse.rest.RESTConstants;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
@@ -65,6 +66,12 @@ public class SubscriberInfoLoader extends AbstractMediator {
             messageContext.setProperty(APIConstants.Webhooks.SUBSCRIBER_CALLBACK_PROPERTY, subscriber.getCallbackURL());
             messageContext.setProperty(APIConstants.Webhooks.SUBSCRIBER_SECRET_PROPERTY, subscriber.getSecret());
             messageContext.setProperty(APIConstants.Webhooks.SUBSCRIBER_APPLICATION_ID_PROPERTY, subscriber.getAppID());
+
+            String linkHeader = messageContext.getProperty(RESTConstants.REST_URL_PREFIX).toString()
+                    + messageContext.getProperty(RESTConstants.REST_API_CONTEXT).toString()
+                    + APIMgtGatewayConstants.SUBSCRIBER_LINK_HEADER_HUB + subscriber.getTopicName()
+                    + APIMgtGatewayConstants.SUBSCRIBER_LINK_HEADER_SELF;
+            messageContext.setProperty(APIMgtGatewayConstants.SUBSCRIBER_LINK_HEADER_PROPERTY, linkHeader);
         }
         return true;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2704,6 +2704,8 @@ public final class APIConstants {
         public static final String SUBSCRIBER_TOPIC_PROPERTY = "SUBSCRIBER_TOPIC";
         public static final String SUBSCRIBER_APPLICATION_ID_PROPERTY = "SUBSCRIBER_APPLICATION_ID";
         public static final String PAYLOAD_PROPERTY = "ORIGINAL_PAYLOAD";
+
+        public static final String SUBSCRIPTION_PARAMETER_PROPERTY = "SUBSCRIPTION_PARAMETERS";
     }
 
     public enum PolicyType {

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/APIConstants.java
@@ -103,6 +103,7 @@ public final class APIConstants {
 
     //This constant is used in Json schema validator
     public static final String API_OVERVIEW_ENABLE_JSON_SCHEMA = "overview_enableSchemaValidation";
+    public static final String API_OVERVIEW_ENABLE_SUB_VERIFICATION = "overview_enableSubscriberVerification";
 
     public static final String API_OVERVIEW_ENABLE_STORE = "overview_enableStore";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/PublisherAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/PublisherAPI.java
@@ -66,7 +66,9 @@ public class PublisherAPI extends PublisherAPIInfo {
     private String sandboxMaxTps;
     private String authorizationHeader;
     private String apiSecurity; // ?check whether same to private List<String> securityScheme = new ArrayList<>();
+
     private boolean enableSchemaValidation;
+    private boolean enableSubscriberVerification;
     private boolean enableStore;
     private String testKey;
     private String contextTemplate;
@@ -363,6 +365,14 @@ public class PublisherAPI extends PublisherAPIInfo {
         this.enableSchemaValidation = enableSchemaValidation;
     }
 
+    public boolean isEnableSubscriberVerification() {
+        return enableSubscriberVerification;
+    }
+
+    public void setEnableSubscriberVerification(boolean enableSubscriberVerification) {
+        this.enableSubscriberVerification = enableSubscriberVerification;
+    }
+
     public boolean isEnableStore() {
         return enableStore;
     }
@@ -613,8 +623,9 @@ public class PublisherAPI extends PublisherAPIInfo {
                 + subscriptionAvailableOrgs + ", implementation=" + implementation + ", productionMaxTps="
                 + productionMaxTps + ", sandboxMaxTps=" + sandboxMaxTps + ", authorizationHeader=" + authorizationHeader
                 + ", apiSecurity=" + apiSecurity + ", enableSchemaValidation=" + enableSchemaValidation
-                + ", enableStore=" + enableStore + ", testKey=" + testKey + ", contextTemplate=" + contextTemplate
-                + ", availableTierNames=" + availableTierNames + ", environments=" + environments
+                + ", enableSubscriberVerification=" + enableSubscriberVerification + ", enableStore=" + enableStore
+                + ", testKey=" + testKey + ", contextTemplate=" + contextTemplate + ", availableTierNames="
+                + availableTierNames + ", environments=" + environments
                 + ", corsConfiguration=" + corsConfiguration + ", websubSubscriptionConfiguration="
                 + websubSubscriptionConfiguration + ", apiCategories="
                 + apiCategories + ", isMonetizationEnabled=" + isMonetizationEnabled + ", monetizationProperties="

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/PublisherAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/PublisherAPI.java
@@ -66,7 +66,6 @@ public class PublisherAPI extends PublisherAPIInfo {
     private String sandboxMaxTps;
     private String authorizationHeader;
     private String apiSecurity; // ?check whether same to private List<String> securityScheme = new ArrayList<>();
-
     private boolean enableSchemaValidation;
     private boolean enableSubscriberVerification;
     private boolean enableStore;

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
@@ -177,6 +177,8 @@ public class RegistryPersistenceUtil {
             artifact.setAttribute(APIConstants.API_OVERVIEW_API_SECURITY, api.getApiSecurity());
             artifact.setAttribute(APIConstants.API_OVERVIEW_ENABLE_JSON_SCHEMA,
                                             Boolean.toString(api.isEnableSchemaValidation()));
+            artifact.setAttribute(APIConstants.API_OVERVIEW_ENABLE_SUB_VERIFICATION,
+                                  Boolean.toString(api.isEnableSubscriberVerification()));
             artifact.setAttribute(APIConstants.API_OVERVIEW_ENABLE_STORE, Boolean.toString(api.isEnableStore()));
             artifact.setAttribute(APIConstants.API_OVERVIEW_TESTKEY, api.getTestKey());
             artifact.setAttribute(APIConstants.API_OVERVIEW_VERSION_COMPARABLE, api.getVersionTimestamp());
@@ -657,6 +659,8 @@ public class RegistryPersistenceUtil {
             api.setLatest(Boolean.parseBoolean(artifact.getAttribute(APIConstants.API_OVERVIEW_IS_LATEST)));
             api.setEnableSchemaValidation(Boolean.parseBoolean(artifact.getAttribute(
                     APIConstants.API_OVERVIEW_ENABLE_JSON_SCHEMA)));
+            api.setEnableSubscriberVerification(
+                    Boolean.parseBoolean(artifact.getAttribute(APIConstants.API_OVERVIEW_ENABLE_SUB_VERIFICATION)));
             api.setEnableStore(Boolean.parseBoolean(artifact.getAttribute(APIConstants.API_OVERVIEW_ENABLE_STORE)));
             api.setTestKey(artifact.getAttribute(APIConstants.API_OVERVIEW_TESTKEY));
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIDTO.java
@@ -60,6 +60,7 @@ public class APIDTO   {
     private String revisionedApiId = null;
     private Integer revisionId = null;
     private Boolean enableSchemaValidation = null;
+    private Boolean enableSubscriberVerification = null;
 
     @XmlType(name="TypeEnum")
     @XmlEnum(String.class)
@@ -611,6 +612,23 @@ return null;
   public void setEnableSchemaValidation(Boolean enableSchemaValidation) {
     this.enableSchemaValidation = enableSchemaValidation;
   }
+
+    /**
+     **/
+    public APIDTO enableSubscriberVerification(Boolean enableSubscriberVerification) {
+        this.enableSubscriberVerification = enableSubscriberVerification;
+        return this;
+    }
+
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("enableSubscriberVerification")
+    public Boolean isEnableSubscriberVerification() {
+        return enableSubscriberVerification;
+    }
+
+    public void setEnableSubscriberVerification(Boolean enableSubscriberVerification) {
+        this.enableSubscriberVerification = enableSubscriberVerification;
+    }
 
   /**
    * The api creation type to be used. Accepted values are HTTP, WS, SOAPTOREST, GRAPHQL, WEBSUB, SSE, WEBHOOK, ASYNC
@@ -1317,6 +1335,7 @@ return null;
         Objects.equals(revisionedApiId, API.revisionedApiId) &&
         Objects.equals(revisionId, API.revisionId) &&
         Objects.equals(enableSchemaValidation, API.enableSchemaValidation) &&
+        Objects.equals(enableSubscriberVerification, API.enableSubscriberVerification) &&
         Objects.equals(type, API.type) &&
         Objects.equals(audience, API.audience) &&
         Objects.equals(transport, API.transport) &&
@@ -1359,7 +1378,7 @@ return null;
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, context, version, provider, lifeCycleStatus, wsdlInfo, wsdlUrl, responseCachingEnabled, cacheTimeout, hasThumbnail, isDefaultVersion, isRevision, revisionedApiId, revisionId, enableSchemaValidation, type, audience, transport, tags, policies, apiThrottlingPolicy, authorizationHeader, securityScheme, maxTps, visibility, visibleRoles, visibleTenants, mediationPolicies, subscriptionAvailability, subscriptionAvailableTenants, additionalProperties, additionalPropertiesMap, monetization, accessControl, accessControlRoles, businessInformation, corsConfiguration, websubSubscriptionConfiguration, workflowStatus, createdTime, lastUpdatedTime, endpointConfig, endpointImplementationType, scopes, operations, threatProtectionPolicies, categories, keyManagers, serviceInfo, advertiseInfo, gatewayVendor, gatewayType, asyncTransportProtocols);
+    return Objects.hash(id, name, description, context, version, provider, lifeCycleStatus, wsdlInfo, wsdlUrl, responseCachingEnabled, cacheTimeout, hasThumbnail, isDefaultVersion, isRevision, revisionedApiId, revisionId, enableSchemaValidation, enableSubscriberVerification, type, audience, transport, tags, policies, apiThrottlingPolicy, authorizationHeader, securityScheme, maxTps, visibility, visibleRoles, visibleTenants, mediationPolicies, subscriptionAvailability, subscriptionAvailableTenants, additionalProperties, additionalPropertiesMap, monetization, accessControl, accessControlRoles, businessInformation, corsConfiguration, websubSubscriptionConfiguration, workflowStatus, createdTime, lastUpdatedTime, endpointConfig, endpointImplementationType, scopes, operations, threatProtectionPolicies, categories, keyManagers, serviceInfo, advertiseInfo, gatewayVendor, gatewayType, asyncTransportProtocols);
   }
 
   @Override
@@ -1384,6 +1403,7 @@ return null;
     sb.append("    revisionedApiId: ").append(toIndentedString(revisionedApiId)).append("\n");
     sb.append("    revisionId: ").append(toIndentedString(revisionId)).append("\n");
     sb.append("    enableSchemaValidation: ").append(toIndentedString(enableSchemaValidation)).append("\n");
+    sb.append("    enableSubscriberVerification: ").append(toIndentedString(enableSubscriberVerification)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    audience: ").append(toIndentedString(audience)).append("\n");
     sb.append("    transport: ").append(toIndentedString(transport)).append("\n");
@@ -1437,4 +1457,3 @@ return null;
     return o.toString().replace("\n", "\n    ");
   }
 }
-

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -207,6 +207,9 @@ public class APIMappingUtil {
         if (dto.isEnableSchemaValidation() != null) {
             model.setEnableSchemaValidation(dto.isEnableSchemaValidation());
         }
+        if (dto.isEnableSubscriberVerification() != null) {
+            model.setEnableSubscriberVerification(dto.isEnableSubscriberVerification());
+        }
         model.setEnableStore(true);
         if (dto.getAdvertiseInfo() != null) {
             AdvertiseInfoDTO advertiseInfoDTO = dto.getAdvertiseInfo();
@@ -972,6 +975,7 @@ public class APIMappingUtil {
         dto.setRevisionedApiId(model.getRevisionedApiId());
         dto.setRevisionId(model.getRevisionId());
         dto.setEnableSchemaValidation(model.isEnabledSchemaValidation());
+        dto.setEnableSubscriberVerification(model.isEnableSubscriberVerification());
 
         AdvertiseInfoDTO advertiseInfoDTO = new AdvertiseInfoDTO();
         advertiseInfoDTO.setAdvertised(model.isAdvertiseOnly());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/template/APITemplateBuilderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/template/APITemplateBuilderImpl.java
@@ -61,6 +61,7 @@ public class APITemplateBuilderImpl implements APITemplateBuilder {
     private static final Log log = LogFactory.getLog(APITemplateBuilderImpl.class);
     private static final String TEMPLATE_TYPE_ENDPOINT = "endpoint_template";
     private static final String TEMPLATE_TYPE_API_PRODUCT = "api_product_template";
+    private static final String WEBSUB_ENABLE_SUBSCRIBER_VERIFICATION = "enableSubscriberVerification";
     private List<SoapToRestMediationDto> soapToRestOutMediationDtoList;
     private List<SoapToRestMediationDto> soapToRestInMediationDtoList;
     private API api;
@@ -136,6 +137,11 @@ public class APITemplateBuilderImpl implements APITemplateBuilder {
                     context.put("signatureHeader", api.getWebsubSubscriptionConfiguration().getSignatureHeader());
                     context.put("isSecurityEnabled", !StringUtils.isEmpty(api.getWebsubSubscriptionConfiguration().
                             getSecret()));
+                    if (api != null) {
+                        context.put(WEBSUB_ENABLE_SUBSCRIBER_VERIFICATION, api.isEnableSubscriberVerification());
+                    } else {
+                        context.put(WEBSUB_ENABLE_SUBSCRIBER_VERIFICATION, false);
+                    }
                 } else if (APIConstants.GRAPHQL_API.equals(api.getType())) {
                     boolean isSubscriptionAvailable = false;
                     if (api.getWebSocketTopicMappingConfiguration() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -8633,6 +8633,9 @@ components:
         enableSchemaValidation:
           type: boolean
           example: false
+        enableSubscriberVerification:
+          type: boolean
+          example: false
         type:
           type: string
           description: The api creation type to be used. Accepted values are HTTP,


### PR DESCRIPTION
Add 'application/x-www-form-urlencoded' support for subscription creation.
Modify Subscription initialization to use 'GET' requests with 'hub.challenge' parameter.
Add link header for content distribution requests.
Add conditional subscription verification.
To enable subscription verification .
 - Go to publisher portal and click on API Configurations.
 - Under WebSub Configurations select 'Enable subscriber verification' checkbox.
 
Fix https://github.com/wso2/api-manager/issues/775
 
 > Related PRs: https://github.com/wso2/apim-apps/pull/358, https://github.com/wso2/product-apim/pull/12989