### PR TITLE
Modify implementation to allow an API and a Common policies with same and version

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -1553,6 +1553,9 @@ public interface APIProvider extends APIManager {
      */
     String importOperationPolicy(OperationPolicyData operationPolicyData, String organization)
             throws APIManagementException;
+    String importOperationPolicyOfGivenType(OperationPolicyData operationPolicyData, String policyType,
+                                            String organization) throws APIManagementException;
+
 
     /**
      * Add an API specific operation policy

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIProvider.java
@@ -1543,8 +1543,10 @@ public interface APIProvider extends APIManager {
     void setOperationPoliciesToURITemplates(String apiId, Set<URITemplate> uriTemplates) throws APIManagementException;
 
     /**
-     * Import an operation policy from the API CTL project. This will either create a new API specific policy,
-     * update existing API specific policy or return the policyID of existing policy if policy content is not changed.
+     * Import an operation policy from the API CTL project which is exported from a product version prior to the update
+     * level which introduced to have an API and a Common policy with identical names and versions.
+     * This will either create a new API specific policy, update existing API specific policy or return the
+     * policyID of existing policy if policy content is not changed.
      *
      * @param operationPolicyData Operation Policy Data
      * @param organization        Organization name
@@ -1553,6 +1555,18 @@ public interface APIProvider extends APIManager {
      */
     String importOperationPolicy(OperationPolicyData operationPolicyData, String organization)
             throws APIManagementException;
+
+    /**
+     * Import an operation policy of a given policy type, from the API CTL project.
+     * This will either create a new API specific policy, update existing API specific policy or return the
+     * policyID of existing policy if policy content is not changed.
+     *
+     * @param operationPolicyData Operation Policy Data
+     * @param organization        Organization name
+     * @param policyType Policy Type
+     * @return UUID of the imported operation policy
+     * @throws APIManagementException
+     */
     String importOperationPolicyOfGivenType(OperationPolicyData operationPolicyData, String policyType,
                                             String organization) throws APIManagementException;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OperationPolicy.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OperationPolicy.java
@@ -25,6 +25,7 @@ public class OperationPolicy implements Comparable<OperationPolicy> {
 
     private String policyName = "";
     private String policyVersion = "v1";
+    private String policyType = null;
     private String direction = null;
     private Map<String, Object> parameters = null;
     private String policyId = null;
@@ -48,6 +49,16 @@ public class OperationPolicy implements Comparable<OperationPolicy> {
     public void setPolicyVersion(String policyVersion) {
 
         this.policyVersion = policyVersion;
+    }
+
+    public String getPolicyType() {
+
+        return policyType;
+    }
+
+    public void setPolicyType(String policyType) {
+
+        this.policyType = policyType;
     }
 
     public Map<String, Object> getParameters() {
@@ -98,7 +109,7 @@ public class OperationPolicy implements Comparable<OperationPolicy> {
         if (o instanceof OperationPolicy) {
             OperationPolicy policyObj = (OperationPolicy) o;
             return Objects.equals(policyName, policyObj.policyName) && Objects.equals(policyVersion,
-                    policyObj.policyVersion) && Objects.equals(direction, policyObj.direction) && Objects.equals(
+                    policyObj.policyVersion) && Objects.equals(direction, policyObj.direction) && policyType.equals(policyObj.policyType) && Objects.equals(
                     parameters, policyObj.parameters) && Objects.equals(policyId, policyObj.policyId);
         }
         return false;

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OperationPolicy.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OperationPolicy.java
@@ -109,7 +109,8 @@ public class OperationPolicy implements Comparable<OperationPolicy> {
         if (o instanceof OperationPolicy) {
             OperationPolicy policyObj = (OperationPolicy) o;
             return Objects.equals(policyName, policyObj.policyName) && Objects.equals(policyVersion,
-                    policyObj.policyVersion) && Objects.equals(direction, policyObj.direction) && policyType.equals(policyObj.policyType) && Objects.equals(
+                    policyObj.policyVersion) && Objects.equals(direction, policyObj.direction)
+                    && policyType.equals(policyObj.policyType) && Objects.equals(
                     parameters, policyObj.parameters) && Objects.equals(policyId, policyObj.policyId);
         }
         return false;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -7339,7 +7339,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             throws APIManagementException {
 
         return apiMgtDAO
-                .getClonedAPISpecificOperationPolicyIdsList(apiUUID);
+                .getClonedIdsMappedApiSpecificOperationPolicies(apiUUID);
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -7178,7 +7178,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             /*To handle scenarios where api is exported from a previous U2 version. API and Common policies with same name
              and same version is not supported there
              */
-            importOperationPolicy(importedPolicyData, organization);
+            policyId = importOperationPolicy(importedPolicyData, organization);
         } else if (policyType.equalsIgnoreCase(ImportExportConstants.POLICY_TYPE_COMMON)) {
             existingOperationPolicy = getCommonOperationPolicyByPolicyName(importedSpec.getName(),
                     importedSpec.getVersion(),organization, false);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5313,11 +5313,6 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (policy.getPolicyId() == null) {
             policyType = ImportExportConstants.POLICY_TYPE_API;
         } else {
-            // In an api product resource update scenario, when existing policy has been removed from an api,
-            // there's no entry attached to api policy id and apiId in AM_API_OPERATION_POLICY table
-            if (!apiOperationPolicyIdToClonedPolicyIdMap.containsKey(policy.getPolicyId())) {
-                return null;
-            }
             // check if cloned policy id is null
             if (apiOperationPolicyIdToClonedPolicyIdMap.get(policy.getPolicyId()) == null) {
                 policyType = ImportExportConstants.POLICY_TYPE_API;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5334,17 +5334,16 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         }
         api.setUriTemplates(uriTemplates);
 
-        if (isAPILevelPolicySupportEnabled) {
-            List<OperationPolicy> apiPolicies = api.getApiPolicies();
-            if (apiPolicies != null && !apiPolicies.isEmpty()) {
-                for (OperationPolicy policy : apiPolicies) {
-                    String policyType = getPolicyType(policy, api.getUuid(),
-                            tenantDomain);
-                    policy.setPolicyType(policyType);
-                }
+        List<OperationPolicy> apiPolicies = api.getApiPolicies();
+        if (apiPolicies != null && !apiPolicies.isEmpty()) {
+            for (OperationPolicy policy : apiPolicies) {
+                String policyType = getPolicyType(policy, api.getUuid(),
+                        tenantDomain);
+                policy.setPolicyType(policyType);
             }
-            api.setApiPolicies(apiPolicies);
         }
+        api.setApiPolicies(apiPolicies);
+
         return api;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5336,10 +5336,12 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
 
         if (isAPILevelPolicySupportEnabled) {
             List<OperationPolicy> apiPolicies = api.getApiPolicies();
-            for (OperationPolicy policy : apiPolicies) {
-                String policyType = getPolicyType(policy, api.getUuid(),
-                        tenantDomain);
-                policy.setPolicyType(policyType);
+            if (apiPolicies != null && !apiPolicies.isEmpty()) {
+                for (OperationPolicy policy : apiPolicies) {
+                    String policyType = getPolicyType(policy, api.getUuid(),
+                            tenantDomain);
+                    policy.setPolicyType(policyType);
+                }
             }
             api.setApiPolicies(apiPolicies);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -7203,12 +7203,16 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     }
                 }
             } else {
+                importedSpec.setName(importedSpec.getName() + "_imported");
+                importedSpec.setDisplayName(importedSpec.getDisplayName() + " Imported");
+                importedPolicyData.setSpecification(importedSpec);
+                importedPolicyData.setMd5Hash(APIUtil.getMd5OfOperationPolicy(importedPolicyData));
                 policyId = addAPISpecificOperationPolicy(importedPolicyData.getApiUUID(), importedPolicyData,
                         organization);
                 if (log.isDebugEnabled()) {
                     log.debug(
-                            "There aren't any existing policies for the imported policy. A new policy created with ID "
-                                    + policyId);
+                            "There aren't any existing common policy for the imported policy. " +
+                                    "A new policy created with ID " + policyId);
                 }
             }
         } else { //api level policy by default

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5309,18 +5309,16 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
      */
     public String getPolicyType(OperationPolicy policy, Map<String, String> apiOperationPolicyIdToClonedPolicyIdMap)
             throws APIManagementException {
-        String policyType = null;
         if (policy.getPolicyId() == null) {
-            policyType = ImportExportConstants.POLICY_TYPE_API;
+            return ImportExportConstants.POLICY_TYPE_API;
         } else {
             // check if cloned policy id is null
             if (apiOperationPolicyIdToClonedPolicyIdMap.get(policy.getPolicyId()) == null) {
-                policyType = ImportExportConstants.POLICY_TYPE_API;
+                return ImportExportConstants.POLICY_TYPE_API;
             } else {
-                policyType = ImportExportConstants.POLICY_TYPE_COMMON;
+                return ImportExportConstants.POLICY_TYPE_COMMON;
             }
         }
-        return policyType;
     }
 
     public String getProductPolicyType(OperationPolicy policy, String apiUUID,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -7192,7 +7192,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     importedSpec.setName(importedSpec.getName() + "_imported");
                     importedSpec.setDisplayName(importedSpec.getDisplayName() + " Imported");
                     importedPolicyData.setSpecification(importedSpec);
-                    importedPolicyData.setMd5Hash(APIUtil.getMd5OfOperationPolicy(importedPolicyData));
+                    importedPolicyData.setMd5Hash(APIUtil.getHashOfOperationPolicy(importedPolicyData));
                     policyId = addAPISpecificOperationPolicy(importedPolicyData.getApiUUID(), importedPolicyData,
                             organization);
                     if (log.isDebugEnabled()) {
@@ -7205,7 +7205,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 importedSpec.setName(importedSpec.getName() + "_imported");
                 importedSpec.setDisplayName(importedSpec.getDisplayName() + " Imported");
                 importedPolicyData.setSpecification(importedSpec);
-                importedPolicyData.setMd5Hash(APIUtil.getMd5OfOperationPolicy(importedPolicyData));
+                importedPolicyData.setMd5Hash(APIUtil.getHashOfOperationPolicy(importedPolicyData));
                 policyId = addAPISpecificOperationPolicy(importedPolicyData.getApiUUID(), importedPolicyData,
                         organization);
                 if (log.isDebugEnabled()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -125,7 +125,6 @@ import org.wso2.carbon.apimgt.impl.dto.TierPermissionDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
 import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
 import org.wso2.carbon.apimgt.impl.factory.SQLConstantManagerFactory;
-import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
@@ -20914,11 +20913,11 @@ public class ApiMgtDAO {
      * @return operation policy
      * @throws APIManagementException
      */
-    public Map<String, String> getClonedAPISpecificOperationPolicyIdsList(String apiUUID)
+    public Map<String, String> getClonedIdsMappedApiSpecificOperationPolicies(String apiUUID)
             throws APIManagementException {
 
         try (Connection connection = APIMgtDBUtil.getConnection()) {
-            return getClonedAPISpecificOperationPolicyIdsList(connection, apiUUID);
+            return getClonedIdsMappedApiSpecificOperationPolicies(connection, apiUUID);
         } catch (SQLException e) {
             handleException("Failed to get the API specific operation policy IDs from API "
                     + apiUUID, e);
@@ -20926,23 +20925,22 @@ public class ApiMgtDAO {
         return null;
     }
 
-    private Map<String, String> getClonedAPISpecificOperationPolicyIdsList(Connection connection, String apiUUID)
+    private Map<String, String> getClonedIdsMappedApiSpecificOperationPolicies(Connection connection, String apiUUID)
             throws SQLException, APIManagementException {
 
         String dbQuery;
         boolean isAPIRevision = checkAPIUUIDIsARevisionUUID(apiUUID) != null;
         if (isAPIRevision) {
             dbQuery = SQLConstants.OperationPolicyConstants.
-                    GET_REVISION_SPECIFIC_OPERATION_POLICY_LIST_FROM_REVISION_UUID;
+                    GET_REVISION_SPECIFIC_OPERATION_POLICY_IDS_FROM_REVISION_UUID;
         } else {
-            dbQuery = SQLConstants.OperationPolicyConstants.GET_API_SPECIFIC_OPERATION_POLICY_LIST_FROM_API_UUID;
+            dbQuery = SQLConstants.OperationPolicyConstants.GET_API_SPECIFIC_OPERATION_POLICY_IDS_FROM_API_UUID;
         }
-        Map<String, String> policyMap = null;
+        Map<String, String> policyMap = new HashMap<>();
         try (PreparedStatement statement = connection.prepareStatement(dbQuery)) {
             statement.setString(1, apiUUID);
             try (ResultSet rs = statement.executeQuery()) {
-                if (rs.next()) {
-                    policyMap = new HashMap<>();
+                while (rs.next()) {
                     policyMap.put(rs.getString("POLICY_UUID"), rs.getString("CLONED_POLICY_UUID"));
                 }
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -20911,11 +20911,10 @@ public class ApiMgtDAO {
      * given API.
      *
      * @param apiUUID                UUID of the API
-     * @param organization           Organization name
      * @return operation policy
      * @throws APIManagementException
      */
-    public List<String> getClonedAPISpecificOperationPolicyIdsList(String apiUUID)
+    public Map<String, String> getClonedAPISpecificOperationPolicyIdsList(String apiUUID)
             throws APIManagementException {
 
         try (Connection connection = APIMgtDBUtil.getConnection()) {
@@ -20927,7 +20926,7 @@ public class ApiMgtDAO {
         return null;
     }
 
-    private List<String> getClonedAPISpecificOperationPolicyIdsList(Connection connection, String apiUUID)
+    private Map<String, String> getClonedAPISpecificOperationPolicyIdsList(Connection connection, String apiUUID)
             throws SQLException, APIManagementException {
 
         String dbQuery;
@@ -20938,17 +20937,17 @@ public class ApiMgtDAO {
         } else {
             dbQuery = SQLConstants.OperationPolicyConstants.GET_API_SPECIFIC_OPERATION_POLICY_LIST_FROM_API_UUID;
         }
-        List<String> policyIdList = null;
+        Map<String, String> policyMap = null;
         try (PreparedStatement statement = connection.prepareStatement(dbQuery)) {
             statement.setString(1, apiUUID);
             try (ResultSet rs = statement.executeQuery()) {
                 if (rs.next()) {
-                    policyIdList = new ArrayList<>();
-                    policyIdList.add(rs.getString("POLICY_UUID"));
+                    policyMap = new HashMap<>();
+                    policyMap.put(rs.getString("POLICY_UUID"), rs.getString("CLONED_POLICY_UUID"));
                 }
             }
         }
-        return policyIdList;
+        return policyMap;
     }
 
     private List<OperationPolicyDefinition> getPolicyDefinitionForPolicyId(Connection connection, String policyId)

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -20905,6 +20905,52 @@ public class ApiMgtDAO {
         return policyData;
     }
 
+    /**
+     * Get the list of API specific operation policy IDs from AM_API_OPERATION_POLICY table where cloned policy ID is
+     * non null. This method is intended to get the common operation policy IDs which have been attached to the
+     * given API.
+     *
+     * @param apiUUID                UUID of the API
+     * @param organization           Organization name
+     * @return operation policy
+     * @throws APIManagementException
+     */
+    public List<String> getClonedAPISpecificOperationPolicyIdsList(String apiUUID)
+            throws APIManagementException {
+
+        try (Connection connection = APIMgtDBUtil.getConnection()) {
+            return getClonedAPISpecificOperationPolicyIdsList(connection, apiUUID);
+        } catch (SQLException e) {
+            handleException("Failed to get the API specific operation policy IDs from API "
+                    + apiUUID, e);
+        }
+        return null;
+    }
+
+    private List<String> getClonedAPISpecificOperationPolicyIdsList(Connection connection, String apiUUID)
+            throws SQLException, APIManagementException {
+
+        String dbQuery;
+        boolean isAPIRevision = checkAPIUUIDIsARevisionUUID(apiUUID) != null;
+        if (isAPIRevision) {
+            dbQuery = SQLConstants.OperationPolicyConstants.
+                    GET_REVISION_SPECIFIC_OPERATION_POLICY_LIST_FROM_REVISION_UUID;
+        } else {
+            dbQuery = SQLConstants.OperationPolicyConstants.GET_API_SPECIFIC_OPERATION_POLICY_LIST_FROM_API_UUID;
+        }
+        List<String> policyIdList = null;
+        try (PreparedStatement statement = connection.prepareStatement(dbQuery)) {
+            statement.setString(1, apiUUID);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    policyIdList = new ArrayList<>();
+                    policyIdList.add(rs.getString("POLICY_UUID"));
+                }
+            }
+        }
+        return policyIdList;
+    }
+
     private List<OperationPolicyDefinition> getPolicyDefinitionForPolicyId(Connection connection, String policyId)
             throws SQLException {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -125,6 +125,7 @@ import org.wso2.carbon.apimgt.impl.dto.TierPermissionDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
 import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
 import org.wso2.carbon.apimgt.impl.factory.SQLConstantManagerFactory;
+import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
@@ -21273,7 +21274,13 @@ public class ApiMgtDAO {
                 while (rs.next()) {
                     String policyName = rs.getString("POLICY_NAME");
                     String policyVersion = rs.getString("POLICY_VERSION");
-                    policyNames.add(APIUtil.getOperationPolicyFileName(policyName, policyVersion));
+                    policyNames.add(APIUtil.getOperationPolicyFileName(policyName, policyVersion, null));
+                    /*since the only usage of this method is to load the common operation policies from the
+                     specifications and we are keeping only the common policies without appending the string "common"
+                     to the file name, it's not required to append the policyType string
+                     (policyNames.add(APIUtil.getOperationPolicyFileName(policyName, policyVersion,
+                     ImportExportConstants.POLICY_TYPE_COMMON));)here as well.
+                     */
                 }
             }
         } catch (SQLException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -4284,7 +4284,7 @@ public class SQLConstants {
                         " WHERE " +
                         " OP.POLICY_UUID = ? AND OP.ORGANIZATION = ? AND AOP.REVISION_UUID = ?";
 
-        public static final String GET_API_SPECIFIC_OPERATION_POLICY_LIST_FROM_API_UUID =
+        public static final String GET_API_SPECIFIC_OPERATION_POLICY_IDS_FROM_API_UUID =
                 "SELECT " +
                         " POLICY_UUID, CLONED_POLICY_UUID " +
                         " FROM " +
@@ -4292,7 +4292,7 @@ public class SQLConstants {
                         " WHERE " +
                         " API_UUID = ?";
 
-        public static final String GET_REVISION_SPECIFIC_OPERATION_POLICY_LIST_FROM_REVISION_UUID =
+        public static final String GET_REVISION_SPECIFIC_OPERATION_POLICY_IDS_FROM_REVISION_UUID =
                 "SELECT " +
                         " POLICY_UUID, CLONED_POLICY_UUID " +
                         " FROM " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -4310,6 +4310,8 @@ public class SQLConstants {
                         " OP.POLICY_UUID = ? AND OP.ORGANIZATION = ?";
 
 
+        // CLONED_POLICY_UUID IS NULL was added to the query to allow creating an API level policy while having a common policy with same name and version
+        // and is attached to the API already
         public static final String GET_API_SPECIFIC_OPERATION_POLICY_FROM_POLICY_NAME =
                 "SELECT " +
                         " OP.POLICY_UUID, OP.POLICY_NAME, OP.POLICY_VERSION, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, OP.API_TYPES, " +
@@ -4318,7 +4320,7 @@ public class SQLConstants {
                         " FROM " +
                         " AM_OPERATION_POLICY OP INNER JOIN AM_API_OPERATION_POLICY AOP ON OP.POLICY_UUID = AOP.POLICY_UUID " +
                         " WHERE " +
-                        " OP.POLICY_NAME = ? AND OP.POLICY_VERSION = ? AND OP.ORGANIZATION = ? AND AOP.API_UUID = ? ";
+                        " OP.POLICY_NAME = ? AND OP.POLICY_VERSION = ? AND OP.ORGANIZATION = ? AND AOP.API_UUID = ? AND AOP.CLONED_POLICY_UUID IS NULL ";
 
         public static final String GET_COMMON_OPERATION_POLICY_FROM_POLICY_NAME =
                 "SELECT " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -4284,6 +4284,22 @@ public class SQLConstants {
                         " WHERE " +
                         " OP.POLICY_UUID = ? AND OP.ORGANIZATION = ? AND AOP.REVISION_UUID = ?";
 
+        public static final String GET_API_SPECIFIC_OPERATION_POLICY_LIST_FROM_API_UUID =
+                "SELECT " +
+                        " POLICY_UUID " +
+                        " FROM " +
+                        " AM_API_OPERATION_POLICY " +
+                        " WHERE " +
+                        " CLONED_POLICY_UUID IS NOT NULL AND API_UUID = ?";
+
+        public static final String GET_REVISION_SPECIFIC_OPERATION_POLICY_LIST_FROM_REVISION_UUID =
+                "SELECT " +
+                        " POLICY_UUID " +
+                        " FROM " +
+                        " AM_API_OPERATION_POLICY " +
+                        " WHERE " +
+                        " CLONED_POLICY_UUID IS NOT NULL AND REVISION_UUID = ?";
+
         public static final String GET_COMMON_OPERATION_POLICY_WITH_OUT_DEFINITION_FROM_POLICY_ID =
                 "SELECT " +
                         " OP.POLICY_UUID, OP.POLICY_NAME, OP.POLICY_VERSION, OP.DISPLAY_NAME, OP.POLICY_DESCRIPTION, OP.APPLICABLE_FLOWS, OP.GATEWAY_TYPES, OP.API_TYPES, " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -4286,19 +4286,19 @@ public class SQLConstants {
 
         public static final String GET_API_SPECIFIC_OPERATION_POLICY_LIST_FROM_API_UUID =
                 "SELECT " +
-                        " POLICY_UUID " +
+                        " POLICY_UUID, CLONED_POLICY_UUID " +
                         " FROM " +
                         " AM_API_OPERATION_POLICY " +
                         " WHERE " +
-                        " CLONED_POLICY_UUID IS NOT NULL AND API_UUID = ?";
+                        " API_UUID = ?";
 
         public static final String GET_REVISION_SPECIFIC_OPERATION_POLICY_LIST_FROM_REVISION_UUID =
                 "SELECT " +
-                        " POLICY_UUID " +
+                        " POLICY_UUID, CLONED_POLICY_UUID " +
                         " FROM " +
                         " AM_API_OPERATION_POLICY " +
                         " WHERE " +
-                        " CLONED_POLICY_UUID IS NOT NULL AND REVISION_UUID = ?";
+                        " REVISION_UUID = ?";
 
         public static final String GET_COMMON_OPERATION_POLICY_WITH_OUT_DEFINITION_FROM_POLICY_ID =
                 "SELECT " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -316,4 +316,7 @@ public final class ImportExportConstants {
     public static final String EXPORT_POLICY_TYPE_JSON = "JSON";
 
     public static final String POLICY_NAME = "name";
+
+    public static final String POLICY_TYPE_API = "api";
+    public static final String POLICY_TYPE_COMMON = "common";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -168,6 +168,7 @@ import org.wso2.carbon.apimgt.impl.dto.SubscriptionPolicyDTO;
 import org.wso2.carbon.apimgt.impl.dto.ThrottleProperties;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
 import org.wso2.carbon.apimgt.impl.gatewayartifactsynchronizer.exception.DataLoadingException;
+import org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants;
 import org.wso2.carbon.apimgt.impl.internal.APIManagerComponent;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.kmclient.ApacheFeignHttpClient;
@@ -10212,7 +10213,7 @@ public final class APIUtil {
                                 policyData.setSpecification(policySpec);
                                 policyData.setOrganization(organization);
                                 String policyFileName = getOperationPolicyFileName(policySpec.getName(),
-                                        policySpec.getVersion());
+                                        policySpec.getVersion(), ImportExportConstants.POLICY_TYPE_COMMON);
                                 OperationPolicyDefinition synapsePolicyDefinition =
                                         getOperationPolicyDefinitionFromFile(policyDefinitionLocation,
                                                 policyFileName, APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
@@ -10536,11 +10537,14 @@ public final class APIUtil {
     }
 
 
-    public static String getOperationPolicyFileName(String policyName, String policyVersion) {
+    public static String getOperationPolicyFileName(String policyName, String policyVersion, String policyType) {
         if (StringUtils.isEmpty(policyVersion)) {
             policyVersion = "v1";
         }
-        return policyName + "_" + policyVersion;
+        if (policyType == null) {
+            return policyName + "_" + policyVersion;
+        }
+        return policyName + "_" + policyVersion + "_" + policyType;
     }
 
     public static String getCustomBackendFileName(String apiUUID, String endpointType) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10212,8 +10212,9 @@ public final class APIUtil {
                                 OperationPolicyData policyData = new OperationPolicyData();
                                 policyData.setSpecification(policySpec);
                                 policyData.setOrganization(organization);
+                                //since the directory contains common policies only, files are not renamed with type
                                 String policyFileName = getOperationPolicyFileName(policySpec.getName(),
-                                        policySpec.getVersion(), ImportExportConstants.POLICY_TYPE_COMMON);
+                                        policySpec.getVersion(), null);
                                 OperationPolicyDefinition synapsePolicyDefinition =
                                         getOperationPolicyDefinitionFromFile(policyDefinitionLocation,
                                                 policyFileName, APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
@@ -13547,6 +13547,8 @@ components:
         policyVersion:
           type: string
           default: v1
+        policyType:
+          type: string
         policyId:
           type: string
         parameters:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/OperationPolicyDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/OperationPolicyDTO.java
@@ -25,6 +25,7 @@ public class OperationPolicyDTO   {
   
     private String policyName = null;
     private String policyVersion = "v1";
+    private String policyType = null;
     private String policyId = null;
     private Map<String, Object> parameters = new HashMap<String, Object>();
 
@@ -61,6 +62,23 @@ public class OperationPolicyDTO   {
   }
   public void setPolicyVersion(String policyVersion) {
     this.policyVersion = policyVersion;
+  }
+
+  /**
+   **/
+  public OperationPolicyDTO policyType(String policyType) {
+    this.policyType = policyType;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("policyType")
+  public String getPolicyType() {
+    return policyType;
+  }
+  public void setPolicyType(String policyType) {
+    this.policyType = policyType;
   }
 
   /**
@@ -109,13 +127,14 @@ public class OperationPolicyDTO   {
     OperationPolicyDTO operationPolicy = (OperationPolicyDTO) o;
     return Objects.equals(policyName, operationPolicy.policyName) &&
         Objects.equals(policyVersion, operationPolicy.policyVersion) &&
+        Objects.equals(policyType, operationPolicy.policyType) &&
         Objects.equals(policyId, operationPolicy.policyId) &&
         Objects.equals(parameters, operationPolicy.parameters);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(policyName, policyVersion, policyId, parameters);
+    return Objects.hash(policyName, policyVersion, policyType, policyId, parameters);
   }
 
   @Override
@@ -125,6 +144,7 @@ public class OperationPolicyDTO   {
     
     sb.append("    policyName: ").append(toIndentedString(policyName)).append("\n");
     sb.append("    policyVersion: ").append(toIndentedString(policyVersion)).append("\n");
+    sb.append("    policyType: ").append(toIndentedString(policyType)).append("\n");
     sb.append("    policyId: ").append(toIndentedString(policyId)).append("\n");
     sb.append("    parameters: ").append(toIndentedString(parameters)).append("\n");
     sb.append("}");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
@@ -192,7 +192,7 @@ public class SynapsePolicyAggregator {
             if (flow.equals(policy.getDirection())) {
                 Map<String, Object> policyParameters = policy.getParameters();
                 String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
-                        policy.getPolicyVersion());
+                        policy.getPolicyVersion(), policy.getPolicyType());
                 OperationPolicySpecification policySpecification = ImportUtils
                         .getOperationPolicySpecificationFromFile(policyDirectory, policyFileName);
                 if (policySpecification.getSupportedGateways()

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -709,19 +709,25 @@ public class ExportUtils {
                 List<OperationPolicy> operationPolicies = uriTemplate.getOperationPolicies();
                 if (operationPolicies != null && !operationPolicies.isEmpty()) {
                     for (OperationPolicy policy : operationPolicies) {
-                        if (!exportedPolicies.contains(policy.getPolicyName() + "_" + policy.getPolicyVersion())) {
-                            String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
-                                    policy.getPolicyVersion());
+                        if (!exportedPolicies.contains(policy.getPolicyName() + "_" + policy.getPolicyVersion() + "_" +
+                                policy.getPolicyType())) {
                             if (policy.getPolicyId() != null) {
+                                String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
+                                        policy.getPolicyVersion(), policy.getPolicyType());
+
                                 OperationPolicyData policyData =
                                         apiProvider.getAPISpecificOperationPolicyByPolicyId(policy.getPolicyId(),
                                                 currentApiUuid, tenantDomain, true);
                                 if (policyData != null) {
                                     exportPolicyData(policyFileName, policyData, archivePath, exportFormat);
-                                    exportedPolicies.add(policy.getPolicyName() + "_" + policy.getPolicyVersion());
+                                    exportedPolicies.add(policy.getPolicyName() + "_" + policy.getPolicyVersion() + "_"
+                                            + policy.getPolicyType());
                                 }
                             } else {
                                 // This path is to handle migrated APIs with mediation policies attached
+                                // These are considered as API policies by default
+                                String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
+                                        policy.getPolicyVersion(), ImportExportConstants.POLICY_TYPE_API);
                                 if (APIUtil.isSequenceDefined(api.getInSequence())
                                         || APIUtil.isSequenceDefined(api.getOutSequence())
                                         || APIUtil.isSequenceDefined(api.getFaultSequence())) {
@@ -736,7 +742,8 @@ public class ExportUtils {
                                             policy.getDirection(), tenantDomain);
                                     if (policyData != null) {
                                         exportPolicyData(policyFileName, policyData, archivePath, exportFormat);
-                                        exportedPolicies.add(policy.getPolicyName() + "_" + policy.getPolicyVersion());
+                                        exportedPolicies.add(policy.getPolicyName() + "_" + policy.getPolicyVersion() +
+                                                "_" + ImportExportConstants.POLICY_TYPE_API);
                                     }
                                 }
                             }
@@ -748,14 +755,15 @@ public class ExportUtils {
             if (api.getApiPolicies() != null && !api.getApiPolicies().isEmpty()) {
                 for (OperationPolicy policy : api.getApiPolicies()) {
                     String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
-                            policy.getPolicyVersion());
+                            policy.getPolicyVersion(), policy.getPolicyType());
                     if (!exportedPolicies.contains(policyFileName)) {
                         OperationPolicyData policyData =
                                 apiProvider.getAPISpecificOperationPolicyByPolicyId(policy.getPolicyId(),
                                         currentApiUuid, tenantDomain, true);
                         if (policyData != null) {
                             exportPolicyData(policyFileName, policyData, archivePath, exportFormat);
-                            exportedPolicies.add(policy.getPolicyName() + "_" + policy.getPolicyVersion());
+                            exportedPolicies.add(policy.getPolicyName() + "_" + policy.getPolicyVersion() + "_" +
+                                    policy.getPolicyType());
                         }
                     }
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -636,7 +636,7 @@ public class ImportUtils {
         String policyDirectory = extractedFolderPath + File.separator + ImportExportConstants.POLICIES_DIRECTORY;
         appliedPolicy.setPolicyId(null);
         String policyFileName = APIUtil.getOperationPolicyFileName(appliedPolicy.getPolicyName(),
-                appliedPolicy.getPolicyVersion());
+                appliedPolicy.getPolicyVersion(), appliedPolicy.getPolicyType());
         OperationPolicySpecification policySpec = null;
 
         if (visitedPoliciesMap.containsKey(policyFileName)) {
@@ -791,7 +791,7 @@ public class ImportUtils {
             boolean policyImported = false;
             try {
                 String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
-                        policy.getPolicyVersion());
+                        policy.getPolicyVersion(), policy.getPolicyType());
                 String policyID = null;
                 if (!importedPolicies.containsKey(policyFileName)) {
                     OperationPolicySpecification policySpec =
@@ -824,7 +824,8 @@ public class ImportUtils {
                         }
                         operationPolicyData.setMd5Hash(
                                 APIUtil.getHashOfOperationPolicy(operationPolicyData));
-                        policyID = provider.importOperationPolicy(operationPolicyData, tenantDomain);
+                        policyID = provider.importOperationPolicyOfGivenType(operationPolicyData,
+                                policy.getPolicyType(), tenantDomain);
                         importedPolicies.put(policyFileName, policyID);
                         policyImported = true;
                     } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -635,8 +635,9 @@ public class ImportUtils {
 
         String policyDirectory = extractedFolderPath + File.separator + ImportExportConstants.POLICIES_DIRECTORY;
         appliedPolicy.setPolicyId(null);
+        String policyType = appliedPolicy.getPolicyType();
         String policyFileName = APIUtil.getOperationPolicyFileName(appliedPolicy.getPolicyName(),
-                appliedPolicy.getPolicyVersion(), appliedPolicy.getPolicyType());
+                appliedPolicy.getPolicyVersion(), policyType);
         OperationPolicySpecification policySpec = null;
 
         if (visitedPoliciesMap.containsKey(policyFileName)) {
@@ -650,22 +651,28 @@ public class ImportUtils {
 
         if (policySpec == null && apiUUID != null) {
             // if policy is not found in the project, policy can be referenced from an existing policy.
-            OperationPolicyData policyData =
-                    provider.getAPISpecificOperationPolicyByPolicyName(appliedPolicy.getPolicyName(),
-                            appliedPolicy.getPolicyVersion(), apiUUID, null, tenantDomain, false);
-            if (policyData != null) {
-                policySpec = policyData.getSpecification();
-                appliedPolicy.setPolicyId(policyData.getPolicyId());
+            if (policyType == null || ImportExportConstants.POLICY_TYPE_API.equalsIgnoreCase(policyType)) {
+                // if policy type is 'api' or not specified, then search API specific operation policies
+                OperationPolicyData policyData =
+                        provider.getAPISpecificOperationPolicyByPolicyName(appliedPolicy.getPolicyName(),
+                                appliedPolicy.getPolicyVersion(), apiUUID, null, tenantDomain, false);
+                if (policyData != null) {
+                    policySpec = policyData.getSpecification();
+                    appliedPolicy.setPolicyId(policyData.getPolicyId());
+                }
             }
         }
 
         if (policySpec == null) {
-            OperationPolicyData policyData =
-                    provider.getCommonOperationPolicyByPolicyName(appliedPolicy.getPolicyName(),
-                            appliedPolicy.getPolicyVersion(), tenantDomain, false);
-            if (policyData != null) {
-                policySpec = policyData.getSpecification();
-                appliedPolicy.setPolicyId(policyData.getPolicyId());
+            if (policyType == null || ImportExportConstants.POLICY_TYPE_COMMON.equalsIgnoreCase(policyType)) {
+                // if policy type is 'common' or not specified, then search common operation policies
+                OperationPolicyData policyData =
+                        provider.getCommonOperationPolicyByPolicyName(appliedPolicy.getPolicyName(),
+                                appliedPolicy.getPolicyVersion(), tenantDomain, false);
+                if (policyData != null) {
+                    policySpec = policyData.getSpecification();
+                    appliedPolicy.setPolicyId(policyData.getPolicyId());
+                }
             }
         }
 
@@ -789,9 +796,10 @@ public class ImportUtils {
         List<OperationPolicy> validatedOperationPolicies = new ArrayList<>();
         for (OperationPolicy policy : policiesList) {
             boolean policyImported = false;
+            String policyType = policy.getPolicyType();
             try {
                 String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
-                        policy.getPolicyVersion(), policy.getPolicyType());
+                        policy.getPolicyVersion(), policyType);
                 String policyID = null;
                 if (!importedPolicies.containsKey(policyFileName)) {
                     OperationPolicySpecification policySpec =
@@ -825,15 +833,18 @@ public class ImportUtils {
                         operationPolicyData.setMd5Hash(
                                 APIUtil.getHashOfOperationPolicy(operationPolicyData));
                         policyID = provider.importOperationPolicyOfGivenType(operationPolicyData,
-                                policy.getPolicyType(), tenantDomain);
+                                policyType, tenantDomain);
                         importedPolicies.put(policyFileName, policyID);
                         policyImported = true;
                     } else {
                         // Check whether the policy has been referenced
-                        OperationPolicyData policyData =
-                                provider.getAPISpecificOperationPolicyByPolicyName(policy.getPolicyName(),
-                                        policy.getPolicyVersion(), api.getUuid(), null,
-                                        tenantDomain, false);
+                        OperationPolicyData policyData = null;
+                        if (policyType == null
+                                || ImportExportConstants.POLICY_TYPE_API.equalsIgnoreCase(policyType)) {
+                            policyData = provider.getAPISpecificOperationPolicyByPolicyName(policy.getPolicyName(),
+                                    policy.getPolicyVersion(), api.getUuid(), null,
+                                    tenantDomain, false);
+                        }
                         if (policyData != null) {
                             OperationPolicySpecification policySpecification = policyData.
                                     getSpecification();
@@ -848,10 +859,13 @@ public class ImportUtils {
                                 }
                             }
                         } else {
-                            OperationPolicyData commonPolicyData =
-                                    provider.getCommonOperationPolicyByPolicyName(policy.getPolicyName(),
-                                            policy.getPolicyVersion(), tenantDomain,
-                                            false);
+                            OperationPolicyData commonPolicyData = null;
+                            if (policyType == null ||
+                                    ImportExportConstants.POLICY_TYPE_COMMON.equalsIgnoreCase(policyType)) {
+                                commonPolicyData = provider.getCommonOperationPolicyByPolicyName(policy.getPolicyName(),
+                                        policy.getPolicyVersion(), tenantDomain,
+                                        false);
+                            }
                             if (commonPolicyData != null) {
                                 log.info(commonPolicyData.getPolicyId());
                                 // A common policy is found for specified policy. This will be validated

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/OperationPolicyMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/OperationPolicyMappingUtil.java
@@ -57,6 +57,7 @@ public class OperationPolicyMappingUtil {
         OperationPolicy operationPolicy = new OperationPolicy();
         operationPolicy.setPolicyName(operationPolicyDTO.getPolicyName());
         operationPolicy.setPolicyVersion(operationPolicyDTO.getPolicyVersion());
+        operationPolicy.setPolicyType(operationPolicyDTO.getPolicyType());
         operationPolicy.setPolicyId(operationPolicyDTO.getPolicyId());
         operationPolicy.setParameters(operationPolicyDTO.getParameters());
         return operationPolicy;
@@ -67,6 +68,7 @@ public class OperationPolicyMappingUtil {
         OperationPolicyDTO dto = new OperationPolicyDTO();
         dto.setPolicyName(operationPolicy.getPolicyName());
         dto.setPolicyVersion(operationPolicy.getPolicyVersion());
+        dto.setPolicyType(operationPolicy.getPolicyType());
         dto.setPolicyId(operationPolicy.getPolicyId());
         dto.setParameters(operationPolicy.getParameters());
         return dto;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -13547,6 +13547,8 @@ components:
         policyVersion:
           type: string
           default: v1
+        policyType:
+          type: string
         policyId:
           type: string
         parameters:


### PR DESCRIPTION
Public fix of https://github.com/wso2-enterprise/wso2-apim-internal/issues/7352

Previously when exporting an API which has an API policy (ex :policy1) and common policy (ex : policy1) with the same name and version, only one of them is exported. The import flow also didn't allow to import those policies. The PR fixes the above.