### PR TITLE
Populate default version only if the migration enabled

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5295,7 +5295,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 populateAPIProductInformation(uuid, organization, product);
                 populateAPIStatus(product);
                 populateAPITier(product);
-                populateDefaultVersion(product);
+                if (migrationEnabled == null) {
+                    populateDefaultVersion(product);
+                }
                 return product;
             } else {
                 String msg = "Failed to get API Product. API Product artifact corresponding to artifactId " + uuid


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/2740

Related PRs: https://github.com/wso2-support/carbon-apimgt/pull/6432