### PR TITLE
[9.22.x] Fix issue with /export REST API call

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -189,7 +189,7 @@ public class ExportUtils {
 
         CommonUtil.createDirectory(archivePath);
         if (preserveDocs) {
-            addThumbnailToArchive(archivePath, apiIdentifier, apiProvider);
+            addThumbnailToArchive(archivePath, apiIdentifier, apiProvider, organization);
             addDocumentationToArchive(archivePath, apiIdentifier, exportFormat, apiProvider,
                     APIConstants.API_IDENTIFIER_TYPE);
         } else {
@@ -279,7 +279,7 @@ public class ExportUtils {
         CommonUtil.createDirectory(archivePath);
 
         if (preserveDocs) {
-            addThumbnailToArchive(archivePath, apiProductIdentifier, apiProvider);
+            addThumbnailToArchive(archivePath, apiProductIdentifier, apiProvider, organization);
             addDocumentationToArchive(archivePath, apiProductIdentifier, exportFormat, apiProvider,
                     APIConstants.API_PRODUCT_IDENTIFIER_TYPE);
         }
@@ -314,13 +314,20 @@ public class ExportUtils {
      * @throws APIImportExportException If an error occurs while retrieving image from the registry or
      *                                  storing in the archive directory
      */
-    public static void addThumbnailToArchive(String archivePath, Identifier identifier, APIProvider apiProvider)
+    public static void addThumbnailToArchive(String archivePath, Identifier identifier, APIProvider apiProvider,
+                                             String organization)
             throws APIImportExportException, APIManagementException {
 
         String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
         String localImagePath = archivePath + File.separator + ImportExportConstants.IMAGE_RESOURCE;
         try {
-            ResourceFile thumbnailResource = apiProvider.getIcon(identifier.getUUID(), tenantDomain);
+
+            ResourceFile thumbnailResource;
+            if (StringUtils.isNotEmpty(organization)) {
+                thumbnailResource = apiProvider.getIcon(identifier.getUUID(), organization);
+            } else {
+                thumbnailResource = apiProvider.getIcon(identifier.getUUID(), tenantDomain);
+            }
             if (thumbnailResource != null) {
                 String mediaType = thumbnailResource.getContentType();
                 String extension = ImportExportConstants.fileExtensionMapping.get(mediaType);


### PR DESCRIPTION
## Purpose

Fix the issue of returning 500 error returns with the following error logs when doing /export REST API call. 

Related Issue:
https://github.com/wso2-enterprise/choreo/issues/9668

**Curl Request:**

```
curl -k -H "Authorization: Bearer ea5f7ea4-d5f6-3eaa-ba61-2d31d1e41268" "https://localhost:9443/api/am/publisher/v2/apis/export?organizationId=12345&apiId=636b8c72a920ee66caf023de&provider=admin&format=YAML" > exportAPI.zip
```

**Error logs:**

```
11/9/2022, 1:47:25 PM
TID: [-1234] [2022-11-09 08:17:25,218] INFO {AUDIT_LOG} 2f32eb06-bc1a-422f-9d85-58e4e53a2d56 - GET /api/am/publisher/apis/export?organizationId=e628f45c-d4fc-4d2a-9105-350b60beb84e&apiId=63628ea96b97733b88a5f480&format=YAML&provider=d5035fcc-656f-4b7b-84c1-6eff0087abea user: choreo_dev_apim_admin@carbon.super app: ikEvfT5VSGWbfoEkq2y4vOhe1Soa
11/9/2022, 1:47:25 PM
[2022-11-09 08:17:25,254] ERROR 2f32eb06-bc1a-422f-9d85-58e4e53a2d56 - GlobalThrowableMapper A defined exception has been captured and mapped to an HTTP response by the global exception mapper
11/9/2022, 1:47:25 PM
org.wso2.carbon.apimgt.api.APIManagementException: Error while accessing thumbnail resource
11/9/2022, 1:47:25 PM
at org.wso2.carbon.apimgt.impl.AbstractAPIManager.getIcon_aroundBody136(AbstractAPIManager.java:1507) ~[org.wso2.carbon.apimgt.impl_9.22.52.jar:?]
11/9/2022, 1:47:25 PM
at org.wso2.carbon.apimgt.impl.AbstractAPIManager.getIcon(AbstractAPIManager.java:1) ~[org.wso2.carbon.apimgt.impl_9.22.52.jar:?]
11/9/2022, 1:47:25 PM
at org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings.ExportUtils.addThumbnailToArchive(ExportUtils.java:323) ~[org.wso2.carbon.apimgt.rest.api.publisher.v1.common_9.22.52.jar:?]
11/9/2022, 1:47:25 PM
at org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings.ExportUtils.exportApi(ExportUtils.java:192) ~[org.wso2.carbon.apimgt.rest.api.publisher.v1.common_9.22.52.jar:?]
11/9/2022, 1:47:25 PM
at org.wso2.carbon.apimgt.rest.api.publisher.v1.common.ImportExportAPIServiceImpl.exportAPI(ImportExportAPIServiceImpl.java:102) ~[?:?]
11/9/2022, 1:47:25 PM
at org.wso2.carbon.apimgt.rest.api.publisher.v1.impl.ApisApiServiceImpl.exportAPI(ApisApiServiceImpl.java:3667) ~[classes/:?]
11/9/2022, 1:47:25 PM
at org.wso2.carbon.apimgt.rest.api.publisher.v1.ApisApi.exportAPI(ApisApi.java:560) ~[classes/:?]
11/9/2022, 1:47:25 PM
```