### PR TITLE
Upgrade graphql-java version

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
@@ -114,7 +114,7 @@
                             com.google.gson.annotations.*,
                             org.apache.commons.logging.*,
                             org.wso2.am.analytics.publisher.*;version="${analytics.event.publisher.client.version.range}",
-                            graphql.*; version="${graphql.java.version}",
+                            graphql.*; version="${graphql.java.version.range}",
                             org.json.simple.*,
                             org.apache.commons.*,
                             org.apache.http.*,

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -471,7 +471,7 @@
                             org.wso2.carbon.mediation.*; version="${carbon.mediation.imp.pkg.version}",
                             org.wso2.carbon.apimgt.tracing.*; version="${carbon.apimgt.imp.pkg.version}",
                             org.wso2.orbit.re2j.*; version="${re2j.version}",
-                            graphql.*; version="${graphql.java.version}",
+                            graphql.*; version="${graphql.java.version.range}",
                             com.amazonaws.*; version="${com.amazonaws.version}",
                             org.apache.servicemix.bundles.jedis.*; version="${servicemix.bundles.jedis.version}",
                             com.nimbusds.jwt.*,

--- a/pom.xml
+++ b/pom.xml
@@ -1995,6 +1995,7 @@
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
 
         <graphql.java.version>19.6.wso2v1</graphql.java.version>
+        <graphql.java.version.range>[19.0,20.0)</graphql.java.version.range>
 
         <carbon.governance.version>4.8.30</carbon.governance.version>
         <carbon.deployment.version>4.11.7</carbon.deployment.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1994,7 +1994,7 @@
         <saml.common.util.version>1.2.1</saml.common.util.version>
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
 
-        <graphql.java.version>19.2.wso2v2</graphql.java.version>
+        <graphql.java.version>19.6.wso2v1</graphql.java.version>
 
         <carbon.governance.version>4.8.30</carbon.governance.version>
         <carbon.deployment.version>4.11.7</carbon.deployment.version>


### PR DESCRIPTION
### Purpose

- Upgrade graphql-java version from 19.2.wso2v2 to 19.6.wso2v1
- Related PR: https://github.com/wso2/orbit/pull/981