### PR TITLE
Upgrade analytics event publisher client to 1.2.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2260,7 +2260,7 @@
         <version.checkstyle>8.34</version.checkstyle>
         <org.wso2.orbit.org.mapstruct.version>1.4.1.wso2v1</org.wso2.orbit.org.mapstruct.version>
         <org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-        <analytics.event.publisher.client.version>1.2.19</analytics.event.publisher.client.version>
+        <analytics.event.publisher.client.version>1.2.20</analytics.event.publisher.client.version>
         <analytics.event.publisher.client.version.range>[1.0.0,2.0.0)</analytics.event.publisher.client.version.range>
         <org.wso2.orbit.atlassian.oai.version>2.12.1.wso2v2</org.wso2.orbit.atlassian.oai.version>
         <maven.spotbugsplugin.exclude.file>${project.parent.basedir}/../../spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>


### PR DESCRIPTION
This PR upgrades the analytics event publisher client to 1.2.20.

Related PR: https://github.com/wso2/apim-analytics-publisher/pull/115