### PR TITLE
Fix the issue of not showing all the tags under Tags/API categories in the devportal

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/TagsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/TagsApiServiceImpl.java
@@ -57,7 +57,9 @@ public class TagsApiServiceImpl implements TagsApiService {
             if (tagSet != null) {
                 tagList.addAll(tagSet);
             }
-            TagListDTO tagListDTO = TagMappingUtil.fromTagListToDTO(tagList, limit, offset);
+            TagListDTO tagListDTO = limit == -1 ?
+                    TagMappingUtil.fromTagListToDTO(tagList, tagList.size(), offset) :
+                    TagMappingUtil.fromTagListToDTO(tagList, limit, offset);
             TagMappingUtil.setPaginationParams(tagListDTO, limit, offset, tagList.size());
             return Response.ok().entity(tagListDTO).build();
         } catch (APIManagementException e) {


### PR DESCRIPTION
When the Devportal UI is loaded and the Tags/API categories section is selected, they can only see the 25 Tags which is the default value. With this update, it will show all the added tags in that section.

Fixes : https://github.com/wso2/api-manager/issues/2947