### PR TITLE
ThrottlingLimit unit value change for rate-limits

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/ThrottlingLimitDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/ThrottlingLimitDTO.java
@@ -25,10 +25,10 @@ public class ThrottlingLimitDTO   {
     @XmlType(name="UnitEnum")
     @XmlEnum(String.class)
     public enum UnitEnum {
-        SECOND("Second"),
-        MINUTE("Minute"),
-        HOUR("Hour"),
-        DAY("Day");
+        SECOND("SECOND"),
+        MINUTE("MINUTE"),
+        HOUR("HOUR"),
+        DAY("DAY");
         private String value;
 
         UnitEnum (String v) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -11644,10 +11644,10 @@ components:
         unit:
           type: string
           enum:
-            - Second
-            - Minute
-            - Hour
-            - Day
+            - SECOND
+            - MINUTE
+            - HOUR
+            - DAY
   responses:
     BadRequest:
       description: Bad Request. Invalid request or validation error.


### PR DESCRIPTION
With this PR, unit value Enums in the throttling limit converts to the upper-case.

Related PRs:

- https://github.com/wso2/carbon-apimgt/pull/11760
- https://github.com/wso2/carbon-apimgt/pull/11785