### PR TITLE
[4.3.0] Upgrade IS and Kernel Versions in carbon-apimgt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2030,7 +2030,7 @@
         <carbon.commons.imp.pkg.version>[4.7.0, 5.0.0)</carbon.commons.imp.pkg.version>
 
         <!-- Carbon platform version comes here-->
-        <carbon.platform.package.import.version.range>[4.7.0, 4.9.0)</carbon.platform.package.import.version.range>
+        <carbon.platform.package.import.version.range>[4.7.0, 4.9.0]</carbon.platform.package.import.version.range>
         <carbon.ntask.import.version.range>[4.6.0, 4.7.0)</carbon.ntask.import.version.range>
 
         <!-- Wsdl4j version comes here-->

--- a/pom.xml
+++ b/pom.xml
@@ -2019,7 +2019,7 @@
 
         <!-- Carbon Identity import version ranges -->
         <carbon.identity.imp.pkg.version>[5.14.0, 6.0.0)</carbon.identity.imp.pkg.version>
-        <carbon.identity.recovery.pkg.version>[1.6.0, 1.8.0)</carbon.identity.recovery.pkg.version>
+        <carbon.identity.recovery.pkg.version>[1.6.0, 1.9.0)</carbon.identity.recovery.pkg.version>
         <carbon.identity-inbound-auth-oauth.imp.pkg.version>[6.0.0, 7.0.0)
         </carbon.identity-inbound-auth-oauth.imp.pkg.version>
         <carbon.identity-user-ws.imp.pkg.version>[5.3.0, 6.0.0)</carbon.identity-user-ws.imp.pkg.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1993,15 +1993,15 @@
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 
         <!-- Carbon Identity versions -->
-        <carbon.identity.version>5.24.10</carbon.identity.version>
-        <carbon.identity.governance.version>1.7.2</carbon.identity.governance.version>
-        <carbon.identity-inbound-auth-oauth.version>6.9.8</carbon.identity-inbound-auth-oauth.version>
-        <carbon.identity-oauth2-grant-jwt.version>2.1.1</carbon.identity-oauth2-grant-jwt.version>
-        <carbon.identity-user-ws.version>5.6.1</carbon.identity-user-ws.version>
-        <carbon.identity-data-publisher-application-authentication.version>5.5.1</carbon.identity-data-publisher-application-authentication.version>
+        <carbon.identity.version>5.25.92</carbon.identity.version>
+        <carbon.identity.governance.version>1.8.14</carbon.identity.governance.version>
+        <carbon.identity-inbound-auth-oauth.version>6.11.21</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-oauth2-grant-jwt.version>2.2.0</carbon.identity-oauth2-grant-jwt.version>
+        <carbon.identity-user-ws.version>5.7.2</carbon.identity-user-ws.version>
+        <carbon.identity-data-publisher-application-authentication.version>5.6.7</carbon.identity-data-publisher-application-authentication.version>
 
         <!--SAML Common Utils Version-->
-        <saml.common.util.version>1.2.1</saml.common.util.version>
+        <saml.common.util.version>1.3.0</saml.common.util.version>
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
 
         <graphql.java.version>19.6.wso2v1</graphql.java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1998,7 +1998,7 @@
         <carbon.identity-inbound-auth-oauth.version>6.11.21</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-oauth2-grant-jwt.version>2.2.0</carbon.identity-oauth2-grant-jwt.version>
         <carbon.identity-user-ws.version>5.7.2</carbon.identity-user-ws.version>
-        <carbon.identity-data-publisher-application-authentication.version>5.6.7</carbon.identity-data-publisher-application-authentication.version>
+        <carbon.identity-data-publisher-application-authentication.version>5.6.6</carbon.identity-data-publisher-application-authentication.version>
 
         <!--SAML Common Utils Version-->
         <saml.common.util.version>1.3.0</saml.common.util.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1981,7 +1981,7 @@
 
         <carbon.analytics.common.version>5.3.5</carbon.analytics.common.version>
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.8.1</carbon.kernel.version>
+        <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
 


### PR DESCRIPTION
- This PR upgrades kernel version to 4.9.0 and IS dependencies to IS 6.1 compatible versions.