### PR TITLE
Modified to support userName and apiContext [9.0.369.x].

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/AnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/AnalyticsDataProvider.java
@@ -63,5 +63,7 @@ public interface AnalyticsDataProvider {
 
     String getUserAgentHeader();
 
+    String getUserName();
+
     String getEndUserIP();
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/SuccessRequestDataCollector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/SuccessRequestDataCollector.java
@@ -70,6 +70,7 @@ public class SuccessRequestDataCollector extends CommonRequestDataCollector impl
         Latencies latencies = provider.getLatencies();
         MetaInfo metaInfo = provider.getMetaInfo();
         String userAgent = provider.getUserAgentHeader();
+        String userName = provider.getUserName();
         String userIp = provider.getEndUserIP();
         if (userIp == null) {
             userIp = Constants.UNKNOWN_VALUE;
@@ -84,6 +85,7 @@ public class SuccessRequestDataCollector extends CommonRequestDataCollector impl
         event.setRequestTimestamp(offsetDateTime);
         event.setMetaInfo(metaInfo);
         event.setUserAgentHeader(userAgent);
+        event.setUserName(userName);
         event.setUserIp(userIp);
 
         this.processor.publish(event);

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/Event.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/Event.java
@@ -40,6 +40,7 @@ public class Event {
     private int proxyResponseCode;
     private String requestTimestamp;
     private String userAgentHeader;
+    private String userName;
     private String userIp;
 
     private String errorType;
@@ -130,6 +131,14 @@ public class Event {
 
     public void setUserAgentHeader(String userAgentHeader) {
         this.userAgentHeader = userAgentHeader;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
     }
 
     public String getUserIp() {

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/ExtendedAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/dto/ExtendedAPI.java
@@ -23,6 +23,7 @@ package org.wso2.carbon.apimgt.common.analytics.publishers.dto;
 public class ExtendedAPI extends API {
 
     private String organizationId;
+    private String apiContext;
 
     public String getOrganizationId() {
         return organizationId;
@@ -30,5 +31,13 @@ public class ExtendedAPI extends API {
 
     public void setOrganizationId(String organizationId) {
         this.organizationId = organizationId;
+    }
+
+    public String getApiContext() {
+        return apiContext;
+    }
+
+    public void setApiContext(String apiContext) {
+        this.apiContext = apiContext;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -295,6 +295,14 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
     }
 
     @Override
+    public String getUserName() {
+        if (messageContext.getPropertyKeySet().contains(APIMgtGatewayConstants.END_USER_NAME)) {
+            return (String) messageContext.getProperty(APIMgtGatewayConstants.END_USER_NAME);
+        }
+        return null;
+    }
+
+    @Override
     public String getEndUserIP() {
 
         if (messageContext.getPropertyKeySet().contains(Constants.USER_IP_PROPERTY)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketAnalyticsDataProvider.java
@@ -62,7 +62,7 @@ public class WebSocketAnalyticsDataProvider implements AnalyticsDataProvider {
         this.ctx = ctx;
     }
 
-    private AuthenticationContext getAuthenticationContext()  {
+    private AuthenticationContext getAuthenticationContext() {
         Object authContext = WebSocketUtils.getPropertyFromChannel(APISecurityUtils.API_AUTH_CONTEXT, ctx);
         if (authContext != null) {
             return (AuthenticationContext) authContext;
@@ -186,7 +186,8 @@ public class WebSocketAnalyticsDataProvider implements AnalyticsDataProvider {
         Operation operation = new Operation();
         String method = (String) WebSocketUtils.getPropertyFromChannel(APIMgtGatewayConstants.HTTP_METHOD, ctx);
         operation.setApiMethod(method);
-        String matchingResource = (String) WebSocketUtils.getPropertyFromChannel(APIConstants.API_ELECTED_RESOURCE, ctx);
+        String matchingResource =
+                (String) WebSocketUtils.getPropertyFromChannel(APIConstants.API_ELECTED_RESOURCE, ctx);
         operation.setApiResourceTemplate(matchingResource);
         return operation;
     }
@@ -269,6 +270,16 @@ public class WebSocketAnalyticsDataProvider implements AnalyticsDataProvider {
     @Override
     public String getUserAgentHeader() {
         return (String) WebSocketUtils.getPropertyFromChannel(Constants.USER_AGENT_PROPERTY, ctx);
+    }
+
+    @Override
+    public String getUserName() {
+
+        Object authContext = WebSocketUtils.getPropertyFromChannel(APISecurityUtils.API_AUTH_CONTEXT, ctx);
+        if (authContext != null && authContext instanceof AuthenticationContext) {
+            return ((AuthenticationContext) authContext).getUsername();
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Note: same as approved PR #11669
# Purpose
Modification to include the end user name and api context in analytics event object.

## Goals
By default, end user name and api context should be included in the event object.

## Approach
Included end user name as a new event attribute.
Included api context inside ExtendedAPI.

## Automation tests
 - Unit tests : No
 - Integration tests : No

### Tested environments
JDK 11.0.16
Ubuntu 22.04.1 LTS