### PR TITLE
Support subscription validation disabling for tokens

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -1686,6 +1686,16 @@ public interface APIProvider extends APIManager {
     String getSecuritySchemeOfAPI(String uuid, String organization) throws APIManagementException;
 
     /**
+     * Returns security scheme of an API
+     *
+     * @param uuid UUID of the API's registry artifact
+     * @param org  Identifier of an organization
+     * @return Whether subscription validation is disabled or not
+     * @throws APIManagementException if failed get API details
+     */
+     boolean getSubscriptionValidationDisabled(String uuid, String org) throws APIManagementException;
+
+    /**
      * Returns details of an API
      * @param uuid   UUID of the API's registry artifact
      * @param organization  Identifier of an organization

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -579,6 +579,13 @@ public enum ExceptionCodes implements ErrorHandler {
             403, "Cannot change the business plan of the subscription with ID '%s' as the " +
             "subscriber does not have permission to access the specified business plan.", false),
 
+    SUBSCRIPTION_NOT_REQUIRED(902024, "Subscription not required.", 400,
+            "Subscriptions are not required to consume this API", false),
+    SUB_VALIDATION_DISABLE_NOT_ALLOWED(902025, "Subscription validation enable/disable is not allowed.",
+            400,
+            "Subscription validation enable/disable is not allowed for the API when in Published state",
+            false),
+
     HTTP_METHOD_INVALID(903201,
             "Invalid HTTP method provided for API resource", 400,
             "The HTTP method '%s' provided for resource '%s' is invalid", false),

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidator.java
@@ -486,6 +486,7 @@ public class JWTValidator {
                                                                                 JWTValidationInfo jwtValidationInfo) {
 
         APIKeyValidationInfoDTO apiKeyValidationInfoDTO = GatewayUtils.populateDTOWhenSubscriptionDisabled(api);
+        apiKeyValidationInfoDTO.setDisableSubscription(true);
         // Setting the 'sub' claim value as the end user details
         apiKeyValidationInfoDTO.setEndUserName(jwtValidationInfo.getUser());
         apiKeyValidationInfoDTO.setSubscriber(jwtValidationInfo.getUser());

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidator.java
@@ -508,7 +508,7 @@ public class JWTValidator {
             }
 
             if (claims.containsKey(APIConstants.Subscriptionless.TIER_CLAIM)) {
-                apiKeyValidationInfoDTO.setSubscriber((String) claims.get(APIConstants.Subscriptionless.TIER_CLAIM));
+                apiKeyValidationInfoDTO.setTier((String) claims.get(APIConstants.Subscriptionless.TIER_CLAIM));
             } else {
                 apiKeyValidationInfoDTO.setTier(APIConstants.Subscriptionless.DEFAULT_SUBSCRIPTION_TIER);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -1569,17 +1569,22 @@ public class GatewayUtils {
             }
             String context = (String) messageContext.getProperty(RESTConstants.REST_API_CONTEXT);
             String version = (String) messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION);
-            SubscriptionDataStore tenantSubscriptionStore =
-                    SubscriptionDataHolder.getInstance().getTenantSubscriptionStore(getTenantDomain());
-            if (tenantSubscriptionStore != null) {
-                API api1 = tenantSubscriptionStore.getApiByContextAndVersion(context, version);
-                if (api1 != null) {
-                    messageContext.setProperty(APIMgtGatewayConstants.API_OBJECT, api1);
-                    return api1;
-                }
+            API api1 = getAPIByContextAndVersion(context, version);
+            if (api1 != null) {
+                messageContext.setProperty(APIMgtGatewayConstants.API_OBJECT, api1);
+                return api1;
             }
             return null;
         }
+    }
+
+    public static API getAPIByContextAndVersion(String context, String version) {
+        SubscriptionDataStore tenantSubscriptionStore =
+                SubscriptionDataHolder.getInstance().getTenantSubscriptionStore(getTenantDomain());
+        if (tenantSubscriptionStore != null) {
+            return tenantSubscriptionStore.getApiByContextAndVersion(context, version);
+        }
+        return null;
     }
 
     public static String getStatus(org.apache.synapse.MessageContext messageContext) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -645,8 +645,12 @@ public class GatewayUtils {
                     return endUsername;
                 }
             }
-            return endUsername + UserCoreConstants.TENANT_DOMAIN_COMBINER
-                    + apiKeyValidationInfoDTO.getSubscriberTenantDomain();
+            if (apiKeyValidationInfoDTO.isDisableSubscription()) {
+                return endUsername;
+            } else {
+                return endUsername + UserCoreConstants.TENANT_DOMAIN_COMBINER
+                        + apiKeyValidationInfoDTO.getSubscriberTenantDomain();
+            }
         }
         return endUsername;
     }
@@ -1869,6 +1873,8 @@ public class GatewayUtils {
         List<String> list = new ArrayList<>();
         list.add(apiLevelThrottlingKey);
         infoDTO.setThrottlingDataList(list);
+        infoDTO.setStopOnQuotaReach(true);
+
         return infoDTO;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidatorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidatorTest.java
@@ -49,6 +49,9 @@ import org.wso2.carbon.apimgt.impl.dto.ExtendedJWTConfigurationDto;
 import org.wso2.carbon.apimgt.impl.jwt.JWTValidationService;
 import org.wso2.carbon.apimgt.impl.jwt.SignedJWTInfo;
 import org.wso2.carbon.apimgt.impl.utils.CertificateMgtUtils;
+import org.wso2.carbon.apimgt.keymgt.SubscriptionDataHolder;
+import org.wso2.carbon.apimgt.keymgt.model.SubscriptionDataStore;
+import org.wso2.carbon.apimgt.keymgt.model.entity.API;
 import org.wso2.carbon.apimgt.keymgt.service.TokenValidationContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -66,12 +69,14 @@ import java.security.cert.X509Certificate;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({JWTValidator.class, GatewayUtils.class, MultitenantUtils.class, PrivilegedCarbonContext.class,
-        ServiceReferenceHolder.class, CertificateMgtUtils.class, RevokedJWTDataHolder.class})
+        ServiceReferenceHolder.class, CertificateMgtUtils.class, RevokedJWTDataHolder.class,
+        SubscriptionDataHolder.class})
 public class JWTValidatorTest {
 
     private static String PASSWORD = "wso2carbon";
     PrivilegedCarbonContext privilegedCarbonContext;
     ServiceReferenceHolder serviceReferenceHolder;
+    API api;
 
     @Before
     public void setup() {
@@ -89,6 +94,8 @@ public class JWTValidatorTest {
         PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
         System.setProperty("javax.net.ssl.trustStorePassword", PASSWORD);
         PowerMockito.mockStatic(CertificateMgtUtils.class);
+        api = new API("1111-2222-3333", 1, "admin", "api1", "1.0", "/api1",
+                "Unlimited", "HTTP", "PUBLISHED", false);
     }
 
     @Test
@@ -144,6 +151,7 @@ public class JWTValidatorTest {
         Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
                 .thenReturn(headers);
         Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.API_OBJECT)).thenReturn(api);
         Mockito.when(messageContext.getProperty(RESTConstants.REST_API_CONTEXT)).thenReturn("/api1");
         Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION)).thenReturn("1.0");
         Mockito.when(messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE)).thenReturn("/pet/findByStatus");
@@ -223,6 +231,7 @@ public class JWTValidatorTest {
         Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
                 .thenReturn(headers);
         Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.API_OBJECT)).thenReturn(api);
         Mockito.when(messageContext.getProperty(RESTConstants.REST_API_CONTEXT)).thenReturn("/api1");
         Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION)).thenReturn("1.0");
         Mockito.when(messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE)).thenReturn("/pet/findByStatus");
@@ -312,6 +321,7 @@ public class JWTValidatorTest {
         Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
                 .thenReturn(headers);
         Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.API_OBJECT)).thenReturn(api);
         Mockito.when(messageContext.getProperty(RESTConstants.REST_API_CONTEXT)).thenReturn("/api1");
         Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION)).thenReturn("1.0");
         Mockito.when(messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE)).thenReturn("/pet/findByStatus");
@@ -409,6 +419,7 @@ public class JWTValidatorTest {
         Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
                 .thenReturn(headers);
         Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.API_OBJECT)).thenReturn(api);
         Mockito.when(messageContext.getProperty(RESTConstants.REST_API_CONTEXT)).thenReturn("/api1");
         Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION)).thenReturn("1.0");
         Mockito.when(messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE)).thenReturn("/pet/findByStatus");
@@ -502,6 +513,7 @@ public class JWTValidatorTest {
         Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
                 .thenReturn(headers);
         Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.API_OBJECT)).thenReturn(api);
         Mockito.when(messageContext.getProperty(RESTConstants.REST_API_CONTEXT)).thenReturn("/api1");
         Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION)).thenReturn("1.0");
         Mockito.when(messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE)).thenReturn("/pet/findByStatus");
@@ -590,6 +602,7 @@ public class JWTValidatorTest {
         Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
                 .thenReturn(headers);
         Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.API_OBJECT)).thenReturn(api);
         Mockito.when(messageContext.getProperty(RESTConstants.REST_API_CONTEXT)).thenReturn("/api1");
         Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION)).thenReturn("1.0");
         Mockito.when(messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE)).thenReturn("/pet/findByStatus");
@@ -679,6 +692,7 @@ public class JWTValidatorTest {
         Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
                 .thenReturn(headers);
         Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.API_OBJECT)).thenReturn(api);
         Mockito.when(messageContext.getProperty(RESTConstants.REST_API_CONTEXT)).thenReturn("/api1");
         Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION)).thenReturn("1.0");
         Mockito.when(messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE)).thenReturn("/pet/findByStatus");
@@ -834,6 +848,7 @@ public class JWTValidatorTest {
         Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
                 .thenReturn(headers);
         Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.API_OBJECT)).thenReturn(api);
         Mockito.when(messageContext.getProperty(RESTConstants.REST_API_CONTEXT)).thenReturn("/api1");
         Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION)).thenReturn("1.0");
         Mockito.when(messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE)).thenReturn("/pet/findByStatus");
@@ -926,6 +941,14 @@ public class JWTValidatorTest {
         apiKeyValidationInfoDTO.setGraphQLMaxDepth(3);
         apiKeyValidationInfoDTO.setGraphQLMaxComplexity(4);
         // testing happy path
+        SubscriptionDataStore mockSubscriptionDataStore = Mockito.mock(SubscriptionDataStore.class);
+        SubscriptionDataHolder mockSubscriptionDataHolder = Mockito.mock(SubscriptionDataHolder.class);
+        PowerMockito.mockStatic(SubscriptionDataHolder.class);
+        Mockito.when(SubscriptionDataHolder.getInstance()).thenReturn(mockSubscriptionDataHolder);
+        Mockito.when(mockSubscriptionDataHolder.getTenantSubscriptionStore(Mockito.anyString()))
+                .thenReturn(mockSubscriptionDataStore);
+        Mockito.when(mockSubscriptionDataStore
+                .getApiByContextAndVersion(Mockito.anyString(), Mockito.anyString())).thenReturn(api);
         Mockito.when(jwtValidationService.validateJWTToken(signedJWTInfo)).thenReturn(jwtValidationInfo);
         JWTValidatorWrapper jwtValidator
                 = new JWTValidatorWrapper("Unlimited", true, apiKeyValidator, false, null, jwtConfigurationDto,
@@ -1091,6 +1114,7 @@ public class JWTValidatorTest {
         Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
                 .thenReturn(headers);
         Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.API_OBJECT)).thenReturn(api);
         Mockito.when(messageContext.getProperty(RESTConstants.REST_API_CONTEXT)).thenReturn("/api1");
         Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION)).thenReturn("1.0");
         Mockito.when(messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE)).thenReturn("/pet/findByStatus");
@@ -1195,6 +1219,7 @@ public class JWTValidatorTest {
             Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
                     .thenReturn(headers);
             Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+            Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.API_OBJECT)).thenReturn(api);
             Mockito.when(messageContext.getProperty(RESTConstants.REST_API_CONTEXT)).thenReturn("/api1");
             Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION)).thenReturn("1.0");
             Mockito.when(messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE)).thenReturn("/pet/findByStatus");
@@ -1293,6 +1318,7 @@ public class JWTValidatorTest {
                 .thenReturn(headers);
         Mockito.when(axis2MsgCntxt.getProperty(APISecurityConstants.DISABLE_CNF_VALIDATION)).thenReturn(true);
         Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.API_OBJECT)).thenReturn(api);
         Mockito.when(messageContext.getProperty(RESTConstants.REST_API_CONTEXT)).thenReturn("/api1");
         Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION)).thenReturn("1.0");
         Mockito.when(messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE)).thenReturn("/pet/findByStatus");
@@ -1329,6 +1355,100 @@ public class JWTValidatorTest {
         Mockito.verify(jwtValidationService, Mockito.only()).validateJWTToken(signedJWTInfo);
         Mockito.verify(gatewayTokenCache, Mockito.atLeast(1)).get(signedJWT.getJWTClaimsSet()
                 .getJWTID());
+    }
+
+    @Test
+    public void testJWTValidatorWithSubscriptionValidationDisabled()
+            throws ParseException, APIManagementException, APISecurityException {
+        Mockito.when(privilegedCarbonContext.getTenantDomain()).thenReturn("carbon.super");
+        SignedJWT signedJWT =
+                SignedJWT.parse("eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik5UZG1aak00WkRrM05qWTBZemM1TW1abU9E" +
+                        "Z3dNVEUzTVdZd05ERTVNV1JsWkRnNE56YzRaQT09In0.eyJhdWQiOiJodHRwOlwvXC9vcmcud3NvMi5hcGltZ3RcL2d" +
+                        "hdGV3YXkiLCJzdWIiOiJhZG1pbkBjYXJib24uc3VwZXIiLCJhcHBsaWNhdGlvbiI6eyJvd25lciI6ImFkbWluIiwidG" +
+                        "llclF1b3RhVHlwZSI6InJlcXVlc3RDb3VudCIsInRpZXIiOiJVbmxpbWl0ZWQiLCJuYW1lIjoiRGVmYXVsdEFwcGxpY" +
+                        "2F0aW9uIiwiaWQiOjEsInV1aWQiOm51bGx9LCJzY29wZSI6ImFtX2FwcGxpY2F0aW9uX3Njb3BlIGRlZmF1bHQiLCJp" +
+                        "c3MiOiJodHRwczpcL1wvbG9jYWxob3N0Ojk0NDNcL29hdXRoMlwvdG9rZW4iLCJ0aWVySW5mbyI6e30sImtleXR5cGU" +
+                        "iOiJQUk9EVUNUSU9OIiwic3Vic2NyaWJlZEFQSXMiOltdLCJjb25zdW1lcktleSI6IlhnTzM5NklIRks3ZUZZeWRycV" +
+                        "FlNEhLR3oxa2EiLCJleHAiOjE1OTAzNDIzMTMsImlhdCI6MTU5MDMzODcxMywianRpIjoiYjg5Mzg3NjgtMjNmZC00Z" +
+                        "GVjLThiNzAtYmVkNDVlYjdjMzNkIn0.sBgeoqJn0log5EZflj_G7ADvm6B3KQ9bdfFCEFVQS1U3oY9-cqPwAPyOLLh9" +
+                        "5pdfjYjakkf1UtjPZjeIupwXnzg0SffIc704RoVlZocAx9Ns2XihjU6Imx2MbXq9ARmQxQkyGVkJUMTwZ8-SfOnprfr" +
+                        "hX2cMQQS8m2Lp7hcsvWFRGKxAKIeyUrbY4ihRIA5vOUrMBWYUx9Di1N7qdKA4S3e8O4KQX2VaZPBzN594c9TGriiH8A" +
+                        "uuqnrftfvidSnlRLaFJmko8-QZo8jDepwacaFhtcaPVVJFG4uYP-_-N6sqfxLw3haazPN0_xU0T1zJLPRLC5HPfZMJD" +
+                        "MGpEuSe9w");
+        ExtendedJWTConfigurationDto jwtConfigurationDto = new ExtendedJWTConfigurationDto();
+        JWTValidationService jwtValidationService = Mockito.mock(JWTValidationService.class);
+        APIKeyValidator apiKeyValidator = Mockito.mock(APIKeyValidator.class);
+        Cache gatewayTokenCache = Mockito.mock(Cache.class);
+        Cache invalidTokenCache = Mockito.mock(Cache.class);
+        Cache gatewayKeyCache = Mockito.mock(Cache.class);
+        Cache gatewayJWTTokenCache = Mockito.mock(Cache.class);
+        JWTValidationInfo jwtValidationInfo = new JWTValidationInfo();
+        jwtValidationInfo.setValid(true);
+        jwtValidationInfo.setIssuer("https://localhost");
+        jwtValidationInfo.setRawPayload(signedJWT.getParsedString());
+        jwtValidationInfo.setJti(UUID.randomUUID().toString());
+        jwtValidationInfo.setIssuedTime(System.currentTimeMillis());
+        jwtValidationInfo.setExpiryTime(System.currentTimeMillis() + 5000L);
+        jwtValidationInfo.setConsumerKey(UUID.randomUUID().toString());
+        jwtValidationInfo.setUser("user1");
+        jwtValidationInfo.setKeyManager("Default");
+        SignedJWTInfo signedJWTInfo = new SignedJWTInfo(signedJWT.getParsedString(), signedJWT,
+                signedJWT.getJWTClaimsSet());
+        Mockito.when(jwtValidationService.validateJWTToken(signedJWTInfo)).thenReturn(jwtValidationInfo);
+        JWTValidatorWrapper jwtValidator = new JWTValidatorWrapper("Unlimited",
+                true, apiKeyValidator, false, null, jwtConfigurationDto,
+                jwtValidationService, invalidTokenCache, gatewayTokenCache, gatewayKeyCache, gatewayJWTTokenCache);
+        MessageContext messageContext = Mockito.mock(Axis2MessageContext.class);
+        org.apache.axis2.context.MessageContext axis2MsgCntxt =
+                Mockito.mock(org.apache.axis2.context.MessageContext.class);
+        Mockito.when(axis2MsgCntxt.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn("GET");
+        Map<String, String> headers = new HashMap<>();
+        Mockito.when(axis2MsgCntxt.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS))
+                .thenReturn(headers);
+        Mockito.when(((Axis2MessageContext) messageContext).getAxis2MessageContext()).thenReturn(axis2MsgCntxt);
+        API api1 = api;
+        api.setDisableSubscriptionValidation(true);
+        Mockito.when(messageContext.getProperty(APIMgtGatewayConstants.API_OBJECT)).thenReturn(api1);
+        Mockito.when(messageContext.getProperty(RESTConstants.REST_API_CONTEXT)).thenReturn("/api1");
+        Mockito.when(messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION)).thenReturn("1.0");
+        Mockito.when(messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE)).thenReturn("/pet/findByStatus");
+        APIManagerConfiguration apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
+        Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.JWT_AUTHENTICATION_SUBSCRIPTION_VALIDATION))
+                .thenReturn("true");
+        jwtValidator.setApiManagerConfiguration(apiManagerConfiguration);
+        APIKeyValidationInfoDTO apiKeyValidationInfoDTO = new APIKeyValidationInfoDTO();
+        apiKeyValidationInfoDTO.setApiName("api1");
+        apiKeyValidationInfoDTO.setApiPublisher("admin");
+        apiKeyValidationInfoDTO.setApiTier("Unlimited");
+        apiKeyValidationInfoDTO.setAuthorized(true);
+        Mockito.when(apiKeyValidator.validateScopes(Mockito.any(TokenValidationContext.class), Mockito.anyString()))
+                .thenReturn(true);
+        SubscriptionDataStore mockSubscriptionDataStore = Mockito.mock(SubscriptionDataStore.class);
+        SubscriptionDataHolder mockSubscriptionDataHolder = Mockito.mock(SubscriptionDataHolder.class);
+        PowerMockito.mockStatic(SubscriptionDataHolder.class);
+        Mockito.when(SubscriptionDataHolder.getInstance()).thenReturn(mockSubscriptionDataHolder);
+        Mockito.when(mockSubscriptionDataHolder.getTenantSubscriptionStore(Mockito.anyString()))
+                .thenReturn(mockSubscriptionDataStore);
+        Mockito.when(mockSubscriptionDataStore.getApiPolicyByName(Mockito.anyString(), Mockito.anyInt()))
+                .thenReturn(null);
+        AuthenticationContext authenticate = jwtValidator.authenticate(signedJWTInfo, messageContext);
+        Mockito.verify(apiKeyValidator, Mockito.never()).validateSubscription(Mockito.anyString(), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        Assert.assertNotNull(authenticate);
+        Assert.assertEquals(authenticate.getApiName(), "api1");
+        Assert.assertEquals(authenticate.getApiPublisher(), "admin");
+        Assert.assertEquals(authenticate.getApplicationName(), APIConstants.Subscriptionless.APPLICATION_NAME);
+        Assert.assertEquals(authenticate.getConsumerKey(), jwtValidationInfo.getConsumerKey());
+        Mockito.when(gatewayTokenCache.get(signedJWT.getJWTClaimsSet().getJWTID())).thenReturn("carbon.super");
+        Mockito.when(gatewayKeyCache.get(signedJWT.getJWTClaimsSet().getJWTID())).thenReturn(jwtValidationInfo);
+        authenticate = jwtValidator.authenticate(signedJWTInfo, messageContext);
+        Assert.assertNotNull(authenticate);
+        Assert.assertEquals(authenticate.getApiName(), "api1");
+        Assert.assertEquals(authenticate.getApiPublisher(), "admin");
+        Assert.assertEquals(authenticate.getConsumerKey(), jwtValidationInfo.getConsumerKey());
+        Mockito.verify(jwtValidationService, Mockito.only()).validateJWTToken(signedJWTInfo);
+        Mockito.verify(gatewayTokenCache, Mockito.atLeast(1))
+                .get(signedJWT.getJWTClaimsSet().getJWTID());
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2635,6 +2635,15 @@ public final class APIConstants {
         }
     }
 
+    public static class Subscriptionless {
+        public static final String APPLICATION_NAME = "SubscriptionlessApplication";
+        public static final String APPLICATION_OWNER = "SubscriptionlessOwner";
+        public static final String DEFAULT_SUBSCRIPTION_TIER = "Unlimited";
+        public static final String APPLICATION_CLAIM = "app_name";
+        public static final String TIER_CLAIM = "business_plan";
+        public static final String SUBSCRIBER_CLAIM = "sub";
+    }
+
     public static class KeyManager {
 
         public static final String SERVICE_URL = "ServiceURL";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2304,6 +2304,8 @@ public final class APIConstants {
             CATEGORY_SEARCH_TYPE_PREFIX, ENABLE_STORE.toLowerCase()};
     // Prefix for registry attributes.
     public static final String OVERVIEW_PREFIX = "overview_";
+    // API Property name for disabling subscription validation
+    public static final String DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY = "disable_sub_validation";
     /**
      * Parameter for enabling tenant load notifications to members in the same HZ cluster
      */

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5213,6 +5213,16 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     }
 
     @Override
