### PR TITLE
[Improvement] Lightweight apikey

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/apikey/ApiKeyAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/apikey/ApiKeyAuthenticator.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.gateway.utils.OpenAPIUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.dto.APIKeyValidationInfoDTO;
 import org.wso2.carbon.apimgt.impl.dto.ExtendedJWTConfigurationDto;
 import org.wso2.carbon.apimgt.impl.dto.VerbInfoDTO;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
@@ -163,12 +164,12 @@ public class ApiKeyAuthenticator implements Authenticator {
                         tenantDomain, payload);
                 ApiKeyAuthenticatorUtils.validateAPIKeyRestrictions(payload, GatewayUtils.getIp(axis2MessageContext),
                         apiContext, apiVersion, referer);
-                net.minidev.json.JSONObject api = GatewayUtils.validateAPISubscription(apiContext, apiVersion, payload,
+                APIKeyValidationInfoDTO apiKeyValidationInfoDTO = GatewayUtils.validateAPISubscription(apiContext, apiVersion, payload,
                         splitToken[0]);
-                String endUserToken = ApiKeyAuthenticatorUtils.getEndUserToken(api, jwtConfigurationDto, apiKey,
-                        signedJWT, payload, tokenIdentifier, isGatewayTokenCacheEnabled);
+                String endUserToken = ApiKeyAuthenticatorUtils.getEndUserToken(apiKeyValidationInfoDTO, jwtConfigurationDto, apiKey,
+                        signedJWT, payload, tokenIdentifier, apiContext, apiVersion, isGatewayTokenCacheEnabled);
                 AuthenticationContext authenticationContext = GatewayUtils.generateAuthenticationContext(tokenIdentifier,
-                        payload, api, apiLevelPolicy, endUserToken, synCtx);
+                        payload, apiKeyValidationInfoDTO, endUserToken);
                 APISecurityUtils.setAuthenticationContext(synCtx, authenticationContext,
                         jwtGenerationEnabled ? getContextHeader() : null);
                 synCtx.setProperty(APIMgtGatewayConstants.END_USER_NAME, authenticationContext.getUsername());

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -54,7 +54,6 @@ import org.apache.synapse.transport.passthru.Pipe;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.gateway.GatewayAPIDTO;
-import org.wso2.carbon.apimgt.common.gateway.constants.GraphQLConstants;
 import org.wso2.carbon.apimgt.common.gateway.constants.JWTConstants;
 import org.wso2.carbon.apimgt.common.gateway.dto.JWTInfoDto;
 import org.wso2.carbon.apimgt.common.gateway.dto.JWTValidationInfo;
@@ -65,7 +64,6 @@ import org.wso2.carbon.apimgt.gateway.handlers.security.APIKeyValidator;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityException;
 import org.wso2.carbon.apimgt.gateway.handlers.security.AuthenticationContext;
-import org.wso2.carbon.apimgt.gateway.inbound.InboundMessageContext;
 import org.wso2.carbon.apimgt.gateway.internal.DataHolder;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.threatprotection.utils.ThreatProtectorConstants;
