### PR TITLE
Fix revoked token cleanup issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/jwt/RevokedJWTMapCleaner.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/jwt/RevokedJWTMapCleaner.java
@@ -47,7 +47,7 @@ public class RevokedJWTMapCleaner extends TimerTask {
         int count = 0;
         while (it.hasNext()) {
             Map.Entry entry = (Map.Entry) it.next();
-            long expiryTime = (long) (entry.getValue()) * 1000;
+            long expiryTime = (long) (entry.getValue());
             if (currentTimestamp > expiryTime) { // if token is expired, remove from the revoked map
                 it.remove();
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
This PR fixes https://github.com/wso2/api-manager/issues/1752.

As in the below image `expiryTime` always gets 1000 times higher value and hence the code block in the condition will not be executed ever. To match the `currentTimestamp` and `expiryTime` in same unit (milliseconds) we have to remove multiplication from 1000.

![image (8)](https://user-images.githubusercontent.com/36144069/233897002-47ac0a9e-49fc-43da-9372-24658f2eaf08.png)
