### PR TITLE
Bump APIM Version Constant to 4.5.0

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -203,7 +203,7 @@ public final class ImportExportConstants {
 
     public static final String TYPE_POLICY_SPECIFICATION = "operation_policy_specification";
 
-    public static final String APIM_VERSION = "v4.4.0";
+    public static final String APIM_VERSION = "v4.5.0";
 
     public static final String ENDPOINT_CONFIG = "endpointConfig";
 


### PR DESCRIPTION
### Purpose
- Bump APIM version constant to 4.5.0. This change is done to support CTL test cases as well