### PR TITLE
`isAttached` internal API endpoint

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/ApisApi.java
@@ -4,6 +4,7 @@ import org.wso2.carbon.apimgt.internal.service.dto.APIListDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.DeployedAPIRevisionDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.ErrorDTO;
 import java.util.List;
+import org.wso2.carbon.apimgt.internal.service.dto.OperationPolicyAttachmentStatusDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.UnDeployedAPIRevisionDTO;
 import org.wso2.carbon.apimgt.internal.service.ApisApiService;
 import org.wso2.carbon.apimgt.internal.service.impl.ApisApiServiceImpl;
@@ -38,6 +39,18 @@ public class ApisApi  {
 
 ApisApiService delegate = new ApisApiServiceImpl();
 
+
+    @GET
+    @Path("/{apiId}/operation-policy/is-attached")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get policy attachment status of an API.", notes = "If at least one policy is attached to an API this resource returns true, otherwise returns false. ", response = OperationPolicyAttachmentStatusDTO.class, tags={ "Operation Policy",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "True or False", response = OperationPolicyAttachmentStatusDTO.class),
+        @ApiResponse(code = 200, message = "Unexpected error", response = ErrorDTO.class) })
+    public Response apisApiIdOperationPolicyIsAttachedGet(@ApiParam(value = "This is used to specify the tenant domain, where the resource need to be   retrieved from. " ,required=true)@HeaderParam("xWSO2Tenant") String xWSO2Tenant, @ApiParam(value = "ID of the API",required=true) @PathParam("apiId") String apiId,  @ApiParam(value = "Organization Id ")  @QueryParam("organizationId") String organizationId) throws APIManagementException{
+        return delegate.apisApiIdOperationPolicyIsAttachedGet(xWSO2Tenant, apiId, organizationId, securityContext);
+    }
 
     @GET
     

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/ApisApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/ApisApiService.java
@@ -13,6 +13,7 @@ import org.wso2.carbon.apimgt.internal.service.dto.APIListDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.DeployedAPIRevisionDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.ErrorDTO;
 import java.util.List;
+import org.wso2.carbon.apimgt.internal.service.dto.OperationPolicyAttachmentStatusDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.UnDeployedAPIRevisionDTO;
 
 import java.util.List;
