### PR TITLE
Basic Auth Intermittent 401 HTTP error fixed.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
@@ -83,6 +83,7 @@ public class OAuthAuthenticator implements Authenticator {
     private boolean removeDefaultAPIHeaderFromOutMessage = true;
     private String requestOrigin;
     private boolean isMandatory;
+    private ThreadLocal<String> remainingAuthHeader = new ThreadLocal<String>();
 
     public OAuthAuthenticator() {
     }
@@ -106,7 +107,7 @@ public class OAuthAuthenticator implements Authenticator {
     public AuthenticationResponse authenticate(MessageContext synCtx) throws APIManagementException {
         boolean isJwtToken = false;
         String accessToken = null;
-        String remainingAuthHeader = "";
+        remainingAuthHeader.set("");
         boolean defaultVersionInvoked = false;
         Map headers = (Map) ((Axis2MessageContext) synCtx).getAxis2MessageContext().
                 getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
@@ -166,7 +167,7 @@ public class OAuthAuthenticator implements Authenticator {
                         }
                     }
                 }
-                remainingAuthHeader = String.join(oauthHeaderSplitter, remainingAuthHeaders);
+                remainingAuthHeader.set(String.join(oauthHeaderSplitter, remainingAuthHeaders));
             }
 
             if (log.isDebugEnabled()) {
@@ -182,7 +183,7 @@ public class OAuthAuthenticator implements Authenticator {
 
         if (removeOAuthHeadersFromOutMessage) {
             //Remove authorization headers sent for authentication at the gateway and pass others to the backend
-            if (StringUtils.isNotBlank(remainingAuthHeader)) {
+            if (StringUtils.isNotBlank(remainingAuthHeader.get())) {
                 if (log.isDebugEnabled()) {
                     log.debug("Removing OAuth key from Authorization header");
                 }


### PR DESCRIPTION
# Purpose
This fix fixes the issue, HTTP 401 has been observed intermittently for Basic Auth with correct credentials if an API has Basic Auth and OAuth as application security. 

# Approach
Since this is concurrence issue, to make the remainingAuthHeader variable thread safe, We have used ThreadLocal method.
# Jmeter Performance Test Results
### OAuth2 Authentication results when running in the fresh pack
![image](https://user-images.githubusercontent.com/43110114/211999008-60af4236-ca54-42df-898a-4afd0524061b.png)

### OAuth2 Authentication results when running in the changed pack after applying the fix
![image](https://user-images.githubusercontent.com/43110114/211998800-fa46070b-2649-4394-8663-d3019925c852.png)

### Basic Authentication results when running in the fresh pack
![image](https://user-images.githubusercontent.com/43110114/212231778-6924230e-5681-43ca-9414-7f53b0197617.png)

### Basic Authentication results when running in the changed pack after applying the fix
![image](https://user-images.githubusercontent.com/43110114/212231925-6a7f7390-bb80-4553-8d92-8eebe74fd5fc.png)

