### PR TITLE
Add JWT as default token for portals

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2146,8 +2146,8 @@ public final class APIConstants {
         public static final String TOKEN_TYPE = "token_type";
         public static final String API_KEY_TOKEN_TYPE = "apiKey";
         public static final String DECODING_ALGORITHM_BASE64URL = "base64url";
-        public static final String APP_DOMAIN = "app_domain";
-        public static final String USER_DOMAIN = "user_domain";
+        public static final String APP_DOMAIN = "app_td";
+        public static final String USER_DOMAIN = "user_td";
     }
 
     public static final String SIGNATURE_ALGORITHM_RS256 = "RS256";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1483,6 +1483,7 @@ public final class APIConstants {
     public static final String API_STORE_GROUP_EXTRACTOR_IMPLEMENTATION = API_STORE + "GroupingExtractor";
     public static final String API_STORE_REST_API_GROUP_EXTRACTOR_IMPLEMENTATION =
             API_STORE + "RESTApiGroupingExtractor";
+    public static final String IS_ENABLE_JWT_FOR_PORTALS = OAUTH_CONFIGS + "EnableJWTForPortals";
     public static final String API_CUSTOM_SEQUENCES_FOLDER_LOCATION =
             "repository" + File.separator + "resources" + File.separator + "customsequences";
     public static final String WORKFLOW_EXTENSION_LOCATION =

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2145,6 +2145,8 @@ public final class APIConstants {
         public static final String TOKEN_TYPE = "token_type";
         public static final String API_KEY_TOKEN_TYPE = "apiKey";
         public static final String DECODING_ALGORITHM_BASE64URL = "base64url";
+        public static final String APP_DOMAIN = "app_domain";
+        public static final String USER_DOMAIN = "user_domain";
     }
 
     public static final String SIGNATURE_ALGORITHM_RS256 = "RS256";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -7053,6 +7053,24 @@ public final class APIUtil {
     }
 
     /**
+     * Enable jwt for portal logins
+     *
+     * @return boolean value of the config
+     */
+    public static boolean isJWTEnabledForPortals() {
+
+        APIManagerConfiguration config = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                .getAPIManagerConfiguration();
+
+        String isEnabledJwtForPortals = config.getFirstProperty(APIConstants.IS_ENABLE_JWT_FOR_PORTALS);
+        if (isEnabledJwtForPortals != null) {
+            return Boolean.valueOf(isEnabledJwtForPortals);
+        }
+
+        return false;
+
+    }
+    /**
      * Used to check whether Provisioning Out-of-Band OAuth Clients feature is enabled
      *
      * @return true if feature is enabled

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsDTO.java
@@ -25,6 +25,7 @@ public class SettingsDTO   {
   
     private List<String> scopes = new ArrayList<String>();
     private List<String> gatewayTypes = new ArrayList<String>();
+    private Boolean isJWTEnabledForLoginTokens = false;
     private List<SettingsKeyManagerConfigurationDTO> keyManagerConfiguration = new ArrayList<SettingsKeyManagerConfigurationDTO>();
     private Boolean analyticsEnabled = null;
 
@@ -60,6 +61,23 @@ public class SettingsDTO   {
   }
   public void setGatewayTypes(List<String> gatewayTypes) {
     this.gatewayTypes = gatewayTypes;
+  }
+
+  /**
+   **/
+  public SettingsDTO isJWTEnabledForLoginTokens(Boolean isJWTEnabledForLoginTokens) {
+    this.isJWTEnabledForLoginTokens = isJWTEnabledForLoginTokens;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("IsJWTEnabledForLoginTokens")
+  public Boolean isIsJWTEnabledForLoginTokens() {
+    return isJWTEnabledForLoginTokens;
+  }
+  public void setIsJWTEnabledForLoginTokens(Boolean isJWTEnabledForLoginTokens) {
+    this.isJWTEnabledForLoginTokens = isJWTEnabledForLoginTokens;
   }
 
   /**
@@ -110,13 +128,14 @@ public class SettingsDTO   {
     SettingsDTO settings = (SettingsDTO) o;
     return Objects.equals(scopes, settings.scopes) &&
         Objects.equals(gatewayTypes, settings.gatewayTypes) &&
+        Objects.equals(isJWTEnabledForLoginTokens, settings.isJWTEnabledForLoginTokens) &&
         Objects.equals(keyManagerConfiguration, settings.keyManagerConfiguration) &&
         Objects.equals(analyticsEnabled, settings.analyticsEnabled);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(scopes, gatewayTypes, keyManagerConfiguration, analyticsEnabled);
+    return Objects.hash(scopes, gatewayTypes, isJWTEnabledForLoginTokens, keyManagerConfiguration, analyticsEnabled);
   }
 
   @Override
@@ -126,6 +145,7 @@ public class SettingsDTO   {
     
     sb.append("    scopes: ").append(toIndentedString(scopes)).append("\n");
     sb.append("    gatewayTypes: ").append(toIndentedString(gatewayTypes)).append("\n");
+    sb.append("    isJWTEnabledForLoginTokens: ").append(toIndentedString(isJWTEnabledForLoginTokens)).append("\n");
     sb.append("    keyManagerConfiguration: ").append(toIndentedString(keyManagerConfiguration)).append("\n");
     sb.append("    analyticsEnabled: ").append(toIndentedString(analyticsEnabled)).append("\n");
     sb.append("}");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
@@ -61,6 +61,7 @@ public class SettingsMappingUtil {
         }
         settingsDTO.setScopes(getScopeList());
         settingsDTO.setGatewayTypes(APIUtil.getGatewayTypes());
+        settingsDTO.setIsJWTEnabledForLoginTokens(APIUtil.isJWTEnabledForPortals());
         return settingsDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -4594,6 +4594,9 @@ components:
           type: array
           items:
             type: string
+        IsJWTEnabledForLoginTokens: 
+          type: boolean
+          default: false
         keyManagerConfiguration:
           type: array
           items:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
@@ -4594,6 +4594,9 @@ components:
           type: array
           items:
             type: string
+        IsJWTEnabledForLoginTokens: 
+          type: boolean
+          default: false
         keyManagerConfiguration:
           type: array
           items:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
@@ -5290,6 +5290,9 @@ components:
         IsPasswordChangeEnabled:
           type: boolean
           default: true
+        IsJWTEnabledForLoginTokens: 
+          type: boolean
+          default: false
         userStorePasswordPattern:
           type: string
           description: The 'PasswordJavaRegEx' cofigured in the UserStoreManager

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
@@ -11915,6 +11915,9 @@ components:
           type: string
           description: Authorization Header
           example: authorization
+        IsJWTEnabledForLoginTokens: 
+          type: boolean
+          default: false
         customProperties:
           type: array
           items:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/java/org/wso2/carbon/apimgt/rest/api/dcr/web/dto/RegistrationProfile.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/java/org/wso2/carbon/apimgt/rest/api/dcr/web/dto/RegistrationProfile.java
@@ -43,6 +43,7 @@ public class RegistrationProfile {
     private boolean saasApp;
     private String audience;
     private String tokenType;
+    private boolean userstoreDomainInSubject;
 
     public String getRecepientValidationURL() {
         return recepientValidationURL;
@@ -213,6 +214,14 @@ public class RegistrationProfile {
 
     public void setTokenType(String tokenType) {
         this.tokenType = tokenType;
+    }
+
+    public boolean isUserStoreDomainInSubject() {
+        return userstoreDomainInSubject;
+    }
+
+    public void setUserStoreDomainInSubject(boolean setUserStoreDomainInSubject) {
+        this.userstoreDomainInSubject = setUserStoreDomainInSubject;
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/java/org/wso2/carbon/apimgt/rest/api/dcr/web/impl/RegistrationServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/java/org/wso2/carbon/apimgt/rest/api/dcr/web/impl/RegistrationServiceImpl.java
@@ -189,7 +189,8 @@ public class RegistrationServiceImpl implements RegistrationService {
                     returnedAPP = this.getExistingApp(applicationName, appServiceProvider.isSaasApp());
                 } else {
                     //create a new application if the application doesn't exists.
-                    returnedAPP = this.createApplication(applicationName, appRequest, grantTypes);
+                    returnedAPP = this.createApplication(applicationName, appRequest, grantTypes,
+                            profile.isUserStoreDomainInSubject());
                 }
                 //ReturnedAPP is null
                 if (returnedAPP == null) {
@@ -278,8 +279,8 @@ public class RegistrationServiceImpl implements RegistrationService {
      * @return created Application
      * @throws APIManagementException if failed to create the new application
      */
-    private OAuthApplicationInfo createApplication(String applicationName, OAuthAppRequest appRequest,
-                                                   String grantType) throws APIManagementException {
+    private OAuthApplicationInfo createApplication(String applicationName, OAuthAppRequest appRequest, String grantType,
+            boolean setUserStoreDomainInSubject) throws APIManagementException {
         String userName;
         OAuthApplicationInfo applicationInfo = appRequest.getOAuthApplicationInfo();
         String appName = applicationInfo.getClientName();
@@ -325,6 +326,12 @@ public class RegistrationServiceImpl implements RegistrationService {
             logoutConsentProperty.setName(APIConstants.APP_SKIP_LOGOUT_CONSENT_NAME);
             logoutConsentProperty.setValue(APIConstants.APP_SKIP_LOGOUT_CONSENT_VALUE);
             serviceProviderProperties.add(logoutConsentProperty);
+            
+            if (setUserStoreDomainInSubject) {
+                LocalAndOutboundAuthenticationConfig localAndOutboundConfig = new LocalAndOutboundAuthenticationConfig();
+                localAndOutboundConfig.setUseUserstoreDomainInLocalSubjectIdentifier(true);
+                serviceProvider.setLocalAndOutBoundAuthenticationConfig(localAndOutboundConfig);
+            }
 
             String orgId = null;
             try {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/java/org/wso2/carbon/apimgt/rest/api/dcr/web/impl/RegistrationServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/java/org/wso2/carbon/apimgt/rest/api/dcr/web/impl/RegistrationServiceImpl.java
@@ -326,14 +326,6 @@ public class RegistrationServiceImpl implements RegistrationService {
             logoutConsentProperty.setValue(APIConstants.APP_SKIP_LOGOUT_CONSENT_VALUE);
             serviceProviderProperties.add(logoutConsentProperty);
 
-            if (APIConstants.JWT.equals(applicationInfo.getTokenType())) {
-                LocalAndOutboundAuthenticationConfig localAndOutboundConfig =
-                        new LocalAndOutboundAuthenticationConfig();
-                localAndOutboundConfig.setSkipConsent(true);
-                localAndOutboundConfig.setSkipLogoutConsent(true);
-                localAndOutboundConfig.setUseTenantDomainInLocalSubjectIdentifier(true);
-                serviceProvider.setLocalAndOutBoundAuthenticationConfig(localAndOutboundConfig);
-            }
             String orgId = null;
             try {
                 orgId = RestApiUtil.getValidatedOrganization(securityContext);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/java/org/wso2/carbon/apimgt/rest/api/dcr/web/impl/RegistrationServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/java/org/wso2/carbon/apimgt/rest/api/dcr/web/impl/RegistrationServiceImpl.java
@@ -329,6 +329,8 @@ public class RegistrationServiceImpl implements RegistrationService {
             
             if (setUserStoreDomainInSubject) {
                 LocalAndOutboundAuthenticationConfig localAndOutboundConfig = new LocalAndOutboundAuthenticationConfig();
+                localAndOutboundConfig.setSkipConsent(true); // to prevent overriding
+                localAndOutboundConfig.setSkipLogoutConsent(true); // to prevent overriding
                 localAndOutboundConfig.setUseUserstoreDomainInLocalSubjectIdentifier(true);
                 serviceProvider.setLocalAndOutBoundAuthenticationConfig(localAndOutboundConfig);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/resources/dcr.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/src/main/resources/dcr.yaml
@@ -94,6 +94,10 @@ components:
           type: string
           readOnly: true
           example: JWT
+        userstoreDomainInSubject:
+          type: string
+          readOnly: true
+          example: true
     DCRResult:
       title: DCRResult
       type: object

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/SettingsDTO.java
@@ -39,6 +39,7 @@ public class SettingsDTO   {
     private String defaultAdvancePolicy = null;
     private String defaultSubscriptionPolicy = null;
     private String authorizationHeader = null;
+    private Boolean isJWTEnabledForLoginTokens = false;
     private List<SettingsCustomPropertiesDTO> customProperties = new ArrayList<SettingsCustomPropertiesDTO>();
 
   /**
@@ -275,6 +276,23 @@ public class SettingsDTO   {
 
   /**
    **/
+  public SettingsDTO isJWTEnabledForLoginTokens(Boolean isJWTEnabledForLoginTokens) {
+    this.isJWTEnabledForLoginTokens = isJWTEnabledForLoginTokens;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("IsJWTEnabledForLoginTokens")
+  public Boolean isIsJWTEnabledForLoginTokens() {
+    return isJWTEnabledForLoginTokens;
+  }
+  public void setIsJWTEnabledForLoginTokens(Boolean isJWTEnabledForLoginTokens) {
+    this.isJWTEnabledForLoginTokens = isJWTEnabledForLoginTokens;
+  }
+
+  /**
+   **/
   public SettingsDTO customProperties(List<SettingsCustomPropertiesDTO> customProperties) {
     this.customProperties = customProperties;
     return this;
@@ -314,12 +332,13 @@ public class SettingsDTO   {
         Objects.equals(defaultAdvancePolicy, settings.defaultAdvancePolicy) &&
         Objects.equals(defaultSubscriptionPolicy, settings.defaultSubscriptionPolicy) &&
         Objects.equals(authorizationHeader, settings.authorizationHeader) &&
+        Objects.equals(isJWTEnabledForLoginTokens, settings.isJWTEnabledForLoginTokens) &&
         Objects.equals(customProperties, settings.customProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(devportalUrl, environment, gatewayTypes, scopes, monetizationAttributes, subscriberContactAttributes, securityAuditProperties, externalStoresEnabled, docVisibilityEnabled, crossTenantSubscriptionEnabled, defaultAdvancePolicy, defaultSubscriptionPolicy, authorizationHeader, customProperties);
+    return Objects.hash(devportalUrl, environment, gatewayTypes, scopes, monetizationAttributes, subscriberContactAttributes, securityAuditProperties, externalStoresEnabled, docVisibilityEnabled, crossTenantSubscriptionEnabled, defaultAdvancePolicy, defaultSubscriptionPolicy, authorizationHeader, isJWTEnabledForLoginTokens, customProperties);
   }
 
   @Override
@@ -340,6 +359,7 @@ public class SettingsDTO   {
     sb.append("    defaultAdvancePolicy: ").append(toIndentedString(defaultAdvancePolicy)).append("\n");
     sb.append("    defaultSubscriptionPolicy: ").append(toIndentedString(defaultSubscriptionPolicy)).append("\n");
     sb.append("    authorizationHeader: ").append(toIndentedString(authorizationHeader)).append("\n");
+    sb.append("    isJWTEnabledForLoginTokens: ").append(toIndentedString(isJWTEnabledForLoginTokens)).append("\n");
     sb.append("    customProperties: ").append(toIndentedString(customProperties)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/SettingsMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/SettingsMappingUtil.java
@@ -87,6 +87,7 @@ public class SettingsMappingUtil {
                     APIUtil.isExternalStoresEnabled(RestApiCommonUtil.getLoggedInUserTenantDomain()));
             settingsDTO.setDocVisibilityEnabled(APIUtil.isDocVisibilityLevelsEnabled());
             settingsDTO.setCrossTenantSubscriptionEnabled(APIUtil.isCrossTenantSubscriptionsEnabled());
+            settingsDTO.setIsJWTEnabledForLoginTokens(APIUtil.isJWTEnabledForPortals());
             Map<String, Environment> gatewayEnvironments = APIUtil.getReadOnlyGatewayEnvironments();
             String authorizationHeader = APIUtil.getOAuthConfiguration(loggedInUserTenantDomain,
                     APIConstants.AUTHORIZATION_HEADER);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -11915,6 +11915,9 @@ components:
           type: string
           description: Authorization Header
           example: authorization
+        IsJWTEnabledForLoginTokens: 
+          type: boolean
+          default: false
         customProperties:
           type: array
           items:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/SettingsDTO.java
@@ -34,6 +34,7 @@ public class SettingsDTO   {
     private SettingsIdentityProviderDTO identityProvider = null;
     private Boolean isAnonymousModeEnabled = true;
     private Boolean isPasswordChangeEnabled = true;
+    private Boolean isJWTEnabledForLoginTokens = false;
     private String userStorePasswordPattern = null;
     private String passwordPolicyPattern = null;
     private Integer passwordPolicyMinLength = null;
@@ -228,6 +229,23 @@ public class SettingsDTO   {
   }
 
   /**
+   **/
+  public SettingsDTO isJWTEnabledForLoginTokens(Boolean isJWTEnabledForLoginTokens) {
+    this.isJWTEnabledForLoginTokens = isJWTEnabledForLoginTokens;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("IsJWTEnabledForLoginTokens")
+  public Boolean isIsJWTEnabledForLoginTokens() {
+    return isJWTEnabledForLoginTokens;
+  }
+  public void setIsJWTEnabledForLoginTokens(Boolean isJWTEnabledForLoginTokens) {
+    this.isJWTEnabledForLoginTokens = isJWTEnabledForLoginTokens;
+  }
+
+  /**
    * The &#39;PasswordJavaRegEx&#39; cofigured in the UserStoreManager
    **/
   public SettingsDTO userStorePasswordPattern(String userStorePasswordPattern) {
@@ -320,6 +338,7 @@ public class SettingsDTO   {
         Objects.equals(identityProvider, settings.identityProvider) &&
         Objects.equals(isAnonymousModeEnabled, settings.isAnonymousModeEnabled) &&
         Objects.equals(isPasswordChangeEnabled, settings.isPasswordChangeEnabled) &&
+        Objects.equals(isJWTEnabledForLoginTokens, settings.isJWTEnabledForLoginTokens) &&
         Objects.equals(userStorePasswordPattern, settings.userStorePasswordPattern) &&
         Objects.equals(passwordPolicyPattern, settings.passwordPolicyPattern) &&
         Objects.equals(passwordPolicyMinLength, settings.passwordPolicyMinLength) &&
@@ -328,7 +347,7 @@ public class SettingsDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(grantTypes, scopes, applicationSharingEnabled, mapExistingAuthApps, apiGatewayEndpoint, monetizationEnabled, recommendationEnabled, isUnlimitedTierPaid, identityProvider, isAnonymousModeEnabled, isPasswordChangeEnabled, userStorePasswordPattern, passwordPolicyPattern, passwordPolicyMinLength, passwordPolicyMaxLength);
+    return Objects.hash(grantTypes, scopes, applicationSharingEnabled, mapExistingAuthApps, apiGatewayEndpoint, monetizationEnabled, recommendationEnabled, isUnlimitedTierPaid, identityProvider, isAnonymousModeEnabled, isPasswordChangeEnabled, isJWTEnabledForLoginTokens, userStorePasswordPattern, passwordPolicyPattern, passwordPolicyMinLength, passwordPolicyMaxLength);
   }
 
   @Override
@@ -347,6 +366,7 @@ public class SettingsDTO   {
     sb.append("    identityProvider: ").append(toIndentedString(identityProvider)).append("\n");
     sb.append("    isAnonymousModeEnabled: ").append(toIndentedString(isAnonymousModeEnabled)).append("\n");
     sb.append("    isPasswordChangeEnabled: ").append(toIndentedString(isPasswordChangeEnabled)).append("\n");
+    sb.append("    isJWTEnabledForLoginTokens: ").append(toIndentedString(isJWTEnabledForLoginTokens)).append("\n");
     sb.append("    userStorePasswordPattern: ").append(toIndentedString(userStorePasswordPattern)).append("\n");
     sb.append("    passwordPolicyPattern: ").append(toIndentedString(passwordPolicyPattern)).append("\n");
     sb.append("    passwordPolicyMinLength: ").append(toIndentedString(passwordPolicyMinLength)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SettingsMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SettingsMappingUtil.java
@@ -60,6 +60,7 @@ public class SettingsMappingUtil {
         SettingsDTO settingsDTO = new SettingsDTO();
         settingsDTO.setScopes(GetScopeList());
         settingsDTO.setApplicationSharingEnabled(APIUtil.isMultiGroupAppSharingEnabled());
+        settingsDTO.setIsJWTEnabledForLoginTokens(APIUtil.isJWTEnabledForPortals());
         settingsDTO.setRecommendationEnabled(recommendationEnabled);
         settingsDTO.setMapExistingAuthApps(APIUtil.isMapExistingAuthAppsEnabled());
         settingsDTO.setMonetizationEnabled(moneatizationEnabled);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -5290,6 +5290,9 @@ components:
         IsPasswordChangeEnabled:
           type: boolean
           default: true
+        IsJWTEnabledForLoginTokens: 
+          type: boolean
+          default: false
         userStorePasswordPattern:
           type: string
           description: The 'PasswordJavaRegEx' cofigured in the UserStoreManager

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
@@ -143,7 +143,12 @@ public class OAuthJwtAuthenticatorImpl extends AbstractOAuthAuthenticator {
         String maskedToken = message.get(RestApiConstants.MASKED_TOKEN).toString();
         OAuthTokenInfo oauthTokenInfo = new OAuthTokenInfo();
         oauthTokenInfo.setAccessToken(accessToken);
-        oauthTokenInfo.setEndUserName(signedJWTInfo.getJwtClaimsSet().getSubject());
+        String tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        if (signedJWTInfo.getJwtClaimsSet().getClaim(JwtTokenConstants.USER_DOMAIN) != null) {
+            tenantDomain = (String) signedJWTInfo.getJwtClaimsSet().getClaim(JwtTokenConstants.USER_DOMAIN);
+        } 
+        log.debug("Tenant domain for user " + tenantDomain);
+        oauthTokenInfo.setEndUserName(signedJWTInfo.getJwtClaimsSet().getSubject() + "@" + tenantDomain);
         oauthTokenInfo.setConsumerKey(signedJWTInfo.getJwtClaimsSet().getStringClaim(JWTConstants.AUTHORIZED_PARTY));
         String scopeClaim = signedJWTInfo.getJwtClaimsSet().getStringClaim(JwtTokenConstants.SCOPE);
         if (scopeClaim != null) {
@@ -160,7 +165,7 @@ public class OAuthJwtAuthenticatorImpl extends AbstractOAuthAuthenticator {
                 //Add the user scopes list extracted from token to the cxf message
                 message.getExchange().put(RestApiConstants.USER_REST_API_SCOPES, oauthTokenInfo.getScopes());
                 //If scope validation successful then set tenant name and user name to current context
-                String tenantDomain = MultitenantUtils.getTenantDomain(oauthTokenInfo.getEndUserName());
+
                 int tenantId;
                 PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
                 RealmService realmService = (RealmService) carbonContext.getOSGiService(RealmService.class, null);
@@ -328,6 +333,10 @@ public class OAuthJwtAuthenticatorImpl extends AbstractOAuthAuthenticator {
                     + tokenIssuer + ") does not match with the token issuer (" + tokenIssuers.keySet() + ")");
         }
         String residentTenantDomain = APIConstants.SUPER_TENANT_DOMAIN;
+        if (jwtClaimsSet.getClaim(JwtTokenConstants.APP_DOMAIN) != null) {
+            residentTenantDomain = (String) jwtClaimsSet.getClaim(JwtTokenConstants.APP_DOMAIN);
+        } 
+        log.debug("Tenant domain for residant IDP " + residentTenantDomain);
         IdentityProvider residentIDP = validateAndGetResidentIDPForIssuer(residentTenantDomain, tokenIssuer);
         if (residentIDP == null) {
             //invalid issuer. invalid token

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
@@ -189,7 +189,7 @@ public class OAuthJwtAuthenticatorImpl extends AbstractOAuthAuthenticator {
                     carbonContext.setTenantId(tenantId);
                     carbonContext.setUsername(username);
                     message.put(RestApiConstants.AUTH_TOKEN_INFO, oauthTokenInfo);
-                    message.put(RestApiConstants.SUB_ORGANIZATION, orgId);
+                    message.put(RestApiConstants.SUB_ORGANIZATION, tenantDomain);
                     if (!tenantDomain.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
                         APIUtil.loadTenantConfigBlockingMode(tenantDomain);
                     }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -434,6 +434,9 @@
         <!-- Whether to validate certificate bound access tokens-->
         <EnableCertificateBoundAccessToken>{{apim.oauth_config.enable_certificate_bound_access_token}}</EnableCertificateBoundAccessToken>
 
+        {% if apim.oauth_config.enable_jwt_for_portals is defined %}
+        <EnableJWTForPortals>{{apim.oauth_config.enable_jwt_for_portals}}</EnableJWTForPortals>
+        {% endif %}
     </OAuthConfigurations>
 
     <AccessTokenBinding>


### PR DESCRIPTION
This PR changes opaque tokens to JWT for portal logins

Note:
This pr needs to be merged after https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2384 and https://github.com/wso2/carbon-identity-framework/pull/5547


After these PRs, Need to add following to the deployment.toml to enable JWT for portals

      [apim.oauth_config]
      enable_jwt_for_portals = true
      
      [transport.https.properties]
      maxHttpHeaderSize = "12288"
      
      [oauth]
      add_tenant_domain_to_access_token = true
