### PR TITLE
Bump the POI version to 5.2.5.wso2v1

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/indexing/indexer/DocumentIndexer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/indexing/indexer/DocumentIndexer.java
@@ -23,22 +23,22 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.pdfbox.cos.COSDocument;
 import org.apache.pdfbox.io.RandomAccessBufferedFileInputStream;
+import org.apache.pdfbox.pdfparser.PDFParser;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
-import org.apache.pdfbox.cos.COSDocument;
-import org.apache.poi.hslf.extractor.PowerPointExtractor;
+import org.apache.poi.hslf.usermodel.HSLFSlideShow;
 import org.apache.poi.hssf.extractor.ExcelExtractor;
 import org.apache.poi.hwpf.extractor.WordExtractor;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
-import org.apache.poi.xslf.extractor.XSLFPowerPointExtractor;
+import org.apache.poi.sl.extractor.SlideShowExtractor;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.apache.poi.xssf.extractor.XSSFExcelExtractor;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.poi.xwpf.extractor.XWPFWordExtractor;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.solr.common.SolrException;
-import org.apache.pdfbox.pdfparser.PDFParser;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.impl.APIConstants;
@@ -47,7 +47,6 @@ import org.wso2.carbon.governance.api.generic.GenericArtifactManager;
 import org.wso2.carbon.governance.api.generic.dataobjects.GenericArtifact;
 import org.wso2.carbon.governance.api.util.GovernanceUtils;
 import org.wso2.carbon.governance.registry.extensions.indexers.RXTIndexer;
-
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.RegistryConstants;
 import org.wso2.carbon.registry.core.Resource;
