### PR TITLE
Bug fix: Populate x-throttle-limit extension with default  throttle limit for operations based on x-throttling-tier

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -872,6 +872,12 @@ public class OAS2Parser extends APIDefinition {
             for (Map.Entry<HttpMethod, Operation> entry : operationMap.entrySet()) {
                 Operation operation = entry.getValue();
                 operation.setVendorExtension(APIConstants.X_WSO2_APP_SECURITY, appSecurityExtension);
+                if (!operation.getVendorExtensions().containsKey(APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
+                    // set default throttling limit if not defined for operation in openapi definition. This is expected
+                    // from the choreo console.
+                    operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT,
+                            APIUtil.getDefaultThrottleLimit());
+                }
             }
         }
         swagger.setVendorExtension(APIConstants.X_WSO2_APP_SECURITY, appSecurityExtension);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -75,6 +75,7 @@ import org.wso2.carbon.apimgt.api.model.SwaggerData;
 import org.wso2.carbon.apimgt.api.model.ThrottlingLimit;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.api.model.endpointurlextractor.EndpointUrl;
+import org.wso2.carbon.apimgt.api.util.ModelUtil;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIEndpointUrlExtractorManager;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
@@ -863,8 +864,8 @@ public class OAS2Parser extends APIDefinition {
                 swagger.setVendorExtension(APIConstants.X_WSO2_MUTUAL_SSL, mutualSSLOptional);
             }
         }
