### PR TITLE
[9.22.x] Add new method to retrieve runtime artifacts by dataPlaneID & API UUID list

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -3269,6 +3269,71 @@ public class SQLConstants {
                     "   AM_API.API_UUID=AM_GW_API_DEPLOYMENTS.API_ID AND" +
                     "   AM_GW_API_ARTIFACTS.REVISION_ID=AM_GW_API_DEPLOYMENTS.REVISION_ID";
 
+    public static final String RETRIEVE_ALL_ARTIFACTS_BY_DATA_PLANE_ID_AND_API_UUIDS =
+            "SELECT " +
+                    "   AM_GW_API_DEPLOYMENTS.API_ID AS API_ID," +
+                    "   AM_GW_API_DEPLOYMENTS.REVISION_ID AS REVISION_ID," +
+                    "   AM_GW_PUBLISHED_API_DETAILS.API_PROVIDER AS API_PROVIDER," +
+                    "   AM_GW_PUBLISHED_API_DETAILS.API_NAME AS API_NAME," +
+                    "   AM_GW_PUBLISHED_API_DETAILS.API_VERSION AS API_VERSION," +
+                    "   AM_GW_PUBLISHED_API_DETAILS.API_TYPE AS API_TYPE," +
+                    "   AM_GW_API_ARTIFACTS.ARTIFACT AS ARTIFACT," +
+                    "   AM_GW_API_DEPLOYMENTS.LABEL AS LABEL," +
+                    "   AM_GW_API_DEPLOYMENTS.VHOST AS VHOST, " +
+                    "   AM_API.CONTEXT AS CONTEXT " +
+                    "FROM" +
+                    "   AM_GW_PUBLISHED_API_DETAILS," +
+                    "   AM_GW_API_ARTIFACTS," +
+                    "   AM_GW_API_DEPLOYMENTS," +
+                    "   AM_API," +
+                    "   CHOREO_GW_ENV_DATA_PLANE_MAPPING," +
+                    "   AM_GW_VHOST," +
+                    "   AM_GATEWAY_ENVIRONMENT " +
+                    "WHERE" +
+                    "   CHOREO_GW_ENV_DATA_PLANE_MAPPING.DATA_PLANE_ID = ? AND" +
+                    "   AM_GATEWAY_ENVIRONMENT.ACCESSIBILITY_TYPE = ? AND" +
+                    "   AM_GW_API_DEPLOYMENTS.API_ID IN (_API_IDS_) AND" +
+                    "   AM_GW_VHOST.GATEWAY_ENV_ID=AM_GATEWAY_ENVIRONMENT.ID AND" +
+                    "   AM_GATEWAY_ENVIRONMENT.UUID=CHOREO_GW_ENV_DATA_PLANE_MAPPING.GATEWAY_ENV_UUID AND" +
+                    "   AM_GW_VHOST.HOST=AM_GW_API_DEPLOYMENTS.VHOST AND" +
+                    "   AM_GW_PUBLISHED_API_DETAILS.API_ID=AM_GW_API_DEPLOYMENTS.API_ID AND" +
+                    "   AM_GW_API_ARTIFACTS.API_ID=AM_GW_API_DEPLOYMENTS.API_ID AND" +
+                    "   AM_API.API_UUID=AM_GW_API_DEPLOYMENTS.API_ID AND" +
+                    "   AM_GW_API_ARTIFACTS.REVISION_ID=AM_GW_API_DEPLOYMENTS.REVISION_ID";
+
+    public static final String RETRIEVE_ARTIFACTS_BY_DATA_PLANE_ID_AND_API_UUIDS =
+            "SELECT " +
+                    "   AM_GW_API_DEPLOYMENTS.API_ID AS API_ID," +
+                    "   AM_GW_API_DEPLOYMENTS.REVISION_ID AS REVISION_ID," +
+                    "   AM_GW_PUBLISHED_API_DETAILS.API_PROVIDER AS API_PROVIDER," +
+                    "   AM_GW_PUBLISHED_API_DETAILS.API_NAME AS API_NAME," +
+                    "   AM_GW_PUBLISHED_API_DETAILS.API_VERSION AS API_VERSION," +
+                    "   AM_GW_PUBLISHED_API_DETAILS.API_TYPE AS API_TYPE," +
+                    "   AM_GW_API_ARTIFACTS.ARTIFACT AS ARTIFACT," +
+                    "   AM_GW_API_DEPLOYMENTS.LABEL AS LABEL," +
+                    "   AM_GW_API_DEPLOYMENTS.VHOST AS VHOST, " +
+                    "   AM_API.CONTEXT AS CONTEXT " +
+                    "FROM" +
+                    "   AM_GW_PUBLISHED_API_DETAILS," +
+                    "   AM_GW_API_ARTIFACTS," +
+                    "   AM_GW_API_DEPLOYMENTS," +
+                    "   AM_API," +
+                    "   CHOREO_GW_ENV_DATA_PLANE_MAPPING," +
+                    "   AM_GW_VHOST," +
+                    "   AM_GATEWAY_ENVIRONMENT " +
+                    "WHERE" +
+                    "   AM_GW_PUBLISHED_API_DETAILS.TENANT_DOMAIN = ? AND" +
+                    "   CHOREO_GW_ENV_DATA_PLANE_MAPPING.DATA_PLANE_ID = ? AND" +
+                    "   AM_GATEWAY_ENVIRONMENT.ACCESSIBILITY_TYPE = ? AND" +
+                    "   AM_GW_API_DEPLOYMENTS.API_ID IN (_API_IDS_) AND" +
+                    "   AM_GW_VHOST.GATEWAY_ENV_ID=AM_GATEWAY_ENVIRONMENT.ID AND" +
+                    "   AM_GATEWAY_ENVIRONMENT.UUID=CHOREO_GW_ENV_DATA_PLANE_MAPPING.GATEWAY_ENV_UUID AND" +
+                    "   AM_GW_VHOST.HOST=AM_GW_API_DEPLOYMENTS.VHOST AND" +
+                    "   AM_GW_PUBLISHED_API_DETAILS.API_ID=AM_GW_API_DEPLOYMENTS.API_ID AND" +
+                    "   AM_GW_API_ARTIFACTS.API_ID=AM_GW_API_DEPLOYMENTS.API_ID AND" +
+                    "   AM_API.API_UUID=AM_GW_API_DEPLOYMENTS.API_ID AND" +
+                    "   AM_GW_API_ARTIFACTS.REVISION_ID=AM_GW_API_DEPLOYMENTS.REVISION_ID";
+
     public static final String RETRIEVE_ARTIFACTS =
             "SELECT AM_GW_API_DEPLOYMENTS.API_ID AS API_ID,AM_GW_API_DEPLOYMENTS.REVISION_ID AS REVISION_ID," +
                     "AM_GW_PUBLISHED_API_DETAILS.TENANT_DOMAIN AS TENANT_DOMAIN,AM_GW_PUBLISHED_API_DETAILS.API_PROVIDER AS " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/RuntimeArtifactGeneratorUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/RuntimeArtifactGeneratorUtil.java
@@ -201,6 +201,36 @@ public class RuntimeArtifactGeneratorUtil {
         }
     }
 
