### PR TITLE
Fix API update when publishing while deprecating old versions

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/LifeCycleUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/LifeCycleUtils.java
@@ -235,7 +235,8 @@ public class LifeCycleUtils {
                     if (oldAPI.getId().getApiName().equals(api.getId().getApiName())
                             && versionComparator.compare(oldAPI, api) < 0
                             && (APIConstants.PUBLISHED.equals(oldAPI.getStatus()))) {
-                        apiProvider.changeLifeCycleStatus(organization, new ApiTypeWrapper(oldAPI),
+                        apiProvider.changeLifeCycleStatus(organization, new ApiTypeWrapper(
+                                        apiProvider.getAPIbyUUID(oldAPI.getUuid(), organization)),
                                 APIConstants.API_LC_ACTION_DEPRECATE, null);
 
                     }


### PR DESCRIPTION
There is an option at the lifecycle change to publish an API while deprecating other versions of the same API. Here, API objects of other APIs are updated with the deprecated state, however, the API object is having very minimal information. This breaks the newly deprecated API in the UI portals as it does not contain the minimum information needed to show in the publisher and dev portal UI.

Resolves: https://github.com/wso2/api-manager/issues/1115