### PR TITLE
[Feature] Api tile enhancement

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -3925,6 +3925,11 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                         api.setContextTemplate(publiserAPI.getContext());
                         api.setStatus(publiserAPI.getStatus());
                         api.setBusinessOwner(publiserAPI.getBusinessOwner());
+                        api.setBusinessOwnerEmail(publiserAPI.getBusinessOwnerEmail());
+                        api.setTechnicalOwner(publiserAPI.getTechnicalOwner());
+                        api.setTechnicalOwnerEmail(publiserAPI.getTechnicalOwnerEmail());
+                        api.setMonetizationEnabled(publiserAPI.getMonetizationStatus());
+                        api.setAdvertiseOnly(publiserAPI.getAdvertiseOnly());
                         api.setRating(0);// need to retrieve from db
                         apiSet.add(api);
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5186,6 +5186,12 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                         api.setContextTemplate(publiserAPI.getContext());
                         api.setStatus(publiserAPI.getStatus());
                         api.setThumbnailUrl(publiserAPI.getThumbnailUri());
+                        api.setBusinessOwner(publiserAPI.getBusinessOwner());
+                        api.setBusinessOwnerEmail(publiserAPI.getBusinessOwnerEmail());
+                        api.setTechnicalOwner(publiserAPI.getTechnicalOwner());
+                        api.setTechnicalOwnerEmail(publiserAPI.getTechnicalOwnerEmail());
+                        api.setMonetizationEnabled(publiserAPI.getMonetizationStatus());
+                        api.setAdvertiseOnly(publiserAPI.getAdvertiseOnly());
                         apiSet.add(api);
                     } else if ("APIProduct".equals(item.getType())) {
 
@@ -5196,6 +5202,11 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                         api.setContextTemplate(publiserAPI.getContext());
                         api.setState(publiserAPI.getStatus());
                         api.setThumbnailUrl(publiserAPI.getThumbnailUri());
+                        api.setBusinessOwner(publiserAPI.getBusinessOwner());
+                        api.setBusinessOwnerEmail(publiserAPI.getBusinessOwnerEmail());
+                        api.setTechnicalOwner(publiserAPI.getTechnicalOwner());
+                        api.setTechnicalOwnerEmail(publiserAPI.getTechnicalOwnerEmail());
+                        api.setMonetizationEnabled(publiserAPI.getMonetizationStatus());
                         apiProductSet.add(api);
                     } else if (item instanceof DocumentSearchContent) {
                         // doc item
@@ -5344,6 +5355,11 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     mappedAPI.setContext(publisherAPIInfo.getContext());
                     mappedAPI.setApiSecurity(publisherAPIInfo.getApiSecurity());
                     mappedAPI.setThumbnailUrl(publisherAPIInfo.getThumbnail());
+                    mappedAPI.setBusinessOwner(publisherAPIInfo.getBusinessOwner());
+                    mappedAPI.setBusinessOwnerEmail(publisherAPIInfo.getBusinessOwnerEmail());
+                    mappedAPI.setTechnicalOwner(publisherAPIInfo.getTechnicalOwner());
+                    mappedAPI.setTechnicalOwnerEmail(publisherAPIInfo.getTechnicalOwnerEmail());
+                    mappedAPI.setMonetizationEnabled(publisherAPIInfo.getMonetizationStatus());
                     populateAPIStatus(mappedAPI);
                     productList.add(mappedAPI);
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -1099,6 +1099,9 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 apiInfo.setStatus(artifact.getAttribute(APIConstants.API_OVERVIEW_STATUS));
                 apiInfo.setThumbnail(artifact.getAttribute(APIConstants.API_OVERVIEW_THUMBNAIL_URL));
                 apiInfo.setBusinessOwner(artifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER));
+                apiInfo.setBusinessOwnerEmail(artifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER_EMAIL));
+                apiInfo.setTechnicalOwner(artifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER));
+                apiInfo.setTechnicalOwnerEmail(artifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER_EMAIL));
                 apiInfo.setVersion(artifact.getAttribute(APIConstants.API_OVERVIEW_VERSION));
                 String tiers = artifact.getAttribute(APIConstants.API_OVERVIEW_TIER);
                 Set<String> availableTiers = new HashSet<String>();

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -979,6 +979,11 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 apiInfo.setGatewayVendor(String.valueOf(artifact.getAttribute(APIConstants.API_OVERVIEW_GATEWAY_VENDOR)));
                 apiInfo.setAdvertiseOnly(Boolean.parseBoolean(artifact
                         .getAttribute(APIConstants.API_OVERVIEW_ADVERTISE_ONLY)));
+                apiInfo.setBusinessOwner(artifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER));
+                apiInfo.setBusinessOwnerEmail(artifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER_EMAIL));
+                apiInfo.setTechnicalOwner(artifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER));
+                apiInfo.setTechnicalOwnerEmail(artifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER_EMAIL));
+                apiInfo.setMonetizationStatus(Boolean.parseBoolean(artifact.getAttribute(APIConstants.Monetization.API_MONETIZATION_STATUS)));
                 publisherAPIInfoList.add(apiInfo);
 
                 // Ensure the APIs returned matches the length, there could be an additional API

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -983,7 +983,8 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 apiInfo.setBusinessOwnerEmail(artifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER_EMAIL));
                 apiInfo.setTechnicalOwner(artifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER));
                 apiInfo.setTechnicalOwnerEmail(artifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER_EMAIL));
-                apiInfo.setMonetizationStatus(Boolean.parseBoolean(artifact.getAttribute(APIConstants.Monetization.API_MONETIZATION_STATUS)));
+                apiInfo.setMonetizationStatus(Boolean.parseBoolean(artifact.
+                        getAttribute(APIConstants.Monetization.API_MONETIZATION_STATUS)));
                 publisherAPIInfoList.add(apiInfo);
 
                 // Ensure the APIs returned matches the length, there could be an additional API

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -1117,6 +1117,10 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 apiInfo.setSubscriptionAvailableOrgs(
                         artifact.getAttribute(APIConstants.API_OVERVIEW_SUBSCRIPTION_AVAILABLE_TENANTS));
                 apiInfo.setGatewayVendor(artifact.getAttribute(APIConstants.API_OVERVIEW_GATEWAY_VENDOR));
+                apiInfo.setMonetizationStatus(Boolean.parseBoolean(artifact.
+                        getAttribute(APIConstants.Monetization.API_MONETIZATION_STATUS)));
+                apiInfo.setAdvertiseOnly(Boolean.parseBoolean(artifact
+                        .getAttribute(APIConstants.API_OVERVIEW_ADVERTISE_ONLY)));
                 devPortalAPIInfoList.add(apiInfo);
 
                 // Ensure the APIs returned matches the length, there could be an additional API
@@ -1231,6 +1235,15 @@ public class RegistryPersistenceImpl implements APIPersistence {
                                 apiInfo.setSubscriptionAvailableOrgs(artifact
                                         .getAttribute(APIConstants.API_OVERVIEW_SUBSCRIPTION_AVAILABLE_TENANTS));
                                 apiInfo.setGatewayVendor(artifact.getAttribute(APIConstants.API_OVERVIEW_GATEWAY_VENDOR));
+                                apiInfo.setAdvertiseOnly(Boolean.parseBoolean(artifact
+                                        .getAttribute(APIConstants.API_OVERVIEW_ADVERTISE_ONLY)));
+                                apiInfo.setBusinessOwnerEmail(artifact.
+                                        getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER_EMAIL));
+                                apiInfo.setTechnicalOwner(artifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER));
+                                apiInfo.setTechnicalOwnerEmail(artifact.
+                                        getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER_EMAIL));
+                                apiInfo.setMonetizationStatus(Boolean.parseBoolean(artifact.
+                                        getAttribute(APIConstants.Monetization.API_MONETIZATION_STATUS)));
                                 devPortalAPIInfoList.add(apiInfo);
                             }
 
@@ -1346,6 +1359,14 @@ public class RegistryPersistenceImpl implements APIPersistence {
                                 apiInfo.setVersion(artifact.getAttribute(APIConstants.API_OVERVIEW_VERSION));
                                 apiInfo.setAdvertiseOnly(Boolean.parseBoolean(artifact
                                         .getAttribute(APIConstants.API_OVERVIEW_ADVERTISE_ONLY)));
+                                apiInfo.setBusinessOwner(artifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER));
+                                apiInfo.setBusinessOwnerEmail(artifact.
+                                        getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER_EMAIL));
+                                apiInfo.setTechnicalOwner(artifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER));
+                                apiInfo.setTechnicalOwnerEmail(artifact.
+                                        getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER_EMAIL));
+                                apiInfo.setMonetizationStatus(Boolean.parseBoolean(artifact.
+                                        getAttribute(APIConstants.Monetization.API_MONETIZATION_STATUS)));
                                 publisherAPIInfoList.add(apiInfo);
                             }
 
