### PR TITLE
Add improvement to yield error when the requested API is not available when exporting APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3469,6 +3469,10 @@ public class ApisApiServiceImpl implements ApisApiService {
             if (StringUtils.isEmpty(apiId) && (StringUtils.isNotEmpty(name) && StringUtils.isNotEmpty(version))) {
                 APIIdentifier apiIdentifier = new APIIdentifier(providerName, name, version);
                 apiId = APIUtil.getUUIDFromIdentifier(apiIdentifier, organization);
+                if (StringUtils.isEmpty(apiId)) {
+                    throw new APIManagementException("API not found for the given name: " + name + ", and version : "
+                            + version, ExceptionCodes.from(ExceptionCodes.API_NOT_FOUND, name + "-" + version));
+                }
             }
             RuntimeArtifactDto runtimeArtifactDto = null;
             if (StringUtils.isNotEmpty(organization)) {


### PR DESCRIPTION
This PR adds the improvement to yield error when the requested API is not available when exporting APIs.

Related issue: https://github.com/wso2/api-manager/issues/3070