### PR TITLE
Add loadAndSyncTenantConf to load tenant rest api scopes before getting tenant configurations

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/SystemScopeUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/SystemScopeUtils.java
@@ -230,6 +230,7 @@ public class SystemScopeUtils {
     public static JSONObject getTenantRESTAPIScopesConfig(String tenantDomain) throws APIManagementException {
 
         JSONObject restAPIConfigJSON = null;
+        APIUtil.loadAndSyncTenantConf(tenantDomain);
         JSONObject tenantConfJson = APIUtil.getTenantConfig(tenantDomain);
         if (tenantConfJson != null) {
             restAPIConfigJSON = getRESTAPIScopesFromTenantConfig(tenantConfJson);


### PR DESCRIPTION
## Purpose

- Error is getting logged in the console when login into the publisher portal via tenant account for the first time.
- Fixed https://github.com/wso2/api-manager/issues/1333

## Approach
- Added `loadAndSyncTenantConf` method to get the tenant configuration from the file system if its not available and then add it to the database so that it can be used or saved in the tenant config cache.