### PR TITLE
Update retry mechanism used in artifact synchroniser

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -535,7 +535,8 @@ public enum ExceptionCodes implements ErrorHandler {
     REVISION_ALREADY_DEPLOYED(902005, "Revision deployment state conflicted", 409,
             "Revision deployment request conflicted with the current deployment state of the revision %s. Please try again later", false),
     INVALID_API_ID(902006, "Invalid API ID", 404, "The provided API ID is not found %s", false),
-    INVALID_ENDPOINT_CONFIG(902012, "Endpoint config value(s) is(are) not valid", 400, "Endpoint config value(s) is(are) not valid");
+    INVALID_ENDPOINT_CONFIG(902012, "Endpoint config value(s) is(are) not valid", 400, "Endpoint config value(s) is(are) not valid"),
+    ARTIFACT_SYNC_HTTP_REQUEST_FAILED(903009, "Error while retrieving from remote endpoint", 500, "Error while executing HTTP request to retrieve from remote endpoint");
 
     private final long errorCode;
     private final String errorMessage;

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
@@ -239,7 +239,7 @@ public class InMemoryAPIDeployer {
                     if (gatewayRuntimeArtifacts.size() == errorCount) {
                         return false;
                     }
-                } catch (ArtifactSynchronizerException | AxisFault e) {
+                } catch (AxisFault e) {
                     String msg = "Error deploying APIs to the Gateway ";
                     log.error(msg, e);
                     return false;

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.config.xml.MultiXMLConfigurationBuilder;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.common.jms.JMSTransportHandler;
 import org.wso2.carbon.apimgt.gateway.APILoggerManager;
 import org.wso2.carbon.apimgt.gateway.EndpointCertificateDeployer;
@@ -310,25 +311,42 @@ public class GatewayStartupListener extends AbstractAxis2ConfigurationContextObs
         }
 
         long retryDuration = gatewayArtifactSynchronizerProperties.getRetryDuartion();
+        int maxRetryCount = gatewayArtifactSynchronizerProperties.getMaxRetryCount();
         double reconnectionProgressionFactor = 2.0;
         long maxReconnectDuration = 1000 * 60 * 60; // 1 hour
-
-        while (true) {
-            boolean isArtifactsDeployed = deployArtifactsAtStartup(tenantDomain);
-            DataHolder.getInstance().setAllApisDeployed(isArtifactsDeployed);
-            if (isArtifactsDeployed) {
-                log.info("Synapse Artifacts deployed Successfully in the Gateway");
-                break;
-            } else {
-                retryDuration = (long) (retryDuration * reconnectionProgressionFactor);
-                if (retryDuration > maxReconnectDuration) {
-                    retryDuration = maxReconnectDuration;
+        int retryCount = 0;
+        boolean retry = true;
+        while (retry) {
+            try {
+                boolean isArtifactsDeployed = deployArtifactsAtStartup(tenantDomain);
+                DataHolder.getInstance().setAllApisDeployed(isArtifactsDeployed);
+                if (isArtifactsDeployed) {
+                    log.info("Synapse Artifacts deployed Successfully in the Gateway");
+                    retry = false;
+                } else {
+                    throw new ArtifactSynchronizerException("Unable to deploy synapse artifacts at gateway");
                 }
-                log.error("Unable to deploy synapse artifacts at gateway. Next retry in " + (retryDuration / 1000)
-                        + " seconds");
-                try {
-                    Thread.sleep(retryDuration);
-                } catch (InterruptedException ignore) {
+            } catch (ArtifactSynchronizerException e) {
+                if (!e.getErrorHandler().equals(ExceptionCodes.ARTIFACT_SYNC_HTTP_REQUEST_FAILED)) {
+                    retryCount++;
+                    if (retryCount <= maxRetryCount) {
+                        log.error("Unable to deploy synapse artifacts at gateway. Retry Attempt " + retryCount + " in "
+                                + (retryDuration / 1000) + " seconds");
+                        try {
+                            Thread.sleep(retryDuration);
+                            retryDuration = (long) (retryDuration * reconnectionProgressionFactor);
+                            if (retryDuration > maxReconnectDuration) {
+                                retryDuration = maxReconnectDuration;
+                            }
+                        } catch (InterruptedException ignore) {
+                            // Ignore
+                        }
+                    } else {
+                        log.error("Unable to deploy synapse artifacts at gateway. Maximum retry count exceeded.");
+                        throw e;
+                    }
+                } else {
+                    throw e;
                 }
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
@@ -134,26 +134,11 @@ public class GatewayStartupListener extends AbstractAxis2ConfigurationContextObs
         GatewayArtifactSynchronizerProperties gatewayArtifactSynchronizerProperties =
                 ServiceReferenceHolder.getInstance()
                         .getAPIManagerConfiguration().getGatewayArtifactSynchronizerProperties();
-
         boolean flag = false;
-        long waitTime = System.currentTimeMillis() + 60 * 1000;
-        long retryDuration = 5000;
-
         if (gatewayArtifactSynchronizerProperties.isRetrieveFromStorageEnabled()) {
             InMemoryAPIDeployer inMemoryAPIDeployer = new InMemoryAPIDeployer();
-
-            while (waitTime > System.currentTimeMillis() && !flag) {
-                flag = inMemoryAPIDeployer.deployAllAPIsAtGatewayStartup(
+            flag = inMemoryAPIDeployer.deployAllAPIsAtGatewayStartup(
                         gatewayArtifactSynchronizerProperties.getGatewayLabels(), tenantDomain);
-                if (!flag) {
-                    log.error("Unable to deploy synapse artifacts at gateway. Next retry in " + (retryDuration / 1000)
-                            + " seconds");
-                    try {
-                        Thread.sleep(retryDuration);
-                    } catch (InterruptedException ignore) {
-                    }
-                }
-            }
         }
         return flag;
     }
@@ -330,8 +315,8 @@ public class GatewayStartupListener extends AbstractAxis2ConfigurationContextObs
                 if (!ExceptionCodes.ARTIFACT_SYNC_HTTP_REQUEST_FAILED.equals(e.getErrorHandler())) {
                     retryCount++;
                     if (retryCount <= maxRetryCount) {
-                        log.error("Unable to deploy synapse artifacts at gateway. Retry Attempt " + retryCount + " in "
-                                + (retryDuration / 1000) + " seconds");
+                        log.error("Unable to deploy synapse artifacts at gateway. Retry Attempt " + retryCount
+                                + " in " + (retryDuration / 1000) + " seconds");
                         try {
                             Thread.sleep(retryDuration);
                             retryDuration = (long) (retryDuration * reconnectionProgressionFactor);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
@@ -327,7 +327,7 @@ public class GatewayStartupListener extends AbstractAxis2ConfigurationContextObs
                     throw new ArtifactSynchronizerException("Unable to deploy synapse artifacts at gateway");
                 }
             } catch (ArtifactSynchronizerException e) {
-                if (!e.getErrorHandler().equals(ExceptionCodes.ARTIFACT_SYNC_HTTP_REQUEST_FAILED)) {
+                if (!ExceptionCodes.ARTIFACT_SYNC_HTTP_REQUEST_FAILED.equals(e.getErrorHandler())) {
                     retryCount++;
                     if (retryCount <= maxRetryCount) {
                         log.error("Unable to deploy synapse artifacts at gateway. Retry Attempt " + retryCount + " in "

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
@@ -297,7 +297,7 @@ public class GatewayStartupListener extends AbstractAxis2ConfigurationContextObs
 
         long retryDuration = gatewayArtifactSynchronizerProperties.getRetryDuartion();
         int maxRetryCount = gatewayArtifactSynchronizerProperties.getMaxRetryCount();
-        double reconnectionProgressionFactor = 2.0;
+        double reconnectionProgressionFactor = gatewayArtifactSynchronizerProperties.getRetryProgressionFactor();
         long maxReconnectDuration = 1000 * 60 * 60; // 1 hour
         int retryCount = 0;
         boolean retry = true;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2651,6 +2651,7 @@ public final class APIConstants {
         public static final String SAVER_CONFIG = "ArtifactSaver";
         public static final String RETRIEVER_CONFIG = "ArtifactRetriever";
         public static final String RETRY_DUARTION = "RetryDuration";
+        public static final String MAX_RETRY_COUNT = "MaxRetryCount";
         public static final String PUBLISH_DIRECTLY_TO_GW_CONFIG = "PublishDirectlyToGW";
         public static final String GATEWAY_LABELS_CONFIG = "GatewayLabels";
         public static final String LABEL_CONFIG = "Label";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2652,6 +2652,7 @@ public final class APIConstants {
         public static final String RETRIEVER_CONFIG = "ArtifactRetriever";
         public static final String RETRY_DUARTION = "RetryDuration";
         public static final String MAX_RETRY_COUNT = "MaxRetryCount";
+        public static final String RETRY_PROGRESSION_FACTOR = "RetryProgressionFactor";
         public static final String PUBLISH_DIRECTLY_TO_GW_CONFIG = "PublishDirectlyToGW";
         public static final String GATEWAY_LABELS_CONFIG = "GatewayLabels";
         public static final String LABEL_CONFIG = "Label";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -2075,6 +2075,15 @@ public class APIManagerConfiguration {
             log.debug("Max Retry Count Element is not set. Set to default count");
         }
 
+        OMElement retryProgressionFactorElement = omElement.getFirstChildWithName(
+                new QName(APIConstants.GatewayArtifactSynchronizer.RETRY_PROGRESSION_FACTOR));
+        if (retryProgressionFactorElement != null) {
+            double retryProgressionFactor = Double.parseDouble(retryProgressionFactorElement.getText());
+            gatewayArtifactSynchronizerProperties.setRetryProgressionFactor(retryProgressionFactor);
+        } else {
+            log.debug("Retry Progression Factor Element is not set. Set to default value");
+        }
+
         OMElement dataRetrievalModeElement = omElement.getFirstChildWithName(
                 new QName(APIConstants.GatewayArtifactSynchronizer.DATA_RETRIEVAL_MODE));
         if (dataRetrievalModeElement!= null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -2063,7 +2063,16 @@ public class APIManagerConfiguration {
             long retryDuration = Long.valueOf(retryDurationElement.getText());
             gatewayArtifactSynchronizerProperties.setRetryDuartion(retryDuration);
         } else {
-            log.debug("Retry Duration Element is not set. Set to default duaration");
+            log.debug("Retry Duration Element is not set. Set to default duration");
+        }
+
+        OMElement maxRetryCountElement = omElement.getFirstChildWithName(
+                new QName(APIConstants.GatewayArtifactSynchronizer.MAX_RETRY_COUNT));
+        if (maxRetryCountElement != null) {
+            int retryCount = Integer.parseInt(maxRetryCountElement.getText());
+            gatewayArtifactSynchronizerProperties.setMaxRetryCount(retryCount);
+        } else {
+            log.debug("Max Retry Count Element is not set. Set to default count");
         }
 
         OMElement dataRetrievalModeElement = omElement.getFirstChildWithName(

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/GatewayArtifactSynchronizerProperties.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/GatewayArtifactSynchronizerProperties.java
@@ -15,6 +15,7 @@ public class GatewayArtifactSynchronizerProperties {
     private String artifactSynchronizerDataSource = "jdbc/WSO2AM_DB";
     private long retryDuartion = 15000 ;
     private int maxRetryCount = 5;
+    private double retryProgressionFactor = 2.0;
     private String gatewayStartup = "sync";
     private long eventWaitingTime = 1;
     private boolean onDemandLoading;
@@ -118,6 +119,16 @@ public class GatewayArtifactSynchronizerProperties {
     public void  setMaxRetryCount(int maxRetryCount) {
 
         this.maxRetryCount = maxRetryCount;
+    }
+
+    public double getRetryProgressionFactor() {
+
+        return retryProgressionFactor;
+    }
+
+    public void  setRetryProgressionFactor(double retryProgressionFactor) {
+
+        this.retryProgressionFactor = retryProgressionFactor;
     }
 
     public String getGatewayStartup() {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/GatewayArtifactSynchronizerProperties.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/GatewayArtifactSynchronizerProperties.java
@@ -14,6 +14,7 @@ public class GatewayArtifactSynchronizerProperties {
     private Set<String> gatewayLabels = new HashSet<>();
     private String artifactSynchronizerDataSource = "jdbc/WSO2AM_DB";
     private long retryDuartion = 15000 ;
+    private int maxRetryCount = 5;
     private String gatewayStartup = "sync";
     private long eventWaitingTime = 1;
     private boolean onDemandLoading;
@@ -107,6 +108,16 @@ public class GatewayArtifactSynchronizerProperties {
     public void  setRetryDuartion(long retryDuartion) {
 
         this.retryDuartion = retryDuartion;
+    }
+
+    public int getMaxRetryCount() {
+
+        return maxRetryCount;
+    }
+
+    public void  setMaxRetryCount(int maxRetryCount) {
+
+        this.maxRetryCount = maxRetryCount;
     }
 
     public String getGatewayStartup() {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/DBRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/DBRetriever.java
@@ -30,6 +30,7 @@ import org.apache.http.util.EntityUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dto.EventHubConfigurationDto;
 import org.wso2.carbon.apimgt.impl.dto.GatewayArtifactSynchronizerProperties;
@@ -141,6 +142,10 @@ public class DBRetriever implements ArtifactRetriever {
             String msg = "Error while executing the http client";
             log.error(msg, e);
             throw new ArtifactSynchronizerException(msg, e);
+        } catch (ArtifactSynchronizerException e) {
+            String msg = "Error while retrieving artifacts";
+            log.error(msg, e);
+            throw new ArtifactSynchronizerException(msg, e, ExceptionCodes.ARTIFACT_SYNC_HTTP_REQUEST_FAILED);
         }
     }
 
@@ -214,7 +219,7 @@ public class DBRetriever implements ArtifactRetriever {
 
         HttpClient httpClient = APIUtil.getHttpClient(port, protocol);
         try {
-            return APIUtil.executeHTTPRequest(method, httpClient);
+            return APIUtil.executeHTTPRequestWithRetries(method, httpClient);
         } catch (APIManagementException e) {
             throw new ArtifactSynchronizerException(e);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/DBRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/DBRetriever.java
@@ -141,7 +141,7 @@ public class DBRetriever implements ArtifactRetriever {
         } catch (IOException e) {
             String msg = "Error while executing the http client";
             log.error(msg, e);
-            throw new ArtifactSynchronizerException(msg, e);
+            throw new ArtifactSynchronizerException(msg, e, ExceptionCodes.ARTIFACT_SYNC_HTTP_REQUEST_FAILED);
         } catch (ArtifactSynchronizerException e) {
             String msg = "Error while retrieving artifacts";
             log.error(msg, e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/exception/ArtifactSynchronizerException.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/exception/ArtifactSynchronizerException.java
@@ -18,20 +18,37 @@
 
 package org.wso2.carbon.apimgt.impl.gatewayartifactsynchronizer.exception;
 
+import org.wso2.carbon.apimgt.api.ErrorHandler;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
+
 public class ArtifactSynchronizerException extends Exception {
+
+    private ErrorHandler errorHandler;
+    public ErrorHandler getErrorHandler() {
+        return errorHandler;
+    }
     public ArtifactSynchronizerException() {
+        this.errorHandler = ExceptionCodes.INTERNAL_ERROR;
     }
 
     public ArtifactSynchronizerException(String message) {
         super(message);
+        this.errorHandler = ExceptionCodes.INTERNAL_ERROR;
     }
 
     public ArtifactSynchronizerException(String message, Throwable cause) {
         super(message, cause);
+        this.errorHandler = ExceptionCodes.INTERNAL_ERROR;
     }
 
     public ArtifactSynchronizerException(Throwable cause) {
         super(cause);
+        this.errorHandler = ExceptionCodes.INTERNAL_ERROR;
+    }
+
+    public ArtifactSynchronizerException(String message, Throwable cause, ErrorHandler code) {
+        super(message, cause);
+        this.errorHandler = code;
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/exception/DataLoadingException.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/exception/DataLoadingException.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.gatewayartifactsynchronizer.exception;
+
+import org.wso2.carbon.apimgt.api.APIManagementException;
+
+public class DataLoadingException extends APIManagementException {
+
+    public DataLoadingException(String message) {
+        super(message);
+    }
+
+    public DataLoadingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DataLoadingException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -372,7 +372,7 @@ public final class APIUtil {
     private static final int retries = 2;
     private static long retrievalTimeout;
     private static final long maxRetrievalTimeout = 1000 * 60 * 60;
-    private static final double retryProgressionFactor = 2.0;
+    private static double retryProgressionFactor;
     private static int maxRetryCount;
 
     //constants for getting masked token
@@ -398,6 +398,8 @@ public final class APIUtil {
                 .parseBoolean(isPublisherRoleCacheEnabledConfiguration);
         retrievalTimeout = apiManagerConfiguration.getGatewayArtifactSynchronizerProperties().getRetryDuartion();
         maxRetryCount = apiManagerConfiguration.getGatewayArtifactSynchronizerProperties().getMaxRetryCount();
+        retryProgressionFactor = apiManagerConfiguration.getGatewayArtifactSynchronizerProperties()
+                .getRetryProgressionFactor();
         try {
             eventPublisherFactory = ServiceReferenceHolder.getInstance().getEventPublisherFactory();
             eventPublishers.putIfAbsent(EventPublisherType.ASYNC_WEBHOOKS,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -166,6 +166,7 @@ import org.wso2.carbon.apimgt.impl.dto.SubscribedApiDTO;
 import org.wso2.carbon.apimgt.impl.dto.SubscriptionPolicyDTO;
 import org.wso2.carbon.apimgt.impl.dto.ThrottleProperties;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
+import org.wso2.carbon.apimgt.impl.gatewayartifactsynchronizer.exception.DataLoadingException;
 import org.wso2.carbon.apimgt.impl.internal.APIManagerComponent;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.kmclient.ApacheFeignHttpClient;
@@ -369,6 +370,10 @@ public final class APIUtil {
     private static String hostAddress = null;
     private static final int timeoutInSeconds = 15;
     private static final int retries = 2;
+    private static long retrievalTimeout;
+    private static final long maxRetrievalTimeout = 1000 * 60 * 60;
+    private static final double retryProgressionFactor = 2.0;
+    private static int maxRetryCount;
 
     //constants for getting masked token
     private static final int MAX_LEN = 36;
@@ -391,6 +396,8 @@ public final class APIUtil {
                 .getFirstProperty(APIConstants.PUBLISHER_ROLE_CACHE_ENABLED);
         isPublisherRoleCacheEnabled = isPublisherRoleCacheEnabledConfiguration == null || Boolean
                 .parseBoolean(isPublisherRoleCacheEnabledConfiguration);
+        retrievalTimeout = apiManagerConfiguration.getGatewayArtifactSynchronizerProperties().getRetryDuartion();
+        maxRetryCount = apiManagerConfiguration.getGatewayArtifactSynchronizerProperties().getMaxRetryCount();
         try {
             eventPublisherFactory = ServiceReferenceHolder.getInstance().getEventPublisherFactory();
             eventPublishers.putIfAbsent(EventPublisherType.ASYNC_WEBHOOKS,
@@ -464,6 +471,54 @@ public final class APIUtil {
                     }
                 } else {
                     throw ex;
+                }
+            }
+        } while (retry);
+        return httpResponse;
+    }
+
+    /**
+     * This method is used to execute an HTTP request with retry parameters obtained from configuration parameters.
+     *
+     * @param method       HttpRequest Type
+     * @param httpClient   HttpClient
+     * @return CloseableHttpResponse
+     */
+    public static CloseableHttpResponse executeHTTPRequestWithRetries(HttpRequestBase method, HttpClient httpClient)
+            throws IOException, APIManagementException {
+        CloseableHttpResponse httpResponse = null;
+        long retryDuration = retrievalTimeout;
+        int retryCount = 0;
+        boolean retry;
+        do {
+            try {
+                httpResponse = (CloseableHttpResponse) httpClient.execute(method);
+                if (HttpStatus.SC_OK != httpResponse.getStatusLine().getStatusCode()) {
+                    throw new DataLoadingException("Error while retrieving artifacts. "
+                            + "Received response with status code "+ httpResponse.getStatusLine().getStatusCode());
+                }
+                retry = false;
+            } catch (IOException | DataLoadingException ex) {
+                retryCount++;
+                if (retryCount <= maxRetryCount) {
+                    retry = true;
+                    log.error("Failed to retrieve from remote endpoint: " + ex.getMessage()
+                            + ". Retry attempt " + retryCount + " in " + (retryDuration / 1000) +
+                            " seconds.");
+                    try {
+                        Thread.sleep(retryDuration);
+                        retryDuration = (long) (retryDuration * retryProgressionFactor);
+                        if (retryDuration > maxRetrievalTimeout) {
+                            retryDuration = maxRetrievalTimeout;
+                        }
+                    } catch (InterruptedException e) {
+                        // Ignore
+                    }
+                } else {
+                    log.error("Failed to retrieve from remote endpoint. Maximum retry count exceeded."
+                            + ex.getMessage());
+                    throw ex;
+
                 }
             }
         } while (retry);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -486,6 +486,7 @@ public final class APIUtil {
      */
     public static CloseableHttpResponse executeHTTPRequestWithRetries(HttpRequestBase method, HttpClient httpClient)
             throws IOException, APIManagementException {
+
         CloseableHttpResponse httpResponse = null;
         long retryDuration = retrievalTimeout;
         int retryCount = 0;
@@ -518,7 +519,6 @@ public final class APIUtil {
                     log.error("Failed to retrieve from remote endpoint. Maximum retry count exceeded."
                             + ex.getMessage());
                     throw ex;
-
                 }
             }
         } while (retry);

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1393,6 +1393,9 @@
         {% if apim.sync_runtime_artifacts.gateway.max_retry_count is defined %}
         <MaxRetryCount>{{apim.sync_runtime_artifacts.gateway.max_retry_count}}</MaxRetryCount>
         {% endif %}
+        {% if apim.sync_runtime_artifacts.gateway.retry_progression_factor is defined %}
+        <RetryProgressionFactor>{{apim.sync_runtime_artifacts.gateway.retry_progression_factor}}</RetryProgressionFactor>
+        {% endif %}
         {% if apim.sync_runtime_artifacts.gateway.data_retrieval_mode is defined %}
         <DataRetrievalMode>{{apim.sync_runtime_artifacts.gateway.data_retrieval_mode}}</DataRetrievalMode>
         {% endif %}

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1390,6 +1390,9 @@
         {% if apim.sync_runtime_artifacts.gateway.deployment_retry_duration is defined %}
         <RetryDuration>{{apim.sync_runtime_artifacts.gateway.deployment_retry_duration}}</RetryDuration>
         {% endif %}
+        {% if apim.sync_runtime_artifacts.gateway.max_retry_count is defined %}
+        <MaxRetryCount>{{apim.sync_runtime_artifacts.gateway.max_retry_count}}</MaxRetryCount>
+        {% endif %}
         {% if apim.sync_runtime_artifacts.gateway.data_retrieval_mode is defined %}
         <DataRetrievalMode>{{apim.sync_runtime_artifacts.gateway.data_retrieval_mode}}</DataRetrievalMode>
         {% endif %}


### PR DESCRIPTION
## Purpose

- Fix https://github.com/wso2/api-manager/issues/1780

## Implementation

- Add `MaxRetryCount` as a configuration parameter
```
[apim.sync_runtime_artifacts.gateway]
gateway_labels =["Default"]
artifact_retriever = "DBRetriever"
deployment_retry_duration = 15000
max_retry_count = 5
data_retrieval_mode = "async"
event_waiting_time = 5000
```
- Retrieve max retry count and retry timeout duration from configurations in newly added `org.wso2.carbon.apimgt.impl.utils.APIUtil#executeHTTPRequestWithRetries` method
- Update retry logic used in `org.wso2.carbon.apimgt.gateway.listeners.GatewayStartupListener#deployArtifactsInGateway`
