### PR TITLE
Fix validating raw MTLS certificates

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
@@ -493,6 +493,7 @@ public class Utils {
                     String msg = "Error while URL decoding certificate";
                     throw new APIManagementException(msg, e);
                 }
+                certificate = APIUtil.getX509certificateContent(certificate);
                 bytes = Base64.decodeBase64(certificate);
             }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
@@ -469,7 +469,22 @@ public class Utils {
         byte[] bytes;
         if (certificate != null) {
             if (!isClientCertificateEncoded()) {
-                certificate = APIUtil.getX509certificateContent(certificate);
+                // Remove invalid characters, restructure line separators, and reconstruct the certificate
+                certificate = certificate
+                        .replaceAll(APIConstants.BEGIN_CERTIFICATE_STRING.concat(System.lineSeparator()), "")
+                        .replaceAll(APIConstants.BEGIN_CERTIFICATE_STRING.concat("\n"), "")
+                        .replaceAll(APIConstants.BEGIN_CERTIFICATE_STRING, "")
+                        .replaceAll(System.lineSeparator().concat(APIConstants.END_CERTIFICATE_STRING), "")
+                        .replaceAll("\n".concat(APIConstants.END_CERTIFICATE_STRING), "")
+                        .replaceAll(APIConstants.END_CERTIFICATE_STRING, "")
+                        .trim()
+                        .replaceAll(" ", System.lineSeparator())
+                        .trim();
+                certificate = APIConstants.BEGIN_CERTIFICATE_STRING
+                        .concat(System.lineSeparator())
+                        .concat(certificate)
+                        .concat(System.lineSeparator())
+                        .concat(APIConstants.END_CERTIFICATE_STRING);
                 bytes = certificate.getBytes();
             } else {
                 try {
@@ -478,8 +493,6 @@ public class Utils {
                     String msg = "Error while URL decoding certificate";
                     throw new APIManagementException(msg, e);
                 }
-
-                certificate = APIUtil.getX509certificateContent(certificate);
                 bytes = Base64.decodeBase64(certificate);
             }
 


### PR DESCRIPTION
## Purpose 
In Mutual SSL, the API manager allows passing the client certificate in base64 encoded format and raw format via an HTTP header. When the certificate is passed in base64 encoded format, the validation happens correctly. However, if the certificate is passed as raw text, it throws the following exception while building the `X509Certificate` object.

Fixes https://github.com/wso2/api-manager/issues/1930

## Approach 
This PR fixes the issue by removing invalid characters and reconstructing the certificate before building the `X509Certificate` object.