### PR TITLE
Add the unlimited throttle tier for soap operations

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -224,7 +224,8 @@ public class RestApiPublisherUtils {
         return "{\"/*\":{\"post\":{\"parameters\":[{\"schema\":{\"type\":\"string\"},\"description\":\"SOAP request.\","
             + "\"name\":\"SOAP Request\",\"required\":true,\"in\":\"body\"},"
                 + "{\"description\":\"SOAPAction header for soap 1.1\",\"name\":\"SOAPAction\",\"type\":\"string\","
-                + "\"required\":false,\"in\":\"header\"}],\"responses\":{\"200\":{\"description\":\"OK\"}}," +
+                + "\"required\":false,\"in\":\"header\"}], \"x-throttling-tier\": \"Unlimited\", " +
+                "\"responses\":{\"200\":{\"description\":\"OK\"}}," +
                 "\"security\":[{\"default\":[]}],\"consumes\":[\"text/xml\",\"application/soap+xml\"]}}}";
     }
 


### PR DESCRIPTION
The unlimited tier is default set to all the operations since wso2/carbon-apimgt#11710.
This PR will set this to the soap operation

Address: https://github.com/wso2/api-manager/issues/1524