### PR TITLE
Fix gateway name validating issues

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/GatewayPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/GatewayPoliciesApiServiceImpl.java
@@ -175,7 +175,7 @@ public class GatewayPoliciesApiServiceImpl implements GatewayPoliciesApiService 
                 String labelToCheck = dto.getGatewayLabel();
                 boolean labelFound = false;
                 for (Environment env : allEnvs) {
-                    if (env.getDisplayName().equals(labelToCheck)) {
+                    if (env.getName().equals(labelToCheck)) {
                         labelFound = true;
                         break;
                     }


### PR DESCRIPTION
### Purpose

To resolve the gateway policy deployment issues. An error occurs when a gateway has different names for name and display name.

```ERROR - GatewayPoliciesApiServiceImpl Invalid gateway labels: GW1```