### PR TITLE
Fixed SOAP APIs are not working properly for "_" path operators

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -3514,9 +3514,8 @@ public class RegistryPersistenceImpl implements APIPersistence {
                     resourceName = ((ResourceImpl) resource).getName();
                 }
                 resourceName = resourceName.replaceAll("\\.xml", "");
-                resourceName = resourceName.split("_")[0];
                 String httpMethod = resource.getProperty("method");
-
+                resourceName = resourceName.split("_" + httpMethod)[0];
                 SOAPToRestSequence seq = new SOAPToRestSequence(httpMethod, resourceName, content, direction);
                 seq.setUuid(resource.getUUID());
                 sequences.add(seq);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -2073,7 +2073,7 @@ public class ImportUtils {
                     if (fileName.split(".xml").length != 0) {
                         method =
                                 fileName.split(".xml")[0].substring(file.getFileName().toString().lastIndexOf("_") + 1);
-                        resource = fileName.substring(0, fileName.indexOf("_"));
+                        resource = fileName.substring(0, fileName.lastIndexOf("_"));
                     }
                     try (InputStream inputFlowStream = new FileInputStream(file.toFile())) {
                         String content = IOUtils.toString(inputFlowStream);


### PR DESCRIPTION
# Purpose
This PR fixes the SOAP APIs are not working for "_" path operators.
Related Github Issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/1004

# Approach
This fix has done by changing the string splitting method from "_" to the "httpmethod" and the other fix is changing the indexof() to lastindexof().