### PR TITLE
Allowing to import Choreo Connect API Policies without .gotmpl

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -978,9 +978,12 @@ public class ImportUtils {
                 ccGatewayDefinition = APIUtil.getOperationPolicyDefinitionFromFile(pathToArchive, fileName,
                         APIConstants.CC_POLICY_DEFINITION_EXTENSION);
 
-                if (ccGatewayDefinition == null && synapseGatewayDefinition == null) {
-                    throw new APIManagementException("Either one of the Gateway Definition files should be present",
-                            ExceptionCodes.OPERATION_POLICY_GATEWAY_ERROR);
+                if (synapseGatewayDefinition == null) {
+                    List<String> supportedGateways = operationPolicyData.getSpecification().getSupportedGateways();
+                    if (supportedGateways.contains(APIConstants.OPERATION_POLICY_SUPPORTED_GATEWAY_SYNAPSE)) {
+                        throw new APIManagementException("Synpase Gateway Definition file should be present",
+                                ExceptionCodes.OPERATION_POLICY_GATEWAY_ERROR);
+                    }
                 }
 
                 if (ccGatewayDefinition != null) {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/1275

## Goals
Allow importing CC API Policies without .gotmpl

## Approach
Mandate checking for .j2 template file only for Synapse. If the type is Choreo Connect, no check has been done