### PR TITLE
Add case-insensitive search capability to the Application search in the Devportal

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantOracle.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantOracle.java
@@ -54,7 +54,7 @@ public class SQLConstantOracle extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And " +
-                    "    NAME like ?" +
+                    "    LOWER (NAME) like LOWER (?)" +
                     " ) a WHERE r BETWEEN ?+1 AND ?"+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
                     " ORDER BY $1 $2 ";
@@ -91,7 +91,7 @@ public class SQLConstantOracle extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " ) a WHERE r BETWEEN ?+1 AND ?"+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
                     " ORDER BY $1 $2 ";
@@ -130,7 +130,7 @@ public class SQLConstantOracle extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And " +
-                    "    NAME like ?" +
+                    "    LOWER (NAME) like LOWER (?)" +
                     " ) a WHERE r BETWEEN ?+1 AND ?"+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
                     " ORDER BY $1 $2 ";
@@ -171,7 +171,7 @@ public class SQLConstantOracle extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And " +
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " ) a WHERE r BETWEEN ?+1 AND ?"+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
                     " ORDER BY $1 $2 ";
@@ -206,7 +206,7 @@ public class SQLConstantOracle extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " ) a WHERE r BETWEEN ?+1 AND ?"+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
                     " ORDER BY $1 $2 ";
@@ -241,7 +241,7 @@ public class SQLConstantOracle extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " ) a WHERE r BETWEEN ?+1 AND ?"+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
                     " ORDER BY $1 $2 ";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantPostgreSQL.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantPostgreSQL.java
@@ -51,7 +51,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And " +
-                    "    NAME like ?" +
+                    "    LOWER (NAME) like LOWER (?)" +
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
@@ -84,7 +84,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
@@ -121,7 +121,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ?" +
+                    "    LOWER (NAME) like LOWER (?)" +
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
@@ -160,7 +160,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And " +
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
@@ -193,7 +193,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
@@ -225,7 +225,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsDB2.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsDB2.java
@@ -55,7 +55,7 @@ public class SQLConstantsDB2 extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And " +
-                    "    NAME like ?" +
+                    "    LOWER (NAME) like LOWER (?)" +
                     " ) a )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 limit ? , ? ";
 
@@ -91,7 +91,7 @@ public class SQLConstantsDB2 extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ?" +
+                    "    LOWER (NAME) like LOWER (?)" +
                     " ) a )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 limit ? , ? ";
 
@@ -124,7 +124,7 @@ public class SQLConstantsDB2 extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ?" +
+                    "    LOWER (NAME) like LOWER (?)" +
                     " ) a )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 limit ? , ? ";
 
@@ -158,7 +158,7 @@ public class SQLConstantsDB2 extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ?" +
+                    "    LOWER (NAME) like LOWER (?)" +
                     " ) a )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 limit ? , ? ";
 
@@ -194,7 +194,7 @@ public class SQLConstantsDB2 extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " ORDER BY $1 $2 " +
                     " limit ? , ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
@@ -232,7 +232,7 @@ public class SQLConstantsDB2 extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And " +
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 limit ? , ?";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsH2MySQL.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsH2MySQL.java
@@ -53,7 +53,7 @@ public class SQLConstantsH2MySQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
             " And " +
-            "    NAME like ?" +
+            "    LOWER (NAME) like LOWER (?)" +
             " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
             " ORDER BY $1 $2 limit ? , ?";
 
@@ -85,7 +85,7 @@ public class SQLConstantsH2MySQL extends SQLConstants{
             " AND " +
             "   APP.ORGANIZATION = ? " +
             " And "+
-            "    NAME like ?"+
+            "    LOWER (NAME) like LOWER (?)"+
             " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
             " ORDER BY $1 $2 limit ? , ?";
 
@@ -122,7 +122,7 @@ public class SQLConstantsH2MySQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And " +
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 limit ? , ?";
 
@@ -159,7 +159,7 @@ public class SQLConstantsH2MySQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 limit ? , ?";
 
@@ -192,7 +192,7 @@ public class SQLConstantsH2MySQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
             " And "+
-            "    NAME like ?"+
+            "    LOWER (NAME) like LOWER (?)"+
             " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
             " ORDER BY $1 $2 limit ? , ?";
 
@@ -223,7 +223,7 @@ public class SQLConstantsH2MySQL extends SQLConstants{
             " AND " +
             "   APP.ORGANIZATION = ? " +
             " And "+
-            "    NAME like ?"+
+            "    LOWER (NAME) like LOWER (?)"+
             " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
             " ORDER BY $1 $2 limit ? , ?";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsMSSQL.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantsMSSQL.java
@@ -55,7 +55,7 @@ public class SQLConstantsMSSQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
             " And " +
-            "    NAME like ?" +
+            "    LOWER (NAME) like LOWER (?)" +
             " ) a " +
             " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = (x.USER_ID + ':') + x.NAME)" +
             " ORDER BY $1 $2 OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
@@ -92,7 +92,7 @@ public class SQLConstantsMSSQL extends SQLConstants{
             " AND " +
             "   APP.ORGANIZATION = ? " +
             " And "+
-            "    NAME like ?"+
+            "    LOWER (NAME) like LOWER (?)"+
             " ) a WHERE a.row > ? and a.row <= a.row + ?"+
             " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = (x.USER_ID + ':') + x.NAME)"+
             " ORDER BY $1 $2 OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
@@ -132,7 +132,7 @@ public class SQLConstantsMSSQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And "+
-                    "    NAME like ? ) a " +
+                    "    LOWER (NAME) like LOWER (?) ) a " +
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = (x.USER_ID + ':') + x.NAME)" +
                     " ORDER BY $1 $2 OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
 
@@ -174,7 +174,7 @@ public class SQLConstantsMSSQL extends SQLConstants{
                     " AND " +
                     "   APP.ORGANIZATION = ? " +
                     " And " +
-                    "    NAME like ?"+
+                    "    LOWER (NAME) like LOWER (?)"+
                     " ) a " +
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = (x.USER_ID + ':') + x.NAME)" +
                     " ORDER BY $1 $2 OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
@@ -209,7 +209,7 @@ public class SQLConstantsMSSQL extends SQLConstants{
             " AND " +
             "   APP.ORGANIZATION = ? " +
             " And "+
-            "    NAME like ?"+
+            "    LOWER (NAME) like LOWER (?)"+
             " )a " +
             " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = (x.USER_ID + ':') + x.NAME)" +
             " ORDER BY $1 $2 OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
@@ -244,7 +244,7 @@ public class SQLConstantsMSSQL extends SQLConstants{
             " AND " +
             "    APP.ORGANIZATION = ? " +
             " And "+
-            "    NAME like ?"+
+            "    LOWER (NAME) like LOWER (?)"+
             " ) a " +
             " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = (x.USER_ID + ':') + x.NAME)" +
             " ORDER BY $1 $2 OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";


### PR DESCRIPTION
## Purpose
API Developer Portal Application search is case sensitive and it does not search applications when case insensitive key words are provided. Searching process need to be case insensitive.

## Fix
Change Application search queries for each DB type to search them case insensitively 

Resolves https://github.com/wso2/api-manager/issues/1434