### PR TITLE
Fix for the AnalyticsException when apim-analytics-publisher added to dropins

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -473,6 +473,7 @@
                             org.apache.commons.codec.*,
                             org.wso2.carbon.apimgt.common.gateway.*,
                             org.wso2.carbon.apimgt.common.jms.*,
+                            org.wso2.carbon.apimgt.common.analytics.*,
                             org.wso2.carbon.apimgt.usage.publisher.*; version="${carbon.apimgt.imp.pkg.version}",
                             javax.annotation;version=0.0.0;resolution:=optional,
                             *;resolution:=optional


### PR DESCRIPTION
Issue: https://github.com/wso2/api-manager/issues/1435

Note: Although the exception gets resolved after this, the warning for OSGiAxis2Service remains.