### PR TITLE
Admin portal API scopes related fixs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/config/APIMConfigServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/config/APIMConfigServiceImpl.java
@@ -188,6 +188,9 @@ public class APIMConfigServiceImpl implements APIMConfigService {
         Cache tenantConfigCache = CacheProvider.getTenantConfigCache();
         String cacheName = organization + "_" + APIConstants.TENANT_CONFIG_CACHE_NAME;
         tenantConfigCache.remove(cacheName);
+        
+        // Clear restapi scope cache
+        CacheProvider.getRESTAPIScopeCache().remove(organization);
         systemConfigurationsDAO.updateSystemConfig(organization, ConfigType.TENANT.toString(), tenantConfig);
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -348,6 +348,14 @@
       {
         "Name": "apim:policies_import_export",
         "Roles": "admin,Internal/devops"
+      },
+      {
+        "Name": "apim:admin_tier_manage",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:admin_tier_view",
+        "Roles": "admin"
       }
     ]
   },

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/ThrottlingApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/ThrottlingApi.java
@@ -56,6 +56,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Export a Throttling Policy", notes = "This operation can be used to export the details of a particular Throttling Policy. ", response = ExportThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
@@ -75,6 +76,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Import a Throttling Policy", notes = "This operation can be used to import a Throttling Policy ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
@@ -184,6 +186,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get all Advanced Throttling Policies", notes = "Retrieves all existing advanced throttling policies. ", response = AdvancedThrottlePolicyListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Advanced Policy (Collection)",  })
@@ -201,6 +204,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Delete an Advanced Throttling Policy", notes = "Deletes an advanced throttling policy. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
@@ -219,6 +223,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get an Advanced Throttling Policy", notes = "Retrieves an advanced throttling policy. ", response = AdvancedThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Advanced Policy (Individual)",  })
@@ -237,6 +242,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Update an Advanced Throttling Policy", notes = "Updates an existing Advanced throttling policy. ", response = AdvancedThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Advanced Policy (Individual)",  })
@@ -255,6 +261,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Add an Advanced Throttling Policy", notes = "Add a new advanced throttling policy. ", response = AdvancedThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Advanced Policy (Collection)",  })
@@ -273,6 +280,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get all Application Throttling Policies", notes = "Retrieves all existing application throttling policies. ", response = ApplicationThrottlePolicyListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Application Policy (Collection)",  })
@@ -290,6 +298,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Delete an Application Throttling policy", notes = "Deletes an application level throttling policy. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
@@ -308,6 +317,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get an Application Throttling Policy", notes = "Retrieves an application throttling policy. ", response = ApplicationThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Application Policy (Individual)",  })
@@ -326,6 +336,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Update an Application Throttling policy", notes = "Updates an existing application level throttling policy. Upon a succesfull update, you will receive the updated application policy as the response. ", response = ApplicationThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Application Policy (Individual)",  })
@@ -344,6 +355,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Add an Application Throttling Policy", notes = "This operation can be used to add a new application level throttling policy. ", response = ApplicationThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Application Policy (Collection)",  })
@@ -362,6 +374,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get all Custom Rules", notes = "Retrieves all custom rules.  **NOTE:** * Only super tenant users are allowed for this operation. ", response = CustomRuleListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Custom Rules (Collection)",  })
@@ -379,6 +392,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Add a Custom Rule", notes = "Adds a new custom rule.  **NOTE:** * Only super tenant users are allowed for this operation. ", response = CustomRuleDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Custom Rules (Collection)",  })
@@ -397,6 +411,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Delete a Custom Rule", notes = "Delete a custom rule. We need to provide the Id of the policy as a path parameter.  **NOTE:** * Only super tenant users are allowed for this operation. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
@@ -415,6 +430,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get a Custom Rule", notes = "Retrieves a custom rule. We need to provide the policy Id as a path parameter.  **NOTE:** * Only super tenant users are allowed for this operation. ", response = CustomRuleDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Custom Rules (Individual)",  })
@@ -433,6 +449,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Update a Custom Rule", notes = "Updates an existing custom rule.  **NOTE:** * Only super tenant users are allowed for this operation. ", response = CustomRuleDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Custom Rules (Individual)",  })
@@ -451,6 +468,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get all Subscription Throttling Policies", notes = "This operation can be used to retrieve all Subscription level throttling policies. ", response = SubscriptionThrottlePolicyListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Subscription Policy (Collection)",  })
@@ -468,6 +486,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Delete a Subscription Policy", notes = "This operation can be used to delete a subscription level throttling policy by specifying the Id of the policy as a path paramter. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
@@ -486,6 +505,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get a Subscription Policy", notes = "This operation can be used to retrieves subscription level throttling policy by specifying the Id of the policy as a path paramter ", response = SubscriptionThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Subscription Policy (Individual)",  })
@@ -504,6 +524,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Update a Subscription Policy", notes = "Updates an existing subscription level throttling policy. ", response = SubscriptionThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Subscription Policy (Individual)",  })
@@ -522,6 +543,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Add a Subscription Throttling Policy", notes = "This operation can be used to add a Subscription level throttling policy specifying the details of the policy in the payload. ", response = SubscriptionThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Subscription Policy (Collection)",  })
@@ -540,6 +562,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Retrieve/Search Throttling Policies ", notes = "This operation provides you a list of available Throttling Policies qualifying the given keyword match. ", response = ThrottlePolicyDetailsListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies"),
             @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/ThrottlingApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/ThrottlingApi.java
