### PR TITLE
Add multipart/form-data support in AWSLambdaMediator

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SwaggerData.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SwaggerData.java
@@ -40,6 +40,7 @@ public class SwaggerData {
         private List<Scope> scopes = new ArrayList<>();
         private String amznResourceName;
         private int amznResourceTimeout;
+        private boolean amznResourceContentEncoded;
 
         public String getPath() {
             return path;
@@ -97,6 +98,14 @@ public class SwaggerData {
             this.amznResourceTimeout = amznResourceTimeout;
         }
 
+        public boolean isAmznResourceContentEncoded() {
+            return amznResourceContentEncoded;
+        }
+
+        public void setAmznResourceContentEncoded(boolean amznResourceContentEncoded) {
+            this.amznResourceContentEncoded = amznResourceContentEncoded;
+        }
+
         public List<Scope> getScopes() {
 
             return scopes;
@@ -144,6 +153,7 @@ public class SwaggerData {
             resource.scopes = uriTemplate.retrieveAllScopes();
             resource.amznResourceName = uriTemplate.getAmznResourceName();
             resource.amznResourceTimeout = uriTemplate.getAmznResourceTimeout();
+            resource.amznResourceContentEncoded = uriTemplate.getAmznResourceContentEncoded();
             resources.add(resource);
         }
 
@@ -182,6 +192,7 @@ public class SwaggerData {
             resource.scopes = uriTemplate.retrieveAllScopes();
             resource.amznResourceName = uriTemplate.getAmznResourceName();
             resource.amznResourceTimeout = uriTemplate.getAmznResourceTimeout();
+            resource.amznResourceContentEncoded = uriTemplate.getAmznResourceContentEncoded();
             resources.add(resource);
         }
         Set<Scope> scopes = apiProduct.getScopes();

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/URITemplate.java
@@ -48,6 +48,7 @@ public class URITemplate implements Serializable{
     private Set<APIProductIdentifier> usedByProducts = new HashSet<>();
     private String amznResourceName;
     private int amznResourceTimeout;
+    private boolean amznResourceContentEncoded;
     private List<OperationPolicy> operationPolicies = new ArrayList<>();
 
     public ConditionGroupDTO[] getConditionGroups() {
@@ -435,6 +436,14 @@ public class URITemplate implements Serializable{
 
     public int getAmznResourceTimeout() {
         return amznResourceTimeout;
+    }
+
+    public void setAmznResourceContentEncoded(boolean amznResourceContentEncoded) {
+        this.amznResourceContentEncoded = amznResourceContentEncoded;
+    }
+
+    public boolean getAmznResourceContentEncoded() {
+        return amznResourceContentEncoded;
     }
 
     public void setOperationPolicies(List<OperationPolicy> operationPolicies) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
@@ -450,4 +450,8 @@ public class AWSLambdaMediator extends AbstractMediator {
     public void setResourceTimeout(int resourceTimeout) {
         this.resourceTimeout = resourceTimeout;
     }
+
+    public void setIsContentEncodingEnabled(boolean isContentEncodingEnabled) {
+        this.isContentEncodingEnabled = isContentEncodingEnabled;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1523,6 +1523,7 @@ public final class APIConstants {
     public static final String SWAGGER_X_SCOPE = "x-scope";
     public static final String SWAGGER_X_AMZN_RESOURCE_NAME = "x-amzn-resource-name";
     public static final String SWAGGER_X_AMZN_RESOURCE_TIMEOUT = "x-amzn-resource-timeout";
+    public static final String SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED = "x-amzn-resource-content-encode";
     public static final String SWAGGER_X_AUTH_TYPE = "x-auth-type";
     public static final String SWAGGER_X_THROTTLING_TIER = "x-throttling-tier";
     public static final String SWAGGER_X_THROTTLING_BANDWIDTH = "x-throttling-bandwidth";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -1288,6 +1288,10 @@ public abstract class AbstractAPIManager implements APIManager {
                                     operation.getAsJsonObject().get(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT)
                                             .getAsInt());
                         }
+                        if (operation.getAsJsonObject().get(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED) != null) {
+                            uriTemplate.setAmznResourceContentEncoded(operation.getAsJsonObject().
+                                    get(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED).getAsBoolean());
+                        }
                     }
                 }
             }
@@ -1430,6 +1434,10 @@ public abstract class AbstractAPIManager implements APIManager {
                             uriTemplate.setAmznResourceTimeout(
                                     operation.getAsJsonObject().get(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT)
                                             .getAsInt());
+                        }
+                        if (operation.getAsJsonObject().get(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED) != null) {
+                            uriTemplate.setAmznResourceContentEncoded(operation.getAsJsonObject().
+                                    get(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED).getAsBoolean());
                         }
                     }
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -397,6 +397,10 @@ public class OAS2Parser extends APIDefinition {
                         template.setAmznResourceTimeout(((Long)
                                 extensions.get(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT)).intValue());
                     }
+                    if (extensions.containsKey(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED)) {
+                        template.setAmznResourceContentEncoded((Boolean)
+                                extensions.get(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED));
+                    }
                 }
                 urlTemplates.add(template);
             }
@@ -942,6 +946,9 @@ public class OAS2Parser extends APIDefinition {
         if (resource.getAmznResourceTimeout() != 0) {
             operation.setVendorExtension(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT, resource.getAmznResourceTimeout());
         }
+        operation.setVendorExtension(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED,
+                resource.isAmznResourceContentEncoded());
+
         updateLegacyScopesFromOperation(resource, operation);
         String oauth2SchemeKey = APIConstants.SWAGGER_APIM_DEFAULT_SECURITY;
         List<Map<String, List<String>>> security = operation.getSecurity();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -499,6 +499,10 @@ public class OAS3Parser extends APIDefinition {
                             template.setAmznResourceTimeout(((Number)
                                     extensions.get(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT)).intValue());
                         }
+                        if (extensions.containsKey(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED)) {
+                            template.setAmznResourceContentEncoded((Boolean)
+                                    extensions.get(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED));
+                        }
                     }
                     urlTemplates.add(template);
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1738,6 +1738,8 @@ public class OASParserUtil {
             updatedVendorExtensions.put(APIConstants.X_WSO2_APP_SECURITY, existingExtensions
                     .get(APIConstants.X_WSO2_APP_SECURITY));
         }
+        updatedVendorExtensions.put(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED, existingExtensions
+                .get(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED));
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIOperationsDTO.java
@@ -32,6 +32,7 @@ public class APIOperationsDTO   {
     private List<String> usedProductIds = new ArrayList<String>();
     private String amznResourceName = null;
     private Integer amznResourceTimeout = null;
+    private Boolean amznResourceContentEncode = null;
     private String payloadSchema = null;
     private String uriMapping = null;
     private APIOperationPoliciesDTO operationPolicies = null;
@@ -191,6 +192,23 @@ public class APIOperationsDTO   {
 
   /**
    **/
+  public APIOperationsDTO amznResourceContentEncode(Boolean amznResourceContentEncode) {
+    this.amznResourceContentEncode = amznResourceContentEncode;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("amznResourceContentEncode")
+  public Boolean isAmznResourceContentEncode() {
+    return amznResourceContentEncode;
+  }
+  public void setAmznResourceContentEncode(Boolean amznResourceContentEncode) {
+    this.amznResourceContentEncode = amznResourceContentEncode;
+  }
+
+  /**
+   **/
   public APIOperationsDTO payloadSchema(String payloadSchema) {
     this.payloadSchema = payloadSchema;
     return this;
@@ -260,6 +278,7 @@ public class APIOperationsDTO   {
         Objects.equals(usedProductIds, apIOperations.usedProductIds) &&
         Objects.equals(amznResourceName, apIOperations.amznResourceName) &&
         Objects.equals(amznResourceTimeout, apIOperations.amznResourceTimeout) &&
+        Objects.equals(amznResourceContentEncode, apIOperations.amznResourceContentEncode) &&
         Objects.equals(payloadSchema, apIOperations.payloadSchema) &&
         Objects.equals(uriMapping, apIOperations.uriMapping) &&
         Objects.equals(operationPolicies, apIOperations.operationPolicies);
@@ -267,7 +286,7 @@ public class APIOperationsDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, target, verb, authType, throttlingPolicy, scopes, usedProductIds, amznResourceName, amznResourceTimeout, payloadSchema, uriMapping, operationPolicies);
+    return Objects.hash(id, target, verb, authType, throttlingPolicy, scopes, usedProductIds, amznResourceName, amznResourceTimeout, amznResourceContentEncode, payloadSchema, uriMapping, operationPolicies);
   }
 
   @Override
@@ -284,6 +303,7 @@ public class APIOperationsDTO   {
     sb.append("    usedProductIds: ").append(toIndentedString(usedProductIds)).append("\n");
     sb.append("    amznResourceName: ").append(toIndentedString(amznResourceName)).append("\n");
     sb.append("    amznResourceTimeout: ").append(toIndentedString(amznResourceTimeout)).append("\n");
+    sb.append("    amznResourceContentEncode: ").append(toIndentedString(amznResourceContentEncode)).append("\n");
     sb.append("    payloadSchema: ").append(toIndentedString(payloadSchema)).append("\n");
     sb.append("    uriMapping: ").append(toIndentedString(uriMapping)).append("\n");
     sb.append("    operationPolicies: ").append(toIndentedString(operationPolicies)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
@@ -468,6 +468,7 @@ public class TemplateBuilderUtil {
                             template.setMediationScripts(uriTemplate.getHTTPVerb(), uriTemplate.getMediationScript());
                             template.setAmznResourceName(uriTemplate.getAmznResourceName());
                             template.setAmznResourceTimeout(uriTemplate.getAmznResourceTimeout());
+                            template.setAmznResourceContentEncoded(uriTemplate.getAmznResourceContentEncoded());
                             break;
                         }
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -10700,6 +10700,8 @@ components:
           example: ""
         amznResourceTimeout:
           type: integer
+        amznResourceContentEncode:
+          type: boolean
         payloadSchema:
           type: string
           example: ""


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/1878

**Implementation Details**

- Added support for multipart/formdata content in AWS lambda mediator

**Bug Fixes**

- While testing with form-data content it was observed that the WSO2 gateway did not send the correct response from lambda back to the client when form-data content is used. This was fixed by adding below change.
`JsonUtil.setJsonStream(axis2MessageContext, new ByteArrayInputStream(invokeResult.getPayload().array()));`
to
`JsonUtil.getNewJsonPayload(axis2MessageContext, new String(invokeResult.getPayload().array()), true, true);`

**Related PRs**

UI : https://github.com/wso2/apim-apps/pull/468
Product : https://github.com/wso2/product-apim/pull/13215