### PR TITLE
Handle NullPointerException for Empty or Null `config_endpoint` in `AnalyticsPublisher`

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/Constants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/Constants.java
@@ -37,4 +37,6 @@ public class Constants {
     public static final String IPV6_MASK_VALUE = "**";
     public static final String EMAIL_MASK_VALUE = "*****";
     public static final String USERNAME_MASK_VALUE = "*****";
+
+    public static final String AUTH_API_URL = "auth.api.url";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
@@ -117,6 +117,12 @@ public class AnalyticsDataPublisher {
                 metricReporter = MetricReporterFactory.getInstance().createLogMetricReporter(configs);
                 metricReporters.add(metricReporter);
             } else {
+                String authEndpoint = configs.get(Constants.AUTH_API_URL);
+
+                if (authEndpoint == null || authEndpoint.isEmpty()) {
+                    throw new MetricCreationException("Analytics Config Endpoint is not provided.");
+                }
+
                 metricReporter = MetricReporterFactory.getInstance().createMetricReporter(configs);
                 metricReporters.add(metricReporter);
             }


### PR DESCRIPTION
### Purpose
> To prevent `NullPointerException` when the `config_endpoint` of the `AnalyticsPublisher` is empty or null.
> Fixes https://github.com/wso2/api-manager/issues/2153

### Approach
> If the `config_endpoint` is empty or null, throw a `MetricCreationException`.