### PR TITLE
Remove the capability to change the subscription availability when cross-tenant subscription is disabled

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -120,6 +120,7 @@ public enum ExceptionCodes implements ErrorHandler {
     API_PRODUCT_NOT_FOUND(900360, "API Product Not Found", 404, "Requested API Product with id '%s' not found"),
     SUB_ORGANIZATION_NOT_IDENTIFIED(900361, "User's Organization Not Identified", 403, "User's Organization is not identified"),
     CANNOT_CREATE_API_VERSION(900362, "New API Version cannot be created from a different provider", 409, "Initial provider of an API must be preserved in all versions of that API"),
+    INTERNAL_ERROR_WHILE_UPDATING_API(900363, "Internal Server Error occurred while updating the API", 500, "Internal Server Error. '%s'"),
     ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES(903010, "Error while updating required properties", 400, "Error while updating required properties."),
 
     //Lifecycle related codes


### PR DESCRIPTION
## Purpose
This PR fixes an issue where the subscription availability could be changed from the REST API level (using an API update) even when the cross tenant subscription was disabled through the configurations.

Fixes https://github.com/wso2/api-manager/issues/3524

## Approach
With this fix, the subscription availability change would be allowed only to CURRENT_TENANT when cross tenant subscription is disabled. There's no impact when subscription availability is not changed. It will stay the same regardless of the configuration.