### PR TITLE
Preserve advanceEndpointConfig when setting endpoint config

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1618,6 +1618,8 @@ public final class APIConstants {
     public static final String X_WSO2_REQUEST_INTERCEPTOR = "x-wso2-request-interceptor";
     public static final String X_WSO2_RESPONSE_INTERCEPTOR = "x-wso2-response-interceptor";
     public static final String X_WSO2_ENDPOINT_TYPE = "type";
+    public static final String ADVANCE_ENDPOINT_CONFIG = "advanceEndpointConfig";
+    public static final String TIMEOUT_IN_MILLIS = "timeoutInMillis";
 
     //API Constants
     public static final String API_DATA_NAME = "name";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -1388,6 +1388,17 @@ public class OASParserUtil {
             ObjectNode endpointResult = objectMapper.createObjectNode();
             endpointResult.set(APIConstants.ENDPOINT_URLS, endpointsArray);
             endpointResult.put(APIConstants.X_WSO2_ENDPOINT_TYPE, type);
+            if (primaryEndpoints.has(APIConstants.ADVANCE_ENDPOINT_CONFIG)
+                    && primaryEndpoints.get(APIConstants.ADVANCE_ENDPOINT_CONFIG) != JSONObject.NULL) {
+                JSONObject advanceEndpointConfig = primaryEndpoints.getJSONObject(APIConstants.ADVANCE_ENDPOINT_CONFIG);
+                ObjectNode advanceEndpointsObject = objectMapper.createObjectNode();
+                if (advanceEndpointConfig.has(APIConstants.TIMEOUT_IN_MILLIS)
+                        && advanceEndpointConfig.get(APIConstants.TIMEOUT_IN_MILLIS) != JSONObject.NULL) {
+                    advanceEndpointsObject.put(APIConstants.TIMEOUT_IN_MILLIS,
+                            advanceEndpointConfig.getInt(APIConstants.TIMEOUT_IN_MILLIS));
+                    endpointResult.set(APIConstants.ADVANCE_ENDPOINT_CONFIG, advanceEndpointsObject);
+                }
+            }
             return endpointResult;
         }
         return null;


### PR DESCRIPTION
## Purpose

This PR adds the change to preserve advanceEndpointConfig when setting endpoint config for the API.

This property is used for MGW for ballerina endpoint configurations.

Please find a sample endpoint config with advanceEndpointConfig.
```
{
   "endpoint_type":"http",
   "production_endpoints":{
      "url":"https://localhost:9443/am/sample/pizzashack/v1/api/",
      "advanceEndpointConfig":{
         "timeoutInMillis":240000
      }
   },
   "sandbox_endpoints":{
      "url":"https://localhost:9443/am/sample/pizzashack/v1/api/"
   }
}
```
Related issue: https://github.com/wso2/product-microgateway/issues/3387