### PR TITLE
Add the support to generate SOAP to REST operation elements in order

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/SequenceGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/SequenceGenerator.java
@@ -122,7 +122,7 @@ public class SequenceGenerator {
             Map<HttpMethod, Operation> operationMap = path.getOperationMap();
             for (HttpMethod httpMethod : operationMap.keySet()) {
                 boolean isResourceFromWSDL = false;
-                Map<String, String> parameterJsonPathMapping = new HashMap<>();
+                Map<String, String> parameterJsonPathMapping = new LinkedHashMap<>();
                 Map<String, String> queryParameters = new HashMap<>();
                 Operation operation = operationMap.get(httpMethod);
                 String operationId = operation.getOperationId();
@@ -163,10 +163,8 @@ public class SequenceGenerator {
                                 Example example = ExampleBuilder
                                         .fromModel(defName, model, definitions, new HashSet<String>());
                                 replaceNullWithStringExample(example);
-                                String jsonExample = Json.pretty(example);
                                 try {
-                                    org.json.JSONObject json = new org.json.JSONObject(jsonExample);
-                                    SequenceUtils.listJson(json, parameterJsonPathMapping);
+                                    SequenceUtils.listExamples(example, parameterJsonPathMapping);
                                 } catch (JSONException e) {
                                     log.error("Error occurred while generating json mapping for the definition", e);
                                 }
@@ -270,11 +268,8 @@ public class SequenceGenerator {
                         String defName = $ref.substring("#/definitions/".length());
                         Model model = definitions.get(defName);
                         Example example = ExampleBuilder.fromModel(defName, model, definitions, new HashSet<String>());
-
-                        String jsonExample = Json.pretty(example);
                         try {
-                            org.json.JSONObject json = new org.json.JSONObject(jsonExample);
-                            SequenceUtils.listJson(json, parameterJsonPathMapping);
+                            SequenceUtils.listExamples(example, parameterJsonPathMapping);
                         } catch (JSONException e) {
                             log.error("Error occurred while generating json mapping for the definition: " + defName, e);
                         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SOAPToRESTConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SOAPToRESTConstants.java
@@ -86,6 +86,8 @@ public class SOAPToRESTConstants {
         public static final String SOAP_VERSION= "x-soap-version";
         public static final String SOAP_MESSAGE_TYPE = "x-soap-message-type";
         public static final String SOAP_STYLE = "x-soap-style";
+        public static final String OBJECT_TYPE ="object";
+        public static final String ARRAY_TYPE ="array";
 
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SequenceUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SequenceUtils.java
@@ -518,7 +518,7 @@ public class SequenceUtils {
     public static void listExamples(String parent, Example example, Map<String, String> parameterJsonPathMapping)
             throws JSONException {
 
-        if (example.getTypeName().equals(SOAPToRESTConstants.Swagger.OBJECT_TYPE)) {
+        if (SOAPToRESTConstants.Swagger.OBJECT_TYPE.equals(example.getTypeName())) {
             Map<String, Example> values = ((ObjectExample) example).getValues();
             if (values != null) {
                 for (Map.Entry<String, Example> entry : values.entrySet()) {
@@ -528,11 +528,11 @@ public class SequenceUtils {
             } else {
                 parameterJsonPathMapping.put(parent, "simple");
             }
-        } else if (example.getTypeName().equals(SOAPToRESTConstants.Swagger.ARRAY_TYPE)) {
+        } else if (SOAPToRESTConstants.Swagger.ARRAY_TYPE.equals(example.getTypeName())) {
             List<Example> exampleArray = ((ArrayExample) example).getItems();
             if (exampleArray.size() > 0) {
                 for (Example exampleItem : exampleArray) {
-                    if (exampleItem.getTypeName().equals(SOAPToRESTConstants.Swagger.OBJECT_TYPE)) {
+                    if (SOAPToRESTConstants.Swagger.OBJECT_TYPE.equals(exampleItem.getTypeName())) {
                         listExamples(parent, exampleItem, parameterJsonPathMapping);
                     } else {
                         parameterJsonPathMapping.put(parent, "array");

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SequenceUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SequenceUtils.java
@@ -515,8 +515,21 @@ public class SequenceUtils {
         listExamples(SOAPToRESTConstants.EMPTY_STRING, example, parameterJsonPathMapping);
     }
 
-    public static void listExamples(String parent, Example example, Map<String, String> parameterJsonPathMapping)
-            throws JSONException {
+    /**
+     * Recursively go through the example schema. A schema can be either a primitive type such as string, int or a
+     * structured such as object or array. If it's a primitive type, If it's a primitive type, schema does not proceed
+     * further and this ends the branch. If it is an object type or an array type, we need to proceed further as objects
+     * can have further schemas included in and array can have either objects in its array elements or primitive
+     * elements. Objects are stored as LinkedHashMaps in the Example data structure and Arrays are stored as ArrayList.
+     * Each schema path will have a value either simple or array mapped which will be used in later operations. In this
+     * method, a simple type will be assigned if the schema ends with a primitive type in an object schema. If it ends
+     * as primitive elements in an array, array type is assigned.
+     *
+     * @param parent                   Parent nodes schema path
+     * @param example                  Example data node
+     * @param parameterJsonPathMapping Map to be populated with the respective schema paths
+     */
+    public static void listExamples(String parent, Example example, Map<String, String> parameterJsonPathMapping) {
 
         if (SOAPToRESTConstants.Swagger.OBJECT_TYPE.equals(example.getTypeName())) {
             Map<String, Example> values = ((ObjectExample) example).getValues();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SequenceUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SequenceUtils.java
@@ -17,6 +17,9 @@
  */
 package org.wso2.carbon.apimgt.impl.wsdl.util;
 
+import io.swagger.inflector.examples.models.ArrayExample;
+import io.swagger.inflector.examples.models.Example;
+import io.swagger.inflector.examples.models.ObjectExample;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.simple.JSONArray;
@@ -504,6 +507,40 @@ public class SequenceUtils {
             parameterJsonPathMapping.put(types[0], types[1]);
         } else {
             parameterJsonPathMapping.put(types[0], "simple");
+        }
+    }
+
+    public static void listExamples(Example example, Map<String, String> parameterJsonPathMapping)
+            throws JSONException {
+        listExamples(SOAPToRESTConstants.EMPTY_STRING, example, parameterJsonPathMapping);
+    }
+
+    public static void listExamples(String parent, Example example, Map<String, String> parameterJsonPathMapping)
+            throws JSONException {
+
+        if (example.getTypeName().equals(SOAPToRESTConstants.Swagger.OBJECT_TYPE)) {
+            Map<String, Example> values = ((ObjectExample) example).getValues();
+            if (values != null) {
+                for (Map.Entry<String, Example> entry : values.entrySet()) {
+                    String childKey = parent.isEmpty() ? entry.getKey() : parent + "." + entry.getKey();
+                    listExamples(childKey, entry.getValue(), parameterJsonPathMapping);
+                }
+            } else {
+                parameterJsonPathMapping.put(parent, "simple");
+            }
+        } else if (example.getTypeName().equals(SOAPToRESTConstants.Swagger.ARRAY_TYPE)) {
+            List<Example> exampleArray = ((ArrayExample) example).getItems();
+            if (exampleArray.size() > 0) {
+                for (Example exampleItem : exampleArray) {
+                    if (exampleItem.getTypeName().equals(SOAPToRESTConstants.Swagger.OBJECT_TYPE)) {
+                        listExamples(parent, exampleItem, parameterJsonPathMapping);
+                    } else {
+                        parameterJsonPathMapping.put(parent, "array");
+                    }
+                }
+            }
+        } else {
+            parameterJsonPathMapping.put(parent, "simple");
         }
     }
 }


### PR DESCRIPTION
n the current SOAP to REST API creation, the SOAP envelop elements are not mapped in the same order
defined in the wsdl. The current implementation used JSONObjects to record the parameters and this will not preserve the order. However, if the operation has sequence elements, the changed order will break the operation. Instead of JSONObject, this implementation uses the swagger example data type which internally uses Linked Hash maps.

Resolves: https://github.com/wso2/api-manager/issues/1441