### PR TITLE
Build the policy definition without super root if the policy contains xml prologs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
@@ -160,7 +160,8 @@ public class SynapsePolicyAggregator {
     private static String sanitizeOMElementWithSuperParentNode(String xmlString) throws Exception {
 
         String updatedXmlString = "<root>" + xmlString + "</root>";
-        OMElement sanitizedPolicyElement = APIUtil.buildOMElement(new ByteArrayInputStream(updatedXmlString.getBytes()));
+        OMElement sanitizedPolicyElement =
+                APIUtil.buildOMElement(new ByteArrayInputStream(updatedXmlString.getBytes()));
         StringBuilder filteredTemplate = new StringBuilder();
         for (Iterator childElements = sanitizedPolicyElement.getChildElements();
              childElements.hasNext(); ) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
@@ -112,21 +112,22 @@ public class SynapsePolicyAggregator {
                         try {
                             String renderedTemplate =
                                     renderPolicyTemplate(policyDefinition.getContent(), policyParameters);
-                            // As there can be multiple child elements without a root element, for sanitization, we will
-                            // first wrap the template with a dummy root element and build the OM element.
-                            // This element will be removed after sanitization step.
                             if (renderedTemplate != null && !renderedTemplate.isEmpty()) {
-                                renderedTemplate = "<root>" + renderedTemplate + "</root>";
-                                OMElement sanitizedPolicyElement =
-                                        APIUtil.buildOMElement(new ByteArrayInputStream(renderedTemplate.getBytes()));
-                                //This is to skip any comments that are added to the policy.
-                                StringBuilder filteredTemplate = new StringBuilder();
-                                for (Iterator childElements = sanitizedPolicyElement.getChildElements();
-                                     childElements.hasNext(); ) {
-                                    OMElement element = (OMElement) childElements.next();
-                                    filteredTemplate.append(element.toString());
+                                String sanitizedPolicy;
+                                try {
+                                    sanitizedPolicy = sanitizeOMElementWithSuperParentNode(renderedTemplate);
+                                } catch (Exception e) {
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("Cannot wrap the policy " + policy.getPolicyName()
+                                                + " with a super parent. Trying without wrapping.");
+                                    }
+                                    // As we can't wrap the policy definition with a super parent, trying the build
+                                    // OM element with the provided policy definition. This will select first child node
+                                    // and drop the other child nodes if a parent node is not configured.
+                                    sanitizedPolicy = APIUtil.buildOMElement(
+                                            new ByteArrayInputStream(renderedTemplate.getBytes())).toString();
                                 }
-                                caseBody.add(filteredTemplate.toString());
+                                caseBody.add(sanitizedPolicy);
                             }
                         } catch (Exception e) {
                             log.error("Error parsing the policy definition for " + policy.getPolicyName());
@@ -149,6 +150,24 @@ public class SynapsePolicyAggregator {
         }
 
         return caseList;
+    }
+
+    /**
+     *  As there can be multiple child elements without a root element, for sanitization, we will
+     *  first wrap the template with a dummy root element and build the OM element.
+     *  This element will be removed after sanitization step.
+     */
+    private static String sanitizeOMElementWithSuperParentNode(String xmlString) throws Exception {
+
+        String updatedXmlString = "<root>" + xmlString + "</root>";
+        OMElement sanitizedPolicyElement = APIUtil.buildOMElement(new ByteArrayInputStream(updatedXmlString.getBytes()));
+        StringBuilder filteredTemplate = new StringBuilder();
+        for (Iterator childElements = sanitizedPolicyElement.getChildElements();
+             childElements.hasNext(); ) {
+            OMElement element = (OMElement) childElements.next();
+            filteredTemplate.append(element.toString());
+        }
+        return filteredTemplate.toString();
     }
 
     public static String renderPolicyTemplate(String template, Map<String, Object> configMap) {


### PR DESCRIPTION
We have introduced a fix[1] to wrap the policy XML String with a super parent before building the OMElement. this was introduced to fix the child elements being dropped when a parent element is not found[2]. However this fix will break if the policy contains XML prologs.

This fix will initially try with the super parent node approach and if this fails, it will just render whatever the policy string provided without any modifications.

[1] - https://github.com/wso2/carbon-apimgt/pull/11347
[2] - https://github.com/wso2/api-manager/issues/25