### PR TITLE
Fix considering the x-wso2-disabled security extension

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -883,15 +883,11 @@ public class OAS2Parser extends APIDefinition {
                 swagger.setVendorExtension(APIConstants.X_WSO2_MUTUAL_SSL, mutualSSLOptional);
             }
         }
-        // This app security should be given in resource level,
-        // otherwise the default oauth2 scheme defined at each resource level will override application securities
-        JsonNode appSecurityExtension = OASParserUtil.getAppSecurity(apiSecurity);
         for (String pathKey : swagger.getPaths().keySet()) {
             Path path = swagger.getPath(pathKey);
             Map<HttpMethod, Operation> operationMap = path.getOperationMap();
             for (Map.Entry<HttpMethod, Operation> entry : operationMap.entrySet()) {
                 Operation operation = entry.getValue();
-                operation.setVendorExtension(APIConstants.X_WSO2_APP_SECURITY, appSecurityExtension);
                 // If throttling limit remains unassigned in the swagger definition, the throttling-tier property
                 // will be used to generate the limit. If throttling-tier is also not defined, the default tier would
                 // be unlimited tier.
@@ -904,7 +900,6 @@ public class OAS2Parser extends APIDefinition {
                 }
             }
         }
-        swagger.setVendorExtension(APIConstants.X_WSO2_APP_SECURITY, appSecurityExtension);
         swagger.setVendorExtension(APIConstants.X_WSO2_RESPONSE_CACHE,
                 OASParserUtil.getResponseCacheConfig(api.getResponseCache(), api.getCacheTimeout()));
 
@@ -1836,7 +1831,6 @@ public class OAS2Parser extends APIDefinition {
                         resourceExtensions = new HashMap<>();
                         extensionsAreEmpty = true;
                     }
-                    resourceExtensions.put(APIConstants.SWAGGER_X_AUTH_TYPE, "None");
                     if (extensionsAreEmpty) {
                         operation.setVendorExtensions(resourceExtensions);
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -970,14 +970,10 @@ public class OAS3Parser extends APIDefinition {
                 openAPI.addExtension(APIConstants.X_WSO2_MUTUAL_SSL, mutualSSLOptional);
             }
         }
-        // This app security should be given in resource level,
-        // otherwise the default oauth2 scheme defined at each resource level will override application securities
-        JsonNode appSecurityExtension = OASParserUtil.getAppSecurity(apiSecurity);
         for (String pathKey : openAPI.getPaths().keySet()) {
             PathItem pathItem = openAPI.getPaths().get(pathKey);
             for (Map.Entry<PathItem.HttpMethod, Operation> entry : pathItem.readOperationsMap().entrySet()) {
                 Operation operation = entry.getValue();
-                operation.addExtension(APIConstants.X_WSO2_APP_SECURITY, appSecurityExtension);
                 // If throttling limit remains unassigned in the swagger definition, the throttling-tier property
                 // will be used to generate the limit. If throttling-tier is also not defined, the default tier would
                 // be unlimited tier.
@@ -2065,7 +2061,6 @@ public class OAS3Parser extends APIDefinition {
                         resourceExtensions = new HashMap<>();
                         extensionsAreEmpty = true;
                     }
-                    resourceExtensions.put(APIConstants.SWAGGER_X_AUTH_TYPE, "None");
                     if (extensionsAreEmpty) {
                         operation.setExtensions(resourceExtensions);
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1378,27 +1378,6 @@ public class OASParserUtil {
     }
 
     /**
-     * generate app security information for OAS definition
-     *
-     * @param security application security
-     * @return JsonNode
-     */
-    static JsonNode getAppSecurity(String security) {
-        List<String> appSecurityList = new ArrayList<>();
-        ObjectNode endpointResult = objectMapper.createObjectNode();
-        boolean appSecurityOptional = false;
-        if (security != null) {
-            List<String> securityList = Arrays.asList(security.split(","));
-            appSecurityList = getAPISecurity(securityList);
-            appSecurityOptional = !securityList.contains(APIConstants.API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY);
-        }
-        ArrayNode appSecurityTypes = objectMapper.valueToTree(appSecurityList);
-        endpointResult.set(APIConstants.WSO2_APP_SECURITY_TYPES, appSecurityTypes);
-        endpointResult.put(APIConstants.OPTIONAL, appSecurityOptional);
-        return endpointResult;
-    }
-
-    /**
      * Generated x-throttling-limit value for the API definition
      *
      * @param throttlingLimit provides throttling limit details

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -675,6 +675,10 @@ public class APIMappingUtil {
             apiInfoDTO.setAdditionalProperties(additionalPropertiesList);
             apiInfoDTO.setAdditionalPropertiesMap(additionalPropertiesMap);
             apiInfoDTO.setGatewayVendor(api.getGatewayVendor());
+            if (StringUtils.equalsIgnoreCase(api.getApiSecurity(), APIConstants.DEFAULT_API_SECURITY_OAUTH2)) {
+                apiInfoDTO.setSecurityScheme(Arrays.asList(APIConstants.DEFAULT_API_SECURITY_OAUTH2,
+                        APIConstants.API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY));
+            }
         }
         return apiInfoDTO;
     }


### PR DESCRIPTION
With the previously created PR (https://github.com/wso2/carbon-apimgt/pull/12076) enabled to disable the security when `x-wso2-disabled-security` extension assigned as `true.` However due to the `x-auth-type` extension value change happened with the above PR avoided to re-enable security after disabling it. With this PR it is fixed. 