### PR TITLE
Fix MSSQL specific shared ts reader issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -16163,9 +16163,8 @@ public class ApiMgtDAO {
                     workflow.setTenantDomain(rs.getString("TENANT_DOMAIN"));
                     workflow.setExternalWorkflowReference(rs.getString("WF_EXTERNAL_REFERENCE"));
                     workflow.setWorkflowDescription(rs.getString("WF_STATUS_DESC"));
-                    InputStream metadataBlob = rs.getBinaryStream("WF_METADATA");
-                    InputStream propertiesBlob = rs.getBinaryStream("WF_PROPERTIES");
 
+                    InputStream metadataBlob = rs.getBinaryStream("WF_METADATA");
                     if (metadataBlob != null) {
                         String metadata = APIMgtDBUtil.getStringFromInputStream(metadataBlob);
                         Gson metadataGson = new Gson();
@@ -16176,6 +16175,7 @@ public class ApiMgtDAO {
                         workflow.setMetadata(metadataJson);
                     }
 
+                    InputStream propertiesBlob = rs.getBinaryStream("WF_PROPERTIES");
                     if (propertiesBlob != null) {
                         String properties = APIMgtDBUtil.getStringFromInputStream(propertiesBlob);
                         Gson propertiesGson = new Gson();
@@ -16233,9 +16233,8 @@ public class ApiMgtDAO {
                     workflow.setTenantId(rs.getInt("TENANT_ID"));
                     workflow.setTenantDomain(rs.getString("TENANT_DOMAIN"));
                     workflow.setExternalWorkflowReference(rs.getString("WF_EXTERNAL_REFERENCE"));
-                    InputStream targetStream = rs.getBinaryStream("WF_METADATA");
-                    InputStream propertiesTargetStream = rs.getBinaryStream("WF_PROPERTIES");
 
+                    InputStream targetStream = rs.getBinaryStream("WF_METADATA");
                     if (targetStream != null) {
                         String metadata = APIMgtDBUtil.getStringFromInputStream(targetStream);
                         Gson metadataGson = new Gson();
@@ -16246,6 +16245,7 @@ public class ApiMgtDAO {
                         workflow.setMetadata(metadataJson);
                     }
 
+                    InputStream propertiesTargetStream = rs.getBinaryStream("WF_PROPERTIES");
                     if (propertiesTargetStream != null) {
                         String properties = APIMgtDBUtil.getStringFromInputStream(propertiesTargetStream);
                         Gson propertiesGson = new Gson();


### PR DESCRIPTION
Fixing : https://github.com/wso2/api-manager/issues/2701

The tsreader (object in the `InputStream`) gets shared when `rs.getBinaryStream` is used to retrieve the `InputStream`. Therefore the subsequent calls should occur after finishing the `InputStream` reading.