### PR TITLE
Kid property for JWT 9.22.x

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/JWTConfigurationDto.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/JWTConfigurationDto.java
@@ -41,6 +41,7 @@ public class JWTConfigurationDto {
     private Certificate publicCert;
     private PrivateKey privateKey;
     private long ttl;
+    private boolean useKid;
 
     public JWTConfigurationDto(JWTConfigurationDto jwtConfigurationDto) {
 
@@ -53,6 +54,15 @@ public class JWTConfigurationDto {
         this.tokenIssuerDtoMap = jwtConfigurationDto.tokenIssuerDtoMap;
         this.jwtExcludedClaims = jwtConfigurationDto.jwtExcludedClaims;
         this.ttl = jwtConfigurationDto.ttl;
+        this.useKid = jwtConfigurationDto.useKid;
+    }
+
+    public boolean useKid() {
+        return useKid;
+    }
+
+    public void setUseKid(boolean useKid) {
+        this.useKid = useKid;
     }
 
     public JWTConfigurationDto() {

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/jwtgenerator/AbstractAPIMgtGatewayJWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/jwtgenerator/AbstractAPIMgtGatewayJWTGenerator.java
@@ -140,7 +140,7 @@ public abstract class AbstractAPIMgtGatewayJWTGenerator {
 
         try {
             Certificate publicCert = jwtConfigurationDto.getPublicCert();
-            return JWTUtil.generateHeader(publicCert, signatureAlgorithm);
+            return JWTUtil.generateHeader(publicCert, signatureAlgorithm, jwtConfigurationDto.useKid());
         } catch (Exception e) {
             String error = "Error in obtaining keystore";
             throw new JWTGeneratorException(error, e);

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/JWTUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/JWTUtil.java
@@ -73,46 +73,69 @@ public final class JWTUtil {
         }
     }
 
+    public static String generateHeader(Certificate publicCert, String signatureAlgorithm)
+            throws JWTGeneratorException {
+        return generateHeader(publicCert, signatureAlgorithm, false);
+    }
+
     /**
      * Utility method to generate JWT header with public certificate thumbprint for signature verification.
      *
      * @param publicCert         - The public certificate which needs to include in the header as thumbprint
      * @param signatureAlgorithm signature algorithm which needs to include in the header
+     * @param useKid - Specifies whether this function should use kid as a thumbprint or x5t
      * @throws JWTGeneratorException
      */
-    public static String generateHeader(Certificate publicCert, String signatureAlgorithm) throws
+
+    public static String generateHeader(Certificate publicCert, String signatureAlgorithm, boolean useKid) throws
             JWTGeneratorException {
 
+        /*
+         * Sample header
+         * {"typ":"JWT", "alg":"SHA256withRSA", "x5t":"a_jhNus21KVuoFx65LmkW2O_l10",
+         * "kid":"a_jhNus21KVuoFx65LmkW2O_l10"}
+         * {"typ":"JWT", "alg":"[2]", "x5t":"[1]", "x5t":"[1]"}
+         * */
         try {
-            //generate the SHA-1 thumbprint of the certificate
-            MessageDigest digestValue = MessageDigest.getInstance("SHA-1");
-            byte[] der = publicCert.getEncoded();
-            digestValue.update(der);
-            byte[] digestInBytes = digestValue.digest();
-            String publicCertThumbprint = hexify(digestInBytes);
-            String base64UrlEncodedThumbPrint;
-            base64UrlEncodedThumbPrint = java.util.Base64.getUrlEncoder()
-                    .encodeToString(publicCertThumbprint.getBytes("UTF-8"));
             StringBuilder jwtHeader = new StringBuilder();
-            /*
-             * Sample header
-             * {"typ":"JWT", "alg":"SHA256withRSA", "x5t":"a_jhNus21KVuoFx65LmkW2O_l10",
-             * "kid":"a_jhNus21KVuoFx65LmkW2O_l10_RS256"}
-             * {"typ":"JWT", "alg":"[2]", "x5t":"[1]", "x5t":"[1]"}
-             * */
             jwtHeader.append("{\"typ\":\"JWT\",");
             jwtHeader.append("\"alg\":\"");
             jwtHeader.append(getJWSCompliantAlgorithmCode(signatureAlgorithm));
             jwtHeader.append("\",");
-
-            jwtHeader.append("\"x5t\":\"");
-            jwtHeader.append(base64UrlEncodedThumbPrint);
+            if (useKid) {
+                jwtHeader.append("\"kid\":\"");
+                // No padding
+                jwtHeader.append(generateThumbprint("SHA-256", publicCert, false));
+            } else {
+                jwtHeader.append("\"x5t\":\"");
+                // Has padding for legacy support
+                jwtHeader.append(generateThumbprint("SHA-1", publicCert, true));
+            }
             jwtHeader.append("\"}");
             return jwtHeader.toString();
-
         } catch (NoSuchAlgorithmException | CertificateEncodingException | UnsupportedEncodingException e) {
             throw new JWTGeneratorException("Error in generating public certificate thumbprint", e);
         }
+    }
+
+    public static String generateThumbprint(String hashType, Certificate publicCert, boolean usePadding)
+            throws CertificateEncodingException,
+            UnsupportedEncodingException, NoSuchAlgorithmException {
+        MessageDigest digestValue;
+        byte[] der = publicCert.getEncoded();
+        digestValue = MessageDigest.getInstance(hashType);
+        digestValue.update(der);
+        byte[] digestInBytes = digestValue.digest();
+        String publicCertThumbprint = hexify(digestInBytes);
+        String base64UrlEncodedThumbPrint;
+        if (usePadding) {
+            base64UrlEncodedThumbPrint = java.util.Base64.getUrlEncoder()
+                    .encodeToString(publicCertThumbprint.getBytes(StandardCharsets.UTF_8));
+        } else {
+            base64UrlEncodedThumbPrint = java.util.Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(publicCertThumbprint.getBytes(StandardCharsets.UTF_8));
+        }
+        return base64UrlEncodedThumbPrint;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/test/java/org/wso2/carbon/apimgt/common/gateway/JWTUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/test/java/org/wso2/carbon/apimgt/common/gateway/JWTUtilTestCase.java
@@ -20,7 +20,11 @@ package org.wso2.carbon.apimgt.common.gateway;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.wso2.carbon.apimgt.common.gateway.util.JWTUtil;
+
+import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
 
 /**
  * Test cases for {@link JWTUtil}
@@ -46,5 +50,19 @@ public class JWTUtilTestCase {
     @Test
     public void testGetJWTClaimsWhenJWTNotAvailable() {
         Assert.assertNull(JWTUtil.getJWTClaims(null));
+    }
+
+    @Test
+    public void testJWTHeader() throws Exception {
+        // Characters are arbitrary
+        String certEncoded = "asdasndlaskjdlaskdjald1321k3jladksj1i3";
+        Certificate cert = Mockito.mock(Certificate.class);
+        Mockito.when(cert.getEncoded()).thenReturn(certEncoded.getBytes(StandardCharsets.UTF_8));
+        String jwt = JWTUtil.generateHeader(cert, "SHA256withRSA", true);
+        Assert.assertNotNull(jwt);
+        Assert.assertTrue(jwt.contains("kid"));
+        jwt = JWTUtil.generateHeader(cert, "SHA256withRSA", false);
+        Assert.assertNotNull(jwt);
+        Assert.assertTrue(jwt.contains("x5t"));
     }
 }


### PR DESCRIPTION
## Purpose

Adding the kid property to the JWT header.

## Implementation

By default the x5t property is used as the identifier. When turned on, kid property will be the sha-256 hash of the public key with no padding.