### PR TITLE
Fix for #19316

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -8337,7 +8337,7 @@ components:
           readOnly: true
           example: 01234567-0123-0123-0123-012345678901
         name:
-          maxLength: 60
+          maxLength: 53
           minLength: 1
           pattern: '(^[^~!@#;:%^*()+={}|\\<>"'',&$\[\]\/]*$)'
           type: string


### PR DESCRIPTION
fixes https://github.com/wso2-enterprise/choreo/issues/19316

The maximum length allowed for a application name is 100. And the maximum length allowed for a API name is 60.

When creating the default application for an API in devportal, it appends a prefix such as `_internal_9c243369-29b5-4e11-844a-05aef97eca49_` to the api name and create the application name. This prefix contains 47 characters. Therefore, if we create an API with a name containing 60 characters, the default application name will exceed 100 characters(47 for the prefix + 60 character api name). Ex: `_internal_9c243369-29b5-4e11-844a-05aef97eca49_Rest API proxy for check the asgardeo key manager int1`

Increasing the maximum length of application name will require database updates in all 3 environments in Choreo since we have defined the application name column size as `VARCHAR(100)` in [DB script](https://github.com/wso2/carbon-apimgt/blob/master/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/sql/mssql.sql#L1651)

Therefore decreasing the maximum length of the API name will be a quick fix for this issue.