### PR TITLE
Fix startup issue due to missing end tag

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1096,6 +1096,7 @@
                 {% endif %}
                 {% if apim.open_tracer.remote_tracer.properties.sampler_param is defined %}
                 <SamplerParam>{{apim.open_tracer.remote_tracer.properties.sampler_param}}</SamplerParam>
+                {% endif %}
                 {% if apim.open_tracer.remote_tracer.properties.proxy_host is defined %}
                 <ProxyHost>{{apim.open_tracer.remote_tracer.properties.proxy_host}}</ProxyHost>
                 {% endif %}


### PR DESCRIPTION
## Purpose

- Fix pack startup issue due to missing end tag under `api-manager.xml.j2` due to the changes added via https://github.com/wso2/carbon-apimgt/pull/12082