### PR TITLE
Fix an API deploy issue when deploying in multiple gateways 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
@@ -92,6 +92,7 @@ public class InMemoryAPIDeployer {
 
         String apiId = gatewayEvent.getUuid();
         Set<String> gatewayLabels = gatewayEvent.getGatewayLabels();
+        gatewayLabels.retainAll(gatewayArtifactSynchronizerProperties.getGatewayLabels());
         try {
             GatewayAPIDTO gatewayAPIDTO = retrieveArtifact(apiId, gatewayLabels);
             if (gatewayAPIDTO != null) {


### PR DESCRIPTION
### Purpose

- Resolves https://github.com/wso2/api-manager/issues/2342

### Implementation

- Filter gateway labels when deploying an API to get the intersection between gateway labels from API deploy event and gateway labels from configurations.
