### PR TITLE
[4.4.0] Get all key managers from all tenant domains

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -389,7 +389,8 @@ public class APIAdminImpl implements APIAdmin {
             if (APIUtil.isInternalOrganization(organization)) {
                 KeyMgtRegistrationService.registerDefaultKeyManager(organization);
             } else {
-                tenantDomain = APIUtil.getInternalOrganizationDomain(organization);
+                tenantDomain = !APIConstants.KeyManager.ALL_KEY_MANAGERS.equals(organization) ?
+                        APIUtil.getInternalOrganizationDomain(organization) : organization;
             }
         } catch (UserStoreException e) {
             throw new APIManagementException("Error while retrieving tenant id for organization "

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2762,6 +2762,7 @@ public final class APIConstants {
         public static final String PERMISSIONS = "permissions";
         public static final String ROLES = "roles";
         public static final String PERMISSION_TYPE = "permissionType";
+        public static final String ALL_KEY_MANAGERS = "ALL";
 
         public static class KeyManagerEvent {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -9421,10 +9421,13 @@ public class ApiMgtDAO {
             throws APIManagementException {
 
         List<KeyManagerConfigurationDTO> keyManagerConfigurationDTOS = new ArrayList<>();
-        final String query = "SELECT * FROM AM_KEY_MANAGER WHERE ORGANIZATION IN (?)";
+        final String query = !APIConstants.KeyManager.ALL_KEY_MANAGERS.equals(organization) ?
+                SQLConstants.GET_KEY_MANAGERS_BY_ORGANIZATION : SQLConstants.GET_ALL_KEY_MANAGERS;
         try (Connection conn = APIMgtDBUtil.getConnection();
              PreparedStatement preparedStatement = conn.prepareStatement(query)) {
-            preparedStatement.setString(1, organization);
+            if (!APIConstants.KeyManager.ALL_KEY_MANAGERS.equals(organization)) {
+                preparedStatement.setString(1, organization);
+            }
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
                 while (resultSet.next()) {
                     KeyManagerConfigurationDTO keyManagerConfigurationDTO = new KeyManagerConfigurationDTO();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -2890,6 +2890,10 @@ public class SQLConstants {
     public static final String GET_SCOPE_KEYS_BY_URL_MAPPING_ID =
             "SELECT SCOPE_NAME FROM AM_API_RESOURCE_SCOPE_MAPPING WHERE URL_MAPPING_ID = ?" ;
 
+    public static final String GET_ALL_KEY_MANAGERS = "SELECT * FROM AM_KEY_MANAGER";
+
+    public static final String GET_KEY_MANAGERS_BY_ORGANIZATION = "SELECT * FROM AM_KEY_MANAGER WHERE ORGANIZATION IN (?)";
+
     /** API Categories related constants **/
 
     public static final String ADD_CATEGORY_SQL = "INSERT INTO AM_API_CATEGORIES "


### PR DESCRIPTION
### Purpose
The Key Manager Gateway's internal endpoint (internal/data/v1/keymanagers) lacked the ability to retrieve all key managers by passing the header xWSO2Tenant: "ALL".
- Resolves https://github.com/wso2/api-manager/issues/3180

### Fix
When the tenant domain is set to "ALL", a query will be executed to retrieve all key managers from the AM_KEY_MANAGER table.