### PR TITLE
[Master] Remove implementation_status flag when updating APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -137,6 +137,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -190,10 +191,14 @@ public class APIMappingUtil {
         model.setContext(context);
         model.setDescription(dto.getDescription());
 
-        if (dto.getEndpointConfig() != null) {
+        Object endpointConfig = dto.getEndpointConfig();
+        if (endpointConfig != null) {
             ObjectMapper mapper = new ObjectMapper();
             try {
-                model.setEndpointConfig(mapper.writeValueAsString(dto.getEndpointConfig()));
+                if (endpointConfig instanceof LinkedHashMap) {
+                    ((LinkedHashMap) endpointConfig).remove(APIConstants.IMPLEMENTATION_STATUS);
+                }
+                model.setEndpointConfig(mapper.writeValueAsString(endpointConfig));
             } catch (IOException e) {
                 handleException("Error while converting endpointConfig to json", e);
             }


### PR DESCRIPTION
When migrating from 2.6.0 to the latest versions, we can see the implementation_status flag in the registry. But in the latest versions, we only have production, sandbox and no API endpoint for prototype. So if the user needs to proceed using HTTP/REST endpoints or any other endpoint after the migration, in the next API update call we need to remove the implementation_status flag which used to identify prototype endpoints. This PR removes the implementation_status flag when updating APIs.