### PR TITLE
Add HTTP response status code & description as Jaeger span tags

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -155,6 +155,9 @@ public class APIMgtGatewayConstants {
     public static final String SPAN_API_VERSION = "span.api.version";
     public static final String SPAN_APPLICATION_CONSUMER_KEY = "span.consumerkey";
     public static final String SPAN_ENDPOINT = "span.endpoint";
+    public static final String SPAN_HTTP_RESPONSE_STATUS_CODE = "span.http.response.status.code";
+    public static final String SPAN_HTTP_RESPONSE_STATUS_CODE_DESCRIPTION =
+            "span.http.response.status.code.description";
 
     public static final String INTERNAL_KEY = "Internal-Key";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -1126,6 +1126,19 @@ public class GatewayUtils {
             TelemetryUtil.setTag(tracingSpan, APIMgtGatewayConstants.SPAN_API_NAME, api.getApiName());
             TelemetryUtil.setTag(tracingSpan, APIMgtGatewayConstants.SPAN_API_VERSION, api.getApiVersion());
         }
+
+        Object httpStatusCode = ((Axis2MessageContext) messageContext).getAxis2MessageContext().getProperty(HTTP_SC);
+        if (httpStatusCode != null) {
+            TelemetryUtil.setTag(tracingSpan, APIMgtGatewayConstants.SPAN_HTTP_RESPONSE_STATUS_CODE,
+                    httpStatusCode.toString());
+        }
+        Object httpStatusCodeDescription =
+                ((Axis2MessageContext) messageContext).getAxis2MessageContext().getProperty(HTTP_SC_DESC);
+        if (httpStatusCodeDescription != null) {
+            TelemetryUtil.setTag(tracingSpan, APIMgtGatewayConstants.SPAN_HTTP_RESPONSE_STATUS_CODE_DESCRIPTION,
+                    httpStatusCodeDescription.toString());
+        }
+
         Object consumerKey = messageContext.getProperty(APIMgtGatewayConstants.CONSUMER_KEY);
         if (consumerKey != null) {
             TelemetryUtil.setTag(tracingSpan, APIMgtGatewayConstants.SPAN_APPLICATION_CONSUMER_KEY,

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -109,6 +109,8 @@ public class GatewayUtils {
 
     private static final Log log = LogFactory.getLog(GatewayUtils.class);
     private static final String HEADER_X_FORWARDED_FOR = "X-FORWARDED-FOR";
+    private static final String HTTP_SC = "HTTP_SC";
+    private static final String HTTP_SC_DESC = "HTTP_SC_DESC";
 
     public static boolean isClusteringEnabled() {
 
@@ -1093,6 +1095,18 @@ public class GatewayUtils {
             Util.setTag(tracingSpan, APIMgtGatewayConstants.SPAN_API_NAME, api.getApiName());
             Util.setTag(tracingSpan, APIMgtGatewayConstants.SPAN_API_VERSION, api.getApiVersion());
         }
+
+        Object httpStatusCode = ((Axis2MessageContext) messageContext).getAxis2MessageContext().getProperty(HTTP_SC);
+        if (httpStatusCode != null) {
+            Util.setTag(tracingSpan, APIMgtGatewayConstants.SPAN_HTTP_RESPONSE_STATUS_CODE, httpStatusCode.toString());
+        }
+        Object httpStatusCodeDescription =
+                ((Axis2MessageContext) messageContext).getAxis2MessageContext().getProperty(HTTP_SC_DESC);
+        if (httpStatusCodeDescription != null) {
+            Util.setTag(tracingSpan, APIMgtGatewayConstants.SPAN_HTTP_RESPONSE_STATUS_CODE_DESCRIPTION,
+                    httpStatusCodeDescription.toString());
+        }
+
         Object consumerKey = messageContext.getProperty(APIMgtGatewayConstants.CONSUMER_KEY);
         if (consumerKey != null) {
             Util.setTag(tracingSpan, APIMgtGatewayConstants.SPAN_APPLICATION_CONSUMER_KEY,


### PR DESCRIPTION
## Purpose
$subject. The following span tags will now be visible in Jaeger UI:
| Span Tag | Value represents |
|---|---|
| `span.http.response.status.code` | `HTTP_SC` property from axis2 msgCtx |
| `span.http.response.status.code.description` | `HTTP_SC_DESC` property from axis2 msgCtx |

![Screen Shot 2023-01-03 at 5 55 38 PM](https://user-images.githubusercontent.com/24828296/210378667-09e67b99-fe92-48ee-95d6-e4bb827121ef.png)

Resolves: https://github.com/wso2/api-manager/issues/1183