### PR TITLE
Fix #3499: Restrict endpoint security type to only available ones

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1840,6 +1840,7 @@ public final class APIConstants {
     public static final String ENDPOINT_URLS = "urls";
     public static final String ENDPOINT_URL = "url";
     public static final String ENDPOINT_SECURITY_TYPE = "type";
+    public static final String ENDPOINT_SECURITY_TYPE_NONE = "none";
     public static final String ENDPOINT_SECURITY_TYPE_BASIC = "basic";
     public static final String ENDPOINT_SECURITY_TYPE_DIGEST = "digest";
     public static final String ENDPOINT_SECURITY_TYPE_OAUTH = "oauth";


### PR DESCRIPTION
Purpose
This PR addresses a validation gap in the Publisher REST API, where custom endpoint security types could be added through API creation, even if they were not part of the predefined set of supported security types.

Previously, there was no restriction on the endpoint security type, allowing users to specify any arbitrary value.

The new implementation introduces validation in the validateEndpointSecurityType method to ensure that only supported security types—None, Basic, Digest, and OAuth—are allowed. If an invalid security type is detected, an appropriate error message is returned.

Related to
Issue: [wso2/api-manager#3499](https://github.com/wso2/api-manager/issues/3499)