### PR TITLE
Add more debug logs to print in WebSocket API invocation flows

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
@@ -89,7 +89,8 @@ public class WebsocketHandler extends CombinedChannelDuplexHandler<WebsocketInbo
                 if (responseDTO.isCloseConnection()) {
                     InboundMessageContextDataHolder.getInstance().removeInboundMessageContextForConnection(channelId);
                     if (log.isDebugEnabled()) {
-                        log.debug("Error while handling Outbound Websocket frame. Closing connection for "
+                        log.debug(channelId + " -- Websocket API request [outbound] : Error while handling Outbound " +
+                                "Websocket frame. Closing connection for "
                                 + ctx.channel().toString());
                     }
                     handleSubscribeFrameErrorEvent(ctx, responseDTO);
@@ -104,7 +105,8 @@ public class WebsocketHandler extends CombinedChannelDuplexHandler<WebsocketInbo
                 }
             } else {
                 if (log.isDebugEnabled()) {
-                    log.debug("Sending Outbound Websocket frame." + ctx.channel().toString());
+                    log.debug(channelId + " -- Websocket API request [outbound] : Sending Outbound Websocket frame." +
+                            ctx.channel().toString());
                 }
                 outboundHandler().write(ctx, msg, promise);
                 // publish analytics events if analytics is enabled
@@ -116,21 +118,25 @@ public class WebsocketHandler extends CombinedChannelDuplexHandler<WebsocketInbo
     }
 
     private void handleSubscribeFrameErrorEvent(ChannelHandlerContext ctx, InboundProcessorResponseDTO responseDTO) {
+        String channelId = ctx.channel().id().asLongText();
         if (responseDTO.getErrorCode() == WebSocketApiConstants.FrameErrorConstants.THROTTLED_OUT_ERROR
                 || responseDTO.getErrorCode() == WebSocketApiConstants.FrameErrorConstants.GRAPHQL_QUERY_TOO_COMPLEX
                 || responseDTO.getErrorCode() == WebSocketApiConstants.FrameErrorConstants.GRAPHQL_QUERY_TOO_DEEP) {
             if (log.isDebugEnabled()) {
-                log.debug("Inbound WebSocket frame is throttled. " + ctx.channel().toString());
+                log.debug(channelId + " -- Websocket API request [inbound] : Inbound WebSocket frame is throttled. " +
+                        ctx.channel().toString());
             }
         } else if (responseDTO.getErrorCode() == WebSocketApiConstants.FrameErrorConstants.API_AUTH_GENERAL_ERROR
                 || responseDTO.getErrorCode() == WebSocketApiConstants.FrameErrorConstants.API_AUTH_INVALID_CREDENTIALS
                 || responseDTO.getErrorCode() == WebSocketApiConstants.FrameErrorConstants.RESOURCE_FORBIDDEN_ERROR) {
             if (log.isDebugEnabled()) {
-                log.debug("Inbound WebSocket frame failed due to auth error. " + ctx.channel().toString());
+                log.debug(channelId + " -- Websocket API request [inbound] : Inbound WebSocket frame failed due to " +
+                        "auth error. " + ctx.channel().toString());
             }
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("Unclassified error in Inbound WebSocket frame. " + ctx.channel().toString());
+                log.debug(channelId + " -- Websocket API request [inbound] : Unclassified error in Inbound WebSocket " +
+                        "frame. " + ctx.channel().toString());
             }
         }
         publishSubscribeFrameErrorEvent(ctx, responseDTO);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
@@ -182,7 +182,8 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
                         }
                     }
                     if (log.isDebugEnabled()) {
-                        log.debug("Error while handling Outbound Websocket frame. Closing connection for "
+                        log.debug(channelId + " -- Websocket API request [outbound] : Error while handling Outbound " +
+                                "Websocket frame. Closing connection for "
                                 + ctx.channel().toString());
                     }
                     handlePublishFrameErrorEvent(ctx, responseDTO);
@@ -196,7 +197,8 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
                 }
             } else {
                 if (log.isDebugEnabled()) {
-                    log.debug("Sending Inbound Websocket frame." + ctx.channel().toString());
+                    log.debug(channelId + " -- Websocket API request [inbound] : Sending Inbound Websocket frame." +
+                            ctx.channel().toString());
                 }
                 ctx.fireChannelRead(msg);
                 // publish analytics events if analytics is enabled
@@ -206,21 +208,25 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
     }
 
     private void handlePublishFrameErrorEvent(ChannelHandlerContext ctx, InboundProcessorResponseDTO responseDTO) {
+        String channelId = ctx.channel().id().asLongText();
         if (responseDTO.getErrorCode() == WebSocketApiConstants.FrameErrorConstants.THROTTLED_OUT_ERROR
                 || responseDTO.getErrorCode() == WebSocketApiConstants.FrameErrorConstants.GRAPHQL_QUERY_TOO_COMPLEX
                 || responseDTO.getErrorCode() == WebSocketApiConstants.FrameErrorConstants.GRAPHQL_QUERY_TOO_DEEP) {
             if (log.isDebugEnabled()) {
-                log.debug("Inbound WebSocket frame is throttled. " + ctx.channel().toString());
+                log.debug(channelId + " -- Websocket API request [inbound] : Inbound WebSocket frame is throttled. " +
+                        ctx.channel().toString());
             }
         } else if (responseDTO.getErrorCode() == WebSocketApiConstants.FrameErrorConstants.API_AUTH_GENERAL_ERROR
                 || responseDTO.getErrorCode() == WebSocketApiConstants.FrameErrorConstants.API_AUTH_INVALID_CREDENTIALS
                 || responseDTO.getErrorCode() == WebSocketApiConstants.FrameErrorConstants.RESOURCE_FORBIDDEN_ERROR) {
             if (log.isDebugEnabled()) {
-                log.debug("Inbound WebSocket frame failed due to auth error. " + ctx.channel().toString());
+                log.debug(channelId + " -- Websocket API request [inbound] : Inbound WebSocket frame failed due to " +
+                        "auth error. " + ctx.channel().toString());
             }
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("Unclassified error in Inbound WebSocket frame. " + ctx.channel().toString());
+                log.debug(channelId + " -- Websocket API request [inbound] : Unclassified error in Inbound WebSocket " +
+                        "frame. " + ctx.channel().toString());
             }
         }
         publishPublishFrameErrorEvent(ctx, responseDTO);


### PR DESCRIPTION
### Purpose
To add more debug logs to print in WebSocket API invocation flows.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/567

### Approach
- In this PR we have added the correlationId and API context to the debug logs where those data are available.
- Furthermore, this has updated the debug logs specific to in and out flows with inbound and outbound tags.