### PR TITLE
Add the support for different API types for policies

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2890,6 +2890,9 @@ public final class APIConstants {
             + "resources" + File.separator + "operation_policies" + File.separator + "definitions";
     public static final String OPERATION_POLICY_SUPPORTED_GATEWAY_SYNAPSE = "Synapse";
     public static final String OPERATION_POLICY_SUPPORTED_API_TYPE_HTTP = "HTTP";
+    public static final String OPERATION_POLICY_SUPPORTED_API_TYPE_SOAP = "SOAP";
+    public static final String OPERATION_POLICY_SUPPORTED_API_TYPE_SOAPTOREST = "SOAPTOREST";
+    public static final String OPERATION_POLICY_SUPPORTED_API_TYPE_GRAPHQL = "GRAPHQL";
     public static final String DEFAULT_POLICY_VERSION = "v1";
 
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -9695,6 +9695,9 @@ public final class APIUtil {
 
         ArrayList<String> supportedAPIList = new ArrayList<>();
         supportedAPIList.add(APIConstants.OPERATION_POLICY_SUPPORTED_API_TYPE_HTTP);
+        supportedAPIList.add(APIConstants.OPERATION_POLICY_SUPPORTED_API_TYPE_SOAP);
+        supportedAPIList.add(APIConstants.OPERATION_POLICY_SUPPORTED_API_TYPE_SOAPTOREST);
+        supportedAPIList.add(APIConstants.OPERATION_POLICY_SUPPORTED_API_TYPE_GRAPHQL);
         policySpecification.setSupportedApiTypes(supportedAPIList);
 
         ArrayList<String> applicableFlows = new ArrayList<>();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/operationPolicy/operation-policy-specification-schema.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/operationPolicy/operation-policy-specification-schema.json
@@ -52,7 +52,10 @@
       "items": {
         "type": "string",
         "enum": [
-          "HTTP"
+          "HTTP",
+          "SOAP",
+          "SOAPTOREST",
+          "GRAPHQL"
         ]
       },
       "minItems": 1


### PR DESCRIPTION
With this PR, we are adding the support for multiple API types for policies framework.

Fixes : https://github.com/wso2/product-apim/issues/12559