### PR TITLE
Route OPTIONS Resource Traffic to the Backend

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/DefaultAPIHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/DefaultAPIHandler.java
@@ -28,6 +28,7 @@ import org.apache.synapse.rest.RESTConstants;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.common.gateway.constants.HealthCheckConstants;
 import org.wso2.carbon.apimgt.common.gateway.constants.JWTConstants;
+import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.InMemoryAPIDeployer;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
@@ -88,6 +89,7 @@ public class DefaultAPIHandler extends AbstractSynapseHandler {
             String selectedPath = selectedAPIS.firstKey();
             API selectedAPI = selectedAPIS.get(selectedPath);
             if (selectedAPI != null) {
+                messageContext.setProperty(APIMgtGatewayConstants.API_OBJECT, selectedAPI);
                 if (GatewayUtils.isOnDemandLoading()) {
                     if (!selectedAPI.isDeployed()) {
                         synchronized ("LoadAPI_".concat(selectedAPI.getContext()).intern()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
@@ -79,7 +79,21 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 import javax.cache.Caching;
 import javax.xml.namespace.QName;
 
@@ -822,17 +836,19 @@ public class Utils {
      */
     public static Set<Resource> getAcceptableResources(Resource[] allAPIResources,
                                                        String httpMethod, String corsRequestMethod) {
-        Set<Resource> acceptableResources = new LinkedHashSet<>();
+        List<Resource> acceptableResourcesList = new LinkedList<>();
         for (Resource resource : allAPIResources) {
             //If the requesting method is OPTIONS or if the Resource contains the requesting method
-            String [] resourceMethods = resource.getMethods();
-            if ((RESTConstants.METHOD_OPTIONS.equals(httpMethod) && resourceMethods != null
-                    && Arrays.asList(resourceMethods).contains(corsRequestMethod))
-                    || (resourceMethods != null && Arrays.asList(resourceMethods).contains(httpMethod))) {
-                acceptableResources.add(resource);
+            if (resource.getMethods() != null && Arrays.asList(resource.getMethods()).contains(httpMethod) &&
+                    RESTConstants.METHOD_OPTIONS.equals(httpMethod)) {
+                acceptableResourcesList.add(0, resource);
+            } else if ((RESTConstants.METHOD_OPTIONS.equals(httpMethod) && resource.getMethods() != null &&
+                    Arrays.asList(resource.getMethods()).contains(corsRequestMethod)) ||
+                    (resource.getMethods() != null && Arrays.asList(resource.getMethods()).contains(httpMethod))) {
+                acceptableResourcesList.add(resource);
             }
         }
-        return acceptableResources;
+        return new LinkedHashSet<>(acceptableResourcesList);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidator.java
@@ -59,6 +59,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -399,15 +400,20 @@ public class APIKeyValidator {
             if (selectedApi != null) {
                 Resource[] selectedAPIResources = selectedApi.getResources();
 
-                Set<Resource> acceptableResources = new LinkedHashSet<Resource>();
+                List<Resource> acceptableResourcesList = new LinkedList<>();
 
                 for (Resource resource : selectedAPIResources) {
                     //If the requesting method is OPTIONS or if the Resource contains the requesting method
-                    if (RESTConstants.METHOD_OPTIONS.equals(httpMethod) ||
+                    if (RESTConstants.METHOD_OPTIONS.equals(httpMethod) &&
                             (resource.getMethods() != null && Arrays.asList(resource.getMethods()).contains(httpMethod))) {
-                        acceptableResources.add(resource);
+                        acceptableResourcesList.add(0, resource);
+                    } else if (RESTConstants.METHOD_OPTIONS.equals(httpMethod) ||
+                            (resource.getMethods() != null && Arrays.asList(resource.getMethods()).contains(httpMethod))) {
+                        acceptableResourcesList.add(resource);
                     }
                 }
+
+                Set<Resource> acceptableResources = new LinkedHashSet<>(acceptableResourcesList);
 
                 if (acceptableResources.size() > 0) {
                     for (RESTDispatcher dispatcher : RESTUtils.getDispatchers()) {

--- a/pom.xml
+++ b/pom.xml
@@ -2112,7 +2112,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>4.0.0-wso2v131</synapse.version>
+        <synapse.version>4.0.0-wso2v152</synapse.version>
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 
         <!-- orbit httpmime versions-->


### PR DESCRIPTION
### Description
- Resources having the OPTIONS method bring to the 0th index of the `acceptableResourcesList` to be selected in the `dispatcher.findResource` logic when routing the OPTIONS traffic to backend.
- Bump the Synapse version to `4.0.0-wso2v152`
- Set the current API object to the `MessageContext` from the `DefaultAPIHandler`
- Related Issue: https://github.com/wso2/api-manager/issues/2226

- Resolves https://github.com/wso2/api-manager/issues/3377
