### PR TITLE
Validate API name when updating the API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -215,6 +215,17 @@ public class PublisherCommonUtils {
         //API Name change not allowed if OnPrem
         if (APIUtil.isOnPremResolver()) {
             apiDtoToUpdate.setName(apiIdentifier.getApiName());
+        } else if (!originalAPI.getId().getApiName().equals(apiDtoToUpdate.getName())) {
+            boolean apiNameExists =
+                    apiProvider.isApiNameExist(apiDtoToUpdate.getName(), originalAPI.getOrganization()) ||
+                            apiProvider.isApiNameWithDifferentCaseExist(apiDtoToUpdate.getName(),
+                                    originalAPI.getOrganization());
+            if (apiNameExists) {
+                throw new APIManagementException(
+                        "Error occurred while updating the API name. API with name " + apiDtoToUpdate.getName() +
+                                " already exists.",
+                        ExceptionCodes.from(ExceptionCodes.API_NAME_ALREADY_EXISTS, apiDtoToUpdate.getName()));
+            }
         }
         apiDtoToUpdate.setVersion(apiIdentifier.getVersion());
         apiDtoToUpdate.setProvider(apiIdentifier.getProviderName());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -682,16 +682,6 @@ public class ApisApiServiceImpl implements ApisApiService {
             //validate if api exists
             validateAPIExistence(apiId);
 
-            //validate if api name exists
-            APIProvider apiProvider = RestApiCommonUtil.getProvider(username);
-            boolean apiNameExists = apiProvider.isApiNameExist(body.getName(), organization) ||
-                    apiProvider.isApiNameWithDifferentCaseExist(body.getName(), organization);
-            if (apiNameExists) {
-                throw new APIManagementException(
-                        "Error occurred while updating the API name. API with name " + body.getName() + " already exists.",
-                        ExceptionCodes.from(ExceptionCodes.API_NAME_ALREADY_EXISTS, body.getName()));
-            }
-
             // validate sandbox and production endpoints
             if (!PublisherCommonUtils.validateEndpoints(body)) {
                 throw new APIManagementException("Invalid/Malformed endpoint URL(s) detected",


### PR DESCRIPTION
Remove erroneous API name validation introduced by https://github.com/wso2/carbon-apimgt/pull/11630.
Add 9.2.x changes of https://github.com/wso2/carbon-apimgt/pull/11640 to valid API name when updating the API.

Related: https://github.com/wso2-enterprise/choreo/issues/16300