### PR TITLE
Add envId to gateway artifact

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/GatewayArtifactsMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/GatewayArtifactsMgtDAO.java
@@ -242,7 +242,7 @@ public class GatewayArtifactsMgtDAO {
             preparedStatement.setString(2, envName);
             preparedStatement.setString(3, revisionUUId);
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
-                if (resultSet.next()) {
+                while (resultSet.next()) {
                     emptyResultSet = false;
                     organization = resultSet.getString("ORGANIZATION");
                     deployedTime = resultSet.getTimestamp("DEPLOYED_TIME");

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/GatewayArtifactsMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/GatewayArtifactsMgtDAO.java
@@ -5,10 +5,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.APIRevisionDeployment;
+import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.impl.dao.constants.SQLConstants;
 import org.wso2.carbon.apimgt.impl.dto.APIRuntimeArtifactDto;
 import org.wso2.carbon.apimgt.impl.dto.APIArtifactPropertyValues;
 import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.impl.utils.GatewayArtifactsMgtDBUtil;
 import org.wso2.carbon.apimgt.impl.utils.VHostUtils;
 
@@ -227,27 +229,60 @@ public class GatewayArtifactsMgtDAO {
     public APIArtifactPropertyValues retrieveAPIArtifactPropertyValues(
             String apiUUID, String envName, String revisionUUId) throws APIManagementException {
 
-        String query = SQLConstants.RETRIEVE_API_ARTIFACT_PROPERTY_VALUES;
+        String query = SQLConstants.RETRIEVE_API_ARTIFACT_PROPERTY_VALUES_WITH_ENV_UUID;
         String organization = null;
         Timestamp deployedTime = null;
+        String envUUID = null;
+        boolean emptyResultSet = true;
         APIArtifactPropertyValues propertyValues = new APIArtifactPropertyValues();
+        Map<String, Environment> readOnlyEnvironments = APIUtil.getReadOnlyEnvironments();
         try (Connection connection = GatewayArtifactsMgtDBUtil.getArtifactSynchronizerConnection();
              PreparedStatement preparedStatement = connection.prepareStatement(query)) {
             preparedStatement.setString(1, apiUUID);
             preparedStatement.setString(2, envName);
             preparedStatement.setString(3, revisionUUId);
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
-                while (resultSet.next()) {
+                if (resultSet.next()) {
+                    emptyResultSet = false;
                     organization = resultSet.getString("ORGANIZATION");
                     deployedTime = resultSet.getTimestamp("DEPLOYED_TIME");
+                    envUUID = resultSet.getString("ENV_UUID");
                 }
             }
         } catch (SQLException e) {
-            handleException("Failed to retrieve organization and API revision deployed time", e);
+            handleException("Failed to retrieve organization, API revision deployed time and environment UUID", e);
+        }
+
+        if (emptyResultSet) {
+            /*
+            * If the API revision is deployed in a read-only environment, result set would be empty as read-only
+            * environments are not persisted in the AM_GATEWAY_ENVIRONMENT table.
+            * */
+            if (!readOnlyEnvironments.containsKey(envName)) {
+                throw new APIManagementException
+                        ("Failed to retrieve environment details for environment name: " + envName);
+            }
+            query = SQLConstants.RETRIEVE_API_ARTIFACT_PROPERTY_VALUES;
+            try (Connection connection = GatewayArtifactsMgtDBUtil.getArtifactSynchronizerConnection();
+                 PreparedStatement preparedStatement = connection.prepareStatement(query)) {
+                preparedStatement.setString(1, apiUUID);
+                preparedStatement.setString(2, envName);
+                preparedStatement.setString(3, revisionUUId);
+                try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                    while (resultSet.next()) {
+                        organization = resultSet.getString("ORGANIZATION");
+                        deployedTime = resultSet.getTimestamp("DEPLOYED_TIME");
+                        envUUID = readOnlyEnvironments.get(envName).getUuid();
+                    }
+                }
+            } catch (SQLException e) {
+                handleException("Failed to retrieve organization and API revision deployed time", e);
+            }
         }
 
         propertyValues.setOrganization(organization);
         propertyValues.setDeployedTime(deployedTime);
+        propertyValues.setEnvUUID(envUUID);
         return propertyValues;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -2907,6 +2907,21 @@ public class SQLConstants {
                     "FROM AM_API, AM_DEPLOYMENT_REVISION_MAPPING " +
                     "WHERE AM_API.API_UUID = ? AND AM_DEPLOYMENT_REVISION_MAPPING.NAME = ? " +
                     "AND AM_DEPLOYMENT_REVISION_MAPPING.REVISION_UUID = ?";
+    public static final String RETRIEVE_API_ARTIFACT_PROPERTY_VALUES_WITH_ENV_UUID =
+            "SELECT " +
+                    "   AM_API.ORGANIZATION AS ORGANIZATION," +
+                    "   AM_DEPLOYMENT_REVISION_MAPPING.DEPLOYED_TIME AS DEPLOYED_TIME," +
+                    "   AM_GATEWAY_ENVIRONMENT.UUID AS ENV_UUID " +
+                    "FROM" +
+                    "   AM_API," +
+                    "   AM_DEPLOYMENT_REVISION_MAPPING," +
+                    "   AM_GATEWAY_ENVIRONMENT " +
+                    "WHERE" +
+                    "   AM_API.API_UUID = ? AND" +
+                    "   AM_DEPLOYMENT_REVISION_MAPPING.NAME = ? AND" +
+                    "   AM_DEPLOYMENT_REVISION_MAPPING.REVISION_UUID = ? AND " +
+                    "   AM_API.ORGANIZATION = AM_GATEWAY_ENVIRONMENT.ORGANIZATION AND" +
+                    "   AM_DEPLOYMENT_REVISION_MAPPING.NAME = AM_GATEWAY_ENVIRONMENT.NAME";
     public static final String RETRIEVE_ARTIFACTS_BY_APIID_AND_LABEL =
             "SELECT AM_GW_API_DEPLOYMENTS.REVISION_ID AS REVISION_ID,AM_GW_PUBLISHED_API_DETAILS" +
                     ".TENANT_DOMAIN AS TENANT_DOMAIN," +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/APIArtifactPropertyValues.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/APIArtifactPropertyValues.java
@@ -27,6 +27,7 @@ public class APIArtifactPropertyValues {
 
     private String organization;
     private Timestamp deployedTime;
+    private String envUUID;
 
     public String getOrganization() {
         return organization;
@@ -42,5 +43,13 @@ public class APIArtifactPropertyValues {
 
     public void setDeployedTime(Timestamp deployedTime) {
         this.deployedTime = deployedTime;
+    }
+
+    public String getEnvUUID() {
+        return envUUID;
+    }
+
+    public void setEnvUUID(String envUUID) {
+        this.envUUID = envUUID;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/APIRuntimeArtifactDto.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/APIRuntimeArtifactDto.java
@@ -12,8 +12,8 @@ public class APIRuntimeArtifactDto extends RuntimeArtifactDto {
     private String type;
     private String organization;
     private String context;
-
     private long deployedTimeStamp;
+    private String envUUID;
 
     public String getType() {
 
@@ -130,5 +130,13 @@ public class APIRuntimeArtifactDto extends RuntimeArtifactDto {
 
     public void setDeployedTimeStamp(long deployedTimeStamp) {
         this.deployedTimeStamp = deployedTimeStamp;
+    }
+
+    public String getEnvUUID() {
+        return envUUID;
+    }
+
+    public void setEnvUUID(String envUUID) {
+        this.envUUID = envUUID;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/ArtifactSynchronizerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/ArtifactSynchronizerUtil.java
@@ -35,11 +35,15 @@ public class ArtifactSynchronizerUtil {
                         apiRuntimeArtifactDto.getLabel(), apiRuntimeArtifactDto.getRevision());
         String organization = apiArtifactPropertyValues.getOrganization();
         Timestamp deployedTime = apiArtifactPropertyValues.getDeployedTime();
+        String envUUID = apiArtifactPropertyValues.getEnvUUID();
         if (organization != null) {
             apiRuntimeArtifactDto.setOrganization(apiArtifactPropertyValues.getOrganization());
         }
         if (deployedTime != null) {
             apiRuntimeArtifactDto.setDeployedTimeStamp(deployedTime.getTime());
+        }
+        if (envUUID != null) {
+            apiRuntimeArtifactDto.setEnvUUID(apiArtifactPropertyValues.getEnvUUID());
         }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/MicroGatewayArtifactGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/MicroGatewayArtifactGenerator.java
@@ -86,6 +86,7 @@ public class MicroGatewayArtifactGenerator implements GatewayArtifactGenerator {
                     // environment is unique for a revision in a deployment
                     // create new environment
                     EnvironmentDto environment = new EnvironmentDto();
+                    environment.setId(apiRuntimeArtifactDto.getEnvUUID());
                     environment.setName(apiRuntimeArtifactDto.getLabel());
                     environment.setVhost(apiRuntimeArtifactDto.getVhost());
                     environment.setDeployedTimeStamp(apiRuntimeArtifactDto.getDeployedTimeStamp());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/RuntimeArtifactGeneratorUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/RuntimeArtifactGeneratorUtil.java
@@ -131,6 +131,7 @@ public class RuntimeArtifactGeneratorUtil {
                         }
 
                         EnvironmentDto environment = new EnvironmentDto();
+                        environment.setId(apiRuntimeArtifactDto.getEnvUUID());
                         environment.setName(apiRuntimeArtifactDto.getLabel());
                         environment.setVhost(apiRuntimeArtifactDto.getVhost());
                         environment.setDeployedTimeStamp(apiRuntimeArtifactDto.getDeployedTimeStamp());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/dto/EnvironmentDto.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/dto/EnvironmentDto.java
@@ -21,14 +21,24 @@ import org.apache.commons.lang3.StringUtils;
 
 /**
  * EnvironmentDto represents a gateway environment.
+ * id: UUID of the environment.
  * name: Name of the environment.
  * vhost: Deployed Vhost.
  * deployedTimeStamp: API deployed time.
  */
 public class EnvironmentDto {
+    private String id;
     private String name;
     private String vhost;
     private DeploymentType deploymentType;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public enum DeploymentType {
         PRODUCTION,


### PR DESCRIPTION
Add envId to gateway artifacts.

This will result in deployment.json to include the related envId to environment info object.

ex:
In here `my-foo-dev` environment id `9ec5b162-3a9b-405a-8d94-e1b9720824b7` attached.
```
{
  "type": "deployments",
  "version": "v4.1.0",
  "data": {
    "deployments": [
      {
        "apiFile": "64477a36d5452c29958fc252-64477b2fd5452c29958fc253.zip",
        "environments": [
          {
            "id": "9ec5b162-3a9b-405a-8d94-e1b9720824b7",
            "name": "my-foo-dev",
            "vhost": "my.wso2.com",
            "deploymentType": "SANDBOX",
            "deployedTimeStamp": 1682406822693
          }
        ],
        "organizationId": "testOrg1"
      }
    ]
  }
}
```