### PR TITLE
Solve invalid/incorrect URLs in Documents UI, OpenAPI/Swagger definition, and Postman collection for third-party APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -1265,7 +1265,7 @@ public class OAS2Parser extends APIDefinition {
     private void updateEndpoints(APIProduct product, Map<String, String> hostsWithSchemes, Swagger swagger) {
         String basePath = product.getContext();
         String transports = product.getTransports();
-        updateEndpoints(swagger, basePath, transports, hostsWithSchemes);
+        updateEndpoints(swagger, basePath, transports, hostsWithSchemes, null);
     }
 
     /**
@@ -1278,7 +1278,7 @@ public class OAS2Parser extends APIDefinition {
     private void updateEndpoints(API api, Map<String,String> hostsWithSchemes, Swagger swagger) {
         String basePath = api.getContext();
         String transports = api.getTransports();
-        updateEndpoints(swagger, basePath, transports, hostsWithSchemes);
+        updateEndpoints(swagger, basePath, transports, hostsWithSchemes, api);
     }
 
     /**
@@ -1288,30 +1288,49 @@ public class OAS2Parser extends APIDefinition {
      * @param basePath       API context
      * @param transports     transports types
      * @param hostsWithSchemes GW hosts with protocol mapping
+     * @param api              API
      */
     private void updateEndpoints(Swagger swagger, String basePath, String transports,
-                                 Map<String, String> hostsWithSchemes) {
-
-        String host = StringUtils.EMPTY;
-        String[] apiTransports = transports.split(",");
+                                 Map<String, String> hostsWithSchemes, API api) {
         List<Scheme> schemes = new ArrayList<>();
-        if (ArrayUtils.contains(apiTransports, APIConstants.HTTPS_PROTOCOL)
-                && hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL) != null) {
-            schemes.add(Scheme.HTTPS);
-            host = hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL).trim()
-                    .replace(APIConstants.HTTPS_PROTOCOL_URL_PREFIX, "");
-        }
-        if (ArrayUtils.contains(apiTransports, APIConstants.HTTP_PROTOCOL)
-                && hostsWithSchemes.get(APIConstants.HTTP_PROTOCOL) != null) {
-            schemes.add(Scheme.HTTP);
-            if (StringUtils.isEmpty(host)) {
-                host = hostsWithSchemes.get(APIConstants.HTTP_PROTOCOL).trim()
-                        .replace(APIConstants.HTTP_PROTOCOL_URL_PREFIX, "");
+        if (api != null && api.isAdvertiseOnly()) {
+            String externalProductionEndpoint = api.getApiExternalProductionEndpoint();
+            if (externalProductionEndpoint != null) {
+                if (externalProductionEndpoint.split("://")[0].contains("https")) {
+                    schemes.add(Scheme.HTTPS);
+                } else {
+                    schemes.add(Scheme.HTTP);
+                }
+                String host = externalProductionEndpoint.split("://")[1].split("/")[0];
+                if (externalProductionEndpoint.split("://")[1].split("/").length > 1) {
+                    swagger.setBasePath(externalProductionEndpoint.split("://")[1].split(host)[1]);
+                } else {
+                    swagger.setBasePath("");
+                }
+                swagger.setHost(host);
+                swagger.setSchemes(schemes);
             }
+        } else {
+            String host = StringUtils.EMPTY;
+            String[] apiTransports = transports.split(",");
+            if (ArrayUtils.contains(apiTransports, APIConstants.HTTPS_PROTOCOL)
+                    && hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL) != null) {
+                schemes.add(Scheme.HTTPS);
+                host = hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL).trim()
+                        .replace(APIConstants.HTTPS_PROTOCOL_URL_PREFIX, "");
+            }
+            if (ArrayUtils.contains(apiTransports, APIConstants.HTTP_PROTOCOL)
+                    && hostsWithSchemes.get(APIConstants.HTTP_PROTOCOL) != null) {
+                schemes.add(Scheme.HTTP);
+                if (StringUtils.isEmpty(host)) {
+                    host = hostsWithSchemes.get(APIConstants.HTTP_PROTOCOL).trim()
+                            .replace(APIConstants.HTTP_PROTOCOL_URL_PREFIX, "");
+                }
+            }
+            swagger.setSchemes(schemes);
+            swagger.setBasePath(basePath);
+            swagger.setHost(host);
         }
