### PR TITLE
[APIM-4.4.0] Upgrade swagger-parser version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2024,7 +2024,7 @@
         <carbon.commons.version>4.9.11</carbon.commons.version>
 
         <carbon.registry.version>4.8.36</carbon.registry.version>
-        <carbon.mediation.version>4.7.218</carbon.mediation.version>
+        <carbon.mediation.version>4.7.219</carbon.mediation.version>
 
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 
@@ -2177,7 +2177,7 @@
         <pdfbox.io.version>3.0.1.wso2v1</pdfbox.io.version>
         <swagger.inflector.version>1.0.16.wso2v1</swagger.inflector.version>
         <swagger.inflector.oas3.version>2.0.5.wso2v2</swagger.inflector.oas3.version>
-        <swagger.parser.v3.version>2.1.20.wso2v1</swagger.parser.v3.version>
+        <swagger.parser.v3.version>2.1.22.wso2v1</swagger.parser.v3.version>
         <swagger.core.version>1.6.11.wso2v1</swagger.core.version>
         <swagger.models.version>1.6.11</swagger.models.version>
         <swagger.annotations.version>1.6.11</swagger.annotations.version>


### PR DESCRIPTION
### Purpose

This PR Upgrades the swagger-parser version to 2.1.22.

#### Related PRs:

Orbit bundles: https://github.com/wso2/orbit/pull/1133
carbon-mediation PR: https://github.com/wso2/carbon-mediation/pull/1733
product-apim PR: https://github.com/wso2/product-apim/pull/13540
