### PR TITLE
Set "all" Value to Key Managers Field in API Products Model Returned from DevPortal REST API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -71,6 +71,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -442,6 +443,7 @@ public class APIMappingUtil {
         String subscriptionAllowedTenants = model.getSubscriptionAvailableTenants();
         dto.setIsSubscriptionAvailable(isSubscriptionAvailable(apiTenant, subscriptionAvailability,
                 subscriptionAllowedTenants));
+        dto.setKeyManagers(Collections.singletonList(APIConstants.KeyManager.API_LEVEL_ALL_KEY_MANAGERS));
         return dto;
     }
 


### PR DESCRIPTION
## Purpose
- Currently, when fetching APIs using the DevPortal REST API, the Key Managers field for API Products is assigned a value of `null`. 
- This PR sets `all` value to the Key Managers fields in API Products model returned from the DevPortal REST API.
- This is done to enable the `SUBSCRIPTION AND KEY GENERATION WIZARD` button in the Subscription page of API Products in DevPortal. This button was disabled based on a condition related to the Key Managers field of the returned API object. Since the value for API products was null, the button was disabled.
- Fixes https://github.com/wso2/api-manager/issues/33

## Approach
- Set `all` value to the Key Managers fields in API Products model returned from the DevPortal REST API