### PR TITLE
Fix the Documentation Visibility Feature

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1682,6 +1682,8 @@ public final class APIConstants {
     public static final String REST_API_SCOPES_CONFIG = "RESTAPIScopes";
     public static final String REST_API_ROLE_MAPPINGS_CONFIG = "RoleMappings";
     public static final String APIM_SUBSCRIBE_SCOPE = "apim:subscribe";
+    public static final String APIM_CREATOR_SCOPE = "apim:api_create";
+    public static final String APIM_PUBLISHER_SCOPE = "apim:api_publish";
 
     public static final String HTTPS_PROTOCOL = "https";
     public static final String HTTPS_PROTOCOL_URL_PREFIX = "https://";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -443,7 +443,7 @@ public abstract class AbstractAPIManager implements APIManager {
                 validDoc = true;
             }
         } else if (APIConstants.DOC_SHARED_VISIBILITY.equals(String.valueOf(doc.getVisibility()))) {
-            if (APIConstants.WSO2_ANONYMOUS_USER != username) {
+            if (APIConstants.WSO2_ANONYMOUS_USER != username && !isTenantDomainNotMatching(requestedTenantDomain)) {
                 try {
                     if (validatePrivateScopes(username, loggedInTenantDomain)) {
                         validDoc = true;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -54,9 +54,7 @@ import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
 import org.wso2.carbon.apimgt.impl.factory.PersistenceFactory;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.notifier.events.ApplicationEvent;
-import org.wso2.carbon.apimgt.impl.utils.APINameComparator;
-import org.wso2.carbon.apimgt.impl.utils.APIUtil;
-import org.wso2.carbon.apimgt.impl.utils.TierNameComparator;
+import org.wso2.carbon.apimgt.impl.utils.*;
 import org.wso2.carbon.apimgt.impl.workflow.WorkflowStatus;
 import org.wso2.carbon.apimgt.persistence.APIPersistence;
 import org.wso2.carbon.apimgt.persistence.dto.*;
@@ -66,6 +64,7 @@ import org.wso2.carbon.apimgt.persistence.mapper.DocumentMapper;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.user.api.TenantManager;
+import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -176,6 +175,13 @@ public abstract class AbstractAPIManager implements APIManager {
         apiMgtDAO.setDefaultVersion(api);
     }
 
+    private boolean isTenantDomainNotMatching(String tenantDomain) {
+
+        if (this.tenantDomain != null) {
+            return !(this.tenantDomain.equals(tenantDomain));
+        }
+        return true;
+    }
 
 
     /**
@@ -294,29 +300,87 @@ public abstract class AbstractAPIManager implements APIManager {
     public List<Documentation> getAllDocumentation(String uuid, String organization) throws APIManagementException {
 
         String username = CarbonContext.getThreadLocalCarbonContext().getUsername();
-
         Organization org = new Organization(organization);
         UserContext ctx = new UserContext(username, org, null, null);
         List<Documentation> convertedList = null;
+        boolean isDocVisibilityEnabled = Boolean.parseBoolean(
+                ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration()
+                        .getFirstProperty(APIConstants.API_PUBLISHER_ENABLE_API_DOC_VISIBILITY_LEVELS));
         try {
             DocumentSearchResult list =
                     apiPersistenceInstance.searchDocumentation(org, uuid, 0, 0, null, ctx);
             if (list != null) {
                 convertedList = new ArrayList<Documentation>();
+                List<Documentation> privateDocs = new ArrayList<Documentation>();
                 List<org.wso2.carbon.apimgt.persistence.dto.Documentation> docList = list.getDocumentationList();
                 if (docList != null) {
                     for (int i = 0; i < docList.size(); i++) {
-                        convertedList.add(DocumentMapper.INSTANCE.toDocumentation(docList.get(i)));
+                        if (!isDocVisibilityEnabled) {
+                            convertedList.add(DocumentMapper.INSTANCE.toDocumentation(docList.get(i)));
+                        } else {
+                            org.wso2.carbon.apimgt.persistence.dto.Documentation doc = docList.get(i);
+                            if (APIConstants.DOC_API_BASED_VISIBILITY.equals(String.valueOf(doc.getVisibility()))) {
+                                convertedList.add(DocumentMapper.INSTANCE.toDocumentation(docList.get(i)));
+                            }
+                            if (APIConstants.DOC_OWNER_VISIBILITY.equals(String.valueOf(doc.getVisibility()))) {
+                                if (APIConstants.WSO2_ANONYMOUS_USER != username
+                                        && !isTenantDomainNotMatching(organization)) {
+                                    convertedList.add(DocumentMapper.INSTANCE.toDocumentation(docList.get(i)));
+                                }
+                            }
+                            if (APIConstants.DOC_SHARED_VISIBILITY.equals(String.valueOf(doc.getVisibility()))) {
+                                if (APIConstants.WSO2_ANONYMOUS_USER != username
+                                        && !isTenantDomainNotMatching(organization)){
+                                    privateDocs.add(DocumentMapper.INSTANCE.toDocumentation(docList.get(i)));
+                                }
+                            }
+
+                        }
+                    }
+                    if (isDocVisibilityEnabled && privateDocs.size() > 0) {
+                        String loggedInTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                                .getTenantDomain();
+                        if (validatePrivateScopes(username, loggedInTenantDomain)) {
+                            convertedList.addAll(privateDocs);
+                        }
                     }
                 }
             } else {
                 convertedList = new ArrayList<Documentation>();
             }
-        } catch (DocumentationPersistenceException e) {
+        } catch (DocumentationPersistenceException | org.wso2.carbon.user.api.UserStoreException e) {
             String msg = "Failed to get documentations for api/product " + uuid;
             throw new APIManagementException(msg, e);
         }
         return convertedList;
+    }
+
+    /**
+     * Validates whether the user has creator or publisher scopes for the documentation visibility control.
+     *
+     * @param username              Username
+     * @param loggedInTenantDomain  Logged in Tenant domain
+     * @return true if user has creator or publisher scopes
+     * @throws UserStoreException if user store is not found.
+     */
+    private boolean validatePrivateScopes(String username, String loggedInTenantDomain)
+            throws org.wso2.carbon.user.api.UserStoreException {
+        int tenantId = APIUtil.getTenantIdFromTenantDomain(loggedInTenantDomain);
+
+        String[] roleList = ServiceReferenceHolder.getInstance().getRealmService().getTenantUserRealm(tenantId)
+                .getUserStoreManager().getRoleListOfUser(MultitenantUtils.getTenantAwareUsername(username));
+        Map<String, String> restAPIScopes = APIUtil.getRESTAPIScopesForTenant(loggedInTenantDomain);
+
+        Set<String> roles = new HashSet();
+        roles.addAll(Arrays.asList(restAPIScopes.get(APIConstants.APIM_CREATOR_SCOPE).split(",")));
+        roles.addAll(Arrays.asList(restAPIScopes.get(APIConstants.APIM_PUBLISHER_SCOPE).split(",")));
+
+        for (String userRole : roleList) {
+            if (roles.contains(userRole)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -335,7 +399,7 @@ public abstract class AbstractAPIManager implements APIManager {
         try {
             org.wso2.carbon.apimgt.persistence.dto.Documentation doc = apiPersistenceInstance
                     .getDocumentation(new Organization(organization), apiId, docId);
-            if (doc != null) {
+            if (doc != null && isDocVisible(doc, organization)) {
                 if (log.isDebugEnabled()) {
                     log.debug("Retrieved doc: " + doc);
                 }
@@ -345,12 +409,59 @@ public abstract class AbstractAPIManager implements APIManager {
                         + " does not exist";
                 throw new APIMgtResourceNotFoundException(msg);
             }
-        } catch (DocumentationPersistenceException e) {
+        } catch (DocumentationPersistenceException  | APIManagementException e) {
             throw new APIManagementException("Error while retrieving document for id " + docId, e);
         }
         return documentation;
     }
 
+/**
+     * Validate the document for doc visibility
+     *
+     * @param doc         Document ID
+     * @return False      if user is not authorized to view the document
+     */
+    public boolean isDocVisible(org.wso2.carbon.apimgt.persistence.dto.Documentation doc,
+                             String requestedTenantDomain) throws APIManagementException {
+        boolean isDocVisibilityEnabled = Boolean.parseBoolean(
+                ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService().
+                        getAPIManagerConfiguration().getFirstProperty(
+                                APIConstants.API_PUBLISHER_ENABLE_API_DOC_VISIBILITY_LEVELS));
+
+        if (!isDocVisibilityEnabled) {
+            return true;
+        }
+
+        String username = CarbonContext.getThreadLocalCarbonContext().getUsername();
+        String loggedInTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+
+        boolean validDoc = false;
+        if (APIConstants.DOC_API_BASED_VISIBILITY.equals(String.valueOf(doc.getVisibility()))) {
+            validDoc = true;
+        } else if (APIConstants.DOC_OWNER_VISIBILITY.equals(String.valueOf(doc.getVisibility()))) {
+            if (APIConstants.WSO2_ANONYMOUS_USER != username && !isTenantDomainNotMatching(requestedTenantDomain)) {
+                validDoc = true;
+            }
+        } else if (APIConstants.DOC_SHARED_VISIBILITY.equals(String.valueOf(doc.getVisibility()))) {
+            if (APIConstants.WSO2_ANONYMOUS_USER != username) {
+                try {
+                    if (validatePrivateScopes(username, loggedInTenantDomain)) {
+                        validDoc = true;
+                    }
+                } catch (org.wso2.carbon.user.api.UserStoreException e) {
+                    throw new APIManagementException(e);
+                }
+            }
+        }
+
+        if(!validDoc) {
+            if (log.isDebugEnabled()) {
+                log.debug("User " + username + " cannot view the requested document " + doc.getId());
+            }
+        }
+        return validDoc;
+    }
+    
     @Override
     public DocumentationContent getDocumentationContent(String apiId, String docId, String organization)
             throws APIManagementException {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AbstractAPIManagerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AbstractAPIManagerTestCase.java
@@ -229,7 +229,16 @@ public class AbstractAPIManagerTestCase {
 
         String  docName = "TestDoc";
         AbstractAPIManager abstractAPIManager = new AbstractAPIManagerWrapper(apiPersistenceInstance);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        ServiceReferenceHolder sh = Mockito.mock(ServiceReferenceHolder.class);
+        APIManagerConfigurationService amConfigService = Mockito.mock(APIManagerConfigurationService.class);
+        APIManagerConfiguration amConfig = Mockito.mock(APIManagerConfiguration.class);
 
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(sh);
+        PowerMockito.when(sh.getAPIManagerConfigurationService()).thenReturn(amConfigService);
+        PowerMockito.when(amConfigService.getAPIManagerConfiguration()).thenReturn(amConfig);
+        PowerMockito.when(amConfig.getFirstProperty(APIConstants.API_PUBLISHER_ENABLE_API_DOC_VISIBILITY_LEVELS))
+                .thenReturn("false");
         org.wso2.carbon.apimgt.persistence.dto.Documentation document = Mockito
                 .mock(org.wso2.carbon.apimgt.persistence.dto.Documentation.class);
         Mockito.when(document.getName()).thenReturn(docName);


### PR DESCRIPTION
This update fixes the feature of having different visibility levels for the documentation of an API as Private, Owners only and Same as API.

Fixes: https://github.com/wso2/api-manager/issues/1610