### PR TITLE
Set DTO Organization When Fetching Key Managers

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/KeymanagersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/KeymanagersApiServiceImpl.java
@@ -23,14 +23,13 @@ public class KeymanagersApiServiceImpl implements KeymanagersApiService {
 
     Log log = LogFactory.getLog(KeymanagersApiServiceImpl.class);
 
-    public static KeyManagerDTO toKeyManagerDTO(String tenantDomain,
-                                                KeyManagerConfigurationDTO keyManagerConfigurationDTO) {
+    public static KeyManagerDTO toKeyManagerDTO(KeyManagerConfigurationDTO keyManagerConfigurationDTO) {
 
         KeyManagerDTO keyManagerDTO = new KeyManagerDTO();
         keyManagerDTO.setUuid(keyManagerConfigurationDTO.getUuid());
         keyManagerDTO.setEnabled(keyManagerConfigurationDTO.isEnabled());
         keyManagerDTO.setName(keyManagerConfigurationDTO.getName());
-        keyManagerDTO.setOrganization(tenantDomain);
+        keyManagerDTO.setOrganization(keyManagerConfigurationDTO.getOrganization());
         keyManagerDTO.setType(keyManagerConfigurationDTO.getType());
         keyManagerDTO.setTokenType(KeyManagerDTO.TokenTypeEnum.fromValue(keyManagerConfigurationDTO.getTokenType()));
         keyManagerDTO.setAdditionalProperties(keyManagerConfigurationDTO.getAdditionalProperties());
@@ -51,7 +50,7 @@ public class KeymanagersApiServiceImpl implements KeymanagersApiService {
             keyManagerConfigurations.addAll(globalKeyManagerConfigurations);
             List<KeyManagerDTO> keyManagerDTOList = new ArrayList<>();
             for (KeyManagerConfigurationDTO keyManagerConfiguration : keyManagerConfigurations) {
-                keyManagerDTOList.add(toKeyManagerDTO(xWSO2Tenant, keyManagerConfiguration));
+                keyManagerDTOList.add(toKeyManagerDTO(keyManagerConfiguration));
             }
             return Response.ok(keyManagerDTOList).build();
         } catch (APIManagementException e) {


### PR DESCRIPTION
## Purpose
- This PR fixes the issue where the Global Key Manager not working after restarting the server. The reason for this was, during server startup, the Key managers are fetched using the internal service API and the tenant domain sent in the header was set as the organization value. But, for Global Key Managers, the tenant domain is WSO2/System. Hence, this value should be set as the organization value. This value is obtained while fetching the Global Key Manager from the DB. So, simply replacing the tenant domain with the organization value in the DTO will fix the issue.
- Related Issue: https://github.com/wso2/api-manager/issues/2788