### PR TITLE
pdfbox bump

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -228,6 +228,10 @@
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.pdfbox</groupId>
+            <artifactId>pdfbox-io</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.wso2.carbon.event-processing</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/indexing/indexer/DocumentIndexer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/indexing/indexer/DocumentIndexer.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.pdfbox.cos.COSDocument;
-import org.apache.pdfbox.io.RandomAccessBufferedFileInputStream;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdfparser.PDFParser;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
@@ -181,9 +181,9 @@ public class DocumentIndexer extends RXTIndexer {
                 inputStream = contentResource.getContentStream();
                 switch (extension) {
                 case APIConstants.PDF_EXTENSION:
-                    PDFParser pdfParser = new PDFParser(new RandomAccessBufferedFileInputStream(inputStream));
+                    PDFParser pdfParser = new PDFParser(new RandomAccessReadBuffer(inputStream));
                     pdfParser.parse();
-                    COSDocument cosDocument = pdfParser.getDocument();
+                    COSDocument cosDocument = pdfParser.parse().getDocument();
                     PDFTextStripper stripper = new PDFTextStripper();
                     contentString = stripper.getText(new PDDocument(cosDocument));
                     break;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/indexing/indexer/PDFIndexer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/indexing/indexer/PDFIndexer.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.pdfbox.io.RandomAccessBufferedFileInputStream;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.pdfbox.cos.COSDocument;
@@ -30,7 +30,7 @@ public class PDFIndexer implements Indexer {
 		try {
 			PDFParser parser = getPdfParser(fileData);
 			parser.parse();
-			cosDoc = parser.getDocument();
+			cosDoc = parser.parse().getDocument();
 
 			PDFTextStripper stripper = getPdfTextStripper();
 			String docText = stripper.getText(new PDDocument(cosDoc));
@@ -70,7 +70,7 @@ public class PDFIndexer implements Indexer {
 	}
 
 	protected PDFParser getPdfParser(File2Index fileData) throws IOException {
-		return new PDFParser(new RandomAccessBufferedFileInputStream(new ByteArrayInputStream(fileData.data)));
+		return new PDFParser(new RandomAccessReadBuffer(new ByteArrayInputStream(fileData.data)));
 	}
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/indexing/indexer/PDFIndexerTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/indexing/indexer/PDFIndexerTest.java
@@ -45,10 +45,13 @@ public class PDFIndexerTest {
         String mediaType = "application/pdf+test";
         final String MEDIA_TYPE = "mediaType";
         PDFParser parser = Mockito.mock(PDFParser.class);
+        PDDocument pdDocument = Mockito.mock(PDDocument.class);
         COSDocument cosDoc = Mockito.mock(COSDocument.class);
         PDFTextStripper pdfTextStripper = Mockito.mock(PDFTextStripper.class);
         Mockito.doThrow(IOException.class).when(cosDoc).close();
-        Mockito.when(parser.getDocument()).thenReturn(new COSDocument()).thenReturn(cosDoc);
+        Mockito.when(parser.parse()).thenReturn(new PDDocument());
+
+        Mockito.when(pdDocument.getDocument()).thenReturn(new COSDocument()).thenReturn(cosDoc);
         Mockito.when(pdfTextStripper.getText(new PDDocument())).thenReturn("");
         PDFIndexer pdfIndexer = new PDFIndexerWrapper(parser, pdfTextStripper);
 

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.store.feature/pom.xml
@@ -329,6 +329,9 @@
                                 <importBundleDef>org.apache.pdfbox:fontbox:${pdfbox.version}</importBundleDef>
                                 <importBundleDef>org.apache.pdfbox:xmpbox:${pdfbox.version}</importBundleDef>
                                 <importBundleDef>
+                                    org.wso2.orbit.org.apache.pdfbox:pdfbox-io:${pdfbox.io.version}
+                                </importBundleDef>
+                                <importBundleDef>
                                     org.wso2.orbit.com.github.dblock.waffle:waffle-jna:${waffle-jna.version}
                                 </importBundleDef>
                                 <importBundleDef>

--- a/pom.xml
+++ b/pom.xml
@@ -1397,6 +1397,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.wso2.orbit.org.apache.pdfbox</groupId>
+                <artifactId>pdfbox-io</artifactId>
+                <version>${pdfbox.io.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>fontbox</artifactId>
                 <version>${pdfbox.version}</version>
@@ -2166,8 +2172,9 @@
         <cxf.version>3.6.2</cxf.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <!-- apache pdfbox version -->
-        <pdfbox.version>2.0.25</pdfbox.version>
         <event.processor.version>2.3.10</event.processor.version>
+        <pdfbox.version>3.0.1</pdfbox.version>
+        <pdfbox.io.version>3.0.1.wso2v1</pdfbox.io.version>
         <swagger.inflector.version>1.0.16.wso2v1</swagger.inflector.version>
         <swagger.inflector.oas3.version>2.0.5.wso2v2</swagger.inflector.oas3.version>
         <swagger.parser.v3.version>2.1.20.wso2v1</swagger.parser.v3.version>


### PR DESCRIPTION
### Purpose
pdfbox bump to 3.0.1 and add necessary pdfbox-io orbit jar

The reason to create pdfbox-io as a orbit jar is to remove sun-misc import