### PR TITLE
Fixed failover enabled in params.yaml appear as disabled in UI

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -641,6 +641,7 @@ public class APIControllerUtil {
 
             //get load balanced configs from params
             JsonElement loadBalancedConfigElement = envParams.get(ImportExportConstants.LOAD_BALANCE_ENDPOINTS_FIELD);
+            JsonElement failOverConfigElement = envParams.get(ImportExportConstants.FAILOVER_TYPE_ENDPOINT);
             JsonObject loadBalancedConfigs;
             if (loadBalancedConfigElement == null) {
                 throw new APIManagementException(
@@ -648,6 +649,10 @@ public class APIControllerUtil {
                         ExceptionCodes.ERROR_READING_PARAMS_FILE);
             } else {
                 loadBalancedConfigs = loadBalancedConfigElement.getAsJsonObject();
+            }
+            if (failOverConfigElement != null) {
+                updatedRESTEndpointParams.addProperty(ImportExportConstants.FAILOVER_TYPE_ENDPOINT,
+                        failOverConfigElement.getAsBoolean());
             }
             updatedRESTEndpointParams.addProperty(ImportExportConstants.ENDPOINT_TYPE_PROPERTY,
                     ImportExportConstants.LOAD_BALANCE_TYPE_ENDPOINT);


### PR DESCRIPTION
## Purpose
Related Issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/3095
Related Public Issue: https://github.com/wso2/api-manager/issues/1859

- To enable the "Enable Failover" config in the endpoint configuration, User have defined "failOver: true" in the params.yaml. When the user has checked the load-balanced configs of the imported API, from the publisher portal. It displays that load-balanced configs specified in the params.yaml are reflected in the publisher portal as follows but the "Enable Failover" config is not selected.

## Approach
- Added the property ```failOver``` to ```updatedRESTEndpointParams```.