### PR TITLE
[4.2.0] Upgrade velocity-engine-core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2078,7 +2078,7 @@
         <commons-codec.version>1.14</commons-codec.version>
         <com.nimbusds.wso2.version>7.3.0.wso2v1</com.nimbusds.wso2.version>
         <json-smart.version>2.3</json-smart.version>
-        <org.apache.velocity.version>2.1</org.apache.velocity.version>
+        <org.apache.velocity.version>2.3</org.apache.velocity.version>
         <org.slf4j.version>1.7.0</org.slf4j.version>
         <slf4j.api.version>1.7.29</slf4j.api.version>
         <slf4j.wso2.version>1.5.10.wso2v1</slf4j.wso2.version>
@@ -2124,7 +2124,7 @@
         <google.guava.version>31.0.1-jre</google.guava.version>
         <xercesImpl.version>2.8.1.wso2v2</xercesImpl.version>
         <commons.scxml.version>0.9.0.wso2v2</commons.scxml.version>
-        <velocity.version>2.1</velocity.version>
+        <velocity.version>2.3</velocity.version>
         <fasterxml.jackson.version>2.14.1</fasterxml.jackson.version>
         <fasterxml.jackson.databind.version>2.14.1</fasterxml.jackson.databind.version>
         <fasterxml.jackson.core.version>2.14.1</fasterxml.jackson.core.version>


### PR DESCRIPTION
Upgrades velocity-engine-core version to 2.3.

Fixes https://github.com/wso2/api-manager/issues/1301