### PR TITLE
Add Implementation to provide OTEL Resource Attributes

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/JaegerTelemetry.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/JaegerTelemetry.java
@@ -68,11 +68,9 @@ public class JaegerTelemetry implements APIMOpenTelemetry {
             log.debug("Jaeger exporter: " + jaegerExporter + " is configured at http://" + hostname + ":" + port);
         }
 
-        Resource serviceNameResource = Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, serviceName));
-
         sdkTracerProvider = SdkTracerProvider.builder()
                 .addSpanProcessor(BatchSpanProcessor.builder(jaegerExporter).build())
-                .setResource(Resource.getDefault().merge(serviceNameResource))
+                .setResource(TelemetryUtil.getTracerProviderResource(serviceName))
                 .build();
 
         openTelemetry = OpenTelemetrySdk.builder()

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/JaegerTelemetry.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/JaegerTelemetry.java
@@ -19,16 +19,13 @@
 package org.wso2.carbon.apimgt.tracing.telemetry;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
 import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/OTLPTelemetry.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/OTLPTelemetry.java
@@ -19,28 +19,21 @@
 package org.wso2.carbon.apimgt.tracing.telemetry;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.tracing.internal.ServiceReferenceHolder;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Class for getting Otlp tracer from reading configuration file.
@@ -48,9 +41,6 @@ import java.util.stream.Collectors;
 public class OTLPTelemetry implements APIMOpenTelemetry {
 
     private static final String NAME = "otlp";
-    private static final String OTEL_RESOURCE_ATTRIBUTE_CONFIG_KEYS_PREFIX =
-            "OpenTelemetry.RemoteTracer.ResourceAttributes.";
-    private static final String OTEL_RESOURCE_ATTRIBUTES_ENV_VAR_NAME = "OTEL_RESOURCE_ATTRIBUTES";
     private static final Log log = LogFactory.getLog(OTLPTelemetry.class);
     private static final APIManagerConfiguration configuration =
             ServiceReferenceHolder.getInstance().getAPIManagerConfiguration();
@@ -80,7 +70,7 @@ public class OTLPTelemetry implements APIMOpenTelemetry {
 
             sdkTracerProvider = SdkTracerProvider.builder()
                     .addSpanProcessor(BatchSpanProcessor.builder(otlpGrpcSpanExporterBuilder.build()).build())
-                    .setResource(getTracerProviderResource(serviceName))
+                    .setResource(TelemetryUtil.getTracerProviderResource(serviceName))
                     .build();
 
             openTelemetry = OpenTelemetrySdk.builder()
@@ -94,48 +84,6 @@ public class OTLPTelemetry implements APIMOpenTelemetry {
         } else {
             log.error("Either endpoint url or the header key value is null or empty");
         }
-    }
-
-    private Resource getTracerProviderResource(String defaultServiceName) {
-        Map<String, String> otelResourceAttributes = getOtelResourceAttributes();
-        AttributesBuilder attributesBuilder = Attributes.builder();
-        for (Map.Entry<String, String> otelResourceAttribute : otelResourceAttributes.entrySet()) {
-            attributesBuilder.put(otelResourceAttribute.getKey(), otelResourceAttribute.getValue());
-        }
-        Attributes attributes = attributesBuilder.build();
-
-        Resource tracerProviderResource = Resource.getDefault();
-        Resource serviceNameResource = Resource.create(
-                Attributes.of(ResourceAttributes.SERVICE_NAME, defaultServiceName));
-        tracerProviderResource = tracerProviderResource.merge(serviceNameResource);
-        tracerProviderResource = tracerProviderResource.merge(Resource.create(attributes));
-
-        return tracerProviderResource;
-    }
-
-    private Map<String, String> getOtelResourceAttributes() {
-        Map<String, String> otelResourceAttributes = new HashMap<>();
-
-        // Get from configuration
-        Set<String> otelResourceAttributeConfigKeys = configuration.getConfigKeySet()
-                .stream().filter(entry -> entry.startsWith(OTEL_RESOURCE_ATTRIBUTE_CONFIG_KEYS_PREFIX))
-                .collect(Collectors.toSet());
-        for (String configKey : otelResourceAttributeConfigKeys) {
-            String otelResourceAttributeKey = configKey.substring(OTEL_RESOURCE_ATTRIBUTE_CONFIG_KEYS_PREFIX.length());
-            otelResourceAttributes.put(otelResourceAttributeKey, configuration.getFirstProperty(configKey));
-        }
-
-        // Get from environment variables
-        String environmentVariableValue = System.getenv(OTEL_RESOURCE_ATTRIBUTES_ENV_VAR_NAME);
-        if (environmentVariableValue != null) {
-            String[] resourceAttributes = StringUtils.split(environmentVariableValue,",");
-            for (String keyValuePair : resourceAttributes) {
-                String[] keyValue = StringUtils.split(keyValuePair, "=");
-                otelResourceAttributes.put(keyValue[0], keyValue[1]);
-            }
-        }
-
-        return otelResourceAttributes;
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/TelemetryConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/TelemetryConstants.java
@@ -64,6 +64,8 @@ public class TelemetryConstants {
      */
     static final String OTLP_CONFIG_URL = "OpenTelemetry.RemoteTracer.Url";
     static final String OPENTELEMETRY_PROPERTIES_PREFIX = "OpenTelemetry.RemoteTracer.Properties.";
+    static final String OTEL_RESOURCE_ATTRIBUTE_CONFIG_KEYS_PREFIX = "OpenTelemetry.ResourceAttributes.";
+    static final String OTEL_RESOURCE_ATTRIBUTES_ENVIRONMENT_VARIABLE_NAME = "OTEL_RESOURCE_ATTRIBUTES";
 
     private TelemetryConstants() {
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/TelemetryUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/TelemetryUtil.java
@@ -242,6 +242,7 @@ public class TelemetryUtil {
 
     /**
      * Gets the tracer provider resource with the provided default service name.
+     *
      * @param defaultServiceName    Default service name.
      * @return                      Tracer provider resource.
      */
@@ -262,7 +263,7 @@ public class TelemetryUtil {
         provided via configuration, the value provided via environment variable will overwrite that. */
         String environmentVariableValue = System.getenv(OTEL_RESOURCE_ATTRIBUTES_ENVIRONMENT_VARIABLE_NAME);
         if (environmentVariableValue != null) {
-            String[] resourceAttributes = StringUtils.split(environmentVariableValue,",");
+            String[] resourceAttributes = StringUtils.split(environmentVariableValue, ",");
             for (String keyValuePair : resourceAttributes) {
                 String[] keyValue = StringUtils.split(keyValuePair, "=");
                 otelResourceAttributes.put(keyValue[0], keyValue[1]);

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/ZipkinTelemetry.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/ZipkinTelemetry.java
@@ -65,11 +65,9 @@ public class ZipkinTelemetry implements APIMOpenTelemetry {
             log.debug("Zipkin exporter: " + zipkinExporter + " is configured at http://" + hostname + ":" + port);
         }
 
-        Resource serviceNameResource = Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, serviceName));
-
         sdkTracerProvider = SdkTracerProvider.builder()
                 .addSpanProcessor(BatchSpanProcessor.builder(zipkinExporter).build())
-                .setResource(Resource.getDefault().merge(serviceNameResource))
+                .setResource(TelemetryUtil.getTracerProviderResource(serviceName))
                 .build();
 
         openTelemetry = OpenTelemetrySdk.builder()

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/ZipkinTelemetry.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/ZipkinTelemetry.java
@@ -19,16 +19,13 @@
 package org.wso2.carbon.apimgt.tracing.telemetry;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1118,6 +1118,11 @@
         <LogTracer>
             <Enabled>{{apim.open_telemetry.log_tracer.enable}}</Enabled>
         </LogTracer>
+        <ResourceAttributes>
+            {% for attribute in apim.open_telemetry.resource_attributes %}
+            <{{attribute.name}}>{{attribute.value}}</{{attribute.name}}>
+            {% endfor %}
+        </ResourceAttributes>
     </OpenTelemetry>
 
     <OpenTracer>


### PR DESCRIPTION
## Purpose
$Subject. Fixes https://github.com/wso2/api-manager/issues/2123

## Approach
OTEL Resource attributes can be provided:
- Via `deployment.toml`
   ```
   [[apim.open_telemetry.resource_attributes]]
   name = "service.name"
   value = "MyService"
   
   [[apim.open_telemetry.resource_attributes]]
   name = "deployment.environment"
   value = "Production"
   ```
AND
- Via the `OTEL_RESOURCE_ATTRIBUTES` environment variable (as per the OpenTelemetry spec [1])
   ```
   export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=Production,service.name=MyService
   ```

When a resource attribute is given via both the `deployment.toml` and the `OTEL_RESOURCE_ATTRIBUTES` env variable, the value of the attribute given via the env variable will replace the value given via deployment.toml.

## Related PRs
Reading the Config - j2 file change: **TODO**

[1] `https://github.com/open-telemetry/opentelemetry-specification/blob/8946dfc6a2302f78b0224fcc3f4dfb816a7bb1f4/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable`