### PR TITLE
Add missing references to api product swagger definition

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -563,6 +563,10 @@ public class OASParserUtil {
 
         PathItem pathItem = paths.get(uriTemplate.getUriTemplate());
         pathItem.operation(httpMethod, srcOperation);
+        if (pathItem.getParameters() == null && srcPathItem.getParameters() != null) {
+            pathItem.setParameters(srcPathItem.getParameters());
+            setRefOfParameters(srcPathItem.getParameters(), context);
+        }
 
         readReferenceObjects(srcOperation, context);
 
@@ -632,8 +636,11 @@ public class OASParserUtil {
                 if (headers != null) {
                     for (Header header : headers.values()) {
                         Content content = header.getContent();
-
                         extractReferenceFromContent(content, context);
+                        String ref = header.get$ref();
+                        if (ref != null) {
+                            addToReferenceObjectMap(ref, context);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Purpose

- Fixes https://github.com/wso2/api-manager/issues/2166

### Description

When creating an API Product using an API resource which has following,
 - parameters given as references in path level,
 - response headers given as references,
 
those references were not added to the API product swagger definition. This fixes the above issue by adding those references to the swagger definition.
