### PR TITLE
Added sandbox key capability to publisher tryout console

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -1428,7 +1428,7 @@ public interface APIProvider extends APIManager {
     void deleteAPIProductRevision(String apiProductId, String apiRevisionId, String organization)
             throws APIManagementException;
 
-    String generateApiKey(String apiId) throws APIManagementException;
+    String generateApiKey(String apiId, String organization) throws APIManagementException;
 
     List<APIRevisionDeployment> getAPIRevisionsDeploymentList(String apiId) throws APIManagementException;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3269,8 +3269,9 @@ public class ApisApiServiceImpl implements ApisApiService {
     public Response generateInternalAPIKey(String apiId, MessageContext messageContext) throws APIManagementException {
 
         String userName = RestApiCommonUtil.getLoggedInUsername();
+        String organization = RestApiUtil.getValidatedOrganization(messageContext);
         APIProvider apiProvider = APIManagerFactory.getInstance().getAPIProvider(userName);
-        String token = apiProvider.generateApiKey(apiId);
+        String token = apiProvider.generateApiKey(apiId, organization);
         APIKeyDTO apiKeyDTO = new APIKeyDTO();
         apiKeyDTO.setApikey(token);
         apiKeyDTO.setValidityTime(60 * 1000);


### PR DESCRIPTION
The publisher portal tryout console should work for either production or sandbox endpoint. But if there is no production endpoint, we could not invoke the API.

This is due to our current code only having the capability to handle this only if a production endpoint is available. In this commit, I added sandbox key capability to publisher tryout console to fix https://github.com/wso2/api-manager/issues/1190