-        // This app security is should given in resource level,
-        // otherwise the default oauth2 scheme defined at each resouce level will override application securities
+        // This app security should be given in resource level,
+        // otherwise the default oauth2 scheme defined at each resource level will override application securities
         JsonNode appSecurityExtension = OASParserUtil.getAppSecurity(apiSecurity);
         for (String pathKey : swagger.getPaths().keySet()) {
             Path path = swagger.getPath(pathKey);
@@ -872,11 +873,15 @@ public class OAS2Parser extends APIDefinition {
             for (Map.Entry<HttpMethod, Operation> entry : operationMap.entrySet()) {
                 Operation operation = entry.getValue();
                 operation.setVendorExtension(APIConstants.X_WSO2_APP_SECURITY, appSecurityExtension);
+                // If throttling limit remains unassigned in the swagger definition, the throttling-tier property
+                // will be used to generate the limit. If throttling-tier is also not defined, the default tier would
+                // be unlimited tier.
                 if (!operation.getVendorExtensions().containsKey(APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
-                    // set default throttling limit if not defined for operation in openapi definition. This is expected
-                    // from the choreo console.
+                    String tier = operation.getVendorExtensions().containsKey(APIConstants.SWAGGER_X_THROTTLING_TIER) ?
+                            (String) operation.getVendorExtensions().get(APIConstants.SWAGGER_X_THROTTLING_TIER) :
+                            APIConstants.UNLIMITED_TIER;
                     operation.setVendorExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT,
-                            APIUtil.getDefaultThrottleLimit());
+                            ModelUtil.generateThrottlingLimitFromThrottlingTier(tier));
                 }
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -960,6 +960,11 @@ public class OAS3Parser extends APIDefinition {
             for (Map.Entry<PathItem.HttpMethod, Operation> entry : pathItem.readOperationsMap().entrySet()) {
                 Operation operation = entry.getValue();
                 operation.addExtension(APIConstants.X_WSO2_APP_SECURITY, appSecurityExtension);
+                // set default throttling limit if not defined for operation in openapi definition. This is expected
+                // from the choreo console.
+                if (!operation.getExtensions().containsKey(APIConstants.SWAGGER_X_THROTTLING_LIMIT)) {
+                    operation.addExtension(APIConstants.SWAGGER_X_THROTTLING_LIMIT, APIUtil.getDefaultThrottleLimit());
+                }
             }
         }
         openAPI.addExtension(APIConstants.X_WSO2_RESPONSE_CACHE,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS2ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS2ParserTest.java
@@ -154,7 +154,7 @@ public class OAS2ParserTest extends OASTestBase {
 
     @Test
     public void getOASDefinitionForPublisher() throws Exception {
-        String relativePath = "definitions" + File.separator + "petstore_v2.yaml";
+        String relativePath = "definitions" + File.separator + "petstore_v2_throttle_limit.yaml";
         String swagger = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(relativePath),
                 "UTF-8");
         API api = Mockito.mock(API.class);
@@ -178,5 +178,15 @@ public class OAS2ParserTest extends OASTestBase {
         Gson gson = new Gson();
         JsonObject jsonObject = gson.toJsonTree(limitObject).getAsJsonObject();
         Assert.assertEquals("requestCount Mismatched", -1, jsonObject.get("requestCount").getAsInt());
+
+        Assert.assertNotNull(parsedSwagger.getPaths().get("/pets").getGet());
+        Assert.assertNotNull(parsedSwagger.getPaths().get("/pets").getGet().getVendorExtensions());
+        Assert.assertNotNull(parsedSwagger.getPaths().get("/pets").getGet().getVendorExtensions()
+                .get(APIConstants.SWAGGER_X_THROTTLING_LIMIT));
+        limitObject = parsedSwagger.getPaths().get("/pets").getGet().getVendorExtensions()
+                .get(APIConstants.SWAGGER_X_THROTTLING_LIMIT);
+        jsonObject = gson.toJsonTree(limitObject).getAsJsonObject();
+        Assert.assertEquals("requestCount Mismatched", 10000, jsonObject.get("requestCount").getAsInt());
+        Assert.assertEquals("timeUnit Mismatched", "MINUTE", jsonObject.get("unit").getAsString());
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS3ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS3ParserTest.java
@@ -146,7 +146,7 @@ public class OAS3ParserTest extends OASTestBase {
 
     @Test
     public void getOASDefinitionForPublisher() throws Exception {
-        String relativePath = "definitions" + File.separator + "petstore_v3.yaml";
+        String relativePath = "definitions" + File.separator + "petstore_v3_throttle_limit.yaml";
         String swagger = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(relativePath),
                 "UTF-8");
         API api = Mockito.mock(API.class);
@@ -170,6 +170,15 @@ public class OAS3ParserTest extends OASTestBase {
         Gson gson = new Gson();
         JsonObject jsonObject = gson.toJsonTree(limitObject).getAsJsonObject();
         Assert.assertEquals("requestCount Mismatched", -1, jsonObject.get("requestCount").getAsInt());
-    }
 
+        Assert.assertNotNull(parsedSwagger.getPaths().get("/pets").getGet());
+        Assert.assertNotNull(parsedSwagger.getPaths().get("/pets").getGet().getExtensions());
+        Assert.assertNotNull(parsedSwagger.getPaths().get("/pets").getGet().getExtensions()
+                .get(APIConstants.SWAGGER_X_THROTTLING_LIMIT));
+        limitObject = parsedSwagger.getPaths().get("/pets").getGet().getExtensions()
+                .get(APIConstants.SWAGGER_X_THROTTLING_LIMIT);
+        jsonObject = gson.toJsonTree(limitObject).getAsJsonObject();
+        Assert.assertEquals("requestCount Mismatched", 10000, jsonObject.get("requestCount").getAsInt());
+        Assert.assertEquals("timeUnit Mismatched", "MINUTE", jsonObject.get("unit").getAsString());
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/petstore_v2_throttle_limit.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/petstore_v2_throttle_limit.yaml
@@ -1,0 +1,104 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: /v1
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      x-throttling-tier: 10KPerMin
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: A paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    type: "object"
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      $ref: '#/definitions/Pet'
+  Error:
+    type: "object"
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/petstore_v3_throttle_limit.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/petstore_v3_throttle_limit.yaml
@@ -1,0 +1,131 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          explode: true
+          style: form
+          required: false
+          schema:
+            type: integer
+            format: int32
+      x-auth-type: Application & Application User
+      x-throttling-tier: 10KPerMin
+      x-scope: testscope
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              explode: false
+              style: simple
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:    
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          explode: false
+          style: simple
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+x-wso2-security:
+  apim:
+    x-wso2-scopes:
+      - name: testscope
+        description: ''
+        key: testscope
+        roles: admin
+      - name: testscope1
+        description: ''
+        key: testscope1
+        roles: admin
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
populate x-throttle-limit extension (using -1 for request count which indicates the unlimited policy) for all the operations in the swagger, if the operations does not have the extension.

P.S.
Correct approach would be process the x-throttling-tier to generate the x-throttling-limit when the operation has that property.