### PR TITLE
Fix errors when hostname verification is set as "DefaultAndLocalhost"

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.ssl.SSLContexts;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -1059,7 +1060,8 @@ public class APIManagerComponent {
                     final String[] localhosts = { "::1", "127.0.0.1", "localhost", "localhost.localdomain" };
                     @Override
                     public boolean verify(String urlHostName, SSLSession session) {
-                        return Arrays.asList(localhosts).contains(urlHostName);
+                        return SSLSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER.verify(urlHostName, session)
+                                || Arrays.asList(localhosts).contains(urlHostName);
                     }
                 };
                 break;


### PR DESCRIPTION
### Purpose
To fix the errors thrown while starting the APIM server even if a SAN entry matches the server hostname when hostname verification is set as "DefaultAndLocalhost".

### Goal
Fixes: https://github.com/wso2/api-manager/issues/1876
and also fixes issues from: https://github.com/wso2/api-manager/issues/1698

### Approach
- When DefaultAndLocalhost hostname verifier is enabled, all hostnames that match the below list should pass hostname verification regardless of what is on the server’s certificate.
"::1", "127.0.0.1", "localhost", "localhost.localdomain"

- Apart from that above should support default hostname verification as well. So DefaultAndLocalhost verification is Default hostname verification + a relaxation on localhost hostnames.

- To fix the above issues we should improve the verify method to validate the hostname against the certs available in the keystore.
