### PR TITLE
Fix NumberFormatException for swagger definitions with high value doubles

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.apimgt.impl;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -1139,11 +1141,10 @@ public abstract class AbstractAPIManager implements APIManager {
             api.setGraphQLSchema(getGraphqlSchemaDefinition(uuid, organization));
         }
 
-        JSONParser jsonParser = new JSONParser();
-        JSONObject paths = null;
+        JsonElement paths = null;
         if (resourceConfigsString != null) {
-            JSONObject resourceConfigsJSON = (JSONObject) jsonParser.parse(resourceConfigsString);
-            paths = (JSONObject) resourceConfigsJSON.get(APIConstants.SWAGGER_PATHS);
+            JsonObject resourceConfigsJSON = new Gson().fromJson(resourceConfigsString, JsonObject.class);
+            paths = resourceConfigsJSON.get(APIConstants.SWAGGER_PATHS);
         }
         Set<URITemplate> uriTemplates = apiMgtDAO.getURITemplatesOfAPI(api.getUuid());
         for (URITemplate uriTemplate : uriTemplates) {
@@ -1162,17 +1163,19 @@ public abstract class AbstractAPIManager implements APIManager {
             uriTemplate.setResourceSandboxURI(api.getSandboxUrl());
             // AWS Lambda: set arn & timeout to URI template
             if (paths != null) {
-                JSONObject path = (JSONObject) paths.get(uTemplate);
+                JsonElement path = paths.getAsJsonObject().get(uTemplate);
                 if (path != null) {
-                    JSONObject operation = (JSONObject) path.get(method.toLowerCase());
+                    JsonElement operation = path.getAsJsonObject().get(method.toLowerCase());
                     if (operation != null) {
-                        if (operation.containsKey(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME)) {
-                            uriTemplate.setAmznResourceName((String)
-                                    operation.get(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME));
+                        if (operation.getAsJsonObject().get(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME) != null) {
+                            uriTemplate.setAmznResourceName(
+                                    operation.getAsJsonObject().get(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME)
+                                            .toString());
                         }
-                        if (operation.containsKey(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT)) {
-                            uriTemplate.setAmznResourceTimeout(((Long)
-                                    operation.get(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT)).intValue());
+                        if (operation.getAsJsonObject().get(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT) != null) {
+                            uriTemplate.setAmznResourceTimeout(
+                                    operation.getAsJsonObject().get(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT)
+                                            .getAsInt());
                         }
                     }
                 }
@@ -1281,11 +1284,10 @@ public abstract class AbstractAPIManager implements APIManager {
             api.setGraphQLSchema(getGraphqlSchemaDefinition(uuid, organization));
         }
 
-        JSONParser jsonParser = new JSONParser();
-        JSONObject paths = null;
+        JsonElement paths = null;
         if (resourceConfigsString != null) {
-            JSONObject resourceConfigsJSON = (JSONObject) jsonParser.parse(resourceConfigsString);
-            paths = (JSONObject) resourceConfigsJSON.get(APIConstants.SWAGGER_PATHS);
+            JsonObject resourceConfigsJSON = new Gson().fromJson(resourceConfigsString, JsonObject.class);
+            paths = resourceConfigsJSON.get(APIConstants.SWAGGER_PATHS);
         }
         Set<URITemplate> uriTemplates = apiMgtDAO.getURITemplatesOfAPI(api.getUuid());
         for (URITemplate uriTemplate : uriTemplates) {
@@ -1304,17 +1306,19 @@ public abstract class AbstractAPIManager implements APIManager {
             uriTemplate.setResourceSandboxURI(api.getSandboxUrl());
             // AWS Lambda: set arn & timeout to URI template
             if (paths != null) {
-                JSONObject path = (JSONObject) paths.get(uTemplate);
+                JsonElement path = paths.getAsJsonObject().get(uTemplate);
                 if (path != null) {
-                    JSONObject operation = (JSONObject) path.get(method.toLowerCase());
+                    JsonElement operation = path.getAsJsonObject().get(method.toLowerCase());
                     if (operation != null) {
-                        if (operation.containsKey(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME)) {
-                            uriTemplate.setAmznResourceName((String)
-                                    operation.get(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME));
+                        if (operation.getAsJsonObject().get(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME) != null) {
+                            uriTemplate.setAmznResourceName(
+                                    operation.getAsJsonObject().get(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME)
+                                            .toString());
                         }
-                        if (operation.containsKey(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT)) {
-                            uriTemplate.setAmznResourceTimeout(((Long)
-                                    operation.get(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT)).intValue());
+                        if (operation.getAsJsonObject().get(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT) != null) {
+                            uriTemplate.setAmznResourceTimeout(
+                                    operation.getAsJsonObject().get(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT)
+                                            .getAsInt());
                         }
                     }
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import io.swagger.models.Path;
 import io.swagger.models.RefModel;
 import io.swagger.models.RefPath;
@@ -889,8 +891,7 @@ public class OASParserUtil {
         }
         APIDefinitionValidationResponse validationResponse = new APIDefinitionValidationResponse();
         try {
-            JSONParser parser = new JSONParser();
-            parser.parse(apiDefinitionProcessed); // Parsing the json content to validate parsing errors
+            new Gson().fromJson(apiDefinitionProcessed, JsonObject.class); // Parsing the json content to validate parsing errors
             apiDefinitionProcessed = removeUnsupportedBlocksFromResources(apiDefinitionProcessed);
             if (apiDefinitionProcessed != null) {
                 apiDefinition = apiDefinitionProcessed;


### PR DESCRIPTION
## Purpose

- Fix https://github.com/wso2/api-manager/issues/1446
- Fix NumberFormatException encountered when swagger contains high values for doubles

## Description

When a user try to create/update an API with large maximum values using swagger definition, it shows the following error message.

<img width="682" alt="Screenshot 2023-02-20 at 15 13 11" src="https://user-images.githubusercontent.com/55122994/220069771-5be4aa43-4ec5-433a-aec0-d26a53cd91a0.png">

Also following error was observed in the APIM server.

```
ERROR - ApisApiServiceImpl Error while parsing OpenAPI definition. Error code: 900754. Error: java.lang.NumberFormatException: For input string: "9223372036854776000"
```

It was identified that this was caused due to a limitation in `json-simple` library which was used to parse the swagger content. In this PR `json-simple` usages were replaced by `gson` as the fix.