@@ -1516,6 +1537,11 @@ public class RegistryPersistenceImpl implements APIPersistence {
                                 content.setStatus(pubAPI.getStatus());
                                 content.setAdvertiseOnly(pubAPI.isAdvertiseOnly());
                                 content.setThumbnailUri(pubAPI.getThumbnail());
+                                content.setBusinessOwner(pubAPI.getBusinessOwner());
+                                content.setBusinessOwnerEmail(pubAPI.getBusinessOwnerEmail());
+                                content.setTechnicalOwner(pubAPI.getTechnicalOwner());
+                                content.setTechnicalOwnerEmail(pubAPI.getTechnicalOwnerEmail());
+                                content.setMonetizationStatus(pubAPI.getMonetizationStatus());
                                 contentData.add(content);
                             } else {
                                 throw new GovernanceException("artifact id is null for " + resourcePath);
@@ -1654,6 +1680,11 @@ public class RegistryPersistenceImpl implements APIPersistence {
                                 content.setStatus(devAPI.getStatus());
                                 content.setBusinessOwner(devAPI.getBusinessOwner());
                                 content.setBusinessOwnerEmail(devAPI.getBusinessOwnerEmail());
+                                content.setBusinessOwnerEmail(devAPI.getBusinessOwnerEmail());
+                                content.setTechnicalOwner(devAPI.getTechnicalOwner());
+                                content.setTechnicalOwnerEmail(devAPI.getTechnicalOwnerEmail());
+                                content.setMonetizationStatus(devAPI.getMonetizationStatus());
+                                content.setAdvertiseOnly(devAPI.isAdvertiseOnly());
 
                                 contentData.add(content);
                             } else {
@@ -3311,6 +3342,12 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 info.setVersion(artifact.getAttribute(APIConstants.API_OVERVIEW_VERSION));
                 info.setApiSecurity(artifact.getAttribute(APIConstants.API_OVERVIEW_API_SECURITY));
                 info.setThumbnail(artifact.getAttribute(APIConstants.API_OVERVIEW_THUMBNAIL_URL));
+                info.setBusinessOwner(artifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER));
+                info.setBusinessOwnerEmail(artifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER_EMAIL));
+                info.setTechnicalOwner(artifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER));
+                info.setTechnicalOwnerEmail(artifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER_EMAIL));
+                info.setMonetizationStatus(Boolean.parseBoolean(artifact.
+                        getAttribute(APIConstants.Monetization.API_MONETIZATION_STATUS)));
 
                 publisherAPIProductInfoList.add(info);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/DevPortalAPIInfo.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/DevPortalAPIInfo.java
