### PR TITLE
Add change to check only the invalid token cache for invalid tokens

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidator.java
@@ -658,8 +658,7 @@ public class JWTValidator {
                     }
                     jwtValidationInfo = tempJWTValidationInfo;
                 }
-            } else if (SignedJWTInfo.ValidationStatus.INVALID.equals(signedJWTInfo.getValidationStatus())
-                    && getInvalidTokenCache().get(jti) != null) {
+            } else if (getInvalidTokenCache().get(jti) != null) {
                 if (log.isDebugEnabled()) {
                     log.debug("Token retrieved from the invalid token cache. Token: " + GatewayUtils
                             .getMaskedToken(jwtHeader));


### PR DESCRIPTION
This PR adds the change to check only the invalid token cache for invalid tokens instead of both the INVALID status of signed token and invalid token cache.

Fixes https://github.com/wso2/api-manager/issues/1820