@@ -56,7 +56,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Export a Throttling Policy", notes = "This operation can be used to export the details of a particular Throttling Policy. ", response = ExportThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
     }, tags={ "Import Export",  })
@@ -75,7 +75,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Import a Throttling Policy", notes = "This operation can be used to import a Throttling Policy ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
     }, tags={ "Import Export",  })
@@ -184,7 +184,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get all Advanced Throttling Policies", notes = "Retrieves all existing advanced throttling policies. ", response = AdvancedThrottlePolicyListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Advanced Policy (Collection)",  })
     @ApiResponses(value = { 
@@ -201,7 +201,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Delete an Advanced Throttling Policy", notes = "Deletes an advanced throttling policy. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
     }, tags={ "Advanced Policy (Individual)",  })
@@ -219,7 +219,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get an Advanced Throttling Policy", notes = "Retrieves an advanced throttling policy. ", response = AdvancedThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Advanced Policy (Individual)",  })
     @ApiResponses(value = { 
@@ -237,7 +237,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Update an Advanced Throttling Policy", notes = "Updates an existing Advanced throttling policy. ", response = AdvancedThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Advanced Policy (Individual)",  })
     @ApiResponses(value = { 
@@ -255,7 +255,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Add an Advanced Throttling Policy", notes = "Add a new advanced throttling policy. ", response = AdvancedThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Advanced Policy (Collection)",  })
     @ApiResponses(value = { 
@@ -273,7 +273,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get all Application Throttling Policies", notes = "Retrieves all existing application throttling policies. ", response = ApplicationThrottlePolicyListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Application Policy (Collection)",  })
     @ApiResponses(value = { 
@@ -290,7 +290,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Delete an Application Throttling policy", notes = "Deletes an application level throttling policy. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
     }, tags={ "Application Policy (Individual)",  })
@@ -308,7 +308,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get an Application Throttling Policy", notes = "Retrieves an application throttling policy. ", response = ApplicationThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Application Policy (Individual)",  })
     @ApiResponses(value = { 
@@ -326,7 +326,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Update an Application Throttling policy", notes = "Updates an existing application level throttling policy. Upon a succesfull update, you will receive the updated application policy as the response. ", response = ApplicationThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Application Policy (Individual)",  })
     @ApiResponses(value = { 
@@ -344,7 +344,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Add an Application Throttling Policy", notes = "This operation can be used to add a new application level throttling policy. ", response = ApplicationThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Application Policy (Collection)",  })
     @ApiResponses(value = { 
@@ -362,7 +362,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get all Custom Rules", notes = "Retrieves all custom rules.  **NOTE:** * Only super tenant users are allowed for this operation. ", response = CustomRuleListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Custom Rules (Collection)",  })
     @ApiResponses(value = { 
@@ -379,7 +379,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Add a Custom Rule", notes = "Adds a new custom rule.  **NOTE:** * Only super tenant users are allowed for this operation. ", response = CustomRuleDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Custom Rules (Collection)",  })
     @ApiResponses(value = { 
@@ -397,7 +397,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Delete a Custom Rule", notes = "Delete a custom rule. We need to provide the Id of the policy as a path parameter.  **NOTE:** * Only super tenant users are allowed for this operation. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
     }, tags={ "Custom Rules (Individual)",  })
