### PR TITLE
Add certificate chain validation to MutualSSLAuthenticator handler

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
@@ -433,6 +433,12 @@ public class Utils {
         return (certs != null && certs.length > 0) ? certs[0] : null;
     }
 
+    /**
+     * Fetches client certificate chain from axis2MessageContext.
+     * @param axis2MessageContext   Relevant axis2MessageContext
+     * @return                      Array containing client certificate chain
+     * @throws APIManagementException
+     */
     public static Certificate[] getClientCertificatesChain(
             org.apache.axis2.context.MessageContext axis2MessageContext) throws APIManagementException {
 
@@ -515,6 +521,10 @@ public class Utils {
         return false;
     }
 
+    /**
+     * Checks whether certificate chain validation is enabled or not from API-M configurations.
+     * @return Boolean indicating certificate chain validation enable/disable state
+     */
     public static boolean isCertificateChainValidationEnabled() {
 
         APIManagerConfiguration apiManagerConfiguration =
@@ -542,6 +552,30 @@ public class Utils {
             }
         }
         return true;
+    }
+
+
+    /**
+     * Fetches certificate for the given distinguished name from listener trust store.
+     * @param certSubjectDN             Distinguished name of the certificate
+     * @return                          X509Certificate
+     * @throws APIManagementException
+     */
+    public static X509Certificate getCertificateFromListenerTrustStore(String certSubjectDN)
+            throws APIManagementException {
+
+        Enumeration<String> aliases = APIUtil.getAliasesFromListenerTrustStore();
+        while (aliases.hasMoreElements()) {
+            String alias = aliases.nextElement();
+            Certificate certificate = APIUtil.getCertificateFromListenerTrustStore(alias);
+            if (certificate instanceof X509Certificate) {
+                X509Certificate x509Certificate = (X509Certificate) certificate;
+                if (StringUtils.equals(x509Certificate.getSubjectDN().getName(), certSubjectDN)) {
+                    return x509Certificate;
+                }
+            }
+        }
+        return null;
     }
 
     /**
@@ -725,6 +759,11 @@ public class Utils {
         return null;
     }
 
+    /**
+     * Convert Certificate array to X509Certificate list.
+     * @param certificates  Certificate array that should be converted
+     * @return              X509Certificate list
+     */
     public static List<X509Certificate> convertCertificatesToX509Certificates(Certificate[] certificates) {
 
         List<X509Certificate> x509Certificates = new ArrayList<>();

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
@@ -60,6 +60,7 @@ import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.caching.CacheProvider;
 import org.wso2.carbon.apimgt.impl.dto.APIKeyValidationInfoDTO;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.impl.utils.GatewayCertificateMgtUtil;
 import org.wso2.carbon.apimgt.keymgt.SubscriptionDataHolder;
 import org.wso2.carbon.apimgt.keymgt.model.SubscriptionDataStore;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -564,10 +565,10 @@ public class Utils {
     public static X509Certificate getCertificateFromListenerTrustStore(String certSubjectDN)
             throws APIManagementException {
 
-        Enumeration<String> aliases = APIUtil.getAliasesFromListenerTrustStore();
+        Enumeration<String> aliases = GatewayCertificateMgtUtil.getAliasesFromListenerTrustStore();
         while (aliases.hasMoreElements()) {
             String alias = aliases.nextElement();
-            Certificate certificate = APIUtil.getCertificateFromListenerTrustStore(alias);
+            Certificate certificate = GatewayCertificateMgtUtil.getCertificateFromListenerTrustStore(alias);
             if (certificate instanceof X509Certificate) {
                 X509Certificate x509Certificate = (X509Certificate) certificate;
                 if (StringUtils.equals(x509Certificate.getSubjectDN().getName(), certSubjectDN)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/MutualSSLAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/MutualSSLAuthenticator.java
@@ -207,7 +207,7 @@ public class MutualSSLAuthenticator implements Authenticator {
             subjectDNIdentifiers.add(subjectDNIdentifier);
             for (Map.Entry<String, String> entry : certificates.entrySet()) {
                 String key = entry.getKey();
-                if (key.contains(subjectDNIdentifier)) {
+                if (StringUtils.equals(subjectDNIdentifier, key)) {
                     uniqueIdentifier = key;
                     tier = entry.getValue();
                     break;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2519,6 +2519,8 @@ public final class APIConstants {
         public static final String CLIENT_CERTIFICATE_ENCODE = MUTUAL_SSL_CONFIG_ROOT + ".ClientCertificateEncode";
         public static final String ENABLE_CLIENT_CERTIFICATE_VALIDATION = MUTUAL_SSL_CONFIG_ROOT +
                 ".EnableClientCertificateValidation";
+        public static final String ENABLE_CERTIFICATE_CHAIN_VALIDATION = MUTUAL_SSL_CONFIG_ROOT +
+                ".EnableCertificateChainValidation";
     }
 
     public static final String DEFAULT_SCOPE_TYPE = "OAUTH2";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8331,6 +8331,30 @@ public final class APIUtil {
     }
 
     /**
+     * Fetches certificate for given certificate alias from listener trust store.
+     * @param certAlias                 Certificate alias
+     * @return                          Certificate
+     * @throws APIManagementException
+     */
+    public static Certificate getCertificateFromListenerTrustStore(String certAlias) throws APIManagementException {
+
+        Certificate publicCert = null;
+        try {
+            KeyStore trustStore = ServiceReferenceHolder.getInstance().getListenerTrustStore();
+            if (trustStore != null) {
+                // Read public certificate from trust store
+                publicCert = trustStore.getCertificate(certAlias);
+            }
+        } catch (KeyStoreException e) {
+            String msg = "Error while retrieving public certificate with alias : "
+                    + certAlias;
+            log.error(msg, e);
+            throw new APIManagementException(msg, e);
+        }
+        return publicCert;
+    }
+
+    /**
      * Verify the JWT token signature.
      * <p>
      * This method only used for API Key revocation which contains some duplicate logic in GatewayUtils class.
@@ -8759,6 +8783,26 @@ public final class APIUtil {
             }
         }
         return false;
+    }
+
+    /**
+     * Fetches all the trusted certificate aliases from listener trust store.
+     * @return                          Trusted certificate aliases
+     * @throws APIManagementException
+     */
+    public static Enumeration<String> getAliasesFromListenerTrustStore() throws APIManagementException {
+
+        try {
+            KeyStore trustStore = ServiceReferenceHolder.getInstance().getListenerTrustStore();
+            if (trustStore != null) {
+                return trustStore.aliases();
+            }
+        } catch (KeyStoreException e) {
+            String msg = "Error getting certificate aliases from trust store";
+            log.error(msg, e);
+            throw new APIManagementException(msg, e);
+        }
+        return null;
     }
 
     public static boolean isDevPortalAnonymous() {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8331,30 +8331,6 @@ public final class APIUtil {
     }
 
     /**
-     * Fetches certificate for given certificate alias from listener trust store.
-     * @param certAlias                 Certificate alias
-     * @return                          Certificate
-     * @throws APIManagementException
-     */
-    public static Certificate getCertificateFromListenerTrustStore(String certAlias) throws APIManagementException {
-
-        Certificate publicCert = null;
-        try {
-            KeyStore trustStore = ServiceReferenceHolder.getInstance().getListenerTrustStore();
-            if (trustStore != null) {
-                // Read public certificate from trust store
-                publicCert = trustStore.getCertificate(certAlias);
-            }
-        } catch (KeyStoreException e) {
-            String msg = "Error while retrieving public certificate with alias : "
-                    + certAlias;
-            log.error(msg, e);
-            throw new APIManagementException(msg, e);
-        }
-        return publicCert;
-    }
-
-    /**
      * Verify the JWT token signature.
      * <p>
      * This method only used for API Key revocation which contains some duplicate logic in GatewayUtils class.
@@ -8783,26 +8759,6 @@ public final class APIUtil {
             }
         }
         return false;
-    }
-
-    /**
-     * Fetches all the trusted certificate aliases from listener trust store.
-     * @return                          Trusted certificate aliases
-     * @throws APIManagementException
-     */
-    public static Enumeration<String> getAliasesFromListenerTrustStore() throws APIManagementException {
-
-        try {
-            KeyStore trustStore = ServiceReferenceHolder.getInstance().getListenerTrustStore();
-            if (trustStore != null) {
-                return trustStore.aliases();
-            }
-        } catch (KeyStoreException e) {
-            String msg = "Error getting certificate aliases from trust store";
-            log.error(msg, e);
-            throw new APIManagementException(msg, e);
-        }
-        return null;
     }
 
     public static boolean isDevPortalAnonymous() {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/CertificateMgtUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/CertificateMgtUtils.java
@@ -616,7 +616,7 @@ public class CertificateMgtUtils {
             while (serverCert.available() > 0) {
                 Certificate generatedCertificate = cf.generateCertificate(serverCert);
                 X509Certificate x509Certificate = (X509Certificate) generatedCertificate;
-                uniqueIdentifier = x509Certificate.getSerialNumber() + "_" + x509Certificate.getIssuerDN();
+                uniqueIdentifier = x509Certificate.getSerialNumber() + "_" + x509Certificate.getSubjectDN();
                 uniqueIdentifier = uniqueIdentifier.replaceAll(",", "#").replaceAll("\"", "'");
             }
         } catch (CertificateException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayCertificateMgtUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayCertificateMgtUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.utils;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.Certificate;
+import java.util.Enumeration;
+
+public class GatewayCertificateMgtUtil {
+
+    private static final Log log = LogFactory.getLog(GatewayCertificateMgtUtil.class);
+
+    /**
+     * Fetches all the trusted certificate aliases from listener trust store.
+     *
+     * @return Trusted certificate aliases
+     * @throws APIManagementException
+     */
+    public static Enumeration<String> getAliasesFromListenerTrustStore() throws APIManagementException {
+
+        try {
+            KeyStore trustStore = ServiceReferenceHolder.getInstance().getListenerTrustStore();
+            if (trustStore != null) {
+                return trustStore.aliases();
+            }
+        } catch (KeyStoreException e) {
+            String msg = "Error getting certificate aliases from trust store";
+            log.error(msg, e);
+            throw new APIManagementException(msg, e);
+        }
+        return null;
+    }
+
+    /**
+     * Fetches certificate for given certificate alias from listener trust store.
+     *
+     * @param certAlias Certificate alias
+     * @return Certificate
+     * @throws APIManagementException
+     */
+    public static Certificate getCertificateFromListenerTrustStore(String certAlias) throws APIManagementException {
+
+        Certificate publicCert = null;
+        try {
+            KeyStore trustStore = ServiceReferenceHolder.getInstance().getListenerTrustStore();
+            if (trustStore != null) {
+                // Read public certificate from trust store
+                publicCert = trustStore.getCertificate(certAlias);
+            }
+        } catch (KeyStoreException e) {
+            String msg = "Error while retrieving public certificate with alias : " + certAlias;
+            log.error(msg, e);
+            throw new APIManagementException(msg, e);
+        }
+        return publicCert;
+    }
+}

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1357,6 +1357,9 @@
      <MutualSSL>
         <ClientCertificateHeader>{{apimgt.mutual_ssl.certificate_header}}</ClientCertificateHeader>
         <EnableClientCertificateValidation>{{apimgt.mutual_ssl.enable_client_validation}}</EnableClientCertificateValidation>
+        {% if apimgt.mutual_ssl.enable_certificate_chain_validation is defined %}
+        <EnableCertificateChainValidation>{{apimgt.mutual_ssl.enable_certificate_chain_validation}}</EnableCertificateChainValidation>
+        {% endif %}
         {% if apimgt.mutual_ssl.client_certificate_encode is defined %}
         <ClientCertificateEncode>{{apimgt.mutual_ssl.client_certificate_encode}}</ClientCertificateEncode>
         {% endif %}


### PR DESCRIPTION
### Purpose

- Resolves https://github.com/wso2/api-manager/issues/873

### Description

- In the current implementation of `MutualSSLAuthenticator` handler client certificate should exist in the truststore to a successful validation
- This PR introduces certificate chain validation to resolve the above limitation
- Following configuration is introduced to the `deployment.toml` to enable certificate chain validation

```
[apimgt.mutual_ssl]
enable_certificate_chain_validation = true
```