### PR TITLE
Fix for the contract test failure

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -365,7 +365,7 @@ public class APIMappingUtil {
         }
         model.setCorsConfiguration(corsConfiguration);
 
-        if (dto.isEnableBackendJWT() && dto.getBackendJWTConfiguration() != null
+        if (dto.isEnableBackendJWT() != null && dto.isEnableBackendJWT() && dto.getBackendJWTConfiguration() != null
                 && dto.getBackendJWTConfiguration().getAudiences() != null) {
             BackendJWTConfiguration backendJWTConfig = new BackendJWTConfiguration(
                     dto.getBackendJWTConfiguration().getAudiences());
@@ -917,7 +917,7 @@ public class APIMappingUtil {
         dto.setEnableSchemaValidation(model.isEnabledSchemaValidation());
         dto.setEnableBackendJWT(model.getEnableBackendJWT() != null ? model.getEnableBackendJWT() : true);
         APIBackendJWTConfigurationDTO backendJWTConfigurationDetailsDTO = new APIBackendJWTConfigurationDTO();
-        if (model.getEnableBackendJWT() && model.getBackendJWTConfiguration() != null &&
+        if (model.getEnableBackendJWT() != null && model.getEnableBackendJWT() && model.getBackendJWTConfiguration() != null &&
                 model.getBackendJWTConfiguration().getAudiences() != null) {
             backendJWTConfigurationDetailsDTO.setAudiences(model.getBackendJWTConfiguration().getAudiences());
         }


### PR DESCRIPTION
This PR fixes a contract test failure happens when accessing a class field maintained to determine backend JWT enabled or not.

Related Previous PR: https://github.com/wso2/carbon-apimgt/pull/12111