### PR TITLE
Upgrade CXF version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2044,7 +2044,7 @@
         <graphql.java.version.range>[19.0,20.0)</graphql.java.version.range>
 
         <carbon.governance.version>4.8.34</carbon.governance.version>
-        <carbon.deployment.version>4.11.14</carbon.deployment.version>
+        <carbon.deployment.version>4.11.15</carbon.deployment.version>
         <carbon.multitenancy.version>4.9.27</carbon.multitenancy.version>
         <wso2-uri-templates.version>1.6.5</wso2-uri-templates.version>
         <apimserver.version>1.10.0</apimserver.version>
@@ -2169,7 +2169,7 @@
         <carbon.throttle.module.version>4.2.1</carbon.throttle.module.version>
 
         <!-- apache cxf version -->
-        <cxf.version>3.6.3</cxf.version>
+        <cxf.version>3.6.4</cxf.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <!-- apache pdfbox version -->
         <event.processor.version>2.3.12</event.processor.version>


### PR DESCRIPTION
### Purpose

Upgrades CXF version from 3.6.3 to 3.6.4.

Related carbon-deployment PR: https://github.com/wso2/carbon-deployment/pull/401
Related product-apim PR: https://github.com/wso2/product-apim/pull/13530