### PR TITLE
Enable mulitple filter options in API search

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistrySearchUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistrySearchUtil.java
@@ -98,31 +98,48 @@ public class RegistrySearchUtil {
      * @throws APIManagementException If there is an error in the search query
      */
     private static String constructQueryWithProvidedCriterias(String inputSearchQuery) throws APIPersistenceException {
-
         String newSearchQuery = "";
-        // sub context and doc content doesn't support AND search
-        if (inputSearchQuery != null && inputSearchQuery.contains(" ")
-                && !inputSearchQuery.contains(TAG_COLON_SEARCH_TYPE_PREFIX)
-                && (!inputSearchQuery.contains(CONTENT_SEARCH_TYPE_PREFIX) || inputSearchQuery.split(":").length > 2)) {
-            if (inputSearchQuery.split(" ").length > 1) {
-                String[] searchCriterias = inputSearchQuery.split(" ");
-                for (int i = 0; i < searchCriterias.length; i++) {
-                    if (searchCriterias[i].contains(":") && searchCriterias[i].split(":").length > 1) {
-                        if (DOCUMENTATION_SEARCH_TYPE_PREFIX.equalsIgnoreCase(searchCriterias[i].split(":")[0])) {
-                            throw new APIPersistenceException("Invalid query. AND based search is not supported for "
-                                    + "doc prefix");
-                        }
-                    }
-                    if (i == 0) {
-                        newSearchQuery = getSingleSearchCriteria(searchCriterias[i]);
-                    } else {
-                        newSearchQuery = newSearchQuery + SEARCH_AND_TAG + getSingleSearchCriteria(searchCriterias[i]);
-                    }
+
+        //for empty search query this method should return name=* as the new search query
+        if (StringUtils.isEmpty(inputSearchQuery)) {
+            newSearchQuery = getSingleSearchCriteria(inputSearchQuery);
+        } else {
+            String[] criterea = inputSearchQuery.split(" ");
+            Map<String, List<String>> critereaMap = new HashMap<>();
+            for (int i = 0; i < criterea.length; i++) {
+                if (criterea[i].contains(":") && criterea[i].split(":").length > 1) {
+                    String searchPrefix = criterea[i].split(":")[0];
+                    String searchValue = criterea[i].split(":")[1];
+
+                    List<String> values = critereaMap.containsKey(searchPrefix) ? critereaMap.get(searchPrefix) : new ArrayList<>();
+                    values.add(searchValue);
+                    critereaMap.put(searchPrefix, values);
                 }
             }
-        } else {
-            newSearchQuery = getSingleSearchCriteria(inputSearchQuery);
+
+            // doc content doesn't support AND search
+            if (critereaMap.size() > 1 && critereaMap.containsKey(DOCUMENTATION_SEARCH_TYPE_PREFIX)) {
+                throw new APIPersistenceException("Invalid query. AND based search is not supported for "
+                        + "doc prefix");
+            }
+
+            // When multiple values are present for the same search key those are considered as an OR based search.
+            // ex: tags:sales tags:dev -> tags=(sales OR dev)
+            // When multiple search keys are present those are considered as an AND based search.
+            // ex: name:pizzashack version:1.0 -> name=pizzashack AND version=1.0
+            for (Map.Entry<String, List<String>> entry : critereaMap.entrySet()) {
+                String nextCriterea = "";
+                if (entry.getValue().size() > 1) {
+                    nextCriterea = entry.getKey() + "=" + getORBasedSearchCriteria(entry.getValue().toArray(new String[0]));
+                } else {
+                    nextCriterea = getSingleSearchCriteria(entry.getKey() + ":" + entry.getValue().get(0));
+                }
+
+                newSearchQuery = StringUtils.isNotEmpty(newSearchQuery) ? (newSearchQuery + SEARCH_AND_TAG + nextCriterea) :
+                        nextCriterea;
+            }
         }
+
         return newSearchQuery;
     }
 


### PR DESCRIPTION
- Fixes https://github.com/wso2/api-manager/issues/2679

When multiple values are present for the same search key those are considered as an OR based search.
`ex: tags:sales tags:dev -> tags=(sales OR dev)`

When multiple search keys are present those are considered as an AND based search.
`ex: name:pizzashack version:1.0 -> name=pizzashack AND version=1.0`