### PR TITLE
Fix default response content missing from generated mock scripts

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -196,6 +196,33 @@ public class OAS3Parser extends APIDefinition {
                                 hasXmlPayload = true;
                             }
                         }
+                    } else {
+                        Content content = op.getResponses().get(responseEntry).getContent();
+                        if (content != null) {
+                            MediaType applicationJson = content.get(APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+                            MediaType applicationXml = content.get(APIConstants.APPLICATION_XML_MEDIA_TYPE);
+                            if (applicationJson != null) {
+                                Schema jsonSchema = applicationJson.getSchema();
+                                if (jsonSchema != null) {
+                                    String jsonExample = getJsonExample(jsonSchema, definitions);
+                                    genCode.append(getGeneratedResponsePayloads(responseEntry, jsonExample, "json", false));
+                                    respCodeInitialized = true;
+                                    hasJsonPayload = true;
+                                }
+                            }
+                            if (applicationXml != null) {
+                                Schema xmlSchema = applicationXml.getSchema();
+                                if (xmlSchema != null) {
+                                    String xmlExample = getXmlExample(xmlSchema, definitions);
+                                    genCode.append(getGeneratedResponsePayloads(responseEntry, xmlExample, "xml", respCodeInitialized));
+                                    hasXmlPayload = true;
+                                }
+                            }
+                        } else {
+                            setDefaultGeneratedResponse(genCode, responseEntry);
+                            hasJsonPayload = true;
+                            hasXmlPayload = true;
+                        }
                     }
                 }
                 //inserts minimum response code and mock payload variables to static script


### PR DESCRIPTION
## Purpose

- Fix https://github.com/wso2/api-manager/issues/1578

## Description

- Mock scripts were not generated for API resource paths with only `default` response in the OAS3 definition. This caused an error while deploying these APIs to the gateway. 
- Related PRs: https://github.com/wso2/carbon-apimgt/pull/11492