### PR TITLE
Add http client connection timeout tuning param config

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/configdto/HttpClientConfigurationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/configdto/HttpClientConfigurationDTO.java
@@ -30,6 +30,7 @@ public class HttpClientConfigurationDTO {
 
     private int connectionLimit;
     private int maximumConnectionsPerRoute;
+    private int connectionTimeout;
     private boolean proxyEnabled;
     private String proxyHost;
     private int proxyPort;
@@ -87,6 +88,10 @@ public class HttpClientConfigurationDTO {
         return sslContext;
     }
 
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
     /**
      * Builder class for @code{HTTPClientConfigurationDTO}
      */
@@ -94,6 +99,7 @@ public class HttpClientConfigurationDTO {
 
         private int connectionLimit;
         private int maximumConnectionsPerRoute;
+        private int connectionTimeout;
         private boolean proxyEnabled;
         private String proxyHost;
         private int proxyPort;
@@ -104,9 +110,11 @@ public class HttpClientConfigurationDTO {
         private SSLContext sslContext;
         private HostnameVerifier hostnameVerifier;
 
-        public Builder withConnectionParams(int connectionLimit, int maximumConnectionsPerRoute) {
+        public Builder withConnectionParams(int connectionLimit, int maximumConnectionsPerRoute,
+                                            int connectionTimeout) {
             this.connectionLimit = connectionLimit;
             this.maximumConnectionsPerRoute = maximumConnectionsPerRoute;
+            this.connectionTimeout = connectionTimeout;
             return this;
         }
 
@@ -138,6 +146,7 @@ public class HttpClientConfigurationDTO {
             HttpClientConfigurationDTO configuration = new HttpClientConfigurationDTO();
             configuration.connectionLimit = this.connectionLimit;
             configuration.maximumConnectionsPerRoute = this.maximumConnectionsPerRoute;
+            configuration.connectionTimeout = this.connectionTimeout;
             configuration.proxyEnabled = this.proxyEnabled;
             configuration.proxyHost = this.proxyHost;
             configuration.proxyPort = this.proxyPort;

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/CommonAPIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/CommonAPIUtil.java
@@ -84,6 +84,7 @@ public class CommonAPIUtil {
 
         int maxTotal = clientConfiguration.getConnectionLimit();
         int defaultMaxPerRoute = clientConfiguration.getMaximumConnectionsPerRoute();
+        int connectionTimeout = clientConfiguration.getConnectionTimeout();
 
         boolean proxyEnabled = clientConfiguration.isProxyEnabled();
         String proxyHost = clientConfiguration.getProxyHost();
@@ -102,7 +103,10 @@ public class CommonAPIUtil {
         pool.setMaxTotal(maxTotal);
         pool.setDefaultMaxPerRoute(defaultMaxPerRoute);
 
-        RequestConfig params = RequestConfig.custom().build();
+        RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+        requestConfigBuilder.setConnectTimeout(connectionTimeout);
+        RequestConfig params = requestConfigBuilder.build();
+
         HttpClientBuilder clientBuilder = HttpClients.custom().setConnectionManager(pool)
                 .setDefaultRequestConfig(params);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/test/java/org/wso2/carbon/apimgt/common/gateway/CommonAPIUtilTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/test/java/org/wso2/carbon/apimgt/common/gateway/CommonAPIUtilTestCase.java
@@ -38,6 +38,7 @@ public class CommonAPIUtilTestCase {
     private static ClientAndServer proxyServer;
     int connectionLimit = 100;
     int maximumConnectionsPerRoute = 10;
+    int connectionTimeout = -1;
     static String trustStorePath = Objects.requireNonNull(CommonAPIUtilTestCase.class.getClassLoader()
             .getResource("client-truststore.jks")).getPath();
     static String trustStorePassword = "wso2carbon";
@@ -91,7 +92,7 @@ public class CommonAPIUtilTestCase {
         // directly to the backend.
         HttpGet httpGetWithTLS = new HttpGet("http://localhost:" + mockServer.getPort() + "/hello");
         HttpClientConfigurationDTO nonProxyHostBasedProxyConfig = builder
-                .withConnectionParams(connectionLimit, maximumConnectionsPerRoute)
+                .withConnectionParams(connectionLimit, maximumConnectionsPerRoute, connectionTimeout)
                 .withSSLContext(sslContext)
                 // proxyProtocol here is https (due to existing limitation)
                 .withProxy(proxyHost, proxyServer.getPort(), proxyUsername, "random", proxyProtocol,
@@ -109,7 +110,7 @@ public class CommonAPIUtilTestCase {
 
         // Given the proxy configuration, checks if the call is successfully routed via the proxy server.
         HttpClientConfigurationDTO configuration = builder
-                .withConnectionParams(connectionLimit, maximumConnectionsPerRoute)
+                .withConnectionParams(connectionLimit, maximumConnectionsPerRoute, connectionTimeout)
                 .withSSLContext(sslContext)
                 .withProxy(proxyHost, proxyServer.getPort(), proxyUsername, proxyPassword, proxyProtocol, nonProxyHosts)
                 .build();
@@ -129,7 +130,7 @@ public class CommonAPIUtilTestCase {
 
         // Given the proxy configuration with wrong credentials, checks if the call fails at the proxy server.
         HttpClientConfigurationDTO configWithWrongProxyCredentials = builder
-                .withConnectionParams(connectionLimit, maximumConnectionsPerRoute)
+                .withConnectionParams(connectionLimit, maximumConnectionsPerRoute, connectionTimeout)
                 .withSSLContext(sslContext)
                 .withProxy(proxyHost, proxyServer.getPort(), proxyUsername, "random", proxyProtocol, nonProxyHosts)
                 .build();
@@ -148,7 +149,7 @@ public class CommonAPIUtilTestCase {
         HttpGet httpsGet = new HttpGet("https://localhost:" + mockServer.getPort() + "/hello");
         HttpClientConfigurationDTO.Builder builder = new HttpClientConfigurationDTO.Builder();
         HttpClientConfigurationDTO configuration = builder
-                .withConnectionParams(connectionLimit, maximumConnectionsPerRoute)
+                .withConnectionParams(connectionLimit, maximumConnectionsPerRoute, connectionTimeout)
                 .withSSLContext(sslContext)
                 .build();
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1512,6 +1512,7 @@ public final class APIConstants {
 
     public static final String HTTP_CLIENT_MAX_TOTAL = "HttpClient.MaxTotal";
     public static final String HTTP_CLIENT_DEFAULT_MAX_PER_ROUTE = "HttpClient.DefaultMaxPerRoute";
+    public static final String HTTP_CLIENT_CONNECTION_TIMEOUT = "HttpClient.ConnectionTimeout";
 
     public static final String PROXY_ENABLE = "ProxyConfig.Enable";
     public static final String PROXY_HOST = "ProxyConfig.Host";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
@@ -1022,6 +1022,7 @@ public class APIManagerComponent {
 
         int maxTotal = Integer.parseInt(configuration.getFirstProperty(APIConstants.HTTP_CLIENT_MAX_TOTAL));
         int defaultMaxPerRoute = Integer.parseInt(configuration.getFirstProperty(APIConstants.HTTP_CLIENT_DEFAULT_MAX_PER_ROUTE));
+        int connectionTimeout = Integer.parseInt(configuration.getFirstProperty(APIConstants.HTTP_CLIENT_CONNECTION_TIMEOUT));
 
         boolean proxyEnabled = Boolean.parseBoolean(configuration.getFirstProperty(APIConstants.PROXY_ENABLE));
 
@@ -1071,7 +1072,8 @@ public class APIManagerComponent {
             default:
                 hostnameVerifier = new BrowserHostnameVerifier();
         }
-        configuration.setHttpClientConfiguration(builder.withConnectionParams(maxTotal, defaultMaxPerRoute)
+        configuration.setHttpClientConfiguration(builder
+                .withConnectionParams(maxTotal, defaultMaxPerRoute, connectionTimeout)
                 .withSSLContext(sslContext, hostnameVerifier).build());
     }
 

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -55,6 +55,7 @@
   "apim.api_quota_limit.enable": false,
   "apim.http_client.max_total": "100",
   "apim.http_client.default_max_per_route": "50",
+  "apim.http_client.connection_timeout": "-1",
   "apim.key_manager.service_url": "https://localhost:${mgt.transport.https.port}${carbon.context}services/",
   "apim.key_manager.username": "${admin.username}",
   "apim.key_manager.password": "${admin.password}",

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -19,6 +19,7 @@
     <HttpClient>
          <MaxTotal>{{apim.http_client.max_total}}</MaxTotal>
          <DefaultMaxPerRoute>{{apim.http_client.default_max_per_route}}</DefaultMaxPerRoute>
+         <ConnectionTimeout>{{apim.http_client.connection_timeout}}</ConnectionTimeout>
      </HttpClient>
 
 


### PR DESCRIPTION
Fixing : https://github.com/wso2/api-manager/issues/3020

Sample config 
```toml
[apim.http_client]
connection_timeout = 5000
```

`-1` : System Default timeout
`0` : No timeout
`any other value` : Timeout in Milliseconds

[1] https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/client/config/RequestConfig.html#getConnectTimeout()