### PR TITLE
Update AnalyticsDataPublisher to Handle Multiple Reporter Types

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/Constants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/Constants.java
@@ -39,4 +39,6 @@ public class Constants {
     public static final String USERNAME_MASK_VALUE = "*****";
 
     public static final String AUTH_API_URL = "auth.api.url";
+
+    public static final String CHOREO_REPORTER_NAME = "choreo";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
@@ -58,7 +58,7 @@ public class AnalyticsDataPublisher {
     }
 
     private List<String> getReporterTypesOrNull(String typeConfig) {
-        if (typeConfig == null) {
+        if (typeConfig == null || typeConfig.isEmpty()) {
             return null;
         }
         if (typeConfig.startsWith("[") && typeConfig.endsWith("]")) {

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/publishers/impl/AnalyticsDataPublisher.java
@@ -30,7 +30,6 @@ import org.wso2.carbon.apimgt.common.analytics.Constants;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -61,14 +60,10 @@ public class AnalyticsDataPublisher {
         if (typeConfig == null || typeConfig.isEmpty()) {
             return null;
         }
-        if (typeConfig.startsWith("[") && typeConfig.endsWith("]")) {
-            return Arrays.stream(typeConfig.substring(1, typeConfig.length() - 1).split(","))
-                    .map(String::trim)
-                    .filter(s -> !s.isEmpty())
-                    .collect(Collectors.toList());
-        } else {
-            return Collections.singletonList(typeConfig);
-        }
+        return Arrays.stream(typeConfig.replaceAll("[\\[\\]]", "").split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
     }
 
     private List<String> getReportersClassesOrNull(Map<String, String> configs) {


### PR DESCRIPTION
### Purpose
<!-- Short description of the feature you are going to add with this PR. -->
To improve the flexibility of APIM analytics by allowing users to configure multiple reporter types. Previously, it was limited to a single reporter type specified in the configuration, defaulting to Choreo analytics if not explicitly set. This PR enables users to setup multiple analytics reporters simultaneously.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/api-manager/issues/3099

### Approach
The new implementation allows for multiple loggers to be enabled through configuration in the `deployment.toml` file. Users can now specify an array of reporter types, which the system will process and initialize accordingly.


### Configuration Examples


**Enable both Choreo and ELK analytics:**
```toml
[apim.analytics]
enable = true
type = ["choreo", "elk"]
```

In this case, `type = "choreo, elk"` is also allowed.

**Enable only ELK analytics:**
```toml
[apim.analytics]
enable = true
type = ["elk"]
```

In this case, `type = "elk"` is also allowed.


**Default behavior (Choreo analytics) when type is not defined:**
```toml
[apim.analytics]
enable = true
```

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)