### PR TITLE
Audience claim addition

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
@@ -19,7 +19,6 @@ package org.wso2.carbon.apimgt.api.model;
 
 import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONObject;
-import org.wso2.carbon.apimgt.api.APIConstants;
 import org.wso2.carbon.apimgt.api.model.policy.Policy;
 import org.wso2.carbon.apimgt.api.util.ModelUtil;
 
@@ -122,6 +121,7 @@ public class API implements Serializable {
     private String subscriptionAvailability;
     private String subscriptionAvailableTenants;
     private CORSConfiguration corsConfiguration;
+    private BackendJWTConfiguration backendJWTConfiguration;
     private String endpointConfig;
     private WebsubSubscriptionConfiguration websubSubscriptionConfiguration;
     private WebSocketTopicMappingConfiguration webSocketTopicMappingConfiguration;
@@ -1380,5 +1380,13 @@ public class API implements Serializable {
 
     public void setVersionInfo(VersionInfo versionInfo) {
         this.versionInfo = versionInfo;
+    }
+
+    public void setBackendJWTConfiguration(BackendJWTConfiguration backendJWTConfig) {
+        this.backendJWTConfiguration = backendJWTConfig;
+    }
+
+    public BackendJWTConfiguration getBackendJWTConfiguration() {
+        return backendJWTConfiguration;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/BackendJWTConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/BackendJWTConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.api.model;
+
+import java.util.List;
+
+public class BackendJWTConfiguration {
+
+    private List<String> audiences;
+
+    public BackendJWTConfiguration(List<String> audiences) {
+        this.setAudiences(audiences);
+    }
+
+    public List<String> getAudiences() {
+        return audiences;
+    }
+
+    public void setAudiences(List<String> audiences) {
+        this.audiences = audiences;
+    }
+
+    @Override
+    public String toString() {
+        return "BackendJWTConfiguration [audiences=" + audiences + "]";
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/BackendJWTConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/BackendJWTConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.persistence.dto;
+
+import java.util.List;
+
+public class BackendJWTConfiguration {
+    private List<String> audiences;
+
+    public BackendJWTConfiguration() {
+    }
+
+    public BackendJWTConfiguration(List<String> audiences) {
+        this.setAudiences(audiences);
+    }
+
+    public List<String> getAudiences() {
+        return audiences;
+    }
+
+    public void setAudiences(List<String> audiences) {
+        this.audiences = audiences;
+    }
+
+    @Override
+    public String toString() {
+        return "BackendJWTConfiguration [audiences=" + audiences + "]";
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/PublisherAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/PublisherAPI.java
@@ -70,6 +70,7 @@ public class PublisherAPI extends PublisherAPIInfo {
     private boolean enableSchemaValidation;
     private boolean enableStore;
     private Boolean enableBackendJWT;
+    private BackendJWTConfiguration backendJWTConfiguration;
     private String testKey;
     private String contextTemplate;
     private Set<String> availableTierNames;
@@ -421,6 +422,14 @@ public class PublisherAPI extends PublisherAPIInfo {
         this.corsConfiguration = corsConfiguration;
     }
 
+    public BackendJWTConfiguration getBackendJWTConfiguration() {
+        return backendJWTConfiguration;
+    }
+
+    public void setBackendJWTConfiguration(BackendJWTConfiguration backendJWTConfig) {
+        this.backendJWTConfiguration = backendJWTConfig;
+    }
+
     public WebsubSubscriptionConfiguration getWebsubSubscriptionConfiguration() {
         return websubSubscriptionConfiguration;
     }
@@ -642,9 +651,10 @@ public class PublisherAPI extends PublisherAPIInfo {
                 + accessControlRoles + ", additionalProperties=" + additionalProperties
                 + ", thumbnail=" + thumbnail + ", createdTime=" + createdTime + ", lastUpdated=" + lastUpdated
                 + ", versionTimestamp=" + versionTimestamp + ",apiExternalProductionEndpoint="
-                + apiExternalProductionEndpoint + ",apiExternalSandboxEndpoint=" + apiExternalSandboxEndpoint
+                + apiExternalProductionEndpoint + ", backendJWTConfiguration=" + backendJWTConfiguration +
+                ",apiExternalSandboxEndpoint=" + apiExternalSandboxEndpoint
                 + ", originalDevportalURL" + redirectURL + ", apiOwner" + apiOwner + ", vendor" + vendor
-                + ", apiOwner" + enableBackendJWT + ", toString()=" + super.toString() + "]";
+                + ", enableBackendJWT" + enableBackendJWT + ", toString()=" + super.toString() + "]";
     }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIBackendJWTConfigurationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIBackendJWTConfigurationDTO.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class APIBackendJWTConfigurationDTO   {
+  
+    private List<String> audiences = new ArrayList<String>();
+
+  /**
+   * The list of audiences to which the JWT should be issued. 
+   **/
+  public APIBackendJWTConfigurationDTO audiences(List<String> audiences) {
+    this.audiences = audiences;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "[\"sampleOrg1.com\",\"sampleOrg2.com\"]", value = "The list of audiences to which the JWT should be issued. ")
+  @JsonProperty("audiences")
+  public List<String> getAudiences() {
+    return audiences;
+  }
+  public void setAudiences(List<String> audiences) {
+    this.audiences = audiences;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    APIBackendJWTConfigurationDTO apIBackendJWTConfiguration = (APIBackendJWTConfigurationDTO) o;
+    return Objects.equals(audiences, apIBackendJWTConfiguration.audiences);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(audiences);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class APIBackendJWTConfigurationDTO {\n");
+    
+    sb.append("    audiences: ").append(toIndentedString(audiences)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIDTO.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIBackendJWTConfigurationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIBusinessInformationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APICorsConfigurationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIInfoAdditionalPropertiesDTO;
@@ -59,6 +60,7 @@ public class APIDTO   {
     private Boolean isDefaultVersion = null;
     private Boolean isRevision = null;
     private Boolean enableBackendJWT = null;
+    private APIBackendJWTConfigurationDTO backendJWTConfiguration = null;
     private String revisionedApiId = null;
     private Integer revisionId = null;
     private Boolean enableSchemaValidation = null;
@@ -579,6 +581,24 @@ return null;
   }
   public void setEnableBackendJWT(Boolean enableBackendJWT) {
     this.enableBackendJWT = enableBackendJWT;
+  }
+
+  /**
+   **/
+  public APIDTO backendJWTConfiguration(APIBackendJWTConfigurationDTO backendJWTConfiguration) {
+    this.backendJWTConfiguration = backendJWTConfiguration;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("backendJWTConfiguration")
+  public APIBackendJWTConfigurationDTO getBackendJWTConfiguration() {
+    return backendJWTConfiguration;
+  }
+  public void setBackendJWTConfiguration(APIBackendJWTConfigurationDTO backendJWTConfiguration) {
+    this.backendJWTConfiguration = backendJWTConfiguration;
   }
 
   /**
@@ -1372,6 +1392,7 @@ return null;
         Objects.equals(isDefaultVersion, API.isDefaultVersion) &&
         Objects.equals(isRevision, API.isRevision) &&
         Objects.equals(enableBackendJWT, API.enableBackendJWT) &&
+        Objects.equals(backendJWTConfiguration, API.backendJWTConfiguration) &&
         Objects.equals(revisionedApiId, API.revisionedApiId) &&
         Objects.equals(revisionId, API.revisionId) &&
         Objects.equals(enableSchemaValidation, API.enableSchemaValidation) &&
@@ -1419,7 +1440,7 @@ return null;
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, context, version, provider, lifeCycleStatus, wsdlInfo, wsdlUrl, responseCachingEnabled, cacheTimeout, hasThumbnail, isDefaultVersion, isRevision, enableBackendJWT, revisionedApiId, revisionId, enableSchemaValidation, type, audience, transport, tags, policies, apiThrottlingPolicy, throttlingLimit, authorizationHeader, securityScheme, maxTps, visibility, visibleRoles, visibleTenants, mediationPolicies, subscriptionAvailability, subscriptionAvailableTenants, additionalProperties, additionalPropertiesMap, monetization, accessControl, accessControlRoles, businessInformation, corsConfiguration, websubSubscriptionConfiguration, workflowStatus, createdTime, lastUpdatedTime, endpointConfig, endpointImplementationType, scopes, scopePrefix, operations, threatProtectionPolicies, categories, keyManagers, serviceInfo, advertiseInfo, gatewayVendor, gatewayType, asyncTransportProtocols);
+    return Objects.hash(id, name, description, context, version, provider, lifeCycleStatus, wsdlInfo, wsdlUrl, responseCachingEnabled, cacheTimeout, hasThumbnail, isDefaultVersion, isRevision, enableBackendJWT, backendJWTConfiguration, revisionedApiId, revisionId, enableSchemaValidation, type, audience, transport, tags, policies, apiThrottlingPolicy, throttlingLimit, authorizationHeader, securityScheme, maxTps, visibility, visibleRoles, visibleTenants, mediationPolicies, subscriptionAvailability, subscriptionAvailableTenants, additionalProperties, additionalPropertiesMap, monetization, accessControl, accessControlRoles, businessInformation, corsConfiguration, websubSubscriptionConfiguration, workflowStatus, createdTime, lastUpdatedTime, endpointConfig, endpointImplementationType, scopes, scopePrefix, operations, threatProtectionPolicies, categories, keyManagers, serviceInfo, advertiseInfo, gatewayVendor, gatewayType, asyncTransportProtocols);
   }
 
   @Override
@@ -1442,6 +1463,7 @@ return null;
     sb.append("    isDefaultVersion: ").append(toIndentedString(isDefaultVersion)).append("\n");
     sb.append("    isRevision: ").append(toIndentedString(isRevision)).append("\n");
     sb.append("    enableBackendJWT: ").append(toIndentedString(enableBackendJWT)).append("\n");
+    sb.append("    backendJWTConfiguration: ").append(toIndentedString(backendJWTConfiguration)).append("\n");
     sb.append("    revisionedApiId: ").append(toIndentedString(revisionedApiId)).append("\n");
     sb.append("    revisionId: ").append(toIndentedString(revisionId)).append("\n");
     sb.append("    enableSchemaValidation: ").append(toIndentedString(enableSchemaValidation)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.apimgt.api.model.APIResourceMediationPolicy;
 import org.wso2.carbon.apimgt.api.model.APIRevision;
 import org.wso2.carbon.apimgt.api.model.APIRevisionDeployment;
 import org.wso2.carbon.apimgt.api.model.APIStateChangeResponse;
+import org.wso2.carbon.apimgt.api.model.BackendJWTConfiguration;
 import org.wso2.carbon.apimgt.api.model.CORSConfiguration;
 import org.wso2.carbon.apimgt.api.model.LifeCycleEvent;
 import org.wso2.carbon.apimgt.api.model.Mediation;
@@ -68,6 +69,7 @@ import org.wso2.carbon.apimgt.impl.wsdl.model.WSDLValidationResponse;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.common.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIBackendJWTConfigurationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIBusinessInformationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APICorsConfigurationDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIDTO;
@@ -362,6 +364,14 @@ public class APIMappingUtil {
             corsConfiguration = APIUtil.getDefaultCorsConfiguration();
         }
         model.setCorsConfiguration(corsConfiguration);
+
+        if (dto.isEnableBackendJWT() && dto.getBackendJWTConfiguration() != null
+                && dto.getBackendJWTConfiguration().getAudiences() != null) {
+            BackendJWTConfiguration backendJWTConfig = new BackendJWTConfiguration(
+                    dto.getBackendJWTConfiguration().getAudiences());
+            model.setBackendJWTConfiguration(backendJWTConfig);
+        }
+
         setMaxTpsFromApiDTOToModel(dto, model);
         model.setAuthorizationHeader(dto.getAuthorizationHeader());
         model.setApiSecurity(getSecurityScheme(dto.getSecurityScheme()));
@@ -906,6 +916,12 @@ public class APIMappingUtil {
         dto.setRevisionId(model.getRevisionId());
         dto.setEnableSchemaValidation(model.isEnabledSchemaValidation());
         dto.setEnableBackendJWT(model.getEnableBackendJWT() != null ? model.getEnableBackendJWT() : true);
+        APIBackendJWTConfigurationDTO backendJWTConfigurationDetailsDTO = new APIBackendJWTConfigurationDTO();
+        if (model.getEnableBackendJWT() && model.getBackendJWTConfiguration() != null &&
+                model.getBackendJWTConfiguration().getAudiences() != null) {
+            backendJWTConfigurationDetailsDTO.setAudiences(model.getBackendJWTConfiguration().getAudiences());
+        }
+        dto.setBackendJWTConfiguration(backendJWTConfigurationDetailsDTO);
 
         AdvertiseInfoDTO advertiseInfoDTO = new AdvertiseInfoDTO();
         advertiseInfoDTO.setAdvertised(model.isAdvertiseOnly());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -8431,6 +8431,18 @@ components:
         enableBackendJWT:
           type: boolean
           example: true
+        backendJWTConfiguration:
+          type: object
+          properties:
+            audiences:
+              type: array
+              description: |
+                The list of audiences to which the JWT should be issued.
+              example:
+                - sampleOrg1.com
+                - sampleOrg2.com
+              items:
+                type: string
         revisionedApiId:
           type: string
           description: |


### PR DESCRIPTION
With the existing implementation, users cannot pass user defined `aud` claims to the backend with the token. 
This PR is created to provide the above mentioned support.

Relevant change added to the `api.yaml` 

```
.
.
.
"backendJWTConfig": {
        "audiences": [
            "abcOrg.com",
            "xyzOrg.com"
        ]
    },
.
.
```