### PR TITLE
Change opaque token to JWT for portals

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/java/org/wso2/carbon/apimgt/rest/api/dcr/web/impl/RegistrationServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/java/org/wso2/carbon/apimgt/rest/api/dcr/web/impl/RegistrationServiceImpl.java
@@ -80,6 +80,7 @@ public class RegistrationServiceImpl implements RegistrationService {
 
     private static final Log log = LogFactory.getLog(RegistrationServiceImpl.class);
     private static final String APP_DISPLAY_NAME = "DisplayName";
+    private static final String OPAQUE = "opaque";
 
     @Context
     MessageContext securityContext;
@@ -144,10 +145,15 @@ public class RegistrationServiceImpl implements RegistrationService {
                     }
                 }
 
-                String tokenType = APIConstants.DEFAULT_TOKEN_TYPE;
+                String tokenType = APIConstants.TOKEN_TYPE_JWT;
                 String profileTokenType = profile.getTokenType();
                 if (StringUtils.isNotEmpty(profileTokenType)) {
-                    tokenType = profileTokenType;
+                    // Since default is JWT, we will use different param to get the opaque token
+                    if (OPAQUE.equalsIgnoreCase(profileTokenType)) {
+                        tokenType = APIConstants.TOKEN_TYPE_DEFAULT;
+                    } else {
+                        tokenType = profileTokenType;
+                    }
                 }
                 oauthApplicationInfo.addParameter(OAUTH_CLIENT_USERNAME, owner);
                 oauthApplicationInfo.setClientId("");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
@@ -230,9 +230,6 @@ public class OAuthJwtAuthenticatorImpl extends AbstractOAuthAuthenticator {
             //validate Issuer
             List<String> tokenAudiences = signedJWTInfo.getJwtClaimsSet().getAudience();
             if (tokenIssuers != null && tokenIssuers.containsKey(issuer)) {
-                //validate audience
-                if (audiencesMap != null && audiencesMap.get(basePath.getPath()) != null &&
-                        tokenAudiences.stream().anyMatch(audiencesMap.get(basePath.getPath())::contains)) {
                     if (isRESTApiTokenCacheEnabled) {
                         JWTValidationInfo tempJWTValidationInfo = (JWTValidationInfo) getRESTAPITokenCache().get(jti);
                         if (tempJWTValidationInfo != null) {
@@ -279,21 +276,6 @@ public class OAuthJwtAuthenticatorImpl extends AbstractOAuthAuthenticator {
                                 "Make sure you have provided the correct security credentials in the token :"
                                 + maskedToken);
                     }
-                } else {
-                    if (audiencesMap == null) {
-                        log.error("JWT token audience validation failed. Reason: No audiences registered " +
-                                "in the server");
-                    } else if (audiencesMap.get(basePath.getPath()) == null) {
-                        log.error("JWT token audience validation failed. Reason: No audiences registered " +
-                                "in the server for the base path (" + basePath.getPath() + ")");
-                    } else {
-                        log.error("JWT token audience validation failed. Reason: None of the aud present "
-                                + "in the JWT (" + tokenAudiences.toString() +
-                                ") matches the intended audience (" + audiencesMap.get(basePath.getPath())
-                                .toString() + ") for base path ( " + basePath.getPath() +  " ).");
-                    }
-                    return null;
-                }
             } else {
                 //invalid issuer. invalid token
                 log.error("JWT token issuer validation failed. Reason: Issuer present in the JWT (" + issuer

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -46,6 +46,12 @@
   "apim.api_quota_limit.enable": false,
   "apim.http_client.max_total": "100",
   "apim.http_client.default_max_per_route": "50",
+  "apim.jwt.issuer": [
+    { 
+      "name" : "https://localhost:9443/oauth2/token",
+      "jwks.url" : "https://localhost:9443/oauth2/jwks"
+    }
+  ],
   "apim.key_manager.service_url": "https://localhost:${mgt.transport.https.port}${carbon.context}services/",
   "apim.key_manager.username": "${admin.username}",
   "apim.key_manager.password": "${admin.password}",


### PR DESCRIPTION
In this fix
- Change the default token type to JWT
- Remove audience validation for product rest API
