### PR TITLE
Add Thumbnail Content Validation for APIs and API Products

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiConstants.java
@@ -333,6 +333,11 @@ public final class RestApiConstants {
     public static final Set<String> ALLOWED_THUMBNAIL_EXTENSIONS = new HashSet<String>(
             Arrays.asList("jpg", "png", "jpeg", "gif", "svg"));
 
+    public static final Set<String> ALLOWED_THUMBNAIL_MEDIA_TYPES = new HashSet<String>(
+            Arrays.asList("image/jpeg", "image/png", "image/gif", "image/svg+xml"));
+
+    public static final String SVG_MEDIA_TYPE = "image/svg+xml";
+
     public static final int TAG_LIMIT_DEFAULT = 1000;
     public static final int TAG_OFFSET_DEFAULT = 0;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
@@ -161,6 +161,14 @@
             <artifactId>org.wso2.carbon.apimgt.solace</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-all</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
@@ -168,6 +168,12 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-all</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
@@ -72,6 +72,7 @@ import org.wso2.carbon.apimgt.rest.api.util.exception.BadRequestException;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
@@ -575,6 +576,7 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
     @Override
     public Response updateAPIProductThumbnail(String apiProductId, InputStream fileInputStream,
             Attachment fileDetail, String ifMatch, MessageContext messageContext) {
+        ByteArrayInputStream inputStream = null;
         try {
             APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
             String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
@@ -582,17 +584,15 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
             String extension = FilenameUtils.getExtension(fileName);
             if (!RestApiConstants.ALLOWED_THUMBNAIL_EXTENSIONS.contains(extension.toLowerCase())) {
                 RestApiUtil.handleBadRequest(
-                        "Unsupported Thumbnail File Extension. Supported extensions are .jpg, .png, .jpeg .svg "
+                        "Unsupported Thumbnail File Extension. Supported extensions are .jpg, .png, .jpeg, .svg "
                                 + "and .gif", log);
             }
-            String fileContentType = URLConnection.guessContentTypeFromName(fileName);
-            if (org.apache.commons.lang3.StringUtils.isBlank(fileContentType)) {
-                fileContentType = fileDetail.getContentType().toString();
-            }
+            inputStream = (ByteArrayInputStream) RestApiPublisherUtils.validateThumbnailContent(fileInputStream);
+            String fileMediaType = RestApiPublisherUtils.detectMediaType(inputStream);
 
             //this will fail if user does not have access to the API or the API does not exist
             APIProduct apiProduct = apiProvider.getAPIProductbyUUID(apiProductId, tenantDomain);
-            ResourceFile apiImage = new ResourceFile(fileInputStream, fileContentType);
+            ResourceFile apiImage = new ResourceFile(inputStream, fileMediaType);
             apiProvider.setThumbnailToAPI(apiProductId, apiImage, tenantDomain);
             /*
             String thumbPath = APIUtil.getProductIconPath(apiProduct.getId());
@@ -618,6 +618,9 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
         } catch (URISyntaxException e) {
             String errorMessage = "Error while retrieving thumbnail location of API Product : " + apiProductId;
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
+        } finally {
+            IOUtils.closeQuietly(fileInputStream);
+            IOUtils.closeQuietly(inputStream);
         }
         return null;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
@@ -589,6 +589,11 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
             }
             inputStream = (ByteArrayInputStream) RestApiPublisherUtils.validateThumbnailContent(fileInputStream);
             String fileMediaType = RestApiPublisherUtils.detectMediaType(inputStream);
+            if (StringUtils.isBlank(fileMediaType)) {
+                RestApiUtil.handleBadRequest(
+                        "Media Type of provided thumbnail is not supported. Supported Media Types are image/jpeg, "
+                                + "image/png, image/gif and image/svg+xml", log);
+            }
 
             //this will fail if user does not have access to the API or the API does not exist
             APIProduct apiProduct = apiProvider.getAPIProductbyUUID(apiProductId, tenantDomain);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
@@ -597,8 +597,8 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
             }
             if (StringUtils.isBlank(fileMediaType)) {
                 RestApiUtil.handleBadRequest(
-                        "Media Type of provided thumbnail is not supported. Supported Media Types are image/jpeg, "
-                                + "image/png, image/gif and image/svg+xml", log);
+                        "Media Type of provided thumbnail is not supported. Supported Media Types are "
+                                + RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES, log);
             }
 
             //this will fail if user does not have access to the API or the API does not exist

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
@@ -74,6 +74,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -587,19 +588,8 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
                         "Unsupported Thumbnail File Extension. Supported extensions are .jpg, .png, .jpeg, .svg "
                                 + "and .gif", log);
             }
-            if (log.isDebugEnabled()) {
-                log.debug("Validating thumbnail content of API Product : " + apiProductId);
-            }
             inputStream = (ByteArrayInputStream) RestApiPublisherUtils.validateThumbnailContent(fileInputStream);
-            String fileMediaType = RestApiPublisherUtils.detectMediaType(inputStream);
-            if (log.isDebugEnabled()) {
-                log.debug("Media Type of thumbnail to be uploaded : " + fileMediaType);
-            }
-            if (StringUtils.isBlank(fileMediaType)) {
-                RestApiUtil.handleBadRequest(
-                        "Media Type of provided thumbnail is not supported. Supported Media Types are "
-                                + RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES, log);
-            }
+            String fileMediaType = RestApiPublisherUtils.getMediaType(inputStream, fileDetail);
 
             //this will fail if user does not have access to the API or the API does not exist
             APIProduct apiProduct = apiProvider.getAPIProductbyUUID(apiProductId, tenantDomain);
@@ -626,8 +616,8 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
         } catch (APIManagementException e) {
             String errorMessage = "Error while updating API Product : " + apiProductId;
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
-        } catch (URISyntaxException e) {
-            String errorMessage = "Error while retrieving thumbnail location of API Product : " + apiProductId;
+        } catch (URISyntaxException | IOException e) {
+            String errorMessage = "Error while updating thumbnail location of API Product : " + apiProductId;
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
         } finally {
             IOUtils.closeQuietly(fileInputStream);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApiProductsApiServiceImpl.java
@@ -587,8 +587,14 @@ public class ApiProductsApiServiceImpl implements ApiProductsApiService {
                         "Unsupported Thumbnail File Extension. Supported extensions are .jpg, .png, .jpeg, .svg "
                                 + "and .gif", log);
             }
+            if (log.isDebugEnabled()) {
+                log.debug("Validating thumbnail content of API Product : " + apiProductId);
+            }
             inputStream = (ByteArrayInputStream) RestApiPublisherUtils.validateThumbnailContent(fileInputStream);
             String fileMediaType = RestApiPublisherUtils.detectMediaType(inputStream);
+            if (log.isDebugEnabled()) {
+                log.debug("Media Type of thumbnail to be uploaded : " + fileMediaType);
+            }
             if (StringUtils.isBlank(fileMediaType)) {
                 RestApiUtil.handleBadRequest(
                         "Media Type of provided thumbnail is not supported. Supported Media Types are image/jpeg, "

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -2580,6 +2580,11 @@ public class ApisApiServiceImpl implements ApisApiService {
             }
             inputStream = (ByteArrayInputStream) RestApiPublisherUtils.validateThumbnailContent(fileInputStream);
             String fileMediaType = RestApiPublisherUtils.detectMediaType(inputStream);
+            if (StringUtils.isBlank(fileMediaType)) {
+                RestApiUtil.handleBadRequest(
+                        "Media Type of provided thumbnail is not supported. Supported Media Types are image/jpeg, "
+                                + "image/png, image/gif and image/svg+xml", log);
+            }
             PublisherCommonUtils.updateThumbnail(inputStream, fileMediaType, apiProvider, apiId, organization);
             String uriString = RestApiConstants.RESOURCE_PATH_THUMBNAIL.replace(RestApiConstants.APIID_PARAM, apiId);
             URI uri = new URI(uriString);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -2578,8 +2578,14 @@ public class ApisApiServiceImpl implements ApisApiService {
                         "Unsupported Thumbnail File Extension. Supported extensions are .jpg, .png, .jpeg, .svg "
                                 + "and .gif", log);
             }
+            if (log.isDebugEnabled()) {
+                log.debug("Validating thumbnail content of API : " + apiId);
+            }
             inputStream = (ByteArrayInputStream) RestApiPublisherUtils.validateThumbnailContent(fileInputStream);
             String fileMediaType = RestApiPublisherUtils.detectMediaType(inputStream);
+            if (log.isDebugEnabled()) {
+                log.debug("Media Type of thumbnail to be uploaded : " + fileMediaType);
+            }
             if (StringUtils.isBlank(fileMediaType)) {
                 RestApiUtil.handleBadRequest(
                         "Media Type of provided thumbnail is not supported. Supported Media Types are image/jpeg, "

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -2578,19 +2578,8 @@ public class ApisApiServiceImpl implements ApisApiService {
                         "Unsupported Thumbnail File Extension. Supported extensions are .jpg, .png, .jpeg, .svg "
                                 + "and .gif", log);
             }
-            if (log.isDebugEnabled()) {
-                log.debug("Validating thumbnail content of API : " + apiId);
-            }
             inputStream = (ByteArrayInputStream) RestApiPublisherUtils.validateThumbnailContent(fileInputStream);
-            String fileMediaType = RestApiPublisherUtils.detectMediaType(inputStream);
-            if (log.isDebugEnabled()) {
-                log.debug("Media Type of thumbnail to be uploaded : " + fileMediaType);
-            }
-            if (StringUtils.isBlank(fileMediaType)) {
-                RestApiUtil.handleBadRequest(
-                        "Media Type of provided thumbnail is not supported. Supported Media Types are "
-                                + RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES, log);
-            }
+            String fileMediaType = RestApiPublisherUtils.getMediaType(inputStream, fileDetail);
             PublisherCommonUtils.updateThumbnail(inputStream, fileMediaType, apiProvider, apiId, organization);
             String uriString = RestApiConstants.RESOURCE_PATH_THUMBNAIL.replace(RestApiConstants.APIID_PARAM, apiId);
             URI uri = new URI(uriString);
@@ -2611,7 +2600,7 @@ public class ApisApiServiceImpl implements ApisApiService {
                 String errorMessage = "Error while updating thumbnail of API : " + apiId;
                 RestApiUtil.handleInternalServerError(errorMessage, e, log);
             }
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException | IOException e) {
             String errorMessage = "Error while updating thumbnail of API: " + apiId;
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
         } finally {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -2588,8 +2588,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             }
             if (StringUtils.isBlank(fileMediaType)) {
                 RestApiUtil.handleBadRequest(
-                        "Media Type of provided thumbnail is not supported. Supported Media Types are image/jpeg, "
-                                + "image/png, image/gif and image/svg+xml", log);
+                        "Media Type of provided thumbnail is not supported. Supported Media Types are "
+                                + RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES, log);
             }
             PublisherCommonUtils.updateThumbnail(inputStream, fileMediaType, apiProvider, apiId, organization);
             String uriString = RestApiConstants.RESOURCE_PATH_THUMBNAIL.replace(RestApiConstants.APIID_PARAM, apiId);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -351,9 +351,11 @@ public class RestApiPublisherUtils {
                 if (log.isDebugEnabled()) {
                     log.debug("Detected Media Type during thumbnail content validation : " + fileMediaType);
                 }
-                if (StringUtils.isBlank(fileMediaType) || !RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES.contains(fileMediaType.toLowerCase())) {
+                if (StringUtils.isBlank(fileMediaType) || !RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES
+                        .contains(fileMediaType.toLowerCase())) {
                     RestApiUtil.handleBadRequest(
-                            "Media Type of provided thumbnail is not supported. Supported Media Types are " + RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES, log);
+                            "Media Type of provided thumbnail is not supported. Supported Media Types are image/jpeg, "
+                                    + "image/png, image/gif and image/svg+xml", log);
                 }
 
                 // Convert svg images to png. This is done to prevent scripts within svg images from executing.

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -349,7 +349,7 @@ public class RestApiPublisherUtils {
             if (StringUtils.isBlank(fileContentType) ||
                     !RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES.contains(fileContentType.toLowerCase())) {
                 RestApiUtil.handleBadRequest(
-                        "Thumbnail does not contain a supported Media Type. Supported Media Types are image/jpeg, "
+                        "Media Type of provided thumbnail is not supported. Supported Media Types are image/jpeg, "
                                 + "image/png, image/gif and image/svg+xml", log);
             }
 
@@ -363,7 +363,7 @@ public class RestApiPublisherUtils {
                 inputStream = new ByteArrayInputStream(outputStream.toByteArray());
             }
         } catch (TranscoderException | IOException e) {
-            throw new APIManagementException("Error while validating API thumbnail content", e);
+            throw new APIManagementException("Error while validating thumbnail content", e);
         } finally {
             IOUtils.closeQuietly(outputStream);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -352,8 +352,8 @@ public class RestApiPublisherUtils {
             if (StringUtils.isBlank(fileMediaType) ||
                     !RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES.contains(fileMediaType.toLowerCase())) {
                 RestApiUtil.handleBadRequest(
-                        "Media Type of provided thumbnail is not supported. Supported Media Types are image/jpeg, "
-                                + "image/png, image/gif and image/svg+xml", log);
+                        "Media Type of provided thumbnail is not supported. Supported Media Types are "
+                                + RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES, log);
             }
 
             // Convert svg images to png. This is done to prevent scripts within svg images from executing.

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -345,16 +345,16 @@ public class RestApiPublisherUtils {
 
             // Detect Media Type and validate.
             inputStream = new ByteArrayInputStream(inputStreamBytes);
-            String fileContentType = RestApiPublisherUtils.detectMediaType(inputStream);
-            if (StringUtils.isBlank(fileContentType) ||
-                    !RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES.contains(fileContentType.toLowerCase())) {
+            String fileMediaType = RestApiPublisherUtils.detectMediaType(inputStream);
+            if (StringUtils.isBlank(fileMediaType) ||
+                    !RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES.contains(fileMediaType.toLowerCase())) {
                 RestApiUtil.handleBadRequest(
                         "Media Type of provided thumbnail is not supported. Supported Media Types are image/jpeg, "
                                 + "image/png, image/gif and image/svg+xml", log);
             }
 
             // Convert svg images to png. This is done to prevent scripts within svg images from executing.
-            if (RestApiConstants.SVG_MEDIA_TYPE.equals(fileContentType)) {
+            if (RestApiConstants.SVG_MEDIA_TYPE.equals(fileMediaType)) {
                 outputStream = new ByteArrayOutputStream();
                 TranscoderInput input_svg_image = new TranscoderInput(inputStream);
                 TranscoderOutput output_png_image = new TranscoderOutput(outputStream);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -346,6 +346,9 @@ public class RestApiPublisherUtils {
             // Detect Media Type and validate.
             inputStream = new ByteArrayInputStream(inputStreamBytes);
             String fileMediaType = RestApiPublisherUtils.detectMediaType(inputStream);
+            if (log.isDebugEnabled()) {
+                log.debug("Detected Media Type during thumbnail content validation : " + fileMediaType);
+            }
             if (StringUtils.isBlank(fileMediaType) ||
                     !RestApiConstants.ALLOWED_THUMBNAIL_MEDIA_TYPES.contains(fileMediaType.toLowerCase())) {
                 RestApiUtil.handleBadRequest(
@@ -355,6 +358,7 @@ public class RestApiPublisherUtils {
 
             // Convert svg images to png. This is done to prevent scripts within svg images from executing.
             if (RestApiConstants.SVG_MEDIA_TYPE.equals(fileMediaType)) {
+                log.debug("Converting svg image to png format");
                 outputStream = new ByteArrayOutputStream();
                 TranscoderInput input_svg_image = new TranscoderInput(inputStream);
                 TranscoderOutput output_png_image = new TranscoderOutput(outputStream);

--- a/pom.xml
+++ b/pom.xml
@@ -1935,6 +1935,16 @@
                 <artifactId>org.wso2.carbon.logging.correlation</artifactId>
                 <version>${carbon.kernel.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.tika</groupId>
+                <artifactId>tika-core</artifactId>
+                <version>${tika.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-all</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -2211,5 +2221,7 @@
         <jinjava.version>2.5.6</jinjava.version>
         <h2.orbit.version>2.1.210.wso2v1</h2.orbit.version>
         <tomcat.version>9.0.53</tomcat.version>
+        <tika.version>2.7.0</tika.version>
+        <batik.version>1.16</batik.version>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
- Add Thumbnail Content Validation for API and API Products
- Related Issue: https://github.com/wso2/api-manager/issues/1280

## Goal
- Prevent files with invalid content to be uploaded as thumbnails for APIs and API Products

## Approach
- Used the Apache Tika dependency to detect the file media type using the input stream
- Validated the detected media type against the allowed media types (image/jpeg, image/png, image/gif, image/svg+xml)
- Converted svg media type images to png using the Apache Batik dependency