### PR TITLE
Fix scope validation issue with wildcard resources

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidator.java
@@ -420,7 +420,11 @@ public class APIKeyValidator {
                         Resource resource = dispatcher.findResource(synCtx, acceptableResources);
                         if (resource != null && Arrays.asList(resource.getMethods()).contains(httpMethod)) {
                             selectedResource = resource;
-                            break;
+                            if (selectedResource.getDispatcherHelper()
+                                    .getString() != null && !selectedResource.getDispatcherHelper().getString()
+                                    .contains("/*")) {
+                                break;
+                            }
                         }
                     }
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/CORSRequestHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/CORSRequestHandler.java
@@ -183,7 +183,11 @@ public class CORSRequestHandler extends AbstractHandler implements ManagedLifecy
                             Resource resource = dispatcher.findResource(messageContext, acceptableResources);
                             if (resource != null) {
                                 selectedResource = resource;
-                                break;
+                                if (selectedResource.getDispatcherHelper()
+                                        .getString() != null && !selectedResource.getDispatcherHelper().getString()
+                                        .contains("/*")) {
+                                    break;
+                                }
                             }
                         }
                         if (selectedResource == null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/InboundWebSocketProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/InboundWebSocketProcessor.java
@@ -331,12 +331,16 @@ public class InboundWebSocketProcessor {
                     Resource resource = dispatcher.findResource(synCtx, acceptableResources);
                     if (resource != null) {
                         selectedResource = resource;
-                        if (APIUtil.isAnalyticsEnabled()) {
-                            WebSocketUtils.setApiPropertyToChannel(ctx, APIMgtGatewayConstants.SYNAPSE_ENDPOINT_ADDRESS,
-                                    WebSocketUtils.getEndpointUrl(resource, synCtx));
+                        if (selectedResource.getDispatcherHelper()
+                                .getString() != null && !selectedResource.getDispatcherHelper().getString()
+                                .contains("/*")) {
+                            break;
                         }
-                        break;
                     }
+                }
+                if (selectedResource != null && APIUtil.isAnalyticsEnabled()) {
+                    WebSocketUtils.setApiPropertyToChannel(ctx, APIMgtGatewayConstants.SYNAPSE_ENDPOINT_ADDRESS,
+                            WebSocketUtils.getEndpointUrl(selectedResource, synCtx));
                 }
             }
             setApiPropertiesToChannel(ctx, inboundMessageContext);


### PR DESCRIPTION
## Purpose

This PR addresses a limitation in the resource matching logic for APIs that involve both wildcard paths (e.g., `/*`) and paths containing path parameters (e.g., `/resource-with-path-param/{path-param}`). 
Previously, when requests were made to paths containing parameters, the system would incorrectly prioritize `URLMappingBasedDispatcher` resource, leading to an unintended selection of wildcard resources over more specific path parameter resources.

The new implementation refines this by introducing a check that prioritizes `URITemplateBasedDispatcher` resources when both types of resources are present, ensuring that path-specific resources are matched before wildcard resources.

## Related to
Issue: https://github.com/wso2/api-manager/issues/3307
Internal: https://github.com/wso2-enterprise/wso2-apim-internal/issues/7771