### PR TITLE
Add enable/disable deploying in-memory JWKS Api and Fix block subscription for production only bug

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.apimgt.gateway.internal.DataHolder;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.service.APIGatewayAdmin;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.dto.ExtendedJWTConfigurationDto;
 import org.wso2.carbon.apimgt.impl.dto.GatewayArtifactSynchronizerProperties;
 import org.wso2.carbon.apimgt.impl.dto.GatewayCleanupSkipList;
 import org.wso2.carbon.apimgt.impl.gatewayartifactsynchronizer.ArtifactRetriever;
@@ -210,7 +211,11 @@ public class InMemoryAPIDeployer {
 
         if (!redeployChangedAPIs) {
             try {
-                deployJWKSSynapseAPI(tenantDomain); // Deploy JWKS API
+                boolean isJWKSApiEnabled =  ServiceReferenceHolder
+                        .getInstance().getAPIManagerConfiguration().getJwtConfigurationDto().isJWKSApiEnabled();
+                if(isJWKSApiEnabled) {
+                    deployJWKSSynapseAPI(tenantDomain); // Deploy JWKS API
+                }
                 if (APIConstants.SUPER_TENANT_DOMAIN.equalsIgnoreCase(tenantDomain)) {
                     deployHealthCheckSynapseAPI(tenantDomain); // Deploy HealthCheck API for the super tenant
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/DefaultAPIHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/DefaultAPIHandler.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.common.gateway.constants.HealthCheckConstants;
 import org.wso2.carbon.apimgt.common.gateway.constants.JWTConstants;
 import org.wso2.carbon.apimgt.gateway.InMemoryAPIDeployer;
+import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.gatewayartifactsynchronizer.exception.ArtifactSynchronizerException;
@@ -62,7 +63,10 @@ public class DefaultAPIHandler extends AbstractSynapseHandler {
             }
         }
 
-        if (isJWKSEndpoint) {
+        boolean isJWKSApiEnabled =  ServiceReferenceHolder
+                .getInstance().getAPIManagerConfiguration().getJwtConfigurationDto().isJWKSApiEnabled();
+
+        if (isJWKSEndpoint && isJWKSApiEnabled) {
             try {
                 InMemoryAPIDeployer.deployJWKSSynapseAPI(tenantDomain);
             } catch(APIManagementException e){

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidator.java
@@ -743,9 +743,9 @@ public class APIKeyValidator {
     }
 
     public APIKeyValidationInfoDTO validateSubscription(String context, String version, int appID,
-                                                        String tenantDomain)
+                                                        String tenantDomain, String keyType)
             throws APISecurityException {
-        return dataStore.validateSubscription(context, version, appID,tenantDomain);
+        return dataStore.validateSubscription(context, version, appID,tenantDomain, keyType);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/APIKeyDataStore.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/APIKeyDataStore.java
@@ -107,7 +107,7 @@ public interface APIKeyDataStore {
      * @return an APIKeyValidationInfoDTO instance containing key validation data
      * @throws org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityException on error
      */
-    APIKeyValidationInfoDTO validateSubscription(String context, String version, int appId, String tenantDomain)
+    APIKeyValidationInfoDTO validateSubscription(String context, String version, int appId, String tenantDomain, String keyType)
             throws APISecurityException;
     /**
      * Validate scopes bound to the resource of the API being invoked against the scopes of the token.

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/APIKeyValidatorClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/APIKeyValidatorClient.java
@@ -76,12 +76,12 @@ public class APIKeyValidatorClient {
     }
 
     public APIKeyValidationInfoDTO validateSubscription(String context, String version, int appId,
-                                                        String tenantDomain)
+                                                        String tenantDomain, String keyType)
             throws APISecurityException {
 
         try {
             return apiKeyValidationService
-                    .validateSubscription(context, version, appId, tenantDomain);
+                    .validateSubscription(context, version, appId, tenantDomain, keyType);
         } catch (APIKeyMgtException | APIManagementException e) {
             log.error("Error while  validate subscriptions", e);
             throw new APISecurityException(APISecurityConstants.API_AUTH_GENERAL_ERROR,

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/WSAPIKeyDataStore.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/WSAPIKeyDataStore.java
@@ -107,11 +107,11 @@ public class WSAPIKeyDataStore implements APIKeyDataStore {
 
     @Override
     public APIKeyValidationInfoDTO validateSubscription(String context, String version, int appId,
-                                                        String tenantDomain)
+                                                        String tenantDomain, String keyType)
             throws APISecurityException {
         APIKeyValidatorClient client = new APIKeyValidatorClient();
         try {
-            return client.validateSubscription(context, version, appId, tenantDomain);
+            return client.validateSubscription(context, version, appId, tenantDomain, keyType);
         } catch (APISecurityException ex) {
             throw new APISecurityException(ex.getErrorCode(),
                     "Resource forbidden", ex);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -796,6 +796,7 @@ public class GatewayUtils {
         APIKeyValidator apiKeyValidator = new APIKeyValidator();
         APIKeyValidationInfoDTO apiKeyValidationInfoDTO = null;
         JSONObject application;
+        String keyType = (String) payload.getClaim(APIConstants.JwtTokenConstants.KEY_TYPE);
         int appId = 0;
         if (payload.getClaim(APIConstants.JwtTokenConstants.APPLICATION) != null) {
             try {
@@ -813,7 +814,7 @@ public class GatewayUtils {
         // if the appId is equal to 0 then it's a internal key
         if (appId != 0) {
             apiKeyValidationInfoDTO =
-                    apiKeyValidator.validateSubscription(apiContext, apiVersion, appId, getTenantDomain());
+                    apiKeyValidator.validateSubscription(apiContext, apiVersion, appId, getTenantDomain(), keyType);
         }
 
         if (payload.getClaim(APIConstants.JwtTokenConstants.SUBSCRIBED_APIS) != null) {
@@ -887,6 +888,7 @@ public class GatewayUtils {
 
         APIKeyValidator apiKeyValidator = new APIKeyValidator();
         APIKeyValidationInfoDTO apiKeyValidationInfoDTO = null;
+        String keyType = (String) payload.getClaim(APIConstants.JwtTokenConstants.KEY_TYPE);
         int appId = 0;
         if (payload.getClaim(APIConstants.JwtTokenConstants.APPLICATION) != null) {
             try {
@@ -904,13 +906,12 @@ public class GatewayUtils {
         // if the appId is equal to 0 then it's a internal key
         if (appId != 0) {
             apiKeyValidationInfoDTO =
-                    apiKeyValidator.validateSubscription(apiContext, apiVersion, appId, getTenantDomain());
+                    apiKeyValidator.validateSubscription(apiContext, apiVersion, appId, getTenantDomain(), keyType);
             if (apiKeyValidationInfoDTO.isAuthorized()) {
                 if (log.isDebugEnabled()) {
                     log.debug("User is subscribed to the API: " + apiContext + ", " +
                             "version: " + apiVersion + ". Token: " + getMaskedToken(token));
                 }
-                String keyType = (String) payload.getClaim(APIConstants.JwtTokenConstants.KEY_TYPE);
                 apiKeyValidationInfoDTO.setType(keyType);
             } else {
                 if (log.isDebugEnabled()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/DefaultAPIHandlerTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/handlers/DefaultAPIHandlerTest.java
@@ -29,8 +29,11 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.dto.ExtendedJWTConfigurationDto;
 import org.wso2.carbon.apimgt.keymgt.model.entity.API;
 import org.wso2.carbon.inbound.endpoint.protocol.websocket.InboundWebsocketConstants;
 
@@ -38,14 +41,27 @@ import java.util.Set;
 import java.util.TreeMap;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ApiUtils.class, Utils.class, GatewayUtils.class})
+@PrepareForTest({ApiUtils.class, Utils.class, GatewayUtils.class, ServiceReferenceHolder.class, APIManagerConfiguration.class, ExtendedJWTConfigurationDto.class})
 public class DefaultAPIHandlerTest {
+
+    private ServiceReferenceHolder serviceReferenceHolder;
+    private APIManagerConfiguration apiManagerConfiguration;
+    private ExtendedJWTConfigurationDto extendedJWTConfigurationDto;
 
     @Before
     public void init() {
         PowerMockito.mockStatic(ApiUtils.class);
         PowerMockito.mockStatic(Utils.class);
         PowerMockito.mockStatic(GatewayUtils.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
+        extendedJWTConfigurationDto = Mockito.mock(ExtendedJWTConfigurationDto.class);
+        Mockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfiguration()).thenReturn(apiManagerConfiguration);
+        Mockito.when(apiManagerConfiguration.getJwtConfigurationDto()).thenReturn(extendedJWTConfigurationDto);
+        Mockito.when(extendedJWTConfigurationDto.isJWKSApiEnabled()).thenReturn(true);
+
     }
 
     @Test

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -464,6 +464,7 @@ public final class APIConstants {
     public static final String BINDING_FEDERATED_USER_CLAIMS = "EnableBindingFederatedUserClaims";
     public static final String TOKEN_GENERATOR_IMPL = "JWTGeneratorImpl";
     public static final String ENABLE_JWT_GENERATION = "EnableJWTGeneration";
+    public static final String Enable_JWKS_API = "EnableJWKSApi";
     public static final String CLAIMS_RETRIEVER_CLASS = "ClaimsRetrieverImplClass";
     public static final String USE_KID = "UseKidProperty";
     public static final String CONSUMER_DIALECT_URI = "ConsumerDialectURI";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -1787,6 +1787,10 @@ public class APIManagerConfiguration {
                 }
             }
         }
+
+        OMElement jwksApiEnableElement =
+                omElement.getFirstChildWithName(new QName(APIConstants.Enable_JWKS_API));
+        jwtConfigurationDto.setJWKSApiEnabled(Boolean.parseBoolean(jwksApiEnableElement.getText()));
     }
 
     public ThrottleProperties getThrottleProperties() {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ExtendedJWTConfigurationDto.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ExtendedJWTConfigurationDto.java
@@ -8,6 +8,7 @@ public class ExtendedJWTConfigurationDto extends JWTConfigurationDto {
     private boolean tenantBasedSigningEnabled;
     private boolean enableUserClaimRetrievalFromUserStore;
     private boolean isBindFederatedUserClaims;
+    private boolean isJWKSApiEnabled;
 
     public String getClaimRetrieverImplClass() {
 
@@ -57,5 +58,13 @@ public class ExtendedJWTConfigurationDto extends JWTConfigurationDto {
     public void setBindFederatedUserClaims(boolean isBindFederatedUserClaims) {
 
         this.isBindFederatedUserClaims = isBindFederatedUserClaims;
+    }
+
+    public boolean isJWKSApiEnabled() {
+        return isJWKSApiEnabled;
+    }
+
+    public void setJWKSApiEnabled(boolean JWKSApiEnabled) {
+        this.isJWKSApiEnabled = JWKSApiEnabled;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/APIMgtDAOTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/APIMgtDAOTest.java
@@ -1818,12 +1818,13 @@ public class APIMgtDAOTest {
     }
 
     /**
-     * Test for getAPIRevisionDeploymentsByWorkflowStatusAndApiUUID method
-     * Checks whether the API revision deployment mapping details are retrieved correctly
+     * Test for testGetAndUpdateAPIRevisionDeploymentsByWorkflowStatusAndApiUUID method
+     * Checks whether the API revision deployment mapping details are retrieved correctly and
+     * Checks whether the API revision deployment status is updated correctly
      * @throws APIManagementException if an error occurs while retrieving revision deployment mapping details
      */
     @Test
-    public void testGetAPIRevisionDeploymentsByWorkflowStatusAndApiUUID() throws Exception {
+    public void testGetAndUpdateAPIRevisionDeploymentsByWorkflowStatusAndApiUUID() throws Exception {
         String workflowStatus = "CREATED";
         String apiUUID = "7af95c9d-6177-4191-ab3e-d3f6c1cdc4c2";
         String revisionUUID = "821b9664-eeca-4173-9f56-3dc6d46bd6eb";
@@ -1836,24 +1837,14 @@ public class APIMgtDAOTest {
         Assert.assertNotNull(apiRevisionDeployment);
         Assert.assertEquals(apiRevisionDeployment.getDeployment(), deployment);
         Assert.assertEquals(apiRevisionDeployment.getRevisionUUID(), revisionUUID);
-    }
 
-    /**
-     * Test for updateAPIRevisionDeploymentStatus method
-     * Checks whether the API revision deployment status is updated correctly
-     * @throws APIManagementException if an error occurs while updating revision deployment status
-     */
-    @Test public void testUpdateAPIRevisionDeploymentStatus() throws Exception {
-        String workflowStatus = "APPROVED";
-        String revisionUUID = "821b9664-eeca-4173-9f56-3dc6d46bd6eb";
-        String apiId = "7af95c9d-6177-4191-ab3e-d3f6c1cdc4c2";
-        String deployment = "default";
-        apiMgtDAO.updateAPIRevisionDeploymentStatus(revisionUUID, workflowStatus, deployment);
-        List<APIRevisionDeployment> apiRevisionDeployments = apiMgtDAO.getAPIRevisionDeploymentByApiUUID(apiId);
-        Assert.assertNotNull(apiRevisionDeployments);
-        APIRevisionDeployment apiRevisionDeployment = apiRevisionDeployments.get(0);
-        Assert.assertNotNull(apiRevisionDeployment);
-        Assert.assertEquals(org.wso2.carbon.apimgt.api.WorkflowStatus.APPROVED,apiRevisionDeployment.getStatus());
+        String workflowStatus2 = "APPROVED";
+        apiMgtDAO.updateAPIRevisionDeploymentStatus(revisionUUID, workflowStatus2, deployment);
+        List<APIRevisionDeployment> apiRevisionDeployments2 = apiMgtDAO.getAPIRevisionDeploymentByApiUUID(apiUUID);
+        Assert.assertNotNull(apiRevisionDeployments2);
+        APIRevisionDeployment apiRevisionDeployment2 = apiRevisionDeployments2.get(0);
+        Assert.assertNotNull(apiRevisionDeployment2);
+        Assert.assertEquals(org.wso2.carbon.apimgt.api.WorkflowStatus.APPROVED,apiRevisionDeployment2.getStatus());
     }
 
     @Test

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/amConfig.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/resources/amConfig.xml
@@ -11,6 +11,7 @@
     </Database>
     <JWTConfiguration>
         <EnableJWTGeneration>false</EnableJWTGeneration>
+        <EnableJWKSApi>true</EnableJWKSApi>
 	    <SignatureAlgorithm>NONE</SignatureAlgorithm>
     </JWTConfiguration>
     <APIUsageTracking>

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/KeyValidationHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/KeyValidationHandler.java
@@ -54,7 +54,7 @@ public interface KeyValidationHandler {
      * @param appId
      * @return APIKeyValidationInfoDTO instance containing key validation data
      */
-    APIKeyValidationInfoDTO validateSubscription(String apiContext, String apiVersion, int appId);
+    APIKeyValidationInfoDTO validateSubscription(String apiContext, String apiVersion, int appId, String keyType);
 
     /**
      * Validate Scopes  by oAuth2TokenValidationMessageContext

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyValidationService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyValidationService.java
@@ -507,11 +507,11 @@ public class APIKeyValidationService {
      * @throws APIManagementException in case of APIM Component initialization failure
      */
     public APIKeyValidationInfoDTO validateSubscription(String context, String version, int appId,
-                                                        String tenantDomain)
+                                                        String tenantDomain, String keyType)
             throws APIKeyMgtException, APIManagementException {
         KeyValidationHandler keyValidationHandler =
                 ServiceReferenceHolder.getInstance().getKeyValidationHandler(tenantDomain);
-        return keyValidationHandler.validateSubscription(context, version, appId);
+        return keyValidationHandler.validateSubscription(context, version, appId, keyType);
     }
 
     public Map<String, Scope> retrieveScopes(String tenantDomain) {

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/resources/amConfig.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/test/resources/amConfig.xml
@@ -11,6 +11,7 @@
     </Database>
     <JWTConfiguration>
         <EnableJWTGeneration>true</EnableJWTGeneration>
+        <EnableJWKSApi>true</EnableJWKSApi>
         <SignatureAlgorithm>NONE</SignatureAlgorithm>
         <UseSHA256Hash>false</UseSHA256Hash>
     </JWTConfiguration>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -22,6 +22,7 @@
   "apim.gateway_type": "Regular",
   "apim.enable_secure_vault": "false",
   "apim.jwt.enable": false,
+  "apim.jwt.enable_jwks_api": true,
   "apim.jwt.header": "X-JWT-Assertion",
   "apim.jwt.claim_dialect": "http://wso2.org/claims",
   "apim.jwt.convert_dialect": false,

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -36,7 +36,8 @@
     <JWTConfiguration>
         <!-- Enable/Disable JWT generation. Default is false. -->
         <EnableJWTGeneration>{{apim.jwt.enable}}</EnableJWTGeneration>
-
+        <!-- Enable/Disable JWKS in memory API deployment. Default is true. -->
+        <EnableJWKSApi>{{apim.jwt.enable_jwks_api}}</EnableJWKSApi>
         <!-- Name of the security context header to be added to the validated requests. -->
         <JWTHeader>{{apim.jwt.header}}</JWTHeader>
 


### PR DESCRIPTION
## Purpose

- Provide the configuration support to disable the deployment of the in memory JWKS api.
- Update Unit tests to include the updated config for JWKS api enabling/disabling
- Fix sandbox invocation using API key is blocked when subscription is blocked for production only.
- Currently instead of key type, application token type  is used to determine if the API key is production or sandbox type in the above condition giving the incorrect behaviour.
- Fixes https://github.com/wso2/api-manager/issues/3136
- Fixes https://github.com/wso2/api-manager/issues/3395

## Implementation

- Add `EnableJWKSApi` configuration constant to enable/disable JWKS Api
- Using the set configuration value check the condition if to deploy the JWKS Api
- Add default value to `EnableJWKSApi` configuration in amConfig.xml
- Mock the method call chain in `DefaultAPIHandlerTest` to retrieve the above configuration value using the method `isJWKSApiEnabled`
- Pass keyType to AbstractKeyValidationHandler from GatewayUtils through the value extracted from the API key payload to fix the 'block subscription for production only' applying to sandbox API key.

## Additional Notes

- This PR includes a fix for an intermittent failure in `testGetAPIRevisionDeploymentsByWorkflowStatusAndApiUUID` unit test
- The failure occurs due to the expected order with `testUpdateAPIRevisionDeploymentStatus` test where the above test case should run before this (JUnit does not run test cases in the order of the code written [[1]](https://junit.org/junit5/docs/current/user-guide/#writing-tests-test-execution-order)).
- To fix this issue, these two test cases were combined to a single test case

[1] - https://junit.org/junit5/docs/current/user-guide/#writing-tests-test-execution-order