### PR TITLE
Remove the extra forward slash from the resource name in api logs.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/logging/APILogHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/logging/APILogHandler.java
@@ -91,8 +91,12 @@ public class APILogHandler {
             ThreadContext.put("apiContext", selectedApi.getContext());
             ThreadContext.put("apiVersion", selectedApi.getApiVersion());
             if (messageContext.getProperty(API_TO) != null) {
-                String apiTo = "/" + messageContext.getProperty(API_TO);
-                ThreadContext.put("resourceName", apiTo.replaceFirst(selectedApi.getContext(), ""));
+                String apiTo = (String) messageContext.getProperty(API_TO);
+                String resourceName = apiTo.replaceFirst(selectedApi.getContext(), "");
+                if(resourceName.isEmpty()){
+                    resourceName = "/";
+                }
+                ThreadContext.put("resourceName", resourceName);
             }
         }
         ThreadContext.put("tenantDomain", (String) messageContext


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/3098