### PR TITLE
Improve Generation of the API Definition for API Products

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -773,7 +773,11 @@ public class OASParserUtil {
             if (ref == null) {
                 if (schema instanceof ArraySchema) {
                     ArraySchema arraySchema = (ArraySchema) schema;
-                    ref = arraySchema.getItems().get$ref();
+                    Schema itemsSchema = arraySchema.getItems();
+                    ref = itemsSchema.get$ref();
+                    if (ref == null) {
+                        extractReferenceFromSchema(itemsSchema, context);
+                    }
                 } else if (schema instanceof ObjectSchema) {
                     references = addSchemaOfSchema(schema);
                 } else if (schema instanceof MapSchema) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -799,7 +799,8 @@ public class OASParserUtil {
                                 }
                             }
                         }
-                    } else if (((ComposedSchema) schema).getAnyOf() != null) {
+                    }
+                    if (((ComposedSchema) schema).getAnyOf() != null) {
                         for (Schema sc : ((ComposedSchema) schema).getAnyOf()) {
                             if (OBJECT_DATA_TYPE.equalsIgnoreCase(sc.getType())) {
                                 references.addAll(addSchemaOfSchema(sc));
@@ -812,7 +813,8 @@ public class OASParserUtil {
                                 }
                             }
                         }
-                    } else if (((ComposedSchema) schema).getOneOf() != null) {
+                    }
+                    if (((ComposedSchema) schema).getOneOf() != null) {
                         for (Schema sc : ((ComposedSchema) schema).getOneOf()) {
                             if (OBJECT_DATA_TYPE.equalsIgnoreCase(sc.getType())) {
                                 references.addAll(addSchemaOfSchema(sc));
@@ -825,7 +827,10 @@ public class OASParserUtil {
                                 }
                             }
                         }
-                    } else {
+                    }
+                    if (((ComposedSchema) schema).getAllOf() == null &&
+                            ((ComposedSchema) schema).getAnyOf() == null &&
+                            ((ComposedSchema) schema).getOneOf() == null) {
                         log.error("Unidentified schema. The schema is not available in the API definition.");
                     }
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -774,8 +774,10 @@ public class OASParserUtil {
                 if (schema instanceof ArraySchema) {
                     ArraySchema arraySchema = (ArraySchema) schema;
                     Schema itemsSchema = arraySchema.getItems();
+                    // Process $ref items
                     ref = itemsSchema.get$ref();
                     if (ref == null) {
+                        // Process items in the form of Composed Schema such as allOf, oneOf, anyOf
                         extractReferenceFromSchema(itemsSchema, context);
                     }
                 } else if (schema instanceof ObjectSchema) {


### PR DESCRIPTION
### Purpose
- This PR adds the following improvements in the generation of the API definition for API products
  - Support for $ref reference within a Composed schema (allOf) in items of array schema
  - Support for $ref reference in header objects of responses 

### Approach
- Added the logic to process $ref reference within a Composed schemas in items of array schema
- Refactored the code segment of extracting references from composed schemas
- Added the logic to process $ref entries in header fields of response headers

### Related Issues
- https://github.com/wso2/api-manager/issues/3132
- https://github.com/wso2/api-manager/issues/3304