### PR TITLE
Bump synapse and dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2024,12 +2024,12 @@
         <carbon.commons.version>4.9.11</carbon.commons.version>
 
         <carbon.registry.version>4.8.36</carbon.registry.version>
-        <carbon.mediation.version>4.7.204</carbon.mediation.version>
+        <carbon.mediation.version>4.7.218</carbon.mediation.version>
 
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 
         <!-- Carbon Identity versions -->
-        <carbon.identity.version>5.25.711</carbon.identity.version>
+        <carbon.identity.version>5.25.713</carbon.identity.version>
         <carbon.identity.governance.version>1.8.107</carbon.identity.governance.version>
         <carbon.identity-inbound-auth-oauth.version>6.13.19</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-oauth2-grant-jwt.version>2.2.4</carbon.identity-oauth2-grant-jwt.version>
@@ -2044,7 +2044,7 @@
         <graphql.java.version.range>[19.0,20.0)</graphql.java.version.range>
 
         <carbon.governance.version>4.8.34</carbon.governance.version>
-        <carbon.deployment.version>4.11.14</carbon.deployment.version>
+        <carbon.deployment.version>4.11.16</carbon.deployment.version>
         <carbon.multitenancy.version>4.9.27</carbon.multitenancy.version>
         <wso2-uri-templates.version>1.6.5</wso2-uri-templates.version>
         <apimserver.version>1.10.0</apimserver.version>
@@ -2104,7 +2104,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>4.0.0-wso2v105</synapse.version>
+        <synapse.version>4.0.0-wso2v125</synapse.version>
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 
         <!-- orbit httpmime versions-->
@@ -2137,7 +2137,7 @@
         <commons-logging.version>1.1.1</commons-logging.version>
         <commons-io.version>2.15.1.wso2v1</commons-io.version>
         <commons-httpclient.version>3.1</commons-httpclient.version>
-        <google.code.gson.version>2.10.1</google.code.gson.version>
+        <google.code.gson.version>2.11.0</google.code.gson.version>
         <httpcomponents.version>4.5.10</httpcomponents.version>
         <commons-codec.version>1.16.0</commons-codec.version>
         <com.nimbusds.wso2.version>9.37.3.wso2v1</com.nimbusds.wso2.version>
@@ -2169,7 +2169,7 @@
         <carbon.throttle.module.version>4.2.1</carbon.throttle.module.version>
 
         <!-- apache cxf version -->
-        <cxf.version>3.6.3</cxf.version>
+        <cxf.version>3.6.4</cxf.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <!-- apache pdfbox version -->
         <event.processor.version>2.3.12</event.processor.version>
@@ -2186,7 +2186,7 @@
         <xercesImpl.version>2.12.2.wso2v1</xercesImpl.version>
         <commons.scxml.version>0.9.0.wso2v2</commons.scxml.version>
         <velocity.version>2.3</velocity.version>
-        <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.17.2</fasterxml.jackson.version>
         <javax.validation-api>2.0.1.Final</javax.validation-api>
         <javax.inject.version>1</javax.inject.version>
         <carbon.broker.version>3.3.33</carbon.broker.version>
@@ -2260,7 +2260,7 @@
         <version.checkstyle>8.34</version.checkstyle>
         <org.wso2.orbit.org.mapstruct.version>1.4.1.wso2v1</org.wso2.orbit.org.mapstruct.version>
         <org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-        <analytics.event.publisher.client.version>1.2.18</analytics.event.publisher.client.version>
+        <analytics.event.publisher.client.version>1.2.19</analytics.event.publisher.client.version>
         <analytics.event.publisher.client.version.range>[1.0.0,2.0.0)</analytics.event.publisher.client.version.range>
         <org.wso2.orbit.atlassian.oai.version>2.12.1.wso2v2</org.wso2.orbit.atlassian.oai.version>
         <maven.spotbugsplugin.exclude.file>${project.parent.basedir}/../../spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>


### PR DESCRIPTION
This PR adds the necessary changes to fix the issues with new synapse versions and changes required to bump gson, jackson, and cxf dependencies

Issue for dependency upgrades: https://github.com/wso2/api-manager/issues/3105