### PR TITLE
Improve behaviour of API search with context as the property

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistrySearchUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistrySearchUtil.java
@@ -213,6 +213,22 @@ public class RegistrySearchUtil {
                         if (!searchValue.startsWith("*")) {
                             searchValue = "*" + searchValue;
                         }
+                    } else {
+                        if (CONTEXT_SEARCH_TYPE_PREFIX.equalsIgnoreCase(searchKey)) {
+                            //Remove quotation marks and forward slash to get the context for exact search.
+                            searchValue = searchValue.substring(1, searchValue.length() - 1);
+                            if (searchValue.startsWith("/")) {
+                                searchValue = searchValue.substring(1);
+                            }
+                            if (searchValue.endsWith("/")) {
+                                searchValue = searchValue.substring(0, searchValue.length() - 1);
+                            }
+                            if (!searchValue.isEmpty()) {
+                                searchValue = "(*\\/" + searchValue + "\\/*" + " OR " + "\\/" + searchValue + ")";
+                            } else {
+                                searchValue = "\"\"";
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Purpose
> Currently when doing exact search with context it is required to append version to the query. eg - **context:"/test/1.0.0"**
> From this fix we will allow user to search all APIs which containing specified context. eg - **context:"test"** 
> Related issue - https://github.com/wso2/api-manager/issues/3554

## Approach

- Modify search query for exact search when the query parameter is context.
- This fix will preserve the original behaviour of this search. (eg - **context:"/test/1.0.0"**)
- Search query as shown bellow when **context:"test"** is given.
> eg - `(*/test/* OR /test)`