### PR TITLE
Add userIP to faulty event

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/FaultyRequestDataCollector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/FaultyRequestDataCollector.java
@@ -84,12 +84,17 @@ public class FaultyRequestDataCollector extends CommonRequestDataCollector imple
         Target target = new Target();
         target.setTargetResponseCode(Constants.UNKNOWN_INT_VALUE);
         MetaInfo metaInfo = provider.getMetaInfo();
+        String userIp = provider.getEndUserIP();
+        if (userIp == null) {
+            userIp = Constants.UNKNOWN_VALUE;
+        }
 
         event.setApi(api);
         event.setTarget(target);
         event.setProxyResponseCode(provider.getProxyResponseCode());
         event.setRequestTimestamp(offsetDateTime);
         event.setMetaInfo(metaInfo);
+        event.setUserIp(userIp);
 
         return event;
     }


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/2504

When a request is failed due to a reason such as authentication failure, we do not log the user IP (X-forwarded header). With this PR the userIP is also added to faulty event response.

Without the fix
```
INFO ELKCounterMetric apimMetrics: apim:faulty, properties :{"apiName":"PizzaShackAPI","requestTimestamp":"2024-02-22T04:06:48.593Z","proxyResponseCode":401,"errorType":"AUTH","applicationOwner":"UNKNOWN","errorMessage":"AUTHENTICATION_FAILURE","errorCode":900902,"apiCreatorTenantDomain":"carbon.super","apiVersion":"1.0.0","gatewayType":"SYNAPSE","apiCreator":"admin","responseCacheHit":false,"regionId":"default","correlationId":"69f0ca19-3e38-4b5c-8da5-81bb4fa2a485","keyType":"UNKNOWN","applicationId":"UNKNOWN","apiId":"135cd373-56bd-4d50-952f-207bc4833fbf","apiType":"HTTP","applicationName":"UNKNOWN","targetResponseCode":-1}
```

With the fix
```
INFO ELKCounterMetric apimMetrics: apim:faulty, properties :{"apiName":"PizzaShackAPI","requestTimestamp":"2024-02-22T04:14:58.433Z","proxyResponseCode":401,"errorType":"AUTH","applicationOwner":"UNKNOWN","errorMessage":"AUTHENTICATION_FAILURE","errorCode":900902,"apiCreatorTenantDomain":"carbon.super","apiVersion":"1.0.0","gatewayType":"SYNAPSE","apiCreator":"admin","responseCacheHit":false,"regionId":"default","userIp":"127.0.0.1","correlationId":"aedea4be-0c18-4ae1-820d-ef08ce35cb7a","keyType":"UNKNOWN","applicationId":"UNKNOWN","apiId":"135cd373-56bd-4d50-952f-207bc4833fbf","apiType":"HTTP","applicationName":"UNKNOWN","properties":{},"targetResponseCode":-1}
```