### PR TITLE
Fix re-enabling OAuth2 security on APIs configured with only mutual SSL

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -119,6 +119,9 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.wso2.carbon.apimgt.api.model.policy.PolicyConstants.AI_API_QUOTA_TYPE;
+import static org.wso2.carbon.apimgt.api.model.policy.PolicyConstants.EVENT_COUNT_TYPE;
+
 /**
  * This is a publisher rest api utility class.
  */
@@ -282,6 +285,7 @@ public class PublisherCommonUtils {
                 || APIConstants.APITransportType.WEBSUB.toString().equals(originalAPI.getType())
                 || APIConstants.APITransportType.SSE.toString().equals(originalAPI.getType())
                 || APIConstants.APITransportType.ASYNC.toString().equals(originalAPI.getType()));
+        boolean isAIAPI = APIConstants.API_SUBTYPE_AI_API.equals(originalAPI.getSubtype());
 
         Scope[] apiDtoClassAnnotatedScopes = APIDTO.class.getAnnotationsByType(Scope.class);
         boolean hasClassLevelScope = checkClassScopeAnnotation(apiDtoClassAnnotatedScopes, tokenScopes);
@@ -442,9 +446,20 @@ public class PublisherCommonUtils {
         if (!APIUtil.isSubscriptionValidationDisablingAllowed(tenantDomain)) {
             if (apiSecurity != null && (apiSecurity.contains(APIConstants.DEFAULT_API_SECURITY_OAUTH2) || apiSecurity
                     .contains(APIConstants.API_SECURITY_API_KEY)) && condition) {
-                throw new APIManagementException(
-                        "A tier should be defined if the API is not in CREATED or PROTOTYPED state",
-                        ExceptionCodes.TIER_CANNOT_BE_NULL);
+                Set<Tier> availableThrottlingPolicyList = apiProvider.getTiers();
+                tiersFromDTO = availableThrottlingPolicyList.stream()
+                        .filter(tier -> isApplicableTier(tier, isAsyncAPI, isAIAPI))
+                        .map(Tier::getName)
+                        .findFirst()
+                        .map(Collections::singletonList)
+                        .orElse(Collections.emptyList());
+                apiDtoToUpdate.setPolicies(tiersFromDTO);
+
+                if (tiersFromDTO.isEmpty()) {
+                    throw new APIManagementException(
+                            "A tier should be defined if the API is not in CREATED or PROTOTYPED state",
+                            ExceptionCodes.TIER_CANNOT_BE_NULL);
+                }
             }
         } else {
             if (apiSecurity != null) {
@@ -577,6 +592,33 @@ public class PublisherCommonUtils {
 
         apiToUpdate.setOrganization(originalAPI.getOrganization());
         return apiToUpdate;
+    }
+
+    private static boolean isApplicableTier(Tier tier, boolean isAsyncAPI, boolean isAIAPI) {
+        if (isAsyncAPI) {
+            return isAsyncAPITier(tier);
+        }
+
+        if (isAIAPI) {
+            return isAIAPITier(tier);
+        }
+
+        return isRegularAPITier(tier);
+    }
+
+    private static boolean isAsyncAPITier(Tier tier) {
+        return EVENT_COUNT_TYPE.equals(tier.getQuotaPolicyType());
+    }
+
+    private static boolean isAIAPITier(Tier tier) {
+        return AI_API_QUOTA_TYPE.equals(tier.getQuotaPolicyType()) ||
+                tier.getName().contains(APIConstants.DEFAULT_SUB_POLICY_SUBSCRIPTIONLESS) ||
+                tier.getQuotaPolicyType() == null;
+    }
+
+    private static boolean isRegularAPITier(Tier tier) {
+        return !AI_API_QUOTA_TYPE.equals(tier.getQuotaPolicyType()) &&
+                !EVENT_COUNT_TYPE.equals(tier.getQuotaPolicyType());
     }
 
     /**


### PR DESCRIPTION
## Purpose
This PR resolves an issue where an API published with only Mutual SSL enabled cannot save updates when OAuth2 or API Key application-level security is subsequently enabled.

## Approach
When Mutual SSL is the sole selected security option for an API, the tier throttling policies are cleared [1]. If OAuth2 or API Key is later enabled for the same API, the update fails because the API is already published and requires a tier throttling policy. This fix ensures that a default throttling policy is applied in such scenarios, allowing the updates to be successfully saved.
Logic to filter AI policies is based on [2].


## Issue
Related to: https://github.com/wso2/api-manager/issues/3486

[1] https://github.com/wso2/carbon-apimgt/blob/bf7e34db673c644cbd34faa7ed458c7acae1822d/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java#L315-L320
[2] https://github.com/wso2/carbon-apimgt/blob/bf7e34db673c644cbd34faa7ed458c7acae1822d/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ThrottlingPoliciesApiServiceImpl.java#L206-L209
