### PR TITLE
Add SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED only if ARN is present

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -930,12 +930,14 @@ public class OAS2Parser extends APIDefinition {
         // AWS Lambda: set arn & timeout to swagger
         if (resource.getAmznResourceName() != null) {
             operation.setVendorExtension(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME, resource.getAmznResourceName());
+            if (resource.isAmznResourceContentEncoded()) {
+                operation.setVendorExtension(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED,
+                        resource.isAmznResourceContentEncoded());
+            }
         }
         if (resource.getAmznResourceTimeout() != 0) {
             operation.setVendorExtension(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT, resource.getAmznResourceTimeout());
         }
-        operation.setVendorExtension(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED,
-                resource.isAmznResourceContentEncoded());
 
         updateLegacyScopesFromOperation(resource, operation);
         String oauth2SchemeKey = APIConstants.SWAGGER_APIM_DEFAULT_SECURITY;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1234,6 +1234,10 @@ public class OAS3Parser extends APIDefinition {
         // AWS Lambda: set arn & timeout to swagger
         if (resource.getAmznResourceName() != null) {
             operation.addExtension(APIConstants.SWAGGER_X_AMZN_RESOURCE_NAME, resource.getAmznResourceName());
+            if (resource.isAmznResourceContentEncoded()) {
+                operation.addExtension(APIConstants.SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED,
+                        resource.isAmznResourceContentEncoded());
+            }
         }
         if (resource.getAmznResourceTimeout() != 0) {
             operation.addExtension(APIConstants.SWAGGER_X_AMZN_RESOURCE_TIMEOUT, resource.getAmznResourceTimeout());


### PR DESCRIPTION
This avoids setting SWAGGER_X_AMZN_RESOURCE_CONTNET_ENCODED vendor extension to normal APIs. The extension is set only if an ARN is present (which is possible only if it is an AWS Lambda Endpoint type API)