### PR TITLE
Upgrade snakeyaml and jsckson dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2107,14 +2107,14 @@
         <xercesImpl.version>2.8.1.wso2v2</xercesImpl.version>
         <commons.scxml.version>0.9.0.wso2v2</commons.scxml.version>
         <velocity.version>2.1</velocity.version>
-        <fasterxml.jackson.version>2.13.1</fasterxml.jackson.version>
-        <fasterxml.jackson.databind.version>2.13.1</fasterxml.jackson.databind.version>
-        <fasterxml.jackson.core.version>2.13.1</fasterxml.jackson.core.version>
+        <fasterxml.jackson.version>2.14.3</fasterxml.jackson.version>
+        <fasterxml.jackson.databind.version>2.14.3</fasterxml.jackson.databind.version>
+        <fasterxml.jackson.core.version>2.14.3</fasterxml.jackson.core.version>
         <javax.validation-api>1.1.0.Final</javax.validation-api>
         <carbon.broker.version>3.3.24</carbon.broker.version>
         <andes.version>3.3.22</andes.version>
         <waffle-jna.version>1.6.wso2v7</waffle-jna.version>
-        <version.snake.yaml>1.28</version.snake.yaml>
+        <version.snake.yaml>1.33</version.snake.yaml>
         <wsdl4j.version>1.6.3.wso2v3</wsdl4j.version>
         <slf4j.test.version>1.7.29</slf4j.test.version>
         <reflection.version>0.9.11</reflection.version>


### PR DESCRIPTION
There were few vulnerable `snakeyaml` versions detected from the choreo-apim product.

Fix for : https://github.com/wso2-enterprise/choreo/issues/16768