### PR TITLE
Skip URL validation for parameterized endpoints

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -9621,9 +9621,10 @@ public final class APIUtil {
         UrlValidator urlValidator = new UrlValidator(authorityValidator, validatorOptions);
 
         for (String endpoint : endpoints) {
-            // If url is a JMS connection url or a Consul service discovery related url, validation is skipped.
-            // If not, validity is checked.
-            if (!endpoint.startsWith("jms:") && !endpoint.startsWith("consul(") && !urlValidator.isValid(endpoint)) {
+            // If url is a JMS connection url or a Consul service discovery related url, or a parameterized URL
+            // validation is skipped. If not, validity is checked.
+            if (!endpoint.startsWith("jms:") && !endpoint.startsWith("consul(") && !endpoint.contains("{") &&
+                    !endpoint.contains("}") && !urlValidator.isValid(endpoint)) {
                 try {
                     // If the url is not identified as valid from the above check,
                     // next step is determine the validity of the encoded url (done through the URI constructor).


### PR DESCRIPTION
Fix the issue of configuring parameterized endpoints after the URL validation is introduced. With this PR it will skip validating parameterized endpoints.

Resolved : https://github.com/wso2/api-manager/issues/1961