### PR TITLE
Fixing API invocation failures when SchemaValidation is enabled for unauthenticated APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/model/OpenAPIRequest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/model/OpenAPIRequest.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.rest.RESTConstants;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.security.utils.SchemaValidationUtils;
 
@@ -38,6 +39,8 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -95,7 +98,12 @@ public class OpenAPIRequest implements Request {
                     "Content-Type" : headerKey.toLowerCase(Locale.ROOT);
             headers.put(headerKey, value);
         }
-        String apiResource = messageContext.getProperty(APIMgtGatewayConstants.RESOURCE).toString();
+        String apiResource = "/";
+        Pattern pattern = Pattern.compile(APIMgtGatewayConstants.RESOURCE_PATTERN);
+        Matcher matcher = pattern.matcher((String) messageContext.getProperty(RESTConstants.REST_FULL_REQUEST_PATH));
+        if (matcher.find()) {
+            apiResource = matcher.group(1);
+        }
         //Extracting query params
         try {
             queryParams = SchemaValidationUtils.getQueryParams(apiResource, (String)

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/TestSchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/TestSchemaValidator.java
@@ -322,5 +322,7 @@ public class TestSchemaValidator {
         headers.put(CONTENT_TYPE_HEADER, contentType);
         Mockito.when(axis2MsgContext.getProperty(TRANSPORT_HEADERS)).thenReturn(headers);
         Mockito.when(messageContext.getProperty(RESOURCE_TAG)).thenReturn(resourcePath);
+        Mockito.when((String) messageContext.getProperty((RESTConstants.REST_FULL_REQUEST_PATH))).
+                thenReturn(resourcePath);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/192