### PR TITLE
Fix Default API Context Generation Issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/subscription/API.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/subscription/API.java
@@ -37,6 +37,7 @@ public class API implements CacheableEntity<String> {
     private String name = null;
     private String version = null;
     private String context = null;
+    private String contextTemplate = null;
     private String policy = null;
     private String apiType = null;
     private Boolean isDefaultVersion = false;
@@ -103,6 +104,16 @@ public class API implements CacheableEntity<String> {
     public void setContext(String context) {
 
         this.context = context;
+    }
+
+    public String getContextTemplate() {
+
+        return contextTemplate;
+    }
+
+    public void setContextTemplate(String contextTemplate) {
+
+        this.contextTemplate = contextTemplate;
     }
 
     public String getProvider() {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/SubscriptionValidationDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/SubscriptionValidationDAO.java
@@ -432,6 +432,7 @@ public class SubscriptionValidationDAO {
                         api.setOrganization(resultSet.getString("ORGANIZATION"));
                         String publishedDefaultApiVersion = resultSet.getString("PUBLISHED_DEFAULT_API_VERSION");
                         String contextTemplate = resultSet.getString("CONTEXT_TEMPLATE");
+                        api.setContextTemplate(contextTemplate);
 
                         setDefaultVersionContext(apiType, api, version, publishedDefaultApiVersion, context, contextTemplate);
 
@@ -1151,6 +1152,7 @@ public class SubscriptionValidationDAO {
                         }
                         String publishedDefaultApiVersion = resultSet.getString("PUBLISHED_DEFAULT_API_VERSION");
                         String contextTemplate = resultSet.getString("CONTEXT_TEMPLATE");
+                        api.setContextTemplate(contextTemplate);
 
                         setDefaultVersionContext(apiType, api, version, publishedDefaultApiVersion, context,
                                 contextTemplate);
@@ -1192,6 +1194,7 @@ public class SubscriptionValidationDAO {
             }
             String synapseContext = context + "/" + APIConstants.API_PRODUCT_VERSION_1_0_0;
             api.setContext(synapseContext);
+            api.setContextTemplate(context);
         }
     }
 
@@ -1267,6 +1270,7 @@ public class SubscriptionValidationDAO {
                         api.setApiType(apiType);
                         api.setPolicy(resultSet.getString("API_TIER"));
                         api.setContext(resultSet.getString("CONTEXT"));
+                        api.setContextTemplate(resultSet.getString("CONTEXT_TEMPLATE"));
                         String revision = resultSet.getString("REVISION_UUID");
                         api.setStatus(resultSet.getString("STATUS"));
                         api.setOrganization(resultSet.getString("ORGANIZATION"));
@@ -1486,6 +1490,7 @@ public class SubscriptionValidationDAO {
                         api.setPolicy(resultSet.getString("API_TIER"));
                         api.setContext(context);
                         api.setStatus(resultSet.getString("STATUS"));
+                        api.setContextTemplate(contextTemplate);
                         if (resultSet.getString("IS_EGRESS") != null) {
                             api.setEgress(parseInt(resultSet.getString("IS_EGRESS")));
                         }
@@ -1591,6 +1596,7 @@ public class SubscriptionValidationDAO {
                         }
                         String publishedDefaultApiVersion = resultSet.getString("PUBLISHED_DEFAULT_API_VERSION");
                         String contextTemplate = resultSet.getString("CONTEXT_TEMPLATE");
+                        api.setContextTemplate(contextTemplate);
 
                         setDefaultVersionContext(apiType, api, version, publishedDefaultApiVersion, context,
                                 contextTemplate);

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/dto/APIDTO.java
@@ -26,6 +26,7 @@ public class APIDTO   {
     private String name = null;
     private String version = null;
     private String context = null;
+    private String contextTemplate = null;
     private String policy = null;
     private String apiType = null;
     private String status = null;
@@ -143,6 +144,24 @@ public class APIDTO   {
   }
   public void setContext(String context) {
     this.context = context;
+  }
+
+  /**
+   * Context template of the API.
+   **/
+  public APIDTO contextTemplate(String contextTemplate) {
+    this.contextTemplate = contextTemplate;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Context template of the API.")
+  @JsonProperty("contextTemplate")
+  public String getContextTemplate() {
+    return contextTemplate;
+  }
+  public void setContextTemplate(String contextTemplate) {
+    this.contextTemplate = contextTemplate;
   }
 
   /**
@@ -357,6 +376,7 @@ public class APIDTO   {
         Objects.equals(name, API.name) &&
         Objects.equals(version, API.version) &&
         Objects.equals(context, API.context) &&
+        Objects.equals(contextTemplate, API.contextTemplate) &&
         Objects.equals(policy, API.policy) &&
         Objects.equals(apiType, API.apiType) &&
         Objects.equals(status, API.status) &&
@@ -372,7 +392,7 @@ public class APIDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(uuid, apiId, provider, name, version, context, policy, apiType, status, organization, isDefaultVersion, apiPolicies, urlMappings, securityScheme, isSubscriptionValidationDisabled, isEgress, subtype);
+    return Objects.hash(uuid, apiId, provider, name, version, context, contextTemplate, policy, apiType, status, organization, isDefaultVersion, apiPolicies, urlMappings, securityScheme, isSubscriptionValidationDisabled, isEgress, subtype);
   }
 
   @Override
@@ -386,6 +406,7 @@ public class APIDTO   {
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("    context: ").append(toIndentedString(context)).append("\n");
+    sb.append("    contextTemplate: ").append(toIndentedString(contextTemplate)).append("\n");
     sb.append("    policy: ").append(toIndentedString(policy)).append("\n");
     sb.append("    apiType: ").append(toIndentedString(apiType)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/utils/SubscriptionValidationDataUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/utils/SubscriptionValidationDataUtil.java
@@ -67,6 +67,7 @@ public class SubscriptionValidationDataUtil {
             apidto.setVersion(model.getVersion());
             apidto.setName(model.getName());
             apidto.setContext(model.getContext());
+            apidto.setContextTemplate(model.getContextTemplate());
             apidto.setPolicy(model.getPolicy());
             apidto.setProvider(model.getProvider());
             apidto.setApiType(model.getApiType());
@@ -134,6 +135,7 @@ public class SubscriptionValidationDataUtil {
             apidto.setApiId(model.getApiId());
             apidto.setVersion(model.getVersion());
             apidto.setContext(model.getContext());
+            apidto.setContextTemplate(model.getContextTemplate());
             apidto.setPolicy(model.getPolicy());
             apidto.setProvider(model.getProvider());
             apidto.setApiType(model.getApiType());

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/resources/api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/resources/api.yaml
@@ -1044,6 +1044,9 @@ definitions:
       context:
         type: string
         description: Context of the API.
+      contextTemplate:
+        type: string
+        description: Context template of the API.
       policy:
         type: string
         description: API level throttling policy.

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/entity/API.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/entity/API.java
@@ -35,6 +35,7 @@ public class API implements CacheableEntity<String> {
     private String name = null;
     private String version = null;
     private String context = null;
+    private String contextTemplate = null;
     private String policy = null;
     private String apiType = null;
     private String status;
@@ -131,6 +132,16 @@ public class API implements CacheableEntity<String> {
         this.context = context;
     }
 
+    public String getContextTemplate() {
+
+        return contextTemplate;
+    }
+
+    public void setContextTemplate(String contextTemplate) {
+
+        this.contextTemplate = contextTemplate;
+    }
+
     public String getApiTier() {
 
         return policy;
@@ -206,6 +217,7 @@ public class API implements CacheableEntity<String> {
                 ", name='" + name + '\'' +
                 ", version='" + version + '\'' +
                 ", context='" + context + '\'' +
+                ", contextTemplate='" + contextTemplate + '\'' +
                 ", policy='" + policy + '\'' +
                 ", apiType='" + apiType + '\'' +
                 ", status='" + status + '\'' +

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/impl/SubscriptionDataStoreImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/impl/SubscriptionDataStoreImpl.java
@@ -774,13 +774,18 @@ public class SubscriptionDataStoreImpl implements SubscriptionDataStore {
         for (API api : apiMap.values()) {
             apiContextAPIMap.put(api.getContext(), api);
             if (api.isDefaultVersion()) {
-                String context = api.getContext();
-                String defaultContext = context;
-                int index =  context.lastIndexOf("/" + api.getApiVersion());
-                if (index != -1) {
-                    defaultContext = context.substring(0, index);
+                if (api.getContextTemplate() != null) {
+                    String context = api.getContextTemplate().replace("/" + APIConstants.VERSION_PLACEHOLDER, "")
+                            .replace(APIConstants.VERSION_PLACEHOLDER, "");
+                    apiContextAPIMap.put(context, api);
+                } else {
+                    String context = api.getContext();
+                    int index =  context.lastIndexOf("/" + api.getApiVersion());
+                    if (index >= 0) {
+                        context = context.substring(0, index);
+                    }
+                    apiContextAPIMap.put(context, api);
                 }
-                apiContextAPIMap.put(defaultContext, api);
             }
         }
         return apiContextAPIMap;


### PR DESCRIPTION
### Description
This PR resolves an issue with generating the default version context for APIs. Previously, the implementation unintentionally removed multiple occurrences of /version-like segments from the API context, even when these segments were not part of the version.

### Fix
The fix utilizes the CONTEXT_TEMPLATE stored in the database to generate the default version context. Specifically, all occurrences of /{version} and {version} are removed from the CONTEXT_TEMPLATE, and the resulting string is used as the context for the default version.
- Resolves https://github.com/wso2/api-manager/issues/3364
