### PR TITLE
Log the connected TM server over the JMS connection during the start-up of the GW server

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.jms/src/main/java/org/wso2/carbon/apimgt/common/jms/JMSListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.jms/src/main/java/org/wso2/carbon/apimgt/common/jms/JMSListener.java
@@ -153,7 +153,9 @@ public class JMSListener implements Runnable {
                 }
             }
         }
-
+        log.info("Connection successfully created towards the JMS provider for the listener: " +
+                stm.getJmsConsumerName() + "#" + stm.getDestinationJNDIName() + ". The connected JMS provider is " +
+                connection.toString().replace("\n", " | "));
         return (connection != null);
     }
 


### PR DESCRIPTION
## Purpose
There is a need to log the currently connected TM of the GW server in the JMS connection for trouble shooting purposes.
Related to - https://github.com/wso2/api-manager/issues/3323

## Approach
Log the `stm.getJmsConsumerName()`, `stm.getDestinationJNDIName()` and `connection` at `INFO` level.