### PR TITLE
Fix Early Throttling by Adding Timestamp Check to Throttling Logic and Refine Throttling Related Unit Tests

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/ThrottleStreamProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/main/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/ThrottleStreamProcessor.java
@@ -131,7 +131,12 @@ public class ThrottleStreamProcessor extends StreamProcessor implements Scheduli
                            StreamEventCloner streamEventCloner, ComplexEventPopulater complexEventPopulater) {
 
         synchronized (this) {
-            if (expireEventTime == -1) {
+            if (expireEventTime != -1) {
+                if (expireEventTime - timeInMilliSeconds > streamEventChunk.getLast().getTimestamp()) {
+                    // if the event chunk is older than the current window, drop the chunk
+                    return;
+                }
+            } else {
                 long currentTime = executionPlanContext.getTimestampGenerator().currentTime();
                 if (startTime != -1) {
                     expireEventTime = addTimeShift(currentTime);

--- a/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/ThrottleTimeBatchWindowTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttling.siddhi.extension/src/test/java/org/wso2/carbon/apimgt/throttling/siddhi/extension/ThrottleTimeBatchWindowTestCase.java
@@ -171,7 +171,7 @@ public class ThrottleTimeBatchWindowTestCase {
         executionPlanRuntime.start();
         inputHandler.send(new Object[]{"IBM", 700f, 0});
         inputHandler.send(new Object[]{"WSO2", 60.5f, 1});
-        Thread.sleep(260000);
+        Thread.sleep(121000);
         inputHandler.send(new Object[]{"IBM", 700f, 0});
         Assert.assertEquals(3, inEventCount);
         Assert.assertTrue("Event expiry time is not valid for the current batch" , (Long) (lastCurrentEvent.getData()[3]) >= System.currentTimeMillis());


### PR DESCRIPTION
### Description
When the TM receives events, it currently places them into the current bucket without considering the original event generation timestamp. As a result, events generated before downtime are counted toward the active throttling period, leading to early throttling.

### Fix
This PR adds a timestamp check to the throttling logic to ensure that each event is evaluated based on its generation time. By incorporating this timestamp, events generated before downtime are dropped, preventing them from causing premature throttling when a DC resumes operation.

- Resolves https://github.com/wso2/api-manager/issues/3322