### PR TITLE
Improve Generation of the API Definition for API Products

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -447,18 +447,7 @@ public class OASParserUtil {
                     if (parameters != null) {
                         for (String refKey : refCategoryEntry.getValue()) {
                             Parameter parameter = parameters.get(refKey);
-                            //Extract the parameter reference only if it exists in the source definition
-                            if(parameter != null) {
-                                Content content = parameter.getContent();
-                                if (content != null) {
-                                    extractReferenceFromContent(content, context);
-                                } else {
-                                    String ref = parameter.get$ref();
-                                    if (ref != null) {
-                                        extractReferenceWithoutSchema(ref, context);
-                                    }
-                                }
-                            }
+                            setRefOfParameter(parameter, context);
                         }
                     }
                 }
@@ -700,6 +689,23 @@ public class OASParserUtil {
     private static void setRefOfParameters(List<Parameter> parameters, SwaggerUpdateContext context) {
         if (parameters != null) {
             for (Parameter parameter : parameters) {
+                setRefOfParameter(parameter, context);
+            }
+        }
+    }
+
+    /**
+     * Process a given parameter entry of the API definition.
+     *
+     * @param parameter  The parameter object which needs to be processed.
+     * @param context The SwaggerUpdateContext object containing the context of the API definition.
+     */
+    private static void setRefOfParameter(Parameter parameter, SwaggerUpdateContext context) {
+        if (parameter != null) {
+            Content content = parameter.getContent();
+            if (content != null) {
+                extractReferenceFromContent(content, context);
+            } else {
                 Schema schema = parameter.getSchema();
                 if (schema != null) {
                     String ref = schema.get$ref();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -480,8 +480,18 @@ public class OASParserUtil {
                     if (headers != null) {
                         for (String refKey : refCategoryEntry.getValue()) {
                             Header header = headers.get(refKey);
-                            Content content = header.getContent();
-                            extractReferenceFromContent(content, context);
+                            setRefOfApiResponseHeader(header, context);
+                        }
+                    }
+                }
+
+                if (EXAMPLES.equalsIgnoreCase(category)) {
+                    Map<String, Example> examples = sourceComponents.getExamples();
+
+                    if (examples != null) {
+                        for (String refKey : refCategoryEntry.getValue()) {
+                            Example example = examples.get(refKey);
+                            setRefOfExample(example, context);
                         }
                     }
                 }
@@ -652,14 +662,21 @@ public class OASParserUtil {
 
                 if (headers != null) {
                     for (Header header : headers.values()) {
-                        Content content = header.getContent();
-                        extractReferenceFromContent(content, context);
-                        String ref = header.get$ref();
-                        if (ref != null) {
-                            addToReferenceObjectMap(ref, context);
-                        }
+                        setRefOfApiResponseHeader(header, context);
                     }
                 }
+            }
+        }
+    }
+
+    private static void setRefOfApiResponseHeader(Header header, SwaggerUpdateContext context) {
+        Content content = header.getContent();
+        if (content != null) {
+            extractReferenceFromContent(content, context);
+        } else {
+            String ref = header.get$ref();
+            if (ref != null) {
+                addToReferenceObjectMap(ref, context);
             }
         }
     }
@@ -683,6 +700,13 @@ public class OASParserUtil {
         }
     }
 
+    private static void setRefOfExample(Example example, SwaggerUpdateContext context) {
+        String ref = example.get$ref();
+        if (ref != null) {
+            addToReferenceObjectMap(ref, context);
+        }
+    }
+
     private static void extractReferenceFromContent(Content content, SwaggerUpdateContext context) {
         if (content != null) {
             for (MediaType mediaType : content.values()) {
@@ -693,11 +717,8 @@ public class OASParserUtil {
                 Map<String, Example> examples = mediaType.getExamples();
                 if (examples != null) {
                     for (Map.Entry<String, Example> exampleEntry : examples.entrySet()) {
-                        Example exampleValue = exampleEntry.getValue();
-                        String ref = exampleValue.get$ref();
-                        if (ref != null) {
-                            addToReferenceObjectMap(ref, context);
-                        }
+                        Example example = exampleEntry.getValue();
+                        setRefOfExample(example, context);
                     }
                 }
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -650,13 +650,15 @@ public class OASParserUtil {
      * @param context The SwaggerUpdateContext object containing the context of the API definition.
      */
     private static void setRefOfApiResponse(ApiResponse response, SwaggerUpdateContext context) {
-        Content content = response.getContent();
-        if (content != null) {
-            extractReferenceFromContent(content, context);
-        } else {
-            String ref = response.get$ref();
-            if (ref != null) {
-                addToReferenceObjectMap(ref, context);
+        if (response != null) {
+            Content content = response.getContent();
+            if (content != null) {
+                extractReferenceFromContent(content, context);
+            } else {
+                String ref = response.get$ref();
+                if (ref != null) {
+                    addToReferenceObjectMap(ref, context);
+                }
             }
         }
     }
@@ -682,13 +684,15 @@ public class OASParserUtil {
      * @param context The SwaggerUpdateContext object containing the context of the API definition.
      */
     private static void setRefOfApiResponseHeader(Header header, SwaggerUpdateContext context) {
-        Content content = header.getContent();
-        if (content != null) {
-            extractReferenceFromContent(content, context);
-        } else {
-            String ref = header.get$ref();
-            if (ref != null) {
-                addToReferenceObjectMap(ref, context);
+        if (header != null) {
+            Content content = header.getContent();
+            if (content != null) {
+                extractReferenceFromContent(content, context);
+            } else {
+                String ref = header.get$ref();
+                if (ref != null) {
+                    addToReferenceObjectMap(ref, context);
+                }
             }
         }
     }
@@ -719,9 +723,11 @@ public class OASParserUtil {
      * @param context The SwaggerUpdateContext object containing the context of the API definition.
      */
     private static void setRefOfExample(Example example, SwaggerUpdateContext context) {
-        String ref = example.get$ref();
-        if (ref != null) {
-            addToReferenceObjectMap(ref, context);
+        if (example != null) {
+            String ref = example.get$ref();
+            if (ref != null) {
+                addToReferenceObjectMap(ref, context);
+            }
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -50,6 +50,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
@@ -143,6 +144,7 @@ public class OASParserUtil {
     private static final String PARAMETERS = "parameters";
     private static final String RESPONSES = "responses";
     private static final String HEADERS = "headers";
+    private static final String EXAMPLES = "examples";
 
     private static final String REF_PREFIX = "#/components/";
     private static final String ARRAY_DATA_TYPE = "array";
@@ -162,6 +164,7 @@ public class OASParserUtil {
             referenceObjectMap.put(PARAMETERS, new HashSet<>());
             referenceObjectMap.put(RESPONSES, new HashSet<>());
             referenceObjectMap.put(HEADERS, new HashSet<>());
+            referenceObjectMap.put(EXAMPLES, new HashSet<>());
         }
 
 
@@ -382,6 +385,19 @@ public class OASParserUtil {
                             Header header = headers.get(refKey);
                             if (header != null) {
                                 components.addHeaders(refKey, header);
+                            }
+                        }
+                    }
+                }
+
+                if (EXAMPLES.equalsIgnoreCase(category)) {
+                    Map<String, Example> examples = sourceComponents.getExamples();
+
+                    if (examples != null) {
+                        for (String refKey : refCategoryEntry.getValue()) {
+                            Example example = examples.get(refKey);
+                            if (example != null) {
+                                components.addExamples(refKey, example);
                             }
                         }
                     }
@@ -674,6 +690,17 @@ public class OASParserUtil {
                 Schema schema = mediaType.getSchema();
 
                 extractReferenceFromSchema(schema, context);
+
+                Map<String, Example> examples = mediaType.getExamples();
+                if (examples != null) {
+                    for (Map.Entry<String, Example> exampleEntry : examples.entrySet()) {
+                        Example exampleValue = exampleEntry.getValue();
+                        String ref = exampleValue.get$ref();
+                        if (ref != null) {
+                            addToReferenceObjectMap(ref, context);
+                        }
+                    }
+                }
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -780,7 +780,12 @@ public class OASParserUtil {
                             if (OBJECT_DATA_TYPE.equalsIgnoreCase(sc.getType())) {
                                 references.addAll(addSchemaOfSchema(sc));
                             } else {
-                                references.add(sc.get$ref());
+                                String schemaRef = sc.get$ref();
+                                if (schemaRef != null) {
+                                    references.add(sc.get$ref());
+                                } else {
+                                    processSchemaProperties(sc, context);
+                                }
                             }
                         }
                     } else if (((ComposedSchema) schema).getAnyOf() != null) {
@@ -788,7 +793,12 @@ public class OASParserUtil {
                             if (OBJECT_DATA_TYPE.equalsIgnoreCase(sc.getType())) {
                                 references.addAll(addSchemaOfSchema(sc));
                             } else {
-                                references.add(sc.get$ref());
+                                String schemaRef = sc.get$ref();
+                                if (schemaRef != null) {
+                                    references.add(sc.get$ref());
+                                } else {
+                                    processSchemaProperties(sc, context);
+                                }
                             }
                         }
                     } else if (((ComposedSchema) schema).getOneOf() != null) {
@@ -796,7 +806,12 @@ public class OASParserUtil {
                             if (OBJECT_DATA_TYPE.equalsIgnoreCase(sc.getType())) {
                                 references.addAll(addSchemaOfSchema(sc));
                             } else {
-                                references.add(sc.get$ref());
+                                String schemaRef = sc.get$ref();
+                                if (schemaRef != null) {
+                                    references.add(sc.get$ref());
+                                } else {
+                                    processSchemaProperties(sc, context);
+                                }
                             }
                         }
                     } else {
@@ -815,13 +830,22 @@ public class OASParserUtil {
                 }
             }
 
-            // Process schema properties if present
-            Map properties = schema.getProperties();
+            processSchemaProperties(schema, context);
+        }
+    }
 
-            if (properties != null) {
-                for (Object propertySchema : properties.values()) {
-                    extractReferenceFromSchema((Schema) propertySchema, context);
-                }
+    /**
+     * Process properties of a schema object of the API definition.
+     *
+     * @param schema  The schema object which contains the properties which needs to be processed.
+     * @param context The SwaggerUpdateContext object containing the context of the API definition.
+     */
+    private static void processSchemaProperties(Schema schema, SwaggerUpdateContext context) {
+        // Process schema properties if present
+        Map properties = schema.getProperties();
+        if (properties != null) {
+            for (Object propertySchema : properties.values()) {
+                extractReferenceFromSchema((Schema) propertySchema, context);
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -469,11 +469,7 @@ public class OASParserUtil {
                     if (responses != null) {
                         for (String refKey : refCategoryEntry.getValue()) {
                             ApiResponse response = responses.get(refKey);
-                            //Extract the response reference only if it exists in the source definition
-                            if(response != null) {
-                                Content content = response.getContent();
-                                extractReferenceFromContent(content, context);
-                            }
+                            setRefOfApiResponse(response, context);
                         }
                     }
                 }
@@ -632,16 +628,19 @@ public class OASParserUtil {
     private static void setRefOfApiResponses(ApiResponses responses, SwaggerUpdateContext context) {
         if (responses != null) {
             for (ApiResponse response : responses.values()) {
-                Content content = response.getContent();
+                setRefOfApiResponse(response, context);
+            }
+        }
+    }
 
-                if (content != null) {
-                    extractReferenceFromContent(content, context);
-                } else {
-                    String ref = response.get$ref();
-                    if (ref != null) {
-                        extractReferenceWithoutSchema(ref, context);
-                    }
-                }
+    private static void setRefOfApiResponse(ApiResponse response, SwaggerUpdateContext context) {
+        Content content = response.getContent();
+        if (content != null) {
+            extractReferenceFromContent(content, context);
+        } else {
+            String ref = response.get$ref();
+            if (ref != null) {
+                addToReferenceObjectMap(ref, context);
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -643,6 +643,12 @@ public class OASParserUtil {
         }
     }
 
+    /**
+     * Process a given response entry of the API definition.
+     *
+     * @param response  The response object which needs to be processed.
+     * @param context The SwaggerUpdateContext object containing the context of the API definition.
+     */
     private static void setRefOfApiResponse(ApiResponse response, SwaggerUpdateContext context) {
         Content content = response.getContent();
         if (content != null) {
@@ -669,6 +675,12 @@ public class OASParserUtil {
         }
     }
 
+    /**
+     * Process a given response header entry of the API definition.
+     *
+     * @param header  The header object which needs to be processed.
+     * @param context The SwaggerUpdateContext object containing the context of the API definition.
+     */
     private static void setRefOfApiResponseHeader(Header header, SwaggerUpdateContext context) {
         Content content = header.getContent();
         if (content != null) {
@@ -700,6 +712,12 @@ public class OASParserUtil {
         }
     }
 
+    /**
+     * Process a given example entry of the API definition.
+     *
+     * @param example  The example object which needs to be processed.
+     * @param context The SwaggerUpdateContext object containing the context of the API definition.
+     */
     private static void setRefOfExample(Example example, SwaggerUpdateContext context) {
         String ref = example.get$ref();
         if (ref != null) {


### PR DESCRIPTION
### Purpose
- This PR improves the generation of the API definition for API products
- The following improvement were done
  - Support for $ref and nested entries of responses
  - Support for $ref and nested entries of response headers
  - Support for $ref and nested entries of examples
  - Support for property entries included in allOf, anyOf and oneOf fields of schema objects

### Related Issues
- https://github.com/wso2/api-manager/issues/2470
- https://github.com/wso2/api-manager/issues/2451

