### PR TITLE
[APIM-4.4.0] Bump the bouncycastle version to 1.78.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2017,7 +2017,7 @@
 
         <carbon.analytics.common.version>5.3.13</carbon.analytics.common.version>
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.9.26</carbon.kernel.version>
+        <carbon.kernel.version>4.9.27</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
 
@@ -2044,8 +2044,8 @@
         <graphql.java.version.range>[19.0,20.0)</graphql.java.version.range>
 
         <carbon.governance.version>4.8.34</carbon.governance.version>
-        <carbon.deployment.version>4.11.14</carbon.deployment.version>
-        <carbon.multitenancy.version>4.9.27</carbon.multitenancy.version>
+        <carbon.deployment.version>4.11.15</carbon.deployment.version>
+        <carbon.multitenancy.version>4.9.28</carbon.multitenancy.version>
         <wso2-uri-templates.version>1.6.5</wso2-uri-templates.version>
         <apimserver.version>1.10.0</apimserver.version>
         <siddhi.version>3.2.13</siddhi.version>
@@ -2104,7 +2104,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>4.0.0-wso2v105</synapse.version>
+        <synapse.version>4.0.0-wso2v122</synapse.version>
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 
         <!-- orbit httpmime versions-->


### PR DESCRIPTION
### Purpose

This PR bumps the carbon kernel, carbon deployment, carbon multitenancy, and synapse versions to upgrade the bouncycastle version to bcprov-jdk18on 1.78.1.

#### Related PRs:

carbon-multitenancy PR: https://github.com/wso2/carbon-multitenancy/pull/270
wso2-synapse PR: https://github.com/wso2/wso2-synapse/pull/2217
carbon-kernel PR: https://github.com/wso2/carbon-kernel/pull/4074
product-apim PR: https://github.com/wso2/product-apim/pull/13532