### PR TITLE
Register the JavaTimeModule in request path

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
@@ -19,6 +19,8 @@ package org.wso2.carbon.apimgt.gateway.handlers.security;
 import com.atlassian.oai.validator.OpenApiInteractionValidator;
 import com.atlassian.oai.validator.report.LevelResolver;
 import com.atlassian.oai.validator.report.ValidationReport;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.swagger.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -37,6 +39,7 @@ public class SchemaValidator extends AbstractHandler {
     private static final String INTERNAL_ERROR_CODE = "500";
     private static final Log logger = LogFactory.getLog(SchemaValidator.class);
     private static final String HTTP_SC_CODE = "400";
+    public static final String REG_TIME_MODULE = "register.timeModule";
 
     /**
      * Method to generate OpenApiInteractionValidator when the openAPI is provided.
@@ -60,6 +63,10 @@ public class SchemaValidator extends AbstractHandler {
     @Override
     public boolean handleRequest(MessageContext messageContext) {
 
+        boolean timeModuleRegisterEnabled = Boolean.parseBoolean(System.getProperty(REG_TIME_MODULE, "false"));
+        if (timeModuleRegisterEnabled) {
+            Json.mapper().registerModule(new JavaTimeModule());
+        }
         logger.debug("Validating the API request Body content..");
         OpenAPI openAPI = (OpenAPI) messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_OBJECT);
         if (openAPI != null) {


### PR DESCRIPTION
This PR fixes https://github.com/wso2/api-manager/issues/2799.

Here we are registering the JavaTimeModule. There can be scenarios where customers already using a custom date/time format that conflicts with the default format used by the JavaTimeModule, might encounter issues with serialization or deserialization. For example, if the application expects dates in a specific format and the JavaTimeModule uses a different format by default, it could lead to inconsistencies or errors. Therefore we have introduced a system property **`register.timeModule`** and if only the property value is true we are registering the javaTimeModule. By default its value is `false`.

Related support PR : https://github.com/wso2-support/carbon-apimgt/pull/6449