### PR TITLE
Add missing properties in the OAuthMediator

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/OAuthMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/OAuthMediator.java
@@ -101,6 +101,13 @@ public class OAuthMediator extends AbstractMediator implements ManagedLifecycle 
         TokenResponse tokenResponse = null;
         if (oAuthEndpoint != null) {
             try {
+                oAuthEndpoint.setUsername(username);
+                if (clientSecret != null) {
+                    oAuthEndpoint.setClientSecret(clientSecret);
+                }
+                if (password != null) {
+                    oAuthEndpoint.setPassword(password.toCharArray());
+                }
                 tokenResponse = OAuthTokenGenerator.generateToken(oAuthEndpoint, latch);
                 latch.await();
             } catch (InterruptedException | APISecurityException e) {


### PR DESCRIPTION
## Purpose
- Fix https://github.com/wso2/api-manager/issues/1224
- Add setters for clientSecret, password and username of oAuthEndpoint.

## Description

When the secure vault is enabled even though the clientSecret and password are in the registry, clientSecret, username and password were passed as null when generating the AccessToken in [1]. 
It was identified that when the secure vault is enabled, password and clientSecret properties are getting resolved in the runtime. Therefore in this PR setters were added to set those missing properties.


[1] - https://github.com/wso2/carbon-apimgt/blob/master/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/OAuthTokenGenerator.java#:~:text=public%20static%20TokenResponse%20generateToken(OAuthEndpoint%20oAuthEndpoint%2C%20CountDownLatch%20latch)