### PR TITLE
Added custom API Indexing handler to bypass indexing of old API revisions.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/handlers/APIIndexingHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/handlers/APIIndexingHandler.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.handlers;
+
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.registry.core.jdbc.handlers.RequestContext;
+import org.wso2.carbon.registry.indexing.IndexingHandler;
+
+/**
+ * This is the Indexing handler to skip indexing of older API revisions
+ */
+public class APIIndexingHandler extends IndexingHandler {
+    public void put(RequestContext requestContext) throws RegistryException {
+        if (requestContext.getResourcePath().getPath().contains("/apimgt/applicationdata/apis/")) {
+            return;
+        }
+        super.put(requestContext);
+    }
+}


### PR DESCRIPTION
## Description

Editing old API revisions result in a Null Pointer Exception due to null being returned from [here](https://github.com/wso2/carbon-apimgt/blob/ba61afcd5ad4ddb2e058e6753bba99bd730c7cac/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/indexing/indexer/CustomAPIIndexer.java#L62) and that null being accessed [here](https://github.com/wso2/carbon-registry/blob/b62a7997e5ccdd8d719c115fcab4dea5c66b060a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/indexer/IndexDocumentCreator.java#L343)

This fix will create a new Indexing Handler that extends the Indexer handler in the carbon registry. it will check if the API being processed is an old revision, and will return immediately if so. 

If it's a current API, it will call the superclass method which will trigger indexing as usual.

The registry.xml.j2 file of the product will have to be updated so that the Indexing handler is pointed to the new class.