### PR TITLE
Filter out SUBSCRIPTION type deny policies

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/throttling/BlockingConditionMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/throttling/BlockingConditionMappingUtil.java
@@ -44,6 +44,11 @@ public class BlockingConditionMappingUtil {
         List<BlockingConditionDTO> blockingConditionDTOList = new ArrayList<>();
         if (blockConditionList != null) {
             for (BlockConditionsDTO blockCondition : blockConditionList) {
+                // Added to skip SUBSCRIPTION type blocking conditions left after migrations since subscription blocks
+                // are no longer added to the AM_BLOCK_CONDITIONS table
+                if (APIConstants.BLOCKING_CONDITIONS_SUBSCRIPTION.equals(blockCondition.getConditionType())) {
+                    continue;
+                }
                 BlockingConditionDTO dto = fromBlockingConditionToDTO(blockCondition);
                 blockingConditionDTOList.add(dto);
             }


### PR DESCRIPTION
This PR filters out the SUBSCRIPTION type deny policies retrieved from the AM_BLOCK_CONDITIONS table since subscription blocking is no longer added to the table.

Fixes https://github.com/wso2/api-manager/issues/1802