### PR TITLE
Improve Permission Check to Consider Publisher Access Control when Accessing an API via the DevPortal

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -2382,7 +2382,7 @@ APIConstants.AuditLogConstants.DELETED, this.username);
             } else {
                 throw new APIManagementException("Invalid Token Type '" + tokenType + "' requested.");
             }
-            
+
             if (appRegistrationWorkflow == null ) {
                 appRegistrationWorkflow = new ApplicationRegistrationSimpleWorkflowExecutor();
             }
@@ -3906,7 +3906,8 @@ APIConstants.AuditLogConstants.DELETED, this.username);
                     uuid);
             if (devPortalApi != null) {
                 checkVisibilityPermission(userNameWithoutChange, devPortalApi.getVisibility(),
-                        devPortalApi.getVisibleRoles());
+                        devPortalApi.getVisibleRoles(), devPortalApi.getPublisherAccessControl(),
+                        devPortalApi.getPublisherAccessControlRoles());
                 if (APIConstants.API_PRODUCT.equalsIgnoreCase(devPortalApi.getType())) {
                     APIProduct apiProduct = APIMapper.INSTANCE.toApiProduct(devPortalApi);
                     apiProduct.setID(new APIProductIdentifier(devPortalApi.getProviderName(),
@@ -3935,7 +3936,8 @@ APIConstants.AuditLogConstants.DELETED, this.username);
         }
     }
 
-    protected void checkVisibilityPermission(String userNameWithTenantDomain, String visibility, String visibilityRoles)
+    protected void checkVisibilityPermission(String userNameWithTenantDomain, String visibility, String visibilityRoles,
+                                             String publisherAccessControl, String publisherAccessControlRoles)
             throws APIManagementException {
 
         if (visibility == null || visibility.trim().isEmpty()
@@ -3945,10 +3947,38 @@ APIConstants.AuditLogConstants.DELETED, this.username);
             }
             return;
         }
