### PR TITLE
Fixed the throwing null value issue for subscription update workflow type

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/WorkflowMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/WorkflowMappingUtil.java
@@ -82,6 +82,8 @@ public class WorkflowMappingUtil {
             workflowInfoDTO.setWorkflowType(WorkflowInfoDTO.WorkflowTypeEnum.API_PRODUCT_STATE);
         } else if (workflow.getWorkflowType().equals("AM_REVISION_DEPLOYMENT")) {
             workflowInfoDTO.setWorkflowType(WorkflowInfoDTO.WorkflowTypeEnum.REVISION_DEPLOYMENT);
+        } else if (workflow.getWorkflowType().equals("AM_SUBSCRIPTION_UPDATE")) {
+            workflowInfoDTO.setWorkflowType(WorkflowInfoDTO.WorkflowTypeEnum.SUBSCRIPTION_UPDATE);
         }
         workflowInfoDTO.setWorkflowStatus(WorkflowInfoDTO.WorkflowStatusEnum.valueOf(workflow.getStatus().toString()));
         workflowInfoDTO.setCreatedTime(workflow.getCreatedTime());


### PR DESCRIPTION
## Purpose
Resolves the issue of getting workflow type as null in the Subscription Update Workflow section of the admin portal.

## Issues
Related to: https://github.com/wso2/api-manager/issues/3494
Internal: https://github.com/wso2-enterprise/wso2-apim-internal/issues/8378