### PR TITLE
Remove revoke endpoint from mandatory list when registering an IDP

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2562,8 +2562,7 @@ public final class APIConstants {
 
         public static final String[] REQUIRED_ENDPOINTS_FOR_EXT_KEY_MANAGERS = {
                 APIConstants.KeyManager.AUTHORIZE_ENDPOINT,
-                APIConstants.KeyManager.TOKEN_ENDPOINT,
-                APIConstants.KeyManager.REVOKE_ENDPOINT
+                APIConstants.KeyManager.TOKEN_ENDPOINT
         };
 
         public static class KeyManagerEvent {


### PR DESCRIPTION
$subject as certain IDP vendors does not include revocation endpoint in their openid-configuration. 