### PR TITLE
Fix publishing analytics event after responseSize calculation in WebSocket messages

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
@@ -125,7 +125,6 @@ public class WebsocketHandler extends CombinedChannelDuplexHandler<WebsocketInbo
                     log.debug(channelId + " -- Websocket API request [outbound] : Sending Outbound Websocket frame." +
                             ctx.channel().toString());
                 }
-                outboundHandler().write(ctx, msg, promise);
                 if (APIUtil.isAnalyticsEnabled()) {
                     WebSocketUtils.setApiPropertyToChannel(ctx, Constants.BACKEND_END_TIME_PROPERTY,
                             System.currentTimeMillis());
@@ -134,6 +133,7 @@ public class WebsocketHandler extends CombinedChannelDuplexHandler<WebsocketInbo
                                     ((TextWebSocketFrame) msg).text().length());
                     }
                 }
+                outboundHandler().write(ctx, msg, promise);
                 // publish analytics events if analytics is enabled
                 publishSubscribeEvent(ctx);
             }


### PR DESCRIPTION
## Purpose
$Subject.

When analytics is enabled, after sending a websocket text message frame to `outboundhandler().write()` in `WebsocketHandler`, we read that WebSocket text message frame again to calculate the message length. This causes an `IllegalReferenceCountException` (which is thrown but absorbed) -  causing the analytics event not published afterwards.

This PR fixes the above issue by reading the text message frame first, and then sending it to `outboundhandler().write()`.