### PR TITLE
[4.3.0-kernel-upgrade] Upgrade poi dependency version

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -69,8 +69,12 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.poi.wso2</groupId>
+            <groupId>org.wso2.orbit.org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.poi</groupId>
+            <artifactId>poi-scratchpad</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.wsdl4j</groupId>
@@ -222,6 +226,12 @@
         <dependency>
             <groupId>org.wso2.carbon.governance</groupId>
             <artifactId>org.wso2.carbon.governance.custom.lifecycles.checklist</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.poi.wso2</groupId>
+                    <artifactId>poi-ooxml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
@@ -584,7 +594,7 @@
                             org.wso2.carbon.registry.indexing.*;
                             version="${carbon.registry.package.import.version.range}",
                             org.apache.pdfbox.*; version="${pdfbox.version}",
-                            org.apache.poi.*,
+                            org.apache.poi.*; version="${apache.poi.import.range}";resolution:=optional,
                             org.apache.neethi.*,
                             org.apache.velocity.*,
                             org.apache.solr.common,

--- a/pom.xml
+++ b/pom.xml
@@ -816,8 +816,13 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.poi.wso2</groupId>
+                <groupId>org.wso2.orbit.org.apache.poi</groupId>
                 <artifactId>poi-ooxml</artifactId>
+                <version>${apache.poi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.apache.poi</groupId>
+                <artifactId>poi-scratchpad</artifactId>
                 <version>${apache.poi.version}</version>
             </dependency>
             <dependency>
@@ -936,6 +941,12 @@
                 <groupId>org.wso2.carbon.governance</groupId>
                 <artifactId>org.wso2.carbon.governance.custom.lifecycles.checklist</artifactId>
                 <version>${carbon.governance.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.poi.wso2</groupId>
+                        <artifactId>poi-scratchpad</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -1076,6 +1087,10 @@
                     <exclusion>
                         <groupId>org.apache.hadoop</groupId>
                         <artifactId>hadoop-common</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.poi.wso2</groupId>
+                        <artifactId>poi-scratchpad</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -2112,7 +2127,8 @@
 
         <json-simple.wso2.version>1.1.1</json-simple.wso2.version>
         <apache.woden.version>1.0.0.M9-wso2v1</apache.woden.version>
-        <apache.poi.version>3.9.0.wso2v3</apache.poi.version>
+        <apache.poi.version>4.1.2.wso2v1</apache.poi.version>
+        <apache.poi.import.range>[3.0, 5.0)</apache.poi.import.range>
         <rhino.js.version>1.7.0.R4.wso2v1</rhino.js.version>
         <owasp.encoder.version>1.2.2</owasp.encoder.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2128,7 +2128,7 @@
         <json-simple.wso2.version>1.1.1</json-simple.wso2.version>
         <apache.woden.version>1.0.0.M9-wso2v1</apache.woden.version>
         <apache.poi.version>4.1.2.wso2v1</apache.poi.version>
-        <apache.poi.import.range>[3.0, 5.0)</apache.poi.import.range>
+        <apache.poi.import.range>[3.0, 4.9)</apache.poi.import.range>
         <rhino.js.version>1.7.0.R4.wso2v1</rhino.js.version>
         <owasp.encoder.version>1.2.2</owasp.encoder.version>
 


### PR DESCRIPTION
### Purpose
Upgrade the poi dependency version to `4.1.2.wso2v1` to fix build issues with product build with the xmlsec version bump.