### PR TITLE
Handle Null value for Throttling_Tier retrieved from DB

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1072,6 +1072,7 @@ public final class APIConstants {
     public static final String API_USAGE_DAS_REST_API_PASSWORD = API_ANALYTICS + "StreamProcessorRestApiPassword";
 
     public static final String UNLIMITED_TIER = "Unlimited";
+    public static final String THROTTLING_TIER = "THROTTLING_TIER";
     public static final String UNLIMITED_TIER_DESC = "Allows unlimited requests";
 
     public static final String UNAUTHENTICATED_TIER = "Unauthenticated";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -6806,7 +6806,11 @@ public class ApiMgtDAO {
                 uriTemplate.setHTTPVerb(rs.getString("HTTP_METHOD"));
                 uriTemplate.setAuthType(rs.getString("AUTH_SCHEME"));
                 uriTemplate.setUriTemplate(rs.getString("URL_PATTERN"));
-                uriTemplate.setThrottlingTier(rs.getString("THROTTLING_TIER"));
+                if (rs.getString(APIConstants.THROTTLING_TIER).isEmpty()) {
+                    uriTemplate.setThrottlingTier(APIConstants.UNLIMITED_TIER);
+                } else {
+                    uriTemplate.setThrottlingTier(rs.getString(APIConstants.THROTTLING_TIER));
+                }
                 InputStream mediationScriptBlob = rs.getBinaryStream("MEDIATION_SCRIPT");
                 if (mediationScriptBlob != null) {
                     script = APIMgtDBUtil.getStringFromInputStream(mediationScriptBlob);
@@ -6900,7 +6904,12 @@ public class ApiMgtDAO {
             String httpVerb = rs.getString("HTTP_METHOD");
             String authType = rs.getString("AUTH_SCHEME");
             String urlPattern = rs.getString("URL_PATTERN");
-            String policyName = rs.getString("THROTTLING_TIER");
+            String policyName;
+            if(rs.getString(APIConstants.THROTTLING_TIER).isEmpty()){
+                policyName = APIConstants.UNLIMITED_TIER;
+            } else {
+                policyName = rs.getString(APIConstants.THROTTLING_TIER);
+            }
             String conditionGroupId = rs.getString("CONDITION_GROUP_ID");
             String applicableLevel = rs.getString("APPLICABLE_LEVEL");
             String policyConditionGroupId = "_condition_" + conditionGroupId;
@@ -7426,7 +7435,12 @@ public class ApiMgtDAO {
                 String uriPattern = resultSet.getString("URL_PATTERN");
                 String httpMethod = resultSet.getString("HTTP_METHOD");
                 String authScheme = resultSet.getString("AUTH_SCHEME");
-                String throttlingTier = resultSet.getString("THROTTLING_TIER");
+                String throttlingTier;
+                if(resultSet.getString(APIConstants.THROTTLING_TIER).isEmpty()){
+                    throttlingTier = APIConstants.UNLIMITED_TIER;
+                } else {
+                    throttlingTier = resultSet.getString(APIConstants.THROTTLING_TIER);
+                }
                 InputStream mediationScriptBlob = resultSet.getBinaryStream("MEDIATION_SCRIPT");
                 if (mediationScriptBlob != null) {
                     script = APIMgtDBUtil.getStringFromInputStream(mediationScriptBlob);
@@ -7495,7 +7509,12 @@ public class ApiMgtDAO {
                         uriTemplate.setHttpVerbs(verb);
                         uriTemplate.setId(uriTemplateId);
                         String authType = rs.getString("AUTH_SCHEME");
-                        String throttlingTier = rs.getString("THROTTLING_TIER");
+                        String throttlingTier;
+                        if(rs.getString(APIConstants.THROTTLING_TIER).isEmpty()) {
+                            throttlingTier = APIConstants.UNLIMITED_TIER;
+                        } else {
+                            throttlingTier = rs.getString(APIConstants.THROTTLING_TIER);
+                        }
                         if (StringUtils.isNotEmpty(scopeName)) {
                             Scope scope = new Scope();
                             scope.setKey(scopeName);
@@ -7555,7 +7574,12 @@ public class ApiMgtDAO {
                         uriTemplate.setHTTPVerb(verb);
                         uriTemplate.setHttpVerbs(verb);
                         String authType = rs.getString("AUTH_SCHEME");
-                        String throttlingTier = rs.getString("THROTTLING_TIER");
+                        String throttlingTier;
+                        if (rs.getString(APIConstants.THROTTLING_TIER).isEmpty()) {
+                            throttlingTier = APIConstants.UNLIMITED_TIER;
+                        } else {
+                            throttlingTier = rs.getString(APIConstants.THROTTLING_TIER);
+                        }
                         if (StringUtils.isNotEmpty(scopeName)) {
                             Scope scope = new Scope();
                             scope.setKey(scopeName);
@@ -7623,7 +7647,12 @@ public class ApiMgtDAO {
                     uriTemplate.setHTTPVerb(verb);
                     uriTemplate.setHttpVerbs(verb);
                     String authType = rs.getString("AUTH_SCHEME");
-                    String throttlingTier = rs.getString("THROTTLING_TIER");
+                    String throttlingTier;
+                    if (rs.getString(APIConstants.THROTTLING_TIER).isEmpty()) {
+                        throttlingTier = APIConstants.UNLIMITED_TIER;
+                    } else {
+                        throttlingTier = rs.getString(APIConstants.THROTTLING_TIER);
+                    }
                     if (StringUtils.isNotEmpty(scopeName)) {
                         Scope scope = new Scope();
                         scope.setKey(scopeName);
@@ -15067,7 +15096,11 @@ public class ApiMgtDAO {
                         uriTemplate.setHTTPVerb(rs.getString("HTTP_METHOD"));
                         uriTemplate.setAuthType(rs.getString("AUTH_SCHEME"));
                         uriTemplate.setUriTemplate(rs.getString("URL_PATTERN"));
-                        uriTemplate.setThrottlingTier(rs.getString("THROTTLING_TIER"));
+                        if(rs.getString(APIConstants.THROTTLING_TIER).isEmpty()){
+                            uriTemplate.setThrottlingTier(APIConstants.UNLIMITED_TIER);
+                        } else {
+                            uriTemplate.setThrottlingTier(rs.getString(APIConstants.THROTTLING_TIER));
+                        }
                         String script = null;
                         InputStream mediationScriptBlob = rs.getBinaryStream("MEDIATION_SCRIPT");
                         if (mediationScriptBlob != null) {
@@ -15455,8 +15488,11 @@ public class ApiMgtDAO {
                             int uriTemplateId = rs.getInt("URL_MAPPING_ID");
                             uriTemplate.setId(uriTemplateId);
                             uriTemplate.setAuthType(rs.getString("AUTH_SCHEME"));
-                            uriTemplate.setThrottlingTier(rs.getString("THROTTLING_TIER"));
-
+                            if(rs.getString(APIConstants.THROTTLING_TIER).isEmpty()){
+                                uriTemplate.setThrottlingTier(APIConstants.UNLIMITED_TIER);
+                            } else {
+                                uriTemplate.setThrottlingTier(rs.getString(APIConstants.THROTTLING_TIER));
+                            }
                             try (PreparedStatement scopesStatement = connection.
                                     prepareStatement(SQLConstants.GET_SCOPE_KEYS_BY_URL_MAPPING_ID)) {
                                 scopesStatement.setInt(1, uriTemplateId);
@@ -15513,7 +15549,11 @@ public class ApiMgtDAO {
                             int uriTemplateId = rs.getInt("URL_MAPPING_ID");
                             uriTemplate.setId(uriTemplateId);
                             uriTemplate.setAuthType(rs.getString("AUTH_SCHEME"));
-                            uriTemplate.setThrottlingTier(rs.getString("THROTTLING_TIER"));
+                            if(rs.getString(APIConstants.THROTTLING_TIER).isEmpty()){
+                                uriTemplate.setThrottlingTier(APIConstants.UNLIMITED_TIER);
+                            } else {
+                                uriTemplate.setThrottlingTier(rs.getString(APIConstants.THROTTLING_TIER));
+                            }
 
                             try (PreparedStatement scopesStatement = connection.
                                     prepareStatement(SQLConstants.GET_SCOPE_KEYS_BY_URL_MAPPING_ID)) {
@@ -18446,7 +18486,11 @@ public class ApiMgtDAO {
                         uriTemplate.setHTTPVerb(httpMethod);
                         uriTemplate.setAuthType(rs.getString("AUTH_SCHEME"));
                         uriTemplate.setUriTemplate(rs.getString("URL_PATTERN"));
-                        uriTemplate.setThrottlingTier(rs.getString("THROTTLING_TIER"));
+                        if(rs.getString(APIConstants.THROTTLING_TIER).isEmpty()){
+                            uriTemplate.setThrottlingTier(APIConstants.UNLIMITED_TIER);
+                        } else {
+                            uriTemplate.setThrottlingTier(rs.getString(APIConstants.THROTTLING_TIER));
+                        }
                         InputStream mediationScriptBlob = rs.getBinaryStream("MEDIATION_SCRIPT");
                         if (mediationScriptBlob != null) {
                             script = APIMgtDBUtil.getStringFromInputStream(mediationScriptBlob);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
@@ -290,16 +290,6 @@ public class APIManagerComponent {
 
                 //Adding default correlation configs at initial server start up
                 APIUtil.addDefaultCorrelationConfigs();
-                // Update all NULL THROTTLING_TIER values to Unlimited
-                boolean isNullThrottlingTierConversionEnabled = APIUtil.updateNullThrottlingTierAtStartup();
-                try {
-                    if (isNullThrottlingTierConversionEnabled) {
-                        ApiMgtDAO.getInstance().convertNullThrottlingTiers();
-                    }
-                } catch (APIManagementException e) {
-                    log.error("Failed to convert NULL THROTTLING_TIERS to Unlimited");
-                }
-
 //            // Initialise KeyManager.
 //            KeyManagerHolder.initializeKeyManager(configuration);
                 // Initialise sql constants


### PR DESCRIPTION
Handle Null value for Throttling_Tier retrieved from DB which causes due to removing tier update query at the server startup as an improvement.