### PR TITLE
Increase the Max Length of the API Provider Field

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2569,7 +2569,7 @@ public final class APIConstants {
 
     public static final int MAX_LENGTH_API_NAME = 60;
     public static final int MAX_LENGTH_VERSION = 30;
-    public static final int MAX_LENGTH_PROVIDER = 50;
+    public static final int MAX_LENGTH_PROVIDER = 200;
     public static final int MAX_LENGTH_CONTEXT = 232; //context becomes context + version + two '/'. Max context is 200
     public static final int MAX_LENGTH_MEDIATION_POLICY_NAME = 255;
 


### PR DESCRIPTION
### Description
This PR increase the maximum length of the API Provider to overcome issues when the API Creator's username length is a larger value

Resolves https://github.com/wso2/api-manager/issues/3365