### PR TITLE
Fix not working deny policies for WebSocket APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/constants/GraphQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/constants/GraphQLConstants.java
@@ -63,4 +63,19 @@ public class GraphQLConstants {
         public static final String PAYLOAD_FIELD_NAME_ID = "id";
         public static final String PAYLOAD_FIELD_TYPE_ERROR = "error";
     }
+
+    public static class FrameErrorConstants {
+        public static final int RESOURCE_FORBIDDEN_ERROR = 4002;
+        public static final String RESOURCE_FORBIDDEN_ERROR_MESSAGE = "User NOT authorized to access the resource";
+        public static final int INTERNAL_SERVER_ERROR = 4004;
+        public static final int BAD_REQUEST = 4005;
+        public static final int BLOCKED_REQUEST = 4006;
+        public static final String BLOCKED_REQUEST_MESSAGE = "Blocked from accessing the API";
+        public static final int GRAPHQL_QUERY_TOO_DEEP = 4020;
+        public static final String GRAPHQL_QUERY_TOO_DEEP_MESSAGE = "QUERY TOO DEEP";
+        public static final int GRAPHQL_QUERY_TOO_COMPLEX = 4021;
+        public static final String GRAPHQL_QUERY_TOO_COMPLEX_MESSAGE = "QUERY TOO COMPLEX";
+        public static final int GRAPHQL_INVALID_QUERY = 4022;
+        public static final String GRAPHQL_INVALID_QUERY_MESSAGE = "INVALID QUERY";
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/constants/GraphQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/constants/GraphQLConstants.java
@@ -64,18 +64,11 @@ public class GraphQLConstants {
         public static final String PAYLOAD_FIELD_TYPE_ERROR = "error";
     }
 
+    /**
+     * Constants related to WebSocket/GraphQL frame errors.
+     */
     public static class FrameErrorConstants {
-        public static final int RESOURCE_FORBIDDEN_ERROR = 4002;
-        public static final String RESOURCE_FORBIDDEN_ERROR_MESSAGE = "User NOT authorized to access the resource";
-        public static final int INTERNAL_SERVER_ERROR = 4004;
-        public static final int BAD_REQUEST = 4005;
         public static final int BLOCKED_REQUEST = 4006;
         public static final String BLOCKED_REQUEST_MESSAGE = "Blocked from accessing the API";
-        public static final int GRAPHQL_QUERY_TOO_DEEP = 4020;
-        public static final String GRAPHQL_QUERY_TOO_DEEP_MESSAGE = "QUERY TOO DEEP";
-        public static final int GRAPHQL_QUERY_TOO_COMPLEX = 4021;
-        public static final String GRAPHQL_QUERY_TOO_COMPLEX_MESSAGE = "QUERY TOO COMPLEX";
-        public static final int GRAPHQL_INVALID_QUERY = 4022;
-        public static final String GRAPHQL_INVALID_QUERY_MESSAGE = "INVALID QUERY";
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketUtil.java
@@ -17,6 +17,10 @@
  */
 package org.wso2.carbon.apimgt.gateway.handlers;
 
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.*;
+import io.netty.util.CharsetUtil;
 import org.apache.axiom.util.UIDGenerator;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.context.ConfigurationContext;
@@ -29,6 +33,10 @@ import org.apache.synapse.core.axis2.MessageContextCreatorForAxis2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.common.gateway.constants.GraphQLConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityException;
+import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
+import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
@@ -228,4 +236,71 @@ public class WebsocketUtil {
 		return axis2MsgCtx;
 	}
 
+	/**
+	 * Send error messages in handshake phase for API request message
+	 *
+	 * @param ctx                   Channel handler context
+	 * @param inboundMessageContext InboundMessageContext
+	 * @param responseDTO           InboundProcessorResponseDTO
+	 * @param errorMessage          Error message
+	 * @param errorCode             Error code
+	 */
+	public static void sendHandshakeErrorMessage(ChannelHandlerContext ctx, InboundMessageContext inboundMessageContext,
+												 InboundProcessorResponseDTO responseDTO, String errorMessage,
+												 int errorCode) {
+		FullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
+		HttpResponseStatus.valueOf(responseDTO.getErrorCode()),
+		Unpooled.copiedBuffer(responseDTO.getErrorMessage(), CharsetUtil.UTF_8));
+		httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8");
+		httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, httpResponse.content().readableBytes());
+		ctx.writeAndFlush(httpResponse);
+		if (log.isDebugEnabled()) {
+			log.debug("API request failed due to " + errorMessage + " for the websocket API: "
+					+ inboundMessageContext.getApiContext());
+		}
+//		throw new APISecurityException(errorCode, errorMessage);
+	}
+
+	/**
+	 * Validates whether there any active deny policies and set error values in InboundProcessorResponseDTO.
+	 *
+	 * @param inboundMessageContext InboundMessageContext
+	 * @return InboundProcessorResponseDTO
+	 */
+	public static InboundProcessorResponseDTO validateDenyPolicies(InboundMessageContext inboundMessageContext) {
+		APIKeyValidationInfoDTO infoDTO = inboundMessageContext.getInfoDTO();
+		String clientIp = inboundMessageContext.getUserIP();
+		String apiTenantDomain = inboundMessageContext.getTenantDomain();
+		String apiContext = inboundMessageContext.getApiContext();
+		String apiVersion = inboundMessageContext.getVersion();
+		InboundProcessorResponseDTO responseDTO = new InboundProcessorResponseDTO();
+		boolean isBlockedRequest = false;
+		String appLevelBlockingKey = "";
+		String subscriptionLevelBlockingKey = "";
+
+		if (ServiceReferenceHolder.getInstance().getThrottleDataHolder().isBlockingConditionsPresent()) {
+			appLevelBlockingKey = infoDTO.getSubscriber() + ":" + infoDTO.getApplicationName();
+			subscriptionLevelBlockingKey = apiContext + ":" + apiVersion + ":" + infoDTO.getSubscriber() + ":"
+					+ infoDTO.getApplicationName() + ":" + infoDTO.getType();
+			isBlockedRequest = ServiceReferenceHolder.getInstance().getThrottleDataHolder()
+					.isRequestBlocked(apiContext, appLevelBlockingKey, infoDTO.getEndUserName(), clientIp,
+							apiTenantDomain, subscriptionLevelBlockingKey);
+		}
+
+		if (isBlockedRequest) {
+			responseDTO = getFrameErrorDTO(GraphQLConstants.FrameErrorConstants.BLOCKED_REQUEST,
+					GraphQLConstants.FrameErrorConstants.BLOCKED_REQUEST_MESSAGE, true);
+		}
+		return responseDTO;
+	}
+
+	private static InboundProcessorResponseDTO getFrameErrorDTO(int errorCode, String errorMessage, boolean closeConnection) {
+		InboundProcessorResponseDTO inboundProcessorResponseDTO = new InboundProcessorResponseDTO();
+		inboundProcessorResponseDTO.setError(true);
+		inboundProcessorResponseDTO.setErrorCode(errorCode);
+		inboundProcessorResponseDTO.setErrorMessage(errorMessage);
+		inboundProcessorResponseDTO.setCloseConnection(closeConnection);
+		return inboundProcessorResponseDTO;
+
+	}
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketUtil.java
@@ -258,7 +258,6 @@ public class WebsocketUtil {
 			log.debug("API request failed due to " + errorMessage + " for the websocket API: "
 					+ inboundMessageContext.getApiContext());
 		}
