### PR TITLE
Fixed colon can't include in the password issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthAuthenticator.java
@@ -264,7 +264,7 @@ public class BasicAuthAuthenticator implements Authenticator {
                     String basicAuthKey = new String(Base64.decode(
                             basicAuthHeader.substring(basicAuthKeyHeaderSegment.length() + 1).trim()));
                     if (basicAuthKey.contains(":")) {
-                        return basicAuthKey.split(":");
+                        return basicAuthKey.split(":", 2);
                     } else {
                         log.error("Basic Authentication: Invalid Basic Auth token");
                         throw new APISecurityException(APISecurityConstants.API_AUTH_INVALID_CREDENTIALS,


### PR DESCRIPTION
## Purpose
When using basic auth for APIs, if the password contains the "colon" character then the requests are getting failed. 
Related Issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/3181

## Approach
Extended the split method by adding 2 as the split parameter. Now the user can use colons as multiples times for the password. But in this approach we have assumed that user don't use colon for the username.