### PR TITLE
Bump json-smart and json-path versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2092,7 +2092,7 @@
         <httpcomponents.version>4.5.10</httpcomponents.version>
         <commons-codec.version>1.14</commons-codec.version>
         <com.nimbusds.wso2.version>7.9.0.wso2v1</com.nimbusds.wso2.version>
-        <json-smart.version>2.3</json-smart.version>
+        <json-smart.version>2.4.11</json-smart.version>
         <org.apache.velocity.version>2.3</org.apache.velocity.version>
         <org.slf4j.version>1.7.0</org.slf4j.version>
         <slf4j.api.version>1.7.29</slf4j.api.version>
@@ -2188,7 +2188,7 @@
         <json.orbit.version>3.0.0.wso2v1</json.orbit.version>
         <aspectj.version>1.9.4</aspectj.version>
         <wso2.securevault.version>1.1.3</wso2.securevault.version>
-        <com.jayway.jsonpath.version>2.6.0.wso2v1</com.jayway.jsonpath.version>
+        <com.jayway.jsonpath.version>2.6.0.wso2v2</com.jayway.jsonpath.version>
         <org.wso2.orbit.commons-text.version>1.6.wso2v1</org.wso2.orbit.commons-text.version>
         <commons.lang.version>2.6.0.wso2v1</commons.lang.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>


### PR DESCRIPTION
## Purpose 

Upgrading json-smart version to the latest for addressing a security vulnerability[1] in currently used version. Json-path is also updated as it packs json-smart [2].

[1] https://nvd.nist.gov/vuln/detail/CVE-2023-1370
[2] https://github.com/wso2/orbit/pull/980