### PR TITLE
Fix for when searching for an API in the publisher, the image disappears

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5100,6 +5100,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                         api.setContext(publiserAPI.getContext());
                         api.setContextTemplate(publiserAPI.getContext());
                         api.setStatus(publiserAPI.getStatus());
+                        api.setThumbnailUrl(publiserAPI.getThumbnailUri());
                         apiSet.add(api);
                     } else if ("APIProduct".equals(item.getType())) {
 
@@ -5109,6 +5110,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                         api.setUuid(publiserAPI.getId());
                         api.setContextTemplate(publiserAPI.getContext());
                         api.setState(publiserAPI.getStatus());
+                        api.setThumbnailUrl(publiserAPI.getThumbnailUri());
                         apiProductSet.add(api);
                     } else if (item instanceof DocumentSearchContent) {
                         // doc item

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -1495,6 +1495,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
                                 content.setVersion(pubAPI.getVersion());
                                 content.setStatus(pubAPI.getStatus());
                                 content.setAdvertiseOnly(pubAPI.isAdvertiseOnly());
+                                content.setThumbnailUri(pubAPI.getThumbnail());
                                 contentData.add(content);
                             } else {
                                 throw new GovernanceException("artifact id is null for " + resourcePath);

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
@@ -1384,6 +1384,7 @@ public class RegistryPersistenceUtil {
             api.setVersion(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_VERSION));
             api.setAdvertiseOnly(Boolean.parseBoolean(apiArtifact
                     .getAttribute(APIConstants.API_OVERVIEW_ADVERTISE_ONLY)));
+            api.setThumbnail(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_THUMBNAIL_URL));
 
         } catch (GovernanceException e) {
             throw new APIPersistenceException("Error while extracting api attributes ", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductSearchResultAllOfDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductSearchResultAllOfDTO.java
@@ -26,6 +26,7 @@ public class APIProductSearchResultAllOfDTO   {
     private String provider = null;
     private String status = null;
     private String thumbnailUri = null;
+    private Boolean hasThumbnail = null;
 
   /**
    * A brief description about the API
@@ -134,6 +135,23 @@ public class APIProductSearchResultAllOfDTO   {
     this.thumbnailUri = thumbnailUri;
   }
 
+  /**
+   **/
+  public APIProductSearchResultAllOfDTO hasThumbnail(Boolean hasThumbnail) {
+    this.hasThumbnail = hasThumbnail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("hasThumbnail")
+  public Boolean isHasThumbnail() {
+    return hasThumbnail;
+  }
+  public void setHasThumbnail(Boolean hasThumbnail) {
+    this.hasThumbnail = hasThumbnail;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -149,12 +167,13 @@ public class APIProductSearchResultAllOfDTO   {
         Objects.equals(version, apIProductSearchResultAllOf.version) &&
         Objects.equals(provider, apIProductSearchResultAllOf.provider) &&
         Objects.equals(status, apIProductSearchResultAllOf.status) &&
-        Objects.equals(thumbnailUri, apIProductSearchResultAllOf.thumbnailUri);
+        Objects.equals(thumbnailUri, apIProductSearchResultAllOf.thumbnailUri) &&
+        Objects.equals(hasThumbnail, apIProductSearchResultAllOf.hasThumbnail);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, version, provider, status, thumbnailUri);
+    return Objects.hash(description, context, version, provider, status, thumbnailUri, hasThumbnail);
   }
 
   @Override
@@ -168,6 +187,7 @@ public class APIProductSearchResultAllOfDTO   {
     sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    thumbnailUri: ").append(toIndentedString(thumbnailUri)).append("\n");
+    sb.append("    hasThumbnail: ").append(toIndentedString(hasThumbnail)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductSearchResultDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductSearchResultDTO.java
@@ -28,6 +28,7 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
     private String provider = null;
     private String status = null;
     private String thumbnailUri = null;
+    private Boolean hasThumbnail = null;
 
   /**
    * A brief description about the API
@@ -136,6 +137,23 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
     this.thumbnailUri = thumbnailUri;
   }
 
+  /**
+   **/
+  public APIProductSearchResultDTO hasThumbnail(Boolean hasThumbnail) {
+    this.hasThumbnail = hasThumbnail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("hasThumbnail")
+  public Boolean isHasThumbnail() {
+    return hasThumbnail;
+  }
+  public void setHasThumbnail(Boolean hasThumbnail) {
+    this.hasThumbnail = hasThumbnail;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -151,12 +169,13 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
         Objects.equals(version, apIProductSearchResult.version) &&
         Objects.equals(provider, apIProductSearchResult.provider) &&
         Objects.equals(status, apIProductSearchResult.status) &&
-        Objects.equals(thumbnailUri, apIProductSearchResult.thumbnailUri);
+        Objects.equals(thumbnailUri, apIProductSearchResult.thumbnailUri) &&
+        Objects.equals(hasThumbnail, apIProductSearchResult.hasThumbnail);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, version, provider, status, thumbnailUri);
+    return Objects.hash(description, context, version, provider, status, thumbnailUri, hasThumbnail);
   }
 
   @Override
@@ -170,6 +189,7 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
     sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    thumbnailUri: ").append(toIndentedString(thumbnailUri)).append("\n");
+    sb.append("    hasThumbnail: ").append(toIndentedString(hasThumbnail)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APISearchResultAllOfDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APISearchResultAllOfDTO.java
@@ -28,6 +28,7 @@ public class APISearchResultAllOfDTO   {
     private String status = null;
     private String thumbnailUri = null;
     private Boolean advertiseOnly = null;
+    private Boolean hasThumbnail = null;
 
   /**
    * A brief description about the API
@@ -171,6 +172,23 @@ public class APISearchResultAllOfDTO   {
     this.advertiseOnly = advertiseOnly;
   }
 
+  /**
+   **/
+  public APISearchResultAllOfDTO hasThumbnail(Boolean hasThumbnail) {
+    this.hasThumbnail = hasThumbnail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("hasThumbnail")
+  public Boolean isHasThumbnail() {
+    return hasThumbnail;
+  }
+  public void setHasThumbnail(Boolean hasThumbnail) {
+    this.hasThumbnail = hasThumbnail;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -188,12 +206,13 @@ public class APISearchResultAllOfDTO   {
         Objects.equals(provider, apISearchResultAllOf.provider) &&
         Objects.equals(status, apISearchResultAllOf.status) &&
         Objects.equals(thumbnailUri, apISearchResultAllOf.thumbnailUri) &&
-        Objects.equals(advertiseOnly, apISearchResultAllOf.advertiseOnly);
+        Objects.equals(advertiseOnly, apISearchResultAllOf.advertiseOnly) &&
+        Objects.equals(hasThumbnail, apISearchResultAllOf.hasThumbnail);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, contextTemplate, version, provider, status, thumbnailUri, advertiseOnly);
+    return Objects.hash(description, context, contextTemplate, version, provider, status, thumbnailUri, advertiseOnly, hasThumbnail);
   }
 
   @Override
@@ -209,6 +228,7 @@ public class APISearchResultAllOfDTO   {
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    thumbnailUri: ").append(toIndentedString(thumbnailUri)).append("\n");
     sb.append("    advertiseOnly: ").append(toIndentedString(advertiseOnly)).append("\n");
+    sb.append("    hasThumbnail: ").append(toIndentedString(hasThumbnail)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APISearchResultDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APISearchResultDTO.java
@@ -30,6 +30,7 @@ public class APISearchResultDTO extends SearchResultDTO  {
     private String status = null;
     private String thumbnailUri = null;
     private Boolean advertiseOnly = null;
+    private Boolean hasThumbnail = null;
 
   /**
    * A brief description about the API
@@ -173,6 +174,23 @@ public class APISearchResultDTO extends SearchResultDTO  {
     this.advertiseOnly = advertiseOnly;
   }
 
+  /**
+   **/
+  public APISearchResultDTO hasThumbnail(Boolean hasThumbnail) {
+    this.hasThumbnail = hasThumbnail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("hasThumbnail")
+  public Boolean isHasThumbnail() {
+    return hasThumbnail;
+  }
+  public void setHasThumbnail(Boolean hasThumbnail) {
+    this.hasThumbnail = hasThumbnail;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -190,12 +208,13 @@ public class APISearchResultDTO extends SearchResultDTO  {
         Objects.equals(provider, apISearchResult.provider) &&
         Objects.equals(status, apISearchResult.status) &&
         Objects.equals(thumbnailUri, apISearchResult.thumbnailUri) &&
-        Objects.equals(advertiseOnly, apISearchResult.advertiseOnly);
+        Objects.equals(advertiseOnly, apISearchResult.advertiseOnly) &&
+        Objects.equals(hasThumbnail, apISearchResult.hasThumbnail);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, contextTemplate, version, provider, status, thumbnailUri, advertiseOnly);
+    return Objects.hash(description, context, contextTemplate, version, provider, status, thumbnailUri, advertiseOnly, hasThumbnail);
   }
 
   @Override
@@ -211,6 +230,7 @@ public class APISearchResultDTO extends SearchResultDTO  {
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    thumbnailUri: ").append(toIndentedString(thumbnailUri)).append("\n");
     sb.append("    advertiseOnly: ").append(toIndentedString(advertiseOnly)).append("\n");
+    sb.append("    hasThumbnail: ").append(toIndentedString(hasThumbnail)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/SearchResultMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/SearchResultMappingUtil.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
@@ -73,6 +74,7 @@ public class SearchResultMappingUtil {
         apiResultDTO.setStatus(api.getStatus());
         apiResultDTO.setThumbnailUri(api.getThumbnailUrl());
         apiResultDTO.setAdvertiseOnly(api.isAdvertiseOnly());
+        apiResultDTO.setHasThumbnail(!StringUtils.isBlank(api.getThumbnailUrl()));
         return apiResultDTO;
     }
 
@@ -99,6 +101,7 @@ public class SearchResultMappingUtil {
         apiProductResultDTO.setDescription(apiProduct.getDescription());
         apiProductResultDTO.setStatus(apiProduct.getState());
         apiProductResultDTO.setThumbnailUri(apiProduct.getThumbnailUrl());
+        apiProductResultDTO.setHasThumbnail(!StringUtils.isBlank(apiProduct.getThumbnailUrl()));
         return apiProductResultDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -11193,6 +11193,9 @@ components:
             advertiseOnly:
               type: boolean
               example: true
+            hasThumbnail:
+              type: boolean
+              example: true
     APIProductSearchResult:
       title: API Result
       allOf:
@@ -11224,6 +11227,9 @@ components:
             thumbnailUri:
               type: string
               example: /apis/01234567-0123-0123-0123-012345678901/thumbnail
+            hasThumbnail:
+              type: boolean
+              example: true
     APIMonetizationInfo:
       title: API monetization object
       required:


### PR DESCRIPTION
The hasThumbnail variable is set so that when searching for APIs and APIProducts the thumbnail will be shown