### PR TITLE
Fix error when pushing Webhook API analytics to apim_metrics.log with ELK enabled

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/SuccessRequestDataCollector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/SuccessRequestDataCollector.java
@@ -72,6 +72,9 @@ public class SuccessRequestDataCollector extends CommonRequestDataCollector impl
         String userAgent = provider.getUserAgentHeader();
         String userName = provider.getUserName();
         String userIp = provider.getEndUserIP();
+        if (userName == null) {
+            userName = Constants.UNKNOWN_VALUE;
+        }
         if (userIp == null) {
             userIp = Constants.UNKNOWN_VALUE;
         }


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/2587

In the current implementation, an error occurs when APIM attempts to push Webhook API analytics to the apim_metrics.log file when ELK analytics is enabled. This issue stems from the lack of handling the scenario where the userName field is null and, this PR fixes this issue by handling the null.