### PR TITLE
Modify graphQL operation retrieval logic in import schema flow

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/GraphQLSchemaDefinition.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/GraphQLSchemaDefinition.java
@@ -99,6 +99,18 @@ public class GraphQLSchemaDefinition {
     }
 
     /**
+     * Extract GraphQL Operations from given schema.
+     *
+     * @param schema graphQL Schema
+     * @return the arrayList of APIOperationsDTO
+     */
+    public List<URITemplate> extractGraphQLOperationList(String schema) {
+        SchemaParser schemaParser = new SchemaParser();
+        TypeDefinitionRegistry typeRegistry = schemaParser.parse(schema);
+        return extractGraphQLOperationList(typeRegistry, null);
+    }
+
+    /**
      * @param entry          Entry
      * @param operationArray operationArray
      */

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -21,9 +21,6 @@ package org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import graphql.language.FieldDefinition;
-import graphql.language.ObjectTypeDefinition;
-import graphql.language.TypeDefinition;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
@@ -1596,9 +1593,12 @@ public class PublisherCommonUtils {
 
         String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
         int tenantId = APIUtil.getTenantIdFromTenantDomain(tenantDomain);
+        GraphQLSchemaDefinition graphql = new GraphQLSchemaDefinition();
+        List<URITemplate> operationList = graphql.extractGraphQLOperationList(schemaDefinition);
+        List<APIOperationsDTO> operationArray = APIMappingUtil
+                .fromURITemplateListToOprationList(operationList);
         List<APIOperationsDTO> operationListWithOldData = APIMappingUtil
-                .getOperationListWithOldData(originalAPI.getUriTemplates(),
-                        extractGraphQLOperationList(schemaDefinition), tenantId);
+                .getOperationListWithOldData(originalAPI.getUriTemplates(), operationArray, tenantId);
 
         Set<URITemplate> uriTemplates = APIMappingUtil.getURITemplates(originalAPI, operationListWithOldData);
         originalAPI.setUriTemplates(uriTemplates);
@@ -1607,33 +1607,6 @@ public class PublisherCommonUtils {
         apiProvider.updateAPI(originalAPI, oldApi);
 
         return originalAPI;
-    }
-
-    /**
-     * Extract GraphQL Operations from given schema.
-     *
-     * @param schema graphQL Schema
-     * @return the arrayList of APIOperationsDTOextractGraphQLOperationList
-     */
-    public static List<APIOperationsDTO> extractGraphQLOperationList(String schema) {
-
-        List<APIOperationsDTO> operationArray = new ArrayList<>();
-        SchemaParser schemaParser = new SchemaParser();
-        TypeDefinitionRegistry typeRegistry = schemaParser.parse(schema);
-        Map<java.lang.String, TypeDefinition> operationList = typeRegistry.types();
-        for (Map.Entry<String, TypeDefinition> entry : operationList.entrySet()) {
-            if (entry.getValue().getName().equals(APIConstants.GRAPHQL_QUERY) || entry.getValue().getName()
-                    .equals(APIConstants.GRAPHQL_MUTATION) || entry.getValue().getName()
-                    .equals(APIConstants.GRAPHQL_SUBSCRIPTION)) {
-                for (FieldDefinition fieldDef : ((ObjectTypeDefinition) entry.getValue()).getFieldDefinitions()) {
-                    APIOperationsDTO operation = new APIOperationsDTO();
-                    operation.setVerb(entry.getKey());
-                    operation.setTarget(fieldDef.getName());
-                    operationArray.add(operation);
-                }
-            }
-        }
-        return operationArray;
     }
 
     /**


### PR DESCRIPTION
## Purpose
This will modify  graphQL operation retrieval logic in import schema flow(This is already fixed in the API Creation flow). 
After this fix, it is not necessary to define the type as   Query, Mutation or Subscription. User can have own namespace and he should map that inside the schema.


### Fixes
- https://github.com/wso2/api-manager/issues/2424