### PR TITLE
Fix endpoint certificate retrieval by using FQDN

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2347,6 +2347,8 @@ public final class APIConstants {
     public static final String JSON_GRANT_TYPES = "grant_types";
     public static final String JSON_USERNAME = "username";
     public static final String REGEX_ILLEGAL_CHARACTERS_FOR_API_METADATA = "[~!@#;:%^*()+={}|<>\"\',\\[\\]&/$\\\\]";
+    public static final String REGEX_URL_TEMPLATE_PLACEHOLDERS = "\\{.*?}";
+    public static final String URL_SCHEME_SEPARATOR = "://";
     public static final String JSON_CLIENT_ID = "client_id";
     public static final String JSON_ADDITIONAL_PROPERTIES = "additionalProperties";
     public static final String JSON_CLIENT_SECRET = "client_secret";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -3506,7 +3506,7 @@ public class SQLConstants {
         public static final String GET_CERTIFICATE_ALL_TENANTS = "SELECT * FROM AM_CERTIFICATE_METADATA WHERE " +
                 "(ALIAS=?)";
         public static final String GET_CERTIFICATE_TENANT = "SELECT * FROM AM_CERTIFICATE_METADATA WHERE TENANT_ID=? " +
-                "AND (ALIAS=? OR END_POINT=?)";
+                "AND (ALIAS=? OR END_POINT like ?)";
         public static final String GET_CERTIFICATE_TENANT_ALIAS_ENDPOINT = "SELECT * FROM AM_CERTIFICATE_METADATA " +
                        "WHERE TENANT_ID=? AND ALIAS=? AND END_POINT=?";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/CertificateMgtDaoTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/CertificateMgtDaoTest.java
@@ -62,8 +62,8 @@ public class CertificateMgtDaoTest {
     private static CertificateMgtDAO certificateMgtDAO;
     private static String TEST_ALIAS = "test alias";
     private static String TEST_ALIAS_2 = "test alias 2";
-    private static String TEST_ENDPOINT = "test end point";
-    private static String TEST_ENDPOINT_2 = "test end point 2";
+    private static String TEST_ENDPOINT = "https://test-end-point.com";
+    private static String TEST_ENDPOINT_2 = "https://test-end-point2.com";
     private static int TENANT_ID = MultitenantConstants.SUPER_TENANT_ID;
     private static final int TENANT_2 = 1001;
     private static final String certificate =


### PR DESCRIPTION
## Purpose
Fix the issue where the 'General Endpoint Configurations' section in the Publisher Portal does not display applied certificates from other APIs with the same domain name.

<img width="1273" alt="image" src="https://github.com/user-attachments/assets/f56b8d22-bcc8-46d1-916e-c913043bcaac" />

## Approach
The current implementation for retrieving certificates in the Publisher Portal relies on an exact match with the applied endpoint of the API. As a result, if another API shares the same domain name but has a different endpoint path, the associated certificate is correctly applied underneath during backend communication but does not appear in the UI.
Ex: `https://google.com` and `https://google.com/api/v1`

This PR addresses the issue by replacing the exact match (`=` operator) with the `like` operator and wildcard (`%`) syntax. This ensures that certificate retrieval is based on the fully qualified domain name (FQDN) rather than the exact endpoint, providing a more accurate and consistent UI representation.

<img width="1257" alt="image" src="https://github.com/user-attachments/assets/50eab024-4221-4d12-bbd7-b533814fccf6" />

## Related to 
Issue: https://github.com/wso2/api-manager/issues/3527
Internal: https://github.com/wso2-enterprise/wso2-apim-internal/issues/8460