### PR TITLE
Upgrade registry version

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
@@ -22,7 +22,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.googlecode.json-simple.wso2</groupId>
+            <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
         </dependency>
         <dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
@@ -58,7 +58,7 @@
             <artifactId>graphQL</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.json-simple.wso2</groupId>
+            <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
         </dependency>
         <dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -170,7 +170,7 @@
             <artifactId>org.wso2.carbon.registry.indexing</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.json-simple.wso2</groupId>
+            <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
         </dependency>
         <dependency>

--- a/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
@@ -82,7 +82,7 @@
             <artifactId>org.wso2.carbon.apimgt.keymgt.stub</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.json-simple.wso2</groupId>
+            <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
         </dependency>
         <dependency>
@@ -245,7 +245,7 @@
                                 <bundleDef>
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.keymgt.stub:${carbon.apimgt.version}
                                 </bundleDef>
-                                <bundleDef>com.googlecode.json-simple.wso2:json-simple</bundleDef>
+                                <bundleDef>com.googlecode.json-simple:json-simple</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.core:jackson-core</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.core:jackson-annotations</bundleDef>
@@ -267,7 +267,7 @@
                                     org.wso2.carbon.mediation:org.wso2.carbon.localentry.stub:${carbon.mediation.version}
                                 </importBundleDef>
 