@@ -211,15 +210,15 @@ public class DocumentIndexer extends RXTIndexer {
                     contentString = xssfExcelExtractor.getText();
                     break;
                 case APIConstants.PPT_EXTENSION: {
-                    POIFSFileSystem fs = new POIFSFileSystem(inputStream);
-                    PowerPointExtractor extractor = new PowerPointExtractor(fs);
+                    HSLFSlideShow slideShow = new HSLFSlideShow(inputStream);
+                    SlideShowExtractor extractor = new SlideShowExtractor(slideShow);
                     contentString = extractor.getText();
                     break;
                 }
                 case APIConstants.PPTX_EXTENSION:
-                    XMLSlideShow xmlSlideShow = new XMLSlideShow(inputStream);
-                    XSLFPowerPointExtractor xslfPowerPointExtractor = new XSLFPowerPointExtractor(xmlSlideShow);
-                    contentString = xslfPowerPointExtractor.getText();
+                    XMLSlideShow slideShow = new XMLSlideShow(inputStream);
+                    SlideShowExtractor extractor = new SlideShowExtractor(slideShow);
+                    contentString = extractor.getText();
                     break;
                 case APIConstants.TXT_EXTENSION:
                 case APIConstants.WSDL_EXTENSION:

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/indexing/indexer/MSPowerpointIndexer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/indexing/indexer/MSPowerpointIndexer.java
@@ -1,25 +1,24 @@
 package org.wso2.carbon.apimgt.impl.indexing.indexer;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.poi.hslf.usermodel.HSLFSlideShow;
+import org.apache.poi.poifs.filesystem.OfficeXmlFileException;
+import org.apache.poi.sl.extractor.SlideShowExtractor;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrException.ErrorCode;
+import org.wso2.carbon.registry.indexing.AsyncIndexer.File2Index;
+import org.wso2.carbon.registry.indexing.IndexingConstants;
+import org.wso2.carbon.registry.indexing.indexer.Indexer;
+import org.wso2.carbon.registry.indexing.solr.IndexDocument;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.poi.hslf.extractor.PowerPointExtractor;
-import org.apache.poi.poifs.filesystem.OfficeXmlFileException;
-import org.apache.poi.poifs.filesystem.POIFSFileSystem;
-import org.apache.poi.xslf.extractor.XSLFPowerPointExtractor;
-import org.apache.poi.xslf.usermodel.XMLSlideShow;
-import org.apache.solr.common.SolrException;
-import org.apache.solr.common.SolrException.ErrorCode;
-import org.wso2.carbon.registry.indexing.IndexingConstants;
-import org.wso2.carbon.registry.indexing.AsyncIndexer.File2Index;
-import org.wso2.carbon.registry.indexing.indexer.Indexer;
-import org.wso2.carbon.registry.indexing.solr.IndexDocument;
 
 public class MSPowerpointIndexer implements Indexer {
 	public static final Log log = LogFactory.getLog(MSPowerpointIndexer.class);
@@ -29,18 +28,15 @@ public class MSPowerpointIndexer implements Indexer {
 		try {
             String ppText = null;
             try {
-                //Extract Powerpoint 2003 (.ppt) document files
-                POIFSFileSystem fs = new POIFSFileSystem(new ByteArrayInputStream(fileData.data));
-
-                PowerPointExtractor extractor = new PowerPointExtractor(fs);
+                //Extract PowerPoint 2003 (.ppt) document files
+				HSLFSlideShow slideShow = new HSLFSlideShow(new ByteArrayInputStream(fileData.data));
+				SlideShowExtractor extractor = new SlideShowExtractor(slideShow);
                 ppText = extractor.getText();
-
             } catch (OfficeXmlFileException e){
-
-                //if 2003 Powerpoint (.ppt) extraction failed, try with Powerpoint 2007 (.pptx) document file extractor
-                XMLSlideShow xmlSlideShow = new XMLSlideShow(new ByteArrayInputStream(fileData.data));
-                XSLFPowerPointExtractor xslfPowerPointExtractor = new XSLFPowerPointExtractor(xmlSlideShow);
-                ppText = xslfPowerPointExtractor.getText();
+                //if 2003 PowerPoint (.ppt) extraction failed, try with PowerPoint 2007 (.pptx) document file extractor
+				XMLSlideShow slideShow = new XMLSlideShow(new ByteArrayInputStream(fileData.data));
+				SlideShowExtractor extractor = new SlideShowExtractor(slideShow);
+                ppText = extractor.getText();
 
             } catch (Exception e){
                 String msg = "Failed to extract the document";

--- a/pom.xml
+++ b/pom.xml
@@ -2135,7 +2135,7 @@
         <httpclient.version>4.3.6.wso2v3</httpclient.version>
         <wss4j.version>1.5.11-wso2v18</wss4j.version>
         <commons-logging.version>1.1.1</commons-logging.version>
-        <commons-io.version>2.4.0.wso2v1</commons-io.version>
+        <commons-io.version>2.15.1.wso2v1</commons-io.version>
         <commons-httpclient.version>3.1</commons-httpclient.version>
         <google.code.gson.version>2.9.1</google.code.gson.version>
         <httpcomponents.version>4.5.10</httpcomponents.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2127,8 +2127,8 @@
 
         <json-simple.wso2.version>1.1.1</json-simple.wso2.version>
         <apache.woden.version>1.0.0.M9-wso2v1</apache.woden.version>
-        <apache.poi.version>4.1.2.wso2v1</apache.poi.version>
-        <apache.poi.import.range>[3.0, 4.9)</apache.poi.import.range>
+        <apache.poi.version>5.2.5.wso2v1</apache.poi.version>
+        <apache.poi.import.range>[5.0, 6.0)</apache.poi.import.range>
         <rhino.js.version>1.7.0.R4.wso2v1</rhino.js.version>
         <owasp.encoder.version>1.2.2</owasp.encoder.version>
 


### PR DESCRIPTION
## Purpose

This PR adds the following changes,

- [Bump POI version to 5.2.5.wso2v1](https://github.com/wso2/carbon-apimgt/commit/02d45828e906cbac95d146fc8621442b2951cba2)
- [Bump commons-io version to 2.15.1.wso2v1](https://github.com/wso2/carbon-apimgt/commit/ae9a54d15462489a5c11095f483149770538e5cb)