### PR TITLE
Change search query to correctly fetch the api-category api count

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -1008,7 +1008,7 @@ public class APIAdminImpl implements APIAdmin {
         APIProviderImpl apiProvider = new APIProviderImpl(username);
         //no need to add type prefix here since we need to ge the total number of category associations including both
         //APIs and API categories
-        String searchQuery = APIConstants.CATEGORY_SEARCH_TYPE_PREFIX + "=*" + category.getName() + "*";
+        String searchQuery = APIConstants.CATEGORY_SEARCH_TYPE_PREFIX + ":*" + category.getName() + "*";
         String tenantDomain = MultitenantUtils.getTenantDomain(username);
         Map<String, Object> result = apiProvider.searchPaginatedAPIs(searchQuery, tenantDomain, 0, Integer.MAX_VALUE, null, null);
         return (int) (Integer) result.get("length");


### PR DESCRIPTION
## Purpose

- The API count under API categories in the admin portal is displayed as zero although APIs are there with the category assigned.
- Fixed https://github.com/wso2/api-manager/issues/1338

## Approach
- Changed api search query with `:` instead of `=` in https://github.com/wso2/carbon-apimgt/blob/0947ffa2befeb438c937e0e5aae5069bfb4b4c71/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java#L1011