### PR TITLE
Fix: Type Casting Issue on GraphQL invocation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -734,9 +734,18 @@ public class GatewayUtils {
                     ;
                 }
                 if (synCtx != null && APIConstants.GRAPHQL_API.equals(synCtx.getProperty(APIConstants.API_TYPE))) {
-                    Integer graphQLMaxDepth = (int) (long) subscriptionTierObj.get(GraphQLConstants.GRAPHQL_MAX_DEPTH);
-                    Integer graphQLMaxComplexity =
-                            (int) (long) subscriptionTierObj.get(GraphQLConstants.GRAPHQL_MAX_COMPLEXITY);
+                    Integer graphQLMaxDepth = 0;
+                    if (subscriptionTierObj != null
+                            && subscriptionTierObj.get(GraphQLConstants.GRAPHQL_MAX_DEPTH) != null) {
+                        graphQLMaxDepth = ((Number) subscriptionTierObj.get(
+                                GraphQLConstants.GRAPHQL_MAX_DEPTH)).intValue();
+                    }
+                    Integer graphQLMaxComplexity = 0;
+                    if (subscriptionTierObj != null
+                            && subscriptionTierObj.get(GraphQLConstants.GRAPHQL_MAX_COMPLEXITY) != null) {
+                        graphQLMaxComplexity = ((Number) subscriptionTierObj.get(
+                                GraphQLConstants.GRAPHQL_MAX_COMPLEXITY)).intValue();
+                    }
                     synCtx.setProperty(GraphQLConstants.MAXIMUM_QUERY_DEPTH, graphQLMaxDepth);
                     synCtx.setProperty(GraphQLConstants.MAXIMUM_QUERY_COMPLEXITY, graphQLMaxComplexity);
                 }


### PR DESCRIPTION
### Purpose

Following error was returned on a graphql api invocation

```
[2024-03-20 20:16:43,230] ERROR - ServerWorker Error processing POST request for : /swapi/1.0.0.
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.Long (java.lang.Integer and java.lang.Long are in module java.base of loader 'bootstrap')
	at org.wso2.carbon.apimgt.gateway.utils.GatewayUtils.generateAuthenticationContext_aroundBody46(GatewayUtils.java:739) ~[org.wso2.carbon.apimgt.gateway_9.29.47.jar:?]
	at org.wso2.carbon.apimgt.gateway.utils.GatewayUtils.generateAuthenticationContext(GatewayUtils.java:1) ~[org.wso2.carbon.apimgt.gateway_9.29.47.jar:?]
	at org.wso2.carbon.apimgt.gateway.handlers.security.apikey.ApiKeyAuthenticator.authenticate_aroundBody4(ApiKeyAuthenticator.java:170) ~[org.wso2.carbon.apimgt.gateway_9.29.47.jar:?]
	at org.wso2.carbon.apimgt.gateway.handlers.security.apikey.ApiKeyAuthenticator.authenticate(ApiKeyAuthenticator.java:1) ~[org.wso2.carbon.apimgt.gateway_9.29.47.jar:?]
	at org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler.isAuthenticate_aroundBody60(APIAuthenticationHandler.java:567) ~[org.wso2.carbon.apimgt.gateway_9.29.47.jar:?]
	at org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler.isAuthenticate(APIAuthenticationHandler.java:1) ~[org.wso2.carbon.apimgt.gateway_9.29.47.jar:?]
	at org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler.handleRequest_aroundBody50(APIAuthenticationHandler.java:435) ~[org.wso2.carbon.apimgt.gateway_9.29.47.jar:?]
	at org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler.handleRequest(APIAuthenticationHandler.java:1) ~[org.wso2.carbon.apimgt.gateway_9.29.47.jar:?]
	at org.apache.synapse.api.API.process(API.java:407) ~[synapse-core_4.0.0.wso2v94.jar:4.0.0-wso2v94]
	at org.apache.synapse.api.AbstractApiHandler.apiProcessNonDefaultStrategy(AbstractApiHandler.java:109) ~[synapse-core_4.0.0.wso2v94.jar:4.0.0-wso2v94]
	at org.apache.synapse.api.AbstractApiHandler.identifyAPI(AbstractApiHandler.java:129) ~[synapse-core_4.0.0.wso2v94.jar:4.0.0-wso2v94]
	at org.apache.synapse.api.AbstractApiHandler.dispatchToAPI(AbstractApiHandler.java:61) ~[synapse-core_4.0.0.wso2v94.jar:4.0.0-wso2v94]
	at org.apache.synapse.api.rest.RestRequestHandler.dispatchToAPI(RestRequestHandler.java:90) ~[synapse-core_4.0.0.wso2v94.jar:4.0.0-wso2v94]
	at org.apache.synapse.api.rest.RestRequestHandler.process(RestRequestHandler.java:76) ~[synapse-core_4.0.0.wso2v94.jar:4.0.0-wso2v94]
	at org.apache.synapse.rest.RESTRequestHandler.process(RESTRequestHandler.java:54) ~[synapse-core_4.0.0.wso2v94.jar:4.0.0-wso2v94]
	at org.apache.synapse.core.axis2.Axis2SynapseEnvironment.injectMessage(Axis2SynapseEnvironment.java:350) ~[synapse-core_4.0.0.wso2v94.jar:4.0.0-wso2v94]
	at org.apache.synapse.core.axis2.SynapseMessageReceiver.receive(SynapseMessageReceiver.java:101) ~[synapse-core_4.0.0.wso2v94.jar:4.0.0-wso2v94]
	at org.apache.axis2.engine.AxisEngine.receive(AxisEngine.java:180) ~[axis2_1.6.1.wso2v76.jar:?]
	at org.apache.synapse.transport.passthru.ServerWorker.processNonEntityEnclosingRESTHandler(ServerWorker.java:401) ~[synapse-nhttp-transport_4.0.0.wso2v94.jar:?]
	at org.apache.synapse.transport.passthru.ServerWorker.processEntityEnclosingRequest(ServerWorker.java:460) ~[synapse-nhttp-transport_4.0.0.wso2v94.jar:?]
	at org.apache.synapse.transport.passthru.ServerWorker.run(ServerWorker.java:208) ~[synapse-nhttp-transport_4.0.0.wso2v94.jar:?]
	at org.apache.axis2.transport.base.threads.NativeWorkerPool$1.run(NativeWorkerPool.java:172) ~[axis2_1.6.1.wso2v76.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
```