### PR TITLE
Add swagger validation for paths with trailing slash

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -96,6 +96,7 @@ import static org.wso2.carbon.apimgt.impl.APIConstants.APPLICATION_JSON_MEDIA_TY
 import static org.wso2.carbon.apimgt.impl.APIConstants.APPLICATION_XML_MEDIA_TYPE;
 import static org.wso2.carbon.apimgt.impl.APIConstants.SWAGGER_APIM_DEFAULT_SECURITY;
 import static org.wso2.carbon.apimgt.impl.APIConstants.SWAGGER_APIM_RESTAPI_SECURITY;
+import static org.wso2.carbon.apimgt.impl.definitions.OASParserUtil.isValidWithPathsWithTrailingSlashes;
 
 /**
  * Models API definition using OAS (swagger 2.0) parser
@@ -696,6 +697,15 @@ public class OAS2Parser extends APIDefinition {
                         return validationResponse;
                     }
                 }
+            }
+
+            // Check for multiple resource paths with and without trailing slashes.
+            // If there are two resource paths with the same name, one with and one without trailing slashes,
+            // it will be considered an error since those are considered as one resource in the API deployment.
+            if (parseAttemptForV2.getSwagger() != null) {
+                if (!isValidWithPathsWithTrailingSlashes(null, parseAttemptForV2.getSwagger(), validationResponse)) {
+                    validationResponse.setValid(false);
+                };
             }
         }
         if (validationResponse.isValid() && parseAttemptForV2.getSwagger() != null){

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -87,6 +87,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.wso2.carbon.apimgt.impl.APIConstants.APPLICATION_JSON_MEDIA_TYPE;
+import static org.wso2.carbon.apimgt.impl.definitions.OASParserUtil.isValidWithPathsWithTrailingSlashes;
 
 /**
  * Models API definition using OAS (OpenAPI 3.0) parser
@@ -806,6 +807,15 @@ public class OAS3Parser extends APIDefinition {
             }
         } else {
             validationResponse.setValid(true);
+
+            // Check for multiple resource paths with and without trailing slashes.
+            // If there are two resource paths with the same name, one with and one without trailing slashes,
+            // it will be considered an error since those are considered as one resource in the API deployment.
+            if (parseAttemptForV3.getOpenAPI() != null) {
+                if (!isValidWithPathsWithTrailingSlashes(parseAttemptForV3.getOpenAPI(), null, validationResponse)) {
+                    validationResponse.setValid(false);
+                };
+            }
         }
         if (validationResponse.isValid()){
             OpenAPI openAPI = parseAttemptForV3.getOpenAPI();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -2185,4 +2185,118 @@ public class OASParserUtil {
             operation.setVendorExtension(APIConstants.SWAGGER_X_BASIC_AUTH_RESOURCE_SCOPES, operationScopes);
         }
     }
+
+    /**
+     * This method will validate the OAS definition against the resource paths with trailing slashes.
+     *
+     * @param openAPI            OpenAPI object
+     * @param swagger         Swagger object
+     * @param validationResponse validation response
+     * @return isSwaggerValid boolean
+     */
+    public static boolean isValidWithPathsWithTrailingSlashes(OpenAPI openAPI, Swagger swagger,
+                                                              APIDefinitionValidationResponse validationResponse) {
+        Map<String, ?> pathItems = null;
+        if (openAPI != null) {
+            pathItems = openAPI.getPaths();
+        } else if (swagger != null) {
+            pathItems = swagger.getPaths();
+        }
+        if (pathItems != null) {
+            for (String path : pathItems.keySet()) {
+                if (path.endsWith("/")) {
+                    String newPath = path.substring(0, path.length() - 1);
+                    if (pathItems.containsKey(newPath)) {
+                        Object pathItem = pathItems.get(newPath);
+                        Object newPathItem = pathItems.get(path);
+
+                        if (pathItem instanceof PathItem && newPathItem instanceof PathItem) {
+                            if (!validateOAS3Paths((PathItem) pathItem, (PathItem) newPathItem, newPath, validationResponse)) {
+                                return false;
+                            }
+                        } else if (pathItem instanceof Path && newPathItem instanceof Path) {
+                            if (!validateOAS2Paths((Path) pathItem, (Path) newPathItem, newPath, validationResponse)) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    private static boolean validateOAS3Paths(PathItem pathItem, PathItem newPathItem, String newPath,
+                                             APIDefinitionValidationResponse validationResponse) {
+        if (pathItem.getGet() != null && newPathItem.getGet() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.GET.name(), APIConstants.OPEN_API);
+            return false;
+        }
+        if (pathItem.getPost() != null && newPathItem.getPost() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.POST.name(), APIConstants.OPEN_API);
+            return false;
+        }
+        if (pathItem.getPut() != null && newPathItem.getPut() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.PUT.name(), APIConstants.OPEN_API);
+            return false;
+        }
+        if (pathItem.getPatch() != null && newPathItem.getPatch() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.PATCH.name(), APIConstants.OPEN_API);
+            return false;
+        }
+        if (pathItem.getDelete() != null && newPathItem.getDelete() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.DELETE.name(), APIConstants.OPEN_API);
+            return false;
+        }
+        if (pathItem.getHead() != null && newPathItem.getHead() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.HEAD.name(), APIConstants.OPEN_API);
+            return false;
+        }
+        if (pathItem.getOptions() != null && newPathItem.getOptions() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.OPTIONS.name(),
+                    APIConstants.OPEN_API);
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean validateOAS2Paths(Path pathItem, Path newPathItem, String newPath,
+                                             APIDefinitionValidationResponse validationResponse) {
+        if (pathItem.getGet() != null && newPathItem.getGet() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.GET.name(), APIConstants.SWAGGER);
+            return false;
+        }
+        if (pathItem.getPost() != null && newPathItem.getPost() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.POST.name(), APIConstants.SWAGGER);
+            return false;
+        }
+        if (pathItem.getPut() != null && newPathItem.getPut() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.PUT.name(), APIConstants.SWAGGER);
+            return false;
+        }
+        if (pathItem.getPatch() != null && newPathItem.getPatch() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.PATCH.name(), APIConstants.SWAGGER);
+            return false;
+        }
+        if (pathItem.getDelete() != null && newPathItem.getDelete() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.DELETE.name(), APIConstants.SWAGGER);
+            return false;
+        }
+        if (pathItem.getHead() != null && newPathItem.getHead() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.HEAD.name(), APIConstants.SWAGGER);
+            return false;
+        }
+        if (pathItem.getOptions() != null && newPathItem.getOptions() != null) {
+            addError(validationResponse, newPath, APIConstants.SupportedHTTPVerbs.OPTIONS.name(), APIConstants.SWAGGER);
+            return false;
+        }
+        return true;
+    }
+
+    private static void addError(APIDefinitionValidationResponse validationResponse, String path, String operation,
+                                 String definitionType) {
+        OASParserUtil.addErrorToValidationResponse(validationResponse,
+                "Multiple " + operation + " operations with the same resource path " + path +
+                        " found in the " + definitionType + " definition");
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS2ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS2ParserTest.java
@@ -170,6 +170,22 @@ public class OAS2ParserTest extends OASTestBase {
     }
 
     @Test
+    public void testOpenAPIValidatorWithMultiplePathsHavingSameNameWithAndWithoutTrailingSlash() throws Exception {
+        String faultySwagger = IOUtils.toString(
+                getClass().getClassLoader().getResourceAsStream("definitions" + File.separator + "oas2"
+                        + File.separator + "oas2_paths_with_trailing_slash.json"),
+                "UTF-8");
+
+        APIDefinitionValidationResponse response = OASParserUtil.validateAPIDefinition(faultySwagger, true);
+        Assert.assertFalse(response.isValid());
+        Assert.assertEquals(ExceptionCodes.OPENAPI_PARSE_EXCEPTION.getErrorCode(),
+                response.getErrorItems().get(0).getErrorCode());
+        Assert.assertEquals("Multiple GET operations with the same resource path /test found in " +
+                "the swagger definition", response.getErrorItems().get(0).getErrorDescription());
+    }
+
+
+    @Test
     public void testRootLevelApplicationSecurity() throws Exception {
         String apiSecurity = "oauth2,oauth_basic_auth_api_key_mandatory,api_key";
         String oasDefinition = IOUtils.toString(

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS3ParserTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/definitions/OAS3ParserTest.java
@@ -228,6 +228,21 @@ public class OAS3ParserTest extends OASTestBase {
     }
 
     @Test
+    public void testOpenAPIValidatorWithMultiplePathsHavingSameNameWithAndWithoutTrailingSlash() throws Exception {
+        String faultySwagger = IOUtils.toString(
+                getClass().getClassLoader().getResourceAsStream("definitions" + File.separator + "oas3"
+                        + File.separator + "oas3_paths_with_trailing_slash.json"),
+                "UTF-8");
+
+        APIDefinitionValidationResponse response = OASParserUtil.validateAPIDefinition(faultySwagger, true);
+        Assert.assertFalse(response.isValid());
+        Assert.assertEquals(ExceptionCodes.OPENAPI_PARSE_EXCEPTION.getErrorCode(),
+                response.getErrorItems().get(0).getErrorCode());
+        Assert.assertEquals("Multiple GET operations with the same resource path /test found in " +
+                "the openapi definition", response.getErrorItems().get(0).getErrorDescription());
+    }
+
+    @Test
     public void testRootLevelApplicationSecurity() throws Exception {
         String apiSecurity = "oauth_basic_auth_api_key_mandatory,oauth2,api_key";
         String oasDefinition = IOUtils.toString(

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas2/oas2_paths_with_trailing_slash.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas2/oas2_paths_with_trailing_slash.json
@@ -1,0 +1,41 @@
+{
+  "paths": {
+    "/test": {
+      "get": {
+        "x-auth-type": "Application & Application User",
+        "x-throttling-tier": "Unlimited",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/test/": {
+      "get": {
+        "x-auth-type": "Application & Application User",
+        "x-throttling-tier": "Unlimited",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "x-wso2-security": {
+    "apim": {
+      "x-wso2-scopes": []
+    }
+  },
+  "swagger": "2.0",
+  "info": {
+    "title": "Swagger path with trailing slash",
+    "description": "Verify paths with trailing slash",
+    "contact": {
+      "email": "xx@ee.com",
+      "name": "xx"
+    },
+    "version": "1.0.0"
+  }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas3/oas3_paths_with_trailing_slash.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/definitions/oas3/oas3_paths_with_trailing_slash.json
@@ -1,0 +1,37 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI path with trailing slash",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "paths": {
+    "/test": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "x-auth-type": "Application",
+        "x-throttling-tier": "Unlimited"
+      }
+    },
+    "/test/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "x-auth-type": "Application",
+        "x-throttling-tier": "Unlimited"
+      }
+    }
+  },
+  "components": {}
+}


### PR DESCRIPTION
## Purpose
This PR add a swagger validation to validate resource path names.
If there are two resource paths with the same name, one with and one without trailing slashes, it will be considered an error since those are considered as one resource in the API deployment.

With this fix, following internal REST APIs provide 400 Bad request in such cases

`PUT https://localhost:9443/api/am/publisher/v4/apis/<apiId>/swagger`

Response:

```
{
    "code": 900754,
    "message": "Error while parsing OpenAPI definition",
    "description": "Multiple GET operations with the same resource path /menu found in the openapi definition",
    "moreInfo": "",
    "error": []
}
```

This validation executes in,
1. API creation
2. API update
3. Import swagger file

### Fixes
- https://github.com/wso2/api-manager/issues/2915