+    public static RuntimeArtifactDto generateAllRuntimeArtifact(String type, String dataPlaneId, String gatewayAccessibilityType,
+                                                                List<String> apiUuids)
+            throws APIManagementException {
+        GatewayArtifactGenerator gatewayArtifactGenerator =
+                ServiceReferenceHolder.getInstance().getGatewayArtifactGenerator(type);
+        if (gatewayArtifactGenerator != null) {
+            List<APIRuntimeArtifactDto> gatewayArtifacts = choreoGatewayArtifactsMgtDAO
+                    .retrieveAllGatewayArtifactsByDataPlaneAndAPIIDs(dataPlaneId, gatewayAccessibilityType, apiUuids);
+
+            if (gatewayArtifacts != null) {
+                if (gatewayArtifacts.isEmpty()) {
+                    throw new APIManagementException("No API Artifacts", ExceptionCodes.NO_API_ARTIFACT_FOUND);
+                }
+                for (APIRuntimeArtifactDto apiRuntimeArtifactDto: gatewayArtifacts) {
+                    ArtifactSynchronizerUtil.setArtifactProperties(apiRuntimeArtifactDto);
+                }
+            }
+            if (gatewayArtifacts == null || gatewayArtifacts.isEmpty()) {
+                return null;
+            }
+            return gatewayArtifactGenerator.generateGatewayArtifact(gatewayArtifacts);
+        } else {
+            Set<String> gatewayArtifactGeneratorTypes =
+                    ServiceReferenceHolder.getInstance().getGatewayArtifactGeneratorTypes();
+            throw new APIManagementException("Couldn't find gateway Type",
+                    ExceptionCodes.from(ExceptionCodes.GATEWAY_TYPE_NOT_FOUND, String.join(",",
+                            gatewayArtifactGeneratorTypes)));
+        }
+    }
+
     public static RuntimeArtifactDto generateAllRuntimeArtifact(String organization, String dataPlaneId,
                                                                 String gatewayAccessibilityType, String type)
             throws APIManagementException {
@@ -217,6 +247,37 @@ public class RuntimeArtifactGeneratorUtil {
                         .retrieveAllGatewayArtifactsByOrganizationAndDataPlaneId(organization, dataPlaneId,
                                 gatewayAccessibilityType);
             }
+            if (gatewayArtifacts != null) {
+                if (gatewayArtifacts.isEmpty()) {
+                    throw new APIManagementException("No API Artifacts", ExceptionCodes.NO_API_ARTIFACT_FOUND);
+                }
+                for (APIRuntimeArtifactDto apiRuntimeArtifactDto: gatewayArtifacts) {
+                    ArtifactSynchronizerUtil.setArtifactProperties(apiRuntimeArtifactDto);
+                }
+            }
+            if (gatewayArtifacts == null || gatewayArtifacts.isEmpty()) {
+                return null;
+            }
+            return gatewayArtifactGenerator.generateGatewayArtifact(gatewayArtifacts);
+        } else {
+            Set<String> gatewayArtifactGeneratorTypes =
+                    ServiceReferenceHolder.getInstance().getGatewayArtifactGeneratorTypes();
+            throw new APIManagementException("Couldn't find gateway Type",
+                    ExceptionCodes.from(ExceptionCodes.GATEWAY_TYPE_NOT_FOUND, String.join(",",
+                            gatewayArtifactGeneratorTypes)));
+        }
+    }
+
+    public static RuntimeArtifactDto generateAllRuntimeArtifact(String organization, String type, String dataPlaneId,
+                                                                String gatewayAccessibilityType, List<String> apiUuids)
+            throws APIManagementException {
+        GatewayArtifactGenerator gatewayArtifactGenerator =
+                ServiceReferenceHolder.getInstance().getGatewayArtifactGenerator(type);
+        if (gatewayArtifactGenerator != null) {
+            List<APIRuntimeArtifactDto> gatewayArtifacts = choreoGatewayArtifactsMgtDAO
+                        .retrieveGatewayArtifactsByDataPlaneAndAPIIDs(organization, dataPlaneId,
+                                gatewayAccessibilityType, apiUuids);
+
             if (gatewayArtifacts != null) {
                 if (gatewayArtifacts.isEmpty()) {
                     throw new APIManagementException("No API Artifacts", ExceptionCodes.NO_API_ARTIFACT_FOUND);

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/RetrieveRuntimeArtifactsApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/RetrieveRuntimeArtifactsApi.java
@@ -1,6 +1,7 @@
 package org.wso2.carbon.apimgt.internal.service;
 
 import org.wso2.carbon.apimgt.internal.service.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.internal.service.dto.UUIDListDTO;
 import org.wso2.carbon.apimgt.internal.service.RetrieveRuntimeArtifactsApiService;
 import org.wso2.carbon.apimgt.internal.service.impl.RetrieveRuntimeArtifactsApiServiceImpl;
 import org.wso2.carbon.apimgt.api.APIManagementException;
@@ -39,11 +40,23 @@ RetrieveRuntimeArtifactsApiService delegate = new RetrieveRuntimeArtifactsApiSer
     
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Get all the runtime artifacts for a given data-planeId", notes = "This will provide access to runtime artifacts in database. ", response = Void.class, tags={ "Retrieving Runtime artifacts" })
+    @ApiOperation(value = "Get all the runtime artifacts for a given data-planeId", notes = "This will provide access to runtime artifacts in database. ", response = Void.class, tags={ "Retrieving Runtime artifacts",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "List of runtime Artifacts", response = Void.class),
         @ApiResponse(code = 200, message = "Unexpected error", response = ErrorDTO.class) })
     public Response retrieveRuntimeArtifactsGet( @NotNull @ApiParam(value = "**Search condition**.  type of gateway ",required=true)  @QueryParam("type") String type,  @NotNull @ApiParam(value = "**Search condition**.  Data-plane ID ",required=true)  @QueryParam("dataPlaneId") String dataPlaneId,  @ApiParam(value = "**Search condition**.   Gateway Accessibility type denotes whether the gateway environment is internal or external ")  @QueryParam("gatewayAccessibilityType") String gatewayAccessibilityType) throws APIManagementException{
         return delegate.retrieveRuntimeArtifactsGet(type, dataPlaneId, gatewayAccessibilityType, securityContext);
+    }
+
+    @POST
+    
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get all the runtime artifacts for a given data-planeId", notes = "This will provide access to runtime artifacts in database. ", response = Void.class, tags={ "Retrieving Runtime artifacts" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "List of runtime Artifacts", response = Void.class),
+        @ApiResponse(code = 200, message = "Unexpected error", response = ErrorDTO.class) })
+    public Response retrieveRuntimeArtifactsPost( @NotNull @ApiParam(value = "**Search condition**.  type of gateway ",required=true)  @QueryParam("type") String type,  @NotNull @ApiParam(value = "**Search condition**.  Data-plane ID ",required=true)  @QueryParam("dataPlaneId") String dataPlaneId,  @NotNull @ApiParam(value = "**Search condition**.   Gateway Accessibility type denotes whether the gateway environment is internal or external ",required=true)  @QueryParam("gatewayAccessibilityType") String gatewayAccessibilityType, @ApiParam(value = "API UUID list payload" ) UUIDListDTO uuidList) throws APIManagementException{
+        return delegate.retrieveRuntimeArtifactsPost(type, dataPlaneId, gatewayAccessibilityType, uuidList, securityContext);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/RetrieveRuntimeArtifactsApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/RetrieveRuntimeArtifactsApiService.java
@@ -10,6 +10,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 
 import org.wso2.carbon.apimgt.internal.service.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.internal.service.dto.UUIDListDTO;
 
 import java.util.List;
 
@@ -21,4 +22,5 @@ import javax.ws.rs.core.SecurityContext;
 
 public interface RetrieveRuntimeArtifactsApiService {
       public Response retrieveRuntimeArtifactsGet(String type, String dataPlaneId, String gatewayAccessibilityType, MessageContext messageContext) throws APIManagementException;
+      public Response retrieveRuntimeArtifactsPost(String type, String dataPlaneId, String gatewayAccessibilityType, UUIDListDTO uuidList, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/resources/api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/resources/api.yaml
@@ -545,6 +545,46 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+    post:
+      summary: Get all the runtime artifacts for a given data-planeId
+      description: |
+        This will provide access to runtime artifacts in database.
+      parameters:
+        - name: type
+          in: query
+          description: |
+            **Search condition**.
+             type of gateway
+          type: string
+          required: true
+        - name: dataPlaneId
+          in: query
+          description: |
+            **Search condition**.
+             Data-plane ID
+          type: string
+          required: true
+        - name: gatewayAccessibilityType
+          in: query
+          description: |
+            **Search condition**.
+              Gateway Accessibility type denotes whether the gateway environment is internal or external
+          type: string
+          required: true
+        - name: uuidList
+          in: body
+          description: 'API UUID list payload'
+          schema:
+            $ref: "#/definitions/UUIDList"
+      tags:
+        - Retrieving Runtime artifacts
+      responses:
+        200:
+          description: List of runtime Artifacts
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /retrieve-api-artifacts:
     post:
       summary: Get API runtime artifacts from ID list

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/swagger.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/swagger.json
@@ -686,6 +686,49 @@
             }
           }
         }
+      },
+      "post" : {
+        "tags" : [ "Retrieving Runtime artifacts" ],
+        "summary" : "Get all the runtime artifacts for a given data-planeId",
+        "description" : "This will provide access to runtime artifacts in database.\n",
+        "parameters" : [ {
+          "name" : "type",
+          "in" : "query",
+          "description" : "**Search condition**.\n type of gateway\n",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "dataPlaneId",
+          "in" : "query",
+          "description" : "**Search condition**.\n Data-plane ID\n",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "gatewayAccessibilityType",
+          "in" : "query",
+          "description" : "**Search condition**.\n  Gateway Accessibility type denotes whether the gateway environment is internal or external\n",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "uuidList",
+          "description" : "API UUID list payload",
+          "required" : false,
+          "schema" : {
+            "$ref" : "#/definitions/UUIDList"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "List of runtime Artifacts"
+          },
+          "default" : {
+            "description" : "Unexpected error",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          }
+        }
       }
     },
     "/retrieve-api-artifacts" : {


### PR DESCRIPTION
### Purpose

Add new method to retrieve runtime artifacts by dataPlaneID & API UUID list
- POST /retrieve-runtime-artifacts?dataPlaneId=<>&gatewayAccessibilityType=<>
- API UUID list should be sent in the body