### PR TITLE
Fix Host Name in Gateway Access URL in Portals for WebSocket APIs Showing Wrong Host

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -163,6 +163,8 @@ public enum ExceptionCodes implements ErrorHandler {
             400, "Name of the gateway is read only"),
     GATEWAY_ENVIRONMENT_VHOST_NOT_PROVIDED(900511, "Gateway Environment virtual hosts name not provided",
             400, "Gateway Environment VHOST name not provided"),
+    INVALID_VHOST(900512, "Invalid virtual host name provided",
+            400, "Virtual host with provided vhost name does not exist"),
 
     // Workflow related codes
     WORKFLOW_EXCEPTION(900550, "Workflow error", 500,

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
@@ -224,6 +224,14 @@ public class VHost {
             throw new APIManagementException("Error while building VHost, missing required HTTP or HTTPS endpoint");
         }
 
+        // If WebSocket host name of Vhost is empty, use HTTP/HTTPS endpoint hostname
+        if ((vhost.getWsHost() == null) || (StringUtils.isEmpty(vhost.getWsHost()))) {
+            vhost.setWsHost(vhost.getHost());
+        }
+        if ((vhost.getWssHost() == null) || (StringUtils.isEmpty(vhost.getWssHost()))) {
+            vhost.setWssHost(vhost.getHost());
+        }
+
         return vhost;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
@@ -27,12 +27,15 @@ import java.net.URL;
  * This class represent an Virtual Host
  */
 public class VHost {
+    // host name from the http endpoint
     private String host;
     private String httpContext = "";
     private Integer httpPort = -1;
     private Integer httpsPort = -1;
     private Integer wsPort = DEFAULT_WS_PORT;
+    private String wsHost;
     private Integer wssPort = DEFAULT_WSS_PORT;
+    private String wssHost;
     private Integer websubHttpPort = DEFAULT_WEBSUB_HTTP_PORT;
     private Integer websubHttpsPort = DEFAULT_WEBSUB_HTTPS_PORT;
 
@@ -95,12 +98,28 @@ public class VHost {
         this.wsPort = wsPort;
     }
 
+    public String getWsHost() {
+        return wsHost;
+    }
+
+    public void setWsHost(String wsHost) {
+        this.wsHost = wsHost;
+    }
+
     public Integer getWssPort() {
         return wssPort;
     }
 
     public void setWssPort(Integer wssPort) {
         this.wssPort = wssPort;
+    }
+
+    public String getWssHost() {
+        return wssHost;
+    }
+
+    public void setWssHost(String wssHost) {
+        this.wssHost = wssHost;
     }
 
     public Integer getWebsubHttpPort() {
@@ -120,27 +139,27 @@ public class VHost {
     }
 
     public String getHttpUrl() {
-        return getUrl("http", httpPort == DEFAULT_HTTP_PORT ? "" : ":" + httpPort, httpContext);
+        return getUrl("http", host, httpPort == DEFAULT_HTTP_PORT ? "" : ":" + httpPort, httpContext);
     }
 
     public String getHttpsUrl() {
-        return getUrl("https", httpsPort == DEFAULT_HTTPS_PORT ? "" : ":" + httpsPort, httpContext);
+        return getUrl("https", host, httpsPort == DEFAULT_HTTPS_PORT ? "" : ":" + httpsPort, httpContext);
     }
 
     public String getWsUrl() {
-        return getUrl("ws", wsPort == DEFAULT_HTTP_PORT ? ""  : ":" + wsPort, "");
+        return getUrl("ws", wsHost, wsPort == DEFAULT_HTTP_PORT ? ""  : ":" + wsPort, "");
     }
 
     public String getWssUrl() {
-        return getUrl("wss", wssPort == DEFAULT_HTTPS_PORT ? "" : ":" + wssPort, "");
+        return getUrl("wss", wssHost, wssPort == DEFAULT_HTTPS_PORT ? "" : ":" + wssPort, "");
     }
 
-    private String getUrl(String protocol, String port, String context) {
+    private String getUrl(String protocol, String hostName, String port, String context) {
         // {protocol}://{host}{port}{context}
         if (StringUtils.isNotEmpty(context) && !context.startsWith("/")) {
             context = "/" + context;
         }
-        return String.format("%s://%s%s%s", protocol, host, port, context);
+        return String.format("%s://%s%s%s", protocol, hostName, port, context);
     }
 
     public static VHost fromEndpointUrls(String[] endpoints) throws APIManagementException {
@@ -178,11 +197,13 @@ public class VHost {
                         // URL is not parsing for wss protocols, hence change to https
                         url = new URL(HTTPS_PROTOCOL + PROTOCOL_SEPARATOR + elem[1]);
                         vhost.setWssPort(url.getPort() < 0 ? DEFAULT_WSS_PORT : url.getPort());
+                        vhost.setWssHost(url.getHost());
                         break;
                     case WS_PROTOCOL:
                         // URL is not parsing for ws protocols, hence change to http
                         url = new URL(HTTP_PROTOCOL + PROTOCOL_SEPARATOR + elem[1]);
                         vhost.setWsPort(url.getPort() < 0 ? DEFAULT_WS_PORT : url.getPort());
+                        vhost.setWsHost(url.getHost());
                         break;
                     case WEBSUB_HTTP_PROTOCOL:
                         url = new URL(HTTP_PROTOCOL + PROTOCOL_SEPARATOR + elem[1]);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -14060,6 +14060,9 @@ public class ApiMgtDAO {
                     vhost.setHttpsPort(httpsPort);
                     vhost.setWsPort(wsPort);
                     vhost.setWssPort(wssPort);
+                    // Since DB does not contain columns for wsHost and wssHost, host is used
+                    vhost.setWsHost(host);
+                    vhost.setWssHost(host);
                     vhosts.add(vhost);
                 }
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/VHostUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/VHostUtils.java
@@ -41,7 +41,9 @@ public class VHostUtils {
         defaultVhost.setHttpsPort(APIConstants.HTTPS_PROTOCOL_PORT);
         defaultVhost.setHttpPort(APIConstants.HTTP_PROTOCOL_PORT);
         defaultVhost.setWsPort(APIConstants.WS_PROTOCOL_PORT);
+        defaultVhost.setWsHost(host);
         defaultVhost.setWssPort(APIConstants.WSS_PROTOCOL_PORT);
+        defaultVhost.setWssHost(host);
 
         if (host == null && environment.getVhosts().size() > 0) {
             // VHost is NULL set first Vhost (set in deployment toml)

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/VHostDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/VHostDTO.java
@@ -25,7 +25,9 @@ public class VHostDTO   {
     private Integer httpPort = null;
     private Integer httpsPort = null;
     private Integer wsPort = null;
+    private String wsHost = null;
     private Integer wssPort = null;
+    private String wssHost = null;
 
   /**
    **/
@@ -115,6 +117,23 @@ public class VHostDTO   {
 
   /**
    **/
+  public VHostDTO wsHost(String wsHost) {
+    this.wsHost = wsHost;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "mg.wso2.com", value = "")
+  @JsonProperty("wsHost")
+  public String getWsHost() {
+    return wsHost;
+  }
+  public void setWsHost(String wsHost) {
+    this.wsHost = wsHost;
+  }
+
+  /**
+   **/
   public VHostDTO wssPort(Integer wssPort) {
     this.wssPort = wssPort;
     return this;
@@ -128,6 +147,23 @@ public class VHostDTO   {
   }
   public void setWssPort(Integer wssPort) {
     this.wssPort = wssPort;
+  }
+
+  /**
+   **/
+  public VHostDTO wssHost(String wssHost) {
+    this.wssHost = wssHost;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "mg.wso2.com", value = "")
+  @JsonProperty("wssHost")
+  public String getWssHost() {
+    return wssHost;
+  }
+  public void setWssHost(String wssHost) {
+    this.wssHost = wssHost;
   }
 
 
@@ -145,12 +181,14 @@ public class VHostDTO   {
         Objects.equals(httpPort, vhost.httpPort) &&
         Objects.equals(httpsPort, vhost.httpsPort) &&
         Objects.equals(wsPort, vhost.wsPort) &&
-        Objects.equals(wssPort, vhost.wssPort);
+        Objects.equals(wsHost, vhost.wsHost) &&
+        Objects.equals(wssPort, vhost.wssPort) &&
+        Objects.equals(wssHost, vhost.wssHost);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, httpContext, httpPort, httpsPort, wsPort, wssPort);
+    return Objects.hash(host, httpContext, httpPort, httpsPort, wsPort, wsHost, wssPort, wssHost);
   }
 
   @Override
@@ -163,7 +201,9 @@ public class VHostDTO   {
     sb.append("    httpPort: ").append(toIndentedString(httpPort)).append("\n");
     sb.append("    httpsPort: ").append(toIndentedString(httpsPort)).append("\n");
     sb.append("    wsPort: ").append(toIndentedString(wsPort)).append("\n");
+    sb.append("    wsHost: ").append(toIndentedString(wsHost)).append("\n");
     sb.append("    wssPort: ").append(toIndentedString(wssPort)).append("\n");
+    sb.append("    wssHost: ").append(toIndentedString(wssHost)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
@@ -152,6 +152,16 @@ public class EnvironmentMappingUtil {
         vhost.setHttpsPort(vhostDTO.getHttpsPort());
         vhost.setWsPort(vhostDTO.getWsPort());
         vhost.setWssPort(vhostDTO.getWssPort());
+        if (vhostDTO.getWsHost() == null) {
+            vhost.setWsHost(vhostDTO.getHost());
+        } else {
+            vhost.setWsHost(vhostDTO.getWsHost());
+        }
+        if (vhostDTO.getWssHost() == null) {
+            vhost.setWssHost(vhostDTO.getHost());
+        } else {
+            vhost.setWssHost(vhostDTO.getWssHost());
+        }
         return vhost;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -4084,9 +4084,15 @@ components:
         wsPort:
           type: integer
           example: 9099
+        wsHost:
+          type: string
+          example: mg.wso2.com
         wssPort:
           type: integer
           example: 8099
+        wssHost:
+          type: string
+          example: mg.wso2.com
     AdditionalProperty:
       title: Additional Gateway Properties
       type: object

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/VHostDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/VHostDTO.java
@@ -25,7 +25,9 @@ public class VHostDTO   {
     private Integer httpPort = null;
     private Integer httpsPort = null;
     private Integer wsPort = null;
+    private String wsHost = null;
     private Integer wssPort = null;
+    private String wssHost = null;
     private Integer websubHttpPort = null;
     private Integer websubHttpsPort = null;
 
@@ -116,6 +118,23 @@ public class VHostDTO   {
 
   /**
    **/
+  public VHostDTO wsHost(String wsHost) {
+    this.wsHost = wsHost;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "mg.wso2.com", value = "")
+  @JsonProperty("wsHost")
+  public String getWsHost() {
+    return wsHost;
+  }
+  public void setWsHost(String wsHost) {
+    this.wsHost = wsHost;
+  }
+
+  /**
+   **/
   public VHostDTO wssPort(Integer wssPort) {
     this.wssPort = wssPort;
     return this;
@@ -129,6 +148,23 @@ public class VHostDTO   {
   }
   public void setWssPort(Integer wssPort) {
     this.wssPort = wssPort;
+  }
+
+  /**
+   **/
+  public VHostDTO wssHost(String wssHost) {
+    this.wssHost = wssHost;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "mg.wso2.com", value = "")
+  @JsonProperty("wssHost")
+  public String getWssHost() {
+    return wssHost;
+  }
+  public void setWssHost(String wssHost) {
+    this.wssHost = wssHost;
   }
 
   /**
@@ -180,14 +216,16 @@ public class VHostDTO   {
         Objects.equals(httpPort, vhost.httpPort) &&
         Objects.equals(httpsPort, vhost.httpsPort) &&
         Objects.equals(wsPort, vhost.wsPort) &&
+        Objects.equals(wsHost, vhost.wsHost) &&
         Objects.equals(wssPort, vhost.wssPort) &&
+        Objects.equals(wssHost, vhost.wssHost) &&
         Objects.equals(websubHttpPort, vhost.websubHttpPort) &&
         Objects.equals(websubHttpsPort, vhost.websubHttpsPort);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, httpContext, httpPort, httpsPort, wsPort, wssPort, websubHttpPort, websubHttpsPort);
+    return Objects.hash(host, httpContext, httpPort, httpsPort, wsPort, wsHost, wssPort, wssHost, websubHttpPort, websubHttpsPort);
   }
 
   @Override
@@ -200,7 +238,9 @@ public class VHostDTO   {
     sb.append("    httpPort: ").append(toIndentedString(httpPort)).append("\n");
     sb.append("    httpsPort: ").append(toIndentedString(httpsPort)).append("\n");
     sb.append("    wsPort: ").append(toIndentedString(wsPort)).append("\n");
+    sb.append("    wsHost: ").append(toIndentedString(wsHost)).append("\n");
     sb.append("    wssPort: ").append(toIndentedString(wssPort)).append("\n");
+    sb.append("    wssHost: ").append(toIndentedString(wssHost)).append("\n");
     sb.append("    websubHttpPort: ").append(toIndentedString(websubHttpPort)).append("\n");
     sb.append("    websubHttpsPort: ").append(toIndentedString(websubHttpsPort)).append("\n");
     sb.append("}");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/EnvironmentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/EnvironmentMappingUtil.java
@@ -117,7 +117,9 @@ public class EnvironmentMappingUtil {
         vHostDTO.setHttpPort(vHost.getHttpPort());
         vHostDTO.setHttpsPort(vHost.getHttpsPort());
         vHostDTO.setWsPort(vHost.getWsPort());
+        vHostDTO.setWsHost(vHost.getWsHost());
         vHostDTO.setWssPort(vHost.getWssPort());
+        vHostDTO.setWssHost(vHost.getWssHost());
         vHostDTO.setWebsubHttpPort(vHost.getWebsubHttpPort());
         vHostDTO.setWebsubHttpsPort(vHost.getWebsubHttpsPort());
         return vHostDTO;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -10363,9 +10363,15 @@ components:
         wsPort:
           type: integer
           example: 9099
+        wsHost:
+          type: string
+          example: mg.wso2.com
         wssPort:
           type: integer
           example: 8099
+        wssHost:
+          type: string
+          example: mg.wso2.com
         websubHttpPort:
           type: integer
           example: 9021


### PR DESCRIPTION
### Purpose

- Fix https://github.com/wso2/api-manager/issues/1844
- ForwardPort https://github.com/wso2-support/carbon-apimgt/pull/5890
---
- ForwardPort https://github.com/wso2-support/carbon-apimgt/pull/5561

### Description

- Gateway Access URL should displays the host name which given for `ws_endpoint` in the `deployment.toml` file. However in the publisher and dev-portal it showed the host name given for `http_endpoint`.
---
- ForwardPort the fix for validating VHost when deploying API revisions.

### Implementation

- Add `wsHost` and `wssHost` to `components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java`.
- Update `org.wso2.carbon.apimgt.api.model.VHost#getUrl` method to fetch `wsHost` and `wssHost` when retrieving URLs.
- Add changes to the UI to use `wsHost` and `wssHost` parameters by PR [1].

[1] - https://github.com/wso2/apim-apps/pull/466