### PR TITLE
Bump sysnapse version to 4.0.0-wso2v1 from 2.1.7-wso2v313

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2046,7 +2046,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>2.1.7-wso2v313</synapse.version>
+        <synapse.version>4.0.0-wso2v1</synapse.version>
 
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1968,7 +1968,7 @@
         <carbon.commons.version>4.9.0</carbon.commons.version>
 
         <carbon.registry.version>4.8.9</carbon.registry.version>
-        <carbon.mediation.version>4.7.146</carbon.mediation.version>
+        <carbon.mediation.version>4.7.147</carbon.mediation.version>
 
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1967,7 +1967,7 @@
 
         <carbon.commons.version>4.9.0</carbon.commons.version>
         <carbon.registry.version>4.8.2</carbon.registry.version>
-        <carbon.mediation.version>4.7.143</carbon.mediation.version>
+        <carbon.mediation.version>4.7.146</carbon.mediation.version>
 
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 


### PR DESCRIPTION
This PR includes changes to sysnapse version to 4.0.0-wso2v1 from 2.1.7-wso2v313