### PR TITLE
Upgrade IS components to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2161,7 +2161,7 @@
         <carbon.broker.version>3.3.27</carbon.broker.version>
         <andes.version>3.3.25</andes.version>
         <waffle-jna.version>1.6.wso2v7</waffle-jna.version>
-        <version.snake.yaml>2.0</version.snake.yaml>
+        <version.snake.yaml>1.33</version.snake.yaml>
         <wsdl4j.version>1.6.3.wso2v3</wsdl4j.version>
         <slf4j.test.version>1.7.29</slf4j.test.version>
         <reflection.version>0.9.11</reflection.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1993,15 +1993,15 @@
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 
         <!-- Carbon Identity versions -->
-        <carbon.identity.version>5.25.92</carbon.identity.version>
-        <carbon.identity.governance.version>1.8.14</carbon.identity.governance.version>
-        <carbon.identity-inbound-auth-oauth.version>6.11.21</carbon.identity-inbound-auth-oauth.version>
-        <carbon.identity-oauth2-grant-jwt.version>2.2.0</carbon.identity-oauth2-grant-jwt.version>
-        <carbon.identity-user-ws.version>5.7.2</carbon.identity-user-ws.version>
-        <carbon.identity-data-publisher-application-authentication.version>5.6.6</carbon.identity-data-publisher-application-authentication.version>
+        <carbon.identity.version>5.25.684</carbon.identity.version>
+        <carbon.identity.governance.version>1.8.105</carbon.identity.governance.version>
+        <carbon.identity-inbound-auth-oauth.version>6.13.1</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-oauth2-grant-jwt.version>2.2.3</carbon.identity-oauth2-grant-jwt.version>
+        <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
+        <carbon.identity-data-publisher-application-authentication.version>5.6.8</carbon.identity-data-publisher-application-authentication.version>
 
         <!--SAML Common Utils Version-->
-        <saml.common.util.version>1.3.0</saml.common.util.version>
+        <saml.common.util.version>1.3.1</saml.common.util.version>
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
 
         <graphql.java.version>19.6.wso2v1</graphql.java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2161,7 +2161,7 @@
         <carbon.broker.version>3.3.27</carbon.broker.version>
         <andes.version>3.3.25</andes.version>
         <waffle-jna.version>1.6.wso2v7</waffle-jna.version>
-        <version.snake.yaml>1.33</version.snake.yaml>
+        <version.snake.yaml>2.0</version.snake.yaml>
         <wsdl4j.version>1.6.3.wso2v3</wsdl4j.version>
         <slf4j.test.version>1.7.29</slf4j.test.version>
         <reflection.version>0.9.11</reflection.version>


### PR DESCRIPTION
This PR upgrades IS components to latest versions

snakeyaml version is kept at 1.33 since it will be upgraded by the dependency upgrade team's PR.