-        swagger.setSchemes(schemes);
-        swagger.setBasePath(basePath);
-        swagger.setHost(host);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS3Parser.java
@@ -1460,7 +1460,7 @@ public class OAS3Parser extends APIDefinition {
 
         String basePath = product.getContext();
         String transports = product.getTransports();
-        updateEndpoints(openAPI, basePath, transports, hostsWithSchemes);
+        updateEndpoints(openAPI, basePath, transports, hostsWithSchemes, null);
     }
 
     /**
@@ -1474,7 +1474,7 @@ public class OAS3Parser extends APIDefinition {
 
         String basePath = api.getContext();
         String transports = api.getTransports();
-        updateEndpoints(openAPI, basePath, transports, hostsWithSchemes);
+        updateEndpoints(openAPI, basePath, transports, hostsWithSchemes, api);
     }
 
     /**
@@ -1484,31 +1484,47 @@ public class OAS3Parser extends APIDefinition {
      * @param basePath         API context
      * @param transports       transports types
      * @param hostsWithSchemes GW hosts with protocol mapping
+     * @param api              API
      */
     private void updateEndpoints(OpenAPI openAPI, String basePath, String transports,
-                                 Map<String, String> hostsWithSchemes) {
-
-        String[] apiTransports = transports.split(",");
+                                 Map<String, String> hostsWithSchemes, API api) {
         List<Server> servers = new ArrayList<>();
-        if (ArrayUtils.contains(apiTransports, APIConstants.HTTPS_PROTOCOL) && hostsWithSchemes
-                .containsKey(APIConstants.HTTPS_PROTOCOL)) {
-            String host = hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL).trim()
-                    .replace(APIConstants.HTTPS_PROTOCOL_URL_PREFIX, "");
-            String httpsURL = APIConstants.HTTPS_PROTOCOL + "://" + host + basePath;
-            Server httpsServer = new Server();
-            httpsServer.setUrl(httpsURL);
-            servers.add(httpsServer);
+        if (api != null && api.isAdvertiseOnly()) {
+            String externalProductionEndpoint = api.getApiExternalProductionEndpoint();
+            String externalSandboxEndpoint = api.getApiExternalSandboxEndpoint();
+            if (externalProductionEndpoint != null) {
+                Server externalProductionServer = new Server();
+                externalProductionServer.setUrl(externalProductionEndpoint);
+                servers.add(externalProductionServer);
+            }
+            if (externalSandboxEndpoint != null) {
+                Server externalSandboxServer = new Server();
+                externalSandboxServer.setUrl(externalSandboxEndpoint);
+                servers.add(externalSandboxServer);
+            }
+            openAPI.setServers(servers);
+        } else {
+            String[] apiTransports = transports.split(",");
+            if (ArrayUtils.contains(apiTransports, APIConstants.HTTPS_PROTOCOL) && hostsWithSchemes
+                    .containsKey(APIConstants.HTTPS_PROTOCOL)) {
+                String host = hostsWithSchemes.get(APIConstants.HTTPS_PROTOCOL).trim()
+                        .replace(APIConstants.HTTPS_PROTOCOL_URL_PREFIX, "");
+                String httpsURL = APIConstants.HTTPS_PROTOCOL + "://" + host + basePath;
+                Server httpsServer = new Server();
+                httpsServer.setUrl(httpsURL);
+                servers.add(httpsServer);
+            }
+            if (ArrayUtils.contains(apiTransports, APIConstants.HTTP_PROTOCOL) && hostsWithSchemes
+                    .containsKey(APIConstants.HTTP_PROTOCOL)) {
+                String host = hostsWithSchemes.get(APIConstants.HTTP_PROTOCOL).trim()
+                        .replace(APIConstants.HTTP_PROTOCOL_URL_PREFIX, "");
+                String httpURL = APIConstants.HTTP_PROTOCOL + "://" + host + basePath;
+                Server httpsServer = new Server();
+                httpsServer.setUrl(httpURL);
+                servers.add(httpsServer);
+            }
+            openAPI.setServers(servers);
         }
-        if (ArrayUtils.contains(apiTransports, APIConstants.HTTP_PROTOCOL) && hostsWithSchemes
-                .containsKey(APIConstants.HTTP_PROTOCOL)) {
-            String host = hostsWithSchemes.get(APIConstants.HTTP_PROTOCOL).trim()
-                    .replace(APIConstants.HTTP_PROTOCOL_URL_PREFIX, "");
-            String httpURL = APIConstants.HTTP_PROTOCOL + "://" + host + basePath;
-            Server httpsServer = new Server();
-            httpsServer.setUrl(httpURL);
-            servers.add(httpsServer);
-        }
-        openAPI.setServers(servers);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
@@ -8843,6 +8843,12 @@ components:
           enum:
             - PUBLIC
             - SINGLE
+        audiences:
+          type: array
+          description: The audiences of the API for jwt validation. Accepted values are any String values
+          items:
+            type: string
+            example: [ "aud1","aud2","aud3" ]
         lifeCycleStatus:
           type: string
           example: CREATED
@@ -9060,6 +9066,12 @@ components:
           enum:
             - PUBLIC
             - SINGLE
+        audiences:
+          type: array
+          description: The audiences of the API for jwt validation. Accepted values are any String values
+          items:
+            type: string
+            example: [ "aud1","aud2","aud3" ]
         transport:
           type: array
           description: |
@@ -9652,6 +9664,12 @@ components:
         gatewayVendor:
           type: string
           example: wso2
+        audiences:
+          type: array
+          description: The audiences of the API product for jwt validation. Accepted values are any String values
+          items:
+            type: string
+            example: [ "aud1","aud2","aud3" ]
         monetizedInfo:
           type: boolean
           example: true
@@ -9925,6 +9943,12 @@ components:
         workflowStatus:
           type: string
           example: APPROVED
+        audiences:
+          type: array
+          description: The audiences of the API for jwt validation. Accepted values are any String values
+          items:
+            type: string
+            example: [ "aud1","aud2","aud3" ]
     ProductAPI:
       title: ProductAPI
       required:


### PR DESCRIPTION
## Purpose
Wrong endpoints display on the Document UI, Swagger definition, and Postman collection for third-party APIs. Production and Sandbox URLs need to be displayed on the Document UI and also need to add them into the Swagger definition

## Fix
Check the current API is Advertised (Third-party) and assign the Production and Sandbox Endpoints for the server  field in the Swagger definition. This has implemented for both OAS2 and OAS3.

Resolves https://github.com/wso2/api-manager/issues/2601