### PR TITLE
use same db connection during API/API product revision restore.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -19100,8 +19100,11 @@ public class ApiMgtDAO {
                             }
                             //This means the common policy is same with our revision. A clone is created and original
                             // common policy ID is referenced as the ClonedCommonPolicyId
+                            String clonedCommonPolicyID = revisionedPolicy.getClonedCommonPolicyId();
+                            //setting null, so that new UUID will be generated in the latter flow.
+                            revisionedPolicy.setClonedCommonPolicyId(null);
                             restoredPolicyId = addAPISpecificOperationPolicy(connection, apiUUID, null,
-                                    revisionedPolicy, revisionedPolicy.getClonedCommonPolicyId());
+                                    revisionedPolicy, clonedCommonPolicyID);
                         } else {
                             // This means the common policy is updated since we created the revision.
                             // we have to create a clone and since policy is different, we can't refer the original common
@@ -19113,6 +19116,8 @@ public class ApiMgtDAO {
                                             + " Restored from revision " + revisionId);
                             revisionedPolicy.setMd5Hash(APIUtil.getMd5OfOperationPolicy(revisionedPolicy));
                             revisionedPolicy.setRevisionUUID(null);
+                            //setting null, so that new UUID will be generated in the latter flow.
+                            revisionedPolicy.setClonedCommonPolicyId(null);
                             restoredPolicyId = addAPISpecificOperationPolicy(connection, apiUUID, null,
                                     revisionedPolicy, null);
                             if (log.isDebugEnabled()) {
@@ -19131,6 +19136,7 @@ public class ApiMgtDAO {
                                         + " Restored from revision " + revisionId);
                         revisionedPolicy.setMd5Hash(APIUtil.getMd5OfOperationPolicy(revisionedPolicy));
                         revisionedPolicy.setRevisionUUID(null);
+                        revisionedPolicy.setClonedCommonPolicyId(null);
                         restoredPolicyId = addAPISpecificOperationPolicy(connection, apiUUID, null, revisionedPolicy, null);
                         if (log.isDebugEnabled()) {
                             log.debug("No matching operation policy found. A new API specific operation " +
@@ -19141,6 +19147,7 @@ public class ApiMgtDAO {
                     // This means this is a completely new policy and we don't have any reference of a previous state in
                     // working copy. A new API specific policy will be created.
                     revisionedPolicy.setRevisionUUID(null);
+                    revisionedPolicy.setClonedCommonPolicyId(null);
                     restoredPolicyId = addAPISpecificOperationPolicy(connection, apiUUID, null, revisionedPolicy, null);
                     if (log.isDebugEnabled()) {
                         log.debug("No matching operation policy found. A new API specific operation " +


### PR DESCRIPTION
fix https://github.com/wso2/api-manager/issues/1387 and 

```
[2023-02-08 12:08:05,678] ERROR - ApiMgtDAO Failed to restore API Revision entry of API UUID 69f5d90b-f36a-4d02-a061-f8388fce67e6
com.microsoft.sqlserver.jdbc.SQLServerException: Violation of PRIMARY KEY constraint 'PK__AM_OPERA__5585D61702BFB128'. Cannot insert duplicate key in object 'dbo.AM_OPERATION_POLICY'. The duplicate key value is (481547eb-4dc7-4550-b7b9-fe5fcc74758d).
	at com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDatabaseError(SQLServerException.java:262) ~[mssql-jdbc-7.4.1.jre11.jar:?]
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.getNextResult(SQLServerStatement.java:1624) ~[mssql-jdbc-7.4.1.jre11.jar:?]

```