### PR TITLE
Fix rule validator version

### DIFF
--- a/components/governance/org.wso2.carbon.apimgt.governance.engine/pom.xml
+++ b/components/governance/org.wso2.carbon.apimgt.governance.engine/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>rule.validator</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2019,7 +2019,7 @@
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>rule.validator</artifactId>
-                <version>1.0-SNAPSHOT</version>
+                <version>1.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.apimgt</groupId>


### PR DESCRIPTION
Removed the rule validator version from the governance engine pom.xml and added the correct version to the base pom.xml.