### PR TITLE
Fix the issue of throwing 500 status when copying an API with same version

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3175,10 +3175,13 @@ public class ApisApiServiceImpl implements ApisApiService {
                 throw new APIMgtResourceNotFoundException("API not found for id " + apiId,
                         ExceptionCodes.from(ExceptionCodes.API_NOT_FOUND, apiId));
             }
-            if (newVersion.equals(existingAPI.getId().getVersion())) {
-                throw new APIMgtResourceAlreadyExistsException("Version " + newVersion + " exists for api "
-                        + existingAPI.getId().getApiName(), ExceptionCodes.from(API_VERSION_ALREADY_EXISTS, newVersion,
-                            existingAPI.getId().getApiName()));
+            //Get all existing versions of API
+            List<String> apiVersions = apiProvider.getApiVersionsMatchingApiNameAndOrganization(
+                    apiIdentifierFromTable.getApiName(), apiIdentifierFromTable.getProviderName(), organization);
+            if (apiVersions.contains(newVersion)) {
+                throw new APIMgtResourceAlreadyExistsException(
+                        "Version " + newVersion + " exists for api " + existingAPI.getId().getApiName(),
+                        ExceptionCodes.from(API_VERSION_ALREADY_EXISTS, newVersion, existingAPI.getId().getApiName()));
             }
             if (StringUtils.isNotEmpty(serviceVersion)) {
                 String serviceName = existingAPI.getServiceInfo("name");


### PR DESCRIPTION
Fix the issue of throwing 500 status when trying to create an API(copy API) with a version that already exists. This issue occurred when more than one version already exists for an API.

Resolves: https://github.com/wso2/api-manager/issues/1094