### PR TITLE
Start tenant flow before creating tenant context

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -4821,11 +4821,19 @@ public final class APIUtil {
      */
     public static void loadTenantConfigBlockingMode(String tenantDomain) {
 
+        boolean isTenantFlowStarted = false;
         try {
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+            isTenantFlowStarted = true;
             ConfigurationContext ctx = ServiceReferenceHolder.getContextService().getServerConfigContext();
             TenantAxisUtils.getTenantAxisConfiguration(tenantDomain, ctx);
         } catch (Exception e) {
             log.error("Error while creating axis configuration for tenant " + tenantDomain, e);
+        } finally {
+            if (isTenantFlowStarted) {
+                PrivilegedCarbonContext.endTenantFlow();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes the following error in a distributed setup

```
[2024-10-14 21:19:43,728] ERROR - APIUtil Error while creating axis configuration for tenant b.com
java.lang.RuntimeException: Cannot create tenant ConfigurationContext for tenant b.com
	at org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils.getTenantConfigurationContext(TenantAxisUtils.java:160) ~[org.wso2.carbon.core_4.9.27.SNAPSHOT.jar:?]
	at org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils.getTenantAxisConfiguration(TenantAxisUtils.java:108) ~[org.wso2.carbon.core_4.9.27.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.utils.APIUtil.loadTenantConfigBlockingMode_aroundBody364(APIUtil.java:4826) ~[org.wso2.carbon.apimgt.impl_9.30.46.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.utils.APIUtil.loadTenantConfigBlockingMode(APIUtil.java:1) ~[org.wso2.carbon.apimgt.impl_9.30.46.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.gateway.listeners.GatewayJMSMessageListener$1.run_aroundBody0(GatewayJMSMessageListener.java:179) ~[org.wso2.carbon.apimgt.gateway_9.30.46.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.gateway.listeners.GatewayJMSMessageListener$1.run(GatewayJMSMessageListener.java:1) ~[org.wso2.carbon.apimgt.gateway_9.30.46.SNAPSHOT.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: java.lang.IllegalStateException: Trying to set the domain from 1 to 2
	at org.wso2.carbon.context.internal.CarbonContextDataHolder.setTenantId(CarbonContextDataHolder.java:1346) ~[org.wso2.carbon.utils_4.9.27.SNAPSHOT.jar:?]
	at org.wso2.carbon.context.PrivilegedCarbonContext.setTenantId(PrivilegedCarbonContext.java:115) ~[org.wso2.carbon.utils_4.9.27.SNAPSHOT.jar:?]
	at org.wso2.carbon.context.PrivilegedCarbonContext.setTenantId(PrivilegedCarbonContext.java:104) ~[org.wso2.carbon.utils_4.9.27.SNAPSHOT.jar:?]
	at org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils.createTenantConfigurationContext(TenantAxisUtils.java:309) ~[org.wso2.carbon.core_4.9.27.SNAPSHOT.jar:?]
	at org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils.getTenantConfigurationContext(TenantAxisUtils.java:158) ~[org.wso2.carbon.core_4.9.27.SNAPSHOT.jar:?]
	... 10 more
```