### PR TITLE
Operation level throttling with rate-limit service

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SwaggerData.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SwaggerData.java
@@ -36,6 +36,7 @@ public class SwaggerData {
         private String verb;
         private String authType;
         private String policy;
+        private String throttlingLimit;
         private Scope scope;
         private List<Scope> scopes = new ArrayList<>();
         private String amznResourceName;
@@ -105,6 +106,13 @@ public class SwaggerData {
             this.scopes = scopes;
         }
 
+        public String getThrottlingLimit() {
+            return throttlingLimit;
+        }
+
+        public void setThrottlingLimit(String throttlingLimit) {
+            this.throttlingLimit = throttlingLimit;
+        }
     }
 
     private String title;
@@ -138,6 +146,7 @@ public class SwaggerData {
             resource.verb = uriTemplate.getHTTPVerb();
             resource.authType = uriTemplate.getAuthType();
             resource.policy = uriTemplate.getThrottlingTier();
+            resource.throttlingLimit = uriTemplate.getThrottlingLimit();
             resource.scope = uriTemplate.getScope();
             resource.scopes = uriTemplate.retrieveAllScopes();
             resource.amznResourceName = uriTemplate.getAmznResourceName();

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SwaggerData.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SwaggerData.java
@@ -36,7 +36,7 @@ public class SwaggerData {
         private String verb;
         private String authType;
         private String policy;
-        private String throttlingLimit;
+        private ThrottlingLimit throttlingLimit;
         private Scope scope;
         private List<Scope> scopes = new ArrayList<>();
         private String amznResourceName;
@@ -106,11 +106,11 @@ public class SwaggerData {
             this.scopes = scopes;
         }
 
-        public String getThrottlingLimit() {
+        public ThrottlingLimit getThrottlingLimit() {
             return throttlingLimit;
         }
 
-        public void setThrottlingLimit(String throttlingLimit) {
+        public void setThrottlingLimit(ThrottlingLimit throttlingLimit) {
             this.throttlingLimit = throttlingLimit;
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/ThrottlingLimit.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/ThrottlingLimit.java
@@ -46,11 +46,6 @@ public class ThrottlingLimit implements Serializable {
     }
 
     @Override
-    public String toString() {
-        return "{ \"requestCount\" : " + this.getRequestCount() + " , \"unit\" : \"" + this.getUnit() + "\" }";
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o)
             return true;

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/ThrottlingLimit.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/ThrottlingLimit.java
@@ -18,10 +18,14 @@
 
 package org.wso2.carbon.apimgt.api.model;
 
+import java.io.Serializable;
+import java.util.Objects;
+
 /**
  * This class represents throttling limit relevant information
  */
-public class ThrottlingLimit {
+public class ThrottlingLimit implements Serializable {
+    private static final long serialVersionUID = 1L;
     private int requestCount;
     private String unit;
 
@@ -44,5 +48,20 @@ public class ThrottlingLimit {
     @Override
     public String toString() {
         return "{ \"requestCount\" : " + this.getRequestCount() + " , \"unit\" : \"" + this.getUnit() + "\" }";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ThrottlingLimit throttlingLimit = (ThrottlingLimit) o;
+        return requestCount == throttlingLimit.getRequestCount() && unit.equals(throttlingLimit.getUnit());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(requestCount, unit);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/ThrottlingLimit.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/ThrottlingLimit.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.api.model;
+
+/**
+ * This class represents throttling limit relevant information
+ */
+public class ThrottlingLimit {
+    private int requestCount;
+    private String unit;
+
+    public int getRequestCount() {
+        return requestCount;
+    }
+
+    public void setRequestCount(int requestCount) {
+        this.requestCount = requestCount;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
+    @Override
+    public String toString() {
+        return "{ \"requestCount\" : " + this.getRequestCount() + " , \"unit\" : \"" + this.getUnit() + "\" }";
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
@@ -353,7 +353,7 @@ public class URITemplate implements Serializable{
         if (applicableLevel != null ? !applicableLevel.equals(that.applicableLevel) : that.applicableLevel != null) {
             return false;
         }
-        if (throttlingTier!= null && !throttlingTier.equals(that.throttlingTier)) {
+        if (throttlingTier != null && !throttlingTier.equals(that.throttlingTier)) {
             return false;
         }
         if (!throttlingTiers.equals(that.throttlingTiers)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
@@ -39,6 +39,7 @@ public class URITemplate implements Serializable{
     private String applicableLevel;
     private String throttlingTier;
     private List<String> throttlingTiers = new ArrayList<String>();
+    private String throttlingLimit;
     private Scope scope;
     private String mediationScript;
     private List<Scope> scopes = new ArrayList<Scope>();
@@ -447,5 +448,31 @@ public class URITemplate implements Serializable{
 
     public void addOperationPolicy(OperationPolicy policy) {
         operationPolicies.add(policy);
+    }
+
+    public String getThrottlingLimit() {
+        return throttlingLimit;
+    }
+
+    public void setThrottlingLimit(String throttlingLimit) {
+        String convertedThrottlingLimit;
+        switch (throttlingLimit) {
+            case "10KPerMin":
+                convertedThrottlingLimit = "{ \"value\" : \"10000\" , \" unit \" : \"min\" }";
+                break;
+            case "20KPerMin":
+                convertedThrottlingLimit = "{ \"value\" : \"20000\" , \" unit \" : \"min\" }";
+                break;
+            case "50KPerMin":
+                convertedThrottlingLimit = "{ \"value\" : \"50000\" , \" unit \" : \"min\" }";
+                break;
+            case "Unlimited":
+                convertedThrottlingLimit = "{ \"value\" : \"123456\" , \" unit \" : \"min\" }";
+                break;
+            default:
+                convertedThrottlingLimit = throttlingLimit;
+                break;
+        }
+        this.throttlingLimit = convertedThrottlingLimit;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
@@ -473,8 +473,7 @@ public class URITemplate implements Serializable{
                 convertedThrottlingLimit.setRequestCount(50000);
                 convertedThrottlingLimit.setUnit("min");
                 break;
-            default:
-                // handles Unlimited value and unmatched throttle tier values
+            case "Unlimited":
                 convertedThrottlingLimit.setRequestCount(-1);
                 convertedThrottlingLimit.setUnit("min");
                 break;

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
@@ -39,7 +39,7 @@ public class URITemplate implements Serializable{
     private String applicableLevel;
     private String throttlingTier;
     private List<String> throttlingTiers = new ArrayList<String>();
-    private String throttlingLimit;
+    private ThrottlingLimit throttlingLimit;
     private Scope scope;
     private String mediationScript;
     private List<Scope> scopes = new ArrayList<Scope>();
@@ -450,29 +450,36 @@ public class URITemplate implements Serializable{
         operationPolicies.add(policy);
     }
 
-    public String getThrottlingLimit() {
+    public ThrottlingLimit getThrottlingLimit() {
         return throttlingLimit;
     }
 
     public void setThrottlingLimit(String throttlingLimit) {
-        String convertedThrottlingLimit;
+        ThrottlingLimit convertedThrottlingLimit = new ThrottlingLimit();
         switch (throttlingLimit) {
             case "10KPerMin":
-                convertedThrottlingLimit = "{ \"value\" : \"10000\" , \" unit \" : \"min\" }";
+                convertedThrottlingLimit.setRequestCount(10000);
+                convertedThrottlingLimit.setUnit("min");
                 break;
             case "20KPerMin":
-                convertedThrottlingLimit = "{ \"value\" : \"20000\" , \" unit \" : \"min\" }";
+                convertedThrottlingLimit.setRequestCount(20000);
+                convertedThrottlingLimit.setUnit("min");
                 break;
             case "50KPerMin":
-                convertedThrottlingLimit = "{ \"value\" : \"50000\" , \" unit \" : \"min\" }";
-                break;
-            case "Unlimited":
-                convertedThrottlingLimit = "{ \"value\" : \"123456\" , \" unit \" : \"min\" }";
+                convertedThrottlingLimit.setRequestCount(50000);
+                convertedThrottlingLimit.setUnit("min");
                 break;
             default:
-                convertedThrottlingLimit = throttlingLimit;
+            case "Unlimited":
+                convertedThrottlingLimit.setRequestCount(-1);
+                convertedThrottlingLimit.setUnit("min");
                 break;
+
         }
         this.throttlingLimit = convertedThrottlingLimit;
+    }
+
+    public void setThrottlingLimit(ThrottlingLimit throttlingLimit) {
+        this.throttlingLimit = throttlingLimit;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
@@ -17,6 +17,8 @@
 */
 package org.wso2.carbon.apimgt.api.model;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.json.simple.JSONValue;
 import org.wso2.carbon.apimgt.api.dto.ConditionGroupDTO;
 import org.wso2.carbon.apimgt.api.model.policy.PolicyConstants;
@@ -27,6 +29,7 @@ import java.util.*;
 public class URITemplate implements Serializable{
 
     private static final long serialVersionUID = 1L;
+    private static final Log log = LogFactory.getLog(URITemplate.class);
 
     private String uriTemplate;
     private String resourceURI;
@@ -458,25 +461,25 @@ public class URITemplate implements Serializable{
         return throttlingLimit;
     }
 
-    public void setThrottlingLimit(String throttlingLimit) {
+    public void setThrottlingLimit(String throttlingTier) {
         ThrottlingLimit convertedThrottlingLimit = new ThrottlingLimit();
-        switch (throttlingLimit) {
+        convertedThrottlingLimit.setUnit("MINUTE");
+        switch (throttlingTier) {
             case "10KPerMin":
                 convertedThrottlingLimit.setRequestCount(10000);
-                convertedThrottlingLimit.setUnit("min");
                 break;
             case "20KPerMin":
                 convertedThrottlingLimit.setRequestCount(20000);
-                convertedThrottlingLimit.setUnit("min");
                 break;
             case "50KPerMin":
                 convertedThrottlingLimit.setRequestCount(50000);
-                convertedThrottlingLimit.setUnit("min");
                 break;
             case "Unlimited":
                 convertedThrottlingLimit.setRequestCount(-1);
-                convertedThrottlingLimit.setUnit("min");
                 break;
+            default:
+                log.warn("Invalid throttling tier value received");
+                return;
         }
         this.throttlingLimit = convertedThrottlingLimit;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
@@ -353,7 +353,7 @@ public class URITemplate implements Serializable{
         if (applicableLevel != null ? !applicableLevel.equals(that.applicableLevel) : that.applicableLevel != null) {
             return false;
         }
-        if (!throttlingTier.equals(that.throttlingTier)) {
+        if (throttlingTier!= null && !throttlingTier.equals(that.throttlingTier)) {
             return false;
         }
         if (!throttlingTiers.equals(that.throttlingTiers)) {
@@ -366,6 +366,9 @@ public class URITemplate implements Serializable{
             return false;
         }
         if (scopes != null ? !scopes.equals(that.scopes) : that.scopes != null) {
+            return false;
+        }
+        if (throttlingLimit != null ? !throttlingLimit.equals(that.throttlingLimit) : that.throttlingLimit != null) {
             return false;
         }
         if (mediationScripts != null ? !mediationScripts.equals(that.mediationScripts) : that.mediationScripts !=
@@ -388,6 +391,7 @@ public class URITemplate implements Serializable{
         result = 31 * result + (throttlingConditions != null ? throttlingConditions.hashCode() : 0);
         result = 31 * result + (applicableLevel != null ? applicableLevel.hashCode() : 0);
         result = 31 * result + (throttlingTier != null ? throttlingTier.hashCode() : 0);
+        result = 31 * result + (throttlingLimit != null ? throttlingLimit.hashCode() : 0);
         result = 31 * result + (throttlingTiers != null ? throttlingTiers.hashCode() : 0);
         result = 31 * result + (scope != null ? scope.hashCode() : 0);
         result = 31 * result + (mediationScript != null ? mediationScript.hashCode() : 0);
@@ -470,11 +474,10 @@ public class URITemplate implements Serializable{
                 convertedThrottlingLimit.setUnit("min");
                 break;
             default:
-            case "Unlimited":
+                // handles Unlimited value unmatched throttle tier values
                 convertedThrottlingLimit.setRequestCount(-1);
                 convertedThrottlingLimit.setUnit("min");
                 break;
-
         }
         this.throttlingLimit = convertedThrottlingLimit;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
@@ -474,7 +474,7 @@ public class URITemplate implements Serializable{
                 convertedThrottlingLimit.setUnit("min");
                 break;
             default:
-                // handles Unlimited value unmatched throttle tier values
+                // handles Unlimited value and unmatched throttle tier values
                 convertedThrottlingLimit.setRequestCount(-1);
                 convertedThrottlingLimit.setUnit("min");
                 break;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1520,6 +1520,7 @@ public final class APIConstants {
     public static final String SWAGGER_X_AMZN_RESOURCE_TIMEOUT = "x-amzn-resource-timeout";
     public static final String SWAGGER_X_AUTH_TYPE = "x-auth-type";
     public static final String SWAGGER_X_THROTTLING_TIER = "x-throttling-tier";
+    public static final String SWAGGER_X_THROTTLING_LIMIT = "x-throttling-limit";
     public static final String SWAGGER_X_THROTTLING_BANDWIDTH = "x-throttling-bandwidth";
     public static final String SWAGGER_X_MEDIATION_SCRIPT = "x-mediation-script";
     public static final String SWAGGER_X_WSO2_SECURITY = "x-wso2-security";
@@ -1821,6 +1822,7 @@ public final class APIConstants {
     public static final String DEFAULT_API_POLICY_TWENTY_THOUSAND_REQ_PER_MIN = "20KPerMin";
     public static final String DEFAULT_API_POLICY_TEN_THOUSAND_REQ_PER_MIN = "10KPerMin";
     public static final String DEFAULT_API_POLICY_UNLIMITED = "Unlimited";
+    public static final String DEFAULT_THROTTLING_LIMIT = "{ \"value\" : \"1234546\" , unit: \"min\" }";
 
     public static final String DEFAULT_API_POLICY_ULTIMATE_DESC = "Allows 50000 requests per minute";
     public static final String DEFAULT_API_POLICY_PLUS_DESC = "Allows 20000 requests per minute";
@@ -2884,8 +2886,8 @@ public final class APIConstants {
         SELF_SIGNUP
     }
 
-    public static final String  PROPERTY_QUERY_KEY = "query";
-    public static final String  PROPERTY_HEADERS_KEY = "headers";
+    public static final String PROPERTY_QUERY_KEY = "query";
+    public static final String PROPERTY_HEADERS_KEY = "headers";
     public static final String DEFAULT_ORG_RESOLVER = "org.wso2.carbon.apimgt.impl.resolver.OnPremResolver";
 
     //Constants related to Operation Policies

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1527,6 +1527,8 @@ public final class APIConstants {
     public static final String WSO2_APP_SECURITY_TYPES = "security-types";
     public static final String OPTIONAL = "optional";
     public static final String MANDATORY = "mandatory";
+    public static final String REQUEST_COUNT = "requestCount";
+    public static final String REQUEST_COUNT_UNIT = "unit";
     public static final String RESPONSE_CACHING_ENABLED = "enabled";
     public static final String RESPONSE_CACHING_TIMEOUT = "cacheTimeoutInSeconds";
     public static final String SWAGGER_X_WSO2_SCOPES = "x-wso2-scopes";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1822,7 +1822,6 @@ public final class APIConstants {
     public static final String DEFAULT_API_POLICY_TWENTY_THOUSAND_REQ_PER_MIN = "20KPerMin";
     public static final String DEFAULT_API_POLICY_TEN_THOUSAND_REQ_PER_MIN = "10KPerMin";
     public static final String DEFAULT_API_POLICY_UNLIMITED = "Unlimited";
-    public static final String DEFAULT_THROTTLING_LIMIT = "{ \"value\" : \"1234546\" , unit: \"min\" }";
 
     public static final String DEFAULT_API_POLICY_ULTIMATE_DESC = "Allows 50000 requests per minute";
     public static final String DEFAULT_API_POLICY_PLUS_DESC = "Allows 20000 requests per minute";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -2650,7 +2650,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (tierMap != null) {
             for (URITemplate template : uriTemplates) {
                 if (template.getThrottlingTier() != null && !tierMap.containsKey(template.getThrottlingTier()) &&
-                        template.getThrottlingLimit().isEmpty()) {
+                        template.getThrottlingLimit() == null) {
                     String message = "Invalid x-throttling tier " + template.getThrottlingTier() +
                             " found in api definition for resource " + template.getHTTPVerb() + " " +
                             template.getUriTemplate();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -2649,7 +2649,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         Map<String, Tier> tierMap = APIUtil.getTiers(APIConstants.TIER_RESOURCE_TYPE, tenantDomain);
         if (tierMap != null) {
             for (URITemplate template : uriTemplates) {
-                if (template.getThrottlingTier() != null && !tierMap.containsKey(template.getThrottlingTier())) {
+                if (template.getThrottlingTier() != null && !tierMap.containsKey(template.getThrottlingTier()) &&
+                        template.getThrottlingLimit().isEmpty()) {
                     String message = "Invalid x-throttling tier " + template.getThrottlingTier() +
                             " found in api definition for resource " + template.getHTTPVerb() + " " +
                             template.getUriTemplate();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -72,6 +72,7 @@ import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
 import org.wso2.carbon.apimgt.api.model.CORSConfiguration;
 import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.SwaggerData;
+import org.wso2.carbon.apimgt.api.model.ThrottlingLimit;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.api.model.endpointurlextractor.EndpointUrl;
 import org.wso2.carbon.apimgt.impl.APIConstants;
@@ -384,26 +385,28 @@ public class OAS2Parser extends APIDefinition {
                         template.setAuthTypes("Any");
                     }
                     if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_TIER) &&
-                            !extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER).toString().isEmpty()) {
+                            !StringUtils.isEmpty(extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER).toString())) {
                         String throttlingTier = (String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER);
                         template.setThrottlingTier(throttlingTier);
                         template.setThrottlingTiers(throttlingTier);
                         // existing APIs do not have the throttling limit value. To support those APIs below
                         // assignment is performing
-                        template.setThrottlingLimit(throttlingTier);
-                    } else {
-                        template.setThrottlingTier("");
-                        template.setThrottlingTiers(new ArrayList<>());
+                        if (!extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
+                            template.setThrottlingLimit(throttlingTier);
+                        }
                     }
                     // assigns x-throttling-limit value if x-throttling-tier is not available
-                    if (template.getThrottlingLimit() == null && extensions.containsKey(
-                            APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
-                        // retrieves x-throttling-tier string value from the API definition file and converts it
-                        // to the relevant throttling limit
-                        template.setThrottlingLimit(OASParserUtil.getThrottlingLimitFromJSON(
-                                extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT)));
-                    } else {
-                        template.setThrottlingLimit(APIUtil.getDefaultThrottleLimit().toString());
+                    if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
+                        ThrottlingLimit throttlingLimit = OASParserUtil.getThrottlingLimitFromJSON(
+                                extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT));
+                        template.setThrottlingLimit(throttlingLimit);
+                        if (template.getThrottlingTier() == null) {
+                            // maps throttlingLimit to throttlingTier
+                            template.setThrottlingTier(
+                                    APIUtil.getThrottlingTierFromThrottlingLimit(throttlingLimit));
+                            template.setThrottlingTiers(
+                                    APIUtil.getThrottlingTierFromThrottlingLimit(throttlingLimit));
+                        }
                     }
                     if (extensions.containsKey(APIConstants.SWAGGER_X_MEDIATION_SCRIPT)) {
                         String mediationScript = (String) extensions.get(APIConstants.SWAGGER_X_MEDIATION_SCRIPT);
@@ -936,14 +939,15 @@ public class OAS2Parser extends APIDefinition {
         }
         operation.setVendorExtension(APIConstants.SWAGGER_X_AUTH_TYPE, authType);
         // handle x-throttling-tier extension
-        if (resource.getPolicy() != null && !resource.getPolicy().isEmpty()) {
+        if (resource.getPolicy() != null && !StringUtils.isEmpty(resource.getPolicy())) {
             operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, resource.getPolicy());
         } else {
-            operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, "");
+            operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_TIER,
+                    APIUtil.getThrottlingTierFromThrottlingLimit(resource.getThrottlingLimit()));
         }
         // assigns x-throttling-limit extension
         if (resource.getThrottlingLimit() != null) {
-            if (!resource.getThrottlingLimit().toString().isEmpty()) {
+            if (!StringUtils.isEmpty(resource.getThrottlingLimit().toString())) {
                 operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, OASParserUtil
                         .getThrottlingLimitJSON(resource.getThrottlingLimit()));
             } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -387,6 +387,7 @@ public class OAS2Parser extends APIDefinition {
                         String throttlingTier = (String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER);
                         template.setThrottlingTier(throttlingTier);
                         template.setThrottlingTiers(throttlingTier);
+                        template.setThrottlingLimit(throttlingTier);
                     }
                     if (extensions.containsKey(APIConstants.SWAGGER_X_MEDIATION_SCRIPT)) {
                         String mediationScript = (String) extensions.get(APIConstants.SWAGGER_X_MEDIATION_SCRIPT);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -390,7 +390,8 @@ public class OAS2Parser extends APIDefinition {
                         template.setThrottlingLimit(throttlingTier);
                     }
                     if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
-                        template.setThrottlingLimit((String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT));
+                        String tlString = extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT).toString();
+                        template.setThrottlingLimit(APIUtil.getThrottlingLimitFromAPIDefinitionString(tlString));
                     }
                     if (extensions.containsKey(APIConstants.SWAGGER_X_MEDIATION_SCRIPT)) {
                         String mediationScript = (String) extensions.get(APIConstants.SWAGGER_X_MEDIATION_SCRIPT);
@@ -923,7 +924,9 @@ public class OAS2Parser extends APIDefinition {
         }
         operation.setVendorExtension(APIConstants.SWAGGER_X_AUTH_TYPE, authType);
         operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, resource.getPolicy());
-        operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, resource.getThrottlingLimit());
+        // retrieves x-throttling-tier string value from the API definition file and converts it
+        // to the relevant throttling limit
+        operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, resource.getThrottlingLimit().toString());
         // AWS Lambda: set arn & timeout to swagger
         if (resource.getAmznResourceName() != null) {
             operation.setVendorExtension(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME, resource.getAmznResourceName());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -384,8 +384,7 @@ public class OAS2Parser extends APIDefinition {
                         template.setAuthType("Any");
                         template.setAuthTypes("Any");
                     }
-                    if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_TIER) &&
-                            !StringUtils.isEmpty(extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER).toString())) {
+                    if (StringUtils.isNotEmpty((String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER))) {
                         String throttlingTier = (String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER);
                         template.setThrottlingTier(throttlingTier);
                         template.setThrottlingTiers(throttlingTier);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -400,8 +400,8 @@ public class OAS2Parser extends APIDefinition {
                             APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
                         // retrieves x-throttling-tier string value from the API definition file and converts it
                         // to the relevant throttling limit
-                        String tlString = extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT).toString();
-                        template.setThrottlingLimit(APIUtil.getThrottlingLimitFromXThrottlingLimitString(tlString));
+                        template.setThrottlingLimit(OASParserUtil.getThrottlingLimitFromJSON(
+                                extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT)));
                     } else {
                         template.setThrottlingLimit(APIUtil.getDefaultThrottleLimit().toString());
                     }
@@ -944,14 +944,15 @@ public class OAS2Parser extends APIDefinition {
         // assigns x-throttling-limit extension
         if (resource.getThrottlingLimit() != null) {
             if (!resource.getThrottlingLimit().toString().isEmpty()) {
-                operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, resource.getThrottlingLimit().toString());
+                operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, OASParserUtil
+                        .getThrottlingLimitJSON(resource.getThrottlingLimit()));
             } else {
                 operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT,
-                        APIUtil.getThrottlingLimitFromThrottlingTier(resource.getPolicy()).toString());
+                        APIUtil.getThrottlingLimitFromThrottlingTier(resource.getPolicy()));
             }
         } else {
             operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT,
-                    APIUtil.getDefaultThrottleLimit().toString());
+                    APIUtil.getDefaultThrottleLimit());
         }
         // AWS Lambda: set arn & timeout to swagger
         if (resource.getAmznResourceName() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -389,6 +389,9 @@ public class OAS2Parser extends APIDefinition {
                         template.setThrottlingTiers(throttlingTier);
                         template.setThrottlingLimit(throttlingTier);
                     }
+                    if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
+                        template.setThrottlingLimit((String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT));
+                    }
                     if (extensions.containsKey(APIConstants.SWAGGER_X_MEDIATION_SCRIPT)) {
                         String mediationScript = (String) extensions.get(APIConstants.SWAGGER_X_MEDIATION_SCRIPT);
                         template.setMediationScript(mediationScript);
@@ -920,6 +923,7 @@ public class OAS2Parser extends APIDefinition {
         }
         operation.setVendorExtension(APIConstants.SWAGGER_X_AUTH_TYPE, authType);
         operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, resource.getPolicy());
+        operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, resource.getThrottlingLimit());
         // AWS Lambda: set arn & timeout to swagger
         if (resource.getAmznResourceName() != null) {
             operation.setVendorExtension(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME, resource.getAmznResourceName());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -941,22 +941,23 @@ public class OAS2Parser extends APIDefinition {
         // handle x-throttling-tier extension
         if (resource.getPolicy() != null && !StringUtils.isEmpty(resource.getPolicy())) {
             operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, resource.getPolicy());
-        } else {
+        } else if (resource.getThrottlingLimit() != null) {
             operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_TIER,
                     APIUtil.getThrottlingTierFromThrottlingLimit(resource.getThrottlingLimit()));
+        } else {
+            operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_TIER,
+                    APIConstants.DEFAULT_API_POLICY_UNLIMITED);
         }
         // assigns x-throttling-limit extension
         if (resource.getThrottlingLimit() != null) {
-            if (!StringUtils.isEmpty(resource.getThrottlingLimit().toString())) {
-                operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, OASParserUtil
-                        .getThrottlingLimitJSON(resource.getThrottlingLimit()));
-            } else {
-                operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT,
-                        APIUtil.getThrottlingLimitFromThrottlingTier(resource.getPolicy()));
-            }
+            operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, OASParserUtil
+                    .getThrottlingLimitJSON(resource.getThrottlingLimit()));
+        } else if (resource.getPolicy() != null) {
+            operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, OASParserUtil
+                    .getThrottlingLimitJSON(APIUtil.getThrottlingLimitFromThrottlingTier(resource.getPolicy())));
         } else {
-            operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT,
-                    APIUtil.getDefaultThrottleLimit());
+            operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, OASParserUtil.getThrottlingLimitJSON(
+                    APIUtil.getDefaultThrottleLimit()));
         }
         // AWS Lambda: set arn & timeout to swagger
         if (resource.getAmznResourceName() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -383,15 +383,27 @@ public class OAS2Parser extends APIDefinition {
                         template.setAuthType("Any");
                         template.setAuthTypes("Any");
                     }
-                    if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_TIER)) {
+                    if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_TIER) &&
+                            !extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER).toString().isEmpty()) {
                         String throttlingTier = (String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER);
                         template.setThrottlingTier(throttlingTier);
                         template.setThrottlingTiers(throttlingTier);
+                        // existing APIs do not have the throttling limit value. To support those APIs below
+                        // assignment is performing
                         template.setThrottlingLimit(throttlingTier);
+                    } else {
+                        template.setThrottlingTier("");
+                        template.setThrottlingTiers(new ArrayList<>());
                     }
-                    if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
+                    // assigns x-throttling-limit value if x-throttling-tier is not available
+                    if (template.getThrottlingLimit() == null && extensions.containsKey(
+                            APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
+                        // retrieves x-throttling-tier string value from the API definition file and converts it
+                        // to the relevant throttling limit
                         String tlString = extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT).toString();
-                        template.setThrottlingLimit(APIUtil.getThrottlingLimitFromAPIDefinitionString(tlString));
+                        template.setThrottlingLimit(APIUtil.getThrottlingLimitFromXThrottlingLimitString(tlString));
+                    } else {
+                        template.setThrottlingLimit(APIUtil.getDefaultThrottleLimit().toString());
                     }
                     if (extensions.containsKey(APIConstants.SWAGGER_X_MEDIATION_SCRIPT)) {
                         String mediationScript = (String) extensions.get(APIConstants.SWAGGER_X_MEDIATION_SCRIPT);
@@ -923,10 +935,24 @@ public class OAS2Parser extends APIDefinition {
             authType = APIConstants.OASResourceAuthTypes.APPLICATION;
         }
         operation.setVendorExtension(APIConstants.SWAGGER_X_AUTH_TYPE, authType);
-        operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, resource.getPolicy());
-        // retrieves x-throttling-tier string value from the API definition file and converts it
-        // to the relevant throttling limit
-        operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, resource.getThrottlingLimit().toString());
+        // handle x-throttling-tier extension
+        if (resource.getPolicy() != null && !resource.getPolicy().isEmpty()) {
+            operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, resource.getPolicy());
+        } else {
+            operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, "");
+        }
+        // assigns x-throttling-limit extension
+        if (resource.getThrottlingLimit() != null) {
+            if (!resource.getThrottlingLimit().toString().isEmpty()) {
+                operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, resource.getThrottlingLimit().toString());
+            } else {
+                operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT,
+                        APIUtil.getThrottlingLimitFromThrottlingTier(resource.getPolicy()).toString());
+            }
+        } else {
+            operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT,
+                    APIUtil.getDefaultThrottleLimit().toString());
+        }
         // AWS Lambda: set arn & timeout to swagger
         if (resource.getAmznResourceName() != null) {
             operation.setVendorExtension(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME, resource.getAmznResourceName());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -445,6 +445,9 @@ public class OAS3Parser extends APIDefinition {
                             template.setThrottlingTier(throttlingTier);
                             template.setThrottlingTiers(throttlingTier);
                         }
+                        if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
+                            template.setThrottlingLimit((String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT));
+                        }
                         if (extensions.containsKey(APIConstants.SWAGGER_X_MEDIATION_SCRIPT)) {
                             String mediationScript = (String) extensions.get(APIConstants.SWAGGER_X_MEDIATION_SCRIPT);
                             template.setMediationScript(mediationScript);
@@ -1178,8 +1181,10 @@ public class OAS3Parser extends APIDefinition {
         operation.addExtension(APIConstants.SWAGGER_X_AUTH_TYPE, authType);
         if (resource.getPolicy() != null) {
             operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, resource.getPolicy());
+            operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, resource.getThrottlingLimit());
         } else {
             operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, APIConstants.DEFAULT_API_POLICY_UNLIMITED);
+            operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, APIConstants.DEFAULT_THROTTLING_LIMIT);
         }
         // AWS Lambda: set arn & timeout to swagger
         if (resource.getAmznResourceName() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -457,12 +457,8 @@ public class OAS3Parser extends APIDefinition {
                         // assigns x-throttling-limit value if x-throttling-tier is not available
                         if (template.getThrottlingLimit() == null && extensions.containsKey(
                                 APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
-                            // retrieves x-throttling-tier string value from the API definition file and converts it
-                            // to the relevant throttling limit
-                            String tlString = extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT).toString();
-                            template.setThrottlingLimit(APIUtil.getThrottlingLimitFromXThrottlingLimitString(tlString));
-                        } else {
-                            template.setThrottlingLimit(APIUtil.getDefaultThrottleLimit().toString());
+                            template.setThrottlingLimit(OASParserUtil.getThrottlingLimitFromJSON(
+                                    extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT)));
                         }
                         if (extensions.containsKey(APIConstants.SWAGGER_X_MEDIATION_SCRIPT)) {
                             String mediationScript = (String) extensions.get(APIConstants.SWAGGER_X_MEDIATION_SCRIPT);
@@ -1204,14 +1200,15 @@ public class OAS3Parser extends APIDefinition {
         // assigns x-throttling-limit extension
         if (resource.getThrottlingLimit() != null) {
             if (!resource.getThrottlingLimit().toString().isEmpty()) {
-                operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, resource.getThrottlingLimit().toString());
+                operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, OASParserUtil.getThrottlingLimitJSON(
+                        resource.getThrottlingLimit()));
             } else {
-                operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT,
-                        APIUtil.getThrottlingLimitFromThrottlingTier(resource.getPolicy()).toString());
+                operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, OASParserUtil.getThrottlingLimitJSON(
+                        APIUtil.getThrottlingLimitFromThrottlingTier(resource.getPolicy())));
             }
         } else {
             operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT,
-                    APIUtil.getDefaultThrottleLimit().toString());
+                    OASParserUtil.getThrottlingLimitJSON(APIUtil.getDefaultThrottleLimit()));
         }
         // AWS Lambda: set arn & timeout to swagger
         if (resource.getAmznResourceName() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -441,8 +441,7 @@ public class OAS3Parser extends APIDefinition {
                             template.setAuthType("Any");
                             template.setAuthTypes("Any");
                         }
-                        if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_TIER) && !StringUtils.isEmpty(
-                                extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER).toString())) {
+                        if (StringUtils.isNotEmpty((String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER))) {
                             String throttlingTier = (String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER);
                             template.setThrottlingTier(throttlingTier);
                             template.setThrottlingTiers(throttlingTier);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -57,6 +57,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
 import org.wso2.carbon.apimgt.api.APIEndpointUrlExtractor;
@@ -446,7 +448,10 @@ public class OAS3Parser extends APIDefinition {
                             template.setThrottlingTiers(throttlingTier);
                         }
                         if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
-                            template.setThrottlingLimit((String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT));
+                            // retrieves x-throttling-tier string value from the API definition file and converts it
+                            // to the relevant throttling limit
+                            String tlString = extensions.get(APIConstants.SWAGGER_X_THROTTLING_LIMIT).toString();
+                            template.setThrottlingLimit(APIUtil.getThrottlingLimitFromAPIDefinitionString(tlString));
                         }
                         if (extensions.containsKey(APIConstants.SWAGGER_X_MEDIATION_SCRIPT)) {
                             String mediationScript = (String) extensions.get(APIConstants.SWAGGER_X_MEDIATION_SCRIPT);
@@ -1181,10 +1186,10 @@ public class OAS3Parser extends APIDefinition {
         operation.addExtension(APIConstants.SWAGGER_X_AUTH_TYPE, authType);
         if (resource.getPolicy() != null) {
             operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, resource.getPolicy());
-            operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, resource.getThrottlingLimit());
+            operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, resource.getThrottlingLimit().toString());
         } else {
             operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, APIConstants.DEFAULT_API_POLICY_UNLIMITED);
-            operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, APIConstants.DEFAULT_THROTTLING_LIMIT);
+            operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, APIUtil.getDefaultThrottleLimit().toString());
         }
         // AWS Lambda: set arn & timeout to swagger
         if (resource.getAmznResourceName() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1199,19 +1199,19 @@ public class OAS3Parser extends APIDefinition {
         // handle x-throttling-tier extension
         if (resource.getPolicy() != null && !StringUtils.isEmpty(resource.getPolicy())) {
             operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, resource.getPolicy());
-        } else {
+        } else if (resource.getThrottlingLimit() != null) {
             operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_TIER,
                     APIUtil.getThrottlingTierFromThrottlingLimit(resource.getThrottlingLimit()));
+        } else {
+            operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_TIER, APIConstants.DEFAULT_API_POLICY_UNLIMITED);
         }
         // assigns x-throttling-limit extension
         if (resource.getThrottlingLimit() != null) {
-            if (!StringUtils.isEmpty(resource.getThrottlingLimit().toString())) {
-                operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, OASParserUtil.getThrottlingLimitJSON(
-                        resource.getThrottlingLimit()));
-            } else {
-                operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, OASParserUtil.getThrottlingLimitJSON(
-                        APIUtil.getThrottlingLimitFromThrottlingTier(resource.getPolicy())));
-            }
+            operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, OASParserUtil.getThrottlingLimitJSON(
+                    resource.getThrottlingLimit()));
+        } else if (resource.getPolicy() != null) {
+            operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, OASParserUtil.getThrottlingLimitJSON(
+                    APIUtil.getThrottlingLimitFromThrottlingTier(resource.getPolicy())));
         } else {
             operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT,
                     OASParserUtil.getThrottlingLimitJSON(APIUtil.getDefaultThrottleLimit()));

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1421,7 +1421,8 @@ public class OASParserUtil {
         ObjectNode tlObjectNode = mapper.convertValue(throttlingLimitJSON, ObjectNode.class);
         ThrottlingLimit throttlingLimit = new ThrottlingLimit();
         throttlingLimit.setRequestCount(mapper.convertValue(tlObjectNode.get(APIConstants.REQUEST_COUNT), Integer.class));
-        throttlingLimit.setUnit(mapper.convertValue(tlObjectNode.get(APIConstants.REQUEST_COUNT_UNIT), String.class));
+        throttlingLimit.setUnit(mapper.convertValue(tlObjectNode.get(
+                APIConstants.REQUEST_COUNT_UNIT), String.class).toUpperCase());
         return throttlingLimit;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -83,6 +83,7 @@ import org.wso2.carbon.apimgt.api.model.APIProductResource;
 import org.wso2.carbon.apimgt.api.model.CORSConfiguration;
 import org.wso2.carbon.apimgt.api.model.Identifier;
 import org.wso2.carbon.apimgt.api.model.Scope;
+import org.wso2.carbon.apimgt.api.model.ThrottlingLimit;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
@@ -1394,6 +1395,34 @@ public class OASParserUtil {
         endpointResult.set(APIConstants.WSO2_APP_SECURITY_TYPES, appSecurityTypes);
         endpointResult.put(APIConstants.OPTIONAL, appSecurityOptional);
         return endpointResult;
+    }
+
+    /**
+     * Generated x-throttling-limit value for the API definition
+     *
+     * @param throttlingLimit provides throttling limit details
+     * @return JsonNode relevant to the x-throttling-limit
+     */
+    static JsonNode getThrottlingLimitJSON(ThrottlingLimit throttlingLimit) {
+        ObjectNode throttlingLimitJson = objectMapper.createObjectNode();
+        throttlingLimitJson.put(APIConstants.REQUEST_COUNT, throttlingLimit.getRequestCount());
+        throttlingLimitJson.put(APIConstants.REQUEST_COUNT_UNIT, throttlingLimit.getUnit());
+        return throttlingLimitJson;
+    }
+
+    /**
+     * Generates throttling limit details from the x-throttling-limit in API definition
+     *
+     * @param throttlingLimitJSON Value relevant to the x-throttling-limit field
+     * @return throttling limit details
+     */
+    static ThrottlingLimit getThrottlingLimitFromJSON(Object throttlingLimitJSON) {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode tlObjectNode = mapper.convertValue(throttlingLimitJSON, ObjectNode.class);
+        ThrottlingLimit throttlingLimit = new ThrottlingLimit();
+        throttlingLimit.setRequestCount(mapper.convertValue(tlObjectNode.get(APIConstants.REQUEST_COUNT), Integer.class));
+        throttlingLimit.setUnit(mapper.convertValue(tlObjectNode.get(APIConstants.REQUEST_COUNT_UNIT), String.class));
+        return throttlingLimit;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10158,13 +10158,14 @@ public final class APIUtil {
     }
 
     /**
-     * Gives the throttling limit details from the string value relevant to the x-throttling-limit in API defnition file
+     * Gives the throttling limit details from the string value relevant to the x-throttling-limit in API definition file
      *
      * @param throttlingLimitStr x-throttling-limit string value
      * @return Throttling limit object with relevant throttling data
      * @throws APIManagementException If an error happens when parsing the string
      */
-    public static ThrottlingLimit getThrottlingLimitFromAPIDefinitionString(String throttlingLimitStr) throws APIManagementException {
+    public static ThrottlingLimit getThrottlingLimitFromXThrottlingLimitString(String throttlingLimitStr) throws
+            APIManagementException {
         ThrottlingLimit throttlingLimit = new ThrottlingLimit();
         JSONParser parser = new JSONParser();
         JSONObject jsonObject;
@@ -10176,6 +10177,37 @@ public final class APIUtil {
         }
         throttlingLimit.setRequestCount(((Long) jsonObject.get("requestCount")).intValue());
         throttlingLimit.setUnit((String) jsonObject.get("unit"));
+        return throttlingLimit;
+    }
+
+    /**
+     * Existing APIs contains the throttling tier value as a string. This method assigns the throttling limit in
+     * SwaggerData object's throttleLimit field considering the throttling tier string value.
+     *
+     * @param throttlingTierStr String value relevant to the throttling tier
+     * @return ThrottleLimit object from throttling tier String value
+     */
+    public static ThrottlingLimit getThrottlingLimitFromThrottlingTier(String throttlingTierStr) {
+        ThrottlingLimit throttlingLimit = new ThrottlingLimit();
+        switch (throttlingTierStr) {
+            case "10KPerMin":
+                throttlingLimit.setRequestCount(10000);
+                throttlingLimit.setUnit("min");
+                break;
+            case "20KPerMin":
+                throttlingLimit.setRequestCount(20000);
+                throttlingLimit.setUnit("min");
+                break;
+            case "50KPerMin":
+                throttlingLimit.setRequestCount(50000);
+                throttlingLimit.setUnit("min");
+                break;
+            default:
+                // handles Unlimited value unmatched throttle tier values
+                throttlingLimit.setRequestCount(-1);
+                throttlingLimit.setUnit("min");
+                break;
+        }
         return throttlingLimit;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -132,6 +132,7 @@ import org.wso2.carbon.apimgt.api.model.OperationPolicyDefinition;
 import org.wso2.carbon.apimgt.api.model.OperationPolicySpecification;
 import org.wso2.carbon.apimgt.api.model.Provider;
 import org.wso2.carbon.apimgt.api.model.Scope;
+import org.wso2.carbon.apimgt.api.model.ThrottlingLimit;
 import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.api.model.VHost;
@@ -10142,5 +10143,39 @@ public final class APIUtil {
             gatewayVendor = APIConstants.WSO2_GATEWAY_ENVIRONMENT;
         }
         return  gatewayVendor;
+    }
+
+    /**
+     * Provides the default throttling limit
+     *
+     * @return Throttling limit object with default values
+     */
+    public static ThrottlingLimit getDefaultThrottleLimit() {
+        ThrottlingLimit throttlingLimit = new ThrottlingLimit();
+        throttlingLimit.setRequestCount(-1);
+        throttlingLimit.setUnit("min");
+        return throttlingLimit;
+    }
+
+    /**
+     * Gives the throttling limit details from the string value relevant to the x-throttling-limit in API defnition file
+     *
+     * @param throttlingLimitStr x-throttling-limit string value
+     * @return Throttling limit object with relevant throttling data
+     * @throws APIManagementException If an error happens when parsing the string
+     */
+    public static ThrottlingLimit getThrottlingLimitFromAPIDefinitionString(String throttlingLimitStr) throws APIManagementException {
+        ThrottlingLimit throttlingLimit = new ThrottlingLimit();
+        JSONParser parser = new JSONParser();
+        JSONObject jsonObject;
+        try {
+            jsonObject = (JSONObject) parser.parse(throttlingLimitStr);
+        } catch (ParseException e) {
+            throw new APIManagementException("Error occurred while converting " +
+                    "x-throttling limit value to a JSON");
+        }
+        throttlingLimit.setRequestCount(((Long) jsonObject.get("requestCount")).intValue());
+        throttlingLimit.setUnit((String) jsonObject.get("unit"));
+        return throttlingLimit;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10143,25 +10143,4 @@ public final class APIUtil {
         }
         return  gatewayVendor;
     }
-
-    /**
-     * @param throttlingTier
-     * @return
-     */
-    public static String getThrottlingLimitFromThrottlingTier(String throttlingTier) {
-        String throttlingLimit;
-        switch (throttlingTier) {
-            case "10KPerMin":
-                throttlingLimit = "{ \"value\" : \"10000\" , \" unit \" : \"min\" }";
-            case "20KPerMin":
-                throttlingLimit = "{ \"value\" : \"20000\" , \" unit \" : \"min\" }";
-            case "50KPerMin":
-                throttlingLimit = "{ \"value\" : \"50000\" , \" unit \" : \"min\" }";
-            case "Unlimited":
-                throttlingLimit = "{ \"value\" : \"123456\" , \" unit \" : \"min\" }";
-            default:
-                throttlingLimit = throttlingTier;
-        }
-        return throttlingLimit;
-    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10153,7 +10153,7 @@ public final class APIUtil {
     public static ThrottlingLimit getDefaultThrottleLimit() {
         ThrottlingLimit throttlingLimit = new ThrottlingLimit();
         throttlingLimit.setRequestCount(-1);
-        throttlingLimit.setUnit("min");
+        throttlingLimit.setUnit("MINUTE");
         return throttlingLimit;
     }
 
@@ -10166,23 +10166,23 @@ public final class APIUtil {
      */
     public static ThrottlingLimit getThrottlingLimitFromThrottlingTier(String throttlingTierStr) {
         ThrottlingLimit throttlingLimit = new ThrottlingLimit();
+        throttlingLimit.setUnit("MINUTE");
         switch (throttlingTierStr) {
             case "10KPerMin":
                 throttlingLimit.setRequestCount(10000);
-                throttlingLimit.setUnit("min");
                 break;
             case "20KPerMin":
                 throttlingLimit.setRequestCount(20000);
-                throttlingLimit.setUnit("min");
                 break;
             case "50KPerMin":
                 throttlingLimit.setRequestCount(50000);
-                throttlingLimit.setUnit("min");
                 break;
             case "Unlimited":
                 throttlingLimit.setRequestCount(-1);
-                throttlingLimit.setUnit("min");
                 break;
+            default:
+                log.warn("Invalid throttling tier value received");
+                return null;
         }
         return throttlingLimit;
     }
@@ -10196,7 +10196,10 @@ public final class APIUtil {
     public static String getThrottlingTierFromThrottlingLimit(ThrottlingLimit throttlingLimit) {
         String requestCount = "";
         String prefix = "";
+        String throttlingTier = "";
         if (throttlingLimit != null) {
+            if (throttlingLimit.getRequestCount() == -1)
+                return APIConstants.UNLIMITED_TIER;
             if (throttlingLimit.getRequestCount() % 100000 == 0) {
                 requestCount = Integer.toString(throttlingLimit.getRequestCount() / 1000000);
                 prefix = "M";
@@ -10206,9 +10209,10 @@ public final class APIUtil {
             } else {
                 requestCount = Integer.toString(throttlingLimit.getRequestCount());
             }
+            throttlingTier = requestCount + prefix + "Per" + throttlingLimit.getUnit();
         } else {
             log.warn("Could not create a throttling tier value. Hence returning an empty value.");
         }
-        return requestCount + prefix + "Per" + throttlingLimit.getUnit();
+        return throttlingTier;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10143,4 +10143,25 @@ public final class APIUtil {
         }
         return  gatewayVendor;
     }
+
+    /**
+     * @param throttlingTier
+     * @return
+     */
+    public static String getThrottlingLimitFromThrottlingTier(String throttlingTier) {
+        String throttlingLimit;
+        switch (throttlingTier) {
+            case "10KPerMin":
+                throttlingLimit = "{ \"value\" : \"10000\" , \" unit \" : \"min\" }";
+            case "20KPerMin":
+                throttlingLimit = "{ \"value\" : \"20000\" , \" unit \" : \"min\" }";
+            case "50KPerMin":
+                throttlingLimit = "{ \"value\" : \"50000\" , \" unit \" : \"min\" }";
+            case "Unlimited":
+                throttlingLimit = "{ \"value\" : \"123456\" , \" unit \" : \"min\" }";
+            default:
+                throttlingLimit = throttlingTier;
+        }
+        return throttlingLimit;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10203,7 +10203,7 @@ public final class APIUtil {
                 throttlingLimit.setUnit("min");
                 break;
             default:
-                // handles Unlimited value unmatched throttle tier values
+                // handles Unlimited value and unmatched throttle tier values
                 throttlingLimit.setRequestCount(-1);
                 throttlingLimit.setUnit("min");
                 break;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OASTestBase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OASTestBase.java
@@ -114,10 +114,10 @@ public class OASTestBase {
         bookGet.setAuthTypes("Application & Application User");
         bookGet.setHTTPVerb("GET");
         bookGet.setHttpVerbs("GET");
-        bookGet.setThrottlingTier("12310PerMin");
-        bookGet.setThrottlingTiers("12310PerMin");
+        bookGet.setThrottlingTier("12310PerMinute");
+        bookGet.setThrottlingTiers("12310PerMinute");
         throttlingLimit.setRequestCount(12310);
-        throttlingLimit.setUnit("Min");
+        throttlingLimit.setUnit("MINUTE");
         bookGet.setThrottlingLimit(throttlingLimit);
         bookGet.setScope(sampleScope);
         bookGet.setScopes(sampleScope);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OASTestBase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OASTestBase.java
@@ -27,9 +27,11 @@ import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.SwaggerData;
+import org.wso2.carbon.apimgt.api.model.ThrottlingLimit;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -42,6 +44,8 @@ public class OASTestBase {
     private URITemplate petPost;
     private URITemplate itemPost;
     private URITemplate itemGet;
+    private URITemplate bookGet;
+    private ThrottlingLimit throttlingLimit = new ThrottlingLimit();
 
     public OASTestBase() {
         sampleScope = new Scope();
@@ -64,6 +68,7 @@ public class OASTestBase {
         petGet.setHttpVerbs("GET");
         petGet.setThrottlingTier("Unlimited");
         petGet.setThrottlingTiers("Unlimited");
+        petGet.setThrottlingLimit("Unlimited");
         petGet.setScope(sampleScope);
         petGet.setScopes(sampleScope);
 
@@ -75,6 +80,7 @@ public class OASTestBase {
         petPost.setHttpVerbs("POST");
         petPost.setThrottlingTier("Unlimited");
         petPost.setThrottlingTiers("Unlimited");
+        petPost.setThrottlingLimit("Unlimited");
         petPost.setScope(sampleScope);
         petPost.setScopes(sampleScope);
 
@@ -86,6 +92,7 @@ public class OASTestBase {
         itemPost.setHttpVerbs("POST");
         itemPost.setThrottlingTier("Unlimited");
         itemPost.setThrottlingTiers("Unlimited");
+        itemPost.setThrottlingLimit("Unlimited");
         itemPost.setScope(sampleScope);
         itemPost.setScopes(sampleScope);
 
@@ -97,8 +104,23 @@ public class OASTestBase {
         itemGet.setHttpVerbs("GET");
         itemGet.setThrottlingTier("Unlimited");
         itemGet.setThrottlingTiers("Unlimited");
+        itemGet.setThrottlingLimit("Unlimited");
         itemGet.setScope(sampleScope);
         itemGet.setScopes(sampleScope);
+
+        bookGet = new URITemplate();
+        bookGet.setUriTemplate("/books");
+        bookGet.setAuthType("Application & Application User");
+        bookGet.setAuthTypes("Application & Application User");
+        bookGet.setHTTPVerb("GET");
+        bookGet.setHttpVerbs("GET");
+        bookGet.setThrottlingTier("");
+        bookGet.setThrottlingTiers(new ArrayList<>());
+        throttlingLimit.setRequestCount(12310);
+        throttlingLimit.setUnit("min");
+        bookGet.setThrottlingLimit(throttlingLimit);
+        bookGet.setScope(sampleScope);
+        bookGet.setScopes(sampleScope);
     }
 
     public void testGetURITemplates(APIDefinition parser, String content) throws Exception {
@@ -112,6 +134,7 @@ public class OASTestBase {
         exUriTemplate.setHttpVerbs("GET");
         exUriTemplate.setThrottlingTier("Unlimited");
         exUriTemplate.setThrottlingTiers("Unlimited");
+        exUriTemplate.setThrottlingLimit("Unlimited");
         exUriTemplate.setScope(extensionScope);
         exUriTemplate.setScopes(extensionScope);
 
@@ -129,6 +152,11 @@ public class OASTestBase {
         uriTemplates = parser.getURITemplates(scopesInExtensionAndSec);
         Assert.assertEquals(1, uriTemplates.size());
         Assert.assertTrue(uriTemplates.contains(petGet));
+
+        String throttlingLimitExtensionUriTemplate = jsonObject.getJSONObject("throttlingLimitInExtension").toString();
+        uriTemplates = parser.getURITemplates(throttlingLimitExtensionUriTemplate);
+        Assert.assertEquals(1, uriTemplates.size());
+        Assert.assertTrue(uriTemplates.contains(bookGet));
     }
 
     public void testGetScopes(APIDefinition parser, String content) throws Exception {
@@ -231,17 +259,18 @@ public class OASTestBase {
 
         // Add operation and path to API object
         String lessResourcesInDefinition = jsonObject.getJSONObject("lessResourcesInDefinition").toString();
-        api.setUriTemplates(new HashSet<>(Arrays.asList(petGet, petPost, itemGet, itemPost)));
+        api.setUriTemplates(new HashSet<>(Arrays.asList(petGet, petPost, itemGet, itemPost, bookGet)));
         definition = parser.generateAPIDefinition(new SwaggerData(api), lessResourcesInDefinition);
         response = parser.validateAPIDefinition(definition, false);
         Assert.assertTrue(response.isValid());
         Assert.assertTrue(response.getParser().getClass().equals(parser.getClass()));
         uriTemplates = parser.getURITemplates(definition);
-        Assert.assertEquals(4, uriTemplates.size());
+        Assert.assertEquals(5, uriTemplates.size());
         Assert.assertTrue(uriTemplates.contains(petGet));
         Assert.assertTrue(uriTemplates.contains(petPost));
         Assert.assertTrue(uriTemplates.contains(itemGet));
         Assert.assertTrue(uriTemplates.contains(itemPost));
+        Assert.assertTrue(uriTemplates.contains(bookGet));
     }
 
     public String testGenerateAPIDefinitionWithExtension(APIDefinition parser, String content) throws Exception {
@@ -262,6 +291,7 @@ public class OASTestBase {
         updatedItemGet.setHttpVerbs("GET");
         updatedItemGet.setThrottlingTier("Unlimited");
         updatedItemGet.setThrottlingTiers("Unlimited");
+        updatedItemGet.setThrottlingLimit("Unlimited");
         updatedItemGet.setScope(newScope);
         updatedItemGet.setScopes(newScope);
 
@@ -285,6 +315,7 @@ public class OASTestBase {
         uriTemplate.setUriTemplate(uriTemplateString);
         uriTemplate.setThrottlingTier("Unlimited");
         uriTemplate.setThrottlingTiers("Unlimited");
+        uriTemplate.setThrottlingLimit("Unlimited");
         uriTemplate.setScope(null);
         return uriTemplate;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OASTestBase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OASTestBase.java
@@ -114,10 +114,10 @@ public class OASTestBase {
         bookGet.setAuthTypes("Application & Application User");
         bookGet.setHTTPVerb("GET");
         bookGet.setHttpVerbs("GET");
-        bookGet.setThrottlingTier("");
-        bookGet.setThrottlingTiers(new ArrayList<>());
+        bookGet.setThrottlingTier("12310PerMin");
+        bookGet.setThrottlingTiers("12310PerMin");
         throttlingLimit.setRequestCount(12310);
-        throttlingLimit.setUnit("min");
+        throttlingLimit.setUnit("Min");
         bookGet.setThrottlingLimit(throttlingLimit);
         bookGet.setScope(sampleScope);
         bookGet.setScopes(sampleScope);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas2/oas2_scopes.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas2/oas2_scopes.json
@@ -229,10 +229,10 @@
             "application/json"
           ],
           "x-auth-type": "Application & Application User",
-          "x-throttling-tier": "",
+          "x-throttling-tier": "12310PerMinute",
           "x-throttling-limit": {
             "requestCount" : 12310 ,
-            "unit" : "Min"
+            "unit" : "Minute"
           },
           "x-scope": "sample",
           "security": [

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas2/oas2_scopes.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas2/oas2_scopes.json
@@ -230,7 +230,10 @@
           ],
           "x-auth-type": "Application & Application User",
           "x-throttling-tier": "",
-          "x-throttling-limit": "{ \"requestCount\" : 12310 , \"unit\" : \"min\" }",
+          "x-throttling-limit": {
+            "requestCount" : 12310 ,
+            "unit" : "min"
+          },
           "x-scope": "sample",
           "security": [
             {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas2/oas2_scopes.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas2/oas2_scopes.json
@@ -232,7 +232,7 @@
           "x-throttling-tier": "",
           "x-throttling-limit": {
             "requestCount" : 12310 ,
-            "unit" : "min"
+            "unit" : "Min"
           },
           "x-scope": "sample",
           "security": [

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas2/oas2_scopes.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas2/oas2_scopes.json
@@ -202,5 +202,88 @@
       "https",
       "http"
     ]
+  },
+
+  "throttlingLimitInExtension": {
+    "swagger": "2.0",
+    "paths": {
+      "/books": {
+        "get": {
+          "responses": {
+            "200": {
+              "description": ""
+            }
+          },
+          "parameters": [
+            {
+              "name": "op",
+              "in": "path",
+              "required": true,
+              "type": "string"
+            }
+          ],
+          "produces": [
+            "application/json"
+          ],
+          "consumes": [
+            "application/json"
+          ],
+          "x-auth-type": "Application & Application User",
+          "x-throttling-tier": "",
+          "x-throttling-limit": "{ \"requestCount\" : 12310 , \"unit\" : \"min\" }",
+          "x-scope": "sample",
+          "security": [
+            {
+              "default": [
+                "sample"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "info": {
+      "title": "sampleApi",
+      "version": "1.0.0"
+    },
+    "x-wso2-security": {
+      "apim": {
+        "x-wso2-scopes": [
+          {
+            "name": "sample",
+            "description": "sample description",
+            "key": "sample",
+            "roles": "admin"
+          },
+          {
+            "name": "extensionScope",
+            "description": "extensionScope description",
+            "key": "extensionScope",
+            "roles": "admin"
+          }
+        ]
+      }
+    },
+    "securityDefinitions": {
+      "default": {
+        "type": "oauth2",
+        "authorizationUrl": "https://192.168.60.1:8243/authorize",
+        "flow": "implicit",
+        "scopes": {
+          "sample": "sample description",
+          "extensionScope": "extensionScope description"
+        },
+        "x-scopes-bindings": {
+          "sample": "admin",
+          "extensionScope": "admin"
+        }
+      }
+    },
+    "basePath": "/sampleContext/1.0.0",
+    "host": "192.168.60.1:8243",
+    "schemes": [
+      "https",
+      "http"
+    ]
   }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas3/oas3_scopes.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas3/oas3_scopes.json
@@ -209,10 +209,10 @@
             ]
           }],
           "x-auth-type": "Application & Application User",
-          "x-throttling-tier": "",
+          "x-throttling-tier": "12310PerMinute",
           "x-throttling-limit": {
             "requestCount" : 12310 ,
-            "unit" : "Min"
+            "unit" : "Minute"
           }
         }
       }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas3/oas3_scopes.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas3/oas3_scopes.json
@@ -210,7 +210,10 @@
           }],
           "x-auth-type": "Application & Application User",
           "x-throttling-tier": "",
-          "x-throttling-limit": "{ \"requestCount\" : 12310 , \"unit\" : \"min\" }"
+          "x-throttling-limit": {
+            "requestCount" : 12310 ,
+            "unit" : "min"
+          }
         }
       }
     },

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas3/oas3_scopes.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas3/oas3_scopes.json
@@ -177,5 +177,80 @@
         ]
       }
     }
+  },
+
+  "throttlingLimitInExtension": {
+    "openapi": "3.0.0",
+    "info": {
+      "title": "Swagger Petstore",
+      "license": {
+        "name": "MIT"
+      },
+      "version": "1.0.0"
+    },
+    "servers": [{
+      "url": "http://petstore.swagger.io/v1"
+    }],
+    "paths": {
+      "/books": {
+        "get": {
+          "tags": [
+            "books"
+          ],
+          "summary": "List all books",
+          "responses": {
+            "default": {
+              "description": "unexpected error"
+            }
+          },
+          "security": [{
+            "default": [
+              "sample"
+            ]
+          }],
+          "x-auth-type": "Application & Application User",
+          "x-throttling-tier": "",
+          "x-throttling-limit": "{ \"requestCount\" : 12310 , \"unit\" : \"min\" }"
+        }
+      }
+    },
+    "components": {
+      "securitySchemes": {
+        "default": {
+          "type": "oauth2",
+          "flows": {
+            "implicit": {
+              "authorizationUrl": "http://example.org/api/oauth/dialog",
+              "scopes": {
+                "sample": "sample description",
+                "extensionScope": "extensionScope description"
+              },
+              "x-scopes-bindings": {
+                "sample": "admin",
+                "extensionScope": "admin"
+              }
+            }
+          }
+        }
+      }
+    },
+    "x-wso2-security": {
+      "default": {
+        "x-wso2-scopes": [
+          {
+            "name": "sample",
+            "description": "sample description",
+            "key": "sample",
+            "roles": "admin"
+          },
+          {
+            "name": "extensionScope",
+            "description": "extensionScope description",
+            "key": "extensionScope",
+            "roles": "admin"
+          }
+        ]
+      }
+    }
   }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas3/oas3_scopes.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas3/oas3_scopes.json
@@ -212,7 +212,7 @@
           "x-throttling-tier": "",
           "x-throttling-limit": {
             "requestCount" : 12310 ,
-            "unit" : "min"
+            "unit" : "Min"
           }
         }
       }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsDTO.java
@@ -28,6 +28,7 @@ public class APIOperationsDTO   {
     private String verb = null;
     private String authType = "Any";
     private String throttlingPolicy = null;
+    private String throttlingLimit = null;
     private List<String> scopes = new ArrayList<String>();
     private List<String> usedProductIds = new ArrayList<String>();
     private String amznResourceName = null;
@@ -119,6 +120,23 @@ public class APIOperationsDTO   {
   }
   public void setThrottlingPolicy(String throttlingPolicy) {
     this.throttlingPolicy = throttlingPolicy;
+  }
+
+  /**
+   **/
+  public APIOperationsDTO throttlingLimit(String throttlingLimit) {
+    this.throttlingLimit = throttlingLimit;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Unlimited", value = "")
+  @JsonProperty("throttlingLimit")
+  public String getThrottlingLimit() {
+    return throttlingLimit;
+  }
+  public void setThrottlingLimit(String throttlingLimit) {
+    this.throttlingLimit = throttlingLimit;
   }
 
   /**
@@ -256,6 +274,7 @@ public class APIOperationsDTO   {
         Objects.equals(verb, apIOperations.verb) &&
         Objects.equals(authType, apIOperations.authType) &&
         Objects.equals(throttlingPolicy, apIOperations.throttlingPolicy) &&
+        Objects.equals(throttlingLimit, apIOperations.throttlingLimit) &&
         Objects.equals(scopes, apIOperations.scopes) &&
         Objects.equals(usedProductIds, apIOperations.usedProductIds) &&
         Objects.equals(amznResourceName, apIOperations.amznResourceName) &&
@@ -267,7 +286,7 @@ public class APIOperationsDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, target, verb, authType, throttlingPolicy, scopes, usedProductIds, amznResourceName, amznResourceTimeout, payloadSchema, uriMapping, operationPolicies);
+    return Objects.hash(id, target, verb, authType, throttlingPolicy, throttlingLimit, scopes, usedProductIds, amznResourceName, amznResourceTimeout, payloadSchema, uriMapping, operationPolicies);
   }
 
   @Override
@@ -280,6 +299,7 @@ public class APIOperationsDTO   {
     sb.append("    verb: ").append(toIndentedString(verb)).append("\n");
     sb.append("    authType: ").append(toIndentedString(authType)).append("\n");
     sb.append("    throttlingPolicy: ").append(toIndentedString(throttlingPolicy)).append("\n");
+    sb.append("    throttlingLimit: ").append(toIndentedString(throttlingLimit)).append("\n");
     sb.append("    scopes: ").append(toIndentedString(scopes)).append("\n");
     sb.append("    usedProductIds: ").append(toIndentedString(usedProductIds)).append("\n");
     sb.append("    amznResourceName: ").append(toIndentedString(amznResourceName)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsDTO.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIOperationPoliciesDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIOperationsThrottlingLimitDTO;
 import javax.validation.constraints.*;
 
 
@@ -28,7 +29,7 @@ public class APIOperationsDTO   {
     private String verb = null;
     private String authType = "Any";
     private String throttlingPolicy = null;
-    private String throttlingLimit = null;
+    private APIOperationsThrottlingLimitDTO throttlingLimit = null;
     private List<String> scopes = new ArrayList<String>();
     private List<String> usedProductIds = new ArrayList<String>();
     private String amznResourceName = null;
@@ -124,18 +125,19 @@ public class APIOperationsDTO   {
 
   /**
    **/
-  public APIOperationsDTO throttlingLimit(String throttlingLimit) {
+  public APIOperationsDTO throttlingLimit(APIOperationsThrottlingLimitDTO throttlingLimit) {
     this.throttlingLimit = throttlingLimit;
     return this;
   }
 
   
-  @ApiModelProperty(example = "Unlimited", value = "")
+  @ApiModelProperty(value = "")
+      @Valid
   @JsonProperty("throttlingLimit")
-  public String getThrottlingLimit() {
+  public APIOperationsThrottlingLimitDTO getThrottlingLimit() {
     return throttlingLimit;
   }
-  public void setThrottlingLimit(String throttlingLimit) {
+  public void setThrottlingLimit(APIOperationsThrottlingLimitDTO throttlingLimit) {
     this.throttlingLimit = throttlingLimit;
   }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsThrottlingLimitDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsThrottlingLimitDTO.java
@@ -21,7 +21,38 @@ import javax.validation.Valid;
 public class APIOperationsThrottlingLimitDTO   {
   
     private Integer requestCount = null;
-    private String unit = null;
+
+    @XmlType(name="UnitEnum")
+    @XmlEnum(String.class)
+    public enum UnitEnum {
+        MIN("min"),
+        HOUR("hour");
+        private String value;
+
+        UnitEnum (String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @JsonCreator
+        public static UnitEnum fromValue(String v) {
+            for (UnitEnum b : UnitEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+return null;
+        }
+    }
+    private UnitEnum unit = null;
 
   /**
    **/
@@ -42,18 +73,18 @@ public class APIOperationsThrottlingLimitDTO   {
 
   /**
    **/
-  public APIOperationsThrottlingLimitDTO unit(String unit) {
+  public APIOperationsThrottlingLimitDTO unit(UnitEnum unit) {
     this.unit = unit;
     return this;
   }
 
   
-  @ApiModelProperty(example = "min", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("unit")
-  public String getUnit() {
+  public UnitEnum getUnit() {
     return unit;
   }
-  public void setUnit(String unit) {
+  public void setUnit(UnitEnum unit) {
     this.unit = unit;
   }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsThrottlingLimitDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsThrottlingLimitDTO.java
@@ -25,8 +25,10 @@ public class APIOperationsThrottlingLimitDTO   {
     @XmlType(name="UnitEnum")
     @XmlEnum(String.class)
     public enum UnitEnum {
-        MIN("min"),
-        HOUR("hour");
+        SECOND("Second"),
+        MINUTE("Minute"),
+        HOUR("Hour"),
+        DAY("Day");
         private String value;
 
         UnitEnum (String v) {
@@ -79,8 +81,9 @@ return null;
   }
 
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(required = true, value = "")
   @JsonProperty("unit")
+  @NotNull
   public UnitEnum getUnit() {
     return unit;
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsThrottlingLimitDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsThrottlingLimitDTO.java
@@ -1,0 +1,101 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class APIOperationsThrottlingLimitDTO   {
+  
+    private Integer requestCount = null;
+    private String unit = null;
+
+  /**
+   **/
+  public APIOperationsThrottlingLimitDTO requestCount(Integer requestCount) {
+    this.requestCount = requestCount;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "10000", value = "")
+  @JsonProperty("requestCount")
+  public Integer getRequestCount() {
+    return requestCount;
+  }
+  public void setRequestCount(Integer requestCount) {
+    this.requestCount = requestCount;
+  }
+
+  /**
+   **/
+  public APIOperationsThrottlingLimitDTO unit(String unit) {
+    this.unit = unit;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "min", value = "")
+  @JsonProperty("unit")
+  public String getUnit() {
+    return unit;
+  }
+  public void setUnit(String unit) {
+    this.unit = unit;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    APIOperationsThrottlingLimitDTO apIOperationsThrottlingLimit = (APIOperationsThrottlingLimitDTO) o;
+    return Objects.equals(requestCount, apIOperationsThrottlingLimit.requestCount) &&
+        Objects.equals(unit, apIOperationsThrottlingLimit.unit);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(requestCount, unit);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class APIOperationsThrottlingLimitDTO {\n");
+    
+    sb.append("    requestCount: ").append(toIndentedString(requestCount)).append("\n");
+    sb.append("    unit: ").append(toIndentedString(unit)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -1582,6 +1582,7 @@ public class APIMappingUtil {
                 }
                 template.setThrottlingTier(operation.getThrottlingPolicy());
                 if (!operation.getThrottlingPolicy().isEmpty()) {
+                    // converts existing throttling policy to the new throttling limit format
                     template.setThrottlingLimit(operation.getThrottlingPolicy());
                 } else {
                     template.setThrottlingLimit(operation.getThrottlingLimit());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -53,6 +53,7 @@ import org.wso2.carbon.apimgt.api.model.OperationPolicy;
 import org.wso2.carbon.apimgt.api.model.ResourcePath;
 import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.api.model.ServiceEntry;
+import org.wso2.carbon.apimgt.api.model.ThrottlingLimit;
 import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.api.model.WebsubSubscriptionConfiguration;
@@ -78,6 +79,7 @@ import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIListDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIMaxTpsDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIMonetizationInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIOperationsDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIOperationsThrottlingLimitDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIProductBusinessInformationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIProductDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIProductDTO.StateEnum;
@@ -1584,8 +1586,11 @@ public class APIMappingUtil {
                 if (!operation.getThrottlingPolicy().isEmpty()) {
                     // converts existing throttling policy to the new throttling limit format
                     template.setThrottlingLimit(operation.getThrottlingPolicy());
-                } else {
-                    template.setThrottlingLimit(operation.getThrottlingLimit());
+                } else if (operation.getThrottlingLimit() != null) {
+                    APIOperationsThrottlingLimitDTO apiOperationsThrottlingLimitDTO = operation.getThrottlingLimit();
+                    ThrottlingLimit throttlingLimit = ThrottlingLimitMappingUtil.fromDTOToThrottlingLimit(
+                            apiOperationsThrottlingLimitDTO);
+                    template.setThrottlingLimit(throttlingLimit);
                 }
                 template.setThrottlingTiers(operation.getThrottlingPolicy());
                 template.setUriTemplate(uriTempVal);
@@ -2105,7 +2110,8 @@ public class APIMappingUtil {
         operationsDTO.setOperationPolicies(
                 OperationPolicyMappingUtil.fromOperationPolicyListToDTO(uriTemplate.getOperationPolicies()));
         operationsDTO.setThrottlingPolicy(uriTemplate.getThrottlingTier());
-        operationsDTO.setThrottlingLimit(uriTemplate.getThrottlingLimit());
+        operationsDTO.setThrottlingLimit(ThrottlingLimitMappingUtil.fromThrottlingLimitToDTO(
+                uriTemplate.getThrottlingLimit()));
         Set<APIProductIdentifier> usedByProducts = uriTemplate.retrieveUsedByProducts();
         List<String> usedProductIds = new ArrayList<>();
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -1581,6 +1581,11 @@ public class APIMappingUtil {
                     authType = APIConstants.AUTH_APPLICATION_OR_USER_LEVEL_TOKEN;
                 }
                 template.setThrottlingTier(operation.getThrottlingPolicy());
+                if (!operation.getThrottlingPolicy().isEmpty()) {
+                    template.setThrottlingLimit(operation.getThrottlingPolicy());
+                } else {
+                    template.setThrottlingLimit(operation.getThrottlingLimit());
+                }
                 template.setThrottlingTiers(operation.getThrottlingPolicy());
                 template.setUriTemplate(uriTempVal);
                 template.setHTTPVerb(httpVerb.toUpperCase());
@@ -2099,6 +2104,7 @@ public class APIMappingUtil {
         operationsDTO.setOperationPolicies(
                 OperationPolicyMappingUtil.fromOperationPolicyListToDTO(uriTemplate.getOperationPolicies()));
         operationsDTO.setThrottlingPolicy(uriTemplate.getThrottlingTier());
+        operationsDTO.setThrottlingLimit(uriTemplate.getThrottlingLimit());
         Set<APIProductIdentifier> usedByProducts = uriTemplate.retrieveUsedByProducts();
         List<String> usedProductIds = new ArrayList<>();
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -1583,7 +1583,7 @@ public class APIMappingUtil {
                     authType = APIConstants.AUTH_APPLICATION_OR_USER_LEVEL_TOKEN;
                 }
                 template.setThrottlingTier(operation.getThrottlingPolicy());
-                if (!operation.getThrottlingPolicy().isEmpty()) {
+                if (operation.getThrottlingPolicy() != null && !operation.getThrottlingPolicy().isEmpty()) {
                     // converts existing throttling policy to the new throttling limit format
                     template.setThrottlingLimit(operation.getThrottlingPolicy());
                 } else if (operation.getThrottlingLimit() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ThrottlingLimitMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ThrottlingLimitMappingUtil.java
@@ -48,8 +48,13 @@ public class ThrottlingLimitMappingUtil {
      */
     public static APIOperationsThrottlingLimitDTO fromThrottlingLimitToDTO(ThrottlingLimit throttlingLimit) {
         APIOperationsThrottlingLimitDTO dto = new APIOperationsThrottlingLimitDTO();
-        dto.setRequestCount(throttlingLimit.getRequestCount());
-        dto.setUnit(APIOperationsThrottlingLimitDTO.UnitEnum.valueOf(throttlingLimit.getUnit()));
+        if (throttlingLimit == null) {
+            dto.setRequestCount(-1);
+            dto.setUnit(APIOperationsThrottlingLimitDTO.UnitEnum.MINUTE);
+        } else {
+            dto.setRequestCount(throttlingLimit.getRequestCount());
+            dto.setUnit(APIOperationsThrottlingLimitDTO.UnitEnum.valueOf(throttlingLimit.getUnit()));
+        }
         return dto;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ThrottlingLimitMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ThrottlingLimitMappingUtil.java
@@ -36,7 +36,7 @@ public class ThrottlingLimitMappingUtil {
     public static ThrottlingLimit fromDTOToThrottlingLimit(APIOperationsThrottlingLimitDTO dto) {
         ThrottlingLimit throttlingLimit = new ThrottlingLimit();
         throttlingLimit.setRequestCount(dto.getRequestCount());
-        throttlingLimit.setUnit(dto.getUnit());
+        throttlingLimit.setUnit(dto.getUnit().toString());
         return throttlingLimit;
     }
 
@@ -49,7 +49,7 @@ public class ThrottlingLimitMappingUtil {
     public static APIOperationsThrottlingLimitDTO fromThrottlingLimitToDTO(ThrottlingLimit throttlingLimit) {
         APIOperationsThrottlingLimitDTO dto = new APIOperationsThrottlingLimitDTO();
         dto.setRequestCount(throttlingLimit.getRequestCount());
-        dto.setUnit(throttlingLimit.getUnit());
+        dto.setUnit(APIOperationsThrottlingLimitDTO.UnitEnum.valueOf(throttlingLimit.getUnit()));
         return dto;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ThrottlingLimitMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ThrottlingLimitMappingUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings;
+
+import org.wso2.carbon.apimgt.api.model.ThrottlingLimit;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIOperationsThrottlingLimitDTO;
+
+/**
+ * This class is responsible for mapping APIOperationsThrottlingLimitDTOs into REST API throttling related manipulations
+ * and vice versa.
+ */
+public class ThrottlingLimitMappingUtil {
+
+    /**
+     * Manipulates ThrottlingLimit object from APIOperationsThrottlingLimitDTO
+     *
+     * @param dto Holds throttling limits relevant to the operations
+     * @return throttlingLimit object
+     */
+    public static ThrottlingLimit fromDTOToThrottlingLimit(APIOperationsThrottlingLimitDTO dto) {
+        ThrottlingLimit throttlingLimit = new ThrottlingLimit();
+        throttlingLimit.setRequestCount(dto.getRequestCount());
+        throttlingLimit.setUnit(dto.getUnit());
+        return throttlingLimit;
+    }
+
+    /**
+     * Manipulates APIOperationsThrottlingLimitDTO object from ThrottlingLimit
+     *
+     * @param throttlingLimit Provides throttling limit details
+     * @return APIOperationsThrottlingLimitDTO object with throttling details
+     */
+    public static APIOperationsThrottlingLimitDTO fromThrottlingLimitToDTO(ThrottlingLimit throttlingLimit) {
+        APIOperationsThrottlingLimitDTO dto = new APIOperationsThrottlingLimitDTO();
+        dto.setRequestCount(throttlingLimit.getRequestCount());
+        dto.setUnit(throttlingLimit.getUnit());
+        return dto;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -10450,8 +10450,14 @@ components:
           type: string
           example: Unlimited
         throttlingLimit:
-          type: string
-          example: Unlimited
+          type: object
+          properties:
+            requestCount:
+              type: integer
+              example: 10000
+            unit:
+              type: string
+              example: min
         scopes:
           type: array
           example: []

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -10451,6 +10451,8 @@ components:
           example: Unlimited
         throttlingLimit:
           type: object
+          required:
+            - unit
           properties:
             requestCount:
               type: integer
@@ -10458,8 +10460,10 @@ components:
             unit:
               type: string
               enum:
-                - min
-                - hour
+                - Second
+                - Minute
+                - Hour
+                - Day
         scopes:
           type: array
           example: []

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -10457,7 +10457,9 @@ components:
               example: 10000
             unit:
               type: string
-              example: min
+              enum:
+                - min
+                - hour
         scopes:
           type: array
           example: []

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -10449,6 +10449,9 @@ components:
         throttlingPolicy:
           type: string
           example: Unlimited
+        throttlingLimit:
+          type: string
+          example: Unlimited
         scopes:
           type: array
           example: []


### PR DESCRIPTION
With the new Envoy rate-limit service users can define own rate-limits from the UI relevant to the operations. With this change UI can provide operation level rate-limits defined by the user to the backend. In the backend provided rate-limit details will be stored in below format in the API definition file (under the `x-throttling-tier`) field value. 

```
{ "requestCount" : "9999" , "unit" : "min" }
```

When sending responses back to the UI below structure is used.
```
"throttlingPolicy": "20KPerMin",
"throttlingLimit": { 
   "requestCount" : 20000, 
   "unit" : "min" 
},
```


related PR:
https://github.com/wso2/carbon-apimgt/pull/11760