### PR TITLE
Gets user credentials for redis when other configs are missing

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/RedisBaseDistributedCountManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/RedisBaseDistributedCountManager.java
@@ -145,7 +145,7 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
 
                 Response<Long> incrementedValue = transaction.incrBy(key, value);
                 transaction.exec();
-                if (currentValue != null) {
+                if (currentValue != null && currentValue.get() != null) {
                     current = Long.parseLong(currentValue.get());
                 }
                 if (log.isDebugEnabled()) {
@@ -177,7 +177,7 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
                 Response<Long> incrementedValue = transaction.incrBy(key, value);
                 transaction.exec();
 
-                if (currentValue != null) {
+                if (currentValue != null && currentValue.get() != null) {
                     current = Long.parseLong(currentValue.get());
                 }
                 if (log.isDebugEnabled()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
@@ -126,11 +126,11 @@ public class APIHandlerServiceComponent {
         RedisConfig redisConfig =
                 ServiceReferenceHolder.getInstance().getAPIManagerConfiguration().getRedisConfig();
         if (redisConfig.isRedisEnabled()) {
+            ServiceReferenceHolder.getInstance().setRedisPool(getJedisPool(redisConfig));
             RedisBaseDistributedCountManager redisBaseDistributedCountManager =
                     new RedisBaseDistributedCountManager(ServiceReferenceHolder.getInstance().getRedisPool());
             context.getBundleContext().registerService(DistributedCounterManager.class,
                     redisBaseDistributedCountManager, null);
-            ServiceReferenceHolder.getInstance().setRedisPool(getJedisPool(redisConfig));
         }
 
         // Create caches for the super tenant

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -386,12 +386,19 @@ public class APIManagerConfiguration {
                 redisConfig.setRedisEnabled(true);
                 redisConfig.setHost(redisHost.getText());
                 redisConfig.setPort(Integer.parseInt(redisPort.getText()));
-                if (redisUser != null && redisPassword != null && redisDatabaseId != null
-                        && redisConnectionTimeout != null && redisIsSslEnabled != null) {
+                if (redisUser != null) {
                     redisConfig.setUser(redisUser.getText());
+                }
+                if (redisPassword != null) {
                     redisConfig.setPassword(MiscellaneousUtil.resolve(redisPassword, secretResolver).toCharArray());
+                }
+                if (redisDatabaseId != null) {
                     redisConfig.setDatabaseId(Integer.parseInt(redisDatabaseId.getText()));
+                }
+                if (redisConnectionTimeout != null) {
                     redisConfig.setConnectionTimeout(Integer.parseInt(redisConnectionTimeout.getText()));
+                }
+                if (redisIsSslEnabled != null) {
                     redisConfig.setSslEnabled(Boolean.parseBoolean(redisIsSslEnabled.getText()));
                 }
                 if (propertiesElement !=null){


### PR DESCRIPTION
## Overview
Checks the conditions of redisConfig seperately to get the user credentials even when the other configs are missing and fix a null pointer exception which occurs due to redisPool being null.

## Resolves
https://github.com/wso2/api-manager/issues/1887
