### PR TITLE
Enabling multiple reporters to publish analytics parallelly.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
@@ -43,6 +43,7 @@
         <dependency>
             <groupId>org.wso2.am.analytics.publisher</groupId>
             <artifactId>org.wso2.am.analytics.publisher.client</artifactId>
+            <version>${org.wso2.am.analytics.publisher.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -98,4 +99,9 @@
             </plugin>
         </plugins>
     </build>
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <org.wso2.am.analytics.publisher.version>1.1.1-SNAPSHOT</org.wso2.am.analytics.publisher.version>
+    </properties>
 </project>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
@@ -43,6 +43,7 @@
         <dependency>
             <groupId>org.wso2.am.analytics.publisher</groupId>
             <artifactId>org.wso2.am.analytics.publisher.client</artifactId>
+            <version>${org.wso2.am.analytics.publisher.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -101,5 +102,6 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <org.wso2.am.analytics.publisher.version>1.1.1-SNAPSHOT</org.wso2.am.analytics.publisher.version>
     </properties>
 </project>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.wso2.am.analytics.publisher</groupId>
             <artifactId>org.wso2.am.analytics.publisher.client</artifactId>
-            <version>${org.wso2.am.analytics.publisher.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -102,6 +101,5 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <org.wso2.am.analytics.publisher.version>1.1.1-SNAPSHOT</org.wso2.am.analytics.publisher.version>
     </properties>
 </project>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/AnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/AnalyticsDataProvider.java
@@ -66,6 +66,8 @@ public interface AnalyticsDataProvider {
 
     String getUserAgentHeader();
 
+    default String getUserName(){ return null;};
+
     String getEndUserIP();
 
     default Map<String, Object> getProperties() {

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/AnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/AnalyticsDataProvider.java
@@ -66,7 +66,7 @@ public interface AnalyticsDataProvider {
 
     String getUserAgentHeader();
 
-    default String getUserName(){ return null;};
+    String getUserName();
 
     String getEndUserIP();
 

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/SuccessRequestDataCollector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/SuccessRequestDataCollector.java
@@ -71,6 +71,7 @@ public class SuccessRequestDataCollector extends CommonRequestDataCollector impl
         Latencies latencies = provider.getLatencies();
         MetaInfo metaInfo = provider.getMetaInfo();
         String userAgent = provider.getUserAgentHeader();
+        String userName = provider.getUserName();
         String userIp = provider.getEndUserIP();
         if (userIp == null) {
             userIp = Constants.UNKNOWN_VALUE;
@@ -88,6 +89,7 @@ public class SuccessRequestDataCollector extends CommonRequestDataCollector impl
         event.setRequestTimestamp(offsetDateTime);
         event.setMetaInfo(metaInfo);
         event.setUserAgentHeader(userAgent);
+        event.setUserName(userName);
         event.setUserIp(userIp);
 
         this.processor.publish(event);

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/RequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/RequestDataPublisher.java
@@ -16,10 +16,9 @@
  */
 package org.wso2.carbon.apimgt.common.analytics.publishers;
 
-import java.util.List;
 import org.wso2.am.analytics.publisher.reporter.CounterMetric;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Event;
-
+import java.util.List;
 /**
  * interface for data publisher.
  */

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/RequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/RequestDataPublisher.java
@@ -16,6 +16,7 @@
  */
 package org.wso2.carbon.apimgt.common.analytics.publishers;
 
+import java.util.List;
 import org.wso2.am.analytics.publisher.reporter.CounterMetric;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Event;
 
@@ -27,4 +28,6 @@ public interface RequestDataPublisher {
     void publish(Event analyticsEvent);
 
     CounterMetric getCounterMetric();
+
+    List<CounterMetric> getMultipleCounterMetrics();
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/Event.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/Event.java
@@ -138,9 +138,13 @@ public class Event {
         this.userAgentHeader = userAgentHeader;
     }
 
-    public String getUserName(){return userName;}
+    public String getUserName() {
+        return userName;
+    }
 
-    public void setUserName(String userName){this.userName= userName;}
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
 
     public String getUserIp() {
         return userIp;

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/Event.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/Event.java
@@ -42,6 +42,8 @@ public class Event {
     private int proxyResponseCode;
     private String requestTimestamp;
     private String userAgentHeader;
+
+    private String userName;
     private String userIp;
 
     private String errorType;
@@ -135,6 +137,10 @@ public class Event {
     public void setUserAgentHeader(String userAgentHeader) {
         this.userAgentHeader = userAgentHeader;
     }
+
+    public String getUserName(){return userName;}
+
+    public void setUserName(String userName){this.userName= userName;}
 
     public String getUserIp() {
         return userIp;

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/ExtendedAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/ExtendedAPI.java
@@ -18,7 +18,7 @@
 package org.wso2.carbon.apimgt.common.analytics.publishers.dto;
 
 /**
- * Extended API Object with organization ID
+ * Extended API Object with organization ID.
  */
 public class ExtendedAPI extends API {
     private String organizationId;
@@ -33,7 +33,11 @@ public class ExtendedAPI extends API {
         this.organizationId = organizationId;
     }
 
-    public void setApiContext(String apiContext){this.apiContext=apiContext;}
+    public String getApiContext() {
+        return this.apiContext;
+    }
 
-    public String getApiContext(){return this.apiContext;}
+    public void setApiContext(String apiContext) {
+        this.apiContext = apiContext;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/ExtendedAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/ExtendedAPI.java
@@ -21,8 +21,9 @@ package org.wso2.carbon.apimgt.common.analytics.publishers.dto;
  * Extended API Object with organization ID
  */
 public class ExtendedAPI extends API {
-
     private String organizationId;
+
+    private String apiContext;
 
     public String getOrganizationId() {
         return organizationId;
@@ -31,4 +32,8 @@ public class ExtendedAPI extends API {
     public void setOrganizationId(String organizationId) {
         this.organizationId = organizationId;
     }
+
+    public void setApiContext(String apiContext){this.apiContext=apiContext;}
+
+    public String getApiContext(){return this.apiContext;}
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AbstractRequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AbstractRequestDataPublisher.java
@@ -44,28 +44,35 @@ public abstract class AbstractRequestDataPublisher implements RequestDataPublish
     @Override
     public void publish(Event analyticsEvent) {
         Map<String, Object> dataMap = OBJECT_MAPPER.convertValue(analyticsEvent, MAP_TYPE_REFERENCE);
-        List<CounterMetric> multipleCounterMetrics= this.getMultipleCounterMetrics();
+        List<CounterMetric> multipleCounterMetrics = this.getMultipleCounterMetrics();
 
-        for(CounterMetric counterMetric : multipleCounterMetrics) {
+        for (CounterMetric counterMetric : multipleCounterMetrics) {
             if (counterMetric == null) {
                 log.error("counterMetric cannot be null.");
-                return;
-            }
-
-            MetricEventBuilder builder = counterMetric.getEventBuilder();
-            for (Map.Entry<String, Object> entry : dataMap.entrySet()) {
-                try {
-                    builder.addAttribute(entry.getKey(), entry.getValue());
-                } catch (MetricReportingException e) {
-                    log.error("Error adding data to the event stream.", e);
-                    return;
+            } else {
+                String counterMetricClassName = counterMetric.getClass().toString().
+                        replaceAll("[\r\n]", "").split(" ")[1];
+                log.info("Started adding data to counterMetric "+counterMetricClassName);
+                boolean caughtException = false;
+                MetricEventBuilder builder = counterMetric.getEventBuilder();
+                for (Map.Entry<String, Object> entry : dataMap.entrySet()) {
+                    try {
+                        builder.addAttribute(entry.getKey(), entry.getValue());
+                    } catch (MetricReportingException e) {
+                        caughtException = true;
+                        log.error("Error adding data to the event stream. counterMetric: "+counterMetricClassName
+                                ,e);
+                        break;
+                    }
                 }
-            }
-
-            try {
-                counterMetric.incrementCount(builder);
-            } catch (MetricReportingException e) {
-                log.error("Error occurred when publishing event.", e);
+                if (!caughtException) {
+                    try {
+                        counterMetric.incrementCount(builder);
+                    } catch (MetricReportingException e) {
+                        log.error("Error occurred when publishing event. counterMetric: "+counterMetricClassName
+                                ,e);
+                    }
+                }
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AbstractRequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AbstractRequestDataPublisher.java
@@ -19,7 +19,7 @@ package org.wso2.carbon.apimgt.common.analytics.publishers.impl;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.am.analytics.publisher.exception.MetricReportingException;
@@ -27,7 +27,7 @@ import org.wso2.am.analytics.publisher.reporter.CounterMetric;
 import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
 import org.wso2.carbon.apimgt.common.analytics.publishers.RequestDataPublisher;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Event;
-
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -52,7 +52,7 @@ public abstract class AbstractRequestDataPublisher implements RequestDataPublish
             } else {
                 String counterMetricClassName = counterMetric.getClass().toString().
                         replaceAll("[\r\n]", "").split(" ")[1];
-                log.info("Started adding data to counterMetric "+counterMetricClassName);
+                log.info("Started adding data to counterMetric " + counterMetricClassName);
                 boolean caughtException = false;
                 MetricEventBuilder builder = counterMetric.getEventBuilder();
                 for (Map.Entry<String, Object> entry : dataMap.entrySet()) {
@@ -60,8 +60,8 @@ public abstract class AbstractRequestDataPublisher implements RequestDataPublish
                         builder.addAttribute(entry.getKey(), entry.getValue());
                     } catch (MetricReportingException e) {
                         caughtException = true;
-                        log.error("Error adding data to the event stream. counterMetric: "+counterMetricClassName
-                                ,e);
+                        log.error("Error adding data to the event stream. counterMetric: " + counterMetricClassName
+                                , e);
                         break;
                     }
                 }
@@ -69,8 +69,8 @@ public abstract class AbstractRequestDataPublisher implements RequestDataPublish
                     try {
                         counterMetric.incrementCount(builder);
                     } catch (MetricReportingException e) {
-                        log.error("Error occurred when publishing event. counterMetric: "+counterMetricClassName
-                                ,e);
+                        log.error("Error occurred when publishing event. counterMetric: " + counterMetricClassName
+                                , e);
                     }
                 }
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
@@ -110,7 +110,7 @@ public class AnalyticsDataPublisher {
                         metricReporters.add(metricReporter);
                     }
                     catch (MetricCreationException e){
-                        log.error("Error while creating a reporter out of multiple metric reporters.", e);
+                        log.error("Error while creating reporter " +reporterClassName+" out of multiple metric reporters.", e);
                     }
                 }
             } else if (reporterType != null && !reporterType.equals("")) {

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
@@ -58,7 +58,7 @@ public class AnalyticsDataPublisher {
         List<String> reporterClasses = new ArrayList<>();
         List<String> reporterKeys = configs.keySet()
                 .stream()
-                .filter(s -> s.matches("address"))
+                .filter(s -> s.matches("^publisher\\.reporter[1-9][0-9]*\\.class$"))
                 .collect(Collectors.toList());
 
         for(String key : reporterKeys){

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
@@ -28,7 +28,10 @@ import org.wso2.am.analytics.publisher.reporter.MetricSchema;
 import org.wso2.carbon.apimgt.common.analytics.AnalyticsCommonConfiguration;
 import org.wso2.carbon.apimgt.common.analytics.Constants;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Analytics event publisher for APIM.
@@ -39,6 +42,8 @@ public class AnalyticsDataPublisher {
     private static AnalyticsDataPublisher instance = new AnalyticsDataPublisher();
     private CounterMetric successMetricReporter;
     private CounterMetric faultyMetricReporter;
+    private List<CounterMetric> successMetricReporters;
+    private List<CounterMetric> faultyMetricReporters;
 
     private AnalyticsDataPublisher() {
 
@@ -49,40 +54,92 @@ public class AnalyticsDataPublisher {
         return instance;
     }
 
+    private List<String> getReportersClassesOrNull(Map<String, String> configs){
+        List<String> reporterClasses = new ArrayList<>();
+        List<String> reporterKeys = configs.keySet()
+                .stream()
+                .filter(s -> s.matches("address"))
+                .collect(Collectors.toList());
+
+        for(String key : reporterKeys){
+            String reporterClass = configs.get(key);
+            if(reporterClass != null && !reporterClass.equals("")){
+                reporterClasses.add(reporterClass);
+            }
+        }
+        if(reporterClasses.size() > 0){
+            return reporterClasses;
+        }
+        return null;
+    }
+
+    private List<CounterMetric> getSuccessOrFaultyCounterMetrics(List<MetricReporter> metricReporters,String name, MetricSchema schema) {
+        List<CounterMetric> counterMetricsList = new ArrayList<>();
+        for(MetricReporter metricReporter : metricReporters){
+            String reporterClassName = metricReporter.getClass().toString().replaceAll("[\r\n]", "");
+            try{
+                CounterMetric counterMetric = metricReporter.createCounterMetric(name,schema);
+                if (counterMetric == null){
+                    throw new MetricCreationException("AnalyticsDataPublisher is not initialized.");
+                }
+                counterMetricsList.add(counterMetric);
+            } catch (MetricCreationException | IllegalArgumentException e) {
+                log.error("Error initializing event publisher for the Reporter of type "+reporterClassName, e);
+            }
+        }
+        return counterMetricsList;
+    }
+
     public void initialize(AnalyticsCommonConfiguration commonConfig) {
         Map<String, String> configs = commonConfig.getConfigurations();
         String reporterClass = configs.get("publisher.reporter.class");
         String reporterType = configs.get("type");
+        List<String> reporterClasses = getReportersClassesOrNull(configs);
         try {
+            List<MetricReporter> metricReporters = new ArrayList<>();
             MetricReporter metricReporter;
             if (reporterClass != null) {
                 metricReporter = MetricReporterFactory.getInstance()
                         .createMetricReporter(reporterClass, configs);
+                metricReporters.add(metricReporter);
+            } else if (reporterClasses != null) {
+                for (String reporterClassName : reporterClasses){
+                    try {
+                        metricReporter = MetricReporterFactory.getInstance()
+                                .createMetricReporter(reporterClassName, configs);
+                        metricReporters.add(metricReporter);
+                    }
+                    catch (MetricCreationException e){
+                        log.error("Error while creating a reporter out of multiple metric reporters.", e);
+                    }
+                }
             } else if (reporterType != null && !reporterType.equals("")) {
                 metricReporter = MetricReporterFactory.getInstance().createLogMetricReporter(configs);
+                metricReporters.add(metricReporter);
             } else {
                 metricReporter = MetricReporterFactory.getInstance().createMetricReporter(configs);
+                metricReporters.add(metricReporter);
             }
 
             if (!StringUtils.isEmpty(commonConfig.getResponseSchema())) {
-                this.successMetricReporter = metricReporter.createCounterMetric(Constants.RESPONSE_METRIC_NAME,
+
+                this.successMetricReporters = getSuccessOrFaultyCounterMetrics(metricReporters, Constants.RESPONSE_METRIC_NAME,
                         MetricSchema.valueOf(commonConfig.getResponseSchema()));
             } else {
-                this.successMetricReporter = metricReporter
-                        .createCounterMetric(Constants.RESPONSE_METRIC_NAME, MetricSchema.RESPONSE);
+                this.successMetricReporters = getSuccessOrFaultyCounterMetrics(metricReporters,Constants.RESPONSE_METRIC_NAME, MetricSchema.RESPONSE);
             }
 
             if (!StringUtils.isEmpty(commonConfig.getFaultSchema())) {
-                this.faultyMetricReporter = metricReporter.createCounterMetric(Constants.FAULTY_METRIC_NAME,
+                this.faultyMetricReporters = getSuccessOrFaultyCounterMetrics(metricReporters,Constants.FAULTY_METRIC_NAME,
                         MetricSchema.valueOf(commonConfig.getFaultSchema()));
             } else {
-                this.faultyMetricReporter = metricReporter
-                        .createCounterMetric(Constants.FAULTY_METRIC_NAME, MetricSchema.ERROR);
+                this.faultyMetricReporters = getSuccessOrFaultyCounterMetrics(metricReporters,Constants.FAULTY_METRIC_NAME, MetricSchema.ERROR);
             }
 
-            // Illegal Argument is possible as the enum conversion could fail
-        } catch (MetricCreationException | IllegalArgumentException e) {
-            log.error("Error initializing event publisher.", e);
+            // not necessary to handle IllegalArgumentException here
+            // since we are handling it in getSuccessOrFaultyCounterMetrics method
+        } catch (MetricCreationException e) {
+            log.error("Error while creating the metric reporter", e);
         }
     }
 
@@ -100,5 +157,21 @@ public class AnalyticsDataPublisher {
             throw new RuntimeException("AnalyticsDataPublisher is not initialized.");
         }
         return faultyMetricReporter;
+    }
+
+    public List<CounterMetric> getSuccessMetricReporters() {
+
+        if (this.successMetricReporters.isEmpty()) {
+            throw new RuntimeException("None of AnalyticsDataPublishers are initialized.");
+        }
+        return successMetricReporters;
+    }
+
+    public List<CounterMetric> getFaultyMetricReporters() {
+
+        if (this.faultyMetricReporters.isEmpty()) {
+            throw new RuntimeException("None of AnalyticsDataPublishers are initialized.");
+        }
+        return faultyMetricReporters;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
@@ -54,37 +54,38 @@ public class AnalyticsDataPublisher {
         return instance;
     }
 
-    private List<String> getReportersClassesOrNull(Map<String, String> configs){
+    private List<String> getReportersClassesOrNull(Map<String, String> configs) {
         List<String> reporterClasses = new ArrayList<>();
         List<String> reporterKeys = configs.keySet()
                 .stream()
                 .filter(s -> s.matches("^publisher\\.reporter[1-9][0-9]*\\.class$"))
                 .collect(Collectors.toList());
 
-        for(String key : reporterKeys){
+        for (String key : reporterKeys) {
             String reporterClass = configs.get(key);
-            if(reporterClass != null && !reporterClass.equals("")){
+            if (reporterClass != null && !reporterClass.equals("")) {
                 reporterClasses.add(reporterClass);
             }
         }
-        if(reporterClasses.size() > 0){
+        if (reporterClasses.size() > 0) {
             return reporterClasses;
         }
         return null;
     }
 
-    private List<CounterMetric> getSuccessOrFaultyCounterMetrics(List<MetricReporter> metricReporters,String name, MetricSchema schema) {
+    private List<CounterMetric> getSuccessOrFaultyCounterMetrics(List<MetricReporter> metricReporters, String name,
+                                                                 MetricSchema schema) {
         List<CounterMetric> counterMetricsList = new ArrayList<>();
-        for(MetricReporter metricReporter : metricReporters){
+        for (MetricReporter metricReporter : metricReporters) {
             String reporterClassName = metricReporter.getClass().toString().replaceAll("[\r\n]", "");
-            try{
-                CounterMetric counterMetric = metricReporter.createCounterMetric(name,schema);
-                if (counterMetric == null){
+            try {
+                CounterMetric counterMetric = metricReporter.createCounterMetric(name, schema);
+                if (counterMetric == null) {
                     throw new MetricCreationException("AnalyticsDataPublisher is not initialized.");
                 }
                 counterMetricsList.add(counterMetric);
             } catch (MetricCreationException | IllegalArgumentException e) {
-                log.error("Error initializing event publisher for the Reporter of type "+reporterClassName, e);
+                log.error("Error initializing event publisher for the Reporter of type " + reporterClassName, e);
             }
         }
         return counterMetricsList;
@@ -103,14 +104,14 @@ public class AnalyticsDataPublisher {
                         .createMetricReporter(reporterClass, configs);
                 metricReporters.add(metricReporter);
             } else if (reporterClasses != null) {
-                for (String reporterClassName : reporterClasses){
+                for (String reporterClassName : reporterClasses) {
                     try {
                         metricReporter = MetricReporterFactory.getInstance()
                                 .createMetricReporter(reporterClassName, configs);
                         metricReporters.add(metricReporter);
-                    }
-                    catch (MetricCreationException e){
-                        log.error("Error while creating reporter " +reporterClassName+" out of multiple metric reporters.", e);
+                    } catch (MetricCreationException e) {
+                        log.error("Error while creating reporter " + reporterClassName +
+                                " out of multiple metric reporters.", e);
                     }
                 }
             } else if (reporterType != null && !reporterType.equals("")) {
@@ -123,17 +124,23 @@ public class AnalyticsDataPublisher {
 
             if (!StringUtils.isEmpty(commonConfig.getResponseSchema())) {
 
-                this.successMetricReporters = getSuccessOrFaultyCounterMetrics(metricReporters, Constants.RESPONSE_METRIC_NAME,
-                        MetricSchema.valueOf(commonConfig.getResponseSchema()));
+                this.successMetricReporters =
+                        getSuccessOrFaultyCounterMetrics(metricReporters, Constants.RESPONSE_METRIC_NAME,
+                                MetricSchema.valueOf(commonConfig.getResponseSchema()));
             } else {
-                this.successMetricReporters = getSuccessOrFaultyCounterMetrics(metricReporters,Constants.RESPONSE_METRIC_NAME, MetricSchema.RESPONSE);
+                this.successMetricReporters =
+                        getSuccessOrFaultyCounterMetrics(metricReporters, Constants.RESPONSE_METRIC_NAME,
+                                MetricSchema.RESPONSE);
             }
 
             if (!StringUtils.isEmpty(commonConfig.getFaultSchema())) {
-                this.faultyMetricReporters = getSuccessOrFaultyCounterMetrics(metricReporters,Constants.FAULTY_METRIC_NAME,
-                        MetricSchema.valueOf(commonConfig.getFaultSchema()));
+                this.faultyMetricReporters =
+                        getSuccessOrFaultyCounterMetrics(metricReporters, Constants.FAULTY_METRIC_NAME,
+                                MetricSchema.valueOf(commonConfig.getFaultSchema()));
             } else {
-                this.faultyMetricReporters = getSuccessOrFaultyCounterMetrics(metricReporters,Constants.FAULTY_METRIC_NAME, MetricSchema.ERROR);
+                this.faultyMetricReporters =
+                        getSuccessOrFaultyCounterMetrics(metricReporters, Constants.FAULTY_METRIC_NAME,
+                                MetricSchema.ERROR);
             }
 
             // not necessary to handle IllegalArgumentException here

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/FaultyRequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/FaultyRequestDataPublisher.java
@@ -17,8 +17,8 @@
 
 package org.wso2.carbon.apimgt.common.analytics.publishers.impl;
 
-import java.util.List;
 import org.wso2.am.analytics.publisher.reporter.CounterMetric;
+import java.util.List;
 
 /**
  * Fault event publisher implementation.

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/FaultyRequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/FaultyRequestDataPublisher.java
@@ -17,6 +17,7 @@
 
 package org.wso2.carbon.apimgt.common.analytics.publishers.impl;
 
+import java.util.List;
 import org.wso2.am.analytics.publisher.reporter.CounterMetric;
 
 /**
@@ -27,5 +28,9 @@ public class FaultyRequestDataPublisher extends AbstractRequestDataPublisher {
     @Override
     public CounterMetric getCounterMetric() {
         return AnalyticsDataPublisher.getInstance().getFaultyMetricReporter();
+    }
+
+    public List<CounterMetric> getMultipleCounterMetrics() {
+        return AnalyticsDataPublisher.getInstance().getFaultyMetricReporters();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/SuccessRequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/SuccessRequestDataPublisher.java
@@ -17,10 +17,11 @@
 
 package org.wso2.carbon.apimgt.common.analytics.publishers.impl;
 
-import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.am.analytics.publisher.reporter.CounterMetric;
+
+import java.util.List;
 
 /**
  * Success event publisher implementation.

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/SuccessRequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/SuccessRequestDataPublisher.java
@@ -17,6 +17,7 @@
 
 package org.wso2.carbon.apimgt.common.analytics.publishers.impl;
 
+import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.am.analytics.publisher.reporter.CounterMetric;
@@ -31,5 +32,9 @@ public class SuccessRequestDataPublisher extends AbstractRequestDataPublisher {
     @Override
     public CounterMetric getCounterMetric() {
         return AnalyticsDataPublisher.getInstance().getSuccessMetricReporter();
+    }
+
+    public List<CounterMetric> getMultipleCounterMetrics() {
+        return AnalyticsDataPublisher.getInstance().getSuccessMetricReporters();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -323,12 +323,15 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
         } else {
             customProperties = new HashMap<>();
         }
-        customProperties.put(Constants.API_USER_NAME_KEY, getUserName());
+        customProperties.put(Constants.API_USER_NAME_KEY, getEndUserName());
         customProperties.put(Constants.API_CONTEXT_KEY, getApiContext());
         return customProperties;
     }
 
-    private String getUserName() {
+    // previously was getUserName
+    // with the modifications in AnalyticsDataProvider
+    // there will be access modifier clash, so renamed as getEndUserName
+    private String getEndUserName() {
 
         if (messageContext.getPropertyKeySet().contains(APIMgtGatewayConstants.END_USER_NAME)) {
             return (String) messageContext.getProperty(APIMgtGatewayConstants.END_USER_NAME);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -306,6 +306,11 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
     }
 
     @Override
+    public String getUserName() {
+        return getEndUserName();
+    }
+
+    @Override
     public String getEndUserIP() {
 
         if (messageContext.getPropertyKeySet().contains(Constants.USER_IP_PROPERTY)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketAnalyticsDataProvider.java
@@ -305,12 +305,15 @@ public class WebSocketAnalyticsDataProvider implements AnalyticsDataProvider {
         } else {
             customProperties = new HashMap<>();
         }
-        customProperties.put(Constants.API_USER_NAME_KEY, getUserName());
+        customProperties.put(Constants.API_USER_NAME_KEY, getEndUserName());
         customProperties.put(Constants.API_CONTEXT_KEY, getApiContext());
         return customProperties;
     }
 
-    private String getUserName() {
+    // previously was getUserName
+    // with the modifications in AnalyticsDataProvider
+    // there will be access modifier clash, so renamed as getEndUserName
+    private String getEndUserName() {
 
         Object authContext = WebSocketUtils.getPropertyFromChannel(APISecurityUtils.API_AUTH_CONTEXT, ctx);
         if (authContext != null && authContext instanceof AuthenticationContext) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketAnalyticsDataProvider.java
@@ -288,6 +288,11 @@ public class WebSocketAnalyticsDataProvider implements AnalyticsDataProvider {
     }
 
     @Override
+    public String getUserName() {
+        return getEndUserName();
+    }
+
+    @Override
     public String getEndUserIP() {
         Object userIp = WebSocketUtils.getPropertyFromChannel(Constants.USER_IP_PROPERTY, ctx);
         if (userIp != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/swagger.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/swagger.json
@@ -1215,8 +1215,8 @@
           "type" : "string",
           "example" : "EXCHANGED",
           "description" : "The type of the tokens to be used (exchanged or without exchanged). Accepted values are EXCHANGED, DIRECT or BOTH.",
-          "enum" : [ "EXCHANGED", "DIRECT", "BOTH" ],
-          "default" : "DIRECT"
+          "default" : "DIRECT",
+          "enum" : [ "EXCHANGED", "DIRECT", "BOTH" ]
         }
       }
     },


### PR DESCRIPTION
Current implementation supports only one reporter to publish data (which means only one analytics dashboard can be used at a time). Currently custom reporters are allowed and the default reporter sends data to Choreo Insights. 
This PR enables to support multiple reporters. Multiple reporters can be included as key-value pairs under enforcer analytics config properties map. keys should be in the following regex form: 
```shell
"^publisher//.reporter[1-9][0-9]*//.class$"   
```
example:
```shell
"publisher.reporter1.class" = "moesif.analytics.reporter.MoesifReporter"
"publisher.reporter2.class" = "org.wso2.am.analytics.publisher.reporter.cloud.DefaultAnalyticsMetricReporter"
```

Existing ways of publishing analytics are still applicable. For ease, lets refer the way above example includes reporters as  'multi reporter listing'. We set a hierarchy for all of these ways as follows (top method denotes the method highest in hierarchy):

- Method 1: Defining a reporter using existing "publisher.reporter.class"
- Method 2: Setting "type" key to "elk", which will send analytics to ELK.
- Method 3: multi reporter listing

Whenever more than one of the above methods are used, the outcome will be the outcome of the method which is higher in the hierarchy. For example if both Method 1 and Method 2 methods were used the analytics will be sent only to the destination defined by the reporter given in the value of "publisher.reporter.class". In case of none of the methods are used the data will be sent to Choreo Insight using the default reporter.

Note worthy features:
- No numerical limit for multi reporter listing as long as latency is not an issue.
- In a failure of one reporter, the implementation will switch to the next reporter.
- Error logs and Exception messages denote from which reporter the particular error/exception was raised (Note if the error/exception occured in CounterMetric level then it will be the associated CounterMetric implementation of the reporter). 

Testing:
Successfully tested against default reporter and a custom reporter.