### PR TITLE
Bumping the carbon-kernel version to 4.8.0-m2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1956,8 +1956,8 @@
 
         <carbon.analytics.common.version>5.2.45</carbon.analytics.common.version>
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.8.0-m1</carbon.kernel.version>
-        <carbon.kernel.feature.version>4.8.0-m1</carbon.kernel.feature.version>
+        <carbon.kernel.version>4.8.0-m2</carbon.kernel.version>
+        <carbon.kernel.feature.version>4.8.0-m2</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
 
         <carbon.commons.version>4.9.0</carbon.commons.version>


### PR DESCRIPTION
## Purpose
Bump the carbon-kernel version to 4.8.0-m2
Related to https://github.com/wso2/api-manager/issues/973