### PR TITLE
Using policy name and version as the key when exporting common API Policies

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -641,7 +641,7 @@ public class ExportUtils {
                 List<OperationPolicy> operationPolicies = uriTemplate.getOperationPolicies();
                 if (operationPolicies != null && !operationPolicies.isEmpty()) {
                     for (OperationPolicy policy : operationPolicies) {
-                        if (!exportedPolicies.contains(policy.getPolicyName())) {
+                        if (!exportedPolicies.contains(policy.getPolicyName() + "_" + policy.getPolicyVersion())) {
                             String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
                                     policy.getPolicyVersion());
                             if (policy.getPolicyId() != null) {
@@ -650,7 +650,7 @@ public class ExportUtils {
                                                 currentApiUuid, tenantDomain, true);
                                 if (policyData != null) {
                                     exportPolicyData(policyFileName, policyData, archivePath, exportFormat);
-                                    exportedPolicies.add(policy.getPolicyName());
+                                    exportedPolicies.add(policy.getPolicyName() + "_" + policy.getPolicyVersion());
                                 }
                             } else {
                                 // This path is to handle migrated APIs with mediation policies attached
@@ -668,7 +668,7 @@ public class ExportUtils {
                                             policy.getDirection(), tenantDomain);
                                     if (policyData != null) {
                                         exportPolicyData(policyFileName, policyData, archivePath, exportFormat);
-                                        exportedPolicies.add(policy.getPolicyName());
+                                        exportedPolicies.add(policy.getPolicyName() + "_" + policy.getPolicyVersion());
                                     }
                                 }
                             }


### PR DESCRIPTION
## Purpose
Fixes the deployment issue in https://github.com/wso2/api-manager/issues/951 step 10.
Fixes: https://github.com/wso2/api-manager/issues/908

## Goal
Using policy name and version as the key when exporting common API Policies