### PR TITLE
Added validation on vhosts

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
@@ -839,6 +839,18 @@ public class ApisApiServiceImplUtils {
             throw new APIManagementException("Required field 'vhost' not found in deployment",
                     ExceptionCodes.GATEWAY_ENVIRONMENT_VHOST_NOT_PROVIDED);
         }
+
+        List<VHost> vhosts = environments.get(environment).getVhosts();
+        boolean isVhostValidated = false;
+        for (VHost vhostItem : vhosts) {
+            //Checking the vhost is included in the available vhost list
+            if (vhostItem.getHost().equals(vhost)) {
+                isVhostValidated = true;
+            }
+        }
+        if (!isVhostValidated) {
+            throw new APIManagementException("Invalid Vhost: " + vhost);
+        }
         return mapApiRevisionDeployment(revisionId, vhost, displayOnDevportal, environment);
     }
 


### PR DESCRIPTION
# Purpose
This fix fixes the wrong flow of passing a wrong vhost(ws.wso2.com) with the correct gateway name. The API call is getting invoked without any issue and the new revision is getting deployed into the gateway with the wrong vhost. 
Related Github Issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/1350 
# Approach
Added a validation to check the vhost, wether it matches the corresponding vhosts in a gateway.