### PR TITLE
Resolve incorrectly returning 500 for an invalid life-cycle state change

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3128,8 +3128,8 @@ public class ApisApiServiceImpl implements ApisApiService {
     }
 
     @Override
-    public Response changeAPILifecycle(String action, String apiId, String lifecycleChecklist,
-                                            String ifMatch, MessageContext messageContext) {
+    public Response changeAPILifecycle(String action, String apiId, String lifecycleChecklist, String ifMatch,
+                                       MessageContext messageContext) throws APIManagementException{
 
         try {
             String organization = RestApiUtil.getValidatedOrganization(messageContext);
@@ -3152,7 +3152,7 @@ public class ApisApiServiceImpl implements ApisApiService {
                 RestApiUtil.handleAuthorizationFailure(
                         "Authorization failure while updating the lifecycle of API " + apiId, e, log);
             } else {
-                RestApiUtil.handleInternalServerError("Error while updating lifecycle of API " + apiId, e, log);
+                throw e;
             }
         }
         return null;


### PR DESCRIPTION
For the REST API call when sending an invalid action parameter below issues were reported,

Return HTTP Status Code 400 instead of 500 which is incorrect
Do not log a huge stack trace, only the `Action 'Deprecate' is not allowed. Allowed actions are [Retire]` line would be sufficient.

This PR will resolve above two issues.

Below is the sample log output that you will observe when you sent an invalid life-cycle state,

`[2023-01-09 21:58:14,021] ERROR - ApisApiServiceImpl Error while updating lifecycle of API 63bc4008a4b76f2f6db146b4 Action 'Deprecate' is not allowed. Allowed actions are [Publish, Deploy as a Prototype]`

Below is the response you will receive for a request with an invalid life-cycle state,

`{"code":400,"message":"Bad Request","description":"Error while updating lifecycle of API 63bc4008a4b76f2f6db146b4 Action 'Deprecate' is not allowed. Allowed actions are [Publish, Deploy as a Prototype]","moreInfo":"","error":[]}`

Related Issue: https://github.com/wso2-enterprise/choreo/issues/17042