### PR TITLE
Added functionality to disable sending auth header to the back end when token_endpoint_auth_method synapse property is defined in the sequence as none.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/OAuthMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/OAuthMediator.java
@@ -120,6 +120,14 @@ public class OAuthMediator extends AbstractMediator implements ManagedLifecycle 
             log.debug("Token Response is empty...");
         }
         messageContext.setProperty(APIMgtGatewayConstants.OAUTH_ENDPOINT_INSTANCE, oAuthEndpoint);
+        Object tokenEndpointAuthMethodProperty = messageContext
+                .getProperty(APIConstants.OAuthConstants.TOKEN_ENDPOINT_AUTH_METHOD);
+        if (tokenEndpointAuthMethodProperty != null) {
+            String tokenEndpointAuthMethod = (String) tokenEndpointAuthMethodProperty;
+            if (StringUtils.isNotEmpty(tokenEndpointAuthMethod)) {
+                oAuthEndpoint.setTokenEndpointAuthMethod(tokenEndpointAuthMethod);
+            }
+        }
         return true;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/OAuthTokenGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/OAuthTokenGenerator.java
@@ -115,7 +115,7 @@ public class OAuthTokenGenerator {
         TokenResponse tokenResponse = OAuthClient.generateToken(oAuthEndpoint.getTokenApiUrl(),
                 oAuthEndpoint.getClientId(), oAuthEndpoint.getClientSecret(), oAuthEndpoint.getUsername(),
                 oAuthEndpoint.getPassword(), oAuthEndpoint.getGrantType(), oAuthEndpoint.getCustomParameters(),
-                refreshToken);
+                refreshToken, oAuthEndpoint.getTokenEndpointAuthMethod());
 
         assert tokenResponse != null;
         if (tokenResponse.getExpiresIn() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/client/OAuthClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/client/OAuthClient.java
@@ -98,7 +98,11 @@ public class OAuthClient {
             log.debug("Initializing token generation request: [token-endpoint] " + url);
         }
         if (tokenEndpointAuthMethod == null) {
+            Object tokenEndpointAuthMethodObject = customParameters.get(APIConstants.OAuthConstants.TOKEN_ENDPOINT_AUTH_METHOD);
             tokenEndpointAuthMethod = APIConstants.OAuthConstants.TOKEN_ENDPOINT_AUTH_BASIC;
+            if (tokenEndpointAuthMethodObject != null) {
+                tokenEndpointAuthMethod = String.valueOf(tokenEndpointAuthMethodObject);
+            }
         }
         URL urlObject;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/conf/OAuthEndpoint.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/conf/OAuthEndpoint.java
@@ -30,6 +30,7 @@ public class OAuthEndpoint {
     private char[] password;
     private String grantType;
     private JSONObject customParameters;
+    private String tokenEndpointAuthMethod;
 
     public String getId() {
         return id;
@@ -93,5 +94,13 @@ public class OAuthEndpoint {
 
     public void setCustomParameters(JSONObject customParameters) {
         this.customParameters = customParameters;
+    }
+
+    public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
+        this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+    }
+
+    public String getTokenEndpointAuthMethod() {
+        return tokenEndpointAuthMethod;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthTokenGeneratorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthTokenGeneratorTest.java
@@ -163,7 +163,8 @@ public class OAuthTokenGeneratorTest {
         oAuthEndpoint.setGrantType("CLIENT_CREDENTIALS");
 
         Mockito.when(OAuthClient.generateToken(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-                        Mockito.isNull(), Mockito.isNull(), Mockito.anyString(), Mockito.any(), Mockito.isNull()))
+                        Mockito.isNull(), Mockito.isNull(), Mockito.anyString(), Mockito.any(), Mockito.isNull(),
+                        Mockito.anyString()))
                 .thenReturn(mockTokenResponse);
         // First token generation operation. Token endpoint will be called and the token response will not be cached.
         TokenResponse tokenResponse = OAuthTokenGenerator.generateToken(oAuthEndpoint, latch);
@@ -195,7 +196,8 @@ public class OAuthTokenGeneratorTest {
         oAuthEndpoint.setGrantType("PASSWORD");
 
         Mockito.when(OAuthClient.generateToken(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-                        Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.isNull()))
+                        Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.isNull(),
+                        Mockito.anyString()))
                 .thenReturn(mockTokenResponse);
         // First token generation operation. Token endpoint will be called and the token response will be cached.
         TokenResponse tokenResponse = OAuthTokenGenerator.generateToken(oAuthEndpoint, latch);
@@ -229,7 +231,8 @@ public class OAuthTokenGeneratorTest {
         oAuthEndpoint.setGrantType("PASSWORD");
 
         Mockito.when(OAuthClient.generateToken(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-                        Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.isNull()))
+                        Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.isNull(),
+                        Mockito.anyString()))
                 .thenReturn(mockTokenResponse);
         // First token generation operation. Token endpoint will be called and the token response will be cached.
         TokenResponse tokenResponse = OAuthTokenGenerator.generateToken(oAuthEndpoint, latch);
@@ -243,7 +246,8 @@ public class OAuthTokenGeneratorTest {
         // token).
         mockTokenResponse.setRefreshToken("testRefreshToken");
         Mockito.when(OAuthClient.generateToken(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-                        Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.anyString()))
+                        Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.anyString(),
+                        Mockito.anyString()))
                 .thenReturn(mockTokenResponse);
         tokenResponse = OAuthTokenGenerator.generateToken(oAuthEndpoint, latch);
         Assert.assertNotNull(tokenResponse);
@@ -267,7 +271,8 @@ public class OAuthTokenGeneratorTest {
         oAuthEndpoint.setGrantType("PASSWORD");
 
         Mockito.when(OAuthClient.generateToken(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-                        Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.isNull()))
+                        Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.isNull(),
+                        Mockito.anyString()))
                 .thenReturn(mockTokenResponse);
         // First token generation operation. Token endpoint will be called and the token response will not be cached.
         TokenResponse tokenResponse = OAuthTokenGenerator.generateToken(oAuthEndpoint, latch);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1384,6 +1384,9 @@ public final class APIConstants {
         public static final String ENDPOINT_SECURITY_TYPE = "type";
         public static final String ENDPOINT_SECURITY_ENABLED = "enabled";
         public static final String ENDPOINT_SECURITY_USERNAME = "username";
+        public static final String TOKEN_ENDPOINT_AUTH_METHOD = "token_endpoint_auth_method";
+        public static final String TOKEN_ENDPOINT_AUTH_BASIC = "client_secret_basic";
+        public static final String TOKEN_ENDPOINT_AUTH_NONE = "none";
 
         private OAuthConstants() {
 


### PR DESCRIPTION
…en token_endpoint_auth_method synapse property is defined in the sequence as none.