### PR TITLE
Update security schema setting logic in the DTO for internal APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/utils/SubscriptionValidationDataUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/utils/SubscriptionValidationDataUtil.java
@@ -95,8 +95,12 @@ public class SubscriptionValidationDataUtil {
             apidto.setStatus(model.getStatus());
             apidto.setIsDefaultVersion(model.isDefaultVersion());
             apidto.setOrganization(model.getOrganization());
-            apidto.setSecurityScheme(RestApiCommonUtil.getLoggedInUserProvider().
-                    getSecuritySchemeOfAPI(model.getApiUUID(), model.getOrganization()));
+            // The security schema is necessary only for the websocket APIs. To prevent unnecessary registry calls,
+            // it has been excluded from other APIs, thus reducing operational costs.
+            if(model.getApiType() != null && model.getApiType().equals("WS")) {
+                apidto.setSecurityScheme(RestApiCommonUtil.getLoggedInUserProvider().
+                        getSecuritySchemeOfAPI(model.getApiUUID(), model.getOrganization()));
+            }
             Map<String, URLMapping> urlMappings = model.getAllResources();
             List<URLMappingDTO> urlMappingsDTO = new ArrayList<>();
             for (URLMapping urlMapping : urlMappings.values()) {


### PR DESCRIPTION
## Description

This PR will remove the security schema setting logic in the DTO for internal APIs other than websocket APIs, as the security schema is only necessary for them. This change aims to prevent unnecessary registry calls

### Fixes
- https://github.com/wso2/api-manager/issues/2855