### PR TITLE
Parameterize EventHub threadpool configurations

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.cache.invalidation/src/main/java/org/wso2/carbon/apimgt/cache/invalidation/APIMgtServerStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.cache.invalidation/src/main/java/org/wso2/carbon/apimgt/cache/invalidation/APIMgtServerStartupListener.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.apimgt.cache.invalidation;
 import org.wso2.carbon.apimgt.cache.invalidation.internal.DataHolder;
 import org.wso2.carbon.apimgt.common.jms.JMSTransportHandler;
 import org.wso2.carbon.apimgt.impl.dto.EventHubConfigurationDto;
+import org.wso2.carbon.apimgt.impl.dto.ThrottleProperties;
 import org.wso2.carbon.apimgt.impl.jms.listener.JMSListenerShutDownService;
 import org.wso2.carbon.core.ServerShutdownHandler;
 import org.wso2.carbon.core.ServerStartupObserver;
@@ -38,9 +39,12 @@ public class APIMgtServerStartupListener implements ServerStartupObserver, Serve
         EventHubConfigurationDto.EventHubReceiverConfiguration eventHubReceiverConfiguration =
                 DataHolder.getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration()
                         .getEventHubConfigurationDto().getEventHubReceiverConfiguration();
+        ThrottleProperties.JMSConnectionProperties.JMSTaskManagerProperties jmsTaskManagerProperties =
+                DataHolder.getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration()
+                        .getThrottleProperties().getJmsConnectionProperties().getJmsTaskManagerProperties();
         if (eventHubReceiverConfiguration != null) {
-            this.jmsTransportHandlerForEventHub =
-                    new JMSTransportHandler(eventHubReceiverConfiguration.getJmsConnectionParameters());
+            this.jmsTransportHandlerForEventHub = new JMSTransportHandler(
+                    eventHubReceiverConfiguration.getJmsConnectionParameters(), jmsTaskManagerProperties);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.common.jms/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.jms/pom.xml
@@ -34,6 +34,10 @@
             <classifier>runtime</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.impl</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
@@ -99,13 +99,16 @@ public class GatewayStartupListener extends AbstractAxis2ConfigurationContextObs
         ThrottleProperties.JMSConnectionProperties jmsConnectionProperties =
                 throttleProperties.getJmsConnectionProperties();
         this.jmsTransportHandlerForTrafficManager =
-                new JMSTransportHandler(jmsConnectionProperties.getJmsConnectionProperties());
+                new JMSTransportHandler(jmsConnectionProperties.getJmsConnectionProperties(), null);
         EventHubConfigurationDto.EventHubReceiverConfiguration eventHubReceiverConfiguration =
                 ServiceReferenceHolder.getInstance().getAPIManagerConfiguration().getEventHubConfigurationDto()
                         .getEventHubReceiverConfiguration();
+        ThrottleProperties.JMSConnectionProperties.JMSTaskManagerProperties jmsTaskManagerProperties =
+                ServiceReferenceHolder.getInstance().getAPIManagerConfiguration().getThrottleProperties()
+                        .getJmsConnectionProperties().getJmsTaskManagerProperties();
         if (eventHubReceiverConfiguration != null) {
-            this.jmsTransportHandlerForEventHub =
-                    new JMSTransportHandler(eventHubReceiverConfiguration.getJmsConnectionParameters());
+            this.jmsTransportHandlerForEventHub = new JMSTransportHandler(
+                    eventHubReceiverConfiguration.getJmsConnectionParameters(), jmsTaskManagerProperties);
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -1382,7 +1382,7 @@ public class APIManagerConfiguration {
                         OMElement jobQueueSizeElement = jmsTaskManagerElement
                                 .getFirstChildWithName(new QName
                                         (APIConstants.AdvancedThrottleConstants.JOB_QUEUE_SIZE));
-                        if (keepAliveTimeInMillisElement != null) {
+                        if (jobQueueSizeElement != null) {
                             jmsTaskManagerProperties.setJobQueueSize(Integer.parseInt(jobQueueSizeElement.getText()));
                         }
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/main/java/org/wso2/carbon/apimgt/jms/listener/utils/JMSListenerStartupShutdownListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/main/java/org/wso2/carbon/apimgt/jms/listener/utils/JMSListenerStartupShutdownListener.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.apimgt.common.jms.JMSTransportHandler;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.dto.EventHubConfigurationDto;
+import org.wso2.carbon.apimgt.impl.dto.ThrottleProperties;
 import org.wso2.carbon.apimgt.impl.jms.listener.JMSListenerShutDownService;
 import org.wso2.carbon.apimgt.jms.listener.internal.ServiceReferenceHolder;
 import org.wso2.carbon.core.ServerShutdownHandler;
@@ -44,9 +45,13 @@ public class JMSListenerStartupShutdownListener implements ServerStartupObserver
         EventHubConfigurationDto.EventHubReceiverConfiguration eventHubReceiverConfiguration =
                 ServiceReferenceHolder.getInstance().getAPIMConfiguration().getEventHubConfigurationDto()
                         .getEventHubReceiverConfiguration();
+        ThrottleProperties.JMSConnectionProperties.JMSTaskManagerProperties jmsTaskManagerProperties =
+                ServiceReferenceHolder.getInstance().getAPIMConfiguration().getThrottleProperties()
+                        .getJmsConnectionProperties().getJmsTaskManagerProperties();
+
         if (eventHubReceiverConfiguration != null) {
-            this.jmsTransportHandlerForEventHub =
-                    new JMSTransportHandler(eventHubReceiverConfiguration.getJmsConnectionParameters());
+            this.jmsTransportHandlerForEventHub = new JMSTransportHandler(
+                    eventHubReceiverConfiguration.getJmsConnectionParameters(), jmsTaskManagerProperties);
         }
 
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/src/main/java/org/wso2/carbon/apimgt/throttle/policy/deployer/utils/ThrottlePolicyStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/src/main/java/org/wso2/carbon/apimgt/throttle/policy/deployer/utils/ThrottlePolicyStartupListener.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.common.jms.JMSTransportHandler;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dto.EventHubConfigurationDto;
+import org.wso2.carbon.apimgt.impl.dto.ThrottleProperties;
 import org.wso2.carbon.apimgt.impl.jms.listener.JMSListenerShutDownService;
 import org.wso2.carbon.apimgt.throttle.policy.deployer.internal.ServiceReferenceHolder;
 import org.wso2.carbon.core.ServerShutdownHandler;
@@ -41,9 +42,12 @@ public class ThrottlePolicyStartupListener implements ServerStartupObserver, Ser
         EventHubConfigurationDto.EventHubReceiverConfiguration eventHubReceiverConfiguration =
                 ServiceReferenceHolder.getInstance().getAPIMConfiguration().getEventHubConfigurationDto()
                         .getEventHubReceiverConfiguration();
+        ThrottleProperties.JMSConnectionProperties.JMSTaskManagerProperties jmsTaskManagerProperties =
+                ServiceReferenceHolder.getInstance().getAPIMConfiguration().getThrottleProperties()
+                        .getJmsConnectionProperties().getJmsTaskManagerProperties();
         if (eventHubReceiverConfiguration != null) {
-            this.jmsTransportHandlerForEventHub =
-                    new JMSTransportHandler(eventHubReceiverConfiguration.getJmsConnectionParameters());
+            this.jmsTransportHandlerForEventHub = new JMSTransportHandler(
+                    eventHubReceiverConfiguration.getJmsConnectionParameters(), jmsTaskManagerProperties);
         }
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -931,6 +931,14 @@
             {% if apim.throttling.jms.start_delay is defined %}
             <InitDelay>{{apim.throttling.jms.start_delay}}</InitDelay>
             {% endif %}
+            {% if (apim.event_hub.listener.min_thread_pool_size is defined)
+            or (apim.event_hub.listener.max_thread_pool_size is defined)
+            or (apim.event_hub.listener.keep_alive_time_in_millis is defined)
+            or (apim.event_hub.listener.job_queue_size is defined)
+            or (apim.throttling.jms.min_thread_pool_size is defined)
+            or (apim.throttling.jms.max_thread_pool_size is defined)
+            or (apim.throttling.jms.keep_alive_time_in_millis is defined)
+            or (apim.throttling.jms.job_queue_size is defined) %}
             <JMSTaskManager>
                 {% if apim.event_hub.listener.min_thread_pool_size is defined %}
                 <MinThreadPoolSize>{{apim.event_hub.listener.min_thread_pool_size}}</MinThreadPoolSize>
@@ -953,6 +961,7 @@
                 <JobQueueSize>{{apim.throttling.jms.job_queue_size}}</JobQueueSize>
                 {% endif %}
             <JMSTaskManager>
+            {% endif %}
             <JMSConnectionParameters>
                 <transport.jms.ConnectionFactoryJNDIName>{{apim.throttling.jms.conn_jndi_name}}</transport.jms.ConnectionFactoryJNDIName>
                 <transport.jms.DestinationType>{{apim.throttling.jms.destination_type}}</transport.jms.DestinationType>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -931,6 +931,28 @@
             {% if apim.throttling.jms.start_delay is defined %}
             <InitDelay>{{apim.throttling.jms.start_delay}}</InitDelay>
             {% endif %}
+            <JMSTaskManager>
+                {% if apim.event_hub.listener.min_thread_pool_size is defined %}
+                <MinThreadPoolSize>{{apim.event_hub.listener.min_thread_pool_size}}</MinThreadPoolSize>
+                {% elif apim.throttling.jms.min_thread_pool_size is defined %}
+                <MinThreadPoolSize>{{apim.throttling.jms.min_thread_pool_size}}</MinThreadPoolSize>
+                {% endif %}
+                {% if apim.event_hub.listener.max_thread_pool_size is defined %}
+                <MaxThreadPoolSize>{{apim.event_hub.listener.max_thread_pool_size}}</MaxThreadPoolSize>
+                {% elif apim.throttling.jms.max_thread_pool_size is defined %}
+                <MaxThreadPoolSize>{{apim.throttling.jms.max_thread_pool_size}}</MaxThreadPoolSize>
+                {% endif %}
+                {% if apim.event_hub.listener.keep_alive_time_in_millis is defined %}
+                <KeepAliveTimeInMillis>{{apim.event_hub.listener.keep_alive_time_in_millis}}</KeepAliveTimeInMillis>
+                {% elif apim.throttling.jms.keep_alive_time_in_millis is defined %}
+                <KeepAliveTimeInMillis>{{apim.throttling.jms.keep_alive_time_in_millis}}</KeepAliveTimeInMillis>
+                {% endif %}
+                {% if apim.event_hub.listener.job_queue_size is defined %}
+                <JobQueueSize>{{apim.event_hub.listener.job_queue_size}}</JobQueueSize>
+                {% elif apim.throttling.jms.job_queue_size is defined %}
+                <JobQueueSize>{{apim.throttling.jms.job_queue_size}}</JobQueueSize>
+                {% endif %}
+            <JMSTaskManager>
             <JMSConnectionParameters>
                 <transport.jms.ConnectionFactoryJNDIName>{{apim.throttling.jms.conn_jndi_name}}</transport.jms.ConnectionFactoryJNDIName>
                 <transport.jms.DestinationType>{{apim.throttling.jms.destination_type}}</transport.jms.DestinationType>


### PR DESCRIPTION
The configuration below allows customization of Thread Pool settings of the JMS TransportHandler for the Event Hub. This can be configured by adding either of the following configs.

```
[apim.event_hub.listener]
min_thread_pool_size = 20
max_thread_pool_size = 100
keep_alive_time_in_millis = 1000
job_queue_size = 10
```
Or
```
[apim.throttling.jms]
min_thread_pool_size = 20
max_thread_pool_size = 100
keep_alive_time_in_millis = 1000
job_queue_size = 10
```

Precendence will be given to apim.event_hub.listener configs. Only if the values are not defined under apim.event_hub.listener configs, configs under apim.throttling.jms are considered.

Git Issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/4613