### PR TITLE
[APIM 420] Porting fix for supporting throttling with custom throttling keys

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/throttling/ThrottleHandler.java
@@ -78,6 +78,7 @@ import org.wso2.carbon.metrics.manager.Timer;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -102,6 +103,7 @@ public class ThrottleHandler extends AbstractHandler implements ManagedLifecycle
     private static final String RESOURCE_THROTTLE = "RESOURCE_THROTTLE";
     private static final String BLOCKED_TEST = "BLOCKED_TEST";
     private final String type = ExtensionType.THROTTLING.toString();
+    private static final String CUSTOM_PROPERTY = "customProperty";
 
     /**
      * The key for getting the throttling policy - key refers to a/an [registry] Resource entry
@@ -992,6 +994,7 @@ public class ThrottleHandler extends AbstractHandler implements ManagedLifecycle
                                         String apiTenant, String appId, String clientIp,
                                         Map<String, String> keyTemplateMap,
                                         MessageContext messageContext) {
+        HashMap<String, Object> propertyFromMap = (HashMap<String, Object>) messageContext.getProperty(CUSTOM_PROPERTY);
         if (keyTemplateMap != null && keyTemplateMap.size() > 0) {
             for (String key : keyTemplateMap.keySet()) {
                 key = key.replaceAll("\\$resourceKey", resourceKey);
@@ -1003,6 +1006,11 @@ public class ThrottleHandler extends AbstractHandler implements ManagedLifecycle
                 key = key.replaceAll("\\$appId", appId);
                 if (clientIp != null) {
                     key = key.replaceAll("\\$clientIp", APIUtil.ipToBigInteger(clientIp).toString());
+                }
+                if (propertyFromMap != null) {
+                    for (String mapKey : propertyFromMap.keySet()) {
+                        key = key.replaceAll("\\$customProperty." + mapKey, (String) propertyFromMap.get(mapKey));
+                    }
                 }
                 if (getThrottleDataHolder().isThrottled(key)) {
                     long timestamp = getThrottleDataHolder().getThrottleNextAccessTimestamp(key);


### PR DESCRIPTION
Adding the functionality to use custom properties in the propertiesMap in addition to currently supported "apiContext, apiVersion, resourceKey, userId, appId, apiTenant, appTenant, clientIp" properties.

Related PR: https://github.com/wso2-support/carbon-apimgt/pull/4031
Issues: https://github.com/wso2-enterprise/financial-open-banking/issues/5583, https://github.com/wso2-enterprise/ob-compliance-toolkit-cds/issues/241

Note: Only a part of the above PR has been ported since the rest is already available in this branch https://github.com/wso2/carbon-apimgt/pull/10692