### PR TITLE
Bump wso2-synapse version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2042,7 +2042,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>4.0.0-wso2v13</synapse.version>
+        <synapse.version>4.0.0-wso2v18</synapse.version>
 
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 


### PR DESCRIPTION
## Purpose

This PR bumps `wso2-synapse` version to `4.0.0-wso2v18` which contains the fix for https://github.com/wso2/api-manager/issues/1219.