### PR TITLE
Fix NPE encountered during API Product export

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -356,7 +356,12 @@ public class ExportUtils {
         String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
         String localImagePath = archivePath + File.separator + ImportExportConstants.IMAGE_RESOURCE;
         try {
-            ResourceFile thumbnailResource = apiProvider.getIcon(currentUuid, tenantDomain);
+            ResourceFile thumbnailResource;
+            if (currentUuid == null) {
+                thumbnailResource = apiProvider.getIcon(identifier.getUUID(), tenantDomain);
+            } else {
+                thumbnailResource = apiProvider.getIcon(currentUuid, tenantDomain);
+            }
             if (thumbnailResource != null) {
                 String mediaType = thumbnailResource.getContentType();
                 String extension = ImportExportConstants.fileExtensionMapping.get(mediaType);


### PR DESCRIPTION
This PR fixes the NPE encountered when trying the download/export an API product

```
[2024-10-15 10:34:11,714] ERROR - GlobalThrowableMapper An unknown exception has been captured by the global exception mapper.
java.lang.NullPointerException: null
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936) ~[?:?]
	at java.util.concurrent.ConcurrentHashMap.containsKey(ConcurrentHashMap.java:964) ~[?:?]
	at org.wso2.carbon.caching.impl.CacheImpl.containsKey(CacheImpl.java:286) ~[javax.cache.wso2_4.9.27.alpha.jar:?]
	at org.wso2.carbon.governance.api.util.GovernanceUtils.getArtifactPath(GovernanceUtils.java:797) ~[org.wso2.carbon.governance.api_4.8.34.jar:?]
	at org.wso2.carbon.governance.api.util.GovernanceUtils.retrieveGovernanceArtifactById(GovernanceUtils.java:976) ~[org.wso2.carbon.governance.api_4.8.34.jar:?]
	at org.wso2.carbon.governance.api.common.GovernanceArtifactManager.getGovernanceArtifact(GovernanceArtifactManager.java:589) ~[org.wso2.carbon.governance.api_4.8.34.jar:?]
	at org.wso2.carbon.governance.api.generic.GenericArtifactManager.getGenericArtifact(GenericArtifactManager.java:231) ~[org.wso2.carbon.governance.api_4.8.34.jar:?]
	at org.wso2.carbon.apimgt.persistence.RegistryPersistenceImpl.getAPIArtifact(RegistryPersistenceImpl.java:3705) ~[org.wso2.carbon.apimgt.persistence_9.30.47.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.persistence.RegistryPersistenceImpl.getThumbnail(RegistryPersistenceImpl.java:2925) ~[org.wso2.carbon.apimgt.persistence_9.30.47.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.AbstractAPIManager.getIcon_aroundBody150(AbstractAPIManager.java:1656) ~[org.wso2.carbon.apimgt.impl_9.30.47.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.AbstractAPIManager.getIcon(AbstractAPIManager.java:1) ~[org.wso2.carbon.apimgt.impl_9.30.47.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings.ExportUtils.addThumbnailToArchive(ExportUtils.java:359) ~[org.wso2.carbon.apimgt.rest.api.publisher.v1.common_9.30.47.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.rest.api.publisher.v1.common.mappings.ExportUtils.exportApiProduct(ExportUtils.java:316) ~[org.wso2.carbon.apimgt.rest.api.publisher.v1.common_9.30.47.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.rest.api.publisher.v1.common.ImportExportAPIServiceImpl.exportAPIProduct(ImportExportAPIServiceImpl.java:190) ~[?:?]
	at org.wso2.carbon.apimgt.rest.api.publisher.v1.impl.ApiProductsApiServiceImpl.exportAPIProduct(ApiProductsApiServiceImpl.java:677) ~[?:?]
	at org.wso2.carbon.apimgt.rest.api.publisher.v1.ApiProductsApi.exportAPIProduct(ApiProductsApi.java:278) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.apache.cxf.service.invoker.AbstractInvoker.performInvocation(AbstractInvoker.java:179) ~[?:?]
	at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:96) ~[?:?]
	at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:201) ~[?:?]
	at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:104) ~[?:?]
	at org.apache.cxf.interceptor.ServiceInvokerInterceptor$1.run(ServiceInvokerInterceptor.java:59) ~[?:?]
	at org.apache.cxf.interceptor.ServiceInvokerInterceptor.handleMessage(ServiceInvokerInterceptor.java:96) ~[?:?]
	at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:307) ~[?:?]
	at org.apache.cxf.transport.ChainInitiationObserver.onMessage(ChainInitiationObserver.java:121) ~[?:?]
	at org.apache.cxf.transport.http.AbstractHTTPDestination.invoke(AbstractHTTPDestination.java:265) ~[?:?]
	at org.apache.cxf.transport.servlet.ServletController.invokeDestination(ServletController.java:234) ~[?:?]
	at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:208) ~[?:?]
	at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:160) ~[?:?]
	at org.apache.cxf.transport.servlet.CXFNonSpringServlet.invoke(CXFNonSpringServlet.java:225) ~[?:?]
	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.handleRequest(AbstractHTTPServlet.java:304) ~[?:?]
	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.doGet(AbstractHTTPServlet.java:222) ~[?:?]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:529) ~[tomcat-servlet-api_9.0.94.wso2v1.jar:?]
	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.service(AbstractHTTPServlet.java:279) ~[?:?]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:199) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:168) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:482) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:130) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.wso2.carbon.identity.context.rewrite.valve.TenantContextRewriteValve.invoke(TenantContextRewriteValve.java:119) ~[org.wso2.carbon.identity.context.rewrite.valve_1.8.41.jar:?]
	at org.wso2.carbon.identity.context.rewrite.valve.OrganizationContextRewriteValve.invoke(OrganizationContextRewriteValve.java:115) ~[org.wso2.carbon.identity.context.rewrite.valve_1.8.41.jar:?]
	at org.wso2.carbon.tomcat.ext.valves.SameSiteCookieValve.invoke(SameSiteCookieValve.java:38) ~[org.wso2.carbon.tomcat.ext_4.9.27.alpha.jar:?]
	at org.wso2.carbon.identity.authz.valve.AuthorizationValve.invoke(AuthorizationValve.java:167) ~[org.wso2.carbon.identity.authz.valve_1.8.41.jar:?]
	at org.wso2.carbon.identity.auth.valve.AuthenticationValve.invoke(AuthenticationValve.java:118) ~[org.wso2.carbon.identity.auth.valve_1.8.41.jar:?]
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.continueInvocation(CompositeValve.java:114) ~[org.wso2.carbon.tomcat.ext_4.9.27.alpha.jar:?]
	at org.wso2.carbon.tomcat.ext.valves.TomcatValveContainer.invokeValves(TomcatValveContainer.java:49) ~[org.wso2.carbon.tomcat.ext_4.9.27.alpha.jar:?]
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.invoke(CompositeValve.java:75) ~[org.wso2.carbon.tomcat.ext_4.9.27.alpha.jar:?]
	at org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve.invoke(CarbonStuckThreadDetectionValve.java:152) ~[org.wso2.carbon.tomcat.ext_4.9.27.alpha.jar:?]
	at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:660) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve.invoke(CarbonContextCreatorValve.java:63) ~[org.wso2.carbon.tomcat.ext_4.9.27.alpha.jar:?]
	at org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve.invoke(RequestCorrelationIdValve.java:137) ~[org.wso2.carbon.tomcat.ext_4.9.27.alpha.jar:?]
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:346) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:383) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:936) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1791) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1190) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659) ~[tomcat_9.0.94.wso2v1.jar:?]
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63) ~[tomcat_9.0.94.wso2v1.jar:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

- Related PR: https://github.com/wso2/carbon-apimgt/pull/12656