### PR TITLE
Fix stream closed error encountered due to XSD validation not working as expected

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -470,6 +470,7 @@ public class GatewayUtils {
                 } else {
                     payload = axis2MC.getEnvelope().getBody().getFirstElement().toString();
                     inputStreamXml = new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8));
+                    inputStreamSchema = new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8));
                 }
             }
         }


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/api-manager/issues/1162

This PR fixes the IOException getting thrown when schema validation is enabled, resulting in a 400 Bad Request even when the XML payload is adhering to the provided XSD.

According to the logic in XMLSchemaValidator and GatewayUtils.cloneRequestMessage(), when the passthrough pipe message is not available we get the inputstream XML from the axis2 msg context's envelope body. But we are only setting it in the returned inputStreamMap under XML key and setting a null stream for the SCHEMA key. This is the root cause for the reported bug.