@@ -24,6 +25,7 @@ import javax.ws.rs.core.SecurityContext;
 
 
 public interface ApisApiService {
+      public Response apisApiIdOperationPolicyIsAttachedGet(String xWSO2Tenant, String apiId, String organizationId, MessageContext messageContext) throws APIManagementException;
       public Response apisGet(String xWSO2Tenant, String apiId, String context, String version, String gatewayLabel, Boolean expand, String accept, MessageContext messageContext) throws APIManagementException;
       public Response deployedAPIRevision(List<DeployedAPIRevisionDTO> deployedAPIRevisionDTOList, MessageContext messageContext) throws APIManagementException;
       public Response unDeployedAPIRevision(UnDeployedAPIRevisionDTO unDeployedAPIRevisionDTO, MessageContext messageContext) throws APIManagementException;

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/dto/OperationPolicyAttachmentStatusDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/dto/OperationPolicyAttachmentStatusDTO.java
@@ -1,0 +1,78 @@
+package org.wso2.carbon.apimgt.internal.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+
+
+public class OperationPolicyAttachmentStatusDTO   {
+  
+    private Boolean isAttached = null;
+
+  /**
+   * True if attached, false if else.
+   **/
+  public OperationPolicyAttachmentStatusDTO isAttached(Boolean isAttached) {
+    this.isAttached = isAttached;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "True if attached, false if else.")
+  @JsonProperty("isAttached")
+  public Boolean isIsAttached() {
+    return isAttached;
+  }
+  public void setIsAttached(Boolean isAttached) {
+    this.isAttached = isAttached;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OperationPolicyAttachmentStatusDTO operationPolicyAttachmentStatus = (OperationPolicyAttachmentStatusDTO) o;
+    return Objects.equals(isAttached, operationPolicyAttachmentStatus.isAttached);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(isAttached);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class OperationPolicyAttachmentStatusDTO {\n");
+    
+    sb.append("    isAttached: ").append(toIndentedString(isAttached)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/ApisApiServiceImpl.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -31,6 +32,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.model.DeployedAPIRevision;
 import org.wso2.carbon.apimgt.api.model.Environment;
+import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.api.model.subscription.API;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.GZIPUtils;
@@ -40,6 +42,7 @@ import org.wso2.carbon.apimgt.internal.service.ApisApiService;
 import org.wso2.carbon.apimgt.internal.service.dto.APIListDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.DeployedAPIRevisionDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.DeployedEnvInfoDTO;
+import org.wso2.carbon.apimgt.internal.service.dto.OperationPolicyAttachmentStatusDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.UnDeployedAPIRevisionDTO;
 import org.wso2.carbon.apimgt.internal.service.utils.SubscriptionValidationDataUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
@@ -141,6 +144,38 @@ public class ApisApiServiceImpl implements ApisApiService {
         APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
         apiProvider.removeUnDeployedAPIRevision(unDeployedAPIRevisionDTO.getApiUUID(), unDeployedAPIRevisionDTO.getRevisionUUID(),
                 unDeployedAPIRevisionDTO.getEnvironment());
+        return Response.ok().build();
+    }
+
+    @Override
+    public Response apisApiIdOperationPolicyIsAttachedGet(String xWSO2Tenant, String apiId, String organizationId,
+                                                          MessageContext messageContext) throws APIManagementException {
+        try {
+            String organization;
+            if (organizationId != null) {
+                organization = organizationId;
+            } else {
+                organization = SubscriptionValidationDataUtil.validateTenantDomain(xWSO2Tenant, messageContext);
+            }
+            APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
+            org.wso2.carbon.apimgt.api.model.API api = apiProvider.getAPIbyUUID(apiId, organization);
+            boolean isAttached = false;
+            Set<URITemplate> uriTemplates = api.getUriTemplates();
+            for (URITemplate uriTemplate : uriTemplates) {
+                if (uriTemplate.getOperationPolicies().size() > 0) {
+                    isAttached = true;
+                    break;
+                }
+            }
+            OperationPolicyAttachmentStatusDTO result = new OperationPolicyAttachmentStatusDTO();
+            result.isAttached(isAttached);
+            return Response.ok().entity(result).build();
+
+        } catch (APIManagementException e) {
+            RestApiUtil.handleBadRequest(
+                    "An error has occurred while getting API for the given organization/tenantDomain and apiId combination.",
+                    e, log);
+        }
         return Response.ok().build();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/resources/api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/resources/api.yaml
@@ -218,6 +218,34 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /apis/{apiId}/operation-policy/is-attached:
+    get:
+      summary: Get policy attachment status of an API.
+      description: |
+        If at least one policy is attached to an API this resource returns true, otherwise returns false.
+      tags:
+        - 'Operation Policy'
+      parameters:
+        - $ref: '#/parameters/requestedTenant'
+        - name: organizationId
+          in: query
+          description: |
+            Organization Id
+          type: string
+        - name: apiId
+          in: path
+          description: ID of the API
+          required: true
+          type: string
+      responses:
+        200:
+          description: 'True or False'
+          schema:
+            $ref: '#/definitions/OperationPolicyAttachmentStatus'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /applications:
     get:
       summary: Get all applications
@@ -841,6 +869,11 @@ definitions:
         type: string
       id:
         type: integer
+  OperationPolicyAttachmentStatus:
+    properties:
+      isAttached:
+        type: boolean
+        description: True if attached, false if else.
   #-----------------------------------------------------
   # The API List resource
   #-----------------------------------------------------

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/swagger.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/swagger.json
@@ -260,6 +260,46 @@
         }
       }
     },
+    "/apis/{apiId}/operation-policy/is-attached" : {
+      "get" : {
+        "tags" : [ "Operation Policy" ],
+        "summary" : "Get policy attachment status of an API.",
+        "description" : "If at least one policy is attached to an API this resource returns true, otherwise returns false.\n",
+        "parameters" : [ {
+          "name" : "xWSO2Tenant",
+          "in" : "header",
+          "description" : "This is used to specify the tenant domain, where the resource need to be\n  retrieved from.\n",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "organizationId",
+          "in" : "query",
+          "description" : "Organization Id\n",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "apiId",
+          "in" : "path",
+          "description" : "ID of the API",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "True or False",
+            "schema" : {
+              "$ref" : "#/definitions/OperationPolicyAttachmentStatus"
+            }
+          },
+          "default" : {
+            "description" : "Unexpected error",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/applications" : {
       "get" : {
         "tags" : [ "Subscription Validation" ],
@@ -1056,6 +1096,14 @@
         },
         "id" : {
           "type" : "integer"
+        }
+      }
+    },
+    "OperationPolicyAttachmentStatus" : {
+      "properties" : {
+        "isAttached" : {
+          "type" : "boolean",
+          "description" : "True if attached, false if else."
         }
       }
     },


### PR DESCRIPTION
An internal endpoint to check whether mediation policies are attached to a particular API.

Request : 
```
<host>/internal/data/v1/apis/<apiId>/operation-policy/is-attached?organizationId=<orgId>
```

Response : 
```
{
    "isAttached": boolean
}
```