### PR TITLE
Fix endpoint basic auth retrieval logic 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -499,6 +499,7 @@ public final class APIConstants {
     public static final String REGISTRY_HIDDEN_ENDPOINT_PROPERTY = "registry.HiddenEpProperty";
     public static final String OVERVIEW_ELEMENT = "overview";
     public static final String ENDPOINT_PASSWORD_ELEMENT = "endpointPpassword";
+    public static final String ENDPOINT_PASSWORD_ELEMENT_ALT = "endpointPassword";
     public static final String FEDERATED_USER = "FEDERATED";
     public static final String ENABLE_CERTIFICATE_BOUND_ACCESS_TOKEN = OAUTH_CONFIGS + "EnableCertificateBoundAccessToken";
     public static final String DIGEST = "x5t#S256";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -332,6 +332,7 @@ public final class APIConstants {
     public static final String API_OVERVIEW_ENDPOINT_AUTH_DIGEST = "overview_endpointAuthDigest";
     public static final String API_OVERVIEW_ENDPOINT_USERNAME = "overview_endpointUsername";
     public static final String API_OVERVIEW_ENDPOINT_PASSWORD = "overview_endpointPpassword";
+    public static final String API_OVERVIEW_ENDPOINT_PASSWORD_ALT = "overview_endpointPassword";
     public static final String API_OVERVIEW_TRANSPORTS = "overview_transports";
     public static final String API_OVERVIEW_INSEQUENCE = "overview_inSequence";
     public static final String API_OVERVIEW_OUTSEQUENCE = "overview_outSequence";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/handlers/APIEndpointPasswordRegistryHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/handlers/APIEndpointPasswordRegistryHandler.java
@@ -61,20 +61,20 @@ public class APIEndpointPasswordRegistryHandler extends Handler {
                 Object childObj = mainChildIt.next();
                 if ((childObj instanceof OMElement) && ((APIConstants.OVERVIEW_ELEMENT)
                         .equals(((OMElement) childObj).getLocalName()))) {
-                    Iterator childIt = ((OMElement) childObj)
+                    // On this flow, only the endpointPpassword can have a value.
+                    Iterator endpointPpasswordIt = ((OMElement) childObj)
                             .getChildrenWithLocalName(APIConstants.ENDPOINT_PASSWORD_ELEMENT);
-                    //There is only one ep-password, hence no iteration
-                    if (childIt.hasNext()) {
-                        OMElement child = (OMElement) childIt.next();
+                    if (endpointPpasswordIt.hasNext()) {
+                        OMElement child = (OMElement) endpointPpasswordIt.next();
                         String pswd = child.getText();
-                        //Password has been edited on put
+                        // Password has been edited on put
                         if (!"".equals(pswd) && !((APIConstants.DEFAULT_MODIFIED_ENDPOINT_PASSWORD).equals(pswd))) {
                             resource.setProperty(APIConstants.REGISTRY_HIDDEN_ENDPOINT_PROPERTY, pswd);
                             child.setText(pswd);
-                        } else if ((APIConstants.DEFAULT_MODIFIED_ENDPOINT_PASSWORD)
-                                .equals(pswd)) { //Password not being changed
-                            String actualPassword = resource
-                                    .getProperty(APIConstants.REGISTRY_HIDDEN_ENDPOINT_PROPERTY);
+                        } else if ((APIConstants.DEFAULT_MODIFIED_ENDPOINT_PASSWORD).equals(pswd)) {
+                            // Password not being changed
+                            String actualPassword =
+                                    resource.getProperty(APIConstants.REGISTRY_HIDDEN_ENDPOINT_PROPERTY);
                             child.setText(actualPassword);
                         }
                     }
@@ -107,16 +107,31 @@ public class APIEndpointPasswordRegistryHandler extends Handler {
                     Object childObj = mainChildIt.next();
                     if ((childObj instanceof OMElement) && ((APIConstants.OVERVIEW_ELEMENT)
                             .equals(((OMElement) childObj).getLocalName()))) {
-                        Iterator childIt = ((OMElement) childObj)
-                                .getChildrenWithLocalName(APIConstants.ENDPOINT_PASSWORD_ELEMENT);
-                        //There is only one ep-password, hence no iteration
-                        if (childIt.hasNext()) {
-                            OMElement child = (OMElement) childIt.next();
+                        OMElement child = null;
+                        // If the endpointPpassword exist and has a value, store it in the hidden field and mask
+                        Iterator endpointPpasswordIt = ((OMElement) childObj).getChildrenWithLocalName(
+                                APIConstants.ENDPOINT_PASSWORD_ELEMENT);
+                        // There is only one ep-password, hence no iteration
+                        if (endpointPpasswordIt.hasNext()) {
+                            child = (OMElement) endpointPpasswordIt.next();
+                        } else {
+                            // If the endpointPassword exist and has a value, store it in the hidden field and mask
+                            Iterator endpointPasswordIt = ((OMElement) childObj).getChildrenWithLocalName(
+                                    APIConstants.ENDPOINT_PASSWORD_ELEMENT_ALT);
+                            // There is only one ep-password, hence no iteration
+                            if (endpointPasswordIt.hasNext()) {
+                                child = (OMElement) endpointPasswordIt.next();
+                            }
+                        }
+                        if (child != null) {
                             String actualPassword = child.getText();
-                            //Store the password in a hidden property to access in the PUT method.
+                            // Store the password in a hidden property to access in the PUT method.
                             if (!actualPassword.isEmpty()) {
                                 resource.setProperty(APIConstants.REGISTRY_HIDDEN_ENDPOINT_PROPERTY, actualPassword);
+                                // Mask the password
                                 child.setText(APIConstants.DEFAULT_MODIFIED_ENDPOINT_PASSWORD);
+                                // If only the endpointPassword exist, no need to update the endpointPpassword as it
+                                // handled while populating the api object from the registry resource down the line.
                             }
                         }
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -2629,9 +2629,12 @@ public final class APIUtil {
             api.setEndpointAuthDigest(Boolean.parseBoolean(artifact.getAttribute(
                     APIConstants.API_OVERVIEW_ENDPOINT_AUTH_DIGEST)));
             api.setEndpointUTUsername(artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_USERNAME));
-            if (!((APIConstants.DEFAULT_MODIFIED_ENDPOINT_PASSWORD)
-                    .equals(artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD)))) {
-                api.setEndpointUTPassword(artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD));
+            String password = artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD);
+            if (password == null) {
+                password = artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD_ALT);
+            }
+            if (!((APIConstants.DEFAULT_MODIFIED_ENDPOINT_PASSWORD).equals(password))) {
+                api.setEndpointUTPassword(password);
             } else { //If APIEndpointPasswordRegistryHandler is enabled take password from the registry hidden property
                 api.setEndpointUTPassword(getActualEpPswdFromHiddenProperty(api, registry));
             }
@@ -9511,9 +9514,12 @@ public final class APIUtil {
             api.setEndpointAuthDigest(Boolean.parseBoolean(artifact.getAttribute(
                     APIConstants.API_OVERVIEW_ENDPOINT_AUTH_DIGEST)));
             api.setEndpointUTUsername(artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_USERNAME));
-            if (!((APIConstants.DEFAULT_MODIFIED_ENDPOINT_PASSWORD)
-                    .equals(artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD)))) {
-                api.setEndpointUTPassword(artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD));
+            String password = artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD);
+            if (password == null) {
+                password = artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD_ALT);
+            }
+            if (!((APIConstants.DEFAULT_MODIFIED_ENDPOINT_PASSWORD).equals(password))) {
+                api.setEndpointUTPassword(password);
             } else { //If APIEndpointPasswordRegistryHandler is enabled take password from the registry hidden property
                 api.setEndpointUTPassword(getActualEpPswdFromHiddenProperty(api, registry));
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/APIConstants.java
@@ -70,6 +70,7 @@ public final class APIConstants {
     public static final String API_OVERVIEW_ENDPOINT_AUTH_DIGEST = "overview_endpointAuthDigest";
     public static final String API_OVERVIEW_ENDPOINT_USERNAME = "overview_endpointUsername";
     public static final String API_OVERVIEW_ENDPOINT_PASSWORD = "overview_endpointPpassword";
+    public static final String API_OVERVIEW_ENDPOINT_PASSWORD_ALT = "overview_endpointPassword";
     public static final String API_OVERVIEW_ENDPOINT_OAUTH = "overview_endpointOAuth";
     public static final String API_OVERVIEW_ENDPOINT_GRANT_TYPE = "overview_grantType";
     public static final String API_OVERVIEW_ENDPOINT_HTTP_METHOD = "overview_httpMethod";

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -491,7 +491,9 @@ public class RegistryPersistenceImpl implements APIPersistence {
                     artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_AUTH_DIGEST));
             String userName = artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_USERNAME);
             String password = artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD);
-
+            if (password == null) {
+                password = artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD_ALT);
+            }
             if (!isSecured && !isDigestSecured && userName != null) {
                 api.setEndpointUTUsername(userName);
                 api.setEndpointUTPassword(password);

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
@@ -604,9 +604,12 @@ public class RegistryPersistenceUtil {
             api.setEndpointAuthDigest(Boolean.parseBoolean(artifact.getAttribute(
                     APIConstants.API_OVERVIEW_ENDPOINT_AUTH_DIGEST)));
             api.setEndpointUTUsername(artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_USERNAME));
-            if (!((APIConstants.DEFAULT_MODIFIED_ENDPOINT_PASSWORD)
-                    .equals(artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD)))) {
-                api.setEndpointUTPassword(artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD));
+            String password = artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD);
+            if (password == null) {
+                password = artifact.getAttribute(APIConstants.API_OVERVIEW_ENDPOINT_PASSWORD_ALT);
+            }
+            if (!((APIConstants.DEFAULT_MODIFIED_ENDPOINT_PASSWORD).equals(password))) {
+                api.setEndpointUTPassword(password);
             } else { //If APIEndpointPasswordRegistryHandler is enabled take password from the registry hidden property
                 api.setEndpointUTPassword(apiResource.getProperty(APIConstants.REGISTRY_HIDDEN_ENDPOINT_PROPERTY));
             }


### PR DESCRIPTION
## Purpose

In APIM 3.0.0, the endpoint password is saved in a registry field named as `endpointPassword`, but in all other versions the field is named as `endpointPpassword`. This causes issues while migrating APIs from 3.0.0 to the latest versions. 

This PR modifies the endpoint's basic auth credential retrieving logic to check for the `endpointPpassword` element as well as the `endpointPpassword` element. 

Resolves https://github.com/wso2/api-manager/issues/2881