### PR TITLE
Fix issues in restoring revision

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -394,7 +394,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
                 GenericArtifact artifact = getAPIArtifact(apiUUID, registry);
                 artifact.setAttribute(APIConstants.API_OVERVIEW_STATUS, lifecycleStatus);
                 // Update with the modified artifact
-                artifactManager.updateGenericArtifact(apiArtifact);
+                artifactManager.updateGenericArtifact(artifact);
                 RegistryPersistenceUtil.clearResourcePermissions(apiPath, api.getId(),
                         ((UserRegistry) registry).getTenantId());
                 RegistryPersistenceUtil.setResourcePermissions(api.getId().getProviderName(), api.getVisibility(),


### PR DESCRIPTION
This PR fixes an issue where restoring a revision to the working copy does not restore any of the attributes of the API.

Fixes https://github.com/wso2/api-manager/issues/3507