### PR TITLE
Fix error creating new API revision  and StuckThreadDetectionValve issue while creating an API Product

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -17022,6 +17022,10 @@ public class ApiMgtDAO {
                 if (connection.getMetaData().getDriverName().contains("MySQL")) {
                     getRevisionedURLMappingsStatement = connection.prepareStatement(
                             SQLConstants.APIRevisionSqlConstants.GET_REVISIONED_URL_MAPPINGS_ID_CASE_SENSITIVE_MYSQL);
+                } else if ((connection.getMetaData().getDriverName().contains("MS SQL") || connection.getMetaData()
+                        .getDriverName().contains("Microsoft"))) {
+                    getRevisionedURLMappingsStatement = connection.prepareStatement(
+                            SQLConstants.APIRevisionSqlConstants.GET_REVISIONED_URL_MAPPINGS_ID_CASE_SENSITIVE_MSSQL);
                 }
                 PreparedStatement insertScopeResourceMappingStatement = connection
                         .prepareStatement(SQLConstants.APIRevisionSqlConstants.INSERT_SCOPE_RESOURCE_MAPPING);
@@ -18240,6 +18244,10 @@ public class ApiMgtDAO {
                 if (connection.getMetaData().getDriverName().contains("MySQL")) {
                     getRevisionedURLMappingsStatement = connection.prepareStatement(
                             SQLConstants.APIRevisionSqlConstants.GET_REVISIONED_URL_MAPPINGS_ID_CASE_SENSITIVE_MYSQL);
+                } else if ((connection.getMetaData().getDriverName().contains("MS SQL") || connection.getMetaData()
+                        .getDriverName().contains("Microsoft"))) {
+                    getRevisionedURLMappingsStatement = connection.prepareStatement(
+                            SQLConstants.APIRevisionSqlConstants.GET_REVISIONED_URL_MAPPINGS_ID_CASE_SENSITIVE_MSSQL);
                 }
                 PreparedStatement insertScopeResourceMappingStatement = connection
                         .prepareStatement(SQLConstants.APIRevisionSqlConstants.INSERT_SCOPE_RESOURCE_MAPPING);
@@ -18485,6 +18493,10 @@ public class ApiMgtDAO {
                 if (connection.getMetaData().getDriverName().contains("MySQL")) {
                     getRevisionedURLMappingsStatement = connection.prepareStatement(
                             SQLConstants.APIRevisionSqlConstants.GET_REVISIONED_URL_MAPPINGS_ID_CASE_SENSITIVE_MYSQL);
+                } else if ((connection.getMetaData().getDriverName().contains("MS SQL") || connection.getMetaData()
+                        .getDriverName().contains("Microsoft"))) {
+                    getRevisionedURLMappingsStatement = connection.prepareStatement(
+                            SQLConstants.APIRevisionSqlConstants.GET_REVISIONED_URL_MAPPINGS_ID_CASE_SENSITIVE_MSSQL);
                 }
                 PreparedStatement addResourceScopeMapping = connection.prepareStatement(
                         SQLConstants.ADD_API_RESOURCE_SCOPE_MAPPING);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -3804,6 +3804,10 @@ public class SQLConstants {
                 "FROM AM_API_URL_MAPPING " + "WHERE API_ID = ? AND REVISION_UUID = ? AND HTTP_METHOD = ? AND " +
                 "AUTH_SCHEME = ? AND URL_PATTERN = CONVERT(? USING utf8mb4) COLLATE utf8mb4_bin " +
                 "AND THROTTLING_TIER = ? ";
+        public static final String GET_REVISIONED_URL_MAPPINGS_ID_CASE_SENSITIVE_MSSQL = "SELECT URL_MAPPING_ID " +
+                "FROM AM_API_URL_MAPPING WHERE API_ID = ? AND REVISION_UUID = ? AND HTTP_METHOD = ? AND " +
+                "AUTH_SCHEME = ? AND URL_PATTERN = CONVERT(nvarchar(max), ?) COLLATE Latin1_General_CS_AS " +
+                "AND THROTTLING_TIER = ?";
 
         public static final String GET_URL_MAPPINGS_ID = "SELECT URL_MAPPING_ID FROM AM_API_URL_MAPPING " +
                 "WHERE API_ID = ? AND HTTP_METHOD = ? AND AUTH_SCHEME = ? AND URL_PATTERN = ? " +

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
@@ -1330,6 +1330,18 @@ paths:
         Retrieves all existing deny policies.
       parameters:
         - $ref: '#/components/parameters/Accept'
+        - name: query
+          in: query
+          description: |
+            **Search condition**.
+            You can search in attributes by using **"conditionType:"** modifier and **"conditionValue:"** modifier.
+            Eg.
+            The entry "conditionType:API" will result in a match with blocking conditions only if the conditionType is "API". Similarly, "conditionValue:test/1.0.0" will result in a match with blocking conditions only if the conditionValue is "test/1.0.0".
+            When you use "conditionType:API & conditionValue:test/1.0.0" as a combination, it will result in a match with blocking conditions only if both the conditionType is "API" and the conditionValue is "test/1.0.0".
+            If query attribute is provided, this returns the blocking conditions that match the specified attributes.
+            Please note that you need to use encoded URL (URL encoding) if you are using a client which does not support URL encoding (such as curl)
+          schema:
+            type: string
       responses:
         200:
           description: |


### PR DESCRIPTION
[FIX-01]
### Purpose
In order to fix the error when creating a new revision, we need to consider a situation where there is an API with two or more resources having the same resource method and the same resource path, but with different cases. This error occurs when attempting to create a new revision from this API.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/2999

### Approach
Configuring resources in this way is not the best practice; however, we have addressed this by performing a case-sensitive URL_PATTERN search using Latin1_General_CS_AS collation on the URL mappings of the API during new revision creation.

[FIX-02]
### Purpose
Fixes StuckThreadDetectionValve issue while creating an API Product.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/3030

### Approach
Introduced getPublishedDefaultVersion method to resolve the default version of both migrated APIs and newly created APIs.