### PR TITLE
Support picking consumer key from array valued claim in DefaultJWTTransformer 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/jwttransformer/DefaultJWTTransformer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/jwttransformer/DefaultJWTTransformer.java
@@ -46,8 +46,14 @@ public class DefaultJWTTransformer implements JWTTransformer {
                     return jwtClaimsSet.getStringClaim(JWTConstants.AUTHORIZED_PARTY);
                 }
             } else {
-                if (jwtClaimsSet.getClaim(tokenIssuer.getConsumerKeyClaim()) != null) {
-                    return jwtClaimsSet.getStringClaim(tokenIssuer.getConsumerKeyClaim());
+                String consumerKeyClaim = tokenIssuer.getConsumerKeyClaim();
+                if (jwtClaimsSet.getClaim(consumerKeyClaim) != null) {
+                    if (jwtClaimsSet.getClaim(consumerKeyClaim) instanceof String) {
+                        return jwtClaimsSet.getStringClaim(tokenIssuer.getConsumerKeyClaim());
+                        // For some IDPs, the consumer key is returned as a list. (ex: ForgeRock)
+                    } else if (jwtClaimsSet.getClaim(consumerKeyClaim) instanceof List) {
+                        return jwtClaimsSet.getStringListClaim(tokenIssuer.getConsumerKeyClaim()).get(0);
+                    }
                 }
             }
         } catch (ParseException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/test/java/org/wso2/carbon/apimgt/common/gateway/jwttransformer/DefaultJWTTransformerTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/test/java/org/wso2/carbon/apimgt/common/gateway/jwttransformer/DefaultJWTTransformerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.common.gateway.jwttransformer;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.common.gateway.dto.TokenIssuerDto;
+import org.wso2.carbon.apimgt.common.gateway.exception.JWTGeneratorException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DefaultJWTTransformerTest {
+
+    @Test
+    public void getTransformedConsumerKey() {
+        DefaultJWTTransformer defaultJWTTransformer = new DefaultJWTTransformer();
+        TokenIssuerDto tokenIssuerDto = new TokenIssuerDto("https://localhost:9443/oauth2/token");
+        tokenIssuerDto.setConsumerKeyClaim("aud");
+        defaultJWTTransformer.loadConfiguration(tokenIssuerDto);
+
+        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder().claim("aud", "stringConsumerKey").build();
+        try {
+            Assert.assertEquals("stringConsumerKey", defaultJWTTransformer.getTransformedConsumerKey(jwtClaimsSet));
+        } catch (JWTGeneratorException e) {
+            Assert.fail("JWTGeneratorException thrown");
+        }
+
+        List<String> audList = new ArrayList<>(2);
+        audList.add("arrayConsumerKey");
+        audList.add("someOtherAudience");
+        jwtClaimsSet = new JWTClaimsSet.Builder().claim("aud",  audList).build();
+        try {
+            Assert.assertEquals("arrayConsumerKey", defaultJWTTransformer.getTransformedConsumerKey(jwtClaimsSet));
+        } catch (JWTGeneratorException e) {
+            Assert.fail("JWTGeneratorException thrown");
+        }
+    }
+}


### PR DESCRIPTION
If AUD claim is provided as the consumerKey containing claim and the value of the claim is an array, pick the 0th element of the array instead of throwing parse exception: when the km is forgerock this issue appears for the choreo connect