### PR TITLE
Add Swagger Relaxed Validation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2966,4 +2966,5 @@ public final class APIConstants {
 
     public static final String CASE_SENSITIVE_CHECK_PATH =    "caseSensitiveRoleValidation";
     public static final String MIGRATE = "migrate";
+    public static final String SWAGGER_RELAXED_VALIDATION = "swaggerRelaxedValidation";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -752,7 +752,16 @@ public class OAS3Parser extends APIDefinition {
                     validationResponse.getErrorItems().add(errorItem);
                 }
             }
+            if (System.getProperty(APIConstants.SWAGGER_RELAXED_VALIDATION) != null &&
+                    parseAttemptForV3.getOpenAPI() != null) {
+                validationResponse.setValid(true);
+            } else {
+                validationResponse.setValid(false);
+            }
         } else {
+            validationResponse.setValid(true);
+        }
+        if (validationResponse.isValid()){
             OpenAPI openAPI = parseAttemptForV3.getOpenAPI();
             io.swagger.v3.oas.models.info.Info info = openAPI.getInfo();
             List<String> endpoints;
@@ -1682,7 +1691,7 @@ public class OAS3Parser extends APIDefinition {
      * @throws APIManagementException
      */
     private OpenAPI injectOtherScopesToDefaultScheme(OpenAPI openAPI) throws APIManagementException {
-        Map<String, SecurityScheme> securitySchemes ;
+        Map<String, SecurityScheme> securitySchemes;
         Components component = openAPI.getComponents();
         List<String> otherSetOfSchemes = new ArrayList<>();
 


### PR DESCRIPTION
This PR will add Swagger relaxed validation to API Manager. With this, the swagger will be only validated to check whether the provided definition returns a valid swagger object after validating via the swagger parser. 

By default, the provided swagger definitions will be returned invalid if any errors are found while parsing via the swagger parser.  
To enable the relaxed validation, the following system property has to be passed to the runtime.

```-DswaggerRelaxedValidation```