### PR TITLE
Add a default version_comparable value to fix error thrown in APIs migrated from the version which doesn't support API Revisions

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -350,6 +350,8 @@ public class RegistryPersistenceImpl implements APIPersistence {
             GenericArtifact apiArtifact = artifactManager.getGenericArtifact(apiUUID);
             String lcState = ((GenericArtifactImpl) apiArtifact).getLcState();
             if (apiArtifact != null) {
+                String existingVersionComparable = apiArtifact.getAttribute(APIConstants
+                        .API_OVERVIEW_VERSION_COMPARABLE);
                 API api = RegistryPersistenceUtil.getApiForPublishing(registry, apiArtifact);
                 String visibleRolesList = api.getVisibleRoles();
                 String[] visibleRoles = new String[0];
@@ -370,6 +372,18 @@ public class RegistryPersistenceImpl implements APIPersistence {
                         ((UserRegistry) registry).getTenantId());
                 RegistryPersistenceUtil.setResourcePermissions(api.getId().getProviderName(), api.getVisibility(),
                         visibleRoles, apiPath);
+                GenericArtifact newArtifact = artifactManager.getGenericArtifact(apiUUID);
+                if (newArtifact != null && newArtifact.getAttribute(APIConstants.API_OVERVIEW_VERSION_COMPARABLE)
+                        == null) {
+                    if (existingVersionComparable != null) {
+                        newArtifact.setAttribute(APIConstants.API_OVERVIEW_VERSION_COMPARABLE
+                                , existingVersionComparable);
+                    } else {
+                        newArtifact.setAttribute(APIConstants.API_OVERVIEW_VERSION_COMPARABLE
+                                , String.valueOf(System.currentTimeMillis()));
+                    }
+                    artifactManager.updateGenericArtifact(newArtifact);
+                }
             }
             registry.commitTransaction();
             transactionCommitted = true;

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -373,14 +373,12 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 RegistryPersistenceUtil.setResourcePermissions(api.getId().getProviderName(), api.getVisibility(),
                         visibleRoles, apiPath);
                 GenericArtifact newArtifact = artifactManager.getGenericArtifact(apiUUID);
-                if (newArtifact != null && newArtifact.getAttribute(APIConstants.API_OVERVIEW_VERSION_COMPARABLE)
-                        == null) {
+                if (newArtifact != null && newArtifact.getAttribute(APIConstants.API_OVERVIEW_VERSION_COMPARABLE) == null) {
                     if (existingVersionComparable != null) {
-                        newArtifact.setAttribute(APIConstants.API_OVERVIEW_VERSION_COMPARABLE
-                                , existingVersionComparable);
+                        newArtifact.setAttribute(APIConstants.API_OVERVIEW_VERSION_COMPARABLE, existingVersionComparable);
                     } else {
-                        newArtifact.setAttribute(APIConstants.API_OVERVIEW_VERSION_COMPARABLE
-                                , String.valueOf(System.currentTimeMillis()));
+                        newArtifact.setAttribute(APIConstants.API_OVERVIEW_VERSION_COMPARABLE,
+                                String.valueOf(System.currentTimeMillis()));
                     }
                     artifactManager.updateGenericArtifact(newArtifact);
                 }


### PR DESCRIPTION
Fixes : https://github.com/wso2/api-manager/issues/1886