### PR TITLE
Fix Oracle Database Issue in Block Condition Search

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -14074,10 +14074,12 @@ public class ApiMgtDAO {
             String conditionTypeUpper = conditionType != null ? conditionType.toUpperCase() : null;
             selectPreparedStatement.setString(1, conditionTypeUpper);
             selectPreparedStatement.setString(2, conditionTypeUpper);
-            selectPreparedStatement.setString(3, conditionValue);
             if (isExactMatch) {
+                selectPreparedStatement.setString(3, conditionValue);
                 selectPreparedStatement.setString(4, tenantDomain);
             } else {
+                String conditionValuePattern = "%" + conditionValue + "%";
+                selectPreparedStatement.setString(3, conditionValuePattern);
                 selectPreparedStatement.setString(4, conditionValue);
                 selectPreparedStatement.setString(5, tenantDomain);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -3397,7 +3397,7 @@ public class SQLConstants {
                         + "BLOCK_CONDITION = ? AND DOMAIN = ? ";
         public static final String GET_BLOCK_CONDITIONS_BY_TYPE_AND_VALUE_SQL =
                 "SELECT CONDITION_ID, TYPE, BLOCK_CONDITION, ENABLED, DOMAIN, UUID FROM AM_BLOCK_CONDITIONS WHERE "
-                        + "(TYPE = ? OR ? IS NULL) AND (BLOCK_CONDITION LIKE CONCAT('%', ?, '%') OR ? IS NULL) AND DOMAIN = ?";
+                        + "(TYPE = ? OR ? IS NULL) AND (BLOCK_CONDITION LIKE ? OR ? IS NULL) AND DOMAIN = ?";
         public static final String GET_BLOCK_CONDITIONS_BY_TYPE_AND_EXACT_VALUE_SQL =
                 "SELECT CONDITION_ID, TYPE, BLOCK_CONDITION, ENABLED, DOMAIN, UUID FROM AM_BLOCK_CONDITIONS WHERE "
                         + "(TYPE = ? OR ? IS NULL) AND (BLOCK_CONDITION = ?) AND DOMAIN = ?";


### PR DESCRIPTION
### Purpose

- $subject
- https://github.com/wso2/api-manager/issues/3236

### Approach

Eliminate the use of CONCAT in the get block condition  by type and value SQL query, as it does not comply with older versions of the Oracle database.

