### PR TITLE
Change Default Certificate Hashing Algorithm to SHA-256

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/constants/JWTConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/constants/JWTConstants.java
@@ -53,4 +53,9 @@ public class JWTConstants {
     public static final String ORGANIZATIONS = "organizations";
     public static final String GATEWAY_JWKS_API_CONTEXT = "/jwks";
     public static final String GATEWAY_JWKS_API_NAME = "_JwksEndpoint_";
+
+    public static final String SHA_256 = "SHA-256";
+    public static final String SHA_1 = "SHA-1";
+    public static final String X5T_PARAMETER = "x5t";
+    public static final String X5T256_PARAMETER = "x5t#S256";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/JWTConfigurationDto.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/JWTConfigurationDto.java
@@ -34,6 +34,8 @@ public class JWTConfigurationDto {
     private String jwtHeader = "X-JWT-Assertion";
     private String consumerDialectUri = "http://wso2.org/claims";
     private String signatureAlgorithm = "SHA256withRSA";
+
+    private boolean useSHA1Hash = false;
     private String jwtDecoding = "base64";
     private boolean enableUserClaims;
     private String gatewayJWTGeneratorImpl;
@@ -59,6 +61,7 @@ public class JWTConfigurationDto {
         this.jwtHeader = jwtConfigurationDto.jwtHeader;
         this.consumerDialectUri = jwtConfigurationDto.consumerDialectUri;
         this.signatureAlgorithm = jwtConfigurationDto.signatureAlgorithm;
+        this.useSHA1Hash = jwtConfigurationDto.useSHA1Hash;
         this.jwtDecoding = jwtConfigurationDto.jwtDecoding;
         this.enableUserClaims = jwtConfigurationDto.enableUserClaims;
         this.gatewayJWTGeneratorImpl = jwtConfigurationDto.gatewayJWTGeneratorImpl;
@@ -190,4 +193,11 @@ public class JWTConfigurationDto {
         return ttl;
     }
 
+    public boolean useSHA1Hash() {
+        return useSHA1Hash;
+    }
+
+    public void setUseSHA1Hash(boolean useSHA1Hash) {
+        this.useSHA1Hash = useSHA1Hash;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/jwtgenerator/AbstractAPIMgtGatewayJWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/jwtgenerator/AbstractAPIMgtGatewayJWTGenerator.java
@@ -57,6 +57,8 @@ public abstract class AbstractAPIMgtGatewayJWTGenerator {
 
     private String signatureAlgorithm;
 
+    private boolean useSHA1Hash;
+
     public AbstractAPIMgtGatewayJWTGenerator() {
     }
 
@@ -71,6 +73,7 @@ public abstract class AbstractAPIMgtGatewayJWTGenerator {
                 || SHA256_WITH_RSA.equals(signatureAlgorithm))) {
             signatureAlgorithm = SHA256_WITH_RSA;
         }
+        useSHA1Hash = jwtConfigurationDto.useSHA1Hash();
 
     }
 
@@ -146,7 +149,8 @@ public abstract class AbstractAPIMgtGatewayJWTGenerator {
 
         try {
             Certificate publicCert = jwtConfigurationDto.getPublicCert();
-            return JWTUtil.generateHeader(publicCert, signatureAlgorithm, jwtConfigurationDto.useKid());
+            return JWTUtil.generateHeader(publicCert, signatureAlgorithm, jwtConfigurationDto.useKid(),
+                    useSHA1Hash);
         } catch (Exception e) {
             String error = "Error in obtaining keystore";
             throw new JWTGeneratorException(error, e);

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/JWTUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/JWTUtil.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wso2.carbon.apimgt.common.gateway.constants.JWTConstants;
 import org.wso2.carbon.apimgt.common.gateway.exception.JWTGeneratorException;
 import org.wso2.carbon.apimgt.common.gateway.jwtgenerator.JWTSignatureAlg;
 
@@ -78,7 +79,7 @@ public final class JWTUtil {
 
     public static String generateHeader(Certificate publicCert, String signatureAlgorithm)
             throws JWTGeneratorException {
-        return generateHeader(publicCert, signatureAlgorithm, false);
+        return generateHeader(publicCert, signatureAlgorithm, false, false);
     }
 
     /**
@@ -87,23 +88,26 @@ public final class JWTUtil {
      * @param publicCert         The public certificate which needs to include in the header as thumbprint
      * @param signatureAlgorithm Signature algorithm which needs to include in the header
      * @param useKid             Specifies whether the header should include the kid property
+     * @param useSHA1Hash        Specifies whether to use SHA-1 algorithm to generate the certificate thumbprint
      * @throws JWTGeneratorException
      */
 
-    public static String generateHeader(Certificate publicCert, String signatureAlgorithm, boolean useKid)
+    public static String generateHeader(Certificate publicCert, String signatureAlgorithm, boolean useKid,
+                                        boolean useSHA1Hash)
             throws JWTGeneratorException {
 
         /*
          * Sample header
-         * {"typ":"JWT", "alg":"SHA256withRSA", "x5t":"a_jhNus21KVuoFx65LmkW2O_l10",
+         * {"typ":"JWT", "alg":"SHA256withRSA", "x5t#S256":"a_jhNus21KVuoFx65LmkW2O_l10",
          * "kid":"a_jhNus21KVuoFx65LmkW2O_l10"}
-         * {"typ":"JWT", "alg":"[2]", "x5t":"[1]", "x5t":"[1]"}
+         * {"typ":"JWT", "alg":"[2]", "x5t#S256":"[1]"}
          * */
         try {
             X509Certificate x509Certificate = (X509Certificate) publicCert;
 
-            //generate the SHA-1 thumbprint of the certificate
-            MessageDigest digestValue = MessageDigest.getInstance("SHA-1");
+            String hashingAlgorithm = useSHA1Hash ? JWTConstants.SHA_1 : JWTConstants.SHA_256;
+            //generate the thumbprint of the certificate
+            MessageDigest digestValue = MessageDigest.getInstance(hashingAlgorithm);
             byte[] der = publicCert.getEncoded();
             digestValue.update(der);
             byte[] digestInBytes = digestValue.digest();
@@ -115,7 +119,12 @@ public final class JWTUtil {
             JSONObject jwtHeader = new JSONObject();
             jwtHeader.put("typ", "JWT");
             jwtHeader.put("alg", getJWSCompliantAlgorithmCode(signatureAlgorithm));
-            jwtHeader.put("x5t", base64UrlEncodedThumbPrint);
+            if (useSHA1Hash) {
+                jwtHeader.put(JWTConstants.X5T_PARAMETER, base64UrlEncodedThumbPrint);
+            } else {
+                jwtHeader.put(JWTConstants.X5T256_PARAMETER, base64UrlEncodedThumbPrint);
+            }
+
             if (useKid) {
                 jwtHeader.put("kid", getKID(x509Certificate));
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/test/java/org/wso2/carbon/apimgt/common/gateway/JWTUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/test/java/org/wso2/carbon/apimgt/common/gateway/JWTUtilTestCase.java
@@ -61,24 +61,25 @@ public class JWTUtilTestCase {
         X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate(
                 Files.newInputStream(Paths.get("src/test/resources/cnf/certificate.pem"))
         );
+        String signatureAlgorithm = "SHA256withRSA";
 
-        String jwt = JWTUtil.generateHeader(cert, "SHA256withRSA", true, false);
+        //Use SHA-256 as the certificate hashing algorithm
+        String jwt = JWTUtil.generateHeader(cert, signatureAlgorithm, true, false);
         Assert.assertNotNull(jwt);
         Assert.assertTrue(jwt.contains("kid"));
 
         String encodedThumbprint = generateCertThumbprint(cert, "SHA-256");
-        //Check if the encoded thumbprint get matched with JWT header's x5t#S256
+        //Check if the encoded thumbprint matches with the JWT header's x5t#S256
         Assert.assertTrue(jwt.contains(encodedThumbprint));
         Assert.assertTrue(jwt.contains("x5t#S256"));
 
-        Assert.assertTrue(jwt.contains("x5t#S256"));
-
-        jwt = JWTUtil.generateHeader(cert, "SHA256withRSA", false, true);
+        //Use SHA-1 as the certificate hashing algorithm
+        jwt = JWTUtil.generateHeader(cert, signatureAlgorithm, false, true);
         Assert.assertNotNull(jwt);
         Assert.assertFalse(jwt.contains("kid"));
 
         encodedThumbprint = generateCertThumbprint(cert, "SHA-1");
-        //Check if the encoded thumbprint get matched with JWT header's x5t
+        //Check if the encoded thumbprint matches with the JWT header's x5t
         Assert.assertTrue(jwt.contains(encodedThumbprint));
         Assert.assertTrue(jwt.contains("x5t"));
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/test/java/org/wso2/carbon/apimgt/common/gateway/JWTUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/test/java/org/wso2/carbon/apimgt/common/gateway/JWTUtilTestCase.java
@@ -24,6 +24,8 @@ import org.wso2.carbon.apimgt.common.gateway.util.JWTUtil;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
@@ -60,12 +62,56 @@ public class JWTUtilTestCase {
                 Files.newInputStream(Paths.get("src/test/resources/cnf/certificate.pem"))
         );
 
-        String jwt = JWTUtil.generateHeader(cert, "SHA256withRSA", true);
+        String jwt = JWTUtil.generateHeader(cert, "SHA256withRSA", true, false);
         Assert.assertNotNull(jwt);
         Assert.assertTrue(jwt.contains("kid"));
 
-        jwt = JWTUtil.generateHeader(cert, "SHA256withRSA", false);
+        String encodedThumbprint = generateCertThumbprint(cert, "SHA-256");
+        //Check if the encoded thumbprint get matched with JWT header's x5t#S256
+        Assert.assertTrue(jwt.contains(encodedThumbprint));
+        Assert.assertTrue(jwt.contains("x5t#S256"));
+
+        Assert.assertTrue(jwt.contains("x5t#S256"));
+
+        jwt = JWTUtil.generateHeader(cert, "SHA256withRSA", false, true);
         Assert.assertNotNull(jwt);
         Assert.assertFalse(jwt.contains("kid"));
+
+        encodedThumbprint = generateCertThumbprint(cert, "SHA-1");
+        //Check if the encoded thumbprint get matched with JWT header's x5t
+        Assert.assertTrue(jwt.contains(encodedThumbprint));
+        Assert.assertTrue(jwt.contains("x5t"));
+    }
+
+    private String generateCertThumbprint(Certificate cert, String hashingAlgorithm) throws Exception {
+        //Get the public certificate's thumbprint and base64url encode it
+        byte[] der = cert.getEncoded();
+        MessageDigest digestValue = MessageDigest.getInstance(hashingAlgorithm);
+        digestValue.update(der);
+        byte[] digestInBytes = digestValue.digest();
+        String publicCertThumbprint = hexify(digestInBytes);
+        return java.util.Base64.getUrlEncoder()
+                .encodeToString(publicCertThumbprint.getBytes("UTF-8"));
+    }
+
+    /**
+     * Helper method to hexify a byte array.
+     *
+     * @param bytes - The input byte array
+     * @return hexadecimal representation
+     */
+    private String hexify(byte bytes[]) {
+
+        char[] hexDigits = {'0', '1', '2', '3', '4', '5', '6', '7',
+                '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+        StringBuilder buf = new StringBuilder(bytes.length * 2);
+
+        for (byte aByte : bytes) {
+            buf.append(hexDigits[(aByte & 0xf0) >> 4]);
+            buf.append(hexDigits[aByte & 0x0f]);
+        }
+
+        return buf.toString();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -461,6 +461,10 @@ public final class APIConstants {
     public static final String USE_KID = "UseKidProperty";
     public static final String CONSUMER_DIALECT_URI = "ConsumerDialectURI";
     public static final String JWT_SIGNATURE_ALGORITHM = "SignatureAlgorithm";
+    public static final String USE_SHA1_HASH = "UseSHA1Hash";
+
+    public static final String X5T_PARAMETER = "x5t";
+    public static final String X5T256_PARAMETER = "x5t#S256";
     public static final String GATEWAY_JWT_GENERATOR = "GatewayJWTGeneration";
     public static final String GATEWAY_JWT_GENERATOR_IMPL = "ImplClass";
     public static final String TOKEN_ISSUERS = "TokenIssuers";
@@ -1377,6 +1381,8 @@ public final class APIConstants {
     public static final String VELOCITY_LOGGER = "VelocityLogger";
 
     public static final String SHA_256 = "SHA-256";
+
+    public static final String SHA_1 = "SHA-1";
 
     public static final String US_ASCII = "US-ASCII";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -1630,6 +1630,11 @@ public class APIManagerConfiguration {
             if (signatureElement != null) {
                 jwtConfigurationDto.setSignatureAlgorithm(signatureElement.getText());
             }
+            OMElement useSHA1HashElement =
+                    omElement.getFirstChildWithName(new QName(APIConstants.USE_SHA1_HASH));
+            if (useSHA1HashElement != null) {
+                jwtConfigurationDto.setUseSHA1Hash(Boolean.parseBoolean(useSHA1HashElement.getText()));
+            }
             OMElement claimRetrieverImplElement =
                     omElement.getFirstChildWithName(new QName(APIConstants.CLAIMS_RETRIEVER_CLASS));
             if (claimRetrieverImplElement != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/DefaultApiKeyGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/DefaultApiKeyGenerator.java
@@ -134,8 +134,8 @@ public class DefaultApiKeyGenerator implements ApiKeyGenerator {
      */
     private JSONObject generateHeader(Certificate publicCert, String signatureAlgorithm) throws APIManagementException {
         try {
-            //generate the SHA-1 thumbprint of the certificate
-            MessageDigest digestValue = MessageDigest.getInstance("SHA-1");
+            //generate the SHA-256 thumbprint of the certificate
+            MessageDigest digestValue = MessageDigest.getInstance("SHA-256");
             byte[] der = publicCert.getEncoded();
             digestValue.update(der);
             byte[] digestInBytes = digestValue.digest();
@@ -146,14 +146,14 @@ public class DefaultApiKeyGenerator implements ApiKeyGenerator {
 
             /*
              * Sample header
-             * {"typ":"JWT", "alg":"SHA256withRSA", "x5t":"a_jhNus21KVuoFx65LmkW2O_l10",
+             * {"typ":"JWT", "alg":"SHA256withRSA", "x5t#S256":"a_jhNus21KVuoFx65LmkW2O_l10",
              * "kid":"a_jhNus21KVuoFx65LmkW2O_l10_RS256"}
-             * {"typ":"JWT", "alg":"[2]", "x5t":"[1]", "x5t":"[1]"}
+             * {"typ":"JWT", "alg":"[2]", "x5t#S256":"[1]", "kid":"gateway_certificate_alias"}
              * */
             JSONObject jwtHeader = new JSONObject();
             jwtHeader.put("typ", "JWT");
             jwtHeader.put("alg", APIUtil.getJWSCompliantAlgorithmCode(signatureAlgorithm));
-            jwtHeader.put("x5t", base64UrlEncodedThumbPrint);
+            jwtHeader.put("x5t#S256", base64UrlEncodedThumbPrint);
             return jwtHeader;
 
         } catch (NoSuchAlgorithmException | CertificateEncodingException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/AbstractJWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/AbstractJWTGenerator.java
@@ -91,6 +91,8 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
     private boolean tenantBasedSigningEnabled;
     private boolean useKid;
 
+    private boolean useSHA1Hash;
+
     public AbstractJWTGenerator() {
 
         ExtendedJWTConfigurationDto jwtConfigurationDto =
@@ -125,6 +127,7 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
         }
         tenantBasedSigningEnabled = jwtConfigurationDto.isTenantBasedSigningEnabled();
         useKid = jwtConfigurationDto.useKid();
+        useSHA1Hash = jwtConfigurationDto.useSHA1Hash();
     }
 
     public String getDialectURI() {
@@ -344,7 +347,7 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
                 KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(MultitenantConstants.SUPER_TENANT_ID);
                 publicCert = keyStoreManager.getDefaultPrimaryCertificate();
             }
-            return generateHeader(publicCert, signatureAlgorithm, useKid);
+            return generateHeader(publicCert, signatureAlgorithm, useKid, useSHA1Hash);
         } catch (Exception e) {
             String error = "Error in obtaining keystore";
             throw new APIManagementException(error, e);
@@ -388,12 +391,15 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
      * @param publicCert         The public certificate which needs to include in the header as thumbprint
      * @param signatureAlgorithm Signature algorithm which needs to include in the header
      * @param useKid             Boolean to indicate whether to include kid property in the header
+     * @param useSHA1Hash        Specifies whether to use SHA-1 algorithm to generate the certificate thumbprint
      */
-    public static String generateHeader(Certificate publicCert, String signatureAlgorithm, boolean useKid)
+    public static String generateHeader(Certificate publicCert, String signatureAlgorithm, boolean useKid,
+                                        boolean useSHA1Hash)
             throws APIManagementException {
         try {
-            //generate the SHA-1 thumbprint of the certificate
-            MessageDigest digestValue = MessageDigest.getInstance("SHA-1");
+            String hashingAlgorithm = useSHA1Hash ? APIConstants.SHA_1 : APIConstants.SHA_256;
+            //generate the thumbprint of the certificate
+            MessageDigest digestValue = MessageDigest.getInstance(hashingAlgorithm);
             byte[] der = publicCert.getEncoded();
             digestValue.update(der);
             byte[] digestInBytes = digestValue.digest();
@@ -405,14 +411,18 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
 
             /*
              * Sample header
-             * {"typ":"JWT", "alg":"SHA256withRSA", "x5t":"a_jhNus21KVuoFx65LmkW2O_l10",
+             * {"typ":"JWT", "alg":"SHA256withRSA", "x5t#S256":"a_jhNus21KVuoFx65LmkW2O_l10",
              * "kid":"a_jhNus21KVuoFx65LmkW2O_l10_RS256"}
-             * {"typ":"JWT", "alg":"[2]", "x5t":"[1]", "x5t":"[1]"}
+             * {"typ":"JWT", "alg":"[2]", "x5t#S256":"[1]"}
              * */
             JSONObject jwtHeader = new JSONObject();
             jwtHeader.put("typ", "JWT");
             jwtHeader.put("alg", APIUtil.getJWSCompliantAlgorithmCode(signatureAlgorithm));
-            jwtHeader.put("x5t", base64UrlEncodedThumbPrint);
+            if (useSHA1Hash) {
+                jwtHeader.put(APIConstants.X5T_PARAMETER, base64UrlEncodedThumbPrint);
+            } else {
+                jwtHeader.put(APIConstants.X5T256_PARAMETER, base64UrlEncodedThumbPrint);
+            }
             if (useKid) {
                 jwtHeader.put("kid", JWTUtil.getKID(x509Certificate));
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/token/TokenGenTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/token/TokenGenTest.java
@@ -58,6 +58,7 @@ import java.util.UUID;
         SubscriptionDataHolder.class})
 public class TokenGenTest {
     private static final Log log = LogFactory.getLog(TokenGenTest.class);
+    private static final String signatureAlgorithm = "SHA256withRSA";
 
     @Before
     public void setUp() throws Exception {
@@ -239,11 +240,11 @@ public class TokenGenTest {
         keystore.load(inputStream, pwd);
         Certificate cert = keystore.getCertificate("wso2carbon");
 
-        //Generate JWT header using the above certificate
-        String header = AbstractJWTGenerator.generateHeader(cert, "SHA256withRSA", false, true);
+        //Generate JWT header using the above certificate. Use SHA-1 as the certificate hashing algorithm.
+        String header = AbstractJWTGenerator.generateHeader(cert, signatureAlgorithm, false, true);
 
         String encodedThumbprint = generateCertThumbprint(cert, "SHA-1");
-        //Check if the encoded thumbprint get matched with JWT header's x5t
+        //Check if the encoded thumbprint matches with the JWT header's x5t
         Assert.assertTrue(header.contains(encodedThumbprint));
         Assert.assertTrue(header.contains("x5t"));
     }
@@ -257,11 +258,11 @@ public class TokenGenTest {
         keystore.load(inputStream, pwd);
         Certificate cert = keystore.getCertificate("wso2carbon");
 
-        //Generate JWT header using the above certificate
-        String header = AbstractJWTGenerator.generateHeader(cert, "SHA256withRSA", false, false);
+        //Generate JWT header using the above certificate. Use SHA-256 as the certificate hashing algorithm.
+        String header = AbstractJWTGenerator.generateHeader(cert, signatureAlgorithm, false, false);
 
         String encodedThumbprint = generateCertThumbprint(cert, "SHA-256");
-        //Check if the encoded thumbprint get matched with JWT header's x5t#S256
+        //Check if the encoded thumbprint matches with the JWT header's x5t#S256
         Assert.assertTrue(header.contains(encodedThumbprint));
         Assert.assertTrue(header.contains("x5t#S256"));
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/resources/amConfig.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/resources/amConfig.xml
@@ -11,7 +11,8 @@
     </Database>
     <JWTConfiguration>
         <EnableJWTGeneration>true</EnableJWTGeneration>
-	    <SignatureAlgorithm>NONE</SignatureAlgorithm>
+        <SignatureAlgorithm>NONE</SignatureAlgorithm>
+        <UseSHA1Hash>false</UseSHA1Hash>
     </JWTConfiguration>
     <APIUsageTracking>
         <Enabled>false</Enabled>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -70,6 +70,9 @@
         <!-- Signature algorithm. Accepts "SHA256withRSA" or "NONE". To disable signing explicitly specify "NONE". -->
         <SignatureAlgorithm>{{apim.jwt.signing_algorithm}}</SignatureAlgorithm>
 
+        <!-- Specifies whether to use SHA-1 algorithm to generate the certificate thumbprint -->
+        <UseSHA1Hash>{{apim.jwt.use_sha1_hash}}</UseSHA1Hash>
+
         <!-- This parameter specifies which implementation should be used for generating the Token. JWTGenerator is the
 	     default implementation provided. -->
         {% if apim.jwt.generator_impl is defined %}


### PR DESCRIPTION
### Purpose
This PR changes the default certificate hashing algorithm to SHA-256 instead of SHA-1. 

The following flows are affected due to this change.

1. The certificate hashing algorithm used in generating API keys will now use SHA-256 as the hashing algorithm

2. The certificate hashing algorithm used in generating backend JWTs for JWT and Opaque token SPs will now use SHA-256 as the default hashing algorithm. A config is provided to use SHA-1 as follows.

**api-manager.xml.j2**
```
<JWTConfiguration>
    ......
    <!-- Specifies whether to use SHA-1 algorithm to generate the certificate thumbprint -->
    <UseSHA1Hash>{{apim.jwt.use_sha1_hash}}</UseSHA1Hash>
    ......
</JWTConfiguration>
```

To use SHA-1 instead of SHA-256, the following has to be added to the deployment.toml.

**deployment.toml**
```
[apim.jwt]
enable = true
use_sha1_hash = false
```

- The PR [1] has to be merged after merging this PR to fix the integration test failures

[1] https://github.com/wso2/product-apim/pull/13455