### PR TITLE
Mark OAuthResponseMediator as content-not-aware

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/OAuthResponseMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/oauth/OAuthResponseMediator.java
@@ -83,6 +83,11 @@ public class OAuthResponseMediator extends AbstractMediator implements ManagedLi
         return true;
     }
 
+    @Override
+    public boolean isContentAware() {
+        return false;
+    }
+
     /**
      * Sends a fault response to the DevPortal console
      *


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/2501.

With this PR OAuthResponseMediator is marked as content not aware.