### PR TITLE
Utilize `APIProvider` to retrieve all APIs in admin REST API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ApisApiServiceImpl.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.wso2.carbon.apimgt.api.APIAdmin;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.impl.APIAdminImpl;
@@ -63,16 +64,14 @@ public class ApisApiServiceImpl implements ApisApiService {
         limit = limit != null ? limit : RestApiConstants.PAGINATION_LIMIT_DEFAULT;
         offset = offset != null ? offset : RestApiConstants.PAGINATION_OFFSET_DEFAULT;
         query = query == null ? APIConstants.CHAR_ASTERIX : query;
-        APIAdmin apiAdmin = new APIAdminImpl();
+        APIProvider apiProvider = RestApiCommonUtil.getLoggedInUserProvider();
         String organization = RestApiUtil.getOrganization(messageContext);
-        Map<String, Object> result = apiAdmin
-                .searchPaginatedApis(query, organization, offset, limit);
+        Map<String, Object> result = apiProvider.searchPaginatedAPIs(query, organization, offset, limit, 
+                RestApiConstants.DEFAULT_SORT_BY, RestApiConstants.DEFAULT_SORT_ORDER);
         List<Object> apis = SearchApiServiceImplUtil.getAPIListFromAPISearchResult(result);
         List<ApiResultDTO> allMatchedResults = getAllMatchedResults(apis);
         resultListDTO.setApis(allMatchedResults);
         resultListDTO.setCount(allMatchedResults.size());
-        APIInfoMappingUtil.setPaginationParams(resultListDTO, limit, offset, (Integer) result
-                .get(APIConstants.ADMIN_API_LIST_RESPONSE_PARAMS_TOTAL));
         return Response.ok().entity(resultListDTO).build();
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/java/org/wso2/carbon/apimgt/rest/api/util/RestApiConstants.java
@@ -175,6 +175,7 @@ public final class RestApiConstants {
     public static final String PAGINATION_PREVIOUS_OFFSET = "previous_offset";
     public static final String PAGINATION_PREVIOUS_LIMIT = "previous_limit";
     public static final String DEFAULT_SORT_ORDER = "asc";
+    public static final String DEFAULT_SORT_BY = "apiName";
 
     public static final int TAG_LIMIT_DEFAULT = 1000;
     public static final int TAG_OFFSET_DEFAULT = 0;


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/3241

## Approach
The current implementation of the `getAllAPIs` method in the admin REST API relies on the `searchPaginatedApis` functionality from `APIAdmin`. This performs a content-based search that retrieves all APIs, API Products, and Documents, subject to a predefined constraint on the number of search results. As outlined in the issue, this approach may result in an empty API result set if the returned list only contains API Products and Documents.

This pr addresses the limitation by leveraging the `APIProvider`'s `searchPaginatedAPIs` method, which directly retrieves all APIs from `APIPersistence`. This change ensures that the API results are not impacted by the presence of other entities such as API Products and Documents.