-                                <bundleDef>com.googlecode.json-simple.wso2:json-simple</bundleDef>
+                                <bundleDef>com.googlecode.json-simple:json-simple</bundleDef>
                                 <bundleDef>com.google.code.gson:gson:${google.code.gson.version}</bundleDef>
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>org.json.wso2:json:${orbit.version.json}</bundleDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.internal.service.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.internal.service.feature/pom.xml
@@ -194,14 +194,14 @@
                                 </bundleDef>
                                 <bundleDef>org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.rest.api.publisher.v1.common:${carbon.apimgt.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.graphQL:graphQL:${graphql.java.version}</bundleDef>
-                                <bundleDef>com.googlecode.json-simple.wso2:json-simple</bundleDef>
+                                <bundleDef>com.googlecode.json-simple:json-simple</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.core:jackson-core</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.core:jackson-annotations</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.core:jackson-databind</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${fasterxml.jackson.version}</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.datatype:jackson-datatype-guava:${fasterxml.jackson.version}</bundleDef>
-                                <bundleDef>com.googlecode.json-simple.wso2:json-simple</bundleDef>
+                                <bundleDef>com.googlecode.json-simple:json-simple</bundleDef>
                                 <bundleDef>com.google.code.gson:gson:${google.code.gson.version}</bundleDef>
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>org.json.wso2:json:${orbit.version.json}</bundleDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.keymanager.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.keymanager.feature/pom.xml
@@ -115,7 +115,7 @@
                                 <bundleDef>
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.user.registration.stub:${carbon.identity.version}
                                 </bundleDef>
-                                <bundleDef>com.googlecode.json-simple.wso2:json-simple</bundleDef>
+                                <bundleDef>com.googlecode.json-simple:json-simple</bundleDef>
                                 <bundleDef>com.google.code.gson:gson:${google.code.gson.version}</bundleDef>
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>org.json.wso2:json:${orbit.version.json}</bundleDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.admin.feature/pom.xml
@@ -257,7 +257,7 @@
                                 <bundleDef>
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.output.adapter.http:${carbon.apimgt.version}
                                 </bundleDef>
-                                <bundleDef>com.googlecode.json-simple.wso2:json-simple</bundleDef>
+                                <bundleDef>com.googlecode.json-simple:json-simple</bundleDef>
                                 <bundleDef>com.google.code.gson:gson:${google.code.gson.version}</bundleDef>
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>org.json.wso2:json:${orbit.version.json}</bundleDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
@@ -250,7 +250,7 @@
                                 </bundleDef>
                                 <bundleDef>org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.rest.api.publisher.v1.common:${carbon.apimgt.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.graphQL:graphQL:${graphql.java.version}</bundleDef>
-                                <bundleDef>com.googlecode.json-simple.wso2:json-simple</bundleDef>
+                                <bundleDef>com.googlecode.json-simple:json-simple</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.core:jackson-core</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.core:jackson-annotations</bundleDef>
@@ -268,7 +268,7 @@
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.output.adapter.http:${carbon.apimgt.version}
                                 </bundleDef>
                                 <bundleDef>org.apache.woden.wso2:woden</bundleDef>
-                                <bundleDef>com.googlecode.json-simple.wso2:json-simple</bundleDef>
+                                <bundleDef>com.googlecode.json-simple:json-simple</bundleDef>
                                 <bundleDef>com.google.code.gson:gson:${google.code.gson.version}</bundleDef>
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>org.json.wso2:json:${orbit.version.json}</bundleDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog.feature/pom.xml
@@ -151,7 +151,7 @@
                                 <bundleDef>
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.rest.api.util:${carbon.apimgt.version}
                                 </bundleDef>
-                                <bundleDef>com.googlecode.json-simple.wso2:json-simple</bundleDef>
+                                <bundleDef>com.googlecode.json-simple:json-simple</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.core:jackson-core</bundleDef>
                                 <bundleDef>com.fasterxml.jackson.core:jackson-annotations</bundleDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
@@ -292,7 +292,7 @@
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.common.gateway:${carbon.apimgt.version}
                                 </bundleDef>
                                 <bundleDef>org.apache.woden.wso2:woden</bundleDef>
-                                <bundleDef>com.googlecode.json-simple.wso2:json-simple</bundleDef>
+                                <bundleDef>com.googlecode.json-simple:json-simple</bundleDef>
                                 <bundleDef>com.google.code.gson:gson:${google.code.gson.version}</bundleDef>
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>org.json.wso2:json:${orbit.version.json}</bundleDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.tokenmgt.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.tokenmgt.feature/pom.xml
@@ -111,7 +111,7 @@
                                 <bundleDef>
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.user.registration.stub:${carbon.identity.version}
                                 </bundleDef>
-                                <bundleDef>com.googlecode.json-simple.wso2:json-simple</bundleDef>
+                                <bundleDef>com.googlecode.json-simple:json-simple</bundleDef>
                                 <bundleDef>com.google.code.gson:gson:${google.code.gson.version}</bundleDef>
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>org.json.wso2:json:${orbit.version.json}</bundleDef>

--- a/pom.xml
+++ b/pom.xml
@@ -1246,7 +1246,7 @@
             </dependency>
 
             <dependency>
-                <groupId>com.googlecode.json-simple.wso2</groupId>
+                <groupId>com.googlecode.json-simple</groupId>
                 <artifactId>json-simple</artifactId>
                 <version>${json-simple.wso2.version}</version>
             </dependency>
@@ -2062,7 +2062,7 @@
         <javax.xml.soap.imp.pkg.version>0.0.0</javax.xml.soap.imp.pkg.version>
         <javax.xml.stream.imp.pkg.version>[1.0.1, 1.1.0)</javax.xml.stream.imp.pkg.version>
 
-        <json-simple.wso2.version>1.1.wso2v1</json-simple.wso2.version>
+        <json-simple.wso2.version>1.1.1</json-simple.wso2.version>
         <apache.woden.version>1.0.0.M9-wso2v1</apache.woden.version>
         <apache.poi.version>3.9.0.wso2v3</apache.poi.version>
         <rhino.js.version>1.7.0.R4.wso2v1</rhino.js.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1962,7 +1962,7 @@
 
         <carbon.commons.version>4.9.2</carbon.commons.version>
 
-        <carbon.registry.version>4.8.9</carbon.registry.version>
+        <carbon.registry.version>4.8.13</carbon.registry.version>
         <carbon.mediation.version>4.7.156</carbon.mediation.version>
 
         <mongodb.driver.version>4.1.0</mongodb.driver.version>


### PR DESCRIPTION
This PR upgrades registry version to latest.

- After upgrading registry version from 4.8.9 to 4.8.10 below issue occured while building product-apim. Hence json-simple version also was upgraded.

```
Installation failed.
Cannot complete the install because one or more required items could not be found.
 Software being installed: WSO2 Carbon - Api Management Cache Invalidation Feature 9.28.47.SNAPSHOT (org.wso2.carbon.apimgt.cache.invalidation.feature.group 9.28.47.SNAPSHOT)
 Missing requirement: org.wso2.carbon.apimgt.impl 9.28.47.SNAPSHOT (org.wso2.carbon.apimgt.impl 9.28.47.SNAPSHOT) requires 'package org.json.simple [1.1.0,2.0.0)' but it could not be found
 Cannot satisfy dependency:
  From: org.wso2.carbon.apimgt.cache.invalidation 9.28.47.SNAPSHOT (org.wso2.carbon.apimgt.cache.invalidation 9.28.47.SNAPSHOT)
  To: package org.wso2.carbon.apimgt.impl [9.0.0,10.0.0)
 Cannot satisfy dependency:
  From: WSO2 Carbon - Api Management Cache Invalidation Feature 9.28.47.SNAPSHOT (org.wso2.carbon.apimgt.cache.invalidation.feature.group 9.28.47.SNAPSHOT)
  To: org.wso2.carbon.apimgt.cache.invalidation [9.28.47.SNAPSHOT]
Application failed, log file location: /private/var/folders/xt/f03662097q99d7g6vkdn24xc0000gp/T/tycho-p2-runtime9193759365161423511.tmp/configuration/1674483736105.log

```
