### PR TITLE
Fix coverage report upload expired failure

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 codecov:
   require_ci_to_pass: no
+  max_report_age: off
 
 coverage:
   precision: 2


### PR DESCRIPTION
This change fixes "upload expired" failure in codecov according to the following thread https://community.codecov.com/t/result-upload-marked-as-upload-expired/4015.

![image](https://user-images.githubusercontent.com/36144069/211567555-043bd7cb-a8ce-4246-97dc-82c1794a4a80.png)
