### PR TITLE
[RRT] Add mandatory custom properties support feature

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -115,6 +115,7 @@ public enum ExceptionCodes implements ErrorHandler {
     API_OR_API_PRODUCT_NOT_FOUND(900359, "API or API Product Not Found", 404, "Requested API or API Product with id '%s' not found"),
     API_PRODUCT_NOT_FOUND(900360, "API Product Not Found", 404, "Requested API Product with id '%s' not found"),
     SUB_ORGANIZATION_NOT_IDENTIFIED(900361, "User's Organization Not Identified", 403, "User's Organization is not identified"),
+    ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES(903010, "Error while updating required properties", 400, "Error while updating required properties."),
 
     //Lifecycle related codes
     API_UPDATE_FORBIDDEN_PER_LC(900380, "Insufficient permission to update the API", 403,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1966,6 +1966,18 @@ public final class APIConstants {
         public static final String TYPE = "Type";
     }
 
+    public static class CustomPropertyAttributes {
+        public static final String PROPERTY_CONFIGURATIONS = "PropertyConfigurations";
+        public static final String CUSTOM_PROPERTIES = "CustomProperties";
+        public static final String PROPERTIES = "Properties";
+        public static final String PROPERTY = "Property";
+        public static final String REQUIRED = "Required";
+        public static final String HIDDEN = "Hidden";
+        public static final String DESCRIPTION = "Description";
+        public static final String DEFAULT = "Default";
+        public static final String NAME = "Name";
+    }
+
     public static final String REGISTRY_ARTIFACT_SEARCH_DESC_ORDER = "DES";
     public static final String REGISTRY_ARTIFACT_SORT_BY_CREATED_TIME = "meta_created_date";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -9378,6 +9378,33 @@ public final class APIUtil {
         return defaultReservedUsername;
     }
 
+    public static JSONArray getCustomProperties(String userId) throws APIManagementException {
+
+        String tenantDomain = MultitenantUtils.getTenantDomain(userId);
+
+        JSONArray customPropertyAttributes = null;
+        JSONObject propertyConfig = getMandatoryPropertyKeysFromRegistry(tenantDomain);
+        if (propertyConfig != null) {
+            customPropertyAttributes = (JSONArray) propertyConfig.get(APIConstants.CustomPropertyAttributes.PROPERTIES);
+        } else {
+            APIManagerConfiguration apiManagerConfiguration =
+                    ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration();
+            customPropertyAttributes = apiManagerConfiguration.getCustomProperties();
+        }
+        return customPropertyAttributes;
+    }
+
+    public static JSONObject getMandatoryPropertyKeysFromRegistry(String organization) throws APIManagementException {
+
+        JSONObject tenantConfigs = getTenantConfig(organization);
+        String property = APIConstants.CustomPropertyAttributes.PROPERTY_CONFIGURATIONS;
+        if (tenantConfigs.keySet().contains(property)) {
+            return (JSONObject) tenantConfigs.get(
+                    APIConstants.CustomPropertyAttributes.PROPERTY_CONFIGURATIONS);
+        }
+        return null;
+    }
+
     public static boolean isDefaultApplicationCreationEnabled() {
         APIManagerConfiguration apiManagerConfiguration =
                 ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/SettingsCustomPropertiesDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/SettingsCustomPropertiesDTO.java
@@ -1,0 +1,123 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class SettingsCustomPropertiesDTO   {
+  
+    private String name = null;
+    private String description = null;
+    private Boolean required = null;
+
+  /**
+   * Custom property name 
+   **/
+  public SettingsCustomPropertiesDTO name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Department", value = "Custom property name ")
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Description of custom property
+   **/
+  public SettingsCustomPropertiesDTO description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Relevant Department", value = "Description of custom property")
+  @JsonProperty("description")
+  public String getDescription() {
+    return description;
+  }
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  /**
+   **/
+  public SettingsCustomPropertiesDTO required(Boolean required) {
+    this.required = required;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "false", value = "")
+  @JsonProperty("required")
+  public Boolean isRequired() {
+    return required;
+  }
+  public void setRequired(Boolean required) {
+    this.required = required;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SettingsCustomPropertiesDTO settingsCustomProperties = (SettingsCustomPropertiesDTO) o;
+    return Objects.equals(name, settingsCustomProperties.name) &&
+        Objects.equals(description, settingsCustomProperties.description) &&
+        Objects.equals(required, settingsCustomProperties.required);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, description, required);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SettingsCustomPropertiesDTO {\n");
+    
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("    required: ").append(toIndentedString(required)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/SettingsDTO.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.EnvironmentDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.MonetizationAttributeDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SettingsCustomPropertiesDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SubscriberContactAttributeDTO;
 import javax.validation.constraints.*;
 
@@ -37,6 +38,7 @@ public class SettingsDTO   {
     private String defaultAdvancePolicy = null;
     private String defaultSubscriptionPolicy = null;
     private String authorizationHeader = null;
+    private List<SettingsCustomPropertiesDTO> customProperties = new ArrayList<SettingsCustomPropertiesDTO>();
 
   /**
    * The Developer Portal URL
@@ -253,6 +255,24 @@ public class SettingsDTO   {
     this.authorizationHeader = authorizationHeader;
   }
 
+  /**
+   **/
+  public SettingsDTO customProperties(List<SettingsCustomPropertiesDTO> customProperties) {
+    this.customProperties = customProperties;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("customProperties")
+  public List<SettingsCustomPropertiesDTO> getCustomProperties() {
+    return customProperties;
+  }
+  public void setCustomProperties(List<SettingsCustomPropertiesDTO> customProperties) {
+    this.customProperties = customProperties;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -274,12 +294,13 @@ public class SettingsDTO   {
         Objects.equals(crossTenantSubscriptionEnabled, settings.crossTenantSubscriptionEnabled) &&
         Objects.equals(defaultAdvancePolicy, settings.defaultAdvancePolicy) &&
         Objects.equals(defaultSubscriptionPolicy, settings.defaultSubscriptionPolicy) &&
-        Objects.equals(authorizationHeader, settings.authorizationHeader);
+        Objects.equals(authorizationHeader, settings.authorizationHeader) &&
+        Objects.equals(customProperties, settings.customProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(devportalUrl, environment, scopes, monetizationAttributes, subscriberContactAttributes, securityAuditProperties, externalStoresEnabled, docVisibilityEnabled, crossTenantSubscriptionEnabled, defaultAdvancePolicy, defaultSubscriptionPolicy, authorizationHeader);
+    return Objects.hash(devportalUrl, environment, scopes, monetizationAttributes, subscriberContactAttributes, securityAuditProperties, externalStoresEnabled, docVisibilityEnabled, crossTenantSubscriptionEnabled, defaultAdvancePolicy, defaultSubscriptionPolicy, authorizationHeader, customProperties);
   }
 
   @Override
@@ -299,6 +320,7 @@ public class SettingsDTO   {
     sb.append("    defaultAdvancePolicy: ").append(toIndentedString(defaultAdvancePolicy)).append("\n");
     sb.append("    defaultSubscriptionPolicy: ").append(toIndentedString(defaultSubscriptionPolicy)).append("\n");
     sb.append("    authorizationHeader: ").append(toIndentedString(authorizationHeader)).append("\n");
+    sb.append("    customProperties: ").append(toIndentedString(customProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -78,6 +78,7 @@ import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIInfoAdditionalPropertiesDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIInfoAdditionalPropertiesMapDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIOperationsDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIProductDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.AdvertiseInfoDTO;
@@ -1979,5 +1980,28 @@ public class PublisherCommonUtils {
 
         apiProvider.addAPI(apiToAdd);
         return apiProvider.getAPIbyUUID(apiToAdd.getUuid(), organization);
+    }
+
+    public static boolean validateMandatoryProperties(org.json.simple.JSONArray customProperties, APIDTO apiDto) {
+
+        Map<String, APIInfoAdditionalPropertiesMapDTO> additionalPropertiesMap = apiDto.getAdditionalPropertiesMap();
+
+        for (int i = 0; i < customProperties.size(); i++) {
+            JSONObject property = (JSONObject) customProperties.get(i);
+            String propertyName = (String) property.get(APIConstants.CustomPropertyAttributes.NAME);
+            boolean isRequired = (boolean) property.get(APIConstants.CustomPropertyAttributes.REQUIRED);
+
+            if (isRequired) {
+                APIInfoAdditionalPropertiesMapDTO mapProperty = additionalPropertiesMap.get(propertyName);
+                if (mapProperty == null) {
+                    return false;
+                }
+                String propertyValue = mapProperty.getValue();
+                if (propertyValue == null || propertyValue.isEmpty()) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -656,6 +656,13 @@ public class ApisApiServiceImpl implements ApisApiService {
                         ExceptionCodes.INVALID_ENDPOINT_URL);
             }
 
+            org.json.simple.JSONArray customProperties = APIUtil.getCustomProperties(username);
+            if (!PublisherCommonUtils.validateMandatoryProperties(customProperties, body)) {
+                Long errorCode = ExceptionCodes.ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES.getErrorCode();
+                RestApiUtil.handleBadRequest(
+                        ExceptionCodes.ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES.getErrorMessage(), errorCode, log);
+            }
+
             // validate sandbox and production endpoints
             if (!PublisherCommonUtils.validateEndpoints(body)) {
                 throw new APIManagementException("Invalid/Malformed endpoint URL(s) detected",

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SettingsApiServiceImpl.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 
 import org.wso2.carbon.apimgt.impl.restapi.publisher.SettingsApiServiceImplUtil;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.SettingsApiService;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.SettingsDTO;
@@ -54,6 +55,7 @@ public class SettingsApiServiceImpl implements SettingsApiService {
             String organization = RestApiUtil.getValidatedOrganization(messageContext);
             SettingsDTO settingsDTO = settingsMappingUtil.fromSettingstoDTO(isUserAvailable, organization);
             settingsDTO.setScopes(getScopeList());
+            settingsDTO.setCustomProperties(APIUtil.getCustomProperties(username));
             return Response.ok().entity(settingsDTO).build();
         } catch (APIManagementException | IOException e) {
             String errorMessage = "Error while retrieving Publisher Settings";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -11451,6 +11451,23 @@ components:
           type: string
           description: Authorization Header
           example: authorization
+        customProperties:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: |
+                  Custom property name
+                example: Department
+              description:
+                type: string
+                description: Description of custom property
+                example: Relevant Department
+              required:
+                type: boolean
+                example: false
     SecurityAuditAttribute:
       title: SecurityAuditAttributeDTO
       type: object

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1504,4 +1504,18 @@
           <CorrelationLogComponent>{{component}}</CorrelationLogComponent>
       {% endfor %}
       </CorrelationLogComponents>
+
+      {% if apim.publisher.custom_properties is defined %}
+        <PropertyConfigurations>
+            <CustomProperties>
+                {% for property in apim.publisher.custom_properties %}
+                <Property Required="{{property.required}}" Hidden="{{property.hidden}}">
+                    <Name>{{property.name}}</Name>
+                    <Description>{{property.description}}</Description>
+                    <Default>{{property.default}}</Default>
+                </Property>
+                {% endfor %}
+            </CustomProperties>
+        </PropertyConfigurations>
+      {% endif %}
 </APIManager>


### PR DESCRIPTION
### Purpose

- This PR resolves the master fix for wso2-enterprise/wso2-apim-internal#3166.

This PR adds the implementation of mandatory custom properties support feature to the publisher portal. This feature can be enabled by defining server config or tenant config as below.

Server Config

```
[[apim.publisher.custom_properties]]
required=true
name="PropertyName"
description="Property Description"
```

Tenant Config
Add the configuration as shown below by navigating to the Settings -> Advanced page of the admin portal

```
"PropertyConfigurations": {
	"Properties": [
		{
			"Name": "PropertyName",
			"Required": true,
			"Description": "Property Description"
		}
        ]
}
```

This PR includes a rest API validation to the mandatory custom properties when updating the additionalPropertiesMap.

Related PRs

- UI PR for Master: https://github.com/wso2/apim-apps/pull/478