### PR TITLE
Validate API name when updating the API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -208,6 +208,17 @@ public class PublisherCommonUtils {
         //API Name change not allowed if OnPrem
         if (APIUtil.isOnPremResolver()) {
             apiDtoToUpdate.setName(apiIdentifier.getApiName());
+        } else if (!originalAPI.getId().getApiName().equals(apiDtoToUpdate.getName())) {
+            boolean apiNameExists =
+                    apiProvider.isApiNameExist(apiDtoToUpdate.getName(), originalAPI.getOrganization()) ||
+                            apiProvider.isApiNameWithDifferentCaseExist(apiDtoToUpdate.getName(),
+                                    originalAPI.getOrganization());
+            if (apiNameExists) {
+                throw new APIManagementException(
+                        "Error occurred while updating the API name. API with name " + apiDtoToUpdate.getName() +
+                                " already exists.",
+                        ExceptionCodes.from(ExceptionCodes.API_NAME_ALREADY_EXISTS, apiDtoToUpdate.getName()));
+            }
         }
         apiDtoToUpdate.setVersion(apiIdentifier.getVersion());
         apiDtoToUpdate.setProvider(apiIdentifier.getProviderName());


### PR DESCRIPTION
$subject to prevent an API being renamed to already existing API name.

Related: https://github.com/wso2-enterprise/choreo/issues/16300