### PR TITLE
Fix NPE when getting the lifecycle state information

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -2061,6 +2061,10 @@ public class ApisApiServiceImpl implements ApisApiService {
             } else {
                 apiIdentifier = APIMappingUtil.getAPIIdentifierFromUUID(apiId);
             }
+            if (apiIdentifier == null) {
+                throw new APIManagementException("Error while getting the api identifier for the API:" +
+                        apiId, ExceptionCodes.INVALID_API_ID);
+            }
             return PublisherCommonUtils.getLifecycleStateInformation(apiIdentifier, organization);
         } catch (APIManagementException e) {
             //Auth failure occurs when cross tenant accessing APIs. Sends 404, since we don't need to expose the existence of the resource


### PR DESCRIPTION
Fixes https://github.com/wso2-enterprise/choreo/issues/17043

- Log output if the api identifier is null when getting the lifecycle state information:

```
ERROR - ApisApiServiceImpl Error while deleting API : 638a2d7269b8a04384698a9c
org.wso2.carbon.apimgt.api.APIManagementException: Error while getting the api identifier for the API:638a2d7269b8a04384698a9c
	at org.wso2.carbon.apimgt.rest.api.publisher.v1.impl.ApisApiServiceImpl.getLifecycleState(ApisApiServiceImpl.java:2065) [classes/:?]
	at org.wso2.carbon.apimgt.rest.api.publisher.v1.impl.ApisApiServiceImpl.getAPILifecycleState(ApisApiServiceImpl.java:2044) [classes/:?]
	at org.wso2.carbon.apimgt.rest.api.publisher.v1.ApisApi.getAPILifecycleState(ApisApi.java:800) [classes/:?]

```