@@ -682,96 +680,39 @@ public class GatewayUtils {
 
 
     public static AuthenticationContext generateAuthenticationContext(String tokenSignature, JWTClaimsSet payload,
-                                                                      JSONObject api,
-                                                                      String apiLevelPolicy, String endUserToken,
-                                                                      org.apache.synapse.MessageContext synCtx)
-            throws java.text.ParseException {
+                                                                      APIKeyValidationInfoDTO apiKeyValidationInfoDTO,
+                                                                      String endUserToken) {
 
         AuthenticationContext authContext = new AuthenticationContext();
         authContext.setAuthenticated(true);
         authContext.setApiKey(tokenSignature);
         authContext.setUsername(payload.getSubject());
-        if (payload.getClaim(APIConstants.JwtTokenConstants.KEY_TYPE) != null) {
-            authContext.setKeyType(payload.getStringClaim(APIConstants.JwtTokenConstants.KEY_TYPE));
-        } else {
-            authContext.setKeyType(APIConstants.API_KEY_TYPE_PRODUCTION);
-        }
 
-        authContext.setApiTier(apiLevelPolicy);
-
-        if (payload.getClaim(APIConstants.JwtTokenConstants.APPLICATION) != null) {
-            Map<String, Object> applicationObjMap =
-                    payload.getJSONObjectClaim(APIConstants.JwtTokenConstants.APPLICATION);
-            JSONObject applicationObj = new JSONObject(applicationObjMap);
-            authContext
-                    .setApplicationId(
-                            String.valueOf(applicationObj.getAsNumber(APIConstants.JwtTokenConstants.APPLICATION_ID)));
-            authContext.setApplicationUUID(
-                    String.valueOf(applicationObj.getAsString(APIConstants.JwtTokenConstants.APPLICATION_UUID)));
-            authContext.setApplicationName(applicationObj.getAsString(APIConstants.JwtTokenConstants.APPLICATION_NAME));
-            authContext.setApplicationTier(applicationObj.getAsString(APIConstants.JwtTokenConstants.APPLICATION_TIER));
-            authContext.setSubscriber(applicationObj.getAsString(APIConstants.JwtTokenConstants.APPLICATION_OWNER));
-            if (applicationObj.containsKey(APIConstants.JwtTokenConstants.QUOTA_TYPE)
-                    && APIConstants.JwtTokenConstants.QUOTA_TYPE_BANDWIDTH
-                    .equals(applicationObj.getAsString(APIConstants.JwtTokenConstants.QUOTA_TYPE))) {
-                authContext.setIsContentAware(true);
-                ;
-            }
-        }
-        if (api != null) {
-
-            // If the user is subscribed to the API
-            String subscriptionTier = api.getAsString(APIConstants.JwtTokenConstants.SUBSCRIPTION_TIER);
-            authContext.setTier(subscriptionTier);
-            authContext.setSubscriberTenantDomain(
-                    api.getAsString(APIConstants.JwtTokenConstants.SUBSCRIBER_TENANT_DOMAIN));
-            Map<String, Object> tierInfoObj = payload.getJSONObjectClaim(APIConstants.JwtTokenConstants.TIER_INFO);
-            JSONObject tierInfo = new JSONObject(tierInfoObj);
-            authContext.setApiName(api.getAsString(APIConstants.JwtTokenConstants.API_NAME));
-            authContext.setApiPublisher(api.getAsString(APIConstants.JwtTokenConstants.API_PUBLISHER));
-            if (tierInfo.get(subscriptionTier) != null) {
-                String jsonString = gson.toJson(tierInfo.get(subscriptionTier));
-                JSONObject subscriptionTierObj = JSONValue.parse(jsonString, JSONObject.class);
-                authContext.setStopOnQuotaReach(
-                        Boolean.parseBoolean(
-                                subscriptionTierObj.getAsString(APIConstants.JwtTokenConstants.STOP_ON_QUOTA_REACH)));
-                authContext.setSpikeArrestLimit
-                        (subscriptionTierObj.getAsNumber(APIConstants.JwtTokenConstants.SPIKE_ARREST_LIMIT).intValue());
-                if (!"null".equals(
-                        subscriptionTierObj.getAsString(APIConstants.JwtTokenConstants.SPIKE_ARREST_UNIT))) {
-                    authContext.setSpikeArrestUnit(
-                            subscriptionTierObj.getAsString(APIConstants.JwtTokenConstants.SPIKE_ARREST_UNIT));
-                }
-                //check whether the quota type is there and it is equal to bandwithVolume type.
-                if (subscriptionTierObj.containsKey(APIConstants.JwtTokenConstants.QUOTA_TYPE)
-                        && APIConstants.JwtTokenConstants.QUOTA_TYPE_BANDWIDTH
-                        .equals(subscriptionTierObj.getAsString(APIConstants.JwtTokenConstants.QUOTA_TYPE))) {
-                    authContext.setIsContentAware(true);
-                    ;
-                }
-                if (synCtx != null && APIConstants.GRAPHQL_API.equals(synCtx.getProperty(APIConstants.API_TYPE))) {
-                    Integer graphQLMaxDepth = 0;
-                    if (subscriptionTierObj != null
-                            && subscriptionTierObj.get(GraphQLConstants.GRAPHQL_MAX_DEPTH) != null) {
-                        graphQLMaxDepth = ((Number) subscriptionTierObj.get(
-                                GraphQLConstants.GRAPHQL_MAX_DEPTH)).intValue();
-                    }
-                    Integer graphQLMaxComplexity = 0;
-                    if (subscriptionTierObj != null
-                            && subscriptionTierObj.get(GraphQLConstants.GRAPHQL_MAX_COMPLEXITY) != null) {
-                        graphQLMaxComplexity = ((Number) subscriptionTierObj.get(
-                                GraphQLConstants.GRAPHQL_MAX_COMPLEXITY)).intValue();
-                    }
-                    synCtx.setProperty(GraphQLConstants.MAXIMUM_QUERY_DEPTH, graphQLMaxDepth);
-                    synCtx.setProperty(GraphQLConstants.MAXIMUM_QUERY_COMPLEXITY, graphQLMaxComplexity);
-                }
-            }
+        if (apiKeyValidationInfoDTO != null) {
+            authContext.setApiTier(apiKeyValidationInfoDTO.getApiTier());
+            authContext.setKeyType(apiKeyValidationInfoDTO.getType());
+            authContext.setApplicationId(apiKeyValidationInfoDTO.getApplicationId());
+            authContext.setApplicationUUID(apiKeyValidationInfoDTO.getApplicationUUID());
+            authContext.setApplicationGroupIds(apiKeyValidationInfoDTO.getApplicationGroupIds());
+            authContext.setApplicationName(apiKeyValidationInfoDTO.getApplicationName());
+            authContext.setApplicationTier(apiKeyValidationInfoDTO.getApplicationTier());
+            authContext.setSubscriber(apiKeyValidationInfoDTO.getSubscriber());
+            authContext.setTier(apiKeyValidationInfoDTO.getTier());
+            authContext.setSubscriberTenantDomain(apiKeyValidationInfoDTO.getSubscriberTenantDomain());
+            authContext.setApiName(apiKeyValidationInfoDTO.getApiName());
+            authContext.setApiPublisher(apiKeyValidationInfoDTO.getApiPublisher());
+            authContext.setStopOnQuotaReach(apiKeyValidationInfoDTO.isStopOnQuotaReach());
+            authContext.setSpikeArrestLimit(apiKeyValidationInfoDTO.getSpikeArrestLimit());
+            authContext.setSpikeArrestUnit(apiKeyValidationInfoDTO.getSpikeArrestUnit());
+            authContext.setConsumerKey(apiKeyValidationInfoDTO.getConsumerKey());
+            authContext.setIsContentAware(apiKeyValidationInfoDTO.isContentAware());
+            authContext.setGraphQLMaxDepth(apiKeyValidationInfoDTO.getGraphQLMaxDepth());
+            authContext.setGraphQLMaxComplexity(apiKeyValidationInfoDTO.getGraphQLMaxComplexity());
         }
         // Set JWT token sent to the backend
         if (StringUtils.isNotEmpty(endUserToken)) {
             authContext.setCallerToken(endUserToken);
         }
-
         return authContext;
     }
 
@@ -854,7 +795,6 @@ public class GatewayUtils {
         JSONObject api = null;
         APIKeyValidator apiKeyValidator = new APIKeyValidator();
         APIKeyValidationInfoDTO apiKeyValidationInfoDTO = null;
-        boolean apiKeySubValidationEnabled = isAPIKeySubscriptionValidationEnabled();
         JSONObject application;
         int appId = 0;
         if (payload.getClaim(APIConstants.JwtTokenConstants.APPLICATION) != null) {
@@ -871,7 +811,7 @@ public class GatewayUtils {
         }
         // validate subscription
         // if the appId is equal to 0 then it's a internal key
-        if (apiKeySubValidationEnabled && appId != 0) {
+        if (appId != 0) {
             apiKeyValidationInfoDTO =
                     apiKeyValidator.validateSubscription(apiContext, apiVersion, appId, getTenantDomain());
         }
@@ -888,7 +828,7 @@ public class GatewayUtils {
                                 .equals(subscribedAPIsJSONObject.getAsString(APIConstants.JwtTokenConstants.API_VERSION)
                                 )) {
                     // check whether the subscription is authorized
-                    if (apiKeySubValidationEnabled && appId != 0) {
+                    if (appId != 0) {
                         if (apiKeyValidationInfoDTO.isAuthorized()) {
                             api = subscribedAPIsJSONObject;
                             if (log.isDebugEnabled()) {
@@ -930,33 +870,30 @@ public class GatewayUtils {
     }
 
     /**
-     * Validate whether the user is subscribed to the invoked API. If subscribed, return a JSON object containing
-     * the API information.
+     * Validate whether the user is subscribed to the invoked API. If subscribed, return a APIKeyValidationInfoDTO
+     * object containing the API information to authenticate API Keys.
      *
      * @param apiContext API context
      * @param apiVersion API version
      * @param payload    The payload of the JWT token
      * @param token      The token which was used to invoke the API
-     * @return an JSON object containing subscribed API information retrieved from token payload.
+     * @return an APIKeyValidationInfoDTO containing APIKey validation information.
      * If the subscription information is not found, return a null object.
      * @throws APISecurityException if the user is not subscribed to the API
      */
-    public static JSONObject validateAPISubscription(String apiContext, String apiVersion, JWTClaimsSet payload,
+    public static APIKeyValidationInfoDTO validateAPISubscription(String apiContext, String apiVersion, JWTClaimsSet payload,
                                                      String token)
             throws APISecurityException {
 
-        JSONObject api = null;
         APIKeyValidator apiKeyValidator = new APIKeyValidator();
         APIKeyValidationInfoDTO apiKeyValidationInfoDTO = null;
-        boolean apiKeySubValidationEnabled = isAPIKeySubscriptionValidationEnabled();
-        JSONObject application;
         int appId = 0;
         if (payload.getClaim(APIConstants.JwtTokenConstants.APPLICATION) != null) {
             try {
                 Map<String, Object> applicationObjMap =
                         payload.getJSONObjectClaim(APIConstants.JwtTokenConstants.APPLICATION);
-                application = new JSONObject(applicationObjMap);
-                appId = Integer.parseInt(application.getAsString(APIConstants.JwtTokenConstants.APPLICATION_ID));
+                JSONObject application = new JSONObject(applicationObjMap);
+                appId = ((Long) application.get(APIConstants.JwtTokenConstants.APPLICATION_ID)).intValue();
             } catch (ParseException e) {
                 log.error("Error while parsing the application object from the JWT token.");
                 throw new APISecurityException(APISecurityConstants.API_AUTH_GENERAL_ERROR,
@@ -965,43 +902,17 @@ public class GatewayUtils {
         }
         // validate subscription
         // if the appId is equal to 0 then it's a internal key
-        if (apiKeySubValidationEnabled && appId != 0) {
+        if (appId != 0) {
             apiKeyValidationInfoDTO =
                     apiKeyValidator.validateSubscription(apiContext, apiVersion, appId, getTenantDomain());
-        }
-
-        if (payload.getClaim(APIConstants.JwtTokenConstants.SUBSCRIBED_APIS) != null) {
-            // Subscription validation
-            ArrayList subscribedAPIs =
-                    (ArrayList) payload.getClaim(APIConstants.JwtTokenConstants.SUBSCRIBED_APIS);
-            for (Object subscribedAPI : subscribedAPIs) {
-                String subscribedAPIsJSONString = gson.toJson(subscribedAPI);
-                JSONObject subscribedAPIsJSONObject = JSONValue.parse(subscribedAPIsJSONString, JSONObject.class);
-                if (apiContext
-                        .equals(subscribedAPIsJSONObject.getAsString(APIConstants.JwtTokenConstants.API_CONTEXT)) &&
-                        apiVersion
-                                .equals(subscribedAPIsJSONObject.getAsString(APIConstants.JwtTokenConstants.API_VERSION)
-                                )) {
-                    // check whether the subscription is authorized
-                    if (apiKeySubValidationEnabled && appId != 0) {
-                        if (apiKeyValidationInfoDTO.isAuthorized()) {
-                            api = subscribedAPIsJSONObject;
-                            if (log.isDebugEnabled()) {
-                                log.debug("User is subscribed to the API: " + apiContext + ", " +
-                                        "version: " + apiVersion + ". Token: " + getMaskedToken(token));
-                            }
-                        }
-                    } else {
-                        api = subscribedAPIsJSONObject;
-                        if (log.isDebugEnabled()) {
-                            log.debug("User is subscribed to the API: " + apiContext + ", " +
-                                    "version: " + apiVersion + ". Token: " + getMaskedToken(token));
-                        }
-                    }
-                    break;
+            if (apiKeyValidationInfoDTO.isAuthorized()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("User is subscribed to the API: " + apiContext + ", " +
+                            "version: " + apiVersion + ". Token: " + getMaskedToken(token));
                 }
-            }
-            if (api == null) {
+                String keyType = (String) payload.getClaim(APIConstants.JwtTokenConstants.KEY_TYPE);
+                apiKeyValidationInfoDTO.setType(keyType);
+            } else {
                 if (log.isDebugEnabled()) {
                     log.debug("User is not subscribed to access the API: " + apiContext +
                             ", version: " + apiVersion + ". Token: " + getMaskedToken(token));
@@ -1010,10 +921,8 @@ public class GatewayUtils {
                 throw new APISecurityException(APISecurityConstants.API_AUTH_FORBIDDEN,
                         APISecurityConstants.API_AUTH_FORBIDDEN_MESSAGE);
             }
-        } else {
-            log.debug("No subscription information found in the token.");
         }
-        return api;
+        return apiKeyValidationInfoDTO;
     }
 
     /**
@@ -1100,18 +1009,6 @@ public class GatewayUtils {
                     "Use default configuration.", e);
         }
         return true;
-    }
-
-    public static boolean isAPIKeySubscriptionValidationEnabled() {
-        try {
-            APIManagerConfiguration config = ServiceReferenceHolder.getInstance().getAPIManagerConfiguration();
-            String subscriptionValidationEnabled = config.getFirstProperty(APIConstants.API_KEY_SUBSCRIPTION_VALIDATION_ENABLED);
-            return Boolean.parseBoolean(subscriptionValidationEnabled);
-        } catch (Exception e) {
-            log.error("Did not find valid API Key Subscription Validation Enabled configuration. " +
-                    "Use default configuration.", e);
-        }
-        return false;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -822,8 +822,8 @@ public final class APIConstants {
     public static final String AUTHSERVER_URL = "ServerURL";
     public static final String API_KEY_VALIDATOR_ENABLE_PROVISION_APP_VALIDATION =
             API_KEY_VALIDATOR + "EnableProvisionedAppValidation";
-    public static final String API_KEY_SUBSCRIPTION_VALIDATION_ENABLED =
-            API_KEY_VALIDATOR + "EnableAPIKeySubscriptionValidation";
+    public static final String LIGHTWEIGHT_API_KEY_GENERATION_ENABLED =
+            API_KEY_VALIDATOR + "EnableLightWeightAPIKeyGeneration";
     public static final String ALLOW_SUBSCRIPTION_VALIDATION_DISABLING = API_KEY_VALIDATOR +
             "AllowSubscriptionValidationDisabling";
     public static final String KEY_MANAGER_OAUTH2_SCOPES_REST_API_BASE_PATH = "/api/identity/oauth2/v1.0/scopes";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/DefaultApiKeyGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/DefaultApiKeyGenerator.java
@@ -22,7 +22,10 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.dto.JwtTokenInfoDTO;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.utils.APIKeyUtils;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.core.util.KeyStoreManager;
@@ -94,9 +97,18 @@ public class DefaultApiKeyGenerator implements ApiKeyGenerator {
         if (expireIn != -1) {
             jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.EXPIRY_TIME, expireIn);
         }
-        jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.SUBSCRIBED_APIS, jwtTokenInfoDTO.getSubscribedApiDTOList());
-        jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.TIER_INFO, jwtTokenInfoDTO.getSubscriptionPolicyDTOList());
-        jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.APPLICATION, jwtTokenInfoDTO.getApplication());
+        if (APIKeyUtils.isLightweightAPIKeyGenerationEnabled()) {
+            JSONObject application = new JSONObject();
+            application.put(APIConstants.JwtTokenConstants.APPLICATION_ID, jwtTokenInfoDTO.getApplication().getId());
+            application.put(APIConstants.JwtTokenConstants.APPLICATION_UUID, jwtTokenInfoDTO.getApplication().getUuid());
+            jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.APPLICATION, application);
+        } else {
+            jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.SUBSCRIBED_APIS,
+                    jwtTokenInfoDTO.getSubscribedApiDTOList());
+            jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.TIER_INFO,
+                    jwtTokenInfoDTO.getSubscriptionPolicyDTOList());
+            jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.APPLICATION, jwtTokenInfoDTO.getApplication());
+        }
         jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.KEY_TYPE, jwtTokenInfoDTO.getKeyType());
         jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.TOKEN_TYPE,
                 APIConstants.JwtTokenConstants.API_KEY_TOKEN_TYPE);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIKeyUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIKeyUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.utils;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+
+public class APIKeyUtils {
+
+    private static final Log log = LogFactory.getLog(JWTUtil.class);
+
+    /**
+     * Check whether Lightweight API Key Generation is enabled.
+     *
+     * @return true if Lightweight API Key Generation is enabled, false otherwise
+     */
+    public static boolean isLightweightAPIKeyGenerationEnabled() {
+        try {
+            APIManagerConfiguration config = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                    .getAPIManagerConfiguration();
+            if (config != null) {
+                String lightweightAPIKeyGenerationEnabled = config.getFirstProperty(APIConstants.LIGHTWEIGHT_API_KEY_GENERATION_ENABLED);
+                return Boolean.parseBoolean(lightweightAPIKeyGenerationEnabled);
+            }
+        } catch (Exception e) {
+            log.error("Error while reading Lightweight API Key Generation configuration", e);
+        }
+        return true;
+    }
+}

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -180,6 +180,7 @@
   "apim.event_hub.username": "$ref{apim.throttling.username}",
   "apim.event_hub.password": "$ref{apim.throttling.password}",
   "apim.key_manager.type": "default",
+  "apim.key_manager.enable_lightweight_apikey_generation": true,
   "apim.devportal.enable_cross_tenant_subscriptions": false,
   "apim.devportal.default_reserved_username": "apim_reserved_user",
   "apim.cache_invalidation.enabled":false,

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -434,8 +434,8 @@
       {% if apim.key_manager.enable_provisioned_app_validation is defined %}
       <EnableProvisionedAppValidation>{{apim.key_manager.enable_provisioned_app_validation}}</EnableProvisionedAppValidation>
       {% endif %}
-      {% if apim.key_manager.enable_apikey_subscription_validation is defined %}
-      <EnableAPIKeySubscriptionValidation>{{apim.key_manager.enable_apikey_subscription_validation}}</EnableAPIKeySubscriptionValidation>
+      {% if apim.key_manager.enable_lightweight_apikey_generation is defined %}
+      <EnableLightWeightAPIKeyGeneration>{{apim.key_manager.enable_lightweight_apikey_generation}}</EnableLightWeightAPIKeyGeneration>
       {% endif %}
       <AllowSubscriptionValidationDisabling>{{apim.key_manager.allow_subscription_validation_disabling}}</AllowSubscriptionValidationDisabling>
     </APIKeyValidator>


### PR DESCRIPTION
## Purpose
The current API Key implementation in the API Manager includes several claims that are not essential for the API Key itself but are required during the API Key authentication process.

## Solution
- Remove the unnecessary claims from the API Key.
- Modify the authentication process to retrieve API, Application, and Subscription-related details directly from the Data Store.
- Remove the subscription validation-related configuration from the configs, making it mandatory to validate the subscription during the authentication process.

Resolves https://github.com/wso2/api-manager/issues/3097