### PR TITLE
Add a validation for operation policies in the import flow

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -1684,4 +1684,14 @@ public interface APIProvider extends APIManager {
      */
     boolean isValidContext(String providerName, String apiName, String contextTemplate, String userName,
                            String organization) throws APIManagementException;
+    /***
+     * Validate the policies with spec
+     * @param policySpecification policy spec
+     * @param appliedPolicy policyID
+     * @param apiType API Type
+     * @return validation status
+     * @throws APIManagementException
+     */
+    boolean validateAppliedPolicyWithSpecification(OperationPolicySpecification policySpecification, OperationPolicy
+            appliedPolicy, String apiType) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -524,6 +524,8 @@ public enum ExceptionCodes implements ErrorHandler {
     OPERATION_POLICY_GATEWAY_ERROR(903008,
             "Either Synapse or Choreo Gateway Definition files or both should be present", 400,
             "Operation Policy cannot be imported due to the missing Gateway files."),
+    ERROR_VALIDATING_API_POLICY(902011, "Error while validating API policies enforced for the API", 400,
+            "Error while validating the API policies enforced for the API"),
 
     SUBSCRIPTION_TIER_NOT_ALLOWED(902002, "Subscription Tier is not allowed for user", 403, "Subscription Tier %s is" +
             " not allowed for user %s ", false),


### PR DESCRIPTION
This PR will add a validation to the API Policies import flow. If the policy mentioned in the API.yaml is not found in the project or from the existing policies map, previously we silently dropped that policy and proceeded with the import flow. With this new change, it will break the import flow and return 400.

Fixes: https://github.com/wso2/api-manager/issues/809