### PR TITLE
Fix the enduser claim of backend jwt to adher with enable.tenant.aware.subclaim property

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -84,6 +84,7 @@ import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -1022,6 +1023,12 @@ public class GatewayUtils {
                 Map<String, Object> claims = jwtInfoDto.getJwtValidationInfo().getClaims();
                 if (claims.get(JWTConstants.SUB) != null) {
                     String sub = (String) jwtInfoDto.getJwtValidationInfo().getClaims().get(JWTConstants.SUB);
+
+                    // A system property is used to enable/disable getting the tenant aware username as sub claim.
+                    String tenantAwareSubClaim = System.getProperty(APIConstants.ENABLE_TENANT_AWARE_SUB_CLAIM);
+                    if (StringUtils.isNotEmpty(tenantAwareSubClaim) && Boolean.parseBoolean(tenantAwareSubClaim)) {
+                        sub = MultitenantUtils.getTenantAwareUsername(sub);
+                    }
                     jwtInfoDto.setSub(sub);
                 }
                 if (claims.get(JWTConstants.ORGANIZATIONS) != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2978,4 +2978,7 @@ public final class APIConstants {
 
     public static final String MIGRATE = "migrate";
     public static final String SWAGGER_RELAXED_VALIDATION = "swaggerRelaxedValidation";
+
+    //Property for enabling tenant aware sub claims when invoking APIs with API key
+    public static final String ENABLE_TENANT_AWARE_SUB_CLAIM= "enable.tenant.aware.subclaim";
 }


### PR DESCRIPTION
https://github.com/wso2/api-manager/issues/1508 has introduced a new system property that change the sub claim of backend jwt with tenant aware username. However this improvement will change the enduser claim as well. Therefore this new improvement address the request in https://github.com/wso2/api-manager/issues/1788 which handles this claim manipulation properly.