### PR TITLE
Unpublishing from external stores null pointer exception fixed.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -2182,7 +2182,12 @@ public class ApisApiServiceImpl implements ApisApiService {
         String organization = RestApiUtil.getValidatedOrganization(messageContext);
         APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
         API api = null;
-        List<String> externalStoreIdList = Arrays.asList(externalStoreIds.split("\\s*,\\s*"));
+        List<String> externalStoreIdList;
+        if (externalStoreIds != null) {
+            externalStoreIdList = Arrays.asList(externalStoreIds.split("\\s*,\\s*"));
+        } else {
+            externalStoreIdList = new ArrayList<>();
+        }
         try {
             APIIdentifier apiIdentifier = APIMappingUtil.getAPIIdentifierFromUUID(apiId);
             if (apiIdentifier == null) {


### PR DESCRIPTION
## Purpose
This PR fixes the Internal Server Error while Trying to Remove All Published External API Developer Portals from an API  issue.
Related to https://github.com/wso2-enterprise/wso2-apim-internal/issues/2465

## Approach
NullPointerException is happening in the org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java:2182.
- ExternalStoreId parameter is missing in the request.
- Since ExternalStoreId is null, 
  ```
  List<String> externalStoreIdList = Arrays.asList(externalStoreIds.split("\\s*,\\s*"));
  ```
     splitting occurs the null pointer exception.
- Added an if condition to check whether the ExternalStoreId is null, and if it is null then it will assign a new empty arraylist.

## Related PRs
- https://github.com/wso2-support/carbon-apimgt/pull/5822
