### PR TITLE
Add WS backend JWT header from the config

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -103,6 +103,10 @@ public class APIMgtGatewayConstants {
      */
     public static final String WS_JWT_TOKEN_HEADER = "websocket.custom.header.X-JWT-Assertion";
 
+    public static final String WS_CUSTOM_HEADER = "ws.custom.header";
+    public static final String WS_NOT_SECURED = "ws";
+    public static final String WS_SECURED = "wss";
+
     public static final String GATEWAY_TYPE = "SYNAPSE";
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandler.java
@@ -41,6 +41,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpHeaders;
 import org.apache.synapse.SynapseConstants;
+import org.wso2.carbon.apimgt.common.gateway.dto.JWTConfigurationDto;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.analytics.Constants;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityConstants;
@@ -54,6 +55,7 @@ import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContextDataHolder;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundWebSocketProcessor;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.utils.InboundWebsocketProcessorUtil;
+import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dto.APIKeyValidationInfoDTO;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
@@ -147,7 +149,16 @@ public class WebsocketInboundHandler extends ChannelInboundHandlerAdapter {
                 setApiAuthPropertiesToChannel(ctx, inboundMessageContext);
                 setApiPropertiesMapToChannel(ctx, inboundMessageContext);
                 if (StringUtils.isNotEmpty(inboundMessageContext.getToken())) {
-                    req.headers().set(APIMgtGatewayConstants.WS_JWT_TOKEN_HEADER, inboundMessageContext.getToken());
+                    String backendJwtHeader = null;
+                    JWTConfigurationDto jwtConfigurationDto = ServiceReferenceHolder.getInstance()
+                            .getAPIManagerConfiguration().getJwtConfigurationDto();
+                    if (jwtConfigurationDto != null) {
+                        backendJwtHeader = jwtConfigurationDto.getJwtHeader();
+                    }
+                    if (StringUtils.isEmpty(backendJwtHeader)) {
+                        backendJwtHeader = APIMgtGatewayConstants.WS_JWT_TOKEN_HEADER;
+                    }
+                    req.headers().set(backendJwtHeader, inboundMessageContext.getToken());
                 }
                 ctx.fireChannelRead(req);
                 publishHandshakeEvent(ctx, inboundMessageContext);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtil.java
@@ -474,6 +474,7 @@ public class InboundWebsocketProcessorUtil {
                         if (info != null) {
                             inboundMessageContext.setKeyType(info.getType());
                             inboundMessageContext.setInfoDTO(info);
+                            inboundMessageContext.setToken(info.getEndUserToken());
                             return info.isAuthorized();
                         }
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/utils/InboundWebsocketProcessorUtil.java
@@ -108,11 +108,13 @@ public class InboundWebsocketProcessorUtil {
         info.setApiTier(authenticationContext.getApiTier());
         info.setGraphQLMaxDepth(authenticationContext.getGraphQLMaxDepth());
         info.setGraphQLMaxComplexity(authenticationContext.getGraphQLMaxComplexity());
+        info.setEndUserToken(authenticationContext.getCallerToken());
 
         inboundMessageContext.setKeyType(info.getType());
         inboundMessageContext.setInfoDTO(info);
         inboundMessageContext.setAuthContext(authenticationContext);
         inboundMessageContext.setInfoDTO(info);
+        inboundMessageContext.setToken(info.getEndUserToken());
         return authenticationContext.isAuthenticated();
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandlerTestCase.java
@@ -22,6 +22,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelId;
+import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
@@ -32,6 +33,8 @@ import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.http.HttpHeaders;
 import org.junit.Assert;
 import org.junit.Before;
@@ -49,8 +52,10 @@ import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContextDataHolder;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundWebSocketProcessor;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.utils.InboundWebsocketProcessorUtil;
+import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.utils.APIMgtGoogleAnalyticsUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.dto.APIKeyValidationInfoDTO;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.keymgt.model.entity.API;
@@ -65,7 +70,7 @@ import java.util.UUID;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ WebSocketUtils.class, InboundWebsocketProcessorUtil.class,
-        APIUtil.class, WebsocketInboundHandler.class })
+        APIUtil.class, WebsocketInboundHandler.class, ServiceReferenceHolder.class })
 public class WebsocketInboundHandlerTestCase {
 
     private static final String channelIdString = "11111";
@@ -153,6 +158,17 @@ public class WebsocketInboundHandlerTestCase {
                 "ws://localhost:8080/graphql");
         fullHttpRequest.headers().set(headerName, headerValue);
         fullHttpRequest.headers().set(HttpHeaders.UPGRADE, strWebSocket);
+        ServiceReferenceHolder   serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        APIManagerConfiguration apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
+        ConfigurationContext configurationContext = Mockito.mock(ConfigurationContext.class);
+        AxisConfiguration axisConfiguration = Mockito.mock(AxisConfiguration.class);
+        ChannelPipeline channelPipeline = Mockito.mock(ChannelPipeline.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfiguration()).thenReturn(apiManagerConfiguration);
+        Mockito.when(serviceReferenceHolder.getServerConfigurationContext()).thenReturn(configurationContext);
+        Mockito.when(configurationContext.getAxisConfiguration()).thenReturn(axisConfiguration);
+        Mockito.when(channelHandlerContext.channel().pipeline()).thenReturn(channelPipeline);
         Mockito.when(inboundWebSocketProcessor.handleHandshake(fullHttpRequest, channelHandlerContext,
                 inboundMessageContext)).thenReturn(responseDTO);
         websocketInboundHandler.channelRead(channelHandlerContext, fullHttpRequest);


### PR DESCRIPTION
This PR adds the change to take WebSocket backend JWT header from configuration instead of the hardcoded value.

Moreover, This PR adds the change to take the backend JWT header prefix from the `ws.custom.header` parameter included in `transport.ws.sender.parameters` and `transport.wss.sender.parameters` instead of including the prefix in the `apim.jwt.header` configuraiton.

Fixes https://github.com/wso2/product-apim/issues/12286