### PR TITLE
Throttling tier fix

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -384,8 +384,7 @@ public class OAS2Parser extends APIDefinition {
                         template.setAuthType("Any");
                         template.setAuthTypes("Any");
                     }
-                    if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_TIER) &&
-                            !StringUtils.isEmpty(extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER).toString())) {
+                    if (StringUtils.isNotEmpty((String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER))) {
                         String throttlingTier = (String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER);
                         template.setThrottlingTier(throttlingTier);
                         template.setThrottlingTiers(throttlingTier);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -441,8 +441,7 @@ public class OAS3Parser extends APIDefinition {
                             template.setAuthType("Any");
                             template.setAuthTypes("Any");
                         }
-                        if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_TIER) && !StringUtils.isEmpty(
-                                extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER).toString())) {
+                        if (StringUtils.isNotEmpty((String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER))) {
                             String throttlingTier = (String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER);
                             template.setThrottlingTier(throttlingTier);
                             template.setThrottlingTiers(throttlingTier);


### PR DESCRIPTION
Fixes the null pointer exception happens due to defining the `x-throttling-tier` as `null

Related PR: https://github.com/wso2/carbon-apimgt/pull/11760