### PR TITLE
Add fix to ommit `getAllAPICategoriesOfOrganization` during migration

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -1452,7 +1452,7 @@ public abstract class AbstractAPIManager implements APIManager {
             }
             List<APICategory> categoryList = new ArrayList<>();
 
-            if (!categoriesOfAPI.isEmpty()) {
+            if (!categoriesOfAPI.isEmpty() && migrationEnabled == null) {
                 // category array retrieved from artifact has only the category name, therefore we need to fetch
                 // categories
                 // and fill out missing attributes before attaching the list to the api


### PR DESCRIPTION
Fixing : https://github.com/wso2/api-manager/issues/2068