### PR TITLE
Add updatedApplication details to the application update event

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -1892,6 +1892,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         }
         validateApplicationPolicy(application, existingApp.getOrganization());
         apiMgtDAO.updateApplication(application);
+        Application updatedApplication = apiMgtDAO.getApplicationById(application.getId());
         if (log.isDebugEnabled()) {
             log.debug("Successfully updated the Application: " + application.getId() + " in the database.");
         }
@@ -1917,9 +1918,10 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
 
         ApplicationEvent applicationEvent = new ApplicationEvent(UUID.randomUUID().toString(),
                 System.currentTimeMillis(), APIConstants.EventType.APPLICATION_UPDATE.name(), tenantId,
-                existingApp.getOrganization(), application.getId(), application.getUUID(), application.getName(),
-                application.getTokenType(), application.getTier(), application.getGroupId(),
-                application.getApplicationAttributes(), existingApp.getSubscriber().getName());
+                existingApp.getOrganization(), updatedApplication.getId(), updatedApplication.getUUID(),
+                updatedApplication.getName(), updatedApplication.getTokenType(), updatedApplication.getTier(),
+                updatedApplication.getGroupId(), updatedApplication.getApplicationAttributes(),
+                existingApp.getSubscriber().getName());
         APIUtil.sendNotification(applicationEvent, APIConstants.NotifierType.APPLICATION.name());
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -91,7 +91,7 @@
   "apim.devportal.api_key_alias": "gateway_certificate_alias",
   "apim.devportal.application_sharing_claim": "http://wso2.org/claims/organization",
   "apim.devportal.enable_anonymous_mode": true,
-  "apim.devportal.enable_empty_values_in_application_attributes": true,
+  "apim.devportal.enable_empty_values_in_application_attributes": false,
   "apim.publisher.key_alias": "gateway_certificate_alias",
   "apim.publisher.enable_api_doc_visibility": false,
   "apim.publisher.display_url": false,


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/2745
An event is triggered when updating an application and updated information of the application will not be included in the event. Therefore, there can be inconsistencies between the application that is stored in the database and the application that is known by the Gateway.

This PR mitigates this issue.