### PR TITLE
Addition of a configuration to define rudder endpoint

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2989,9 +2989,10 @@ public final class APIConstants {
     // Constants related to API backend URL validation
     public static final String CHOREO_API_BACKEND_URL_VALIDATION_CONFIGS = "ChoreoApiBackendUrlValidationConfigs";
     public static final String ENABLE_CHOREO_API_BACKEND_URL_ORG_VALIDATION = "EnableOrgValidation";
+    public static final String RUDDER_ENDPOINT_URL = "RudderEndpointUrl";
     public static final String DEFAULT_ENABLE_CHOREO_API_BACKEND_URL_ORG_VALIDATION = "false";
     public static final String SERVICE_ENDPOINT_URL_IDENTIFIER = "svc.cluster.local";
-    public static final String RUDDER_ENDPOINT_URL = "http://localhost:8002";
+    public static final String RUDDER_ENDPOINT_URL_VALUE = "dp-rudder.dev-choreo-system:80";
 
     // Constants related to internal API key configurations
     public static final String INTERNAL_API_TEST_KEY_EXPIRY_TIME = "exp";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -2046,6 +2046,8 @@ public class APIManagerConfiguration {
     private void setApiBackendUrlValidationConfigurations(OMElement omElement) {
         OMElement enableOrgValidationElement = omElement
                 .getFirstChildWithName(new QName(APIConstants.ENABLE_CHOREO_API_BACKEND_URL_ORG_VALIDATION));
+        OMElement rudderEpUrlElement = omElement
+                .getFirstChildWithName(new QName(APIConstants.RUDDER_ENDPOINT_URL));
         if (enableOrgValidationElement != null) {
             apiEndpointValidationProperties.put(APIConstants.ENABLE_CHOREO_API_BACKEND_URL_ORG_VALIDATION,
                     enableOrgValidationElement.getText());
@@ -2053,6 +2055,13 @@ public class APIManagerConfiguration {
             apiEndpointValidationProperties.put(APIConstants.ENABLE_CHOREO_API_BACKEND_URL_ORG_VALIDATION,
                     APIConstants.DEFAULT_ENABLE_CHOREO_API_BACKEND_URL_ORG_VALIDATION);
             log.debug("Enable API Creator Organization Validation not set. Set to default false");
+        }
+        // Set rudder endpoint URL
+        if (rudderEpUrlElement != null) {
+            apiEndpointValidationProperties.put(APIConstants.RUDDER_ENDPOINT_URL, rudderEpUrlElement.getText());
+        } else {
+            apiEndpointValidationProperties.put(APIConstants.RUDDER_ENDPOINT_URL, APIConstants.RUDDER_ENDPOINT_URL_VALUE);
+            log.debug("Rudder endpoint URL not assigned. Hence assigning the default value");
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/clients/Rudder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/clients/Rudder.java
@@ -47,7 +47,7 @@ public class Rudder {
             if (apiEndpointValidationConfigs != null &&
                     apiEndpointValidationConfigs.containsKey(APIConstants.RUDDER_ENDPOINT_URL)) {
                 rudderEp = apiEndpointValidationConfigs.get(APIConstants.RUDDER_ENDPOINT_URL);
-                return client = Feign.builder().decoder(new GsonDecoder())
+                client = Feign.builder().decoder(new GsonDecoder())
                         .target(RudderClient.class, rudderEp);
             } else {
                 throw new APIManagementException("Error occurred while obtaining Rudder endpoint URL");

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1497,9 +1497,10 @@
      </APITestKeyConfigs>
      {% endif %}}
 
-     {% if choreo.apiBackendUrlValidation is defined %}
+     {% if choreo.api_backend_url_validation is defined %}
      <ChoreoApiBackendUrlValidationConfigs>
-        <EnableOrgValidation>{{choreo.apiBackendUrlValidation.enableOrganizationValidation}}</EnableOrgValidation>
+        <EnableOrgValidation>{{choreo.api_backend_url_validation.enable_organization_validation}}</EnableOrgValidation>
+        <RudderEndpointUrl>{{choreo.api_backend_url_validation.rudder_endpoint_url}}</RudderEndpointUrl>
      </ChoreoApiBackendUrlValidationConfigs>
      {% endif %}}
 </APIManager>


### PR DESCRIPTION
$subject

```
[choreo.api_backend_url_validation]
enable_organization_validation = true
rudder_endpoint_url = "http://localhost:8002"
```