### PR TITLE
Fix error adding WSO2-IS as Key Manager from Admin portal

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -701,14 +701,6 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                     .concat(getTenantAwareContext().trim()).concat
                             (APIConstants.KeyManager.KEY_MANAGER_OPERATIONS_USERINFO_ENDPOINT);
         }
-        String revokeOneTimeTokenEndpoint;
-        if (configuration.getParameter(APIConstants.KeyManager.REVOKE_TOKEN_ENDPOINT) != null) {
-            revokeOneTimeTokenEndpoint = (String) configuration.getParameter(APIConstants.KeyManager.REVOKE_ENDPOINT);
-        } else {
-            revokeOneTimeTokenEndpoint = keyManagerServiceUrl.split("/" + APIConstants.SERVICES_URL_RELATIVE_PATH)[0]
-                    .concat(getTenantAwareContext().trim()).concat
-                            (APIConstants.KeyManager.KEY_MANAGER_OPERATIONS_REVOKE_TOKEN_ENDPOINT);
-        }
 
         dcrClient = Feign.builder()
                 .client(new ApacheFeignHttpClient(APIUtil.getHttpClient(dcrEndpoint)))
@@ -756,15 +748,28 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                 .requestInterceptor(new TenantHeaderInterceptor(tenantDomain))
                 .errorDecoder(new KMClientErrorDecoder())
                 .target(UserClient.class, userInfoEndpoint);
-        revokeClient = Feign.builder()
-                .client(new ApacheFeignHttpClient(APIUtil.getHttpClient(revokeOneTimeTokenEndpoint)))
-                .encoder(new GsonEncoder())
-                .decoder(new GsonDecoder())
-                .logger(new Slf4jLogger())
-                .requestInterceptor(new BasicAuthRequestInterceptor(username, password))
-                .requestInterceptor(new TenantHeaderInterceptor(tenantDomain))
-                .errorDecoder(new KMClientErrorDecoder())
-                .target(RevokeClient.class, revokeOneTimeTokenEndpoint);
+
+        if (!configuration.getType().equals(APIConstants.KeyManager.WSO2_IS_KEY_MANAGER_TYPE)) {
+            String revokeOneTimeTokenEndpoint;
+            if (configuration.getParameter(APIConstants.KeyManager.REVOKE_TOKEN_ENDPOINT) != null) {
+                revokeOneTimeTokenEndpoint = (String) configuration
+                        .getParameter(APIConstants.KeyManager.REVOKE_ENDPOINT);
+            } else {
+                revokeOneTimeTokenEndpoint = keyManagerServiceUrl
+                        .split("/" + APIConstants.SERVICES_URL_RELATIVE_PATH)[0].concat(getTenantAwareContext().trim())
+                        .concat(APIConstants.KeyManager.KEY_MANAGER_OPERATIONS_REVOKE_TOKEN_ENDPOINT);
+            }
+
+            revokeClient = Feign.builder()
+                    .client(new ApacheFeignHttpClient(APIUtil.getHttpClient(revokeOneTimeTokenEndpoint)))
+                    .encoder(new GsonEncoder())
+                    .decoder(new GsonDecoder())
+                    .logger(new Slf4jLogger())
+                    .requestInterceptor(new BasicAuthRequestInterceptor(username, password))
+                    .requestInterceptor(new TenantHeaderInterceptor(tenantDomain))
+                    .errorDecoder(new KMClientErrorDecoder())
+                    .target(RevokeClient.class, revokeOneTimeTokenEndpoint);
+        }
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -749,7 +749,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                 .errorDecoder(new KMClientErrorDecoder())
                 .target(UserClient.class, userInfoEndpoint);
 
-        if (!configuration.getType().equals(APIConstants.KeyManager.WSO2_IS_KEY_MANAGER_TYPE)) {
+        if (!APIConstants.KeyManager.WSO2_IS_KEY_MANAGER_TYPE.equals(configuration.getType())) {
             String revokeOneTimeTokenEndpoint;
             if (configuration.getParameter(APIConstants.KeyManager.REVOKE_TOKEN_ENDPOINT) != null) {
                 revokeOneTimeTokenEndpoint = (String) configuration

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2473,6 +2473,7 @@ public final class APIConstants {
         public static final String DEFAULT_KEY_MANAGER = "Resident Key Manager";
         public static final String DEFAULT_KEY_MANAGER_TYPE = "default";
         public static final String DEFAULT_KEY_MANAGER_DESCRIPTION = "This is Resident Key Manager";
+        public static final String WSO2_IS_KEY_MANAGER_TYPE = "WSO2-IS";
 
         public static final String ISSUER = "issuer";
         public static final String JWKS_ENDPOINT = "jwks_endpoint";


### PR DESCRIPTION
### Purpose
To fix the NPE error when adding WSO2-IS as Key Manager from the Admin portal.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/885

### Approach
- Validation added to validate before searching a value for revokeOneTimeTokenEndpoint since this is only for resident KM.
- UI validation added for other required fields: userInfoEndpoint and scopeManagementEndpoint

Related PR: https://github.com/wso2/apim-apps/pull/379