### PR TITLE
JNDI2 Config Upgrade for the Broker Connect Timeout and Upgrade Andes and Broker Versions

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/jndi2-cp.properties.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/jndi2-cp.properties.j2
@@ -19,12 +19,12 @@
         #connectionfactory.TopicConnectionFactory = amqp://{{apim.throttling.jms.username}}:{{apim.throttling.jms.password}}@clientid/carbon?brokerlist='{{apim.throttling.throttle_decision_endpoints | join("?retries='5'%26connectdelay='50';")}}?retries='5'%26connectdelay='50';'
         {% if apim.event_hub.event_duplicate_url is defined %}
         {% if (apim.event_hub.jms.username is defined) and (apim.event_hub.jms.password is defined) %}
-        connectionfactory.TopicConnectionFactory = amqp://{{apim.event_hub.jms.username}}:{{apim.event_hub.jms.password}}@clientid/carbon?brokerlist='{% for url in apim.event_hub.event_duplicate_url %}{{url}}?retries='5'%26connectdelay='50'{% if apim.event_hub.ssl is defined %}%26ssl='{{apim.event_hub.ssl}}'{% endif %};{% endfor %}'
+        connectionfactory.TopicConnectionFactory = amqp://{{apim.event_hub.jms.username}}:{{apim.event_hub.jms.password}}@clientid/carbon?brokerlist='{% for url in apim.event_hub.event_duplicate_url %}{{url}}{% if '?' in url %}%26{% else %}?{% endif %}retries='5'%26connectdelay='50'{% if apim.event_hub.ssl is defined %}%26ssl='{{apim.event_hub.ssl}}'{% endif %};{% endfor %}'
         {% else %}
-        connectionfactory.TopicConnectionFactory = amqp://{{apim.event_hub.username}}:{{apim.event_hub.password}}@clientid/carbon?brokerlist='{% for url in apim.event_hub.event_duplicate_url %}{{url}}?retries='5'%26connectdelay='50'{% if apim.event_hub.ssl is defined %}%26ssl='{{apim.event_hub.ssl}}'{% endif %};{% endfor %}'
+        connectionfactory.TopicConnectionFactory = amqp://{{apim.event_hub.username}}:{{apim.event_hub.password}}@clientid/carbon?brokerlist='{% for url in apim.event_hub.event_duplicate_url %}{{url}}{% if '?' in url %}%26{% else %}?{% endif %}retries='5'%26connectdelay='50'{% if apim.event_hub.ssl is defined %}%26ssl='{{apim.event_hub.ssl}}'{% endif %};{% endfor %}'
          {% endif %}
         {% elif apim.throttling.event_duplicate_url is defined %}
-        connectionfactory.TopicConnectionFactory = amqp://{{apim.throttling.jms.username}}:{{apim.throttling.jms.password}}@clientid/carbon?brokerlist='{% for url in apim.throttling.event_duplicate_url %}{{url}}?retries='5'%26connectdelay='50'{% if apim.throttling.jms.ssl is defined %}%26ssl='{{apim.throttling.jms.ssl}}'{% endif %};{% endfor %}'
+        connectionfactory.TopicConnectionFactory = amqp://{{apim.throttling.jms.username}}:{{apim.throttling.jms.password}}@clientid/carbon?brokerlist='{% for url in apim.throttling.event_duplicate_url %}{{url}}{% if '?' in url %}%26{% else %}?{% endif %}retries='5'%26connectdelay='50'{% if apim.throttling.jms.ssl is defined %}%26ssl='{{apim.throttling.jms.ssl}}'{% endif %};{% endfor %}'
         {% else %}
         connectionfactory.TopicConnectionFactory = amqp://{{apim.throttling.jms.username}}:{{apim.throttling.jms.password}}@clientid/carbon?brokerlist='tcp://${carbon.local.ip}:${jms.port}{% if apim.throttling.jms.ssl is defined %}?ssl='{{apim.throttling.jms.ssl}}'{% endif %}'
         {% endif %}

--- a/pom.xml
+++ b/pom.xml
@@ -2021,7 +2021,7 @@
         <carbon.apimgt.version>9.30.49-SNAPSHOT</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
-        <carbon.analytics.common.version>5.3.13</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.15</carbon.analytics.common.version>
         <!-- Carbon kernel version -->
         <carbon.kernel.version>4.9.27-alpha</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
@@ -2195,8 +2195,8 @@
         <fasterxml.jackson.version>2.17.2</fasterxml.jackson.version>
         <javax.validation-api>2.0.1.Final</javax.validation-api>
         <javax.inject.version>1</javax.inject.version>
-        <carbon.broker.version>3.3.33</carbon.broker.version>
-        <andes.version>3.3.29</andes.version>
+        <carbon.broker.version>3.3.35</carbon.broker.version>
+        <andes.version>3.3.33</andes.version>
         <waffle-jna.version>1.6.wso2v7</waffle-jna.version>
         <version.snake.yaml>2.2</version.snake.yaml>
         <wsdl4j.version>1.6.3.wso2v3</wsdl4j.version>


### PR DESCRIPTION
## Purpose
- Broker connect timeout cannot be explicitly configured for TM duplication URLs.
- Upgrade Andes and the Carbon Broker versions.

### Fix
Add a logic to the .j2 file to handle "connecttimeout" broker parameter.

- Related issue https://github.com/wso2/api-manager/issues/3125