### PR TITLE
Fix dev portal API get issue for backend JWT

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/interceptors/PreAuthenticationInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/interceptors/PreAuthenticationInterceptor.java
@@ -62,9 +62,8 @@ public class PreAuthenticationInterceptor extends AbstractPhaseInterceptor {
         Dictionary<URITemplate,List<String>> allowedResourcePathsMap;
 
         //If Authorization headers are present anonymous URI check will be skipped
-        ArrayList authHeaders = (ArrayList) ((TreeMap) (message.get(Message.PROTOCOL_HEADERS)))
-                .get(RestApiConstants.AUTH_HEADER_NAME);
-        if (authHeaders != null) {
+        if (((TreeMap) (message.get(Message.PROTOCOL_HEADERS))).get(RestApiConstants.AUTH_HEADER_NAME) != null
+                || ((TreeMap) (message.get(Message.PROTOCOL_HEADERS))).get(RestApiConstants.BACKEND_JWT_HEADER_NAME) != null) {
             return;
         }
 


### PR DESCRIPTION
Observed an issue while fetching developer portal APIs using a backend JWT. If the request contains the `x-jwt-assertion` header , authentication function consider that request as a anonymous user's request.

this PR fixes that issue.