### PR TITLE
Fix minor bugs related to Organizations

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/OrganizationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/OrganizationDTO.java
@@ -35,9 +35,8 @@ public class OrganizationDTO   {
   }
 
   
-  @ApiModelProperty(example = "ece92bdc-e1e6-325c-b6f4-656208a041e9", required = true, value = "UUID of the organization. ")
+  @ApiModelProperty(example = "ece92bdc-e1e6-325c-b6f4-656208a041e9", value = "UUID of the organization. ")
   @JsonProperty("organizationId")
-  @NotNull
   public String getOrganizationId() {
     return organizationId;
   }
@@ -54,8 +53,9 @@ public class OrganizationDTO   {
   }
 
   
-  @ApiModelProperty(example = "ece92bdc-e1e6-325c-b6f4-656208a041e9", value = "External id of the organization. ")
+  @ApiModelProperty(example = "ece92bdc-e1e6-325c-b6f4-656208a041e9", required = true, value = "External id of the organization. ")
   @JsonProperty("externalOrganizationId")
+  @NotNull
   public String getExternalOrganizationId() {
     return externalOrganizationId;
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/OrganizationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/OrganizationsApiServiceImpl.java
@@ -130,6 +130,10 @@ public class OrganizationsApiServiceImpl implements OrganizationsApiService {
                 orgId = orgInfo.getOrganizationId();
                 organizationDTO.setParentOrganizationId(orgId); // set current users organization as parent id if available.
             }
+            if (organizationDTO.getParentOrganizationId() == null) {
+                throw new APIManagementException("Parent Organization not found",
+                        ExceptionCodes.MISSING_ORGANINATION);
+            }
             OrganizationDetailsDTO orgDto = OrganizationsMappingUtil.toOrganizationDetailsDTO(organizationDTO);
             orgDto.setTenantDomain(superOrganization);
             orgDto = apiAdmin.addOrganization(orgDto);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -4889,7 +4889,7 @@ components:
     Organization:
       title: Organization
       required:
-        - organizationId
+        - externalOrganizationId
       type: object
       properties:
         organizationId:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
@@ -4889,7 +4889,7 @@ components:
     Organization:
       title: Organization
       required:
-        - organizationId
+        - externalOrganizationId
       type: object
       properties:
         organizationId:


### PR DESCRIPTION
### Purpose

1. Organization ID is the UUID assigned by apim side and it can't be a required field when registering new orgs.
2. Users without an organization should not be able to register orgs to apim.


### Approach

1. Removed organizationId and add externalOrganizationId as required which is already created by the external IDP.
2. Throw a 403 error when user's parent organization is null.