### PR TITLE
Use SHA-1 as Default Certificate Hashing Algorithm and Provide Config to Use SHA-256

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/JWTConfigurationDto.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/JWTConfigurationDto.java
@@ -35,7 +35,7 @@ public class JWTConfigurationDto {
     private String consumerDialectUri = "http://wso2.org/claims";
     private String signatureAlgorithm = "SHA256withRSA";
 
-    private boolean useSHA1Hash = false;
+    private boolean useSHA256Hash = false;
     private String jwtDecoding = "base64";
     private boolean enableUserClaims;
     private String gatewayJWTGeneratorImpl;
@@ -61,7 +61,7 @@ public class JWTConfigurationDto {
         this.jwtHeader = jwtConfigurationDto.jwtHeader;
         this.consumerDialectUri = jwtConfigurationDto.consumerDialectUri;
         this.signatureAlgorithm = jwtConfigurationDto.signatureAlgorithm;
-        this.useSHA1Hash = jwtConfigurationDto.useSHA1Hash;
+        this.useSHA256Hash = jwtConfigurationDto.useSHA256Hash;
         this.jwtDecoding = jwtConfigurationDto.jwtDecoding;
         this.enableUserClaims = jwtConfigurationDto.enableUserClaims;
         this.gatewayJWTGeneratorImpl = jwtConfigurationDto.gatewayJWTGeneratorImpl;
@@ -193,11 +193,11 @@ public class JWTConfigurationDto {
         return ttl;
     }
 
-    public boolean useSHA1Hash() {
-        return useSHA1Hash;
+    public boolean useSHA256Hash() {
+        return useSHA256Hash;
     }
 
-    public void setUseSHA1Hash(boolean useSHA1Hash) {
-        this.useSHA1Hash = useSHA1Hash;
+    public void setUseSHA256Hash(boolean useSHA256Hash) {
+        this.useSHA256Hash = useSHA256Hash;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/jwtgenerator/AbstractAPIMgtGatewayJWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/jwtgenerator/AbstractAPIMgtGatewayJWTGenerator.java
@@ -57,7 +57,7 @@ public abstract class AbstractAPIMgtGatewayJWTGenerator {
 
     private String signatureAlgorithm;
 
-    private boolean useSHA1Hash;
+    private boolean useSHA256Hash = false;
 
     public AbstractAPIMgtGatewayJWTGenerator() {
     }
@@ -73,7 +73,7 @@ public abstract class AbstractAPIMgtGatewayJWTGenerator {
                 || SHA256_WITH_RSA.equals(signatureAlgorithm))) {
             signatureAlgorithm = SHA256_WITH_RSA;
         }
-        useSHA1Hash = jwtConfigurationDto.useSHA1Hash();
+        useSHA256Hash = jwtConfigurationDto.useSHA256Hash();
 
     }
 
@@ -150,7 +150,7 @@ public abstract class AbstractAPIMgtGatewayJWTGenerator {
         try {
             Certificate publicCert = jwtConfigurationDto.getPublicCert();
             return JWTUtil.generateHeader(publicCert, signatureAlgorithm, jwtConfigurationDto.useKid(),
-                    useSHA1Hash);
+                    useSHA256Hash);
         } catch (Exception e) {
             String error = "Error in obtaining keystore";
             throw new JWTGeneratorException(error, e);

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/JWTUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/JWTUtil.java
@@ -88,24 +88,24 @@ public final class JWTUtil {
      * @param publicCert         The public certificate which needs to include in the header as thumbprint
      * @param signatureAlgorithm Signature algorithm which needs to include in the header
      * @param useKid             Specifies whether the header should include the kid property
-     * @param useSHA1Hash        Specifies whether to use SHA-1 algorithm to generate the certificate thumbprint
+     * @param useSHA256Hash      Specifies whether to use SHA-256 algorithm to generate the certificate thumbprint
      * @throws JWTGeneratorException
      */
 
     public static String generateHeader(Certificate publicCert, String signatureAlgorithm, boolean useKid,
-                                        boolean useSHA1Hash)
+                                        boolean useSHA256Hash)
             throws JWTGeneratorException {
 
         /*
          * Sample header
-         * {"typ":"JWT", "alg":"SHA256withRSA", "x5t#S256":"a_jhNus21KVuoFx65LmkW2O_l10",
+         * {"typ":"JWT", "alg":"SHA256withRSA", "x5t":"a_jhNus21KVuoFx65LmkW2O_l10",
          * "kid":"a_jhNus21KVuoFx65LmkW2O_l10"}
-         * {"typ":"JWT", "alg":"[2]", "x5t#S256":"[1]"}
+         * {"typ":"JWT", "alg":"[2]", "x5t":"[1]"}
          * */
         try {
             X509Certificate x509Certificate = (X509Certificate) publicCert;
 
-            String hashingAlgorithm = useSHA1Hash ? JWTConstants.SHA_1 : JWTConstants.SHA_256;
+            String hashingAlgorithm = useSHA256Hash ? JWTConstants.SHA_256 : JWTConstants.SHA_1;
             //generate the thumbprint of the certificate
             MessageDigest digestValue = MessageDigest.getInstance(hashingAlgorithm);
             byte[] der = publicCert.getEncoded();
@@ -119,10 +119,10 @@ public final class JWTUtil {
             JSONObject jwtHeader = new JSONObject();
             jwtHeader.put("typ", "JWT");
             jwtHeader.put("alg", getJWSCompliantAlgorithmCode(signatureAlgorithm));
-            if (useSHA1Hash) {
-                jwtHeader.put(JWTConstants.X5T_PARAMETER, base64UrlEncodedThumbPrint);
-            } else {
+            if (useSHA256Hash) {
                 jwtHeader.put(JWTConstants.X5T256_PARAMETER, base64UrlEncodedThumbPrint);
+            } else {
+                jwtHeader.put(JWTConstants.X5T_PARAMETER, base64UrlEncodedThumbPrint);
             }
 
             if (useKid) {

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/test/java/org/wso2/carbon/apimgt/common/gateway/JWTUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/test/java/org/wso2/carbon/apimgt/common/gateway/JWTUtilTestCase.java
@@ -64,7 +64,7 @@ public class JWTUtilTestCase {
         String signatureAlgorithm = "SHA256withRSA";
 
         //Use SHA-256 as the certificate hashing algorithm
-        String jwt = JWTUtil.generateHeader(cert, signatureAlgorithm, true, false);
+        String jwt = JWTUtil.generateHeader(cert, signatureAlgorithm, true, true);
         Assert.assertNotNull(jwt);
         Assert.assertTrue(jwt.contains("kid"));
 
@@ -74,7 +74,7 @@ public class JWTUtilTestCase {
         Assert.assertTrue(jwt.contains("x5t#S256"));
 
         //Use SHA-1 as the certificate hashing algorithm
-        jwt = JWTUtil.generateHeader(cert, signatureAlgorithm, false, true);
+        jwt = JWTUtil.generateHeader(cert, signatureAlgorithm, false, false);
         Assert.assertNotNull(jwt);
         Assert.assertFalse(jwt.contains("kid"));
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -461,7 +461,7 @@ public final class APIConstants {
     public static final String USE_KID = "UseKidProperty";
     public static final String CONSUMER_DIALECT_URI = "ConsumerDialectURI";
     public static final String JWT_SIGNATURE_ALGORITHM = "SignatureAlgorithm";
-    public static final String USE_SHA1_HASH = "UseSHA1Hash";
+    public static final String USE_SHA256_HASH = "UseSHA256Hash";
 
     public static final String X5T_PARAMETER = "x5t";
     public static final String X5T256_PARAMETER = "x5t#S256";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -1638,10 +1638,10 @@ public class APIManagerConfiguration {
             if (signatureElement != null) {
                 jwtConfigurationDto.setSignatureAlgorithm(signatureElement.getText());
             }
-            OMElement useSHA1HashElement =
-                    omElement.getFirstChildWithName(new QName(APIConstants.USE_SHA1_HASH));
-            if (useSHA1HashElement != null) {
-                jwtConfigurationDto.setUseSHA1Hash(Boolean.parseBoolean(useSHA1HashElement.getText()));
+            OMElement useSHA256HashElement =
+                    omElement.getFirstChildWithName(new QName(APIConstants.USE_SHA256_HASH));
+            if (useSHA256HashElement != null) {
+                jwtConfigurationDto.setUseSHA256Hash(Boolean.parseBoolean(useSHA256HashElement.getText()));
             }
             OMElement claimRetrieverImplElement =
                     omElement.getFirstChildWithName(new QName(APIConstants.CLAIMS_RETRIEVER_CLASS));

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/AbstractJWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/AbstractJWTGenerator.java
@@ -91,7 +91,7 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
     private boolean tenantBasedSigningEnabled;
     private boolean useKid;
 
-    private boolean useSHA1Hash;
+    private boolean useSHA256Hash = false;
 
     public AbstractJWTGenerator() {
 
@@ -127,7 +127,7 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
         }
         tenantBasedSigningEnabled = jwtConfigurationDto.isTenantBasedSigningEnabled();
         useKid = jwtConfigurationDto.useKid();
-        useSHA1Hash = jwtConfigurationDto.useSHA1Hash();
+        useSHA256Hash = jwtConfigurationDto.useSHA256Hash();
     }
 
     public String getDialectURI() {
@@ -347,7 +347,7 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
                 KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(MultitenantConstants.SUPER_TENANT_ID);
                 publicCert = keyStoreManager.getDefaultPrimaryCertificate();
             }
-            return generateHeader(publicCert, signatureAlgorithm, useKid, useSHA1Hash);
+            return generateHeader(publicCert, signatureAlgorithm, useKid, useSHA256Hash);
         } catch (Exception e) {
             String error = "Error in obtaining keystore";
             throw new APIManagementException(error, e);
@@ -391,13 +391,13 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
      * @param publicCert         The public certificate which needs to include in the header as thumbprint
      * @param signatureAlgorithm Signature algorithm which needs to include in the header
      * @param useKid             Boolean to indicate whether to include kid property in the header
-     * @param useSHA1Hash        Specifies whether to use SHA-1 algorithm to generate the certificate thumbprint
+     * @param useSHA256Hash        Specifies whether to use SHA-256 algorithm to generate the certificate thumbprint
      */
     public static String generateHeader(Certificate publicCert, String signatureAlgorithm, boolean useKid,
-                                        boolean useSHA1Hash)
+                                        boolean useSHA256Hash)
             throws APIManagementException {
         try {
-            String hashingAlgorithm = useSHA1Hash ? APIConstants.SHA_1 : APIConstants.SHA_256;
+            String hashingAlgorithm = useSHA256Hash ? APIConstants.SHA_256 : APIConstants.SHA_1;
             //generate the thumbprint of the certificate
             MessageDigest digestValue = MessageDigest.getInstance(hashingAlgorithm);
             byte[] der = publicCert.getEncoded();
@@ -411,17 +411,17 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
 
             /*
              * Sample header
-             * {"typ":"JWT", "alg":"SHA256withRSA", "x5t#S256":"a_jhNus21KVuoFx65LmkW2O_l10",
+             * {"typ":"JWT", "alg":"SHA256withRSA", "x5t":"a_jhNus21KVuoFx65LmkW2O_l10",
              * "kid":"a_jhNus21KVuoFx65LmkW2O_l10_RS256"}
-             * {"typ":"JWT", "alg":"[2]", "x5t#S256":"[1]"}
+             * {"typ":"JWT", "alg":"[2]", "x5t":"[1]"}
              * */
             JSONObject jwtHeader = new JSONObject();
             jwtHeader.put("typ", "JWT");
             jwtHeader.put("alg", APIUtil.getJWSCompliantAlgorithmCode(signatureAlgorithm));
-            if (useSHA1Hash) {
-                jwtHeader.put(APIConstants.X5T_PARAMETER, base64UrlEncodedThumbPrint);
-            } else {
+            if (useSHA256Hash) {
                 jwtHeader.put(APIConstants.X5T256_PARAMETER, base64UrlEncodedThumbPrint);
+            } else {
+                jwtHeader.put(APIConstants.X5T_PARAMETER, base64UrlEncodedThumbPrint);
             }
             if (useKid) {
                 jwtHeader.put("kid", JWTUtil.getKID(x509Certificate));

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/token/TokenGenTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/java/org/wso2/carbon/apimgt/keymgt/token/TokenGenTest.java
@@ -241,7 +241,7 @@ public class TokenGenTest {
         Certificate cert = keystore.getCertificate("wso2carbon");
 
         //Generate JWT header using the above certificate. Use SHA-1 as the certificate hashing algorithm.
-        String header = AbstractJWTGenerator.generateHeader(cert, signatureAlgorithm, false, true);
+        String header = AbstractJWTGenerator.generateHeader(cert, signatureAlgorithm, false, false);
 
         String encodedThumbprint = generateCertThumbprint(cert, "SHA-1");
         //Check if the encoded thumbprint matches with the JWT header's x5t
@@ -259,7 +259,7 @@ public class TokenGenTest {
         Certificate cert = keystore.getCertificate("wso2carbon");
 
         //Generate JWT header using the above certificate. Use SHA-256 as the certificate hashing algorithm.
-        String header = AbstractJWTGenerator.generateHeader(cert, signatureAlgorithm, false, false);
+        String header = AbstractJWTGenerator.generateHeader(cert, signatureAlgorithm, false, true);
 
         String encodedThumbprint = generateCertThumbprint(cert, "SHA-256");
         //Check if the encoded thumbprint matches with the JWT header's x5t#S256

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/resources/amConfig.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/resources/amConfig.xml
@@ -12,7 +12,7 @@
     <JWTConfiguration>
         <EnableJWTGeneration>true</EnableJWTGeneration>
         <SignatureAlgorithm>NONE</SignatureAlgorithm>
-        <UseSHA1Hash>false</UseSHA1Hash>
+        <UseSHA256Hash>false</UseSHA256Hash>
     </JWTConfiguration>
     <APIUsageTracking>
         <Enabled>false</Enabled>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -70,8 +70,8 @@
         <!-- Signature algorithm. Accepts "SHA256withRSA" or "NONE". To disable signing explicitly specify "NONE". -->
         <SignatureAlgorithm>{{apim.jwt.signing_algorithm}}</SignatureAlgorithm>
 
-        <!-- Specifies whether to use SHA-1 algorithm to generate the certificate thumbprint -->
-        <UseSHA1Hash>{{apim.jwt.use_sha1_hash}}</UseSHA1Hash>
+        <!-- Specifies whether to use SHA-256 algorithm to generate the certificate thumbprint -->
+        <UseSHA256Hash>{{apim.jwt.use_sha256_hash}}</UseSHA256Hash>
 
         <!-- This parameter specifies which implementation should be used for generating the Token. JWTGenerator is the
 	     default implementation provided. -->


### PR DESCRIPTION
With [1], the default certificate hashing algorithm in Backend JWT generation was made as SHA-256. But we will revert this change and make SHA-1 as the default certificate hashing algorithm. A config will be provided to use SHA256 as the certificate hashing algorithm

**api-manager.xml.j2**
```
<JWTConfiguration>
    ......
    <!-- Specifies whether to use SHA-1 algorithm to generate the certificate thumbprint -->
    <UseSHA256Hash>{{apim.jwt.use_sha256_hash}}</UseSHA256Hash>
    ......
</JWTConfiguration>
```

To use SHA-256 instead of SHA-1, the following has to be added to the deployment.toml.

**deployment.toml**
```
[apim.jwt]
enable = true
use_sha256_hash = true
```

[1] https://github.com/wso2/carbon-apimgt/pull/12365