### PR TITLE
Fix business owner details not showing in dev portal

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -3909,6 +3909,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                         api.setContext(publiserAPI.getContext());
                         api.setContextTemplate(publiserAPI.getContext());
                         api.setStatus(publiserAPI.getStatus());
+                        api.setBusinessOwner(publiserAPI.getBusinessOwner());
                         api.setRating(0);// need to retrieve from db
                         apiSet.add(api);
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
@@ -1402,6 +1402,7 @@ public class RegistryPersistenceUtil {
             api.setApiName(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_NAME));
             api.setProviderName(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_PROVIDER));
             api.setVersion(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_VERSION));
+            api.setBusinessOwner(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER));
 
         } catch (GovernanceException e) {
             throw new APIPersistenceException("Error while extracting api attributes ", e);


### PR DESCRIPTION
## Purpose

- Fix https://github.com/wso2/api-manager/issues/1502
- Set business owner name for APIs when getting API details for dev portal

## Description

When a user add Business owner name to an API, in the dev-portal API listing page it should be displayed instead of the provider name. However, when users try to use the search function it did not display Business owner name even though it was provided by the publisher. 