### PR TITLE
Remove organizationName from organization subscription policies

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OrganizationTiers.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OrganizationTiers.java
@@ -25,7 +25,6 @@ import java.util.Set;
 public class OrganizationTiers {
 
     private String organizationID;
-    private String organizationName;
     private Set<Tier> tiers;
 
     public String getOrganizationID() {
@@ -34,14 +33,6 @@ public class OrganizationTiers {
 
     public void setOrganizationID(String organizationID) {
         this.organizationID = organizationID;
-    }
-
-    public String getOrganizationName() {
-        return organizationName;
-    }
-
-    public void setOrganizationName(String organizationName) {
-        this.organizationName = organizationName;
     }
 
     public Set<Tier> getTiers() {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -11205,7 +11205,7 @@ public final class APIUtil {
         Set<org.wso2.carbon.apimgt.api.model.OrganizationTiers> availableTiersForOrganizations
                 = api.getAvailableTiersForOrganizations();
         if (availableTiersForOrganizations == null || availableTiersForOrganizations.isEmpty()) {
-            return null;
+            return "";
         }
         try {
             ObjectMapper objectMapper = new ObjectMapper();

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/OrganizationTiers.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/OrganizationTiers.java
@@ -21,7 +21,6 @@ import java.util.Set;
 
 public class OrganizationTiers {
     private String organizationID;
-    private String organizationName;
     private Set<String> tiers;
 
     public String getOrganizationID() {
@@ -30,14 +29,6 @@ public class OrganizationTiers {
 
     public void setOrganizationID(String organizationID) {
         this.organizationID = organizationID;
-    }
-
-    public String getOrganizationName() {
-        return organizationName;
-    }
-
-    public void setOrganizationName(String organizationName) {
-        this.organizationName = organizationName;
     }
 
     public Set<String> getTiers() {

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
@@ -358,7 +358,7 @@ public class RegistryPersistenceUtil {
         Set<org.wso2.carbon.apimgt.api.model.OrganizationTiers> availableTiersForOrganizations
                 = api.getAvailableTiersForOrganizations();
         if (availableTiersForOrganizations == null || availableTiersForOrganizations.isEmpty()) {
-            return null;
+            return "";
         }
         try {
             ObjectMapper objectMapper = new ObjectMapper();

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/utils/RegistryPersistenceUtil.java
@@ -432,7 +432,6 @@ public class RegistryPersistenceUtil {
 
         OrganizationTiers organizationTiers = new OrganizationTiers();
         organizationTiers.setOrganizationID(organizationTiersToMap.getOrganizationID());
-        organizationTiers.setOrganizationName(organizationTiersToMap.getOrganizationName());
         Set<Tier> tiersToMap = organizationTiersToMap.getTiers();
         Set<String> tiers = new LinkedHashSet<>();
         for (Tier tierToMap : tiersToMap) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
@@ -12683,9 +12683,6 @@ components:
         organizationID:
           type: string
           example: "36c87e00-57f0-4000-9f97-b379acc4e577"
-        organizationName:
-          type: string
-          example: "wso2"
         policies:
           type: array
           example: ["Silver", "Gold", "Unlimited"]

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/OrganizationPoliciesDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/OrganizationPoliciesDTO.java
@@ -23,7 +23,6 @@ import javax.validation.Valid;
 public class OrganizationPoliciesDTO   {
   
     private String organizationID = null;
-    private String organizationName = null;
     private List<String> policies = new ArrayList<String>();
 
   /**
@@ -42,23 +41,6 @@ public class OrganizationPoliciesDTO   {
   }
   public void setOrganizationID(String organizationID) {
     this.organizationID = organizationID;
-  }
-
-  /**
-   **/
-  public OrganizationPoliciesDTO organizationName(String organizationName) {
-    this.organizationName = organizationName;
-    return this;
-  }
-
-  
-  @ApiModelProperty(example = "wso2", value = "")
-  @JsonProperty("organizationName")
-  public String getOrganizationName() {
-    return organizationName;
-  }
-  public void setOrganizationName(String organizationName) {
-    this.organizationName = organizationName;
   }
 
   /**
@@ -89,13 +71,12 @@ public class OrganizationPoliciesDTO   {
     }
     OrganizationPoliciesDTO organizationPolicies = (OrganizationPoliciesDTO) o;
     return Objects.equals(organizationID, organizationPolicies.organizationID) &&
-        Objects.equals(organizationName, organizationPolicies.organizationName) &&
         Objects.equals(policies, organizationPolicies.policies);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(organizationID, organizationName, policies);
+    return Objects.hash(organizationID, policies);
   }
 
   @Override
@@ -104,7 +85,6 @@ public class OrganizationPoliciesDTO   {
     sb.append("class OrganizationPoliciesDTO {\n");
     
     sb.append("    organizationID: ").append(toIndentedString(organizationID)).append("\n");
-    sb.append("    organizationName: ").append(toIndentedString(organizationName)).append("\n");
     sb.append("    policies: ").append(toIndentedString(policies)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -324,7 +324,6 @@ public class APIMappingUtil {
                     apiTiersForOrganization.add(new Tier(tier));
                 }
                 organizationTiers.setOrganizationID(organizationPoliciesDTO.getOrganizationID());
-                organizationTiers.setOrganizationName(organizationPoliciesDTO.getOrganizationName());
                 organizationTiers.setTiers(apiTiersForOrganization);
                 organizationAPITiers.add(organizationTiers);
             }
@@ -2754,7 +2753,6 @@ public class APIMappingUtil {
         }
         organizationPoliciesDTO.setPolicies(tiersToReturn);
         organizationPoliciesDTO.setOrganizationID(organizationTiers.getOrganizationID());
-        organizationPoliciesDTO.setOrganizationName(organizationTiers.getOrganizationName());
         return organizationPoliciesDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -12683,9 +12683,6 @@ components:
         organizationID:
           type: string
           example: "36c87e00-57f0-4000-9f97-b379acc4e577"
-        organizationName:
-          type: string
-          example: "wso2"
         policies:
           type: array
           example: ["Silver", "Gold", "Unlimited"]


### PR DESCRIPTION
### Purpose

- Change publisher REST API to remove organizationName from organizationPolicies
- Fix organization policies not being removed issue