### PR TITLE
Make Policy Path Comparison Case-Insensitive

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2751,7 +2751,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
             int prependIndex = apiPath.lastIndexOf("/api");
             String apiResourcePath = apiPath.substring(0, prependIndex);
             String policyPath = GovernanceUtils.getArtifactPath(registry, mediationPolicyId);
-            if (!policyPath.startsWith(apiResourcePath)) {
+            if (!policyPath.toLowerCase().startsWith(apiResourcePath.toLowerCase())) {
                 throw new MediationPolicyPersistenceException("Policy not foud ", ExceptionCodes.POLICY_NOT_FOUND);
             }
             Resource mediationResource = registry.get(policyPath);


### PR DESCRIPTION
### Description
Currently, the comparison between the Policy Registry Resource Path and the API Registry Resource Path is case-sensitive. However, case sensitivity is not essential for this check and may cause unnecessary mismatches.
- Resolves https://github.com/wso2/api-manager/issues/3402

### Fix
Update the comparison logic to be case-insensitive by converting both paths to lowercase before comparison. This ensures consistency regardless of case differences.