-//		throw new APISecurityException(errorCode, errorMessage);
 	}
 
 	/**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/request/GraphQLRequestProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/request/GraphQLRequestProcessor.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.apimgt.common.gateway.graphql.QueryAnalyzer;
 import org.wso2.carbon.apimgt.common.gateway.graphql.QueryValidator;
 import org.wso2.carbon.apimgt.gateway.dto.GraphQLOperationDTO;
 import org.wso2.carbon.apimgt.common.gateway.graphql.GraphQLProcessorUtil;
+import org.wso2.carbon.apimgt.gateway.handlers.WebsocketUtil;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketApiConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketUtils;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
@@ -71,12 +72,14 @@ public class GraphQLRequestProcessor extends RequestProcessor {
     @Override
     public InboundProcessorResponseDTO handleRequest(int msgSize, String msgText,
                                                      InboundMessageContext inboundMessageContext) {
-
         InboundProcessorResponseDTO responseDTO;
         JSONObject graphQLMsg = new JSONObject(msgText);
         responseDTO = InboundWebsocketProcessorUtil.authenticateToken(inboundMessageContext);
         Parser parser = new Parser();
 
+        if (!responseDTO.isError()) {
+            responseDTO = WebsocketUtil.validateDenyPolicies(inboundMessageContext);
+        }
         //for gql subscription operation payloads
         if (!responseDTO.isError() && checkIfSubscribeMessage(graphQLMsg)) {
             String operationId = graphQLMsg.getString(

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/request/RequestProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/request/RequestProcessor.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.apimgt.gateway.inbound.websocket.request;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.gateway.handlers.WebsocketUtil;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.utils.InboundWebsocketProcessorUtil;
@@ -42,14 +43,16 @@ public class RequestProcessor {
      */
     public InboundProcessorResponseDTO handleRequest(int msgSize, String msgText,
                                                      InboundMessageContext inboundMessageContext) {
-
         InboundProcessorResponseDTO responseDTO;
         responseDTO = InboundWebsocketProcessorUtil.authenticateToken(inboundMessageContext);
         if (!responseDTO.isError()) {
-            if (log.isDebugEnabled()) {
-                log.debug("Perform websocket request throttling for: " + inboundMessageContext.getApiContext());
+            responseDTO = WebsocketUtil.validateDenyPolicies(inboundMessageContext);
+            if (!responseDTO.isError()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Perform websocket request throttling for: " + inboundMessageContext.getApiContext());
+                }
+                responseDTO = InboundWebsocketProcessorUtil.doThrottle(msgSize, null, inboundMessageContext, responseDTO);
             }
-            responseDTO = InboundWebsocketProcessorUtil.doThrottle(msgSize, null, inboundMessageContext, responseDTO);
         }
         return responseDTO;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/response/GraphQLResponseProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/response/GraphQLResponseProcessor.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.gateway.inbound.websocket.response;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONObject;
 import org.wso2.carbon.apimgt.common.gateway.constants.GraphQLConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.WebsocketUtil;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketUtils;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.dto.GraphQLOperationDTO;
@@ -45,10 +46,13 @@ public class GraphQLResponseProcessor extends ResponseProcessor {
     @Override
     public InboundProcessorResponseDTO handleResponse(int msgSize, String msgText,
                                                       InboundMessageContext inboundMessageContext) {
-
         InboundProcessorResponseDTO responseDTO =
                 InboundWebsocketProcessorUtil.authenticateToken(inboundMessageContext);
         JSONObject graphQLMsg = new JSONObject(msgText);
+
+        if (!responseDTO.isError()) {
+            responseDTO = WebsocketUtil.validateDenyPolicies(inboundMessageContext);
+        }
         if (!responseDTO.isError() && checkIfSubscribeMessageResponse(graphQLMsg)) {
             if (graphQLMsg.has(GraphQLConstants.SubscriptionConstants.PAYLOAD_FIELD_NAME_ID)
                     && graphQLMsg.getString(GraphQLConstants.SubscriptionConstants.PAYLOAD_FIELD_NAME_ID) != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/response/ResponseProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/response/ResponseProcessor.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.apimgt.gateway.inbound.websocket.response;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.gateway.handlers.WebsocketUtil;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.utils.InboundWebsocketProcessorUtil;
@@ -42,14 +43,16 @@ public class ResponseProcessor {
      */
     public InboundProcessorResponseDTO handleResponse(int msgSize, String msgText,
                                                       InboundMessageContext inboundMessageContext) throws Exception {
-
         InboundProcessorResponseDTO responseDTO;
         responseDTO = InboundWebsocketProcessorUtil.authenticateToken(inboundMessageContext);
         if (!responseDTO.isError()) {
-            if (log.isDebugEnabled()) {
-                log.debug("Perform websocket response throttling for: " + inboundMessageContext.getApiContext());
+            responseDTO = WebsocketUtil.validateDenyPolicies(inboundMessageContext);
+            if (!responseDTO.isError()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Perform websocket response throttling for: " + inboundMessageContext.getApiContext());
+                }
+                responseDTO = InboundWebsocketProcessorUtil.doThrottle(msgSize, null, inboundMessageContext, responseDTO);
             }
-            responseDTO = InboundWebsocketProcessorUtil.doThrottle(msgSize, null, inboundMessageContext, responseDTO);
         }
         return responseDTO;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandlerTestCase.java
@@ -41,7 +41,10 @@ import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContextDataHolder;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.utils.InboundWebsocketProcessorUtil;
+import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
 import org.wso2.carbon.apimgt.impl.dto.VerbInfoDTO;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.keymgt.model.entity.API;
@@ -52,7 +55,7 @@ import java.util.UUID;
  * Test class for WebsocketHandler
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({InboundWebsocketProcessorUtil.class, APIUtil.class})
+@PrepareForTest({InboundWebsocketProcessorUtil.class, APIUtil.class, ServiceReferenceHolder.class, WebsocketUtil.class})
 public class WebsocketHandlerTestCase {
 
     private static final String channelIdString = "11111";
@@ -82,6 +85,14 @@ public class WebsocketHandlerTestCase {
                 APIConstants.API_TYPE_WS, APIConstants.PUBLISHED_STATUS, false);
         graphQLAPI = new API(UUID.randomUUID().toString(), 2, "admin", "GraphQLAPI", "1.0.0", "graphql", "Unlimited",
                 APIConstants.GRAPHQL_API, APIConstants.PUBLISHED_STATUS, false);
+
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfiguration apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
+        PowerMockito.when(serviceReferenceHolder.getAPIManagerConfiguration()).thenReturn(apiManagerConfiguration);
+
+        PowerMockito.mockStatic(WebsocketUtil.class);
     }
 
     /*
@@ -115,6 +126,7 @@ public class WebsocketHandlerTestCase {
         PowerMockito.when(InboundWebsocketProcessorUtil.authenticateToken(Mockito.anyObject())).thenReturn(responseDTO);
         PowerMockito.when(InboundWebsocketProcessorUtil.doThrottle(Mockito.anyInt(), Mockito.anyObject(),
                 Mockito.anyObject(), Mockito.anyObject())).thenReturn(responseDTO);
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
         websocketHandler.write(channelHandlerContext, msg, channelPromise);
         Assert.assertTrue((InboundMessageContextDataHolder.getInstance().getInboundMessageContextMap()
                 .containsKey(channelIdString)));// No error has occurred context exists in data-holder map.
@@ -175,6 +187,7 @@ public class WebsocketHandlerTestCase {
         PowerMockito.when(InboundWebsocketProcessorUtil.authenticateToken(inboundMessageContext))
                 .thenReturn(responseDTO);
         //happy path
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
         websocketHandler.write(channelHandlerContext, msg, channelPromise);
         Assert.assertTrue((InboundMessageContextDataHolder.getInstance().getInboundMessageContextMap()
                 .containsKey(channelIdString)));// No error has occurred context exists in data-holder map.

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandlerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketInboundHandlerTestCase.java
@@ -44,6 +44,7 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.common.gateway.constants.GraphQLConstants;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketApiConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketUtils;
@@ -70,7 +71,7 @@ import java.util.UUID;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ WebSocketUtils.class, InboundWebsocketProcessorUtil.class,
-        APIUtil.class, WebsocketInboundHandler.class, ServiceReferenceHolder.class })
+        APIUtil.class, WebsocketInboundHandler.class, ServiceReferenceHolder.class, WebsocketUtil.class})
 public class WebsocketInboundHandlerTestCase {
 
     private static final String channelIdString = "11111";
@@ -123,6 +124,14 @@ public class WebsocketInboundHandlerTestCase {
         };
         websocketAPI = new API(UUID.randomUUID().toString(), 1, "admin", "WSAPI", "1.0.0", "/wscontext", "Unlimited",
                 APIConstants.API_TYPE_WS, APIConstants.PUBLISHED_STATUS, false);
+
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfiguration apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
+        PowerMockito.when(serviceReferenceHolder.getAPIManagerConfiguration()).thenReturn(apiManagerConfiguration);
+
+        PowerMockito.mockStatic(WebsocketUtil.class);
     }
 
     @Test
@@ -171,6 +180,7 @@ public class WebsocketInboundHandlerTestCase {
         Mockito.when(channelHandlerContext.channel().pipeline()).thenReturn(channelPipeline);
         Mockito.when(inboundWebSocketProcessor.handleHandshake(fullHttpRequest, channelHandlerContext,
                 inboundMessageContext)).thenReturn(responseDTO);
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
         websocketInboundHandler.channelRead(channelHandlerContext, fullHttpRequest);
         validateApiProperties(apiProperties, infoDTO, inboundMessageContext);
 
@@ -207,6 +217,7 @@ public class WebsocketInboundHandlerTestCase {
         Mockito.when(msg.content()).thenReturn(content);
         InboundProcessorResponseDTO responseDTO = new InboundProcessorResponseDTO();
         Mockito.when(inboundWebSocketProcessor.handleRequest(msg, inboundMessageContext)).thenReturn(responseDTO);
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
         websocketInboundHandler.channelRead(channelHandlerContext, msg);
         Assert.assertTrue((InboundMessageContextDataHolder.getInstance().getInboundMessageContextMap()
                 .containsKey(channelIdString)));// No error has occurred context exists in data-holder map.

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/request/RequestProcessorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/request/RequestProcessorTest.java
@@ -26,15 +26,19 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.gateway.handlers.WebsocketUtil;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.utils.InboundWebsocketProcessorUtil;
+import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
 /**
  * Test class for RequestProcessor.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ InboundWebsocketProcessorUtil.class })
+@PrepareForTest({ InboundWebsocketProcessorUtil.class, ServiceReferenceHolder.class, APIUtil.class, WebsocketUtil.class})
 public class RequestProcessorTest {
     private RequestProcessor requestProcessor;
     private int msgSize = 22;
@@ -42,10 +46,20 @@ public class RequestProcessorTest {
     private InboundMessageContext inboundMessageContext;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         requestProcessor = new RequestProcessor();
         PowerMockito.mockStatic(InboundWebsocketProcessorUtil.class);
         inboundMessageContext = Mockito.mock(InboundMessageContext.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfiguration apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
+        PowerMockito.when(serviceReferenceHolder.getAPIManagerConfiguration()).thenReturn(apiManagerConfiguration);
+
+        PowerMockito.mockStatic(APIUtil.class);
+        PowerMockito.when(APIUtil.getOAuthConfigurationFromAPIMConfig(Mockito.anyString())).thenReturn("");
+
+        PowerMockito.mockStatic(WebsocketUtil.class);
     }
 
     @Test
@@ -55,6 +69,7 @@ public class RequestProcessorTest {
                 .thenReturn(responseDTO);
         PowerMockito.when(InboundWebsocketProcessorUtil.doThrottle(msgSize, null, inboundMessageContext, responseDTO))
                 .thenReturn(responseDTO);
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
         responseDTO = requestProcessor.handleRequest(msgSize, msgText, inboundMessageContext);
         Assert.assertFalse(responseDTO.isError());
     }
@@ -79,6 +94,7 @@ public class RequestProcessorTest {
                 .thenReturn(responseDTO);
         PowerMockito.when(InboundWebsocketProcessorUtil.doThrottle(msgSize, null, inboundMessageContext, responseDTO))
                 .thenReturn(errorResponseDTO);
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
         responseDTO = requestProcessor.handleRequest(msgSize, msgText, inboundMessageContext);
         Assert.assertTrue(responseDTO.isError());
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/response/GraphQLResponseProcessorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/response/GraphQLResponseProcessorTest.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -29,13 +30,17 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.gateway.dto.GraphQLOperationDTO;
+import org.wso2.carbon.apimgt.gateway.handlers.WebsocketUtil;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketApiConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketUtils;
 import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.GraphQLProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.InboundProcessorResponseDTO;
 import org.wso2.carbon.apimgt.gateway.inbound.websocket.utils.InboundWebsocketProcessorUtil;
+import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.dto.VerbInfoDTO;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,8 +49,23 @@ import java.util.Map;
  * Test class for GraphQLResponseProcessor.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({InboundWebsocketProcessorUtil.class, WebSocketUtils.class})
+@PrepareForTest({InboundWebsocketProcessorUtil.class, WebSocketUtils.class, WebsocketUtil.class,
+        ServiceReferenceHolder.class, APIUtil.class})
 public class GraphQLResponseProcessorTest {
+
+    @Before
+    public void setup() throws Exception {
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfiguration apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
+        PowerMockito.when(serviceReferenceHolder.getAPIManagerConfiguration()).thenReturn(apiManagerConfiguration);
+
+        PowerMockito.mockStatic(APIUtil.class);
+        PowerMockito.when(APIUtil.getOAuthConfigurationFromAPIMConfig(Mockito.anyString())).thenReturn("");
+
+        PowerMockito.mockStatic(WebsocketUtil.class);
+    }
 
     @Test
     public void testHandleResponseSuccess() {
@@ -75,6 +95,7 @@ public class GraphQLResponseProcessorTest {
         PowerMockito.mockStatic(WebSocketUtils.class);
         Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
         PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
         InboundProcessorResponseDTO processorResponseDTO =
                 responseProcessor.handleResponse(msgSize, msgText, inboundMessageContext);
         Assert.assertFalse(processorResponseDTO.isError());
@@ -91,6 +112,8 @@ public class GraphQLResponseProcessorTest {
         InboundProcessorResponseDTO responseDTO = new InboundProcessorResponseDTO();
         PowerMockito.when(InboundWebsocketProcessorUtil.authenticateToken(inboundMessageContext))
                 .thenReturn(responseDTO);
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
         GraphQLResponseProcessor responseProcessor = new GraphQLResponseProcessor();
         InboundProcessorResponseDTO processorResponseDTO =
                 responseProcessor.handleResponse(msgSize, msgText, inboundMessageContext);
@@ -118,7 +141,7 @@ public class GraphQLResponseProcessorTest {
         PowerMockito.when(InboundWebsocketProcessorUtil
                         .getBadRequestFrameErrorDTO("Missing mandatory id field in the message"))
                 .thenReturn(inboundProcessorResponseDTO);
-
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
         InboundProcessorResponseDTO processorResponseDTO =
                 responseProcessor.handleResponse(msgSize, msgText, inboundMessageContext);
         Assert.assertTrue(processorResponseDTO.isError());
@@ -164,6 +187,7 @@ public class GraphQLResponseProcessorTest {
         PowerMockito.mockStatic(WebSocketUtils.class);
         Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
         PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
         InboundProcessorResponseDTO processorResponseDTO =
                 responseProcessor.handleResponse(msgSize, msgText, inboundMessageContext);
         Assert.assertTrue(processorResponseDTO.isError());
@@ -211,6 +235,7 @@ public class GraphQLResponseProcessorTest {
         PowerMockito.mockStatic(WebSocketUtils.class);
         Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
         PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
         InboundProcessorResponseDTO processorResponseDTO =
                 responseProcessor.handleResponse(msgSize, msgText, inboundMessageContext);
         Assert.assertTrue(processorResponseDTO.isError());
@@ -265,6 +290,7 @@ public class GraphQLResponseProcessorTest {
         PowerMockito.mockStatic(WebSocketUtils.class);
         Mockito.when(channel.attr(WebSocketUtils.WSO2_PROPERTIES)).thenReturn(getChannelAttributeMap());
         PowerMockito.when(WebSocketUtils.getApiProperties(ctx)).thenReturn(new HashMap<>());
+        PowerMockito.when(WebsocketUtil.validateDenyPolicies(Mockito.anyObject())).thenReturn(responseDTO);
         InboundProcessorResponseDTO processorResponseDTO = responseProcessor
                 .handleResponse(msgSize, msgText, inboundMessageContext);
         Assert.assertFalse(processorResponseDTO.isError());


### PR DESCRIPTION
## Purpose
When applying a deny policy to WebSocket/GraphQL API using the admin portal in the WSO2 API manager, It doesn't block the requests which in turn gives the ability to invoke the WS API regardless of the blocking condition.

This PR fixes the issue.

Resolves https://github.com/wso2/api-manager/issues/1128