### PR TITLE
add set the property once in the test class ExtendedHTTPEventAdaptorTestCase

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.output.adapter.http/src/test/java/org/wso2/carbon/apimgt/output/adapter/http/ExtendedHTTPEventAdaptorTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.output.adapter.http/src/test/java/org/wso2/carbon/apimgt/output/adapter/http/ExtendedHTTPEventAdaptorTestCase.java
@@ -20,7 +20,7 @@ package org.wso2.carbon.apimgt.output.adapter.http;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.event.output.adapter.core.OutputEventAdapterConfiguration;
@@ -41,8 +41,8 @@ public class ExtendedHTTPEventAdaptorTestCase {
     private static final Log logger = LogFactory.getLog(ExtendedHTTPEventAdaptorTestCase.class);
     private static final Path testDir = Paths.get("src", "test", "resources");
 
-    @Before
-    public void setupCarbonConfig() {
+    @BeforeClass
+    public static void setupCarbonConfig() {
         System.setProperty("carbon.home",
                 Paths.get(testDir.toString(), "carbon-context").toString());
         System.setProperty("tenant.name", "tenant.name");


### PR DESCRIPTION
The test class `ExtendedHTTPEventAdaptorTestCase` tries to set the System Property before every test method runs. There are 6 tests in this test class. However, these tests are not trying to modifying the System properties. Besides, `testDir` is also a static field that is only initialized once in this test class. This `testDir` is also utilized to set properties every time.  These is no need to set the properties repeatedly to increase the test runtime.