### PR TITLE
Fix accessing API resources using id_token

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -666,6 +666,7 @@ public final class APIConstants {
     public static final String JWKS_URI = "jwksUri";
 
     public static final String ORG_ALL_QUERY_PARAM = "ALL";
+    public static final String JWT_HEADER_ACCESS_TOKEN_TYPE = "at+jwt";
 
     public static class TokenStatus {
 
@@ -3161,4 +3162,9 @@ public final class APIConstants {
 
     //Property for enabling tenant aware sub claims when invoking APIs with API key
     public static final String ENABLE_TENANT_AWARE_SUB_CLAIM= "enable.tenant.aware.subclaim";
+
+    public static class TokenValidationConstants {
+        public static final String TOKEN_VALIDATION_CONFIG = "TokenValidation";
+        public static final String ENFORCE_JWT_TYPE_HEADER_VALIDATION = "EnforceTypeHeaderValidation";
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.apimgt.impl.dto.GatewayArtifactSynchronizerProperties;
 import org.wso2.carbon.apimgt.impl.dto.GatewayCleanupSkipList;
 import org.wso2.carbon.apimgt.impl.dto.RedisConfig;
 import org.wso2.carbon.apimgt.impl.dto.ThrottleProperties;
+import org.wso2.carbon.apimgt.impl.dto.TokenValidationDto;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowProperties;
 import org.wso2.carbon.apimgt.impl.monetization.MonetizationConfigurationDto;
 import org.wso2.carbon.apimgt.impl.recommendationmgt.RecommendationEnvironment;
@@ -133,6 +134,7 @@ public class APIManagerConfiguration {
     private Map<String, List<String>> restApiJWTAuthAudiences = new HashMap<>();
     private JSONObject subscriberAttributes = new JSONObject();
     private static Map<String, String> analyticsMaskProps;
+    private TokenValidationDto tokenValidationDto = new TokenValidationDto();
 
     public Map<String, List<String>> getRestApiJWTAuthAudiences() {
         return restApiJWTAuthAudiences;
@@ -656,6 +658,8 @@ public class APIManagerConfiguration {
                 setMarketplaceAssistantConfiguration(element);
             } else if (APIConstants.AI.API_CHAT.equals(localName)) {
                 setApiChatConfiguration(element);
+            } else if (APIConstants.TokenValidationConstants.TOKEN_VALIDATION_CONFIG.equals(localName)) {
+                setTokenValidation(element);
             }
             readChildElements(element, nameStack);
             nameStack.pop();
@@ -691,6 +695,20 @@ public class APIManagerConfiguration {
             } else {
                 log.debug("Subscriber email delimiter field is set to default (,).");
             }
+        }
+    }
+
+    /**
+     * Set token validation configurations from the api-manager.xml file
+     *
+     * @param omElement OMElement of the TokenValidation configuration block
+     */
+    private void setTokenValidation(OMElement omElement) {
+        OMElement enforceTypeHeaderValidation = omElement.getFirstChildWithName(new QName(
+                APIConstants.TokenValidationConstants.ENFORCE_JWT_TYPE_HEADER_VALIDATION));
+        if (enforceTypeHeaderValidation != null) {
+            tokenValidationDto.setEnforceTypeHeaderValidation(Boolean.parseBoolean(
+                    enforceTypeHeaderValidation.getText()));
         }
     }
 
@@ -2477,5 +2495,9 @@ public class APIManagerConfiguration {
             return Boolean.parseBoolean(jwtClaimCacheExpiryEnabledString);
         }
         return false;
+    }
+
+    public TokenValidationDto getTokenValidationDto() {
+        return tokenValidationDto;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/DefaultKeyManagerConnectorConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/DefaultKeyManagerConnectorConfiguration.java
@@ -21,7 +21,7 @@ package org.wso2.carbon.apimgt.impl;
 import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.apimgt.api.model.ConfigurationDto;
 import org.wso2.carbon.apimgt.api.model.KeyManagerConnectorConfiguration;
-import org.wso2.carbon.apimgt.impl.jwt.JWTValidatorImpl;
+import org.wso2.carbon.apimgt.impl.jwt.TypeEnforcedJWTValidatorImpl;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,7 +46,7 @@ public class DefaultKeyManagerConnectorConfiguration implements KeyManagerConnec
     @Override
     public String getJWTValidator() {
 
-        return JWTValidatorImpl.class.getName();
+        return TypeEnforcedJWTValidatorImpl.class.getName();
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/TokenValidationDto.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/TokenValidationDto.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.dto;
+
+import java.io.Serializable;
+
+public class TokenValidationDto implements Serializable {
+    private boolean enforceTypeHeaderValidation = false;
+
+    public boolean isEnforceTypeHeaderValidation() {
+        return enforceTypeHeaderValidation;
+    }
+
+    public void setEnforceTypeHeaderValidation(boolean enforceTypeHeaderValidation) {
+        this.enforceTypeHeaderValidation = enforceTypeHeaderValidation;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/jwt/TypeEnforcedJWTValidatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/jwt/TypeEnforcedJWTValidatorImpl.java
@@ -27,6 +27,17 @@ import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 public class TypeEnforcedJWTValidatorImpl extends JWTValidatorImpl {
     @Override
     public JWTValidationInfo validateToken(SignedJWTInfo signedJWTInfo) throws APIManagementException {
+        // If this is a refresh token, return an error
+        String tokenTypeClaim = (String) signedJWTInfo.getJwtClaimsSet().getClaim(
+                APIConstants.JwtTokenConstants.TOKEN_TYPE);
+        if (APIConstants.OAuthConstants.REFRESH_TOKEN.equals(tokenTypeClaim)) {
+            // Invalid type header
+            JWTValidationInfo jwtValidationInfo = new JWTValidationInfo();
+            jwtValidationInfo.setValid(false);
+            jwtValidationInfo.setValidationCode(APIConstants.KeyValidationStatus.API_AUTH_INVALID_CREDENTIALS);
+            return jwtValidationInfo;
+        }
+
         APIManagerConfiguration apiManagerConfiguration = ServiceReferenceHolder.getInstance()
                 .getAPIManagerConfigurationService().getAPIManagerConfiguration();
         if (apiManagerConfiguration.getTokenValidationDto().isEnforceTypeHeaderValidation()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/jwt/TypeEnforcedJWTValidatorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/jwt/TypeEnforcedJWTValidatorImpl.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.jwt;
+
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.common.gateway.dto.JWTValidationInfo;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+
+public class TypeEnforcedJWTValidatorImpl extends JWTValidatorImpl {
+    @Override
+    public JWTValidationInfo validateToken(SignedJWTInfo signedJWTInfo) throws APIManagementException {
+        APIManagerConfiguration apiManagerConfiguration = ServiceReferenceHolder.getInstance()
+                .getAPIManagerConfigurationService().getAPIManagerConfiguration();
+        if (apiManagerConfiguration.getTokenValidationDto().isEnforceTypeHeaderValidation()) {
+            // JWT type header validation is enforced via the configuration
+            if (signedJWTInfo.getSignedJWT().getHeader().getType() != null
+                    && APIConstants.JWT_HEADER_ACCESS_TOKEN_TYPE.equals(
+                    signedJWTInfo.getSignedJWT().getHeader().getType().toString())) {
+                // The type header present with the value "at+jwt"
+                return super.validateToken(signedJWTInfo);
+            } else {
+                // Invalid type header
+                JWTValidationInfo jwtValidationInfo = new JWTValidationInfo();
+                jwtValidationInfo.setValid(false);
+                jwtValidationInfo.setValidationCode(APIConstants.KeyValidationStatus.API_AUTH_INVALID_CREDENTIALS);
+                return jwtValidationInfo;
+            }
+        }
+        return super.validateToken(signedJWTInfo);
+    }
+}

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -509,6 +509,11 @@
         {% endif %}
     </TokenRevocationNotifiers>
 
+    <TokenValidation>
+        <!-- Enforce validating JWT type header -->
+        <EnforceTypeHeaderValidation>{{apim.token.validation.enforce_type_header_validation}}</EnforceTypeHeaderValidation>
+    </TokenValidation>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
@@ -284,6 +284,11 @@
         </PersistentNotifier>
     </TokenRevocationNotifiers>
 
+    <TokenValidation>
+        <!-- Enforce validating JWT type header -->
+        <EnforceTypeHeaderValidation>false</EnforceTypeHeaderValidation>
+    </TokenValidation>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/2948

To enforce JWT `typ` header validation, a new configuration was introduced.

#### deployment.toml:
```toml
[apim.token.validation]
enforce_type_header_validation = true
```
Default: `false`