### PR TITLE
Fix for Filter-Based API Search with Space Characters in DevPortal

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistrySearchUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistrySearchUtil.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -122,6 +123,7 @@ public class RegistrySearchUtil {
             newSearchQuery = getSingleSearchCriteria(inputSearchQuery);
         } else {
             String[] criterea = inputSearchQuery.split(" ");
+            criterea = processInput(criterea);
             Map<String, List<String>> critereaMap = new HashMap<>();
             List<String> untaggedContent = new ArrayList();
             for (int i = 0; i < criterea.length; i++) {
@@ -152,6 +154,14 @@ public class RegistrySearchUtil {
             for (Map.Entry<String, List<String>> entry : critereaMap.entrySet()) {
                 String nextCriterea = "";
                 if (entry.getValue().size() > 1) {
+                    if (TAG_SEARCH_TYPE_PREFIX.equals(entry.getKey()) ||
+                            TAGS_SEARCH_TYPE_PREFIX.equals(entry.getKey())) {
+                        List<String> updatedValues = entry.getValue().stream()
+                                .map(value -> value.replace(" ", "\\ "))
+                                .collect(Collectors.toList());
+                        entry.setValue(updatedValues);
+                    }
+
                     nextCriterea = entry.getKey() + "=" + getORBasedSearchCriteria(
                             entry.getValue().toArray(new String[0]));
                 } else {
@@ -172,6 +182,47 @@ public class RegistrySearchUtil {
         }
 
         return newSearchQuery;
+    }
+
+    /**
+     * Processes an input array of strings by grouping related elements.
+     *
+     * This method consolidates input strings by combining elements around delimiter strings
+     * containing a colon (':'), creating a new array where each entry represents a consolidated group.
+     *
+     * @param input An array of strings to be processed
+     * @return A processed array of strings where related elements are grouped together
+     *
+     * Key behaviors:
+     * - Identifies delimiter strings containing a colon
+     * - Aggregates subsequent strings with delimiter entries
+     * - Trims whitespace from consolidated entries
+     *
+     * Example:
+     * Input:  ["tag:Sample", "APIs", "-", "New", "name:Google"]
+     * Output: ["tag:Sample APIs - New ", "name:Google"]
+     */
+    private static String[] processInput(String[] input) {
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+
+        for (String element : input) {
+            if (element.contains(":")) {
+                if (current.length() > 0) {
+                    result.add(current.toString().trim());
+                    current.setLength(0);
+                }
+                current.append(element);
+            } else {
+                current.append(" ").append(element);
+            }
+        }
+
+        if (current.length() > 0) {
+            result.add(current.toString().trim());
+        }
+
+        return result.toArray(new String[0]);
     }
 
     /**
@@ -196,7 +247,7 @@ public class RegistrySearchUtil {
                 // if search key is 'tag' instead of 'tags', allow it as well since rest api document says query
                 // param to use for tag search is 'tag'
 
-                if (TAG_SEARCH_TYPE_PREFIX.equals(searchKey)) {
+                if (TAG_SEARCH_TYPE_PREFIX.equals(searchKey) || TAGS_SEARCH_TYPE_PREFIX.equals(searchKey)) {
                     searchKey = TAGS_SEARCH_TYPE_PREFIX;
                     searchValue = searchValue.replace(" ", "\\ ");
                 }


### PR DESCRIPTION
## Purpose  
The current **DevPortal API search** supports multiple filter criteria, introduced in PR [1][2]. However, this update inadvertently broke the previous behavior where tags containing space characters were supported. For example, **APIM 3.2.0** allowed searches like `tag:Sample APIs - New`.  

This PR resolves the issue by restoring support for space-containing tags in search queries. Additionally, it ensures that both `tag` and `tags` filters function correctly when used with space characters.  

### Supported Search Examples  
- `tag:Sample APIs - New`  
- `tags:Sample APIs - New tags:pizza`  

## Approach  
The solution modifies the search logic by concatenating the following search components into the previous filter criteria:  

### Example Transformations  
1. **`tag:Sample APIs - New name:Google`** → `tag:Sample APIs - New && name:Google`  
2. **`Google tag:Sample APIs - New`** → `name:Google && tag:Sample APIs - New`  
3. **`Google tags:Sample APIs - New tags:pizza`** → `name:Google && (tags:Sample APIs - New || tags:pizza)`  
4. **`tags:pizza`** → `tags:pizza`  
5. **`name:google tag:Sample APIs - New tag:pizza name:abc`** → `(name:Google || name:abc) && (tags:Sample APIs - New || tags:pizza)`  


[1] https://github.com/wso2/carbon-apimgt/pull/12370
[2] https://github.com/wso2/carbon-apimgt/pull/12466

## Related issue
Issue: https://github.com/wso2/api-manager/issues/3535
Internal: https://github.com/wso2-enterprise/wso2-apim-internal/issues/8509
