### PR TITLE
Add the missing enduser name to msgContext property

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/apikey/ApiKeyAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/apikey/ApiKeyAuthenticator.java
@@ -400,6 +400,7 @@ public class ApiKeyAuthenticator implements Authenticator {
                         .generateAuthenticationContext(tokenIdentifier, payload, api, getApiLevelPolicy(),
                                 endUserToken, synCtx);
                 APISecurityUtils.setAuthenticationContext(synCtx, authenticationContext, contextHeader);
+                synCtx.setProperty(APIMgtGatewayConstants.END_USER_NAME, authenticationContext.getUsername());
                 if (log.isDebugEnabled()) {
                     log.debug("User is authorized to access the resource using Api Key.");
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/InternalAPIKeyAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/InternalAPIKeyAuthenticator.java
@@ -243,6 +243,7 @@ public class InternalAPIKeyAuthenticator implements Authenticator {
 
                     AuthenticationContext authenticationContext = GatewayUtils
                             .generateAuthenticationContext(tokenIdentifier, payload, api, retrievedApi.getApiTier());
+                    synCtx.setProperty(APIMgtGatewayConstants.END_USER_NAME, authenticationContext.getUsername());
                     APISecurityUtils.setAuthenticationContext(synCtx, authenticationContext);
                     if (log.isDebugEnabled()) {
                         log.debug("User is authorized to access the resource using Internal Key.");

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/MutualSSLAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/MutualSSLAuthenticator.java
@@ -24,6 +24,7 @@ import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.Utils;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityException;
@@ -190,6 +191,7 @@ public class MutualSSLAuthenticator implements Authenticator {
             log.debug("Auth context for the API " + getAPIIdentifier(messageContext) + ": Username[" + authContext
                     .getUsername() + "APIKey[(" + authContext.getApiKey() + "] Tier[" + authContext.getTier() + "]");
         }
+        messageContext.setProperty(APIMgtGatewayConstants.END_USER_NAME, authContext.getUsername());
         APISecurityUtils.setAuthenticationContext(messageContext, authContext, null);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticator.java
@@ -234,6 +234,7 @@ public class BasicAuthAuthenticator implements Authenticator {
                     authContext.setConsumerKey(null);
                     authContext.setApiTier(apiLevelPolicy);
                     APISecurityUtils.setAuthenticationContext(synCtx, authContext, null);
+                    synCtx.setProperty(APIMgtGatewayConstants.END_USER_NAME, authContext.getUsername());
                 }
                 log.debug("Basic Authentication: Scope validation passed");
                 return new AuthenticationResponse(true, isMandatory, false, 0, null);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticatorTest.java
@@ -56,12 +56,11 @@ public class BasicAuthAuthenticatorTest {
         PowerMockito.when(OpenAPIUtils.getResourceAuthenticationScheme(Mockito.any(), Mockito.any()))
                 .thenReturn(APIConstants.AUTH_APPLICATION_OR_USER_LEVEL_TOKEN);
 
-        messageContext = Mockito.mock(Axis2MessageContext.class);
         axis2MsgCntxt = Mockito.mock(org.apache.axis2.context.MessageContext.class);
-        Mockito.when(axis2MsgCntxt.getProperty(APIMgtGatewayConstants.REQUEST_RECEIVED_TIME)).thenReturn("1506576365");
-        Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
-        Mockito.when((messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_OBJECT)))
-                .thenReturn(Mockito.mock(OpenAPI.class));
+        messageContext = new Axis2MessageContext(axis2MsgCntxt, null,null);
+        messageContext.setProperty(APIMgtGatewayConstants.REQUEST_RECEIVED_TIME,"1506576365");
+        messageContext.setProperty(APIMgtGatewayConstants.OPEN_API_OBJECT, Mockito.mock(OpenAPI.class));
+        messageContext.setProperty(BasicAuthAuthenticator.PUBLISHER_TENANT_DOMAIN, "carbon.super");
 
         basicAuthAuthenticator = new BasicAuthAuthenticator(CUSTOM_AUTH_HEADER, true, UNLIMITED_THROTTLE_POLICY);
         BasicAuthCredentialValidator basicAuthCredentialValidator = Mockito.mock(BasicAuthCredentialValidator.class);
@@ -100,8 +99,6 @@ public class BasicAuthAuthenticatorTest {
             return false;
         });
         PowerMockito.whenNew(BasicAuthCredentialValidator.class).withNoArguments().thenReturn(basicAuthCredentialValidator);
-        Mockito.when(messageContext.getProperty(BasicAuthAuthenticator.PUBLISHER_TENANT_DOMAIN)).
-                thenReturn("carbon.super");
 
         PowerMockito.mockStatic(ServiceReferenceHolder.class);
         ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
@@ -177,6 +174,7 @@ public class BasicAuthAuthenticatorTest {
         Assert.assertTrue(basicAuthAuthenticator.authenticate(messageContext).isAuthenticated());
         transportHeaders = (TreeMap) axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
         Assert.assertNull(transportHeaders.get(CUSTOM_AUTH_HEADER));
+        Assert.assertEquals(messageContext.getProperty(APIMgtGatewayConstants.END_USER_NAME),"test_username@carbon.super");
     }
 
     @Test


### PR DESCRIPTION
Set the message context properly `api.ut.userName` for missing authenticators.

Resolves: https://github.com/wso2/api-manager/issues/1482