### PR TITLE
Bug fix: Avoid NPE when the x-throttling-tier value is null.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/util/ModelUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/util/ModelUtil.java
@@ -34,6 +34,10 @@ public class ModelUtil {
     public static String generateThrottlePolicyFromThrottleLimit(ThrottlingLimit throttlingLimit) {
         String requestCount;
         String shortenerSuffix = "";
+        // Since it is a utility method, it is better to check for null values
+        if (throttlingLimit == null) {
+            return APIConstants.UNLIMITED_TIER;
+        }
         if (throttlingLimit.getRequestCount() == -1)
             return APIConstants.UNLIMITED_TIER;
         if (throttlingLimit.getRequestCount() % 100000 == 0) {
@@ -65,6 +69,13 @@ public class ModelUtil {
     public static ThrottlingLimit generateThrottlingLimitFromThrottlingTier(String throttlingTierStr) {
         ThrottlingLimit throttlingLimit = new ThrottlingLimit();
         throttlingLimit.setUnit("MINUTE");
+        // If the tier is null or empty, then the default value is unlimited
+        // Since this is a utility method, and it is required to avoid null pointer exception if a null
+        // object is provided as a parameter.
+        if (throttlingTierStr == null) {
+            throttlingLimit.setRequestCount(-1);
+            return throttlingLimit;
+        }
         switch (throttlingTierStr) {
             case "10KPerMin":
                 throttlingLimit.setRequestCount(10000);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS2ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS2ParserTest.java
@@ -188,5 +188,17 @@ public class OAS2ParserTest extends OASTestBase {
         jsonObject = gson.toJsonTree(limitObject).getAsJsonObject();
         Assert.assertEquals("requestCount Mismatched", 10000, jsonObject.get("requestCount").getAsInt());
         Assert.assertEquals("timeUnit Mismatched", "MINUTE", jsonObject.get("unit").getAsString());
+
+        // Swagger Parser for v2 does not keep the null valued extensions. Still added the test
+        // to make sure that the behavior does not change
+        Assert.assertNotNull(parsedSwagger.getPaths().get("/pets").getPost());
+        Assert.assertNotNull(parsedSwagger.getPaths().get("/pets").getPost().getVendorExtensions());
+        Assert.assertNotNull(parsedSwagger.getPaths().get("/pets").getPost().getVendorExtensions()
+                .get(APIConstants.SWAGGER_X_THROTTLING_LIMIT));
+        limitObject = parsedSwagger.getPaths().get("/pets").getPost().getVendorExtensions()
+                .get(APIConstants.SWAGGER_X_THROTTLING_LIMIT);
+        jsonObject = gson.toJsonTree(limitObject).getAsJsonObject();
+        Assert.assertEquals("requestCount Mismatched", -1, jsonObject.get("requestCount").getAsInt());
+        Assert.assertEquals("timeUnit Mismatched", "MINUTE", jsonObject.get("unit").getAsString());
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS3ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS3ParserTest.java
@@ -180,5 +180,15 @@ public class OAS3ParserTest extends OASTestBase {
         jsonObject = gson.toJsonTree(limitObject).getAsJsonObject();
         Assert.assertEquals("requestCount Mismatched", 10000, jsonObject.get("requestCount").getAsInt());
         Assert.assertEquals("timeUnit Mismatched", "MINUTE", jsonObject.get("unit").getAsString());
+
+        Assert.assertNotNull(parsedSwagger.getPaths().get("/pets").getPost());
+        Assert.assertNotNull(parsedSwagger.getPaths().get("/pets").getPost().getExtensions());
+        Assert.assertNotNull(parsedSwagger.getPaths().get("/pets").getPost().getExtensions()
+                .get(APIConstants.SWAGGER_X_THROTTLING_LIMIT));
+        limitObject = parsedSwagger.getPaths().get("/pets").getPost().getExtensions()
+                .get(APIConstants.SWAGGER_X_THROTTLING_LIMIT);
+        jsonObject = gson.toJsonTree(limitObject).getAsJsonObject();
+        Assert.assertEquals("requestCount Mismatched", -1, jsonObject.get("requestCount").getAsInt());
+        Assert.assertEquals("timeUnit Mismatched", "MINUTE", jsonObject.get("unit").getAsString());
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/petstore_v2_throttle_limit.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/petstore_v2_throttle_limit.yaml
@@ -43,6 +43,7 @@ paths:
     post:
       summary: Create a pet
       operationId: createPets
+      x-throttling-tier: null
       tags:
         - pets
       responses:

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/petstore_v3_throttle_limit.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/petstore_v3_throttle_limit.yaml
@@ -49,6 +49,7 @@ paths:
     post:
       summary: Create a pet
       operationId: createPets
+      x-throttling-tier: null
       tags:
         - pets
       responses:


### PR DESCRIPTION
bug fix: In openapi v3 scenario, if the already existing api openapi definition contains the x-throttling-tier extension but the value is null, then it would result in a Null pointer error, with this fix, if the x-throttling-tier is null, it is considered as Unlimited