### PR TITLE
Enabling multiple reporters to publish analytics in parallel. 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/RequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/RequestDataPublisher.java
@@ -19,6 +19,8 @@ package org.wso2.carbon.apimgt.common.analytics.publishers;
 import org.wso2.am.analytics.publisher.reporter.CounterMetric;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Event;
 
+import java.util.List;
+
 /**
  * interface for data publisher.
  */
@@ -27,4 +29,6 @@ public interface RequestDataPublisher {
     void publish(Event analyticsEvent);
 
     CounterMetric getCounterMetric();
+
+    List<CounterMetric> getMultipleCounterMetrics();
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/ExtendedAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/ExtendedAPI.java
@@ -18,7 +18,7 @@
 package org.wso2.carbon.apimgt.common.analytics.publishers.dto;
 
 /**
- * Extended API Object with organization ID
+ * Extended API Object with organization ID.
  */
 public class ExtendedAPI extends API {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AbstractRequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AbstractRequestDataPublisher.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.apimgt.common.analytics.publishers.impl;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.am.analytics.publisher.exception.MetricReportingException;
@@ -27,6 +28,7 @@ import org.wso2.am.analytics.publisher.reporter.MetricEventBuilder;
 import org.wso2.carbon.apimgt.common.analytics.publishers.RequestDataPublisher;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Event;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -43,27 +45,37 @@ public abstract class AbstractRequestDataPublisher implements RequestDataPublish
     @Override
     public void publish(Event analyticsEvent) {
 
-        CounterMetric counterMetric = this.getCounterMetric();
-        if (counterMetric == null) {
-            log.error("counterMetric cannot be null.");
-            return;
-        }
-
         Map<String, Object> dataMap = OBJECT_MAPPER.convertValue(analyticsEvent, MAP_TYPE_REFERENCE);
-        MetricEventBuilder builder = counterMetric.getEventBuilder();
-        for (Map.Entry<String, Object> entry : dataMap.entrySet()) {
-            try {
-                builder.addAttribute(entry.getKey(), entry.getValue());
-            } catch (MetricReportingException e) {
-                log.error("Error adding data to the event stream.", e);
-                return;
-            }
-        }
+        List<CounterMetric> multipleCounterMetrics = this.getMultipleCounterMetrics();
 
-        try {
-            counterMetric.incrementCount(builder);
-        } catch (MetricReportingException e) {
-            log.error("Error occurred when publishing event.", e);
+        for (CounterMetric counterMetric : multipleCounterMetrics) {
+            if (counterMetric == null) {
+                log.error("counterMetric cannot be null.");
+            } else {
+                String counterMetricClassName = counterMetric.getClass().toString().
+                        replaceAll("[\r\n]", "").split(" ")[1];
+                log.info("Started adding data to counterMetric " + counterMetricClassName);
+                boolean caughtException = false;
+                MetricEventBuilder builder = counterMetric.getEventBuilder();
+                for (Map.Entry<String, Object> entry : dataMap.entrySet()) {
+                    try {
+                        builder.addAttribute(entry.getKey(), entry.getValue());
+                    } catch (MetricReportingException e) {
+                        caughtException = true;
+                        log.error("Error adding data to the event stream. counterMetric: " + counterMetricClassName
+                                , e);
+                        break;
+                    }
+                }
+                if (!caughtException) {
+                    try {
+                        counterMetric.incrementCount(builder);
+                    } catch (MetricReportingException e) {
+                        log.error("Error occurred when publishing event. counterMetric: " + counterMetricClassName
+                                , e);
+                    }
+                }
+            }
         }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/FaultyRequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/FaultyRequestDataPublisher.java
@@ -16,9 +16,10 @@
  */
 
 package org.wso2.carbon.apimgt.common.analytics.publishers.impl;
+import org.wso2.am.analytics.publisher.reporter.CounterMetric;
 
 import java.util.List;
-import org.wso2.am.analytics.publisher.reporter.CounterMetric;
+
 
 /**
  * Fault event publisher implementation.

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/FaultyRequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/FaultyRequestDataPublisher.java
@@ -17,6 +17,7 @@
 
 package org.wso2.carbon.apimgt.common.analytics.publishers.impl;
 
+import java.util.List;
 import org.wso2.am.analytics.publisher.reporter.CounterMetric;
 
 /**
@@ -27,5 +28,10 @@ public class FaultyRequestDataPublisher extends AbstractRequestDataPublisher {
     @Override
     public CounterMetric getCounterMetric() {
         return AnalyticsDataPublisher.getInstance().getFaultyMetricReporter();
+    }
+
+    @Override
+    public List<CounterMetric> getMultipleCounterMetrics() {
+        return AnalyticsDataPublisher.getInstance().getFaultyMetricReporters();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/SuccessRequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/SuccessRequestDataPublisher.java
@@ -17,11 +17,11 @@
 
 package org.wso2.carbon.apimgt.common.analytics.publishers.impl;
 
-import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.am.analytics.publisher.reporter.CounterMetric;
 
+import java.util.List;
 /**
  * Success event publisher implementation.
  */

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/SuccessRequestDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/SuccessRequestDataPublisher.java
@@ -17,6 +17,7 @@
 
 package org.wso2.carbon.apimgt.common.analytics.publishers.impl;
 
+import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.am.analytics.publisher.reporter.CounterMetric;
@@ -31,5 +32,10 @@ public class SuccessRequestDataPublisher extends AbstractRequestDataPublisher {
     @Override
     public CounterMetric getCounterMetric() {
         return AnalyticsDataPublisher.getInstance().getSuccessMetricReporter();
+    }
+
+    @Override
+    public List<CounterMetric> getMultipleCounterMetrics() {
+        return AnalyticsDataPublisher.getInstance().getSuccessMetricReporters();
     }
 }


### PR DESCRIPTION
Current implementation supports only one reporter to publish data (which means only one analytics dashboard can be used at a time). Currently custom reporters are allowed and the default reporter sends data to Choreo Insights. 
This PR enables to support multiple reporters. Multiple reporters can be included as key-value pairs under enforcer analytics config properties map. keys should be in the following regex form: 
```shell
"^publisher//.reporter[1-9][0-9]*//.class$"   
```
example:
```shell
"publisher.reporter1.class" = "moesif.analytics.reporter.MoesifReporter"
"publisher.reporter2.class" = "org.wso2.am.analytics.publisher.reporter.cloud.DefaultAnalyticsMetricReporter"
```

Existing ways of publishing analytics are still applicable. For ease, lets refer the way above example includes reporters as  'multi reporter listing'. We set a hierarchy for all of these ways as follows (top method denotes the method highest in hierarchy):

- Method 1: Defining a reporter using existing "publisher.reporter.class"
- Method 2: Setting "type" key to "elk", which will send analytics to ELK.
- Method 3: multi reporter listing

Whenever more than one of the above methods are used, the outcome will be the outcome of the method which is higher in the hierarchy. For example if both Method 1 and Method 2 methods were used the analytics will be sent only to the destination defined by the reporter given in the value of "publisher.reporter.class". In case of none of the methods are used the data will be sent to Choreo Insight using the default reporter.

Note worthy features:
- No numerical limit for multi reporter listing as long as latency is not an issue.
- In a failure of one reporter, the implementation will switch to the next reporter.
- Error logs and Exception messages denote from which reporter the particular error/exception was raised (Note if the error/exception occured in CounterMetric level then it will be the associated CounterMetric implementation of the reporter). 

Testing:
Successfully tested against default reporter and a custom reporter.