@@ -415,7 +415,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get a Custom Rule", notes = "Retrieves a custom rule. We need to provide the policy Id as a path parameter.  **NOTE:** * Only super tenant users are allowed for this operation. ", response = CustomRuleDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Custom Rules (Individual)",  })
     @ApiResponses(value = { 
@@ -433,7 +433,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Update a Custom Rule", notes = "Updates an existing custom rule.  **NOTE:** * Only super tenant users are allowed for this operation. ", response = CustomRuleDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Custom Rules (Individual)",  })
     @ApiResponses(value = { 
@@ -451,7 +451,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get all Subscription Throttling Policies", notes = "This operation can be used to retrieve all Subscription level throttling policies. ", response = SubscriptionThrottlePolicyListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Subscription Policy (Collection)",  })
     @ApiResponses(value = { 
@@ -468,7 +468,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Delete a Subscription Policy", notes = "This operation can be used to delete a subscription level throttling policy by specifying the Id of the policy as a path paramter. ", response = Void.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies"),
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
     }, tags={ "Subscription Policy (Individual)",  })
@@ -486,7 +486,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Get a Subscription Policy", notes = "This operation can be used to retrieves subscription level throttling policy by specifying the Id of the policy as a path paramter ", response = SubscriptionThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies")
         })
     }, tags={ "Subscription Policy (Individual)",  })
     @ApiResponses(value = { 
@@ -504,7 +504,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Update a Subscription Policy", notes = "Updates an existing subscription level throttling policy. ", response = SubscriptionThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Subscription Policy (Individual)",  })
     @ApiResponses(value = { 
@@ -522,7 +522,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Add a Subscription Throttling Policy", notes = "This operation can be used to add a Subscription level throttling policy specifying the details of the policy in the payload. ", response = SubscriptionThrottlePolicyDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_manage", description = "Update and delete throttling policies")
+            @AuthorizationScope(scope = "apim:admin_tier_manage", description = "Update and delete throttling policies")
         })
     }, tags={ "Subscription Policy (Collection)",  })
     @ApiResponses(value = { 
@@ -540,7 +540,7 @@ ThrottlingApiService delegate = new ThrottlingApiServiceImpl();
     @ApiOperation(value = "Retrieve/Search Throttling Policies ", notes = "This operation provides you a list of available Throttling Policies qualifying the given keyword match. ", response = ThrottlePolicyDetailsListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:tier_view", description = "View throttling policies"),
+            @AuthorizationScope(scope = "apim:admin_tier_view", description = "View throttling policies"),
             @AuthorizationScope(scope = "apim:policies_import_export", description = "Export and import policies related operations")
         })
     }, tags={ "Unified Search" })

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -74,14 +74,14 @@ info:
     ```
     curl https://localhost:9443/oauth2/token -k \
     -H "Authorization: Basic Zk9DaTR2Tko1OVBwSHVjQzJDQVlmWXVBRGRNYTphNEZ3SGxxMGlDSUtWczJNUElJRG5lcFpuWU1h" \
-    -d "grant_type=password&username=admin&password=admin&scope=apim:admin apim:tier_view"
+    -d "grant_type=password&username=admin&password=admin&scope=apim:admin apim:admin_tier_view"
     ```
     Shown below is a sample response to the above request.
     ```
     {
     "access_token": "e79bda48-3406-3178-acce-f6e4dbdcbb12",
     "refresh_token": "a757795d-e69f-38b8-bd85-9aded677a97c",
-    "scope": "apim:admin apim:tier_view",
+    "scope": "apim:admin apim:admin_tier_view",
     "token_type": "Bearer",
     "expires_in": 3600
     }
@@ -144,7 +144,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_view
+            - apim:admin_tier_view
             - apim:policies_import_export
       x-code-samples:
         - lang: Curl
@@ -184,7 +184,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_view
+            - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -247,7 +247,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -300,7 +300,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_view
+            - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -363,7 +363,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -388,7 +388,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
             - apim:policies_import_export
       x-code-samples:
         - lang: Curl
@@ -428,7 +428,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_view
+            - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -496,7 +496,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -554,7 +554,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_view
+            - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -622,7 +622,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -647,7 +647,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
             - apim:policies_import_export
       x-code-samples:
         - lang: Curl
@@ -689,7 +689,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_view
+            - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -754,7 +754,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -809,7 +809,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_view
+            - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -874,7 +874,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -902,7 +902,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
             - apim:policies_import_export
       x-code-samples:
         - lang: Curl
@@ -941,7 +941,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_view
+            - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -1004,7 +1004,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -1057,7 +1057,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_view
+            - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -1120,7 +1120,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
@@ -1145,7 +1145,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
             - apim:policies_import_export
       x-code-samples:
         - lang: Curl
@@ -1232,7 +1232,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
             - apim:policies_import_export
       x-code-samples:
         - lang: Curl
@@ -1285,7 +1285,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
-            - apim:tier_manage
+            - apim:admin_tier_manage
             - apim:policies_import_export
       x-code-samples:
         - lang: Curl
@@ -5206,8 +5206,8 @@ components:
             openid: Authorize access to user details
             apim:policies_import_export: Export and import policies related operations
             apim:admin: Manage all admin operations
-            apim:tier_view: View throttling policies
-            apim:tier_manage: Update and delete throttling policies
+            apim:admin_tier_view: View throttling policies
+            apim:admin_tier_manage: Update and delete throttling policies
             apim:bl_view: View deny policies
             apim:bl_manage: Update and delete deny policies
             apim:mediation_policy_view: View mediation policies

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -74,14 +74,14 @@ info:
     ```
     curl https://localhost:9443/oauth2/token -k \
     -H "Authorization: Basic Zk9DaTR2Tko1OVBwSHVjQzJDQVlmWXVBRGRNYTphNEZ3SGxxMGlDSUtWczJNUElJRG5lcFpuWU1h" \
