### PR TITLE
Fix export flow to detect thumbnail changes from the current API as opposed to the latest revision

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -193,7 +193,7 @@ public class ExportUtils {
 
         CommonUtil.createDirectory(archivePath);
         if (preserveDocs) {
-            addThumbnailToArchive(archivePath, apiIdentifier, apiProvider);
+            addThumbnailToArchive(archivePath, apiIdentifier, apiProvider, currentApiUuid);
             addDocumentationToArchive(archivePath, apiIdentifier, exportFormat, apiProvider,
                     APIConstants.API_IDENTIFIER_TYPE);
         } 
@@ -313,7 +313,8 @@ public class ExportUtils {
         CommonUtil.createDirectory(archivePath);
 
         if (preserveDocs) {
-            addThumbnailToArchive(archivePath, apiProductIdentifier, apiProvider);
+            addThumbnailToArchive(archivePath, apiProductIdentifier, apiProvider,
+                    apiProductDtoToReturn.getRevisionedApiProductId());
             addDocumentationToArchive(archivePath, apiProductIdentifier, exportFormat, apiProvider,
                     APIConstants.API_PRODUCT_IDENTIFIER_TYPE);
         }
@@ -345,16 +346,17 @@ public class ExportUtils {
      * @param archivePath File path to export the thumbnail image
      * @param identifier  ID of the requesting API or API Product
      * @param apiProvider API Provider
-     * @throws APIImportExportException If an error occurs while retrieving image from the registry or
-     *                                  storing in the archive directory
+     * @param currentUuid UUID of the API or API Product
+     * @throws APIImportExportException If an error occurs while retrieving image from the registry or storing in the
+     *                                  archive directory
      */
-    public static void addThumbnailToArchive(String archivePath, Identifier identifier, APIProvider apiProvider)
-            throws APIImportExportException, APIManagementException {
+    public static void addThumbnailToArchive(String archivePath, Identifier identifier, APIProvider apiProvider,
+            String currentUuid) throws APIImportExportException, APIManagementException {
 
         String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
         String localImagePath = archivePath + File.separator + ImportExportConstants.IMAGE_RESOURCE;
         try {
-            ResourceFile thumbnailResource = apiProvider.getIcon(identifier.getUUID(), tenantDomain);
+            ResourceFile thumbnailResource = apiProvider.getIcon(currentUuid, tenantDomain);
             if (thumbnailResource != null) {
                 String mediaType = thumbnailResource.getContentType();
                 String extension = ImportExportConstants.fileExtensionMapping.get(mediaType);


### PR DESCRIPTION
### Purpose

- Resolves: https://github.com/wso2/api-manager/issues/3006

API thumbnail is not getting exported when the `--latest` tag is used with the export command. However, this behavior is only noticed when the thumbnail uploading was done post-deployment. Thereby, the deployed API had no knowledge on the thumbnail update that was made to the current API.

In order to resolve this issue, we have replaced the revisioned version with the current API state when it comes to the thumbnail extraction flow. The same applies to API products as well. This PR fixes the issue for both APIs and API Products.