### PR TITLE
Fix: Sequence Template Issue deployed in gateway

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
@@ -243,7 +243,7 @@ public class SynapsePolicyAggregator {
         try {
             sequence = updateSequenceName(sequence, sequenceName);
         } catch (Exception ex) {
-            throw new APIManagementException("Error when updating the sequence name");
+            throw new APIManagementException("Error when updating the sequence name: " + sequenceName, ex);
         }
         return sequence;
     }


### PR DESCRIPTION
**Description**

When a sequence with `<sequence name="sequence">` is uploaded, it gives an error on the API invocation. This is due to a missing sequence file with the given name. Previously, this content was embedded inside a `<sequence>` tag with the help of a j2 template. With the new implementation, there's no need of a template. First the logic checks whether the given file has a `<sequence>` tag as its root element. If presents, then it will update its name attribute. If tag is not present, it will add the hardcoded `<sequence>` tag and then build the `OMElement` using it. This way, it prevents having two sequence tags unnecessarily which causes issues during the sequence engagement.

**Issue**
- https://github.com/wso2/api-manager/issues/3448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced backend sequence generation by incorporating additional configuration support for improved API product handling.

- **Bug Fixes**
  - Improved error management during custom sequence processing to ensure sequences are correctly formatted.

- **Refactor**
  - Streamlined sequence rendering logic for greater robustness and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->