### PR TITLE
Fix the issue of throwing 500 status when copying an API with same version

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3182,8 +3182,8 @@ public class ApisApiServiceImpl implements ApisApiService {
                         ExceptionCodes.from(ExceptionCodes.API_NOT_FOUND, apiId));
             }
             //Get all existing versions of API
-            List<String> apiVersions = apiProvider.getApiVersionsMatchingApiNameAndOrganization(
-                    apiIdentifierFromTable.getApiName(), apiIdentifierFromTable.getProviderName(), organization);
+            Set<String> apiVersions = apiProvider.getAPIVersions(apiIdentifierFromTable.getProviderName(),
+                    apiIdentifierFromTable.getApiName(), organization);
             if (apiVersions.contains(newVersion)) {
                 throw new APIMgtResourceAlreadyExistsException(
                         "Version " + newVersion + " exists for api " + existingAPI.getId().getApiName(),


### PR DESCRIPTION
Fixing the issue of getting a server error when trying to create an API(copy API) with a version that already exists. This issue occurred when more than one version already exists for an API.

Resolves: https://github.com/wso2/api-manager/issues/1094