### PR TITLE
Change to java.security.cert.X509Certificate class

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/TokenIssuerDto.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/TokenIssuerDto.java
@@ -18,9 +18,9 @@
 
 package org.wso2.carbon.apimgt.common.gateway.dto;
 
+import java.security.cert.Certificate;
 import java.util.HashMap;
 import java.util.Map;
-import javax.security.cert.Certificate;
 
 /**
  * Holds data related to token issuers.

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/factory/KeyManagerHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/factory/KeyManagerHolder.java
@@ -46,8 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.security.cert.X509Certificate;
+import java.security.cert.X509Certificate;
 
 /**
  * This is a factory class.you have to use this when you need to initiate classes by reading config file.

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -287,7 +287,7 @@ import javax.cache.Cache;
 import javax.cache.CacheConfiguration;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
-import javax.security.cert.X509Certificate;
+import java.security.cert.X509Certificate;
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -9268,8 +9268,9 @@ public final class APIUtil {
             base64EncodedCertificate = APIUtil.getX509certificateContent(base64EncodedCertificate);
             byte[] bytes = Base64.decodeBase64(base64EncodedCertificate);
             try (InputStream inputStream = new ByteArrayInputStream(bytes)) {
-                return X509Certificate.getInstance(inputStream);
-            } catch (IOException | javax.security.cert.CertificateException e) {
+                CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                return (X509Certificate) cf.generateCertificate(inputStream);
+            } catch (IOException | CertificateException e) {
                 String msg = "Error while converting into X509Certificate";
                 log.error(msg, e);
                 throw new APIManagementException(msg, e);
@@ -9292,8 +9293,9 @@ public final class APIUtil {
             base64EncodedCertificate = APIUtil.getX509certificateContent(base64EncodedCertificate);
             byte[] bytes = Base64.decodeBase64(base64EncodedCertificate.getBytes());
             try (InputStream inputStream = new ByteArrayInputStream(bytes)) {
-                return X509Certificate.getInstance(inputStream);
-            } catch (IOException | javax.security.cert.CertificateException e) {
+                CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                return (X509Certificate) cf.generateCertificate(inputStream);
+            } catch (IOException | CertificateException e) {
                 String msg = "Error while converting into X509Certificate";
                 log.error(msg, e);
                 throw new APIManagementException(msg, e);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/impl/OAuthJwtAuthenticatorImpl.java
@@ -55,7 +55,7 @@ import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
-import javax.security.cert.X509Certificate;
+import java.security.cert.X509Certificate;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.ParseException;


### PR DESCRIPTION
### Description
In Java 17, the javax.security.cert package has been removed. To work with X.509 certificates in Java 17 and beyond, we need to use the java.security.cert.X509Certificate class.


Fixes https://github.com/wso2/api-manager/issues/2665