### PR TITLE
Implement API Health Check Endpoints for the Traffic Ports and Avoid Publishing Analytics Data from File-Based APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/constants/HealthCheckConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/constants/HealthCheckConstants.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.common.gateway.constants;
+
+/**
+ * Constants related to Health Check.
+ */
+public class HealthCheckConstants {
+    public static final String HEALTH_CHECK_API_NAME = "_HealthCheckAPI_";
+    public static final String HEALTH_CHECK_API_CONTEXT = "/health-check";
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
@@ -39,7 +39,9 @@ import org.wso2.carbon.apimgt.api.gateway.GraphQLSchemaDTO;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIProductIdentifier;
+import org.wso2.carbon.apimgt.common.gateway.constants.HealthCheckConstants;
 import org.wso2.carbon.apimgt.common.gateway.constants.JWTConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.analytics.Constants;
 import org.wso2.carbon.apimgt.gateway.internal.DataHolder;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.service.APIGatewayAdmin;
@@ -209,8 +211,11 @@ public class InMemoryAPIDeployer {
         if (!redeployChangedAPIs) {
             try {
                 deployJWKSSynapseAPI(tenantDomain); // Deploy JWKS API
+                if (APIConstants.SUPER_TENANT_DOMAIN.equalsIgnoreCase(tenantDomain)) {
+                    deployHealthCheckSynapseAPI(tenantDomain); // Deploy HealthCheck API for the super tenant
+                }
             } catch (APIManagementException e) {
-                log.error("Error while deploying JWKS API for tenant domain :" + tenantDomain, e);
+                log.error("Error while deploying in-memory APIs for tenant domain :" + tenantDomain, e);
             }
         }
         if (gatewayArtifactSynchronizerProperties.isRetrieveFromStorageEnabled()) {
@@ -548,6 +553,62 @@ public class InMemoryAPIDeployer {
                 MessageContext.destroyCurrentMessageContext();
                 PrivilegedCarbonContext.endTenantFlow();
             }
+        }
+    }
+
+    /**
+     * Deploy Synapse API for the Health Check endpoint
+     *
+     * @param tenantDomain tenant domain
+     */
+    public static void deployHealthCheckSynapseAPI(String tenantDomain) throws APIManagementException {
+        try {
+            // Deploy Health Check API for tenant
+            MessageContext.setCurrentMessageContext(
+                    org.wso2.carbon.apimgt.gateway.utils.GatewayUtils.createAxis2MessageContext());
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+            GatewayAPIDTO healthCheckAPIDto = new GatewayAPIDTO();
+
+            String healthCheckSynapseAPI = "<api xmlns=\"http://ws.apache.org/ns/synapse\" name=\"" +
+                    HealthCheckConstants.HEALTH_CHECK_API_NAME + "\" context=\""
+                    + HealthCheckConstants.HEALTH_CHECK_API_CONTEXT
+                    + "\" binds-to=\"default,WebhookServer,SecureWebhookServer\">\n"
+                    + "    <resource binds-to=\"default,WebhookServer,SecureWebhookServer\" methods=\"GET\" "
+                    + "url-mapping=\"/*\" faultSequence=\"fault\">\n"
+                    + "        <inSequence>\n"
+                    + "            <property name=\"" + Constants.SKIP_METRICS_PUBLISHING + "\" "
+                    + "value=\"true\" type=\"BOOLEAN\" xmlns:m0=\"http://services.samples/xsd\"/>\n"
+                    + "            <send>\n"
+                    + "                <endpoint name=\"" + HealthCheckConstants.HEALTH_CHECK_API_NAME + "\">\n"
+                    + "                     <address uri=\"https://localhost:"
+                    + System.getProperty(APIConstants.HTTPS_TRANSPORT_PORT)
+                    + "/api/am/gateway/v2/server-startup-healthcheck\" format=\"GET\">\n"
+                    + "                           <timeout>\n"
+                    + "                                <duration>30000</duration>\n"
+                    + "                                <responseAction>fault</responseAction>\n"
+                    + "                           </timeout>\n"
+                    + "                     </address>\n"
+                    + "                </endpoint>\n"
+                    + "            </send>\n"
+                    + "        </inSequence>\n"
+                    + "    </resource>\n"
+                    + "</api>\n";
+
+            healthCheckAPIDto.setName(HealthCheckConstants.HEALTH_CHECK_API_NAME);
+            healthCheckAPIDto.setTenantDomain(tenantDomain);
+            healthCheckAPIDto.setApiDefinition(healthCheckSynapseAPI);
+
+            log.info("Deploying synapse artifacts of " + healthCheckAPIDto.getName());
+            APIGatewayAdmin apiGatewayAdmin = new APIGatewayAdmin();
+            apiGatewayAdmin.deployAPI(healthCheckAPIDto);
+            DataHolder.getInstance().markAPIAsDeployed(healthCheckAPIDto);
+        } catch (AxisFault axisFault) {
+            throw new APIManagementException("Error while retrieving Health Check API Artifact", axisFault,
+                    ExceptionCodes.INTERNAL_ERROR);
+        } finally {
+            MessageContext.destroyCurrentMessageContext();
+            PrivilegedCarbonContext.endTenantFlow();
         }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/DefaultAPIHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/DefaultAPIHandler.java
@@ -26,12 +26,11 @@ import org.apache.synapse.api.ApiUtils;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.RESTConstants;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.common.gateway.constants.HealthCheckConstants;
 import org.wso2.carbon.apimgt.common.gateway.constants.JWTConstants;
 import org.wso2.carbon.apimgt.gateway.InMemoryAPIDeployer;
-import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
-import org.wso2.carbon.apimgt.impl.dto.GatewayArtifactSynchronizerProperties;
 import org.wso2.carbon.apimgt.impl.gatewayartifactsynchronizer.exception.ArtifactSynchronizerException;
 import org.wso2.carbon.apimgt.keymgt.model.entity.API;
 import org.wso2.carbon.inbound.endpoint.protocol.websocket.InboundWebsocketConstants;
@@ -69,6 +68,10 @@ public class DefaultAPIHandler extends AbstractSynapseHandler {
             } catch(APIManagementException e){
                 log.error("Error while deploying JWKS API for tenant domain :" + tenantDomain, e);
             }
+            return true;
+        }
+
+        if (GatewayUtils.checkForFileBasedApiContexts(path, tenantDomain)) {
             return true;
         }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/LogsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/LogsHandler.java
@@ -26,11 +26,13 @@ import org.apache.http.HttpHeaders;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.synapse.AbstractSynapseHandler;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.api.ApiUtils;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
 import org.wso2.carbon.apimgt.gateway.APILoggerManager;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.logging.APILogHandler;
+import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.correlation.MethodCallsCorrelationConfigDataHolder;
 
@@ -94,6 +96,11 @@ public class LogsHandler extends AbstractSynapseHandler {
 
     public boolean handleRequestOutFlow(MessageContext messageContext) {
         if (isEnabled()) {
+            if (GatewayUtils.checkForFileBasedApiContexts(ApiUtils.getFullRequestPath(messageContext)
+                    , GatewayUtils.getTenantDomain())) {
+                return true;
+            }
+
             try {
                 Map headers = LogUtils.getTransportHeaders(messageContext);
                 String correlationIdHeader = null;

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsMetricsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/AnalyticsMetricsHandler.java
@@ -22,10 +22,10 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.AbstractExtendedSynapseHandler;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.api.ApiUtils;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.wso2.carbon.apimgt.common.analytics.collectors.AnalyticsDataProvider;
 import org.wso2.carbon.apimgt.common.analytics.collectors.impl.GenericRequestDataCollector;
-import org.wso2.carbon.apimgt.common.analytics.exceptions.AnalyticsException;
 import org.wso2.carbon.apimgt.gateway.handlers.DataPublisherUtil;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.AsyncAnalyticsDataProvider;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
@@ -79,12 +79,22 @@ public class AnalyticsMetricsHandler extends AbstractExtendedSynapseHandler {
 
     @Override
     public boolean handleResponseOutFlow(MessageContext messageContext) {
+        if (GatewayUtils.checkForFileBasedApiContexts(ApiUtils.getFullRequestPath(messageContext),
+                GatewayUtils.getTenantDomain())) {
+            return true;
+        }
+
+        Object skipPublishMetrics = messageContext.getProperty(Constants.SKIP_METRICS_PUBLISHING);
+        if (skipPublishMetrics != null && (Boolean) skipPublishMetrics) {
+            return true;
+        }
+
         if (messageContext.getPropertyKeySet().contains(InboundWebsocketConstants.WEBSOCKET_SUBSCRIBER_PATH)) {
             return true;
         }
         AnalyticsDataProvider provider;
-        Object skipPublishMetrics = messageContext.getProperty(Constants.SKIP_DEFAULT_METRICS_PUBLISHING);
-        if (skipPublishMetrics != null && (Boolean) skipPublishMetrics) {
+        Object isAsyncAPI = messageContext.getProperty(Constants.IS_ASYNC_API);
+        if (isAsyncAPI != null && (Boolean) isAsyncAPI) {
             provider = new AsyncAnalyticsDataProvider(messageContext);
         } else {
             provider = new SynapseAnalyticsDataProvider(messageContext,

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/Constants.java
@@ -29,7 +29,8 @@ public class Constants {
     public static final String USER_AGENT_PROPERTY = "api.analytics.user.agent";
     public static final String USER_IP_PROPERTY = "api.analytics.user.ip";
     public static final String CACHED_RESPONSE_KEY = "CachableResponse";
-    public static final String SKIP_DEFAULT_METRICS_PUBLISHING = "skip_default_metrics_publishing";
+    public static final String IS_ASYNC_API = "isAsyncAPI";
+    public static final String SKIP_METRICS_PUBLISHING = "SKIP_METRICS_PUBLISHING";
     public static final String REQUEST_CACHE_HIT = "api.analytics.cacheHit";
     public static final String API_USER_NAME_KEY = "userName";
     public static final String API_CONTEXT_KEY = "apiContext";

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencySynapseHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencySynapseHandler.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.apimgt.gateway.handlers.common;
 import io.opentelemetry.context.Context;
 import org.apache.synapse.AbstractSynapseHandler;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.api.ApiUtils;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
@@ -43,6 +44,11 @@ public class APIMgtLatencySynapseHandler extends AbstractSynapseHandler {
     public boolean handleRequestInFlow(MessageContext messageContext) {
         TracingTracer tracer = ServiceReferenceHolder.getInstance().getTracer();
         TelemetryTracer telemetryTracer = ServiceReferenceHolder.getInstance().getTelemetryTracer();
+
+        if (GatewayUtils.checkForFileBasedApiContexts(ApiUtils.getFullRequestPath(messageContext),
+                GatewayUtils.getTenantDomain())) {
+            return true;
+        }
 
         if (TelemetryUtil.telemetryEnabled()) {
             org.apache.axis2.context.MessageContext axis2MessageContext =

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/sse/SseApiHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/sse/SseApiHandler.java
@@ -74,7 +74,7 @@ public class SseApiHandler extends APIAuthenticationHandler {
 
         org.apache.axis2.context.MessageContext axisCtx = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
         axisCtx.setProperty(PassThroughConstants.SYNAPSE_ARTIFACT_TYPE, APIConstants.API_TYPE_SSE);
-        synCtx.setProperty(org.wso2.carbon.apimgt.gateway.handlers.analytics.Constants.SKIP_DEFAULT_METRICS_PUBLISHING,
+        synCtx.setProperty(org.wso2.carbon.apimgt.gateway.handlers.analytics.Constants.IS_ASYNC_API,
                            true);
         synCtx.setProperty(ASYNC_MESSAGE_TYPE, ASYNC_MESSAGE_TYPE_SUBSCRIBE);
         GatewayUtils.setRequestDestination(synCtx);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
@@ -165,6 +165,8 @@ public class APIHandlerServiceComponent {
         CacheProvider.createGatewayInternalKeyCache();
         CacheProvider.createGatewayInternalKeyDataCache();
         CacheProvider.createInvalidInternalKeyCache();
+
+        setTransportHttpsPort();
     }
 
     @Deactivate
@@ -541,6 +543,13 @@ public class APIHandlerServiceComponent {
             log.debug("Un-setting SynapseConfigurationService");
         }
         ServiceReferenceHolder.getInstance().setSynapseConfigurationService(null);
+    }
+
+    private void setTransportHttpsPort() {
+        ConfigurationContextService configurationContextService =
+                ServiceReferenceHolder.getInstance().getConfigurationContextService();
+        System.setProperty(APIConstants.HTTPS_TRANSPORT_PORT,
+                Integer.toString(CarbonUtils.getTransportPort(configurationContextService, APIConstants.HTTPS_PROTOCOL)));
     }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/webhooks/SubscribersPersistMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/webhooks/SubscribersPersistMediator.java
@@ -64,7 +64,7 @@ public class SubscribersPersistMediator extends AbstractMediator {
             String mode = params.get(APIConstants.Webhooks.HUB_MODE_QUERY_PARAM);
             String secret = params.get(APIConstants.Webhooks.HUB_SECRET_QUERY_PARAM);
             String leaseSeconds = params.get(APIConstants.Webhooks.HUB_LEASE_SECONDS_QUERY_PARAM);
-            messageContext.setProperty(Constants.SKIP_DEFAULT_METRICS_PUBLISHING, true);
+            messageContext.setProperty(Constants.IS_ASYNC_API, true);
             org.apache.axis2.context.MessageContext axisCtx =
                     ((Axis2MessageContext) messageContext).getAxis2MessageContext();
             axisCtx.setProperty(PassThroughConstants.SYNAPSE_ARTIFACT_TYPE, APIConstants.API_TYPE_WEBSUB);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -1731,4 +1731,18 @@ public class GatewayUtils {
             throw new OAuth2Exception(error, e);
         }
     }
+
+    /**
+     * This method returns True if the given path contains a file based API context
+     *
+     * @param path  Full Request Path
+     * @param tenantDomain  Tenant domain
+     * @return True if the given path contains a file based API context
+     */
+    public static boolean checkForFileBasedApiContexts(String path, String tenantDomain){
+        path = path.replace(APIConstants.TENANT_PREFIX + tenantDomain, "");
+        path = path.split("\\?")[0];
+        return ServiceReferenceHolder.getInstance().getAPIManagerConfiguration()
+                .getGatewayArtifactSynchronizerProperties().getFileBasedApiContexts().contains(path);
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -259,6 +259,7 @@ public final class APIConstants {
     // For HTTP requests
     public static final String HEADER_ACCEPT = "Accept";
     public static final String HEADER_CONTENT_TYPE = "Content-Type";
+    public static final String HEADER_CONTENT_LENGTH = "Content-Length";
     public static final String HEADER_API_TOKEN = "X-API-KEY";
     public static final String HEADER_USER_AGENT = "User-Agent";
     public static final String MULTIPART_FORM_BOUNDARY = "X-WSO2-BOUNDARY";
@@ -1550,6 +1551,7 @@ public final class APIConstants {
     public static final String KEYMANAGER_PORT = "keyManagerPort";
     public static final String KEYMANAGER_SERVERURL = API_KEY_VALIDATOR + "ServerURL";
     public static final String CARBON_LOCALIP = "carbon.local.ip";
+    public static final String HTTPS_TRANSPORT_PORT = "https.transport.port";
 
     public static final String APIPROVIDER_HOSTCACHE = "apiProvideHostObjectCache";
     public static final String TENANTCOUNT_CACHEKEY = "apiProviderCacheKey";
@@ -2898,6 +2900,8 @@ public final class APIConstants {
         public static final String API_ID = "apiId";
         public static final String LABEL = "label";
         public static final String LABELS = "labels";
+        public static final String FILE_BASED_API_CONTEXTS = "FileBasedApiContexts";
+        public static final String FILE_BASED_API_CONTEXT = "FileBasedApiContext";
         public static final String EnableOnDemandLoadingAPIS = "EnableOnDemandLoadingAPIS";
 
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -2315,6 +2315,19 @@ public class APIManagerConfiguration {
             }
         }
 
+        OMElement gatewayFileBasedContextsElement = omElement
+                .getFirstChildWithName(new QName(APIConstants.GatewayArtifactSynchronizer.FILE_BASED_API_CONTEXTS));
+        if (gatewayFileBasedContextsElement != null) {
+            Iterator contextsIterator = gatewayFileBasedContextsElement
+                    .getChildrenWithLocalName(APIConstants.GatewayArtifactSynchronizer.FILE_BASED_API_CONTEXT);
+            while (contextsIterator.hasNext()) {
+                OMElement contextElement = (OMElement) contextsIterator.next();
+                if (contextElement != null) {
+                    gatewayArtifactSynchronizerProperties.getFileBasedApiContexts().add(contextElement.getText());
+                }
+            }
+        }
+
         OMElement properties = omElement.getFirstChildWithName(new
                 QName(APIConstants.API_GATEWAY_ADDITIONAL_PROPERTIES));
         Map<String, String> additionalProperties = new HashMap<>();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/GatewayArtifactSynchronizerProperties.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/GatewayArtifactSynchronizerProperties.java
@@ -12,6 +12,7 @@ public class GatewayArtifactSynchronizerProperties {
     private String saverName = APIConstants.GatewayArtifactSynchronizer.DB_SAVER_NAME;
     private String retrieverName = APIConstants.GatewayArtifactSynchronizer.DB_RETRIEVER_NAME;
     private Set<String> gatewayLabels = new HashSet<>();
+    private Set<String> fileBasedApiContexts = new HashSet<>();
     private String artifactSynchronizerDataSource = "jdbc/WSO2AM_DB";
     private long retryDuartion = 15000 ;
     private int maxRetryCount = 5;
@@ -75,6 +76,16 @@ public class GatewayArtifactSynchronizerProperties {
     public void setGatewayLabels(Set<String> gatewayLabels) {
 
         this.gatewayLabels = gatewayLabels;
+    }
+
+    public Set<String> getFileBasedApiContexts() {
+
+        return fileBasedApiContexts;
+    }
+
+    public void setFileBasedApiContexts(Set<String> fileBasedApiContexts) {
+
+        this.fileBasedApiContexts = fileBasedApiContexts;
     }
 
     public void setPublishDirectlyToGatewayEnabled(boolean publishDirectlyToGatewayEnabled) {

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1663,6 +1663,13 @@
          {% endif %}
         </LocalEntries>
         </SkipList>
+        <FileBasedApiContexts>
+            {% if apim.sync_runtime_artifacts.gateway.file_based_api_contexts is defined %}
+                {%- for context in apim.sync_runtime_artifacts.gateway.file_based_api_contexts -%}
+                    <FileBasedApiContext>{{context}}</FileBasedApiContext>
+                {% endfor %}
+            {% endif %}
+        </FileBasedApiContexts>
         <EnableOnDemandLoadingAPIS>{{apim.sync_runtime_artifacts.gateway.enable_on_demand_loading}}</EnableOnDemandLoadingAPIS>
     </SyncRuntimeArtifactsGateway>
     {% endif %}


### PR DESCRIPTION
## Purpose
### 1. API Health Check from Traffic Ports
- Resolves https://github.com/wso2/api-manager/issues/3094

Implemented endpoints to retrieve the API health status through various traffic ports. This enables checking the health of APIs deployed on the Gateway. Following are the implemented Health Check Endpoints,

- https://localhost:8243/health-check
- http://localhost:9099/health-check
- https://localhost:8099/]health-check
- http://localhost:9021/health-check
- https://localhost:8021/health-check

### 2. Avoid Publishing Analytics Data from File-Based APIs

Introduced a new configuration to add file-based API contexts. These file-based API contexts will no longer publish data to analytics. The following configuration is added to the `deployment.toml` file,

```
[apim.sync_runtime_artifacts.gateway]
file_based_api_contexts = ["/jwks", "/health-check"]
```
Add your file-based API contexts here to avoid publishing data to analytics.