@@ -40,6 +40,12 @@ public class DevPortalAPIInfo {
     private String description;
     private String gatewayVendor;
     private Map<String, String> additionalProperties;
+    private String businessOwnerEmail;
+    private String technicalOwner;
+    private String technicalOwnerEmail;
+    private Boolean isMonetizationEnabled;
+
+    private boolean advertiseOnly;
 
     public void setGatewayVendor(String gatewayVendor) {
         this.gatewayVendor = gatewayVendor;
@@ -145,13 +151,56 @@ public class DevPortalAPIInfo {
         this.additionalProperties = additionalProperties;
     }
 
+    public String getBusinessOwnerEmail() {
+        return businessOwnerEmail;
+    }
+
+    public void setBusinessOwnerEmail(String businessOwnerEmail) {
+        this.businessOwnerEmail = businessOwnerEmail;
+    }
+
+    public String getTechnicalOwner() {
+        return technicalOwner;
+    }
+
+    public void setTechnicalOwner(String technicalOwner) {
+        this.technicalOwner = technicalOwner;
+    }
+
+    public String getTechnicalOwnerEmail() {
+        return technicalOwnerEmail;
+    }
+
+    public void setTechnicalOwnerEmail(String technicalOwnerEmail) {
+        this.technicalOwnerEmail = technicalOwnerEmail;
+    }
+
+    public Boolean getMonetizationStatus() {
+        return isMonetizationEnabled;
+    }
+
+    public void setMonetizationStatus(Boolean isMonetizationEnabled) {
+        this.isMonetizationEnabled = isMonetizationEnabled;
+    }
+
+    public boolean isAdvertiseOnly() {
+        return advertiseOnly;
+    }
+
+    public void setAdvertiseOnly(boolean advertiseOnly) {
+        this.advertiseOnly = advertiseOnly;
+    }
+
     @Override
     public String toString() {
         return "DevPortalAPIInfo [id=" + id + ", apiName=" + apiName + ", description=" + description + ", version="
                 + version + ", providerName=" + providerName + ", context=" + context + ", type=" + type + ", " +
-                "thumbnail=" + thumbnail + ", businessOwner=" + businessOwner + ", status=" + status + ", " +
-                "availableTierNames=" + availableTierNames + ", subscriptionAvailability=" + subscriptionAvailability
-                + ", subscriptionAvailableOrgs=" + subscriptionAvailableOrgs + "]";
+                "thumbnail=" + thumbnail + ", businessOwner=" + businessOwner + ", businessOwnerEmail="
+                + businessOwnerEmail + ", technicalOwner=" + technicalOwner + ", technicalOwnerEmail="
+                + technicalOwnerEmail + ", status=" + status + ", " + "availableTierNames=" + availableTierNames +
+                ", subscriptionAvailability=" + subscriptionAvailability + ", subscriptionAvailableOrgs="
+                + subscriptionAvailableOrgs + ", isMonetizationEnabled=" + isMonetizationEnabled + ", advertiseOnly="
+                + advertiseOnly +"]";
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/DevPortalAPIInfo.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/DevPortalAPIInfo.java
@@ -44,7 +44,6 @@ public class DevPortalAPIInfo {
     private String technicalOwner;
     private String technicalOwnerEmail;
     private Boolean isMonetizationEnabled;
-
     private boolean advertiseOnly;
 
     public void setGatewayVendor(String gatewayVendor) {

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/DevPortalSearchContent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/DevPortalSearchContent.java
@@ -32,6 +32,8 @@ public class DevPortalSearchContent implements SearchContent {
     String technicalOwner;
     String technicalOwnerEmail;
     String avgRating;
+    Boolean isMonetizationEnabled;
+    Boolean advertiseOnly;
 
     @Override
     public String getId() {
@@ -153,6 +155,22 @@ public class DevPortalSearchContent implements SearchContent {
 
     public void setAvgRating(String avgRating) {
         this.avgRating = avgRating;
+    }
+
+    public Boolean getAdvertiseOnly() {
+        return advertiseOnly;
+    }
+
+    public void setAdvertiseOnly(Boolean advertiseOnly) {
+        this.advertiseOnly = advertiseOnly;
+    }
+
+    public Boolean getMonetizationStatus() {
+        return isMonetizationEnabled;
+    }
+
+    public void setMonetizationStatus(Boolean isMonetizationEnabled) {
+        this.isMonetizationEnabled = isMonetizationEnabled;
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/PublisherAPIInfo.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/PublisherAPIInfo.java
@@ -43,6 +43,11 @@ public class PublisherAPIInfo {
     private String gatewayVendor;
     private boolean advertiseOnly;
     private String updatedBy;
+    private String businessOwner;
+    private String businessOwnerEmail;
+    private String technicalOwner;
+    private String technicalOwnerEmail;
+    private Boolean isMonetizationEnabled;
 
     public String getAudience() {
         return audience;
@@ -156,11 +161,53 @@ public class PublisherAPIInfo {
         this.advertiseOnly = advertiseOnly;
     }
 
+    public String getBusinessOwner() {
+        return businessOwner;
+    }
+
+    public void setBusinessOwner(String businessOwner) {
+        this.businessOwner = businessOwner;
+    }
+
+    public String getBusinessOwnerEmail() {
+        return businessOwnerEmail;
+    }
+
+    public void setBusinessOwnerEmail(String businessOwnerEmail) {
+        this.businessOwnerEmail = businessOwnerEmail;
+    }
+
+    public String getTechnicalOwner() {
+        return technicalOwner;
+    }
+
+    public void setTechnicalOwner(String technicalOwner) {
+        this.technicalOwner = technicalOwner;
+    }
+
+    public String getTechnicalOwnerEmail() {
+        return technicalOwnerEmail;
+    }
+
+    public void setTechnicalOwnerEmail(String technicalOwnerEmail) {
+        this.technicalOwnerEmail = technicalOwnerEmail;
+    }
+
+    public Boolean getMonetizationStatus() {
+        return isMonetizationEnabled;
+    }
+
+    public void setMonetizationStatus(Boolean isMonetizationEnabled) {
+        this.isMonetizationEnabled = isMonetizationEnabled;
+    }
+
     @Override
     public String toString() {
         return "PublisherAPIInfo [id=" + id + ", apiName=" + apiName + ", description=" + description + ", version=" +
                 version + ", providerName=" + providerName + ", context=" + context + ", status=" + status + ", type="
-                + type + ", thumbnail=" + thumbnail + ", advertiseOnly=" + advertiseOnly + "]";
+                + type + ", thumbnail=" + thumbnail + ", advertiseOnly=" + advertiseOnly + ", businessOwner=" +
+                businessOwner + ", businessOwnerEmail=" + businessOwnerEmail + ", technicalOwner=" + technicalOwner +
+                ", technicalOwnerEmail=" + technicalOwnerEmail + ", isMonetizationEnabled=" + isMonetizationEnabled +"]";
     }
 
     public Map<String, String> getAdditionalProperties() {

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/PublisherAPIProductInfo.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/PublisherAPIProductInfo.java
@@ -33,6 +33,11 @@ public class PublisherAPIProductInfo {
     private String type;
     private String apiSecurity;
     private String thumbnail;
+    private String businessOwner;
+    private String businessOwnerEmail;
+    private String technicalOwner;
+    private String technicalOwnerEmail;
+    private Boolean isMonetizationEnabled;
     public String getThumbnail() {
         return thumbnail;
     }
@@ -88,5 +93,34 @@ public class PublisherAPIProductInfo {
         this.apiSecurity = apiSecurity;
     }
     private String gatewayVendor;
-    
+    public String getBusinessOwner() {
+        return businessOwner;
+    }
+    public void setBusinessOwner(String businessOwner) {
+        this.businessOwner = businessOwner;
+    }
+    public String getBusinessOwnerEmail() {
+        return businessOwnerEmail;
+    }
+    public void setBusinessOwnerEmail(String businessOwnerEmail) {
+        this.businessOwnerEmail = businessOwnerEmail;
+    }
+    public String getTechnicalOwner() {
+        return technicalOwner;
+    }
+    public void setTechnicalOwner(String technicalOwner) {
+        this.technicalOwner = technicalOwner;
+    }
+    public String getTechnicalOwnerEmail() {
+        return technicalOwnerEmail;
+    }
+    public void setTechnicalOwnerEmail(String technicalOwnerEmail) {
+        this.technicalOwnerEmail = technicalOwnerEmail;
+    }
+    public Boolean getMonetizationStatus() {
+        return isMonetizationEnabled;
+    }
+    public void setMonetizationStatus(Boolean isMonetizationEnabled) {
+        this.isMonetizationEnabled = isMonetizationEnabled;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/PublisherSearchContent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/PublisherSearchContent.java
@@ -28,6 +28,11 @@ public class PublisherSearchContent implements SearchContent {
     String status;
     String thumbnailUri;
     Boolean advertiseOnly;
+    String businessOwner;
+    String businessOwnerEmail;
+    String technicalOwner;
+    String technicalOwnerEmail;
+    Boolean isMonetizationEnabled;
 
     @Override
     public String getId() {
@@ -117,5 +122,45 @@ public class PublisherSearchContent implements SearchContent {
 
     public void setAdvertiseOnly(Boolean advertiseOnly) {
         this.advertiseOnly = advertiseOnly;
+    }
+
+    public String getBusinessOwner() {
+        return businessOwner;
+    }
+
+    public void setBusinessOwner(String businessOwner) {
+        this.businessOwner = businessOwner;
+    }
+
+    public String getBusinessOwnerEmail() {
+        return businessOwnerEmail;
+    }
+
+    public void setBusinessOwnerEmail(String businessOwnerEmail) {
+        this.businessOwnerEmail = businessOwnerEmail;
+    }
+
+    public String getTechnicalOwner() {
+        return technicalOwner;
+    }
+
+    public void setTechnicalOwner(String technicalOwner) {
+        this.technicalOwner = technicalOwner;
+    }
+
+    public String getTechnicalOwnerEmail() {
+        return technicalOwnerEmail;
+    }
+
+    public void setTechnicalOwnerEmail(String technicalOwnerEmail) {
+        this.technicalOwnerEmail = technicalOwnerEmail;
+    }
+
+    public Boolean getMonetizationStatus() {
+        return isMonetizationEnabled;
+    }
+
+    public void setMonetizationStatus(Boolean isMonetizationEnabled) {
+        this.isMonetizationEnabled = isMonetizationEnabled;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
@@ -1389,6 +1389,12 @@ public class RegistryPersistenceUtil {
             api.setAdvertiseOnly(Boolean.parseBoolean(apiArtifact
                     .getAttribute(APIConstants.API_OVERVIEW_ADVERTISE_ONLY)));
             api.setThumbnail(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_THUMBNAIL_URL));
+            api.setBusinessOwner(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER));
+            api.setBusinessOwnerEmail(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER_EMAIL));
+            api.setTechnicalOwner(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER));
+            api.setTechnicalOwnerEmail(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER_EMAIL));
+            api.setMonetizationStatus(Boolean.parseBoolean(apiArtifact.
+                    getAttribute(APIConstants.Monetization.API_MONETIZATION_STATUS)));
 
         } catch (GovernanceException e) {
             throw new APIPersistenceException("Error while extracting api attributes ", e);
@@ -1408,6 +1414,13 @@ public class RegistryPersistenceUtil {
             api.setProviderName(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_PROVIDER));
             api.setVersion(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_VERSION));
             api.setBusinessOwner(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER));
+            api.setBusinessOwnerEmail(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_BUSS_OWNER_EMAIL));
+            api.setTechnicalOwner(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER));
+            api.setTechnicalOwnerEmail(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_TEC_OWNER_EMAIL));
+            api.setMonetizationStatus(Boolean.parseBoolean(apiArtifact.
+                    getAttribute(APIConstants.Monetization.API_MONETIZATION_STATUS)));
+            api.setAdvertiseOnly(Boolean.parseBoolean(apiArtifact
+                    .getAttribute(APIConstants.API_OVERVIEW_ADVERTISE_ONLY)));
 
         } catch (GovernanceException e) {
             throw new APIPersistenceException("Error while extracting api attributes ", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIInfoDTO.java
@@ -76,6 +76,11 @@ return null;
     private String updatedBy = null;
     private String gatewayVendor = null;
     private Boolean advertiseOnly = null;
+    private Boolean monetizedInfo = null;
+    private String businessOwner = null;
+    private String businessOwnerEmail = null;
+    private String technicalOwner = null;
+    private String technicalOwnerEmail = null;
 
   /**
    **/
@@ -405,6 +410,91 @@ return null;
     this.advertiseOnly = advertiseOnly;
   }
 
+  /**
+   **/
+  public APIInfoDTO monetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("monetizedInfo")
+  public Boolean isMonetizedInfo() {
+    return monetizedInfo;
+  }
+  public void setMonetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+  }
+
+  /**
+   **/
+  public APIInfoDTO businessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Business Owner", value = "")
+  @JsonProperty("businessOwner")
+  public String getBusinessOwner() {
+    return businessOwner;
+  }
+  public void setBusinessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
+  }
+
+  /**
+   **/
+  public APIInfoDTO businessOwnerEmail(String businessOwnerEmail) {
+    this.businessOwnerEmail = businessOwnerEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "businessowner@abc.com", value = "")
+  @JsonProperty("businessOwnerEmail")
+  public String getBusinessOwnerEmail() {
+    return businessOwnerEmail;
+  }
+  public void setBusinessOwnerEmail(String businessOwnerEmail) {
+    this.businessOwnerEmail = businessOwnerEmail;
+  }
+
+  /**
+   **/
+  public APIInfoDTO technicalOwner(String technicalOwner) {
+    this.technicalOwner = technicalOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Technical Owner", value = "")
+  @JsonProperty("TechnicalOwner")
+  public String getTechnicalOwner() {
+    return technicalOwner;
+  }
+  public void setTechnicalOwner(String technicalOwner) {
+    this.technicalOwner = technicalOwner;
+  }
+
+  /**
+   **/
+  public APIInfoDTO technicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "technicalowner@abc.com", value = "")
+  @JsonProperty("TechnicalOwnerEmail")
+  public String getTechnicalOwnerEmail() {
+    return technicalOwnerEmail;
+  }
+  public void setTechnicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -433,12 +523,17 @@ return null;
         Objects.equals(updatedTime, apIInfo.updatedTime) &&
         Objects.equals(updatedBy, apIInfo.updatedBy) &&
         Objects.equals(gatewayVendor, apIInfo.gatewayVendor) &&
-        Objects.equals(advertiseOnly, apIInfo.advertiseOnly);
+        Objects.equals(advertiseOnly, apIInfo.advertiseOnly) &&
+        Objects.equals(monetizedInfo, apIInfo.monetizedInfo) &&
+        Objects.equals(businessOwner, apIInfo.businessOwner) &&
+        Objects.equals(businessOwnerEmail, apIInfo.businessOwnerEmail) &&
+        Objects.equals(technicalOwner, apIInfo.technicalOwner) &&
+        Objects.equals(technicalOwnerEmail, apIInfo.technicalOwnerEmail);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, context, additionalProperties, additionalPropertiesMap, version, provider, type, audience, lifeCycleStatus, workflowStatus, hasThumbnail, securityScheme, createdTime, updatedTime, updatedBy, gatewayVendor, advertiseOnly);
+    return Objects.hash(id, name, description, context, additionalProperties, additionalPropertiesMap, version, provider, type, audience, lifeCycleStatus, workflowStatus, hasThumbnail, securityScheme, createdTime, updatedTime, updatedBy, gatewayVendor, advertiseOnly, monetizedInfo, businessOwner, businessOwnerEmail, technicalOwner, technicalOwnerEmail);
   }
 
   @Override
@@ -465,6 +560,11 @@ return null;
     sb.append("    updatedBy: ").append(toIndentedString(updatedBy)).append("\n");
     sb.append("    gatewayVendor: ").append(toIndentedString(gatewayVendor)).append("\n");
     sb.append("    advertiseOnly: ").append(toIndentedString(advertiseOnly)).append("\n");
+    sb.append("    monetizedInfo: ").append(toIndentedString(monetizedInfo)).append("\n");
+    sb.append("    businessOwner: ").append(toIndentedString(businessOwner)).append("\n");
+    sb.append("    businessOwnerEmail: ").append(toIndentedString(businessOwnerEmail)).append("\n");
+    sb.append("    technicalOwner: ").append(toIndentedString(technicalOwner)).append("\n");
+    sb.append("    technicalOwnerEmail: ").append(toIndentedString(technicalOwnerEmail)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductInfoDTO.java
@@ -31,6 +31,11 @@ public class APIProductInfoDTO   {
     private String state = null;
     private List<String> securityScheme = new ArrayList<String>();
     private String gatewayVendor = null;
+    private Boolean monetizedInfo = null;
+    private String businessOwner = null;
+    private String businessOwnerEmail = null;
+    private String technicalOwner = null;
+    private String technicalOwnerEmail = null;
 
   /**
    * UUID of the api product 
@@ -191,6 +196,91 @@ public class APIProductInfoDTO   {
     this.gatewayVendor = gatewayVendor;
   }
 
+  /**
+   **/
+  public APIProductInfoDTO monetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("monetizedInfo")
+  public Boolean isMonetizedInfo() {
+    return monetizedInfo;
+  }
+  public void setMonetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+  }
+
+  /**
+   **/
+  public APIProductInfoDTO businessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Business Owner", value = "")
+  @JsonProperty("businessOwner")
+  public String getBusinessOwner() {
+    return businessOwner;
+  }
+  public void setBusinessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
+  }
+
+  /**
+   **/
+  public APIProductInfoDTO businessOwnerEmail(String businessOwnerEmail) {
+    this.businessOwnerEmail = businessOwnerEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "businessowner@abc.com", value = "")
+  @JsonProperty("businessOwnerEmail")
+  public String getBusinessOwnerEmail() {
+    return businessOwnerEmail;
+  }
+  public void setBusinessOwnerEmail(String businessOwnerEmail) {
+    this.businessOwnerEmail = businessOwnerEmail;
+  }
+
+  /**
+   **/
+  public APIProductInfoDTO technicalOwner(String technicalOwner) {
+    this.technicalOwner = technicalOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Technical Owner", value = "")
+  @JsonProperty("TechnicalOwner")
+  public String getTechnicalOwner() {
+    return technicalOwner;
+  }
+  public void setTechnicalOwner(String technicalOwner) {
+    this.technicalOwner = technicalOwner;
+  }
+
+  /**
+   **/
+  public APIProductInfoDTO technicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "technicalowner@abc.com", value = "")
+  @JsonProperty("TechnicalOwnerEmail")
+  public String getTechnicalOwnerEmail() {
+    return technicalOwnerEmail;
+  }
+  public void setTechnicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -209,12 +299,17 @@ public class APIProductInfoDTO   {
         Objects.equals(hasThumbnail, apIProductInfo.hasThumbnail) &&
         Objects.equals(state, apIProductInfo.state) &&
         Objects.equals(securityScheme, apIProductInfo.securityScheme) &&
-        Objects.equals(gatewayVendor, apIProductInfo.gatewayVendor);
+        Objects.equals(gatewayVendor, apIProductInfo.gatewayVendor) &&
+        Objects.equals(monetizedInfo, apIProductInfo.monetizedInfo) &&
+        Objects.equals(businessOwner, apIProductInfo.businessOwner) &&
+        Objects.equals(businessOwnerEmail, apIProductInfo.businessOwnerEmail) &&
+        Objects.equals(technicalOwner, apIProductInfo.technicalOwner) &&
+        Objects.equals(technicalOwnerEmail, apIProductInfo.technicalOwnerEmail);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, context, description, provider, hasThumbnail, state, securityScheme, gatewayVendor);
+    return Objects.hash(id, name, context, description, provider, hasThumbnail, state, securityScheme, gatewayVendor, monetizedInfo, businessOwner, businessOwnerEmail, technicalOwner, technicalOwnerEmail);
   }
 
   @Override
@@ -231,6 +326,11 @@ public class APIProductInfoDTO   {
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    securityScheme: ").append(toIndentedString(securityScheme)).append("\n");
     sb.append("    gatewayVendor: ").append(toIndentedString(gatewayVendor)).append("\n");
+    sb.append("    monetizedInfo: ").append(toIndentedString(monetizedInfo)).append("\n");
+    sb.append("    businessOwner: ").append(toIndentedString(businessOwner)).append("\n");
+    sb.append("    businessOwnerEmail: ").append(toIndentedString(businessOwnerEmail)).append("\n");
+    sb.append("    technicalOwner: ").append(toIndentedString(technicalOwner)).append("\n");
+    sb.append("    technicalOwnerEmail: ").append(toIndentedString(technicalOwnerEmail)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductSearchResultAllOfDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductSearchResultAllOfDTO.java
@@ -27,6 +27,11 @@ public class APIProductSearchResultAllOfDTO   {
     private String status = null;
     private String thumbnailUri = null;
     private Boolean hasThumbnail = null;
+    private Boolean monetizedInfo = null;
+    private String businessOwner = null;
+    private String businessOwnerEmail = null;
+    private String technicalOwner = null;
+    private String technicalOwnerEmail = null;
 
   /**
    * A brief description about the API
@@ -152,6 +157,91 @@ public class APIProductSearchResultAllOfDTO   {
     this.hasThumbnail = hasThumbnail;
   }
 
+  /**
+   **/
+  public APIProductSearchResultAllOfDTO monetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("monetizedInfo")
+  public Boolean isMonetizedInfo() {
+    return monetizedInfo;
+  }
+  public void setMonetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+  }
+
+  /**
+   **/
+  public APIProductSearchResultAllOfDTO businessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Business Owner", value = "")
+  @JsonProperty("businessOwner")
+  public String getBusinessOwner() {
+    return businessOwner;
+  }
+  public void setBusinessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
+  }
+
+  /**
+   **/
+  public APIProductSearchResultAllOfDTO businessOwnerEmail(String businessOwnerEmail) {
+    this.businessOwnerEmail = businessOwnerEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "businessowner@abc.com", value = "")
+  @JsonProperty("businessOwnerEmail")
+  public String getBusinessOwnerEmail() {
+    return businessOwnerEmail;
+  }
+  public void setBusinessOwnerEmail(String businessOwnerEmail) {
+    this.businessOwnerEmail = businessOwnerEmail;
+  }
+
+  /**
+   **/
+  public APIProductSearchResultAllOfDTO technicalOwner(String technicalOwner) {
+    this.technicalOwner = technicalOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Technical Owner", value = "")
+  @JsonProperty("TechnicalOwner")
+  public String getTechnicalOwner() {
+    return technicalOwner;
+  }
+  public void setTechnicalOwner(String technicalOwner) {
+    this.technicalOwner = technicalOwner;
+  }
+
+  /**
+   **/
+  public APIProductSearchResultAllOfDTO technicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "technicalowner@abc.com", value = "")
+  @JsonProperty("TechnicalOwnerEmail")
+  public String getTechnicalOwnerEmail() {
+    return technicalOwnerEmail;
+  }
+  public void setTechnicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -168,12 +258,17 @@ public class APIProductSearchResultAllOfDTO   {
         Objects.equals(provider, apIProductSearchResultAllOf.provider) &&
         Objects.equals(status, apIProductSearchResultAllOf.status) &&
         Objects.equals(thumbnailUri, apIProductSearchResultAllOf.thumbnailUri) &&
-        Objects.equals(hasThumbnail, apIProductSearchResultAllOf.hasThumbnail);
+        Objects.equals(hasThumbnail, apIProductSearchResultAllOf.hasThumbnail) &&
+        Objects.equals(monetizedInfo, apIProductSearchResultAllOf.monetizedInfo) &&
+        Objects.equals(businessOwner, apIProductSearchResultAllOf.businessOwner) &&
+        Objects.equals(businessOwnerEmail, apIProductSearchResultAllOf.businessOwnerEmail) &&
+        Objects.equals(technicalOwner, apIProductSearchResultAllOf.technicalOwner) &&
+        Objects.equals(technicalOwnerEmail, apIProductSearchResultAllOf.technicalOwnerEmail);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, version, provider, status, thumbnailUri, hasThumbnail);
+    return Objects.hash(description, context, version, provider, status, thumbnailUri, hasThumbnail, monetizedInfo, businessOwner, businessOwnerEmail, technicalOwner, technicalOwnerEmail);
   }
 
   @Override
@@ -188,6 +283,11 @@ public class APIProductSearchResultAllOfDTO   {
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    thumbnailUri: ").append(toIndentedString(thumbnailUri)).append("\n");
     sb.append("    hasThumbnail: ").append(toIndentedString(hasThumbnail)).append("\n");
+    sb.append("    monetizedInfo: ").append(toIndentedString(monetizedInfo)).append("\n");
+    sb.append("    businessOwner: ").append(toIndentedString(businessOwner)).append("\n");
+    sb.append("    businessOwnerEmail: ").append(toIndentedString(businessOwnerEmail)).append("\n");
+    sb.append("    technicalOwner: ").append(toIndentedString(technicalOwner)).append("\n");
+    sb.append("    technicalOwnerEmail: ").append(toIndentedString(technicalOwnerEmail)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductSearchResultDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductSearchResultDTO.java
@@ -29,6 +29,11 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
     private String status = null;
     private String thumbnailUri = null;
     private Boolean hasThumbnail = null;
+    private Boolean monetizedInfo = null;
+    private String businessOwner = null;
+    private String businessOwnerEmail = null;
+    private String technicalOwner = null;
+    private String technicalOwnerEmail = null;
 
   /**
    * A brief description about the API
@@ -154,6 +159,91 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
     this.hasThumbnail = hasThumbnail;
   }
 
+  /**
+   **/
+  public APIProductSearchResultDTO monetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("monetizedInfo")
+  public Boolean isMonetizedInfo() {
+    return monetizedInfo;
+  }
+  public void setMonetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+  }
+
+  /**
+   **/
+  public APIProductSearchResultDTO businessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Business Owner", value = "")
+  @JsonProperty("businessOwner")
+  public String getBusinessOwner() {
+    return businessOwner;
+  }
+  public void setBusinessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
+  }
+
+  /**
+   **/
+  public APIProductSearchResultDTO businessOwnerEmail(String businessOwnerEmail) {
+    this.businessOwnerEmail = businessOwnerEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "businessowner@abc.com", value = "")
+  @JsonProperty("businessOwnerEmail")
+  public String getBusinessOwnerEmail() {
+    return businessOwnerEmail;
+  }
+  public void setBusinessOwnerEmail(String businessOwnerEmail) {
+    this.businessOwnerEmail = businessOwnerEmail;
+  }
+
+  /**
+   **/
+  public APIProductSearchResultDTO technicalOwner(String technicalOwner) {
+    this.technicalOwner = technicalOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Technical Owner", value = "")
+  @JsonProperty("TechnicalOwner")
+  public String getTechnicalOwner() {
+    return technicalOwner;
+  }
+  public void setTechnicalOwner(String technicalOwner) {
+    this.technicalOwner = technicalOwner;
+  }
+
+  /**
+   **/
+  public APIProductSearchResultDTO technicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "technicalowner@abc.com", value = "")
+  @JsonProperty("TechnicalOwnerEmail")
+  public String getTechnicalOwnerEmail() {
+    return technicalOwnerEmail;
+  }
+  public void setTechnicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -170,12 +260,17 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
         Objects.equals(provider, apIProductSearchResult.provider) &&
         Objects.equals(status, apIProductSearchResult.status) &&
         Objects.equals(thumbnailUri, apIProductSearchResult.thumbnailUri) &&
-        Objects.equals(hasThumbnail, apIProductSearchResult.hasThumbnail);
+        Objects.equals(hasThumbnail, apIProductSearchResult.hasThumbnail) &&
+        Objects.equals(monetizedInfo, apIProductSearchResult.monetizedInfo) &&
+        Objects.equals(businessOwner, apIProductSearchResult.businessOwner) &&
+        Objects.equals(businessOwnerEmail, apIProductSearchResult.businessOwnerEmail) &&
+        Objects.equals(technicalOwner, apIProductSearchResult.technicalOwner) &&
+        Objects.equals(technicalOwnerEmail, apIProductSearchResult.technicalOwnerEmail);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, version, provider, status, thumbnailUri, hasThumbnail);
+    return Objects.hash(description, context, version, provider, status, thumbnailUri, hasThumbnail, monetizedInfo, businessOwner, businessOwnerEmail, technicalOwner, technicalOwnerEmail);
   }
 
   @Override
@@ -190,6 +285,11 @@ public class APIProductSearchResultDTO extends SearchResultDTO  {
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    thumbnailUri: ").append(toIndentedString(thumbnailUri)).append("\n");
     sb.append("    hasThumbnail: ").append(toIndentedString(hasThumbnail)).append("\n");
+    sb.append("    monetizedInfo: ").append(toIndentedString(monetizedInfo)).append("\n");
+    sb.append("    businessOwner: ").append(toIndentedString(businessOwner)).append("\n");
+    sb.append("    businessOwnerEmail: ").append(toIndentedString(businessOwnerEmail)).append("\n");
+    sb.append("    technicalOwner: ").append(toIndentedString(technicalOwner)).append("\n");
+    sb.append("    technicalOwnerEmail: ").append(toIndentedString(technicalOwnerEmail)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APISearchResultAllOfDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APISearchResultAllOfDTO.java
@@ -29,6 +29,11 @@ public class APISearchResultAllOfDTO   {
     private String thumbnailUri = null;
     private Boolean advertiseOnly = null;
     private Boolean hasThumbnail = null;
+    private Boolean monetizedInfo = null;
+    private String businessOwner = null;
+    private String businessOwnerEmail = null;
+    private String technicalOwner = null;
+    private String technicalOwnerEmail = null;
 
   /**
    * A brief description about the API
@@ -189,6 +194,91 @@ public class APISearchResultAllOfDTO   {
     this.hasThumbnail = hasThumbnail;
   }
 
+  /**
+   **/
+  public APISearchResultAllOfDTO monetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("monetizedInfo")
+  public Boolean isMonetizedInfo() {
+    return monetizedInfo;
+  }
+  public void setMonetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+  }
+
+  /**
+   **/
+  public APISearchResultAllOfDTO businessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Business Owner", value = "")
+  @JsonProperty("businessOwner")
+  public String getBusinessOwner() {
+    return businessOwner;
+  }
+  public void setBusinessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
+  }
+
+  /**
+   **/
+  public APISearchResultAllOfDTO businessOwnerEmail(String businessOwnerEmail) {
+    this.businessOwnerEmail = businessOwnerEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "businessowner@abc.com", value = "")
+  @JsonProperty("businessOwnerEmail")
+  public String getBusinessOwnerEmail() {
+    return businessOwnerEmail;
+  }
+  public void setBusinessOwnerEmail(String businessOwnerEmail) {
+    this.businessOwnerEmail = businessOwnerEmail;
+  }
+
+  /**
+   **/
+  public APISearchResultAllOfDTO technicalOwner(String technicalOwner) {
+    this.technicalOwner = technicalOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Technical Owner", value = "")
+  @JsonProperty("TechnicalOwner")
+  public String getTechnicalOwner() {
+    return technicalOwner;
+  }
+  public void setTechnicalOwner(String technicalOwner) {
+    this.technicalOwner = technicalOwner;
+  }
+
+  /**
+   **/
+  public APISearchResultAllOfDTO technicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "technicalowner@abc.com", value = "")
+  @JsonProperty("TechnicalOwnerEmail")
+  public String getTechnicalOwnerEmail() {
+    return technicalOwnerEmail;
+  }
+  public void setTechnicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -207,12 +297,17 @@ public class APISearchResultAllOfDTO   {
         Objects.equals(status, apISearchResultAllOf.status) &&
         Objects.equals(thumbnailUri, apISearchResultAllOf.thumbnailUri) &&
         Objects.equals(advertiseOnly, apISearchResultAllOf.advertiseOnly) &&
-        Objects.equals(hasThumbnail, apISearchResultAllOf.hasThumbnail);
+        Objects.equals(hasThumbnail, apISearchResultAllOf.hasThumbnail) &&
+        Objects.equals(monetizedInfo, apISearchResultAllOf.monetizedInfo) &&
+        Objects.equals(businessOwner, apISearchResultAllOf.businessOwner) &&
+        Objects.equals(businessOwnerEmail, apISearchResultAllOf.businessOwnerEmail) &&
+        Objects.equals(technicalOwner, apISearchResultAllOf.technicalOwner) &&
+        Objects.equals(technicalOwnerEmail, apISearchResultAllOf.technicalOwnerEmail);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, contextTemplate, version, provider, status, thumbnailUri, advertiseOnly, hasThumbnail);
+    return Objects.hash(description, context, contextTemplate, version, provider, status, thumbnailUri, advertiseOnly, hasThumbnail, monetizedInfo, businessOwner, businessOwnerEmail, technicalOwner, technicalOwnerEmail);
   }
 
   @Override
@@ -229,6 +324,11 @@ public class APISearchResultAllOfDTO   {
     sb.append("    thumbnailUri: ").append(toIndentedString(thumbnailUri)).append("\n");
     sb.append("    advertiseOnly: ").append(toIndentedString(advertiseOnly)).append("\n");
     sb.append("    hasThumbnail: ").append(toIndentedString(hasThumbnail)).append("\n");
+    sb.append("    monetizedInfo: ").append(toIndentedString(monetizedInfo)).append("\n");
+    sb.append("    businessOwner: ").append(toIndentedString(businessOwner)).append("\n");
+    sb.append("    businessOwnerEmail: ").append(toIndentedString(businessOwnerEmail)).append("\n");
+    sb.append("    technicalOwner: ").append(toIndentedString(technicalOwner)).append("\n");
+    sb.append("    technicalOwnerEmail: ").append(toIndentedString(technicalOwnerEmail)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APISearchResultDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APISearchResultDTO.java
@@ -31,6 +31,11 @@ public class APISearchResultDTO extends SearchResultDTO  {
     private String thumbnailUri = null;
     private Boolean advertiseOnly = null;
     private Boolean hasThumbnail = null;
+    private Boolean monetizedInfo = null;
+    private String businessOwner = null;
+    private String businessOwnerEmail = null;
+    private String technicalOwner = null;
+    private String technicalOwnerEmail = null;
 
   /**
    * A brief description about the API
@@ -191,6 +196,91 @@ public class APISearchResultDTO extends SearchResultDTO  {
     this.hasThumbnail = hasThumbnail;
   }
 
+  /**
+   **/
+  public APISearchResultDTO monetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("monetizedInfo")
+  public Boolean isMonetizedInfo() {
+    return monetizedInfo;
+  }
+  public void setMonetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+  }
+
+  /**
+   **/
+  public APISearchResultDTO businessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Business Owner", value = "")
+  @JsonProperty("businessOwner")
+  public String getBusinessOwner() {
+    return businessOwner;
+  }
+  public void setBusinessOwner(String businessOwner) {
+    this.businessOwner = businessOwner;
+  }
+
+  /**
+   **/
+  public APISearchResultDTO businessOwnerEmail(String businessOwnerEmail) {
+    this.businessOwnerEmail = businessOwnerEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "businessowner@abc.com", value = "")
+  @JsonProperty("businessOwnerEmail")
+  public String getBusinessOwnerEmail() {
+    return businessOwnerEmail;
+  }
+  public void setBusinessOwnerEmail(String businessOwnerEmail) {
+    this.businessOwnerEmail = businessOwnerEmail;
+  }
+
+  /**
+   **/
+  public APISearchResultDTO technicalOwner(String technicalOwner) {
+    this.technicalOwner = technicalOwner;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "Technical Owner", value = "")
+  @JsonProperty("TechnicalOwner")
+  public String getTechnicalOwner() {
+    return technicalOwner;
+  }
+  public void setTechnicalOwner(String technicalOwner) {
+    this.technicalOwner = technicalOwner;
+  }
+
+  /**
+   **/
+  public APISearchResultDTO technicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "technicalowner@abc.com", value = "")
+  @JsonProperty("TechnicalOwnerEmail")
+  public String getTechnicalOwnerEmail() {
+    return technicalOwnerEmail;
+  }
+  public void setTechnicalOwnerEmail(String technicalOwnerEmail) {
+    this.technicalOwnerEmail = technicalOwnerEmail;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -209,12 +299,17 @@ public class APISearchResultDTO extends SearchResultDTO  {
         Objects.equals(status, apISearchResult.status) &&
         Objects.equals(thumbnailUri, apISearchResult.thumbnailUri) &&
         Objects.equals(advertiseOnly, apISearchResult.advertiseOnly) &&
-        Objects.equals(hasThumbnail, apISearchResult.hasThumbnail);
+        Objects.equals(hasThumbnail, apISearchResult.hasThumbnail) &&
+        Objects.equals(monetizedInfo, apISearchResult.monetizedInfo) &&
+        Objects.equals(businessOwner, apISearchResult.businessOwner) &&
+        Objects.equals(businessOwnerEmail, apISearchResult.businessOwnerEmail) &&
+        Objects.equals(technicalOwner, apISearchResult.technicalOwner) &&
+        Objects.equals(technicalOwnerEmail, apISearchResult.technicalOwnerEmail);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, contextTemplate, version, provider, status, thumbnailUri, advertiseOnly, hasThumbnail);
+    return Objects.hash(description, context, contextTemplate, version, provider, status, thumbnailUri, advertiseOnly, hasThumbnail, monetizedInfo, businessOwner, businessOwnerEmail, technicalOwner, technicalOwnerEmail);
   }
 
   @Override
@@ -231,6 +326,11 @@ public class APISearchResultDTO extends SearchResultDTO  {
     sb.append("    thumbnailUri: ").append(toIndentedString(thumbnailUri)).append("\n");
     sb.append("    advertiseOnly: ").append(toIndentedString(advertiseOnly)).append("\n");
     sb.append("    hasThumbnail: ").append(toIndentedString(hasThumbnail)).append("\n");
+    sb.append("    monetizedInfo: ").append(toIndentedString(monetizedInfo)).append("\n");
+    sb.append("    businessOwner: ").append(toIndentedString(businessOwner)).append("\n");
+    sb.append("    businessOwnerEmail: ").append(toIndentedString(businessOwnerEmail)).append("\n");
+    sb.append("    technicalOwner: ").append(toIndentedString(technicalOwner)).append("\n");
+    sb.append("    technicalOwnerEmail: ").append(toIndentedString(technicalOwnerEmail)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -2279,6 +2279,11 @@ public class APIMappingUtil {
             if (apiProduct.getApiSecurity() != null) {
                 productDto.setSecurityScheme(Arrays.asList(apiProduct.getApiSecurity().split(",")));
             }
+            productDto.setBusinessOwner(apiProduct.getBusinessOwner());
+            productDto.setBusinessOwnerEmail(apiProduct.getBusinessOwnerEmail());
+            productDto.setTechnicalOwner(apiProduct.getTechnicalOwner());
+            productDto.setTechnicalOwnerEmail(apiProduct.getTechnicalOwnerEmail());
+            productDto.setMonetizedInfo(apiProduct.isMonetizationEnabled());
 
             list.add(productDto);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -705,6 +705,11 @@ public class APIMappingUtil {
             apiInfoDTO.setAdditionalPropertiesMap(additionalPropertiesMap);
             apiInfoDTO.setGatewayVendor(api.getGatewayVendor());
         }
+        apiInfoDTO.setMonetizedInfo(api.isMonetizationEnabled());
+        apiInfoDTO.setBusinessOwner(api.getBusinessOwner());
+        apiInfoDTO.setBusinessOwnerEmail(api.getBusinessOwnerEmail());
+        apiInfoDTO.setTechnicalOwner(api.getTechnicalOwner());
+        apiInfoDTO.setTechnicalOwnerEmail(api.getTechnicalOwnerEmail());
         return apiInfoDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/SearchResultMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/SearchResultMappingUtil.java
@@ -75,6 +75,11 @@ public class SearchResultMappingUtil {
         apiResultDTO.setThumbnailUri(api.getThumbnailUrl());
         apiResultDTO.setAdvertiseOnly(api.isAdvertiseOnly());
         apiResultDTO.setHasThumbnail(!StringUtils.isBlank(api.getThumbnailUrl()));
+        apiResultDTO.setBusinessOwner(api.getBusinessOwner());
+        apiResultDTO.setBusinessOwnerEmail(api.getBusinessOwnerEmail());
+        apiResultDTO.setTechnicalOwner(api.getTechnicalOwner());
+        apiResultDTO.setTechnicalOwnerEmail(api.getTechnicalOwnerEmail());
+        apiResultDTO.setMonetizedInfo(api.isMonetizationEnabled());
         return apiResultDTO;
     }
 
@@ -102,6 +107,11 @@ public class SearchResultMappingUtil {
         apiProductResultDTO.setStatus(apiProduct.getState());
         apiProductResultDTO.setThumbnailUri(apiProduct.getThumbnailUrl());
         apiProductResultDTO.setHasThumbnail(!StringUtils.isBlank(apiProduct.getThumbnailUrl()));
+        apiProductResultDTO.setBusinessOwner(apiProduct.getBusinessOwner());
+        apiProductResultDTO.setBusinessOwnerEmail(apiProduct.getBusinessOwnerEmail());
+        apiProductResultDTO.setTechnicalOwner(apiProduct.getTechnicalOwner());
+        apiProductResultDTO.setTechnicalOwnerEmail(apiProduct.getTechnicalOwnerEmail());
+        apiProductResultDTO.setMonetizedInfo(apiProduct.isMonetizationEnabled());
         return apiProductResultDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -9257,6 +9257,21 @@ components:
         gatewayVendor:
           type: string
           example: wso2
+        monetizedInfo:
+          type: boolean
+          example: true
+        businessOwner:
+          type: string
+          example: Business Owner
+        businessOwnerEmail:
+          type: string
+          example: businessowner@abc.com
+        TechnicalOwner:
+          type: string
+          example: Technical Owner
+        TechnicalOwnerEmail:
+          type: string
+          example: technicalowner@abc.com
     APIProduct:
       title: API Product object
       required:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -8493,6 +8493,21 @@ components:
         advertiseOnly:
           type: boolean
           example: true
+        monetizedInfo:
+          type: boolean
+          example: true
+        businessOwner:
+          type: string
+          example: Business Owner
+        businessOwnerEmail:
+          type: string
+          example: businessowner@abc.com
+        TechnicalOwner:
+          type: string
+          example: Technical Owner
+        TechnicalOwnerEmail:
+          type: string
+          example: technicalowner@abc.com
     APIMetadata:
       title: API Info object with basic minimal API details.
       type: object

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -11251,6 +11251,21 @@ components:
             hasThumbnail:
               type: boolean
               example: true
+            monetizedInfo:
+              type: boolean
+              example: true
+            businessOwner:
+              type: string
+              example: Business Owner
+            businessOwnerEmail:
+              type: string
+              example: businessowner@abc.com
+            TechnicalOwner:
+              type: string
+              example: Technical Owner
+            TechnicalOwnerEmail:
+              type: string
+              example: technicalowner@abc.com
     APIProductSearchResult:
       title: API Result
       allOf:
@@ -11285,6 +11300,21 @@ components:
             hasThumbnail:
               type: boolean
               example: true
+            monetizedInfo:
+              type: boolean
+              example: true
+            businessOwner:
+              type: string
+              example: Business Owner
+            businessOwnerEmail:
+              type: string
+              example: businessowner@abc.com
+            TechnicalOwner:
+              type: string
+              example: Technical Owner
+            TechnicalOwnerEmail:
+              type: string
+              example: technicalowner@abc.com
     APIMonetizationInfo:
       title: API monetization object
       required:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIInfoDTO.java
@@ -43,6 +43,7 @@ public class APIInfoDTO   {
     private String monetizationLabel = null;
     private String gatewayVendor = null;
     private List<APIInfoAdditionalPropertiesDTO> additionalProperties = new ArrayList<APIInfoAdditionalPropertiesDTO>();
+    private Boolean monetizedInfo = null;
 
   /**
    **/
@@ -357,6 +358,23 @@ public class APIInfoDTO   {
     this.additionalProperties = additionalProperties;
   }
 
+  /**
+   **/
+  public APIInfoDTO monetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("monetizedInfo")
+  public Boolean isMonetizedInfo() {
+    return monetizedInfo;
+  }
+  public void setMonetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -384,12 +402,13 @@ public class APIInfoDTO   {
         Objects.equals(isSubscriptionAvailable, apIInfo.isSubscriptionAvailable) &&
         Objects.equals(monetizationLabel, apIInfo.monetizationLabel) &&
         Objects.equals(gatewayVendor, apIInfo.gatewayVendor) &&
-        Objects.equals(additionalProperties, apIInfo.additionalProperties);
+        Objects.equals(additionalProperties, apIInfo.additionalProperties) &&
+        Objects.equals(monetizedInfo, apIInfo.monetizedInfo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, context, version, type, createdTime, provider, lifeCycleStatus, thumbnailUri, avgRating, throttlingPolicies, advertiseInfo, businessInformation, isSubscriptionAvailable, monetizationLabel, gatewayVendor, additionalProperties);
+    return Objects.hash(id, name, description, context, version, type, createdTime, provider, lifeCycleStatus, thumbnailUri, avgRating, throttlingPolicies, advertiseInfo, businessInformation, isSubscriptionAvailable, monetizationLabel, gatewayVendor, additionalProperties, monetizedInfo);
   }
 
   @Override
@@ -415,6 +434,7 @@ public class APIInfoDTO   {
     sb.append("    monetizationLabel: ").append(toIndentedString(monetizationLabel)).append("\n");
     sb.append("    gatewayVendor: ").append(toIndentedString(gatewayVendor)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
+    sb.append("    monetizedInfo: ").append(toIndentedString(monetizedInfo)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APISearchResultAllOfDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APISearchResultAllOfDTO.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIBusinessInformationDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.AdvertiseInfoDTO;
 import javax.validation.constraints.*;
 
 
@@ -29,6 +30,8 @@ public class APISearchResultAllOfDTO   {
     private String thumbnailUri = null;
     private APIBusinessInformationDTO businessInformation = null;
     private String avgRating = null;
+    private Boolean monetizedInfo = null;
+    private AdvertiseInfoDTO advertiseInfo = null;
 
   /**
    * A brief description about the API
@@ -173,6 +176,41 @@ public class APISearchResultAllOfDTO   {
     this.avgRating = avgRating;
   }
 
+  /**
+   **/
+  public APISearchResultAllOfDTO monetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("monetizedInfo")
+  public Boolean isMonetizedInfo() {
+    return monetizedInfo;
+  }
+  public void setMonetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+  }
+
+  /**
+   **/
+  public APISearchResultAllOfDTO advertiseInfo(AdvertiseInfoDTO advertiseInfo) {
+    this.advertiseInfo = advertiseInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("advertiseInfo")
+  public AdvertiseInfoDTO getAdvertiseInfo() {
+    return advertiseInfo;
+  }
+  public void setAdvertiseInfo(AdvertiseInfoDTO advertiseInfo) {
+    this.advertiseInfo = advertiseInfo;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -190,12 +228,14 @@ public class APISearchResultAllOfDTO   {
         Objects.equals(status, apISearchResultAllOf.status) &&
         Objects.equals(thumbnailUri, apISearchResultAllOf.thumbnailUri) &&
         Objects.equals(businessInformation, apISearchResultAllOf.businessInformation) &&
-        Objects.equals(avgRating, apISearchResultAllOf.avgRating);
+        Objects.equals(avgRating, apISearchResultAllOf.avgRating) &&
+        Objects.equals(monetizedInfo, apISearchResultAllOf.monetizedInfo) &&
+        Objects.equals(advertiseInfo, apISearchResultAllOf.advertiseInfo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, version, provider, status, thumbnailUri, businessInformation, avgRating);
+    return Objects.hash(description, context, version, provider, status, thumbnailUri, businessInformation, avgRating, monetizedInfo, advertiseInfo);
   }
 
   @Override
@@ -211,6 +251,8 @@ public class APISearchResultAllOfDTO   {
     sb.append("    thumbnailUri: ").append(toIndentedString(thumbnailUri)).append("\n");
     sb.append("    businessInformation: ").append(toIndentedString(businessInformation)).append("\n");
     sb.append("    avgRating: ").append(toIndentedString(avgRating)).append("\n");
+    sb.append("    monetizedInfo: ").append(toIndentedString(monetizedInfo)).append("\n");
+    sb.append("    advertiseInfo: ").append(toIndentedString(advertiseInfo)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APISearchResultDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APISearchResultDTO.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIBusinessInformationDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APISearchResultAllOfDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.AdvertiseInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SearchResultDTO;
 import javax.validation.constraints.*;
 
@@ -31,6 +32,8 @@ public class APISearchResultDTO extends SearchResultDTO  {
     private String thumbnailUri = null;
     private APIBusinessInformationDTO businessInformation = null;
     private String avgRating = null;
+    private Boolean monetizedInfo = null;
+    private AdvertiseInfoDTO advertiseInfo = null;
 
   /**
    * A brief description about the API
@@ -175,6 +178,41 @@ public class APISearchResultDTO extends SearchResultDTO  {
     this.avgRating = avgRating;
   }
 
+  /**
+   **/
+  public APISearchResultDTO monetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("monetizedInfo")
+  public Boolean isMonetizedInfo() {
+    return monetizedInfo;
+  }
+  public void setMonetizedInfo(Boolean monetizedInfo) {
+    this.monetizedInfo = monetizedInfo;
+  }
+
+  /**
+   **/
+  public APISearchResultDTO advertiseInfo(AdvertiseInfoDTO advertiseInfo) {
+    this.advertiseInfo = advertiseInfo;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("advertiseInfo")
+  public AdvertiseInfoDTO getAdvertiseInfo() {
+    return advertiseInfo;
+  }
+  public void setAdvertiseInfo(AdvertiseInfoDTO advertiseInfo) {
+    this.advertiseInfo = advertiseInfo;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -192,12 +230,14 @@ public class APISearchResultDTO extends SearchResultDTO  {
         Objects.equals(status, apISearchResult.status) &&
         Objects.equals(thumbnailUri, apISearchResult.thumbnailUri) &&
         Objects.equals(businessInformation, apISearchResult.businessInformation) &&
-        Objects.equals(avgRating, apISearchResult.avgRating);
+        Objects.equals(avgRating, apISearchResult.avgRating) &&
+        Objects.equals(monetizedInfo, apISearchResult.monetizedInfo) &&
+        Objects.equals(advertiseInfo, apISearchResult.advertiseInfo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, context, version, provider, status, thumbnailUri, businessInformation, avgRating);
+    return Objects.hash(description, context, version, provider, status, thumbnailUri, businessInformation, avgRating, monetizedInfo, advertiseInfo);
   }
 
   @Override
@@ -213,6 +253,8 @@ public class APISearchResultDTO extends SearchResultDTO  {
     sb.append("    thumbnailUri: ").append(toIndentedString(thumbnailUri)).append("\n");
     sb.append("    businessInformation: ").append(toIndentedString(businessInformation)).append("\n");
     sb.append("    avgRating: ").append(toIndentedString(avgRating)).append("\n");
+    sb.append("    monetizedInfo: ").append(toIndentedString(monetizedInfo)).append("\n");
+    sb.append("    advertiseInfo: ").append(toIndentedString(advertiseInfo)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -888,6 +888,7 @@ public class APIMappingUtil {
         apiInfoDTO.setIsSubscriptionAvailable(isSubscriptionAvailable(apiTenant, subscriptionAvailability,
                 subscriptionAllowedTenants));
         apiInfoDTO.setGatewayVendor(api.getGatewayVendor());
+        apiInfoDTO.setMonetizedInfo(api.isMonetizationEnabled());
 
         return apiInfoDTO;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SearchResultMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SearchResultMappingUtil.java
@@ -25,12 +25,7 @@ import org.wso2.carbon.apimgt.api.model.APIProductIdentifier;
 import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
-import org.wso2.carbon.apimgt.rest.api.store.v1.dto.DocumentSearchResultDTO;
-import org.wso2.carbon.apimgt.rest.api.store.v1.dto.PaginationDTO;
-import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SearchResultDTO;
-import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APISearchResultDTO;
-import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SearchResultListDTO;
-import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIBusinessInformationDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.*;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 
 import java.util.Map;
@@ -78,6 +73,10 @@ public class SearchResultMappingUtil {
         apiResultDTO.setDescription(api.getDescription());
         apiResultDTO.setStatus(api.getStatus());
         apiResultDTO.setThumbnailUri(api.getThumbnailUrl());
+        AdvertiseInfoDTO advertiseInfoDTO = new AdvertiseInfoDTO();
+        advertiseInfoDTO.setAdvertised(api.isAdvertiseOnly());
+        apiResultDTO.setAdvertiseInfo(advertiseInfoDTO);
+        apiResultDTO.setMonetizedInfo(api.isMonetizationEnabled());
         return apiResultDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SearchResultMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SearchResultMappingUtil.java
@@ -25,7 +25,13 @@ import org.wso2.carbon.apimgt.api.model.APIProductIdentifier;
 import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
-import org.wso2.carbon.apimgt.rest.api.store.v1.dto.*;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.DocumentSearchResultDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.PaginationDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SearchResultDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APISearchResultDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.SearchResultListDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIBusinessInformationDTO;
+import org.wso2.carbon.apimgt.rest.api.store.v1.dto.AdvertiseInfoDTO;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 
 import java.util.Map;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -3757,6 +3757,9 @@ components:
           description: |
             Custom(user defined) properties of API
           example: { }
+        monetizedInfo:
+          type: boolean
+          example: true
     APIInfoList:
       title: API Info List
       type: object

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -5136,6 +5136,11 @@ components:
               type: string
               description: Average rating of the API
               example: "4.5"
+            monetizedInfo:
+              type: boolean
+              example: true
+            advertiseInfo:
+              $ref: '#/components/schemas/AdvertiseInfo'
     DocumentSearchResult:
       title: Document Result
       allOf:


### PR DESCRIPTION
We introduced this PR to add the new feature API tile enhancement to both the publisher & dev portals. The current API tile information lacks some necessary business details from a marketplace perspective. With this feature, we are extending the API tile information structure to accommodate optional properties such as business information, external APIs, and the monetization-enabled state of the APIs. These properties are displayed in the API tile through a config. Users can set the 'display' property of optional properties as per their preference. By default, the configuration for the 'display' property is set to 'false.' This configuration can be found in the 'settings.json' file in both portals.

For the publisher portal, the configuration is as follows:
```
"apis": {
    "tileDisplayInfo": {
      "showMonetizedState": false,
      "showBusinessDetails": false,
      "showTechnicalDetails": false
    }, 
```

For the dev portal, the configuration is as follows:

```
"apis": {
        "tileDisplayInfo": {
            "showMonetizedState": false,
            "showBusinessDetails": false,
            "showTechnicalDetails": false
        }
    }
```

Please note that we haven't introduced a new configuration for the 'display' property of external APIs, as this label is already displayed in the API tile of the publisher portal when an API is marked as a Third-Party API. Therefore, we have added the same behaviour to the dev portal as well.

Below are screenshots of the new API tile for reference.

**Publisher Portal**

![publisher_tile](https://github.com/wso2/carbon-apimgt/assets/31464477/6b2b3f29-d3fb-4f88-aeb7-6490c59a0ff0)

**Dev Portal**

![dev_tile](https://github.com/wso2/carbon-apimgt/assets/31464477/b5e0f7dc-e69b-4567-a4e1-8e1e2f5ce74e)

Here we have added a popover to display the email of the business owner & technical owner. But we are not going to add more details here by taking the performance impact into consideration.

**With Popover**

![With_popover](https://github.com/wso2/carbon-apimgt/assets/31464477/e9864734-3932-46a6-adce-1abf1b5c8604)

Additionally, we have added this business info, monetization status and third-party label to the API Thumb plain tile as well for both portals. Below are the screenshots of the new Plain API tile for reference.

**Publisher Portal**

![Pub_APIThumbPlain](https://github.com/wso2/carbon-apimgt/assets/31464477/ceaa07e0-f3e2-4707-8a22-77be1be0c25f)

**Dev Portal**

![Dev_APIThumbPlain](https://github.com/wso2/carbon-apimgt/assets/31464477/19b520a3-6c54-4cc4-b081-13a0902b4255)

**Related PRs:**

- apim-apps PR : [https://github.com/wso2/apim-apps/pull/501](https://github.com/wso2/apim-apps/pull/501)
