### PR TITLE
Update retry logic used for internal API requests

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/EndpointCertificateDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/EndpointCertificateDeployer.java
@@ -132,7 +132,7 @@ public class EndpointCertificateDeployer {
 
         HttpClient httpClient = APIUtil.getHttpClient(port, protocol);
         try {
-            return APIUtil.executeHTTPRequest(method, httpClient);
+            return APIUtil.executeHTTPRequestWithRetries(method, httpClient);
         } catch (APIManagementException e) {
             throw new ArtifactSynchronizerException(e);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/GoogleAnalyticsConfigDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/GoogleAnalyticsConfigDeployer.java
@@ -118,7 +118,7 @@ public class GoogleAnalyticsConfigDeployer {
 
         HttpClient httpClient = APIUtil.getHttpClient(port, protocol);
         try {
-            return APIUtil.executeHTTPRequest(method, httpClient);
+            return APIUtil.executeHTTPRequestWithRetries(method, httpClient);
         } catch (APIManagementException e) {
             throw new ArtifactSynchronizerException(e);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/util/BlockingConditionRetrieverTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/util/BlockingConditionRetrieverTest.java
@@ -17,10 +17,9 @@
  */
 package org.wso2.carbon.apimgt.gateway.throttling.util;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.entity.BasicHttpEntity;
 import org.junit.Assert;
@@ -49,14 +48,15 @@ public class BlockingConditionRetrieverTest {
                 ".super\"}],\"user\":[\"admin\"],\"custom\":[]}";
         PowerMockito.mockStatic(APIUtil.class);
         HttpClient httpClient = Mockito.mock(HttpClient.class);
-        HttpResponse httpResponse = Mockito.mock(HttpResponse.class);
+        CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
         BasicHttpEntity httpEntity = new BasicHttpEntity();
         httpEntity.setContent(new ByteArrayInputStream(content.getBytes()));
         Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
         StatusLine status = Mockito.mock(StatusLine.class);
         Mockito.when(status.getStatusCode()).thenReturn(200);
         Mockito.when(httpResponse.getStatusLine()).thenReturn(status);
-        Mockito.when(httpClient.execute(Mockito.any(HttpGet.class))).thenReturn(httpResponse);
+        Mockito.when(APIUtil.executeHTTPRequestWithRetries(Mockito.any(HttpGet.class), Mockito.any(HttpClient.class)))
+                .thenReturn(httpResponse);
         BDDMockito.given(APIUtil.getHttpClient(Mockito.anyInt(), Mockito.anyString())).willReturn(httpClient);
         EventHubConfigurationDto eventHubConfigurationDto = new EventHubConfigurationDto();
         eventHubConfigurationDto.setUsername("admin");

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/util/KeyTemplateRetrieverTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/throttling/util/KeyTemplateRetrieverTest.java
@@ -18,9 +18,9 @@
 
 package org.wso2.carbon.apimgt.gateway.throttling.util;
 
-import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.entity.BasicHttpEntity;
 import org.junit.Assert;
@@ -33,7 +33,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.gateway.throttling.ThrottleDataHolder;
 import org.wso2.carbon.apimgt.impl.dto.EventHubConfigurationDto;
-import org.wso2.carbon.apimgt.impl.dto.ThrottleProperties;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
 import java.io.ByteArrayInputStream;
@@ -52,11 +51,13 @@ public class KeyTemplateRetrieverTest {
         String content = "[\"$userId\",\"$apiContext\",\"$apiVersion\"]";
         PowerMockito.mockStatic(APIUtil.class);
         HttpClient httpClient = Mockito.mock(HttpClient.class);
-        HttpResponse httpResponse = Mockito.mock(HttpResponse.class);
+        CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
         BasicHttpEntity httpEntity = new BasicHttpEntity();
         httpEntity.setContent(new ByteArrayInputStream(content.getBytes()));
         Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
         Mockito.when(httpClient.execute(Mockito.any(HttpGet.class))).thenReturn(httpResponse);
+        Mockito.when(APIUtil.executeHTTPRequestWithRetries(Mockito.any(HttpGet.class), Mockito.any(HttpClient.class)))
+                .thenReturn(httpResponse);
         StatusLine status = Mockito.mock(StatusLine.class);
         Mockito.when(status.getStatusCode()).thenReturn(200);
         Mockito.when(httpResponse.getStatusLine()).thenReturn(status);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -490,6 +490,7 @@ public final class APIUtil {
             throws IOException, APIManagementException {
 
         CloseableHttpResponse httpResponse = null;
+        String path = method.getURI().getPath();
         long retryDuration = retrievalTimeout;
         int retryCount = 0;
         boolean retry;
@@ -497,15 +498,16 @@ public final class APIUtil {
             try {
                 httpResponse = (CloseableHttpResponse) httpClient.execute(method);
                 if (HttpStatus.SC_OK != httpResponse.getStatusLine().getStatusCode()) {
-                    throw new DataLoadingException("Error while retrieving artifacts. "
-                            + "Received response with status code "+ httpResponse.getStatusLine().getStatusCode());
+                    throw new DataLoadingException("Error while retrieving "
+                            + path + ". Received response with status code "
+                            + httpResponse.getStatusLine().getStatusCode());
                 }
                 retry = false;
             } catch (IOException | DataLoadingException ex) {
                 retryCount++;
                 if (retryCount <= maxRetryCount) {
                     retry = true;
-                    log.error("Failed to retrieve from remote endpoint: " + ex.getMessage()
+                    log.error("Failed to retrieve " + path + " from remote endpoint: " + ex.getMessage()
                             + ". Retry attempt " + retryCount + " in " + (retryDuration / 1000) +
                             " seconds.");
                     try {
@@ -518,7 +520,7 @@ public final class APIUtil {
                         // Ignore
                     }
                 } else {
-                    log.error("Failed to retrieve from remote endpoint. Maximum retry count exceeded."
+                    log.error("Failed to retrieve " + path + " from remote endpoint. Maximum retry count exceeded."
                             + ex.getMessage());
                     throw ex;
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/src/main/java/org/wso2/carbon/apimgt/throttle/policy/deployer/PolicyRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/src/main/java/org/wso2/carbon/apimgt/throttle/policy/deployer/PolicyRetriever.java
@@ -237,7 +237,7 @@ public class PolicyRetriever {
                 + new String(credentials, APIConstants.DigestAuthConstants.CHARSET));
         HttpClient httpClient = APIUtil.getHttpClient(port, protocol);
         try {
-            return APIUtil.executeHTTPRequest(method, httpClient);
+            return APIUtil.executeHTTPRequestWithRetries(method, httpClient);
         } catch (APIManagementException e) {
             throw new ThrottlePolicyDeployerException(e);
         }


### PR DESCRIPTION
### Purpose

- Fix https://github.com/wso2/api-manager/issues/1853

### Implementation

- In this PR, retry mechanism used for following internal API requests were updated.
   - /internal/data/v1/api-logging-configs 
   - /internal/data/v1/applications
   - /internal/data/v1/api-policies
   - /internal/data/v1/revokedjwt
   - /internal/data/v1/keyTemplates
   - /internal/data/v1/block
   - /internal/data/v1/subscription-policies
   - /internal/data/v1/application-key-mappings
   - /internal/data/v1/application-policies
   - /internal/data/v1/subscriptions
   - /internal/data/v1/scopes
   - /internal/data/v1/ga-config
   - /internal/data/v1/endpoint-certificates