### PR TITLE
Check for empty resource paths in OAS2 definitions

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -676,6 +676,24 @@ public class OAS2Parser extends APIDefinition {
             }
         } else {
             validationResponse.setValid(true);
+            // Check whether the given OpenAPI definition contains empty resource paths
+            // We are checking this manually since the Swagger parser does not throw an error for this
+            // Which is a known issue of Swagger 2.0 parser
+            Set<URITemplate> uriTemplates = null;
+            uriTemplates = getURITemplates(apiDefinition);
+            if (uriTemplates == null) {
+                validationResponse.setValid(false);
+                return validationResponse;
+            } else {
+                for (URITemplate uriTemplate : uriTemplates) {
+                    if (uriTemplate.getUriTemplate().isEmpty()) {
+                        OASParserUtil.addErrorToValidationResponse(validationResponse,
+                                "A resource path is empty in the swagger definition");
+                        validationResponse.setValid(false);
+                        return validationResponse;
+                    }
+                }
+            }
         }
         if (validationResponse.isValid() && parseAttemptForV2.getSwagger() != null){
             Swagger swagger = parseAttemptForV2.getSwagger();


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/1167

## Description

- With this change for the OAS2 parser, we check whether a given OpenAPI definition contains empty resource paths and throws an error.
- We do this manually since the Swagger parser does not throw an error for this which is a known issue of the Swagger 2.0 parser. ( OAS3 parser does not have this issue )
- According to the OpenAPI specification empty paths are a violation of the specification.
- API paths get stored in the AM_API_URL_MAPPING table under the URL_PATTERN column. But it seems having empty paths does not affect APIM 3.2.0 in most cases as most of the databases store empty strings as it is.
- But in the Oracle database, empty strings are converted and stored as Null.
- This behavior could result in Null pointer exceptions in APIM with Swagger 2.0 definitions similar to https://github.com/wso2/api-manager/issues/1167
- This change should fix similar issues.

## Integration tests

- https://github.com/wso2/product-apim/pull/13077