### PR TITLE
Upgrade analytics-common and jsonpath versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1954,7 +1954,7 @@
         <carbon.apimgt.version>9.28.59-SNAPSHOT</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
-        <carbon.analytics.common.version>5.3.2</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.4</carbon.analytics.common.version>
         <!-- Carbon kernel version -->
         <carbon.kernel.version>4.8.0-alpha</carbon.kernel.version>
         <carbon.kernel.feature.version>4.8.0-alpha</carbon.kernel.feature.version>
@@ -2173,7 +2173,7 @@
         <json.orbit.version>3.0.0.wso2v1</json.orbit.version>
         <aspectj.version>1.9.4</aspectj.version>
         <wso2.securevault.version>1.1.3</wso2.securevault.version>
-        <com.jayway.jsonpath.version>2.4.0.wso2v2</com.jayway.jsonpath.version>
+        <com.jayway.jsonpath.version>2.6.0.wso2v1</com.jayway.jsonpath.version>
         <org.wso2.orbit.commons-text.version>1.6.wso2v1</org.wso2.orbit.commons-text.version>
         <commons.lang.version>2.6.0.wso2v1</commons.lang.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>


### PR DESCRIPTION
Upgrades carbon-analytics-common version to reflect jsonpath upgrade in PR [1].
Related git issue : https://github.com/wso2/api-manager/issues/1297

[1]. https://github.com/wso2/carbon-analytics-common/pull/822