### PR TITLE
Fix NPE when http port is not defined

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
@@ -29,15 +29,15 @@ import java.net.URL;
 public class VHost {
     private String host;
     private String httpContext = "";
-    private Integer httpPort = DEFAULT_HTTP_PORT;
-    private Integer httpsPort = DEFAULT_HTTPS_PORT;
+    private Integer httpPort = -1;
+    private Integer httpsPort = -1;
     private Integer wsPort = DEFAULT_WS_PORT;
     private Integer wssPort = DEFAULT_WSS_PORT;
     private Integer websubHttpPort = DEFAULT_WEBSUB_HTTP_PORT;
     private Integer websubHttpsPort = DEFAULT_WEBSUB_HTTPS_PORT;
 
-    public static Integer DEFAULT_HTTP_PORT;
-    public static Integer DEFAULT_HTTPS_PORT;
+    public static final int DEFAULT_HTTP_PORT = 80;
+    public static final int DEFAULT_HTTPS_PORT = 443;
     public static final int DEFAULT_WS_PORT = 9099;
     public static final int DEFAULT_WSS_PORT = 8099;
     public static final int DEFAULT_WEBSUB_HTTP_PORT = 9021;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -3379,11 +3379,11 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
 
             VHost vhost = VHostUtils.getVhostFromEnvironment(environment, host);
             if (StringUtils.containsIgnoreCase(api.getTransports(), APIConstants.HTTP_PROTOCOL)
-                    && vhost.getHttpPort() != null) {
+                    && vhost.getHttpPort() != -1) {
                 hostsWithSchemes.put(APIConstants.HTTP_PROTOCOL, vhost.getHttpUrl());
             }
             if (StringUtils.containsIgnoreCase(api.getTransports(), APIConstants.HTTPS_PROTOCOL)
-                    && vhost.getHttpsPort() != null) {
+                    && vhost.getHttpsPort() != -1) {
                 hostsWithSchemes.put(APIConstants.HTTPS_PROTOCOL, vhost.getHttpsUrl());
             }
         }


### PR DESCRIPTION
This PR resolves https://github.com/wso2/api-manager/issues/942.

Earlier `DEFAULT_HTTP_PORT` and `DEFAULT_HTTPS_PORT` were initialized to 80 and 443 respectively. Even though http or https endpoint is not defined, both endpoints were reflected in Publisher Portal and Devportal UIs. To overcome this issue [1], `DEFAULT_HTTP_PORT` and `DEFAULT_HTTPS_PORT` were changed to `Integer` type assigning null as default values by [2]. It introduced an NPE when http or https endpoint is not defined or defined without ports in deployment.toml. 

This PR reverts port numbers back to 80 and 443 and change httpPort and httpsPort of VHost to -1 as the default value. By this change we can identify whether an endpoint is defined or not by referring only to the port number. Following table describes how UI acts according to the port number.

| Port | Description |
| - | - |
| -1 | Endpoint should not be displayed |
| 80 or 443 | Only hostname should be displayed |
| other integers > 0 | Both hostname and port should be displayed |

[1] https://github.com/wso2-enterprise/wso2-apim-internal/issues/871
[2] https://github.com/wso2/carbon-apimgt/pull/11610