### PR TITLE
Set setResolveCombinators to false when parsing OpenAPI/Swagger definition

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
@@ -131,7 +131,9 @@ public class APIMgtLatencyStatsHandler extends AbstractHandler {
                         swagger = localEntryObj.getValue().toString();
                         OpenAPIParser parser = new OpenAPIParser();
                         ParseOptions parseOptions = new ParseOptions();
+                        parseOptions.setResolve(true);
                         parseOptions.setResolveFully(true);
+                        parseOptions.setResolveCombinators(false);
                         openAPI = parser.readContents(swagger, null, parseOptions).getOpenAPI();
                         // HTTP headers should be case insensitive as for HTTP 1.1 RFC
                         // Thus converting headers to lowercase for schema validation.


### PR DESCRIPTION
### Purpose 

> - This PR fixes the issue of incorrect request validation when schemas are defined as composed schemas (`allOf`, `anyOf`, and `oneOf`). In the current code, the `setResolveCombinators` option is not set to `false` during parsing, which introduces this issue.
> - By default, the `setResolveCombinators` option is `true` during parsing, which transforms composed schemas into "non-composed" ones by merging all properties into a single resulting schema. Because of this, requests are not validated as intended when schemas are defined as composed schemas.
> - Resolves: https://github.com/wso2/api-manager/issues/3409

### Approach

> - The `setResolveCombinators` option is explicitly set to `false`.
> - Additionally, the `setResolve` option is explicitly set to `true`. Although this is implicitly enabled with the `setResolveFully` option, setting it explicitly is considered a best practice.