### PR TITLE
Support export/import API policies with Synapse and CC gateway types

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -9655,6 +9655,9 @@ public final class APIUtil {
                 policyDefinition = new OperationPolicyDefinition();
                 policyDefinition.setContent(yamlContent);
                 policyDefinition.setMd5Hash(getMd5OfOperationPolicyDefinition(policyDefinition));
+                if (StringUtils.equals(APIConstants.CC_POLICY_DEFINITION_EXTENSION, fileExtension)) {
+                    policyDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.ChoreoConnect);
+                }
             }
         } catch (IOException e) {
             throw new APIManagementException("Error while reading policy specification from path: "


### PR DESCRIPTION
## Purpose
Earlier there was an error when export/importing an API Policy that supports both Synapse and Choreo Connect gateways. This will fix that issue.
Fixes: https://github.com/wso2/api-manager/issues/1274

## Goals
Support export/import API policies with Synapse and CC gateway types

## Approach
Check the extension type of the definition file and if it is ".gotmpl", then set the gateway type accordingly.

