### PR TITLE
Add llm related scope mappings to tenant-conf.json

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -368,6 +368,14 @@
       {
         "Name": "apim:gateway_policy_view",
         "Roles": "admin,Internal/creator,Internal/publisher,Internal/observer"
+      },
+      {
+        "Name": "apim:llm_provider_manage",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:llm_provider_read",
+        "Roles": "admin,Internal/publisher,Internal/creator"
       }
     ]
   },


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/3240

## Approach
The current `tenant-conf.json` is missing the newly introduced LLM-related scope mappings `apim:llm_provider_manage` and `apim:llm_provider_read`. As a result, the following warnings are triggered,
```bash
[2024-10-10 18:47:26,442]  WARN - SystemScopesMappingUtil The scope apim:llm_provider_manage does not exist in tenant.conf
[2024-10-10 18:47:26,442]  WARN - SystemScopesMappingUtil The scope apim:llm_provider_read does not exist in tenant.conf
```

This pr resolves the issue by adding the necessary scope mappings, specifically `apim:llm_provider_manage` scope to role `admin` and `apim:llm_provider_read` scope to `admin`, `Internal/publisher`, and `Internal/creator`.