### PR TITLE
json smart and json path bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1993,9 +1993,9 @@
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 
         <!-- Carbon Identity versions -->
-        <carbon.identity.version>5.24.8</carbon.identity.version>
+        <carbon.identity.version>5.25.687</carbon.identity.version>
         <carbon.identity.governance.version>1.7.2</carbon.identity.governance.version>
-        <carbon.identity-inbound-auth-oauth.version>6.9.7</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version>6.13.3</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-oauth2-grant-jwt.version>2.1.1</carbon.identity-oauth2-grant-jwt.version>
         <carbon.identity-user-ws.version>5.6.1</carbon.identity-user-ws.version>
         <carbon.identity-data-publisher-application-authentication.version>5.5.1</carbon.identity-data-publisher-application-authentication.version>
@@ -2068,7 +2068,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>4.0.0-wso2v50</synapse.version>
+        <synapse.version>4.0.0-wso2v80</synapse.version>
 
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 
@@ -2106,7 +2106,7 @@
         <httpcomponents.version>4.5.10</httpcomponents.version>
         <commons-codec.version>1.14</commons-codec.version>
         <com.nimbusds.wso2.version>7.9.0.wso2v1</com.nimbusds.wso2.version>
-        <json-smart.version>2.4.11</json-smart.version>
+        <json-smart.version>2.5.0</json-smart.version>
         <org.apache.velocity.version>2.3</org.apache.velocity.version>
         <org.slf4j.version>1.7.0</org.slf4j.version>
         <slf4j.api.version>1.7.29</slf4j.api.version>
@@ -2204,7 +2204,7 @@
         <json.orbit.version>3.0.0.wso2v1</json.orbit.version>
         <aspectj.version>1.9.4</aspectj.version>
         <wso2.securevault.version>1.1.3</wso2.securevault.version>
-        <com.jayway.jsonpath.version>2.6.0.wso2v2</com.jayway.jsonpath.version>
+        <com.jayway.jsonpath.version>2.9.0.wso2v1</com.jayway.jsonpath.version>
         <org.wso2.orbit.commons-text.version>1.6.wso2v1</org.wso2.orbit.commons-text.version>
         <commons.lang.version>2.6.0.wso2v1</commons.lang.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>


### PR DESCRIPTION
Purpose
Bump json-smart, json-path and related repositories,

- json-smart : 2.5.0
- jsonpath : 2.9.0.wso2v1
- carbon.identity.framework : 5.25.687
- identity-inbound-auth-oauth : 6.13.3
- synapse :  4.0.0-wso2v80
