### PR TITLE
Set autocommit to true, to get visibility over other transactions' changes when defaultAutoCommit=false

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -16674,6 +16674,7 @@ public class ApiMgtDAO {
         try (Connection connection = APIMgtDBUtil.getConnection();
              PreparedStatement statement = connection
                      .prepareStatement(SQLConstants.APIRevisionSqlConstants.GET_REVISION_APIID_BY_REVISION_UUID)) {
+            connection.setAutoCommit(true);
             statement.setString(1, apiUUID);
             try (ResultSet rs = statement.executeQuery()) {
                 if (rs.next()) {


### PR DESCRIPTION
Resolves: https://github.com/wso2/api-manager/issues/1270

We have a configuration property called defaultAutoCommit. When this property is set to zero and if the database transaction isolation level is REPEATABLE-READ or higher, lookup queries do not have visibility over changes that happened after a connection creation. In order to support both true and false for this defaultAutoCommit configuration we should always set auto-commit to true before doing any database lookups.  