### PR TITLE
Fix subscription update flow when importing existing application

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -865,7 +865,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
 
         WorkflowResponse workflowResponse = null;
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(userId);
-        checkSubscriptionAllowed(apiTypeWrapper);
+        checkSubscriptionAllowed(apiTypeWrapper, apiTypeWrapper.getTier());
         int subscriptionId;
         if (APIConstants.PUBLISHED.equals(state) || APIConstants.PROTOTYPED.equals(state)) {
             subscriptionId = apiMgtDAO.addSubscription(apiTypeWrapper, application,
@@ -1056,7 +1056,7 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             apiContext = api.getContext();
             apiOrgId = api.getOrganization();
         }
-        checkSubscriptionAllowed(apiTypeWrapper);
+        checkSubscriptionAllowed(apiTypeWrapper, requestedThrottlingPolicy);
         WorkflowResponse workflowResponse = null;
         int subscriptionId;
         if (APIConstants.PUBLISHED.equals(state) || APIConstants.PROTOTYPED.equals(state)) {
@@ -4434,7 +4434,7 @@ APIConstants.AuditLogConstants.DELETED, this.username);
      *                                subscription, this will throw an instance of APIMgtAuthorizationFailedException
       *                                with the reason as the message
      */
-    private void checkSubscriptionAllowed(ApiTypeWrapper apiTypeWrapper)
+    private void checkSubscriptionAllowed(ApiTypeWrapper apiTypeWrapper, String requestedThrottlingPolicy)
             throws APIManagementException {
 
         Set<Tier> tiers;
@@ -4492,17 +4492,17 @@ APIConstants.AuditLogConstants.DELETED, this.username);
         List<String> allowedTierList = new ArrayList<>();
         while (iterator.hasNext()) {
             Tier t = iterator.next();
-            if (t.getName() != null && (t.getName()).equals(apiTypeWrapper.getTier())) {
+            if (t.getName() != null && (t.getName()).equals(requestedThrottlingPolicy)) {
                 isTierAllowed = true;
             }
             allowedTierList.add(t.getName());
         }
         if (!isTierAllowed) {
             String msg =
- "Tier " + apiTypeWrapper.getTier() + " is not allowed for API/API Product " + apiTypeWrapper + ". Only "
+ "Tier " + requestedThrottlingPolicy + " is not allowed for API/API Product " + apiTypeWrapper + ". Only "
                     + Arrays.toString(allowedTierList.toArray()) + " Tiers are allowed.";
             throw new APIManagementException(msg, ExceptionCodes.from(ExceptionCodes.SUBSCRIPTION_TIER_NOT_ALLOWED,
-                    apiTypeWrapper.getTier(), username));
+                    requestedThrottlingPolicy, username));
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
@@ -53,7 +53,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ImportUtils {
     private static final Log log = LogFactory.getLog(ImportUtils.class);
@@ -152,28 +154,90 @@ public class ImportUtils {
      * @throws UserStoreException     if an error occurs while checking whether the tenant domain exists
      */
     public static List<APIIdentifier> importSubscriptions(Set<ExportedSubscribedAPI> subscribedAPIs, String userId,
-                                                          Application application, Boolean update, APIConsumer apiConsumer, String organization)
+                                                          Application application, Boolean update,
+                                                          APIConsumer apiConsumer, String organization)
             throws APIManagementException,
             UserStoreException {
         List<APIIdentifier> skippedAPIList = new ArrayList<>();
-        // removing existing subscribed apis
+
+        // Create a map of the imported subscriptions. The key is a combination of apiName and version
+        Map<String, ExportedSubscribedAPI> importedSubscriptionMap = subscribedAPIs.stream()
+                .collect(Collectors.toMap(
+                        api -> api.getApiId().getApiName() + "_" + api.getApiId().getVersion(),
+                        api -> api));
+
+        // If update flag is set, remove the existing subscriptions that are not in the imported list
         if (update) {
             Subscriber subscriber = apiConsumer.getSubscriber(userId);
-            Set<SubscribedAPI> currentSubscribedAPIs = apiConsumer.getSubscribedAPIs(subscriber, application.getName(),
-                    application.getGroupId());
-            for (SubscribedAPI subscribedAPI : currentSubscribedAPIs) {
-                apiConsumer.removeSubscription(subscribedAPI.getAPIIdentifier(), userId, application.getId(),
-                        application.getGroupId(), application.getOrganization());
+            Set<SubscribedAPI> currentSubscribedAPIs = apiConsumer.getSubscribedAPIs(subscriber,
+                    application.getName(), application.getGroupId());
+
+            for (SubscribedAPI existingSubscribedAPI : currentSubscribedAPIs) {
+                String existingSubscriptionKey = existingSubscribedAPI.getIdentifier().getName() + "_" +
+                        existingSubscribedAPI.getIdentifier().getVersion();
+                APIIdentifier existingApi = existingSubscribedAPI.getAPIIdentifier();
+                if (importedSubscriptionMap.containsKey(existingSubscriptionKey)) {
+
+                    // Update the tier if the existing tier is different from the imported tier
+                    if (!existingSubscribedAPI.getTier().getName().equals(
+                            importedSubscriptionMap.get(existingSubscriptionKey).getThrottlingPolicy())) {
+
+
+                        String tenantDomain = MultitenantUtils
+                                .getTenantDomain(APIUtil.replaceEmailDomainBack(existingApi.getProviderName()));
+                        if (!StringUtils.isEmpty(tenantDomain) && APIUtil.isTenantAvailable(tenantDomain)) {
+                            String uuidFromIdentifier = ApiMgtDAO.getInstance().getUUIDFromIdentifier(existingApi,
+                                    tenantDomain);
+                            if (StringUtils.isNotEmpty(uuidFromIdentifier)) {
+                                ApiTypeWrapper apiTypeWrapper = apiConsumer.getAPIorAPIProductByUUID(
+                                        uuidFromIdentifier, tenantDomain);
+                                // Tier of the imported subscription
+                                String targetTier = importedSubscriptionMap.get(existingSubscriptionKey).
+                                        getThrottlingPolicy();
+                                // Checking whether the target tier is available
+                                if (isTierAvailable(targetTier, apiTypeWrapper) && apiTypeWrapper.getStatus() != null
+                                        && APIConstants.PUBLISHED.equals(apiTypeWrapper.getStatus())) {
+
+                                    apiConsumer.updateSubscription(apiTypeWrapper, userId, application,
+                                            existingSubscribedAPI.getUUID(), existingSubscribedAPI.getTier().getName(),
+                                            targetTier);
+                                } else {
+                                    log.error("Failed to import Subscription as API/API Product "
+                                            + existingApi.getName() + "-" + existingApi.getVersion() +
+                                            " as one or more tiers may be unavailable or the API/API Product may " +
+                                            "not have been published ");
+                                }
+                            } else {
+                                log.error("Failed to import Subscription as API " + existingApi.getName() + "-" +
+                                        existingApi.getVersion() + " is not available");
+                            }
+                        } else {
+                            log.error("Failed to import Subscription as Tenant domain: " + tenantDomain +
+                                    " is not available");
+                        }
+                    }
+
+                    // Remove the existing subscription from the imported list
+                    importedSubscriptionMap.remove(existingSubscriptionKey);
+                } else {
+                    // Remove the subscription if it is not in the imported list
+                    apiConsumer.removeSubscription(existingApi, userId, application.getId(), application.getGroupId(),
+                            organization);
+
+                }
             }
         }
-        for (ExportedSubscribedAPI subscribedAPI : subscribedAPIs) {
+
+        for (String importedSubscriptionKey : importedSubscriptionMap.keySet()) {
+            ExportedSubscribedAPI subscribedAPI = importedSubscriptionMap.get(importedSubscriptionKey);
             APIIdentifier apiIdentifier = subscribedAPI.getApiId();
             String tenantDomain = MultitenantUtils
                     .getTenantDomain(APIUtil.replaceEmailDomainBack(apiIdentifier.getProviderName()));
             if (!StringUtils.isEmpty(tenantDomain) && APIUtil.isTenantAvailable(tenantDomain)) {
                 String uuidFromIdentifier = ApiMgtDAO.getInstance().getUUIDFromIdentifier(apiIdentifier, tenantDomain);
                 if (StringUtils.isNotEmpty(uuidFromIdentifier)) {
-                    ApiTypeWrapper apiTypeWrapper = apiConsumer.getAPIorAPIProductByUUID(uuidFromIdentifier, tenantDomain);
+                    ApiTypeWrapper apiTypeWrapper = apiConsumer.getAPIorAPIProductByUUID(uuidFromIdentifier,
+                            tenantDomain);
                     // Tier of the imported subscription
                     String targetTier = subscribedAPI.getThrottlingPolicy();
                     // Checking whether the target tier is available
@@ -191,7 +255,8 @@ public class ImportUtils {
                         }
                     } else {
                         log.error("Failed to import Subscription as API/API Product "
-                                + apiIdentifier.getName() + "-" + apiIdentifier.getVersion() + " as one or more tiers may "
+                                + apiIdentifier.getName() + "-" + apiIdentifier.getVersion() + " as one or more " +
+                                "tiers may "
                                 + "be unavailable or the API/API Product may not have been published ");
                         skippedAPIList.add(subscribedAPI.getApiId());
                     }


### PR DESCRIPTION
## Description

This will fix subscription update flow when importing existing application.

Additionally, a new improvement will be added to the subscription updating flow in the application import process. 
In this improvement, the current subscription will only be deleted if it is not available in the imported application. 

Also if only the subscription tier is different, it will update only the subscription tier.

### Fixes
- https://github.com/wso2/api-manager/issues/2328
- https://github.com/wso2/api-manager/issues/2874