### PR TITLE
Introduce system property for CORS request blocking with 403 error

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -132,6 +132,7 @@ public class APIMgtGatewayConstants {
     public static final String THROTTLE_HANDLER_ERROR = "Error in Throttle Handler";
     public static final String API_THROTTLE_HANDLER_ERROR = "Error in API Throttle Handler";
     public static final String CORS_REQUEST_HANDLER_ERROR = "Error in CORS_Request Handler";
+    public static final String CORS_FORBID_BLOCKED_REQUESTS = "corsForbidBlockedRequests";
     public static final String GOOGLE_ANALYTICS_ERROR = "Error in Google Analytics Handler";
     public static final String CUSTOM_ANALYTICS_REQUEST_PROPERTIES = "apim.analytics.request.properties";
     public static final String CUSTOM_ANALYTICS_RESPONSE_PROPERTIES = "apim.analytics.response.properties";

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -133,6 +133,7 @@ public class APIMgtGatewayConstants {
     public static final String API_THROTTLE_HANDLER_ERROR = "Error in API Throttle Handler";
     public static final String CORS_REQUEST_HANDLER_ERROR = "Error in CORS_Request Handler";
     public static final String CORS_FORBID_BLOCKED_REQUESTS = "corsForbidBlockedRequests";
+    public static final String CORS_SET_STATUS_CODE_FROM_MSG_CONTEXT = "corsSetStatusCodeFromMsgContext";
     public static final String GOOGLE_ANALYTICS_ERROR = "Error in Google Analytics Handler";
     public static final String CUSTOM_ANALYTICS_REQUEST_PROPERTIES = "apim.analytics.request.properties";
     public static final String CUSTOM_ANALYTICS_RESPONSE_PROPERTIES = "apim.analytics.response.properties";

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/CORSRequestHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/CORSRequestHandler.java
@@ -227,9 +227,11 @@ public class CORSRequestHandler extends AbstractHandler implements ManagedLifecy
                 if (corsSequence != null) {
                     corsSequence.mediate(messageContext);
                 }
-                if (messageContext.getProperty(APIMgtGatewayConstants.HTTP_SC) != null) {
-                    Utils.send(messageContext, Integer.parseInt(
-                            messageContext.getProperty(APIMgtGatewayConstants.HTTP_SC).toString()));
+                if (Boolean.parseBoolean(
+                        System.getProperty(APIMgtGatewayConstants.CORS_SET_STATUS_CODE_FROM_MSG_CONTEXT))
+                        && messageContext.getProperty(APIMgtGatewayConstants.HTTP_SC) != null) {
+                    Utils.send(messageContext,
+                               Integer.parseInt(messageContext.getProperty(APIMgtGatewayConstants.HTTP_SC).toString()));
                 } else {
                     Utils.send(messageContext, HttpStatus.SC_OK);
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/CORSRequestHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/CORSRequestHandler.java
@@ -334,7 +334,8 @@ public class CORSRequestHandler extends AbstractHandler implements ManagedLifecy
 
         messageContext.setProperty(APIConstants.CORSHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, allowedOrigin);
         //If the request origin is not allowed, set the HTTP status code to 403
-        if (allowedOrigin == null) {
+        if (Boolean.parseBoolean(System.getProperty(APIMgtGatewayConstants.CORS_FORBID_BLOCKED_REQUESTS))
+                && allowedOrigin == null) {
             messageContext.setProperty(APIMgtGatewayConstants.HTTP_SC, HttpStatus.SC_FORBIDDEN);
         }
         String allowedMethods;


### PR DESCRIPTION
- Modify the feature introduced in https://github.com/wso2/carbon-apimgt/pull/11926/files, so that it enables only when both system properties, namely "**corsForbidBlockedRequests**" and "**corsSetStatusCodeFromMsgContext**," are enabled.
- To enable this feature start API Manager as following.
`./wso2server.sh -DcorsForbidBlockedRequests=true -DcorsSetStatusCodeFromMsgContext=true`
> Git Issue: https://github.com/wso2/api-manager/issues/1902
