### PR TITLE
Fix certificate loading issues

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/EndpointCertificateDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/EndpointCertificateDeployer.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.dto.CertificateMetadataDTO;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.certificatemgt.CertificateManager;
 import org.wso2.carbon.apimgt.impl.certificatemgt.CertificateManagerImpl;
 import org.wso2.carbon.apimgt.impl.dto.EventHubConfigurationDto;
 import org.wso2.carbon.apimgt.impl.gatewayartifactsynchronizer.exception.ArtifactSynchronizerException;
@@ -86,7 +87,7 @@ public class EndpointCertificateDeployer {
     }
 
     private void retrieveCertificatesAndDeploy(CloseableHttpResponse closeableHttpResponse) throws IOException {
-
+        CertificateManager certificateManager = CertificateManagerImpl.getInstance();
         boolean tenantFlowStarted = false;
         if (closeableHttpResponse.getStatusLine().getStatusCode() == 200) {
             String content = EntityUtils.toString(closeableHttpResponse.getEntity());
@@ -99,10 +100,12 @@ public class EndpointCertificateDeployer {
                 PrivilegedCarbonContext.startTenantFlow();
                 PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
                 tenantFlowStarted = true;
-                for (CertificateMetadataDTO certificateMetadataDTO : certificateMetadataDTOList) {
-                    CertificateManagerImpl.getInstance()
-                            .addCertificateToGateway(certificateMetadataDTO.getCertificate(),
-                                    certificateMetadataDTO.getAlias());
+                synchronized (certificateManager) {
+                    for (CertificateMetadataDTO certificateMetadataDTO : certificateMetadataDTOList) {
+                        CertificateManagerImpl.getInstance()
+                                .addCertificateToGateway(certificateMetadataDTO.getCertificate(),
+                                        certificateMetadataDTO.getAlias());
+                    }
                 }
             } finally {
                 if (tenantFlowStarted) {
@@ -155,16 +158,18 @@ public class EndpointCertificateDeployer {
     }
 
     private void retrieveAllCertificatesAndDeploy(HttpEntity certContent) throws IOException {
-
+        CertificateManager certificateManager = CertificateManagerImpl.getInstance();
         String content = EntityUtils.toString(certContent);
         List<CertificateMetadataDTO> certificateMetadataDTOList;
         Type listType = new TypeToken<List<CertificateMetadataDTO>>() {
         }.getType();
         certificateMetadataDTOList = new Gson().fromJson(content, listType);
-        for (CertificateMetadataDTO certificateMetadataDTO : certificateMetadataDTOList) {
-            CertificateManagerImpl.getInstance()
-                    .addAllCertificateToGateway(certificateMetadataDTO.getCertificate(),
-                            certificateMetadataDTO.getAlias(), certificateMetadataDTO.getTenantId());
+        synchronized (certificateManager) {
+            for (CertificateMetadataDTO certificateMetadataDTO : certificateMetadataDTOList) {
+                CertificateManagerImpl.getInstance()
+                        .addAllCertificateToGateway(certificateMetadataDTO.getCertificate(),
+                                certificateMetadataDTO.getAlias(), certificateMetadataDTO.getTenantId());
+            }
         }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/listeners/GatewayStartupListener.java
@@ -480,7 +480,7 @@ public class GatewayStartupListener extends AbstractAxis2ConfigurationContextObs
         cleanDeployment(configContext.getAxisConfiguration().getRepository().getPath());
         new Thread(() -> {
             try {
-                new EndpointCertificateDeployer(tenantDomain).deployCertificatesAtStartup();
+                new EndpointCertificateDeployer(tenantDomain).deployAllTenantCertificatesAtStartup();
                 new GoogleAnalyticsConfigDeployer(tenantDomain).deploy();
             } catch (APIManagementException e) {
                 log.error(e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/certificatemgt/CertificateManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/certificatemgt/CertificateManager.java
@@ -259,6 +259,14 @@ public interface CertificateManager {
     boolean addAllCertificateToGateway(String certificate, String alias, int tenantId);
 
     /**
+     * Method to add the all tenant's certificate to gateway nodes.
+     *
+     * @param certificateMetadataDTOList : The list of all certificates of a tenant
+     */
+    void addAllTenantCertificatesToGateway(List<CertificateMetadataDTO> certificateMetadataDTOList);
+
+
+    /**
      * This method is used to retrieve all the certificates.
      *
      * @return : List of Certificate metadata objects.

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/certificatemgt/CertificateManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/certificatemgt/CertificateManagerImpl.java
@@ -576,6 +576,12 @@ public class CertificateManagerImpl implements CertificateManager {
     }
 
     @Override
+    public void addAllTenantCertificatesToGateway(List<CertificateMetadataDTO> certificateMetadataDTOList) {
+        certificateMgtUtils.deployTenantCertsToGatewaySenderInABatch(certificateMetadataDTOList);
+        touchSSLSenderConfigFile();
+    }
+
+    @Override
     public boolean addAllCertificateToGateway(String certificate, String alias, int tenantId) {
         // Check whether the api is invoked via the APIGatewayAdmin service.
         alias = alias + "_" + tenantId;

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/swagger.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/swagger.json
@@ -1354,8 +1354,8 @@
           "type" : "string",
           "example" : "EXCHANGED",
           "description" : "The type of the tokens to be used (exchanged or without exchanged). Accepted values are EXCHANGED, DIRECT or BOTH.",
-          "default" : "DIRECT",
-          "enum" : [ "EXCHANGED", "DIRECT", "BOTH" ]
+          "enum" : [ "EXCHANGED", "DIRECT", "BOTH" ],
+          "default" : "DIRECT"
         }
       }
     },


### PR DESCRIPTION
Approach : Previously we called trustore.store() after adding each certificate to the temporary trustore. With this fix the calls are reduced to one per each tenant.