+    public boolean getSubscriptionValidationDisabled(String uuid, String org) throws APIManagementException {
+        Organization organization = new Organization(org);
+        try {
+            return apiPersistenceInstance.getSubscriptionValidationDisabled(organization, uuid);
+        } catch (APIPersistenceException e) {
+            throw new APIManagementException("Failed to get the subscription validation status of the API", e);
+        }
+    }
+
+    @Override
     public API getAPIbyUUID(String uuid, String organization) throws APIManagementException {
         Organization org = new Organization(organization);
         try {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/APIKeyValidationInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/APIKeyValidationInfoDTO.java
@@ -72,6 +72,7 @@ public class APIKeyValidationInfoDTO implements Serializable {
     private String applicationUUID;
     private Set<String> applicationGroupIds = new HashSet<>();
     private Map<String, String> appAttributes;
+    private boolean disableSubscription = false;
 
     public List<String> getThrottlingDataList() {
         return throttlingDataList;
@@ -414,6 +415,14 @@ public class APIKeyValidationInfoDTO implements Serializable {
     public void setAppAttributes(Map<String, String> appAttributes) {
 
         this.appAttributes = appAttributes;
+    }
+
+    public boolean isDisableSubscription() {
+        return disableSubscription;
+    }
+
+    public void setDisableSubscription(boolean disableSubscription) {
+        this.disableSubscription = disableSubscription;
     }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/dto/APIDTO.java
@@ -34,6 +34,7 @@ public class APIDTO   {
     private List<OperationPolicyDTO> apiPolicies = new ArrayList<>();
     private List<URLMappingDTO> urlMappings = new ArrayList<>();
     private String securityScheme = null;
+    private Boolean disableSubscriptionValidation = false;
 
   /**
    * UUID of API
@@ -284,6 +285,24 @@ public class APIDTO   {
     this.securityScheme = securityScheme;
   }
 
+  /**
+   * Whether subscription validation is disabled.
+   **/
+  public APIDTO disableSubscriptionValidation(Boolean disableSubscriptionValidation) {
+    this.disableSubscriptionValidation = disableSubscriptionValidation;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "false", value = "Whether subscription validation is disabled.")
+  @JsonProperty("disableSubscriptionValidation")
+  public Boolean isDisableSubscriptionValidation() {
+    return disableSubscriptionValidation;
+  }
+  public void setDisableSubscriptionValidation(Boolean disableSubscriptionValidation) {
+    this.disableSubscriptionValidation = disableSubscriptionValidation;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -307,12 +326,13 @@ public class APIDTO   {
         Objects.equals(isDefaultVersion, API.isDefaultVersion) &&
         Objects.equals(apiPolicies, API.apiPolicies) &&
         Objects.equals(urlMappings, API.urlMappings) &&
-        Objects.equals(securityScheme, API.securityScheme);
+        Objects.equals(securityScheme, API.securityScheme) &&
+        Objects.equals(disableSubscriptionValidation, API.disableSubscriptionValidation);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(uuid, apiId, provider, name, version, context, policy, apiType, status, organization, isDefaultVersion, apiPolicies, urlMappings, securityScheme);
+    return Objects.hash(uuid, apiId, provider, name, version, context, policy, apiType, status, organization, isDefaultVersion, apiPolicies, urlMappings, securityScheme, disableSubscriptionValidation);
   }
 
   @Override
@@ -334,6 +354,7 @@ public class APIDTO   {
     sb.append("    apiPolicies: ").append(toIndentedString(apiPolicies)).append("\n");
     sb.append("    urlMappings: ").append(toIndentedString(urlMappings)).append("\n");
     sb.append("    securityScheme: ").append(toIndentedString(securityScheme)).append("\n");
+    sb.append("    disableSubscriptionValidation: ").append(toIndentedString(disableSubscriptionValidation)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/utils/SubscriptionValidationDataUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/utils/SubscriptionValidationDataUtil.java
@@ -22,6 +22,7 @@ import edu.emory.mathcs.backport.java.util.Arrays;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.dto.ConditionDTO;
 import org.wso2.carbon.apimgt.api.model.OperationPolicy;
 import org.wso2.carbon.apimgt.api.model.Scope;
@@ -81,6 +82,7 @@ public class SubscriptionValidationDataUtil {
     private static APIDTO fromAPItoDTO(API model) throws APIManagementException {
 
         APIDTO apidto = null;
+        APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
         if (model != null) {
             apidto = new APIDTO();
             apidto.setUuid(model.getApiUUID());
@@ -98,9 +100,11 @@ public class SubscriptionValidationDataUtil {
             // The security schema is necessary only for the websocket APIs. To prevent unnecessary registry calls,
             // it has been excluded from other APIs, thus reducing operational costs.
             if(model.getApiType() != null && model.getApiType().equals("WS")) {
-                apidto.setSecurityScheme(RestApiCommonUtil.getLoggedInUserProvider().
-                        getSecuritySchemeOfAPI(model.getApiUUID(), model.getOrganization()));
+                apidto.setSecurityScheme(apiProvider
+                        .getSecuritySchemeOfAPI(model.getApiUUID(), model.getOrganization()));
             }
+            apidto.setDisableSubscriptionValidation(apiProvider
+                    .getSubscriptionValidationDisabled(model.getApiUUID(), model.getOrganization()));
             Map<String, URLMapping> urlMappings = model.getAllResources();
             List<URLMappingDTO> urlMappingsDTO = new ArrayList<>();
             for (URLMapping urlMapping : urlMappings.values()) {
@@ -144,6 +148,7 @@ public class SubscriptionValidationDataUtil {
     public static APIListDTO fromAPIToAPIListDTO(API model) throws APIManagementException {
 
         APIListDTO apiListdto = new APIListDTO();
+        APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
         if (model != null) {
             APIDTO apidto = new APIDTO();
             apidto.setUuid(model.getApiUUID());
@@ -157,8 +162,10 @@ public class SubscriptionValidationDataUtil {
             apidto.setStatus(model.getStatus());
             apidto.setIsDefaultVersion(model.isDefaultVersion());
             apidto.setOrganization(model.getOrganization());
-            apidto.setSecurityScheme(RestApiCommonUtil.getLoggedInUserProvider().
-                    getSecuritySchemeOfAPI(model.getApiUUID(), model.getOrganization()));
+            apidto.setSecurityScheme(apiProvider
+                    .getSecuritySchemeOfAPI(model.getApiUUID(), model.getOrganization()));
+            apidto.setDisableSubscriptionValidation(apiProvider
+                    .getSubscriptionValidationDisabled(model.getApiUUID(), model.getOrganization()));
             Map<String, URLMapping> urlMappings = model.getAllResources();
             List<URLMappingDTO> urlMappingsDTO = new ArrayList<>();
             for (URLMapping urlMapping : urlMappings.values()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/resources/api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/resources/api.yaml
@@ -950,6 +950,11 @@ definitions:
         type: string
         description: Available authentication methods of the API.
         example: Oauth2,api_key
+      disableSubscriptionValidation:
+        type: boolean
+        description: Whether subscription validation is disabled.
+        example: false
+        default: false
 
   #-----------------------------------------------------
   # synapse Artifact resource

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/swagger.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/swagger.json
@@ -1222,6 +1222,12 @@
           "type" : "string",
           "example" : "Oauth2,api_key",
           "description" : "Available authentication methods of the API."
+        },
+        "disableSubscriptionValidation" : {
+          "type" : "boolean",
+          "example" : false,
+          "description" : "Whether subscription validation is disabled.",
+          "default" : false
         }
       }
     },
@@ -1354,8 +1360,8 @@
           "type" : "string",
           "example" : "EXCHANGED",
           "description" : "The type of the tokens to be used (exchanged or without exchanged). Accepted values are EXCHANGED, DIRECT or BOTH.",
-          "enum" : [ "EXCHANGED", "DIRECT", "BOTH" ],
-          "default" : "DIRECT"
+          "default" : "DIRECT",
+          "enum" : [ "EXCHANGED", "DIRECT", "BOTH" ]
         }
       }
     },

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/entity/API.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/entity/API.java
@@ -44,6 +44,7 @@ public class API implements CacheableEntity<String> {
     private String securityScheme;
     private String revisionId;
     private List<OperationPolicy> apiPolicies = new ArrayList<>();
+    private boolean disableSubscriptionValidation = false;
 
     public API() {
     }
@@ -210,6 +211,7 @@ public class API implements CacheableEntity<String> {
                 ", isDefaultVersion=" + isDefaultVersion +
                 ", urlMappings=" + urlMappings +
                 ", apiPolicies=" + apiPolicies +
+                ", disableSubscriptionValidation=" + disableSubscriptionValidation +
                 '}';
     }
 
@@ -323,5 +325,13 @@ public class API implements CacheableEntity<String> {
 
     public List<OperationPolicy> getApiPolicies() {
         return apiPolicies;
+    }
+
+    public boolean isDisableSubscriptionValidation() {
+        return disableSubscriptionValidation;
+    }
+
+    public void setDisableSubscriptionValidation(boolean disableSubscriptionValidation) {
+        this.disableSubscriptionValidation = disableSubscriptionValidation;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/JWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/JWTGenerator.java
@@ -85,14 +85,20 @@ public class JWTGenerator extends AbstractJWTGenerator {
         String applicationTier = validationContext.getValidationInfoDTO().getApplicationTier();
         String enduserTenantId = String.valueOf(APIUtil.getTenantId(endUserName));
         String apiName = validationContext.getValidationInfoDTO().getApiName();
-        Application application =
-                getApplicationById(validationContext.getValidationInfoDTO().getSubscriberTenantDomain(),
-                        Integer.parseInt(applicationId));
+
         String uuid = null;
         Map<String, String> appAttributes = null;
-        if (application != null) {
-            appAttributes = application.getAttributes();
-            uuid = application.getUUID();
+        // Skipping the application lookup if subscription validation is disabled
+        if (!validationContext.getValidationInfoDTO().isDisableSubscription()) {
+            Application application =
+                    getApplicationById(validationContext.getValidationInfoDTO().getSubscriberTenantDomain(),
+                            Integer.parseInt(applicationId));
+            if (application != null) {
+                appAttributes = application.getAttributes();
+                uuid = application.getUUID();
+            }
+        } else {
+            uuid = validationContext.getValidationInfoDTO().getApplicationUUID();
         }
         Map<String, String> claims = new LinkedHashMap<String, String>(20);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/APIConstants.java
@@ -227,6 +227,8 @@ public final class APIConstants {
 
     // Prefix used for saving the custom properties related with APIs
     public static final String API_RELATED_CUSTOM_PROPERTIES_PREFIX = "api_meta.";
+    // API Property name for disabling subscription validation
+    public static final String DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY = "disable_sub_validation";
 
     /**
      * CustomIndexer property to indicate whether it is gone through API Custom Indexer.

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/APIPersistence.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/APIPersistence.java
@@ -127,6 +127,16 @@ public interface APIPersistence {
     String getSecuritySchemeOfAPI(Organization org, String apiId) throws APIPersistenceException;
 
     /**
+     * Get security scheme of API
+     *
+     * @param org   Organization the API is owned by
+     * @param apiId API ID
+     * @return A String containing the value of the API property
+     * @throws APIPersistenceException if failed to get the property of the API
+     */
+    boolean getSubscriptionValidationDisabled(Organization org, String apiId) throws APIPersistenceException;
+
+    /**
      * Get the API information stored in persistence layer, that is used for publisher operations
      *
      * @param org   Organization the API is owned by

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -1161,6 +1161,9 @@ public class RegistryPersistenceImpl implements APIPersistence {
             int tempLength = 0;
             for (GovernanceArtifact artifact : governanceArtifacts) {
 
+                String artifactPath = GovernanceUtils.getArtifactPath(userRegistry, artifact.getId());
+                Resource apiResource = userRegistry.get(artifactPath);
+
                 DevPortalAPIInfo apiInfo = new DevPortalAPIInfo();
                 //devPortalAPIInfoList apiInfo = new devPortalAPIInfoList();
                 apiInfo.setType(artifact.getAttribute(APIConstants.API_OVERVIEW_TYPE));
@@ -1194,6 +1197,8 @@ public class RegistryPersistenceImpl implements APIPersistence {
                         getAttribute(APIConstants.Monetization.API_MONETIZATION_STATUS)));
                 apiInfo.setAdvertiseOnly(Boolean.parseBoolean(artifact
                         .getAttribute(APIConstants.API_OVERVIEW_ADVERTISE_ONLY)));
+                apiInfo.setAdditionalProperties(RegistryPersistenceUtil
+                        .getSubscriptionValidationDisabledProperty(apiResource));
                 devPortalAPIInfoList.add(apiInfo);
 
                 // Ensure the APIs returned matches the length, there could be an additional API

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -685,9 +685,10 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 Resource apiResource = registry.get(artifactPath);
                 Properties properties = apiResource.getProperties();
                 if (properties != null) {
-                    if (properties.containsKey(APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY)) {
-                        return Boolean.parseBoolean(
-                                properties.get(APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY).toString());
+                    String propName = APIConstants.API_RELATED_CUSTOM_PROPERTIES_PREFIX +
+                            APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY;
+                    if (properties.containsKey(propName)) {
+                        return Boolean.parseBoolean(apiResource.getProperty(propName));
                     } else {
                         return false;
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
@@ -81,6 +81,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -870,6 +871,20 @@ public class RegistryPersistenceUtil {
 
         apiProduct.setAccessControlRoles(accessControlRoles);
         return apiProduct;
+    }
+
+    public static  Map<String, String> getSubscriptionValidationDisabledProperty(Resource apiResource) {
+        Properties properties = apiResource.getProperties();
+        Map<String, String> apiProperties = new HashMap<String, String>();
+        if (properties != null) {
+            String propName = APIConstants.API_RELATED_CUSTOM_PROPERTIES_PREFIX +
+                    APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY;
+            if (properties.containsKey(propName)) {
+                apiProperties.put(APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY,
+                        apiResource.getProperty(propName));
+            }
+        }
+        return apiProperties;
     }
     protected GenericArtifactManager getAPIGenericArtifactManagerFromUtil(Registry registry, String keyType)
                                     throws APIPersistenceException {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/java/org/wso2/carbon/apimgt/rest/api/common/RestApiConstants.java
@@ -351,4 +351,5 @@ public final class RestApiConstants {
     public static final String RESOURCE_PATH_GATEWAY_POLICIES = "gateway-policies";
 
     public static final String AUTH_TOKEN_INFO = "AUTH_TOKEN_INFO";
+    public static final String DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY = "disable_sub_validation";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
@@ -3956,6 +3956,10 @@ components:
         isSubscriptionAvailable:
           type: boolean
           example: false
+        disableSubscriptionValidation:
+          type: boolean
+          example: false
+          default: false
         monetizationLabel:
           type: string
           example: Free
@@ -4217,6 +4221,10 @@ components:
             format: int64
             description: The number of subscriptions for the API
             example: 10
+        disableSubscriptionValidation:
+          type: boolean
+          example: false
+          default: false
         advertiseInfo:
           $ref: '#/components/schemas/AdvertiseInfo'
         isSubscriptionAvailable:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
@@ -9226,6 +9226,12 @@ components:
           enum:
             - PUBLIC
             - SINGLE
+        audiences:
+          type: array
+          description: The audiences of the API for jwt validation. Accepted values are any String values
+          items:
+            type: string
+            example: [ "aud1","aud2","aud3" ]
         lifeCycleStatus:
           type: string
           example: CREATED
@@ -9447,6 +9453,12 @@ components:
           enum:
             - PUBLIC
             - SINGLE
+        audiences:
+          type: array
+          description: The audiences of the API for jwt validation. Accepted values are any String values
+          items:
+            type: string
+            example: [ "aud1","aud2","aud3" ]
         transport:
           type: array
           description: |
@@ -10039,6 +10051,12 @@ components:
         gatewayVendor:
           type: string
           example: wso2
+        audiences:
+          type: array
+          description: The audiences of the API product for jwt validation. Accepted values are any String values
+          items:
+            type: string
+            example: [ "aud1","aud2","aud3" ]
         monetizedInfo:
           type: boolean
           example: true
@@ -10316,6 +10334,12 @@ components:
         workflowStatus:
           type: string
           example: APPROVED
+        audiences:
+          type: array
+          description: The audiences of the API for jwt validation. Accepted values are any String values
+          items:
+            type: string
+            example: [ "aud1","aud2","aud3" ]
     ProductAPI:
       title: ProductAPI
       required:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
@@ -9226,12 +9226,6 @@ components:
           enum:
             - PUBLIC
             - SINGLE
-        audiences:
-          type: array
-          description: The audiences of the API for jwt validation. Accepted values are any String values
-          items:
-            type: string
-            example: [ "aud1","aud2","aud3" ]
         lifeCycleStatus:
           type: string
           example: CREATED
@@ -9426,6 +9420,10 @@ components:
         enableSubscriberVerification:
           type: boolean
           example: false
+        disableSubscriptionValidation:
+          type: boolean
+          example: false
+          default: false
         type:
           type: string
           description: The api creation type to be used. Accepted values are HTTP,
@@ -9449,12 +9447,6 @@ components:
           enum:
             - PUBLIC
             - SINGLE
-        audiences:
-          type: array
-          description: The audiences of the API for jwt validation. Accepted values are any String values
-          items:
-            type: string
-            example: [ "aud1","aud2","aud3" ]
         transport:
           type: array
           description: |
@@ -10047,12 +10039,6 @@ components:
         gatewayVendor:
           type: string
           example: wso2
-        audiences:
-          type: array
-          description: The audiences of the API product for jwt validation. Accepted values are any String values
-          items:
-            type: string
-            example: [ "aud1","aud2","aud3" ]
         monetizedInfo:
           type: boolean
           example: true
@@ -10119,6 +10105,10 @@ components:
         enableSchemaValidation:
           type: boolean
           example: false
+        disableSubscriptionValidation:
+          type: boolean
+          example: false
+          default: false
         isDefaultVersion:
           type: boolean
           example: false
@@ -10326,12 +10316,6 @@ components:
         workflowStatus:
           type: string
           example: APPROVED
-        audiences:
-          type: array
-          description: The audiences of the API for jwt validation. Accepted values are any String values
-          items:
-            type: string
-            example: [ "aud1","aud2","aud3" ]
     ProductAPI:
       title: ProductAPI
       required:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIDTO.java
@@ -62,6 +62,7 @@ public class APIDTO   {
     private Integer revisionId = null;
     private Boolean enableSchemaValidation = null;
     private Boolean enableSubscriberVerification = null;
+    private Boolean disableSubscriptionValidation = false;
 
     @XmlType(name="TypeEnum")
     @XmlEnum(String.class)
@@ -636,6 +637,23 @@ return null;
   }
 
   /**
+   **/
+  public APIDTO disableSubscriptionValidation(Boolean disableSubscriptionValidation) {
+    this.disableSubscriptionValidation = disableSubscriptionValidation;
+    return this;
+  }
+
+
+  @ApiModelProperty(example = "false", value = "")
+  @JsonProperty("disableSubscriptionValidation")
+  public Boolean isDisableSubscriptionValidation() {
+    return disableSubscriptionValidation;
+  }
+  public void setDisableSubscriptionValidation(Boolean disableSubscriptionValidation) {
+    this.disableSubscriptionValidation = disableSubscriptionValidation;
+  }
+
+  /**
    * The api creation type to be used. Accepted values are HTTP, WS, SOAPTOREST, GRAPHQL, WEBSUB, SSE, WEBHOOK, ASYNC
    **/
   public APIDTO type(TypeEnum type) {
@@ -679,7 +697,7 @@ return null;
     return this;
   }
 
-  
+
   @ApiModelProperty(value = "The audiences of the API for jwt validation. Accepted values are any String values")
   @JsonProperty("audiences")
   public List<String> getAudiences() {
@@ -1412,6 +1430,7 @@ return null;
         Objects.equals(revisionId, API.revisionId) &&
         Objects.equals(enableSchemaValidation, API.enableSchemaValidation) &&
         Objects.equals(enableSubscriberVerification, API.enableSubscriberVerification) &&
+        Objects.equals(disableSubscriptionValidation, API.disableSubscriptionValidation) &&
         Objects.equals(type, API.type) &&
         Objects.equals(audience, API.audience) &&
         Objects.equals(audiences, API.audiences) &&
@@ -1484,6 +1503,7 @@ return null;
     sb.append("    revisionId: ").append(toIndentedString(revisionId)).append("\n");
     sb.append("    enableSchemaValidation: ").append(toIndentedString(enableSchemaValidation)).append("\n");
     sb.append("    enableSubscriberVerification: ").append(toIndentedString(enableSubscriberVerification)).append("\n");
+    sb.append("    disableSubscriptionValidation: ").append(toIndentedString(disableSubscriptionValidation)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    audience: ").append(toIndentedString(audience)).append("\n");
     sb.append("    audiences: ").append(toIndentedString(audiences)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIDTO.java
@@ -643,7 +643,7 @@ return null;
     return this;
   }
 
-
+  
   @ApiModelProperty(example = "false", value = "")
   @JsonProperty("disableSubscriptionValidation")
   public Boolean isDisableSubscriptionValidation() {
@@ -697,7 +697,7 @@ return null;
     return this;
   }
 
-
+  
   @ApiModelProperty(value = "The audiences of the API for jwt validation. Accepted values are any String values")
   @JsonProperty("audiences")
   public List<String> getAudiences() {
@@ -1477,7 +1477,7 @@ return null;
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, context, version, provider, lifeCycleStatus, wsdlInfo, wsdlUrl, responseCachingEnabled, cacheTimeout, hasThumbnail, isDefaultVersion, isRevision, revisionedApiId, revisionId, enableSchemaValidation, enableSubscriberVerification, type, audience, audiences, transport, tags, policies, apiThrottlingPolicy, authorizationHeader, apiKeyHeader, securityScheme, maxTps, visibility, visibleRoles, visibleTenants, mediationPolicies, apiPolicies, subscriptionAvailability, subscriptionAvailableTenants, additionalProperties, additionalPropertiesMap, monetization, accessControl, accessControlRoles, businessInformation, corsConfiguration, websubSubscriptionConfiguration, workflowStatus, createdTime, lastUpdatedTimestamp, lastUpdatedTime, endpointConfig, endpointImplementationType, scopes, operations, threatProtectionPolicies, categories, keyManagers, serviceInfo, advertiseInfo, gatewayVendor, gatewayType, asyncTransportProtocols);
+    return Objects.hash(id, name, description, context, version, provider, lifeCycleStatus, wsdlInfo, wsdlUrl, responseCachingEnabled, cacheTimeout, hasThumbnail, isDefaultVersion, isRevision, revisionedApiId, revisionId, enableSchemaValidation, enableSubscriberVerification, disableSubscriptionValidation, type, audience, audiences, transport, tags, policies, apiThrottlingPolicy, authorizationHeader, apiKeyHeader, securityScheme, maxTps, visibility, visibleRoles, visibleTenants, mediationPolicies, apiPolicies, subscriptionAvailability, subscriptionAvailableTenants, additionalProperties, additionalPropertiesMap, monetization, accessControl, accessControlRoles, businessInformation, corsConfiguration, websubSubscriptionConfiguration, workflowStatus, createdTime, lastUpdatedTimestamp, lastUpdatedTime, endpointConfig, endpointImplementationType, scopes, operations, threatProtectionPolicies, categories, keyManagers, serviceInfo, advertiseInfo, gatewayVendor, gatewayType, asyncTransportProtocols);
   }
 
   @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductDTO.java
@@ -40,6 +40,7 @@ public class APIProductDTO   {
     private Boolean hasThumbnail = null;
     private String state = "CREATED";
     private Boolean enableSchemaValidation = null;
+    private Boolean disableSubscriptionValidation = false;
     private Boolean isDefaultVersion = null;
     private Boolean isRevision = null;
     private String revisionedApiProductId = null;
@@ -361,6 +362,23 @@ return null;
   }
   public void setEnableSchemaValidation(Boolean enableSchemaValidation) {
     this.enableSchemaValidation = enableSchemaValidation;
+  }
+
+  /**
+   **/
+  public APIProductDTO disableSubscriptionValidation(Boolean disableSubscriptionValidation) {
+    this.disableSubscriptionValidation = disableSubscriptionValidation;
+    return this;
+  }
+
+
+  @ApiModelProperty(example = "false", value = "")
+  @JsonProperty("disableSubscriptionValidation")
+  public Boolean isDisableSubscriptionValidation() {
+    return disableSubscriptionValidation;
+  }
+  public void setDisableSubscriptionValidation(Boolean disableSubscriptionValidation) {
+    this.disableSubscriptionValidation = disableSubscriptionValidation;
   }
 
   /**
@@ -971,7 +989,7 @@ return null;
     return this;
   }
 
-  
+
   @ApiModelProperty(value = "The audiences of the API for jwt validation. Accepted values are any String values")
   @JsonProperty("audiences")
   public List<String> getAudiences() {
@@ -1000,6 +1018,7 @@ return null;
         Objects.equals(hasThumbnail, apIProduct.hasThumbnail) &&
         Objects.equals(state, apIProduct.state) &&
         Objects.equals(enableSchemaValidation, apIProduct.enableSchemaValidation) &&
+        Objects.equals(disableSubscriptionValidation, apIProduct.disableSubscriptionValidation) &&
         Objects.equals(isDefaultVersion, apIProduct.isDefaultVersion) &&
         Objects.equals(isRevision, apIProduct.isRevision) &&
         Objects.equals(revisionedApiProductId, apIProduct.revisionedApiProductId) &&
@@ -1056,6 +1075,7 @@ return null;
     sb.append("    hasThumbnail: ").append(toIndentedString(hasThumbnail)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    enableSchemaValidation: ").append(toIndentedString(enableSchemaValidation)).append("\n");
+    sb.append("    disableSubscriptionValidation: ").append(toIndentedString(disableSubscriptionValidation)).append("\n");
     sb.append("    isDefaultVersion: ").append(toIndentedString(isDefaultVersion)).append("\n");
     sb.append("    isRevision: ").append(toIndentedString(isRevision)).append("\n");
     sb.append("    revisionedApiProductId: ").append(toIndentedString(revisionedApiProductId)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/APIProductDTO.java
@@ -371,7 +371,7 @@ return null;
     return this;
   }
 
-
+  
   @ApiModelProperty(example = "false", value = "")
   @JsonProperty("disableSubscriptionValidation")
   public Boolean isDisableSubscriptionValidation() {
@@ -989,7 +989,7 @@ return null;
     return this;
   }
 
-
+  
   @ApiModelProperty(value = "The audiences of the API for jwt validation. Accepted values are any String values")
   @JsonProperty("audiences")
   public List<String> getAudiences() {
@@ -1058,7 +1058,7 @@ return null;
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, context, version, description, provider, hasThumbnail, state, enableSchemaValidation, isDefaultVersion, isRevision, revisionedApiProductId, revisionId, responseCachingEnabled, cacheTimeout, visibility, visibleRoles, visibleTenants, accessControl, accessControlRoles, apiType, transport, tags, policies, apiThrottlingPolicy, authorizationHeader, apiKeyHeader, securityScheme, subscriptionAvailability, subscriptionAvailableTenants, additionalProperties, additionalPropertiesMap, monetization, businessInformation, corsConfiguration, createdTime, lastUpdatedTime, lastUpdatedTimestamp, gatewayVendor, apis, scopes, categories, workflowStatus, audiences);
+    return Objects.hash(id, name, context, version, description, provider, hasThumbnail, state, enableSchemaValidation, disableSubscriptionValidation, isDefaultVersion, isRevision, revisionedApiProductId, revisionId, responseCachingEnabled, cacheTimeout, visibility, visibleRoles, visibleTenants, accessControl, accessControlRoles, apiType, transport, tags, policies, apiThrottlingPolicy, authorizationHeader, apiKeyHeader, securityScheme, subscriptionAvailability, subscriptionAvailableTenants, additionalProperties, additionalPropertiesMap, monetization, businessInformation, corsConfiguration, createdTime, lastUpdatedTime, lastUpdatedTimestamp, gatewayVendor, apis, scopes, categories, workflowStatus, audiences);
   }
 
   @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -354,6 +354,13 @@ public class APIMappingUtil {
             }
         }
 
+        // Disable subscription validation
+        if (dto.isDisableSubscriptionValidation()) {
+            model.addProperty(APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY, Boolean.TRUE.toString());
+        } else {
+            model.addProperty(APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY, Boolean.FALSE.toString());
+        }
+
         ObjectMapper objectMapper = new ObjectMapper();
         APIBusinessInformationDTO apiBusinessInformationDTO = objectMapper.convertValue(dto.getBusinessInformation(),
                 APIBusinessInformationDTO.class);
@@ -1289,6 +1296,9 @@ public class APIMappingUtil {
             dto.setVisibleRoles(Arrays.asList(model.getVisibleTenants().split(",")));
         }
 
+        // Set subscription validation to false by default to cater APIs that were created before migration.
+        dto.disableSubscriptionValidation(false);
+
         if (model.getAdditionalProperties() != null) {
             JSONObject additionalProperties = model.getAdditionalProperties();
             List<APIInfoAdditionalPropertiesDTO> additionalPropertiesList = new ArrayList<>();
@@ -1298,21 +1308,27 @@ public class APIMappingUtil {
                 APIInfoAdditionalPropertiesMapDTO apiInfoAdditionalPropertiesMapDTO =
                         new APIInfoAdditionalPropertiesMapDTO();
                 String key = (String) propertyKey;
-                int index = key.lastIndexOf(APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX);
-                additionalPropertiesDTO.setValue((String) additionalProperties.get(key));
-                apiInfoAdditionalPropertiesMapDTO.setValue((String) additionalProperties.get(key));
-                if (index > 0) {
-                    additionalPropertiesDTO.setName(key.substring(0, index));
-                    apiInfoAdditionalPropertiesMapDTO.setName(key.substring(0, index));
-                    additionalPropertiesDTO.setDisplay(true);
+                // Skip the disable_sub_validation property as it is not a custom property
+                // but an internal property used to disable subscription validation
+                if (APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY.equals(key)) {
+                    dto.disableSubscriptionValidation(Boolean.parseBoolean(additionalProperties.get(key).toString()));
                 } else {
-                    additionalPropertiesDTO.setName(key);
-                    apiInfoAdditionalPropertiesMapDTO.setName(key);
-                    additionalPropertiesDTO.setDisplay(false);
+                    int index = key.lastIndexOf(APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX);
+                    additionalPropertiesDTO.setValue((String) additionalProperties.get(key));
+                    apiInfoAdditionalPropertiesMapDTO.setValue((String) additionalProperties.get(key));
+                    if (index > 0) {
+                        additionalPropertiesDTO.setName(key.substring(0, index));
+                        apiInfoAdditionalPropertiesMapDTO.setName(key.substring(0, index));
+                        additionalPropertiesDTO.setDisplay(true);
+                    } else {
+                        additionalPropertiesDTO.setName(key);
+                        apiInfoAdditionalPropertiesMapDTO.setName(key);
+                        additionalPropertiesDTO.setDisplay(false);
+                    }
+                    apiInfoAdditionalPropertiesMapDTO.setDisplay(false);
+                    additionalPropertiesMap.put(key, apiInfoAdditionalPropertiesMapDTO);
+                    additionalPropertiesList.add(additionalPropertiesDTO);
                 }
-                apiInfoAdditionalPropertiesMapDTO.setDisplay(false);
-                additionalPropertiesMap.put(key, apiInfoAdditionalPropertiesMapDTO);
-                additionalPropertiesList.add(additionalPropertiesDTO);
             }
             dto.setAdditionalProperties(additionalPropertiesList);
             dto.setAdditionalPropertiesMap(additionalPropertiesMap);
@@ -2525,6 +2541,9 @@ public class APIMappingUtil {
             productDto.setTransport(Arrays.asList(product.getTransports().split(",")));
         }
 
+        // Set subscription validation to false by default to cater products that were created before migration.
+        productDto.disableSubscriptionValidation(false);
+
         if (product.getAdditionalProperties() != null) {
             JSONObject additionalProperties = product.getAdditionalProperties();
             List<APIInfoAdditionalPropertiesDTO> additionalPropertiesList = new ArrayList<>();
@@ -2534,21 +2553,28 @@ public class APIMappingUtil {
                 APIInfoAdditionalPropertiesMapDTO apiInfoAdditionalPropertiesMapDTO =
                         new APIInfoAdditionalPropertiesMapDTO();
                 String key = (String) propertyKey;
-                int index = key.lastIndexOf(APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX);
-                additionalPropertiesDTO.setValue((String) additionalProperties.get(key));
-                apiInfoAdditionalPropertiesMapDTO.setValue((String) additionalProperties.get(key));
-                if (index > 0) {
-                    additionalPropertiesDTO.setName(key.substring(0, index));
-                    apiInfoAdditionalPropertiesMapDTO.setName(key.substring(0, index));
-                    additionalPropertiesDTO.setDisplay(true);
+                // Skip the disable_sub_validation property as it is not a custom property
+                // but an internal property used to disable subscription validation
+                if (APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY.equals(key)) {
+                    productDto.disableSubscriptionValidation(
+                            Boolean.parseBoolean(additionalProperties.get(key).toString()));
                 } else {
-                    additionalPropertiesDTO.setName(key);
-                    apiInfoAdditionalPropertiesMapDTO.setName(key);
-                    additionalPropertiesDTO.setDisplay(false);
+                    int index = key.lastIndexOf(APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX);
+                    additionalPropertiesDTO.setValue((String) additionalProperties.get(key));
+                    apiInfoAdditionalPropertiesMapDTO.setValue((String) additionalProperties.get(key));
+                    if (index > 0) {
+                        additionalPropertiesDTO.setName(key.substring(0, index));
+                        apiInfoAdditionalPropertiesMapDTO.setName(key.substring(0, index));
+                        additionalPropertiesDTO.setDisplay(true);
+                    } else {
+                        additionalPropertiesDTO.setName(key);
+                        apiInfoAdditionalPropertiesMapDTO.setName(key);
+                        additionalPropertiesDTO.setDisplay(false);
+                    }
+                    apiInfoAdditionalPropertiesMapDTO.setDisplay(false);
+                    additionalPropertiesMap.put(key, apiInfoAdditionalPropertiesMapDTO);
+                    additionalPropertiesList.add(additionalPropertiesDTO);
                 }
-                apiInfoAdditionalPropertiesMapDTO.setDisplay(false);
-                additionalPropertiesMap.put(key, apiInfoAdditionalPropertiesMapDTO);
-                additionalPropertiesList.add(additionalPropertiesDTO);
             }
             productDto.setAdditionalPropertiesMap(additionalPropertiesMap);
             productDto.setAdditionalProperties(additionalPropertiesList);
@@ -2732,6 +2758,14 @@ public class APIMappingUtil {
                 }
             }
         }
+
+        // Disable subscription validation
+        if (dto.isDisableSubscriptionValidation()) {
+            product.addProperty(APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY, Boolean.TRUE.toString());
+        } else {
+            product.addProperty(APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY, Boolean.FALSE.toString());
+        }
+
         if (dto.getSubscriptionAvailableTenants() != null) {
             product.setSubscriptionAvailableTenants(StringUtils.join(dto.getSubscriptionAvailableTenants(), ","));
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -316,6 +316,7 @@ public class ImportUtils {
                     importedApiDTO.setSubscriptionAvailableTenants(convertedOldAPI.getSubscriptionAvailableTenants());
                     importedApiDTO.monetization(convertedOldAPI.getMonetization());
                     importedApiDTO.setTags(convertedOldAPI.getTags());
+                    importedApiDTO.setDisableSubscriptionValidation(convertedOldAPI.isDisableSubscriptionValidation());
                     List<APIInfoAdditionalPropertiesDTO> additionalProperties =
                             convertedOldAPI.getAdditionalProperties();
                     if (additionalProperties != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -623,9 +623,9 @@ public class PublisherCommonUtils {
                     }
                 }
             }
-        }
-        if (isSubscriptionValidationDisabled != newAPIDTO.isDisableSubscriptionValidation()) {
-            throw new APIManagementException(ExceptionCodes.SUB_VALIDATION_DISABLE_NOT_ALLOWED);
+            if (isSubscriptionValidationDisabled != newAPIDTO.isDisableSubscriptionValidation()) {
+                throw new APIManagementException(ExceptionCodes.SUB_VALIDATION_DISABLE_NOT_ALLOWED);
+            }
         }
     }
 
@@ -649,9 +649,9 @@ public class PublisherCommonUtils {
                     }
                 }
             }
-        }
-        if (isSubscriptionValidationDisabled != apiProductDTO.isDisableSubscriptionValidation()) {
-            throw new APIManagementException(ExceptionCodes.SUB_VALIDATION_DISABLE_NOT_ALLOWED);
+            if (isSubscriptionValidationDisabled != apiProductDTO.isDisableSubscriptionValidation()) {
+                throw new APIManagementException(ExceptionCodes.SUB_VALIDATION_DISABLE_NOT_ALLOWED);
+            }
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -9426,6 +9426,10 @@ components:
         enableSubscriberVerification:
           type: boolean
           example: false
+        disableSubscriptionValidation:
+          type: boolean
+          example: false
+          default: false
         type:
           type: string
           description: The api creation type to be used. Accepted values are HTTP,
@@ -10119,6 +10123,10 @@ components:
         enableSchemaValidation:
           type: boolean
           example: false
+        disableSubscriptionValidation:
+          type: boolean
+          example: false
+          default: false
         isDefaultVersion:
           type: boolean
           example: false

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIDTO.java
@@ -57,6 +57,7 @@ public class APIDTO   {
     private List<ScopeInfoDTO> scopes = new ArrayList<ScopeInfoDTO>();
     private String avgRating = null;
     private Long subscriptions = null;
+    private Boolean disableSubscriptionValidation = false;
     private AdvertiseInfoDTO advertiseInfo = null;
     private Boolean isSubscriptionAvailable = null;
     private List<String> categories = new ArrayList<String>();
@@ -558,6 +559,23 @@ public class APIDTO   {
 
   /**
    **/
+  public APIDTO disableSubscriptionValidation(Boolean disableSubscriptionValidation) {
+    this.disableSubscriptionValidation = disableSubscriptionValidation;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "false", value = "")
+  @JsonProperty("disableSubscriptionValidation")
+  public Boolean isDisableSubscriptionValidation() {
+    return disableSubscriptionValidation;
+  }
+  public void setDisableSubscriptionValidation(Boolean disableSubscriptionValidation) {
+    this.disableSubscriptionValidation = disableSubscriptionValidation;
+  }
+
+  /**
+   **/
   public APIDTO advertiseInfo(AdvertiseInfoDTO advertiseInfo) {
     this.advertiseInfo = advertiseInfo;
     return this;
@@ -734,6 +752,7 @@ public class APIDTO   {
         Objects.equals(scopes, API.scopes) &&
         Objects.equals(avgRating, API.avgRating) &&
         Objects.equals(subscriptions, API.subscriptions) &&
+        Objects.equals(disableSubscriptionValidation, API.disableSubscriptionValidation) &&
         Objects.equals(advertiseInfo, API.advertiseInfo) &&
         Objects.equals(isSubscriptionAvailable, API.isSubscriptionAvailable) &&
         Objects.equals(categories, API.categories) &&
@@ -746,7 +765,7 @@ public class APIDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, context, version, provider, apiDefinition, wsdlUri, lifeCycleStatus, isDefaultVersion, type, transport, operations, authorizationHeader, apiKeyHeader, securityScheme, tags, tiers, hasThumbnail, additionalProperties, monetization, endpointURLs, businessInformation, environmentList, scopes, avgRating, subscriptions, advertiseInfo, isSubscriptionAvailable, categories, keyManagers, createdTime, lastUpdatedTime, gatewayVendor, asyncTransportProtocols);
+    return Objects.hash(id, name, description, context, version, provider, apiDefinition, wsdlUri, lifeCycleStatus, isDefaultVersion, type, transport, operations, authorizationHeader, apiKeyHeader, securityScheme, tags, tiers, hasThumbnail, additionalProperties, monetization, endpointURLs, businessInformation, environmentList, scopes, avgRating, subscriptions, disableSubscriptionValidation, advertiseInfo, isSubscriptionAvailable, categories, keyManagers, createdTime, lastUpdatedTime, gatewayVendor, asyncTransportProtocols);
   }
 
   @Override
@@ -781,6 +800,7 @@ public class APIDTO   {
     sb.append("    scopes: ").append(toIndentedString(scopes)).append("\n");
     sb.append("    avgRating: ").append(toIndentedString(avgRating)).append("\n");
     sb.append("    subscriptions: ").append(toIndentedString(subscriptions)).append("\n");
+    sb.append("    disableSubscriptionValidation: ").append(toIndentedString(disableSubscriptionValidation)).append("\n");
     sb.append("    advertiseInfo: ").append(toIndentedString(advertiseInfo)).append("\n");
     sb.append("    isSubscriptionAvailable: ").append(toIndentedString(isSubscriptionAvailable)).append("\n");
     sb.append("    categories: ").append(toIndentedString(categories)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIInfoDTO.java
@@ -40,6 +40,7 @@ public class APIInfoDTO   {
     private AdvertiseInfoDTO advertiseInfo = null;
     private APIBusinessInformationDTO businessInformation = null;
     private Boolean isSubscriptionAvailable = null;
+    private Boolean disableSubscriptionValidation = false;
     private String monetizationLabel = null;
     private String gatewayVendor = null;
     private List<APIInfoAdditionalPropertiesDTO> additionalProperties = new ArrayList<APIInfoAdditionalPropertiesDTO>();
@@ -307,6 +308,23 @@ public class APIInfoDTO   {
 
   /**
    **/
+  public APIInfoDTO disableSubscriptionValidation(Boolean disableSubscriptionValidation) {
+    this.disableSubscriptionValidation = disableSubscriptionValidation;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "false", value = "")
+  @JsonProperty("disableSubscriptionValidation")
+  public Boolean isDisableSubscriptionValidation() {
+    return disableSubscriptionValidation;
+  }
+  public void setDisableSubscriptionValidation(Boolean disableSubscriptionValidation) {
+    this.disableSubscriptionValidation = disableSubscriptionValidation;
+  }
+
+  /**
+   **/
   public APIInfoDTO monetizationLabel(String monetizationLabel) {
     this.monetizationLabel = monetizationLabel;
     return this;
@@ -400,6 +418,7 @@ public class APIInfoDTO   {
         Objects.equals(advertiseInfo, apIInfo.advertiseInfo) &&
         Objects.equals(businessInformation, apIInfo.businessInformation) &&
         Objects.equals(isSubscriptionAvailable, apIInfo.isSubscriptionAvailable) &&
+        Objects.equals(disableSubscriptionValidation, apIInfo.disableSubscriptionValidation) &&
         Objects.equals(monetizationLabel, apIInfo.monetizationLabel) &&
         Objects.equals(gatewayVendor, apIInfo.gatewayVendor) &&
         Objects.equals(additionalProperties, apIInfo.additionalProperties) &&
@@ -408,7 +427,7 @@ public class APIInfoDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, context, version, type, createdTime, provider, lifeCycleStatus, thumbnailUri, avgRating, throttlingPolicies, advertiseInfo, businessInformation, isSubscriptionAvailable, monetizationLabel, gatewayVendor, additionalProperties, monetizedInfo);
+    return Objects.hash(id, name, description, context, version, type, createdTime, provider, lifeCycleStatus, thumbnailUri, avgRating, throttlingPolicies, advertiseInfo, businessInformation, isSubscriptionAvailable, disableSubscriptionValidation, monetizationLabel, gatewayVendor, additionalProperties, monetizedInfo);
   }
 
   @Override
@@ -431,6 +450,7 @@ public class APIInfoDTO   {
     sb.append("    advertiseInfo: ").append(toIndentedString(advertiseInfo)).append("\n");
     sb.append("    businessInformation: ").append(toIndentedString(businessInformation)).append("\n");
     sb.append("    isSubscriptionAvailable: ").append(toIndentedString(isSubscriptionAvailable)).append("\n");
+    sb.append("    disableSubscriptionValidation: ").append(toIndentedString(disableSubscriptionValidation)).append("\n");
     sb.append("    monetizationLabel: ").append(toIndentedString(monetizationLabel)).append("\n");
     sb.append("    gatewayVendor: ").append(toIndentedString(gatewayVendor)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SubscriptionsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/SubscriptionsApiServiceImpl.java
@@ -26,6 +26,7 @@ import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.wso2.carbon.apimgt.api.APIConsumer;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIMgtAuthorizationFailedException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.MonetizationException;
 import org.wso2.carbon.apimgt.api.SubscriptionAlreadyExistingException;
 import org.wso2.carbon.apimgt.api.SubscriptionBlockedException;
@@ -221,7 +222,10 @@ public class SubscriptionsApiServiceImpl implements SubscriptionsApiService {
             }
 
             ApiTypeWrapper apiTypeWrapper = apiConsumer.getAPIorAPIProductByUUID(body.getApiId(), organization);
-
+            // Ignore subscriptions if subscription validation is disabled
+            if (SubscriptionMappingUtil.isSubValidationDisabled(apiTypeWrapper)) {
+                throw new APIManagementException(ExceptionCodes.SUBSCRIPTION_NOT_REQUIRED);
+            }
 
             apiTypeWrapper.setTier(body.getThrottlingPolicy());
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -217,18 +217,28 @@ public class APIMappingUtil {
             dto.setHasThumbnail(true);
         }
 
+        // Set subscription validation to false by default to cater products that were created before migration.
+        dto.disableSubscriptionValidation(false);
+
         if (model.getAdditionalProperties() != null) {
             JSONObject additionalProperties = model.getAdditionalProperties();
             List<APIInfoAdditionalPropertiesDTO> additionalPropertiesList = new ArrayList<>();
             for (Object propertyKey : additionalProperties.keySet()) {
                 APIInfoAdditionalPropertiesDTO additionalPropertiesDTO = new APIInfoAdditionalPropertiesDTO();
                 String key = (String) propertyKey;
-                int index = key.lastIndexOf(APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX);
-                additionalPropertiesDTO.setValue((String) additionalProperties.get(key));
-                if (index > 0) {
-                    additionalPropertiesDTO.setName(key.substring(0, index));
-                    additionalPropertiesDTO.setDisplay(true);
-                    additionalPropertiesList.add(additionalPropertiesDTO);
+                // Skip the disable_sub_validation property as it is not a custom property
+                // but an internal property used to disable subscription validation
+                if (APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY.equals(key)) {
+                    dto.disableSubscriptionValidation(
+                            Boolean.parseBoolean(additionalProperties.get(key).toString()));
+                } else {
+                    int index = key.lastIndexOf(APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX);
+                    additionalPropertiesDTO.setValue((String) additionalProperties.get(key));
+                    if (index > 0) {
+                        additionalPropertiesDTO.setName(key.substring(0, index));
+                        additionalPropertiesDTO.setDisplay(true);
+                        additionalPropertiesList.add(additionalPropertiesDTO);
+                    }
                 }
             }
             dto.setAdditionalProperties(additionalPropertiesList);
@@ -408,19 +418,30 @@ public class APIMappingUtil {
             dto.setHasThumbnail(true);
         }
 
+        // Set subscription validation to false by default to cater products that were created before migration.
+        dto.disableSubscriptionValidation(false);
+
         if (model.getAdditionalProperties() != null) {
             JSONObject additionalProperties = model.getAdditionalProperties();
             List<APIInfoAdditionalPropertiesDTO> additionalPropertiesList = new ArrayList<>();
             for (Object propertyKey : additionalProperties.keySet()) {
                 APIInfoAdditionalPropertiesDTO additionalPropertiesDTO = new APIInfoAdditionalPropertiesDTO();
                 String key = (String) propertyKey;
-                int index = key.lastIndexOf(APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX);
-                additionalPropertiesDTO.setValue((String) additionalProperties.get(key));
-                if (index > 0) {
-                    additionalPropertiesDTO.setName(key.substring(0, index));
-                    additionalPropertiesDTO.setDisplay(true);
-                    additionalPropertiesList.add(additionalPropertiesDTO);
+                // Skip the disable_sub_validation property as it is not a custom property
+                // but an internal property used to disable subscription validation
+                if (APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY.equals(key)) {
+                    dto.disableSubscriptionValidation(
+                            Boolean.parseBoolean(additionalProperties.get(key).toString()));
+                } else {
+                    int index = key.lastIndexOf(APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX);
+                    additionalPropertiesDTO.setValue((String) additionalProperties.get(key));
+                    if (index > 0) {
+                        additionalPropertiesDTO.setName(key.substring(0, index));
+                        additionalPropertiesDTO.setDisplay(true);
+                        additionalPropertiesList.add(additionalPropertiesDTO);
+                    }
                 }
+
             }
             dto.setAdditionalProperties(additionalPropertiesList);
         }
@@ -790,18 +811,28 @@ public class APIMappingUtil {
         String providerName = apiId.getProviderName();
         apiInfoDTO.setProvider(APIUtil.replaceEmailDomainBack(providerName));
 
+        // Set subscription validation to false by default to cater products that were created before migration.
+        apiInfoDTO.disableSubscriptionValidation(false);
+
         if (apiProduct.getAdditionalProperties() != null) {
             JSONObject additionalProperties = apiProduct.getAdditionalProperties();
             List<APIInfoAdditionalPropertiesDTO> additionalPropertiesList = new ArrayList<>();
             for (Object propertyKey : additionalProperties.keySet()) {
                 APIInfoAdditionalPropertiesDTO additionalPropertiesDTO = new APIInfoAdditionalPropertiesDTO();
                 String key = (String) propertyKey;
-                int index = key.lastIndexOf(APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX);
-                additionalPropertiesDTO.setValue((String) additionalProperties.get(key));
-                if (index > 0) {
-                    additionalPropertiesDTO.setName(key.substring(0, index));
-                    additionalPropertiesDTO.setDisplay(true);
-                    additionalPropertiesList.add(additionalPropertiesDTO);
+                // Skip the disable_sub_validation property as it is not a custom property
+                // but an internal property used to disable subscription validation
+                if (APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY.equals(key)) {
+                    apiInfoDTO.disableSubscriptionValidation(
+                            Boolean.parseBoolean(additionalProperties.get(key).toString()));
+                } else {
+                    int index = key.lastIndexOf(APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX);
+                    additionalPropertiesDTO.setValue((String) additionalProperties.get(key));
+                    if (index > 0) {
+                        additionalPropertiesDTO.setName(key.substring(0, index));
+                        additionalPropertiesDTO.setDisplay(true);
+                        additionalPropertiesList.add(additionalPropertiesDTO);
+                    }
                 }
             }
             apiInfoDTO.setAdditionalProperties(additionalPropertiesList);
@@ -852,18 +883,28 @@ public class APIMappingUtil {
         String providerName = api.getId().getProviderName();
         apiInfoDTO.setProvider(APIUtil.replaceEmailDomainBack(providerName));
 
+        // Set subscription validation to false by default to cater products that were created before migration.
+        apiInfoDTO.disableSubscriptionValidation(false);
+
         if (api.getAdditionalProperties() != null) {
             JSONObject additionalProperties = api.getAdditionalProperties();
             List<APIInfoAdditionalPropertiesDTO> additionalPropertiesList = new ArrayList<>();
             for (Object propertyKey : additionalProperties.keySet()) {
                 APIInfoAdditionalPropertiesDTO additionalPropertiesDTO = new APIInfoAdditionalPropertiesDTO();
                 String key = (String) propertyKey;
-                int index = key.lastIndexOf(APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX);
-                additionalPropertiesDTO.setValue((String) additionalProperties.get(key));
-                if (index > 0) {
-                    additionalPropertiesDTO.setName(key.substring(0, index));
-                    additionalPropertiesDTO.setDisplay(true);
-                    additionalPropertiesList.add(additionalPropertiesDTO);
+                // Skip the disable_sub_validation property as it is not a custom property
+                // but an internal property used to disable subscription validation
+                if (APIConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY.equals(key)) {
+                    apiInfoDTO.disableSubscriptionValidation(
+                            Boolean.parseBoolean(additionalProperties.get(key).toString()));
+                } else {
+                    int index = key.lastIndexOf(APIConstants.API_RELATED_CUSTOM_PROPERTIES_SURFIX);
+                    additionalPropertiesDTO.setValue((String) additionalProperties.get(key));
+                    if (index > 0) {
+                        additionalPropertiesDTO.setName(key.substring(0, index));
+                        additionalPropertiesDTO.setDisplay(true);
+                        additionalPropertiesList.add(additionalPropertiesDTO);
+                    }
                 }
             }
             apiInfoDTO.setAdditionalProperties(additionalPropertiesList);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SubscriptionMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SubscriptionMappingUtil.java
@@ -225,4 +225,38 @@ public class SubscriptionMappingUtil {
         pagination.setTotal(size);
         subscriptionListDTO.setPagination(pagination);
     }
+
+    /**
+     * Check whether subscription validation is disabled for the given API or API Product
+     *
+     * @param apiTypeWrapper API or API Product
+     * @return true if subscription validation is disabled
+     */
+    public static boolean isSubValidationDisabled(ApiTypeWrapper apiTypeWrapper) {
+        boolean isSubscriptionValidationDisabled = false;
+        if (apiTypeWrapper.isAPIProduct()) {
+            APIProduct apiProduct = apiTypeWrapper.getApiProduct();
+            if (apiProduct.getAdditionalProperties() != null) {
+                for (Object key : apiProduct.getAdditionalProperties().keySet()) {
+                    if (RestApiConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY.equals(key)) {
+                        isSubscriptionValidationDisabled = Boolean.parseBoolean(
+                                apiProduct.getAdditionalProperties().get(key).toString());
+                        break;
+                    }
+                }
+            }
+        } else {
+            API api = apiTypeWrapper.getApi();
+            if (api.getAdditionalProperties() != null) {
+                for (Object key : api.getAdditionalProperties().keySet()) {
+                    if (RestApiConstants.DISABLE_SUBSCRIPTION_VALIDATION_PROPERTY.equals(key)) {
+                        isSubscriptionValidationDisabled = Boolean.parseBoolean(
+                                api.getAdditionalProperties().get(key).toString());
+                        break;
+                    }
+                }
+            }
+        }
+        return isSubscriptionValidationDisabled;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -3956,6 +3956,10 @@ components:
         isSubscriptionAvailable:
           type: boolean
           example: false
+        disableSubscriptionValidation:
+          type: boolean
+          example: false
+          default: false
         monetizationLabel:
           type: string
           example: Free
@@ -4217,6 +4221,10 @@ components:
             format: int64
             description: The number of subscriptions for the API
             example: 10
+        disableSubscriptionValidation:
+          type: boolean
+          example: false
+          default: false
         advertiseInfo:
           $ref: '#/components/schemas/AdvertiseInfo'
         isSubscriptionAvailable:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/store-api.yaml
@@ -4127,6 +4127,10 @@ definitions:
       isSubscriptionAvailable:
         type: boolean
         example: false
+      disableSubscriptionValidation:
+        type: boolean
+        example: false
+        default: false
       monetizationLabel:
         type: string
         example: Free
@@ -4361,6 +4365,10 @@ definitions:
       isSubscriptionAvailable:
         type: boolean
         example: false
+      disableSubscriptionValidation:
+        type: boolean
+        example: false
+        default: false
       categories:
         description: |
           API categories

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/devportal-api.yaml
@@ -3508,6 +3508,10 @@ components:
         isSubscriptionAvailable:
           type: boolean
           example: false
+        disableSubscriptionValidation:
+          type: boolean
+          example: false
+          default: false
         monetizationLabel:
           type: string
           example: Free
@@ -3747,6 +3751,10 @@ components:
         isSubscriptionAvailable:
           type: boolean
           example: false
+        disableSubscriptionValidation:
+          type: boolean
+          example: false
+          default: false
         categories:
           type: array
           description: |

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
@@ -8403,6 +8403,10 @@ components:
         enableSchemaValidation:
           type: boolean
           example: false
+        disableSubscriptionValidation:
+          type: boolean
+          example: false
+          default: false
         type:
           type: string
           description: The api creation type to be used. Accepted values are HTTP,
@@ -9058,6 +9062,10 @@ components:
         enableSchemaValidation:
           type: boolean
           example: false
+        disableSubscriptionValidation:
+          type: boolean
+          example: false
+          default: false
         isRevision:
           type: boolean
           example: false


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/3011

This PR adds the backend implementation to support subscription validation disabling for tokens.