-    -d "grant_type=password&username=admin&password=admin&scope=apim:admin apim:admin_tier_view"
+    -d "grant_type=password&username=admin&password=admin&scope=apim:admin apim:tier_view"
     ```
     Shown below is a sample response to the above request.
     ```
     {
     "access_token": "e79bda48-3406-3178-acce-f6e4dbdcbb12",
     "refresh_token": "a757795d-e69f-38b8-bd85-9aded677a97c",
-    "scope": "apim:admin apim:admin_tier_view",
+    "scope": "apim:admin apim:tier_view",
     "token_type": "Bearer",
     "expires_in": 3600
     }
@@ -144,6 +144,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_view
             - apim:admin_tier_view
             - apim:policies_import_export
       x-code-samples:
@@ -184,6 +185,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_view
             - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
@@ -247,6 +249,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
@@ -300,6 +303,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_view
             - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
@@ -363,6 +367,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
@@ -388,6 +393,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
             - apim:policies_import_export
       x-code-samples:
@@ -428,6 +434,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_view
             - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
@@ -496,6 +503,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
@@ -554,6 +562,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_view
             - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
@@ -622,6 +631,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
@@ -647,6 +657,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
             - apim:policies_import_export
       x-code-samples:
@@ -689,6 +700,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_view
             - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
@@ -754,6 +766,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
@@ -809,6 +822,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_view
             - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
@@ -874,6 +888,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
@@ -902,6 +917,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
             - apim:policies_import_export
       x-code-samples:
@@ -941,6 +957,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_view
             - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
@@ -1004,6 +1021,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
@@ -1057,6 +1075,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_view
             - apim:admin_tier_view
       x-code-samples:
         - lang: Curl
@@ -1120,6 +1139,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
       x-code-samples:
         - lang: Curl
@@ -1145,6 +1165,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
             - apim:policies_import_export
       x-code-samples:
@@ -1232,6 +1253,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
             - apim:policies_import_export
       x-code-samples:
@@ -1285,6 +1307,7 @@ paths:
       security:
         - OAuth2Security:
             - apim:admin
+            - apim:tier_manage
             - apim:admin_tier_manage
             - apim:policies_import_export
       x-code-samples:
@@ -5206,6 +5229,8 @@ components:
             openid: Authorize access to user details
             apim:policies_import_export: Export and import policies related operations
             apim:admin: Manage all admin operations
+            apim:tier_view: View throttling policies
+            apim:tier_manage: Update and delete throttling policies
             apim:admin_tier_view: View throttling policies
             apim:admin_tier_manage: Update and delete throttling policies
             apim:bl_view: View deny policies


### PR DESCRIPTION
This fix includes
- rename throttling policy related scope name in the admin api. Existing `apim:tier_manage` and `apim:tier_view` roles are already used in publisher rest api. Fixing https://github.com/wso2/api-manager/issues/2255
- Fix for https://github.com/wso2/api-manager/issues/2256 