### PR TITLE
Add erroneous properties to the response message in API mandatory prop validation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -2220,8 +2220,16 @@ public class PublisherCommonUtils {
         return apiProvider.getAPIbyUUID(apiToAdd.getUuid(), organization);
     }
 
-    public static boolean validateMandatoryProperties(org.json.simple.JSONArray customProperties, APIDTO apiDto) {
+    /**
+     * This method is used to validate the mandatory custom properties of an API
+     *
+     * @param customProperties custom properties of the API
+     * @param apiDto API DTO to validate
+     * @return list of erroneous property names. returns an empty array if there are no errors.
+     */
+    public static List<String> validateMandatoryProperties(org.json.simple.JSONArray customProperties, APIDTO apiDto) {
 
+        List<String> errorPropertyNames = new ArrayList<>();
         Map<String, APIInfoAdditionalPropertiesMapDTO> additionalPropertiesMap = apiDto.getAdditionalPropertiesMap();
 
         for (int i = 0; i < customProperties.size(); i++) {
@@ -2234,7 +2242,8 @@ public class PublisherCommonUtils {
                         additionalPropertiesMap.get(propertyName + "__display");
                 APIInfoAdditionalPropertiesMapDTO mapProperty = additionalPropertiesMap.get(propertyName);
                 if (mapProperty == null && mapPropertyDisplay == null) {
-                    return false;
+                    errorPropertyNames.add(propertyName);
+                    continue;
                 }
                 String propertyValue = "";
                 String propertyValueDisplay = "";
@@ -2246,10 +2255,10 @@ public class PublisherCommonUtils {
                 }
                 if ((propertyValue == null || propertyValue.isEmpty()) &&
                         (propertyValueDisplay == null || propertyValueDisplay.isEmpty())) {
-                    return false;
+                    errorPropertyNames.add(propertyName);
                 }
             }
         }
-        return true;
+        return errorPropertyNames;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -658,11 +658,14 @@ public class ApisApiServiceImpl implements ApisApiService {
                         ExceptionCodes.INVALID_ENDPOINT_URL);
             }
 
+            // validate custom properties
             org.json.simple.JSONArray customProperties = APIUtil.getCustomProperties(username);
-            if (!PublisherCommonUtils.validateMandatoryProperties(customProperties, body)) {
-                Long errorCode = ExceptionCodes.ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES.getErrorCode();
+            List<String> errorProperties = PublisherCommonUtils.validateMandatoryProperties(customProperties, body);
+            if (!errorProperties.isEmpty()) {
+                String errorString = " : " + String.join(", ", errorProperties);
                 RestApiUtil.handleBadRequest(
-                        ExceptionCodes.ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES.getErrorMessage(), errorCode, log);
+                        ExceptionCodes.ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES.getErrorMessage() + errorString,
+                        ExceptionCodes.ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES.getErrorCode(), log);
             }
 
             // validate sandbox and production endpoints


### PR DESCRIPTION
Fixing : https://github.com/wso2-enterprise/wso2-apim-internal/issues/5635

Related PR: https://github.com/wso2-support/carbon-apimgt/pull/6374