### PR TITLE
Fixed transformation configuration for the 2 SOAP versions.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/SequenceGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/SequenceGenerator.java
@@ -198,7 +198,7 @@ public class SequenceGenerator {
                     sequenceMap.put("sequence", payloadSequence.get(operationId));
                     RESTToSOAPMsgTemplate template = new RESTToSOAPMsgTemplate();
                     String inSequence = template.getMappingInSequence(sequenceMap, operationId, soapAction,
-                            namespace, soapNamespace, arraySequenceElements);
+                            namespace, soapNamespace, soapVersion, arraySequenceElements);
                     String outSequence = template.getMappingOutSequence();
                     if (isResourceFromWSDL) {
                         SOAPToRestSequence inSeq = new SOAPToRestSequence(httpMethod.toString().toLowerCase(), pathName,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/template/RESTToSOAPMsgTemplate.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/template/RESTToSOAPMsgTemplate.java
@@ -58,10 +58,16 @@ public class RESTToSOAPMsgTemplate {
      * @return in sequence string
      */
     public String getMappingInSequence(Map<String, String> mapping, String method, String soapAction, String namespace,
-            String soapNamespace, JSONArray array) {
+            String soapNamespace, String soapVersion, JSONArray array) {
+
+        String mediaType;
+        if(soapVersion.equals(SOAPToRESTConstants.SOAP_VERSION_11))
+            mediaType = SOAPToRESTConstants.TEXT_XML;
+        else
+            mediaType = SOAPToRESTConstants.APPLICATION_SOAP_XML;
 
         ConfigContext configcontext = new SOAPToRESTConfigContext(mapping, method, soapAction, namespace, soapNamespace,
-                array);
+                mediaType, array);
         StringWriter writer = new StringWriter();
         try {
             VelocityContext context = configcontext.getContext();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/template/SOAPToRESTConfigContext.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/template/SOAPToRESTConfigContext.java
@@ -35,6 +35,7 @@ class SOAPToRESTConfigContext extends ConfigContext {
     private String method;
     private String soapAction;
     private String namespace;
+    private String mediaType;
     private String resourcePath;
     private Map<String, String> mappingObj;
     private JSONArray arrayElements;
@@ -49,12 +50,13 @@ class SOAPToRESTConfigContext extends ConfigContext {
      * @param arrayElements array type parameters mapping, if exists
      */
     SOAPToRESTConfigContext(Map<String, String> mapping, String method, String soapAction, String namespace,
-            String soapNamespace, JSONArray arrayElements) {
+            String soapNamespace, String mediaType, JSONArray arrayElements) {
         this.mappingObj = mapping;
         this.method = method;
         this.soapAction = soapAction;
         this.namespace = namespace;
         this.soapNamespace = soapNamespace;
+        this.mediaType = mediaType;
         this.arrayElements = arrayElements;
         init();
     }
@@ -82,6 +84,7 @@ class SOAPToRESTConfigContext extends ConfigContext {
         context.put(SOAPToRESTConstants.Template.RESOURCE_PATH, resourcePath);
         context.put(SOAPToRESTConstants.Template.MAPPING, mappingObj);
         context.put(SOAPToRESTConstants.Template.ARRAY_ELEMENTS, arrayElements);
+        context.put(SOAPToRESTConstants.Template.MEDIA_TYPE, mediaType);
         return context;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SOAPToRESTConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/util/SOAPToRESTConstants.java
@@ -47,6 +47,7 @@ public class SOAPToRESTConstants {
     public static final String SOAP11_NAMESPACE = "http://schemas.xmlsoap.org/soap/envelope/";
     public static final String SOAP12_NAMSPACE = "http://www.w3.org/2003/05/soap-envelope";
     public static final String TEXT_XML = "text/xml";
+    public static final String APPLICATION_SOAP_XML = "application/soap+xml";
     public static final String ELEMENT_FORM_DEFAULT= "elementFormDefault";
     public static final String QUALIFIED = "qualified";
     public static final String X_NAMESPACE_QUALIFIED = "x-namespace-qualified";
@@ -144,5 +145,6 @@ public class SOAPToRESTConstants {
         public static final String IN_SEQUENCES = "in_sequences";
         public static final String OUT_SEQUENCES = "out_sequences";
         public static final String NOT_DEFINED = "not-defined";
+        public static final String MEDIA_TYPE = "mediaType";
     }
 }


### PR DESCRIPTION
### Purpose

Currently APIM only creates transformation configurations for SOAP 1.2. Even if the WSDL is describing a SOAP 1.1, internally the transformation configuration is hardcoded to be SOAP 1.2. 

2 new variables were added to the file [soap_to_rest_in_seq_template.xml](https://github.com/wso2/product-apim/blob/master/modules/distribution/resources/api_templates/soap_to_rest_in_seq_template.xml) in https://github.com/wso2/product-apim/pull/13511.

The mediaType should be `txt/xml` for SOAP 1.1 and it should be `application/soap+xml` for SOAP 1.2. The mediaType is determined by the `soapVersion` and passed to the `configContext` in order for it to be populated in the template.

### Fixes
https://github.com/wso2/api-manager/issues/2939