### PR TITLE
Handling Null Point Exception | JWT Conditional Policy 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleConditionEvaluator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleConditionEvaluator.java
@@ -221,6 +221,10 @@ public class ThrottleConditionEvaluator {
 
     private boolean isJWTClaimPresent(AuthenticationContext authenticationContext, ConditionDto.JWTClaimConditions
             condition) {
+                
+        if (authenticationContext.getCallerToken() == null) {
+            return false;
+        }
 
         Map<String, String> assertions = JWTUtil.getJWTClaims(authenticationContext.getCallerToken());
         boolean status = true;


### PR DESCRIPTION
When we set up the JWT conditional rate limiting policy under advanced throttling policies there was a NullPointException popping up without throttling out at the expected limit at the time a non-authenticated resource is invoked. That issue is fixed with this PR. Now for non-authenticated resources, it throttles out from the default limit as the security limit is not applicable.