### PR TITLE
Engaging cors_request_handler sequence in the web socket cors flow

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -889,6 +889,8 @@ public final class APIConstants {
     public static final String CORS_CONFIGURATION = "CORSConfiguration.";
     public static final String CORS_CONFIGURATION_ENABLED = CORS_CONFIGURATION + "Enabled";
     public static final String CORS_CONFIGURATION_ENABLE_VALIDATION_FOR_WS = CORS_CONFIGURATION + "EnableValidationForWS";
+    public static final String WS_ORIGIN = "WSOrigin";
+    public static final String WS_CORS_ORIGIN_SUCCESS = "WSCORSOriginSuccess";
     public static final String CORS_CONFIGURATION_ACCESS_CTL_ALLOW_ORIGIN = CORS_CONFIGURATION
             + "Access-Control-Allow-Origin";
     public static final String CORS_CONFIGURATION_ACCESS_CTL_ALLOW_HEADERS = CORS_CONFIGURATION


### PR DESCRIPTION
Engaging the cors_request_handler.xml file for web socket APIs flow only if the product level cors validation failed.
Unified solution for both REST API flow and web socket flow to update the origin header values in the cors_request_handler.xml. With this PR we can support the cors sequence for web socket flow. It paves a way to engage the cors_request_handler.xml sequence in the web socket flow and it will be triggered when the default cors validation of the product fails. If the normal cors validation(Including the deployment.toml configs and UI level origin addition) is succeeded, we do not need to engage this sequence in that flow.But, if the above default cors validation fails,
 then we can engage the cors_request_handler.xml sequence in the web socket
flow to do an additional validation where we are going to maintain a boolean property to return a value. If the value is returned from the sequence as false, then we will proceed with handle cors failure method. Since it is a cors validation failure scenario, we kept the value as false by default. But, if the value is changed to true in the mediation, then the cors validation will be succeeded and it will proceed with the request.

Fixes: https://github.com/wso2/api-manager/issues/1484