### PR TITLE
Avoid concurrent issues in registry during high traffic

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -169,6 +169,10 @@
             <artifactId>org.wso2.carbon.rest.api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.mediation</groupId>
+            <artifactId>org.wso2.carbon.application.mgt.synapse</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-kernel</artifactId>
         </dependency>
@@ -463,6 +467,7 @@
                             org.wso2.carbon.sequences.stub.types,
                             org.wso2.carbon.localentry.stub.*,
                             org.wso2.carbon.context,
+                            org.wso2.carbon.application.mgt.synapse.*; version="${carbon.mediation.imp.pkg.version}",
                             org.wso2.carbon.mediation.*; version="${carbon.mediation.imp.pkg.version}",
                             org.wso2.carbon.apimgt.tracing.*; version="${carbon.apimgt.imp.pkg.version}",
                             org.wso2.orbit.re2j.*; version="${re2j.version}",

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
@@ -57,6 +57,7 @@ import org.wso2.carbon.core.ServerShutdownHandler;
 import org.wso2.carbon.core.ServerStartupObserver;
 import org.wso2.carbon.endpoint.service.EndpointAdmin;
 import org.wso2.carbon.localentry.service.LocalEntryAdmin;
+import org.wso2.carbon.mediation.initializer.services.SynapseConfigurationService;
 import org.wso2.carbon.mediation.security.vault.MediationSecurityAdminService;
 import org.wso2.carbon.rest.api.service.RestApiAdmin;
 import org.wso2.carbon.sequences.services.SequenceAdmin;
@@ -484,6 +485,24 @@ public class APIHandlerServiceComponent {
 
         }
         return jedisPool;
+    }
+
+    @Reference(
+            name = "application.mgt.synapse.dscomponent",
+            service = SynapseConfigurationService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetSynapseConfigurationService")
+    protected void setSynapseConfigurationService(SynapseConfigurationService synapseConfigurationService) {
+
+        log.debug("Setting SynapseConfigurationService");
+        ServiceReferenceHolder.getInstance().setSynapseConfigurationService(synapseConfigurationService);
+    }
+
+    protected void unsetSynapseConfigurationService(SynapseConfigurationService synapseConfigurationService) {
+
+        log.debug("Un-setting SynapseConfigurationService");
+        ServiceReferenceHolder.getInstance().setSynapseConfigurationService(null);
     }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/ServiceReferenceHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/ServiceReferenceHolder.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.endpoint.service.EndpointAdmin;
 import org.wso2.carbon.localentry.service.LocalEntryAdmin;
+import org.wso2.carbon.mediation.initializer.services.SynapseConfigurationService;
 import org.wso2.carbon.mediation.security.vault.MediationSecurityAdminService;
 import org.wso2.carbon.rest.api.service.RestApiAdmin;
 import org.wso2.carbon.sequences.services.SequenceAdmin;
@@ -88,6 +89,7 @@ public class ServiceReferenceHolder {
     private CacheInvalidationService cacheInvalidationService;
     private RevokedTokenService revokedTokenService;
     private APIThrottleDataService throttleDataService;
+    private SynapseConfigurationService synapseConfigurationService;
     private Certificate publicCert;
     private PrivateKey privateKey;
 
@@ -437,5 +439,13 @@ public class ServiceReferenceHolder {
                 log.error("Error in obtaining custom publisher class", e);
             }
         }
+    }
+
+    public SynapseConfigurationService getSynapseConfigurationService() {
+        return synapseConfigurationService;
+    }
+
+    public void setSynapseConfigurationService(SynapseConfigurationService synapseConfigurationService) {
+        this.synapseConfigurationService = synapseConfigurationService;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1698,6 +1698,11 @@
                 <version>${carbon.mediation.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.mediation</groupId>
+                <artifactId>org.wso2.carbon.application.mgt.synapse</artifactId>
+                <version>${carbon.mediation.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.json.wso2</groupId>
                 <artifactId>json</artifactId>
                 <version>${json.orbit.version}</version>


### PR DESCRIPTION
$subject

When API redeployment, and API invocation are occuring in parallel, both threads are trying to create Endpoint objects in the SynapseConfiguration registry. We need to synchronize the API undeployment and deployment part on SynapseConfiguration object, to avoid this issue. Hence we are registering the SynapseConfigurationService in Gateway and synchoronizing the thread based on the SynapseConfiguration object.

<img width="1074" alt="Screenshot 2023-03-16 at 13 05 28" src="https://user-images.githubusercontent.com/17047910/225546776-5690e738-b2e8-4c1b-97d9-90d627fea098.png">

Resolves https://github.com/wso2/api-manager/issues/1538