### PR TITLE
Fix API import when publisher access control enabled

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -2225,7 +2225,7 @@ public class ImportUtils {
                 }
             }
 
-            APIProvider apiProvider = RestApiCommonUtil.getProvider(importedApiProductDTO.getProvider());
+            APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
 
             // Check whether the API resources are valid
             checkAPIProductResourcesValid(extractedFolderPath, userName, apiProvider, importedApiProductDTO,

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -801,7 +801,7 @@ public class PublisherCommonUtils {
                 isWSAPI || APIDTO.TypeEnum.WEBSUB.equals(apiDto.getType()) ||
                         APIDTO.TypeEnum.SSE.equals(apiDto.getType()) || APIDTO.TypeEnum.ASYNC.equals(apiDto.getType());
         username = StringUtils.isEmpty(username) ? RestApiCommonUtil.getLoggedInUsername() : username;
-        APIProvider apiProvider = RestApiCommonUtil.getProvider(username);
+        APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
 
         // validate web socket api endpoint configurations
         if (isWSAPI && !PublisherCommonUtils.isValidWSAPI(apiDto)) {
@@ -1653,7 +1653,7 @@ public class PublisherCommonUtils {
             String organization) throws APIManagementException, FaultGatewaysException {
 
         username = StringUtils.isEmpty(username) ? RestApiCommonUtil.getLoggedInUsername() : username;
-        APIProvider apiProvider = RestApiCommonUtil.getProvider(username);
+        APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
         // if not add product
         String provider = apiProductDTO.getProvider();
         String context = apiProductDTO.getContext();


### PR DESCRIPTION
When importing multiple versions of APIs with publisher access control enabled by a different user than the API provider, role validation is done based on the provider. Previously provider was taken from the artefact which was the original user and if that user does not exist in the new environment, there were multiple errors and this sets the provider to the logged in user.

Resolves: https://github.com/wso2/api-manager/issues/1020