### PR TITLE
Fix the issue of Publishing APIs via Service Catalog with Basic Authentication

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
@@ -657,6 +657,12 @@ public class ApisApiServiceImplUtils {
             apiToAdd.setServiceInfo("md5", service.getMd5());
             apiToAdd.setEndpointConfig(constructEndpointConfigForService(service
                     .getServiceUrl(), null));
+            if (APIConstants.SWAGGER_API_SECURITY_BASIC_AUTH_TYPE.equalsIgnoreCase(
+                    service.getSecurityType().toString())) {
+                apiToAdd.setApiSecurity(APIConstants.API_SECURITY_BASIC_AUTH);
+            } else {
+                apiToAdd.setApiSecurity(service.getSecurityType().toString());
+            }
         }
         APIDefinition apiDefinition = validationResponse.getParser();
         SwaggerData swaggerData;


### PR DESCRIPTION
When using Service Catalog to push Integration Services from Micro Integrator, although the securityType is set as "BASIC", it is getting changed to "OAuth2" after creating an API. With this PR it will fix this issue.

Resolves: https://github.com/wso2/api-manager/issues/2457