### PR TITLE
Upgrade gson to 2.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1957,7 +1957,7 @@
         <carbon.analytics.common.version>5.3.4</carbon.analytics.common.version>
         <!-- Carbon kernel version -->
         <carbon.kernel.version>4.8.0-beta</carbon.kernel.version>
-        <carbon.kernel.feature.version>4.8.0-beta</carbon.kernel.feature.version>
+        <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
 
         <carbon.commons.version>4.9.2</carbon.commons.version>
@@ -2042,7 +2042,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>4.0.0-wso2v9</synapse.version>
+        <synapse.version>4.0.0-wso2v13</synapse.version>
 
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 
@@ -2073,7 +2073,7 @@
         <commons-logging.version>1.1.1</commons-logging.version>
         <commons-io.version>2.4.0.wso2v1</commons-io.version>
         <commons-httpclient.version>3.1</commons-httpclient.version>
-        <google.code.gson.version>2.8.9</google.code.gson.version>
+        <google.code.gson.version>2.9.1</google.code.gson.version>
         <httpcomponents.version>4.5.10</httpcomponents.version>
         <commons-codec.version>1.14</commons-codec.version>
         <com.nimbusds.wso2.version>7.9.0.wso2v1</com.nimbusds.wso2.version>
@@ -2198,7 +2198,7 @@
         <version.checkstyle>8.34</version.checkstyle>
         <org.wso2.orbit.org.mapstruct.version>1.4.1.wso2v1</org.wso2.orbit.org.mapstruct.version>
         <org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-        <analytics.event.publisher.client.version>1.1.2</analytics.event.publisher.client.version>
+        <analytics.event.publisher.client.version>1.1.3</analytics.event.publisher.client.version>
         <analytics.event.publisher.client.version.range>[1.0.0,2.0.0)</analytics.event.publisher.client.version.range>
         <org.wso2.orbit.atlassian.oai.version>2.12.1.wso2v2</org.wso2.orbit.atlassian.oai.version>
         <maven.spotbugsplugin.exclude.file>spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>


### PR DESCRIPTION
This PR upgrades gson to 2.9.1 and removes multiple versions of the jar available in the pack.

Related issue: https://github.com/wso2/api-manager/issues/1310