### PR TITLE
Fix NPE when invoking GraphQL subscriptions with invalid scope token when analytics enabled

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/FaultCodeClassifier.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/FaultCodeClassifier.java
@@ -69,7 +69,7 @@ public class FaultCodeClassifier {
         case APISecurityConstants.SUBSCRIPTION_INACTIVE:
             return FaultSubCategories.Authentication.SUBSCRIPTION_VALIDATION_FAILURE;
         default:
-            return FaultSubCategories.TargetConnectivity.OTHER;
+            return FaultSubCategories.Authentication.OTHER;
         }
     }
 


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/1487