### PR TITLE
Fix performance issue in OpenAPI Schema validation logic

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
@@ -33,7 +33,6 @@ import org.wso2.carbon.apimgt.gateway.handlers.security.model.OpenAPIResponse;
 import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 
 import java.util.HashMap;
-
 /**
  * This SchemaValidator handler validates the request/response messages against schema defined in the swagger.
  */
@@ -77,6 +76,7 @@ public class SchemaValidator extends AbstractHandler {
         if (openAPI != null && openAPIStringObject != null) {
             OpenApiInteractionValidator validator;
             String openAPIIdentifier = DigestUtils.md5Hex(openAPIStringObject.toString());
+            // Use existing validator if present
             if (validatorMap.containsKey(openAPIIdentifier)) {
                 validator = validatorMap.get(openAPIIdentifier);
             } else {
@@ -106,6 +106,7 @@ public class SchemaValidator extends AbstractHandler {
         OpenAPI openAPI = (OpenAPI) messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_OBJECT);
         Object openAPIStringObject = messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_STRING);
         if (openAPI != null && openAPIStringObject != null) {
+            // Use existing validator if present
             OpenApiInteractionValidator validator;
             String openAPIIdentifier = DigestUtils.md5Hex(openAPIStringObject.toString());
             if (validatorMap.containsKey(openAPIIdentifier)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/model/OpenAPIRequest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/model/OpenAPIRequest.java
@@ -19,11 +19,8 @@ package org.wso2.carbon.apimgt.gateway.handlers.security.model;
 import com.atlassian.oai.validator.model.Request;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Paths;
-import io.swagger.v3.parser.core.models.ParseOptions;
-import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
@@ -33,7 +30,6 @@ import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.security.utils.SchemaValidationUtils;
 
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Locale;
@@ -73,12 +69,8 @@ public class OpenAPIRequest implements Request {
         //Set Request path
         path = SchemaValidationUtils.getRestSubRequestPath(
                 messageContext.getProperty(REST_SUB_REQUEST_PATH).toString());
-        String swagger = messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_STRING).toString();
-        if (swagger != null) {
-            OpenAPIParser openAPIParser = new OpenAPIParser();
-            SwaggerParseResult swaggerParseResult =
-                    openAPIParser.readContents(swagger, new ArrayList<>(), new ParseOptions());
-            OpenAPI openAPI = swaggerParseResult.getOpenAPI();
+        OpenAPI openAPI = (OpenAPI) messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_OBJECT);
+        if (openAPI != null) {
             validatePath(openAPI);
         }
         //extract transport headers


### PR DESCRIPTION
## Fix performance issue in OpenAPI Schema validation logic

> This PR will add following changes to overcome the performance degrade observed after enabling OpenAPI schema validation.
    - Reuse the already created validator for each API in schema validation. 
    - Get OpenAPI object from the message context instead of creating a new OpenAPI object.

**Issue link: *https://github.com/wso2-enterprise/wso2-apim-internal/issues/6782***

**Doc Issue:** *Optional, link issue from [documentation repository]*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*