-        if (APIUtil.hasPermission(userNameWithTenantDomain, APIConstants.Permissions.APIM_ADMIN)
-                || APIUtil.hasPermission(userNameWithTenantDomain, APIConstants.Permissions.API_CREATE)
-                || APIUtil.hasPermission(userNameWithTenantDomain, APIConstants.Permissions.API_PUBLISH)) {
+        if (APIUtil.hasPermission(userNameWithTenantDomain, APIConstants.Permissions.APIM_ADMIN)) {
             return;
+        }
+        if (APIUtil.hasPermission(userNameWithTenantDomain, APIConstants.Permissions.API_CREATE)
+                || APIUtil.hasPermission(userNameWithTenantDomain, APIConstants.Permissions.API_PUBLISH)) {
+            if (publisherAccessControl == null || publisherAccessControl.trim().isEmpty()
+                    || publisherAccessControl.equalsIgnoreCase(APIConstants.NO_ACCESS_CONTROL)) {
+                // If the API has not been restricted with publisher access control, the API will be visible to all
+                // creators and publishers irrespective of devportal visibility restrictions.
+                return;
+            } else {
+                // If the API has been restricted with publisher access control, the API will be visible to creators
+                // and publishers having the roles which has been specified under publisher access control irrespective
+                // of devportal visibility restrictions.
+                if (publisherAccessControlRoles != null && !publisherAccessControlRoles.trim().isEmpty()) {
+                    String[] accessControlRoleList = publisherAccessControlRoles.replaceAll("\\s+", "").split(",");
+                    if (log.isDebugEnabled()) {
+                        log.debug("API has restricted access to creators and publishers with the roles : "
+                                + Arrays.toString(accessControlRoleList));
+                    }
+                    String[] userRoleList = APIUtil.getListOfRoles(userNameWithTenantDomain);
+                    if (log.isDebugEnabled()) {
+                        log.debug("User " + username + " has roles " + Arrays.toString(userRoleList));
+                    }
+                    for (String role : accessControlRoleList) {
+                        if (!role.equalsIgnoreCase(APIConstants.NULL_USER_ROLE_LIST)
+                                && APIUtil.compareRoleList(userRoleList, role)) {
+                            return;
+                        }
+                    }
+                }
+            }
         }
 
         if (visibilityRoles != null && !visibilityRoles.trim().isEmpty()) {
@@ -4032,7 +4062,8 @@ APIConstants.AuditLogConstants.DELETED, this.username);
             DevPortalAPI devPortalApi = apiPersistenceInstance.getDevPortalAPI(org, uuid);
             if (devPortalApi != null) {
                 checkVisibilityPermission(userNameWithoutChange, devPortalApi.getVisibility(),
-                        devPortalApi.getVisibleRoles());
+                        devPortalApi.getVisibleRoles(), devPortalApi.getPublisherAccessControl(),
+                        devPortalApi.getPublisherAccessControlRoles());
                 API api = APIMapper.INSTANCE.toApi(devPortalApi);
 
                 /// populate relavant external info
@@ -4266,7 +4297,8 @@ APIConstants.AuditLogConstants.DELETED, this.username);
         try {
             DevPortalAPI api = apiPersistenceInstance.getDevPortalAPI(new Organization(organization), apiId);
             if (api != null) {
-                checkVisibilityPermission(userNameWithoutChange, api.getVisibility(), api.getVisibleRoles());
+                checkVisibilityPermission(userNameWithoutChange, api.getVisibility(), api.getVisibleRoles(),
+                        api.getPublisherAccessControl(), api.getPublisherAccessControlRoles());
             }
         } catch (APIPersistenceException e) {
             throw new APIManagementException("Error while accessing dev portal API", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/UserAwareAPIConsumer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/UserAwareAPIConsumer.java
@@ -138,7 +138,7 @@ public class UserAwareAPIConsumer extends APIConsumerImpl {
     public API getLightweightAPI(APIIdentifier identifier, String orgId) throws APIManagementException {
         API api = super.getLightweightAPI(identifier, orgId);
         checkVisibilityPermission(userNameWithoutChange, api.getVisibility(),
-                api.getVisibleRoles());
+                api.getVisibleRoles(), api.getAccessControl(), api.getAccessControlRoles());
         return api;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/DevPortalAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/DevPortalAPI.java
@@ -65,6 +65,8 @@ public class DevPortalAPI extends DevPortalAPIInfo {
     private String visibleRoles;
     private String gatewayVendor;
     private String asyncTransportProtocols;
+    private String publisherAccessControl;
+    private String publisherAccessControlRoles;
 
     public String getContextTemplate() {
         return contextTemplate;
@@ -390,7 +392,23 @@ public class DevPortalAPI extends DevPortalAPIInfo {
     public void setVisibility(String visibility) {
         this.visibility = visibility;
     }
-    
+
+    public String getPublisherAccessControl() {
+        return publisherAccessControl;
+    }
+
+    public void setPublisherAccessControl(String publisherAccessControl) {
+        this.publisherAccessControl = publisherAccessControl;
+    }
+
+    public String getPublisherAccessControlRoles() {
+        return publisherAccessControlRoles;
+    }
+
+    public void setPublisherAccessControlRoles(String publisherAccessControlRoles) {
+        this.publisherAccessControlRoles = publisherAccessControlRoles;
+    }
+
 
     /*
     private String accessControl; //publisher accessControl : 'restricted', 'all' // this won't be required

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/DevPortalAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/DevPortalAPI.java
@@ -409,7 +409,6 @@ public class DevPortalAPI extends DevPortalAPIInfo {
         this.publisherAccessControlRoles = publisherAccessControlRoles;
     }
 
-
     /*
     private String accessControl; //publisher accessControl : 'restricted', 'all' // this won't be required
 

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/mapper/APIMapper.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/mapper/APIMapper.java
@@ -110,6 +110,8 @@ public interface APIMapper {
     //@Mapping(source = "visibleTenants", target = "visibleOrganizations")
     @Mapping(source = "subscriptionAvailableTenants", target = "subscriptionAvailableOrgs")
     //@Mapping(source = "environmentList", target = "environments")
+    @Mapping(source = "accessControl", target = "publisherAccessControl")
+    @Mapping(source = "accessControlRoles", target = "publisherAccessControlRoles")
     DevPortalAPI toDevPortalApi(API api);
     
     //@Mapping(source = "providerName", target = "id.providerName")


### PR DESCRIPTION
### Purpose
- This PR fixes the issue where an API with publisher access control is visible in the DevPortal to creators and publishers irrespective whether those users have the restricted roles specified under publisher access control of the API
- Related Public Issue: https://github.com/wso2/api-manager/issues/3391

### Approach
- Implemented the logic to honour the following conditions
  - If the API has not been restricted with publisher access control, the API will be visible to all creators and publishers irrespective of devportal visibility restrictions.
  - If the API has been restricted with publisher access control, the API will be visible to creators and publishers having the roles which has been specified under publisher access control irrespective of devportal visibility restrictions.
 