### PR TITLE
Application level security disabling

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConstants.java
@@ -37,4 +37,5 @@ public class APIConstants {
     public static final String DEFAULT_KEY_MANAGER_HOST = "https://localhost:9443";
 
     public static final String UNLIMITED_TIER = "Unlimited";
+    public static final String X_WSO2_DISABLE_SECURITY = "x-wso2-disable-security";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIDefinition.java
@@ -228,7 +228,7 @@ public abstract class APIDefinition {
      * @param api            API
      * @return API
      */
-    public abstract API setExtensionsToAPI(String swaggerContent, API api)
+    public abstract API setExtensionsToAPI(String swaggerContent, API api, boolean isExistingApi)
             throws APIManagementException;
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
@@ -1127,9 +1127,6 @@ public class API implements Serializable {
      * @return Relevant type of gateway security.
      */
     public String getApiSecurity() {
-        if (apiSecurity == null) {
-            return null;
-        }
         return apiSecurity;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
@@ -1114,8 +1114,10 @@ public class API implements Serializable {
      * @param apiSecurity Relevant type of gateway security for the API.
      */
     public void setApiSecurity(String apiSecurity) {
-        if (apiSecurity != null) {
+        if (StringUtils.isNotEmpty(apiSecurity)) {
             this.apiSecurity = apiSecurity;
+        } else {
+            this.apiSecurity = null;
         }
     }
 
@@ -1125,6 +1127,9 @@ public class API implements Serializable {
      * @return Relevant type of gateway security.
      */
     public String getApiSecurity() {
+        if (apiSecurity == null) {
+            return null;
+        }
         return apiSecurity;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SwaggerData.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SwaggerData.java
@@ -172,7 +172,7 @@ public class SwaggerData {
 
         transportType = api.getType();
         security = api.getApiSecurity();
-        if (security != null && StringUtils.isNotEmpty(security)) {
+        if (StringUtils.isNotEmpty(security)) {
             extensionsList.put(APIConstants.X_WSO2_DISABLE_SECURITY, "false");
         } else {
             extensionsList.put(APIConstants.X_WSO2_DISABLE_SECURITY, "true");

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SwaggerData.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SwaggerData.java
@@ -172,7 +172,7 @@ public class SwaggerData {
 
         transportType = api.getType();
         security = api.getApiSecurity();
-        if (StringUtils.isNotEmpty(security)) {
+        if (security != null && StringUtils.isNotEmpty(security)) {
             extensionsList.put(APIConstants.X_WSO2_DISABLE_SECURITY, "false");
         } else {
             extensionsList.put(APIConstants.X_WSO2_DISABLE_SECURITY, "true");

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SwaggerData.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/SwaggerData.java
@@ -18,10 +18,15 @@
 package org.wso2.carbon.apimgt.api.model;
 
 
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.apimgt.api.APIConstants;
+
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -135,6 +140,7 @@ public class SwaggerData {
     private Set<Resource> resources = new LinkedHashSet<>();
     private Set<Scope> scopes = new HashSet<>();
     private ThrottlingLimit throttlingLimit;
+    private Map<String, String> extensionsList = new HashMap<>();
 
     public SwaggerData(API api) {
         title = api.getId().getName();
@@ -166,6 +172,11 @@ public class SwaggerData {
 
         transportType = api.getType();
         security = api.getApiSecurity();
+        if (StringUtils.isNotEmpty(security)) {
+            extensionsList.put(APIConstants.X_WSO2_DISABLE_SECURITY, "false");
+        } else {
+            extensionsList.put(APIConstants.X_WSO2_DISABLE_SECURITY, "true");
+        }
         apiLevelPolicy = api.getApiLevelPolicy();
         setThrottlingLimit(api.getThrottleLimit());
         Set<Scope> scopes = api.getScopes();
@@ -247,5 +258,13 @@ public class SwaggerData {
 
     public String getApiLevelPolicy() {
         return apiLevelPolicy;
+    }
+
+    public void setExtensionsList(Map<String, String> extensionsList) {
+        this.extensionsList = extensionsList;
+    }
+
+    public Map<String, String> getExtensionsList() {
+        return extensionsList;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1683,10 +1683,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             }
         }
 
-        // If no security schema found, set OAuth2 as default
+        // If no security schema found, empty array list will be returned.
         if (!securitySchemeFound) {
-            isOauth2 = true;
-            securityLevels.add(APIConstants.DEFAULT_API_SECURITY_OAUTH2);
+            return securityLevels;
         }
         // If Only OAuth2/Basic-Auth specified, set it as mandatory
         if (!isMutualSSL && !isOauthBasicAuthMandatory) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1709,7 +1709,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
      * @param api Relevant API that need to be validated.
      */
     private void validateAndSetAPISecurity(API api) {
-        String apiSecurity = APIConstants.DEFAULT_API_SECURITY_OAUTH2;
+        String apiSecurity = StringUtils.EMPTY;
         String security = api.getApiSecurity();
         if (security!= null) {
             apiSecurity = security;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/AsyncApiParser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/AsyncApiParser.java
@@ -1906,7 +1906,7 @@ public class AsyncApiParser extends APIDefinition {
     }
 
     @Override
-    public API setExtensionsToAPI(String swaggerContent, API api) throws APIManagementException {
+    public API setExtensionsToAPI(String swaggerContent, API api, boolean isExistingApi) throws APIManagementException {
         return null;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -634,6 +634,16 @@ public class OAS2Parser extends APIDefinition {
             swaggerObj.getInfo().setVersion(swaggerData.getVersion());
         }
         preserveResourcePathOrderFromAPI(swaggerData, swaggerObj);
+
+        // sets x-wso2-disable-security extension
+        if (swaggerData.getExtensionsList() != null && !swaggerData.getExtensionsList().isEmpty()) {
+            if (swaggerData.getExtensionsList() == null) {
+                swaggerData.setExtensionsList(new HashMap<>());
+            }
+            swaggerObj.getVendorExtensions().put(APIConstants.X_WSO2_DISABLE_SECURITY,
+                    swaggerData.getExtensionsList().get(APIConstants.X_WSO2_DISABLE_SECURITY));
+        }
+
         return getSwaggerJsonString(swaggerObj);
     }
 
@@ -834,6 +844,12 @@ public class OAS2Parser extends APIDefinition {
         Swagger swagger = getSwagger(oasDefinition);
         if (api.getAuthorizationHeader() != null) {
             swagger.setVendorExtension(APIConstants.X_WSO2_AUTH_HEADER, api.getAuthorizationHeader());
+        }
+        // sets x-wso2-disable-security vendor extension
+        if (StringUtils.isNotEmpty(api.getApiSecurity())){
+            swagger.setVendorExtension(APIConstants.X_WSO2_DISABLE_SECURITY, false);
+        } else {
+            swagger.setVendorExtension(APIConstants.X_WSO2_DISABLE_SECURITY, true);
         }
         if (api.getApiLevelPolicy() != null) {
             swagger.setVendorExtension(APIConstants.X_THROTTLING_TIER, api.getApiLevelPolicy());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -1708,7 +1708,7 @@ public class OAS2Parser extends APIDefinition {
      * @return API
      */
     @Override
-    public API setExtensionsToAPI(String apiDefinition, API api) throws APIManagementException {
+    public API setExtensionsToAPI(String apiDefinition, API api, boolean isExistingApi) throws APIManagementException {
         Swagger swagger = getSwagger(apiDefinition);
         Map<String, Object> extensions = swagger.getVendorExtensions();
         if (extensions == null) {
@@ -1719,6 +1719,20 @@ public class OAS2Parser extends APIDefinition {
         String authHeader = OASParserUtil.getAuthorizationHeaderFromSwagger(extensions);
         if (StringUtils.isNotBlank(authHeader)) {
             api.setAuthorizationHeader(authHeader);
+        }
+
+        // handles x-wso2-security extension with the API object
+        if (extensions.containsKey(APIConstants.X_WSO2_DISABLE_SECURITY)) {
+            if (Boolean.valueOf(extensions.get(APIConstants.X_WSO2_DISABLE_SECURITY).toString())) {
+                api.setApiSecurity("");
+            } else {
+                api.setApiSecurity(new StringBuilder()
+                        .append(APIConstants.DEFAULT_API_SECURITY_OAUTH2).append(",")
+                        .append(APIConstants.API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY).toString());
+            }
+            if (isExistingApi){
+                return api;
+            }
         }
         //Setup application Security
         List<String> applicationSecurity = OASParserUtil.getApplicationSecurityTypes(extensions);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -636,7 +636,11 @@ public class OAS2Parser extends APIDefinition {
         preserveResourcePathOrderFromAPI(swaggerData, swaggerObj);
 
         // sets x-wso2-disable-security extension
-        if (swaggerData.getExtensionsList() != null && !swaggerData.getExtensionsList().isEmpty()) {
+        if (swaggerData.getExtensionsList() != null && swaggerData.getExtensionsList()
+                .containsKey(APIConstants.X_WSO2_DISABLE_SECURITY)) {
+            if (swaggerObj.getVendorExtensions() == null) {
+                swaggerObj.setVendorExtensions(new HashMap<>());
+            }
             swaggerObj.getVendorExtensions().put(APIConstants.X_WSO2_DISABLE_SECURITY,
                     swaggerData.getExtensionsList().get(APIConstants.X_WSO2_DISABLE_SECURITY));
         } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -1718,24 +1718,24 @@ public class OAS2Parser extends APIDefinition {
             return api;
         }
 
+        // handles x-wso2-security extension with the API object
+        if (extensions.containsKey(APIConstants.X_WSO2_DISABLE_SECURITY) &&
+                Boolean.valueOf(extensions.get(APIConstants.X_WSO2_DISABLE_SECURITY).toString())) {
+            api.setApiSecurity(new StringBuilder().toString());
+        } else {
+            api.setApiSecurity(new StringBuilder()
+                    .append(APIConstants.DEFAULT_API_SECURITY_OAUTH2).append(",")
+                    .append(APIConstants.API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY).toString());
+        }
+        // returning existing APIs from here since no need to execute the remaining logic
+        // for an existing API.
+        if (isExistingApi) {
+            return api;
+        }
         //Setup Custom auth header for API
         String authHeader = OASParserUtil.getAuthorizationHeaderFromSwagger(extensions);
         if (StringUtils.isNotBlank(authHeader)) {
             api.setAuthorizationHeader(authHeader);
-        }
-
-        // handles x-wso2-security extension with the API object
-        if (extensions.containsKey(APIConstants.X_WSO2_DISABLE_SECURITY)) {
-            if (Boolean.valueOf(extensions.get(APIConstants.X_WSO2_DISABLE_SECURITY).toString())) {
-                api.setApiSecurity("");
-            } else {
-                api.setApiSecurity(new StringBuilder()
-                        .append(APIConstants.DEFAULT_API_SECURITY_OAUTH2).append(",")
-                        .append(APIConstants.API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY).toString());
-            }
-            if (isExistingApi){
-                return api;
-            }
         }
         //Setup application Security
         List<String> applicationSecurity = OASParserUtil.getApplicationSecurityTypes(extensions);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -637,11 +637,10 @@ public class OAS2Parser extends APIDefinition {
 
         // sets x-wso2-disable-security extension
         if (swaggerData.getExtensionsList() != null && !swaggerData.getExtensionsList().isEmpty()) {
-            if (swaggerData.getExtensionsList() == null) {
-                swaggerData.setExtensionsList(new HashMap<>());
-            }
             swaggerObj.getVendorExtensions().put(APIConstants.X_WSO2_DISABLE_SECURITY,
                     swaggerData.getExtensionsList().get(APIConstants.X_WSO2_DISABLE_SECURITY));
+        } else {
+            swaggerData.setExtensionsList(new HashMap<>());
         }
 
         return getSwaggerJsonString(swaggerObj);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1917,27 +1917,25 @@ public class OAS3Parser extends APIDefinition {
         if (extensions == null) {
             return api;
         }
-
+        // handle x-wso2-disable-security extension with the API object
+        if (extensions.containsKey(APIConstants.X_WSO2_DISABLE_SECURITY) &&
+                Boolean.valueOf(extensions.get(APIConstants.X_WSO2_DISABLE_SECURITY).toString())) {
+            api.setApiSecurity(new StringBuilder().toString());
+        } else {
+            api.setApiSecurity(new StringBuilder()
+                    .append(APIConstants.DEFAULT_API_SECURITY_OAUTH2).append(",")
+                    .append(APIConstants.API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY).toString());
+        }
+        // returning existing APIs from here since no need to execute the remaining logic
+        // for an existing API.
+        if (isExistingApi) {
+            return api;
+        }
         //Setup Custom auth header for API
         String authHeader = OASParserUtil.getAuthorizationHeaderFromSwagger(extensions);
         if (StringUtils.isNotBlank(authHeader)) {
             api.setAuthorizationHeader(authHeader);
         }
-
-        // handle x-wso2-disable-security extension with the API object
-        if (extensions.containsKey(APIConstants.X_WSO2_DISABLE_SECURITY)) {
-            if (Boolean.valueOf(extensions.get(APIConstants.X_WSO2_DISABLE_SECURITY).toString())) {
-                api.setApiSecurity("");
-            } else {
-                api.setApiSecurity(new StringBuilder()
-                        .append(APIConstants.DEFAULT_API_SECURITY_OAUTH2).append(",")
-                        .append(APIConstants.API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY).toString());
-            }
-            if (isExistingApi){
-                return api;
-            }
-        }
-
         //Setup application Security
         List<String> applicationSecurity = OASParserUtil.getApplicationSecurityTypes(extensions);
         Boolean isOptional = OASParserUtil.getAppSecurityStateFromSwagger(extensions);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -677,11 +677,10 @@ public class OAS3Parser extends APIDefinition {
 
         // sets x-wso2-disable-security extension
         if (swaggerData.getExtensionsList() != null && !swaggerData.getExtensionsList().isEmpty()) {
-            if (openAPI.getExtensions() == null) {
-                openAPI.setExtensions(new HashMap<>());
-            }
             openAPI.getExtensions().put(APIConstants.X_WSO2_DISABLE_SECURITY,
                     swaggerData.getExtensionsList().get(APIConstants.X_WSO2_DISABLE_SECURITY));
+        } else {
+            openAPI.setExtensions(new HashMap<>());
         }
         return Json.pretty(openAPI);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -676,11 +676,13 @@ public class OAS3Parser extends APIDefinition {
         }
 
         // sets x-wso2-disable-security extension
-        if (swaggerData.getExtensionsList() != null && !swaggerData.getExtensionsList().isEmpty()) {
+        if (swaggerData.getExtensionsList() != null && swaggerData.getExtensionsList()
+                .containsKey(APIConstants.X_WSO2_DISABLE_SECURITY)) {
+            if (openAPI.getExtensions() == null) {
+                openAPI.setExtensions(new HashMap<>());
+            }
             openAPI.getExtensions().put(APIConstants.X_WSO2_DISABLE_SECURITY,
                     swaggerData.getExtensionsList().get(APIConstants.X_WSO2_DISABLE_SECURITY));
-        } else {
-            openAPI.setExtensions(new HashMap<>());
         }
         return Json.pretty(openAPI);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -674,6 +674,15 @@ public class OAS3Parser extends APIDefinition {
         if (!APIConstants.GRAPHQL_API.equals(swaggerData.getTransportType())) {
             preserveResourcePathOrderFromAPI(swaggerData, openAPI);
         }
+
+        // sets x-wso2-disable-security extension
+        if (swaggerData.getExtensionsList() != null && !swaggerData.getExtensionsList().isEmpty()) {
+            if (openAPI.getExtensions() == null) {
+                openAPI.setExtensions(new HashMap<>());
+            }
+            openAPI.getExtensions().put(APIConstants.X_WSO2_DISABLE_SECURITY,
+                    swaggerData.getExtensionsList().get(APIConstants.X_WSO2_DISABLE_SECURITY));
+        }
         return Json.pretty(openAPI);
     }
 
@@ -917,6 +926,13 @@ public class OAS3Parser extends APIDefinition {
             oAuthFlow.setScopes(new Scopes());
         }
         oAuthFlow.setAuthorizationUrl(OPENAPI_DEFAULT_AUTHORIZATION_URL);
+
+        // sets x-wso2-disable-security extension
+        if( StringUtils.isNotEmpty(api.getApiSecurity())) {
+            openAPI.addExtension(APIConstants.X_WSO2_DISABLE_SECURITY, false);
+        } else {
+            openAPI.addExtension(APIConstants.X_WSO2_DISABLE_SECURITY, true);
+        }
 
         if (api.getAuthorizationHeader() != null) {
             openAPI.addExtension(APIConstants.X_WSO2_AUTH_HEADER, api.getAuthorizationHeader());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1910,7 +1910,7 @@ public class OAS3Parser extends APIDefinition {
      * @return API
      */
     @Override
-    public API setExtensionsToAPI(String apiDefinition, API api) throws APIManagementException {
+    public API setExtensionsToAPI(String apiDefinition, API api, boolean isExistingApi) throws APIManagementException {
         OpenAPI openAPI = getOpenAPI(apiDefinition);
         Map<String, Object> extensions = openAPI.getExtensions();
         if (extensions == null) {
@@ -1922,6 +1922,21 @@ public class OAS3Parser extends APIDefinition {
         if (StringUtils.isNotBlank(authHeader)) {
             api.setAuthorizationHeader(authHeader);
         }
+
+        // handle x-wso2-disable-security extension with the API object
+        if (extensions.containsKey(APIConstants.X_WSO2_DISABLE_SECURITY)) {
+            if (Boolean.valueOf(extensions.get(APIConstants.X_WSO2_DISABLE_SECURITY).toString())) {
+                api.setApiSecurity("");
+            } else {
+                api.setApiSecurity(new StringBuilder()
+                        .append(APIConstants.DEFAULT_API_SECURITY_OAUTH2).append(",")
+                        .append(APIConstants.API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY).toString());
+            }
+            if (isExistingApi){
+                return api;
+            }
+        }
+
         //Setup application Security
         List<String> applicationSecurity = OASParserUtil.getApplicationSecurityTypes(extensions);
         Boolean isOptional = OASParserUtil.getAppSecurityStateFromSwagger(extensions);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1479,9 +1479,9 @@ public class OASParserUtil {
      * @param api            API
      * @return API
      */
-    public static API setExtensionsToAPI(String swaggerContent, API api) throws APIManagementException {
+    public static API setExtensionsToAPI(String swaggerContent, API api, boolean isExistingApi) throws APIManagementException {
         APIDefinition apiDefinition = getOASParser(swaggerContent);
-        return apiDefinition.setExtensionsToAPI(swaggerContent, api);
+        return apiDefinition.setExtensionsToAPI(swaggerContent, api, isExistingApi);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -1231,6 +1231,9 @@ public class PublisherCommonUtils {
         } else {
             apiDefinition = OASParserUtil.preProcess(apiDefinition);
         }
+
+        OASParserUtil.setExtensionsToAPI(apiDefinition, existingAPI, true);
+
         if (APIConstants.API_TYPE_SOAPTOREST.equals(existingAPI.getType())) {
             List<SOAPToRestSequence> sequenceList = SequenceGenerator.generateSequencesFromSwagger(apiDefinition);
             existingAPI.setSoapToRestSequences(sequenceList);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -195,6 +195,12 @@ public class ApisApiServiceImpl implements ApisApiService {
         APIDTO createdApiDTO;
         try {
             String organization = RestApiUtil.getValidatedOrganization(messageContext);
+            // enables OAuth2 by default
+            if (body.getSecurityScheme() != null && body.getSecurityScheme().isEmpty()) {
+                body.setSecurityScheme( new ArrayList<>(Arrays.asList(APIConstants.DEFAULT_API_SECURITY_OAUTH2,
+                        APIConstants.API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY)));
+            }
+
             API createdApi = PublisherCommonUtils
                     .addAPIWithGeneratedSwaggerDefinition(body, oasVersion, RestApiCommonUtil.getLoggedInUsername(),
                             organization);
@@ -4805,7 +4811,7 @@ public class ApisApiServiceImpl implements ApisApiService {
         apiToAdd.setScopePrefix(apiDTOFromProperties.getScopePrefix());
         APIUtil.updateAPIScopesWithPrefix(apiToAdd);
         //Set extensions from API definition to API object
-        apiToAdd = OASParserUtil.setExtensionsToAPI(definitionToAdd, apiToAdd);
+        apiToAdd = OASParserUtil.setExtensionsToAPI(definitionToAdd, apiToAdd, false);
         if (!syncOperations) {
             PublisherCommonUtils.validateScopes(apiToAdd);
             swaggerData = new SwaggerData(apiToAdd);


### PR DESCRIPTION
With this PR users will be able disable/ enable application level security.
Also the `x-wso2-disable-security` extension will be added to the API definition based on the enabling or disabling of application level security.