### PR TITLE
Add null/empty check for the targetStatus in API import flow

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -2314,7 +2314,7 @@ public class ImportUtils {
             throws APIManagementException {
         Map<String, String> lifeCycleActions = new LinkedHashMap<>();
         // No need to change the lifecycle if both the statuses are same
-        if (!StringUtils.equalsIgnoreCase(currentStatus, targetStatus)) {
+        if (!StringUtils.equalsIgnoreCase(currentStatus, targetStatus) && StringUtils.isNotEmpty(targetStatus)) {
             LCManager lcManager = LCManagerFactory.getInstance().getLCManager();
             if (StringUtils.equals(targetStatus, APIStatus.BLOCKED.toString()) || StringUtils.equals(targetStatus,
                     APIStatus.DEPRECATED.toString()) || StringUtils.equals(targetStatus,


### PR DESCRIPTION
This PR adds a null/empty check for the targetStatus in API import flow.

Fixes https://github.com/wso2/api-manager/issues/2423