### PR TITLE
Add chat and generate API payload REST API resources with token implementation for API Design Assistant

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -549,6 +549,16 @@ public final class APIConstants {
         public static final String MARKETPLACE_ASSISTANT_API_COUNT_RESOURCE = "ApiCountResource";
         public static final String AI_CONFIGURATION = "AiConfiguration";
 
+        public static final String DESIGN_ASSISTANT = "DesignAssistant";
+        public static final String DESIGN_ASSISTANT_ENABLED = "Enabled";
+        public static final String DESIGN_ASSISTANT_AUTH_TOKEN = "AuthToken";
+        public static final String DESIGN_ASSISTANT_KEY = "Key";
+        public static final String DESIGN_ASSISTANT_ENDPOINT = "Endpoint";
+        public static final String DESIGN_ASSISTANT_TOKEN_ENDPOINT = "TokenEndpoint";
+        public static final String DESIGN_ASSISTANT_CHAT_RESOURCE = "ChatResource";
+        public static final String DESIGN_ASSISTANT_GEN_API_PAYLOAD_RESOURCE = "GenApiPayloadResource";
+        public static final String DESIGN_ASSISTANT_CONFIGURATION = "AiConfiguration";
+
         private AI() {
 
         }
@@ -1771,6 +1781,8 @@ public final class APIConstants {
     public static final String API_SPEC_NAME = "api_name";
     public static final String TENANT_DOMAIN = "tenant_domain";
     public static final String QUERY = "query";
+    public static final String TEXT = "text";
+    public static final String SESSIONID = "sessionId";
     public static final String HISTORY = "history";
     public static final String VERSION = "version";
     public static final String VISIBILITYROLES = "visibility_roles";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1,7 +1,7 @@
 /*
- *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License.
  *  You may obtain a copy of the License at
@@ -557,7 +557,6 @@ public final class APIConstants {
         public static final String DESIGN_ASSISTANT_TOKEN_ENDPOINT = "TokenEndpoint";
         public static final String DESIGN_ASSISTANT_CHAT_RESOURCE = "ChatResource";
         public static final String DESIGN_ASSISTANT_GEN_API_PAYLOAD_RESOURCE = "GenApiPayloadResource";
-        public static final String DESIGN_ASSISTANT_CONFIGURATION = "AiConfiguration";
 
         private AI() {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.VHost;
 import org.wso2.carbon.apimgt.common.gateway.configdto.HttpClientConfigurationDTO;
 import org.wso2.carbon.apimgt.impl.dto.ai.ApiChatConfigurationDTO;
+import org.wso2.carbon.apimgt.impl.dto.ai.DesignAssistantConfigurationDTO;
 import org.wso2.carbon.apimgt.impl.dto.ai.MarketplaceAssistantConfigurationDTO;
 import org.wso2.carbon.apimgt.common.gateway.dto.ClaimMappingDto;
 import org.wso2.carbon.apimgt.common.gateway.dto.JWKSConfigurationDTO;
@@ -125,6 +126,7 @@ public class APIManagerConfiguration {
     private ExtendedJWTConfigurationDto jwtConfigurationDto = new ExtendedJWTConfigurationDto();
     private static MarketplaceAssistantConfigurationDTO marketplaceAssistantConfigurationDto = new MarketplaceAssistantConfigurationDTO();
     private static ApiChatConfigurationDTO apiChatConfigurationDto = new ApiChatConfigurationDTO();
+    private static DesignAssistantConfigurationDTO designAssistantConfigurationDto = new DesignAssistantConfigurationDTO();
 
     private WorkflowProperties workflowProperties = new WorkflowProperties();
     private Map<String, Environment> apiGatewayEnvironments = new LinkedHashMap<String, Environment>();
@@ -192,6 +194,11 @@ public class APIManagerConfiguration {
     public ApiChatConfigurationDTO getApiChatConfigurationDto() {
 
         return apiChatConfigurationDto;
+    }
+
+    public DesignAssistantConfigurationDTO getDesignAssistantConfigurationDto() {
+
+        return designAssistantConfigurationDto;
     }
 
     private Set<APIStore> externalAPIStores = new HashSet<APIStore>();
@@ -675,6 +682,8 @@ public class APIManagerConfiguration {
                 setMarketplaceAssistantConfiguration(element);
             } else if (APIConstants.AI.API_CHAT.equals(localName)) {
                 setApiChatConfiguration(element);
+            } else if (APIConstants.AI.DESIGN_ASSISTANT.equals(localName)) {
+                setDesignAssistantConfiguration(element);
             } else if (APIConstants.AI.AI_CONFIGURATION.equals(localName)){
                 setAiConfiguration(element);
             } else if (APIConstants.TokenValidationConstants.TOKEN_VALIDATION_CONFIG.equals(localName)) {
@@ -2672,6 +2681,58 @@ public class APIManagerConfiguration {
             return Boolean.parseBoolean(jwtClaimCacheExpiryEnabledString);
         }
         return false;
+    }
+
+    public void setDesignAssistantConfiguration(OMElement omElement){
+        OMElement designAssistantEnableElement =
+                omElement.getFirstChildWithName(new QName(APIConstants.AI.DESIGN_ASSISTANT_ENABLED));
+        if (designAssistantEnableElement != null) {
+            designAssistantConfigurationDto.setEnabled(Boolean.parseBoolean(designAssistantEnableElement.getText()));
+        }
+        if (designAssistantConfigurationDto.isEnabled()) {
+            OMElement designAssistantEndpoint =
+                    omElement.getFirstChildWithName(new QName(APIConstants.AI.DESIGN_ASSISTANT_ENDPOINT));
+            if (designAssistantEndpoint != null) {
+                designAssistantConfigurationDto.setEndpoint(designAssistantEndpoint.getText());
+            }
+            OMElement designAssistantTokenEndpoint =
+                    omElement.getFirstChildWithName(new QName(APIConstants.AI.DESIGN_ASSISTANT_TOKEN_ENDPOINT));
+            if (designAssistantTokenEndpoint != null) {
+                designAssistantConfigurationDto.setTokenEndpoint(designAssistantTokenEndpoint.getText());
+            }
+            OMElement designAssistantKey =
+                    omElement.getFirstChildWithName(new QName(APIConstants.AI.DESIGN_ASSISTANT_KEY));
+
+            if (designAssistantKey != null) {
+                String Key = MiscellaneousUtil.resolve(designAssistantKey, secretResolver);
+                designAssistantConfigurationDto.setKey(Key);
+                if (!Key.isEmpty()){
+                    designAssistantConfigurationDto.setKeyProvided(true);
+                }
+            }
+            OMElement designAssistantToken =
+                    omElement.getFirstChildWithName(new QName(APIConstants.AI.DESIGN_ASSISTANT_AUTH_TOKEN));
+            if (designAssistantToken != null) {
+                String AccessToken = MiscellaneousUtil.resolve(designAssistantToken, secretResolver);
+                designAssistantConfigurationDto.setAccessToken(AccessToken);
+                if (!AccessToken.isEmpty()){
+                    designAssistantConfigurationDto.setAuthTokenProvided(true);
+                }
+            }
+            OMElement resources =
+                    omElement.getFirstChildWithName(new QName(APIConstants.AI.RESOURCES));
+
+            OMElement designAssistantChatResource =
+                    resources.getFirstChildWithName(new QName(APIConstants.AI.DESIGN_ASSISTANT_CHAT_RESOURCE));
+            if (designAssistantChatResource != null) {
+                designAssistantConfigurationDto.setChatResource(designAssistantChatResource.getText());
+            }
+            OMElement designAssistantGenApiPayloadResource =
+                    resources.getFirstChildWithName(new QName(APIConstants.AI.DESIGN_ASSISTANT_GEN_API_PAYLOAD_RESOURCE));
+            if (designAssistantGenApiPayloadResource != null) {
+                designAssistantConfigurationDto.setGenApiPayloadResource(designAssistantGenApiPayloadResource.getText());
+            }
+        }
     }
 
     public TokenValidationDto getTokenValidationDto() {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ai/DesignAssistantConfigurationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ai/DesignAssistantConfigurationDTO.java
@@ -1,0 +1,134 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.dto.ai;
+
+/**
+ * This class represent the Design Assistant configuration DTO.
+ */
+public class DesignAssistantConfigurationDTO {
+
+    private String accessToken;
+    private String key;
+    private String endpoint;
+    private String tokenEndpoint;
+    private String apiPublishResource;
+    private String chatResource;
+    private String genApiPayload;
+    private String apiDeleteResource;
+    private String apiCountResource;
+    private boolean isEnabled;
+    private boolean isAuthTokenProvided;
+    private boolean isKeyProvided;
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getTokenEndpoint() {
+        return tokenEndpoint;
+    }
+
+    public void setTokenEndpoint(String tokenEndpoint) {
+        this.tokenEndpoint = tokenEndpoint;
+    }
+
+    public String getApiPublishResource() {
+        return apiPublishResource;
+    }
+
+    public void setApiPublishResource(String apiPublishResource) {
+        this.apiPublishResource = apiPublishResource;
+    }
+
+    public String getChatResource() {
+        return chatResource;
+    }
+
+    public void setChatResource(String chatResource) {
+        this.chatResource = chatResource;
+    }
+
+    public String getGenApiPayloadResource() {
+        return genApiPayload;
+    }
+
+    public void setGenApiPayloadResource(String genApiPayload) {
+        this.genApiPayload = genApiPayload;
+    }
+
+    public String getApiDeleteResource() {
+        return apiDeleteResource;
+    }
+
+    public void setApiDeleteResource(String apiDeleteResource) {
+        this.apiDeleteResource = apiDeleteResource;
+    }
+
+    public String getApiCountResource() {
+        return apiCountResource;
+    }
+
+    public void setApiCountResource(String apiCountResource) {
+        this.apiCountResource = apiCountResource;
+    }
+
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.isEnabled = enabled;
+    }
+
+    public boolean isAuthTokenProvided() {
+        return isAuthTokenProvided;
+    }
+
+    public boolean isKeyProvided() {
+        return isKeyProvided;
+    }
+
+    public void setAuthTokenProvided(boolean authTokenProvided) {
+        this.isAuthTokenProvided = authTokenProvided;
+    }
+
+    public void setKeyProvided(boolean keyProvided) {
+        this.isKeyProvided = keyProvided;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
@@ -301,7 +301,7 @@ paths:
             - apim:api_manage
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -X POST -H Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
+          source: 'curl -k -X POST -H Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"sessionId\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
       operationId: designAssistantChat
 
   ######################################################################
@@ -338,7 +338,7 @@ paths:
             - apim:api_manage
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/generate-api-payload"'
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"sessionId\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/generate-api-payload"'
       operationId: designAssistantApiPayloadGen
 
   ######################################################

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
@@ -262,6 +262,85 @@ paths:
           -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis"'
       operationId: createAPI
 
+  #######################################################
+  # The "API Design Assistant - Chat" resource APIs
+  #######################################################
+  /design-assistant/chat:
+    post:
+      tags:
+        - API Design Assistant
+      summary: Generate API Specifications with API Design Assistant
+      description: |
+        Generates API specifications based on natural language input.
+
+        Key features:
+        - Converts text descriptions into structured API specifications
+        - Provides QoS suggestions and other improvements
+        - Supports session-based API generation
+      requestBody:
+        description: Input for API specification generation
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DesignAssistantChatQuery'
+      responses:
+        200:
+          description: Successful API specification generation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DesignAssistantChatResponse'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        415:
+          $ref: '#/components/responses/UnsupportedMediaType'
+      security:
+        - OAuth2Security:
+            - apim:api_create
+            - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
+      operationId: designAssistantChat
+
+  ######################################################################
+  # The "API Design Assistant - Generate API Payloads" resource APIs
+  ######################################################################
+  /design-assistant/generate-api-payload:
+    post:
+      tags:
+        - API Design Assistant
+      summary: Create API Payload with API Design Assistant
+      description: |
+        Creates an API payload using the stored specification.
+      requestBody:
+        description: Input for API payload creation
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DesignAssistantGenAPIPayload'
+      responses:
+        200:
+          description: API payload successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DesignAssistantAPIPayloadResponse'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        415:
+          $ref: '#/components/responses/UnsupportedMediaType'
+      security:
+        - OAuth2Security:
+            - apim:api_create
+            - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/generate-api-payload"'
+      operationId: designAssistantApiPayloadGen
+
   ######################################################
   # The "Individual API" resource APIs
   ######################################################
@@ -9735,6 +9814,52 @@ paths:
 
 components:
   schemas:
+    DesignAssistantChatQuery:
+      type: object
+      properties:
+        text:
+          type: string
+          example: create an API for a banking transaction
+        session_id:
+          type: string
+          example: 1234567890
+    DesignAssistantChatResponse:
+      type: object
+      properties:
+        backendResponse:
+          type: string
+        isSuggestions:
+          type: boolean
+          example: true
+        typeOfApi:
+          type: string
+          example: REST
+        code:
+          type: string
+        paths:
+          type: array
+          example: []
+          items:
+            type: string
+        apiTypeSuggestion:
+          type: string
+          example: This is suitable for CRUD operations in banking. Do you want to proceed?
+        missingValues:
+          type: string
+        state:
+          type: string
+          example: COMPLETE
+    DesignAssistantGenAPIPayload:
+      type: object
+      properties:
+        session_id:
+          type: string
+          example: 1234567890
+    DesignAssistantAPIPayloadResponse:
+      type: object
+      properties:
+        generated_payload:
+          type: string
     SequenceBackendList:
       title: Sequence Backend List
       type: object

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/DesignAssistantAPIPayloadResponseDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/DesignAssistantAPIPayloadResponseDTO.java
@@ -1,0 +1,81 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class DesignAssistantAPIPayloadResponseDTO   {
+  
+    private String generatedPayload = null;
+
+  /**
+   **/
+  public DesignAssistantAPIPayloadResponseDTO generatedPayload(String generatedPayload) {
+    this.generatedPayload = generatedPayload;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("generated_payload")
+  public String getGeneratedPayload() {
+    return generatedPayload;
+  }
+  public void setGeneratedPayload(String generatedPayload) {
+    this.generatedPayload = generatedPayload;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DesignAssistantAPIPayloadResponseDTO designAssistantAPIPayloadResponse = (DesignAssistantAPIPayloadResponseDTO) o;
+    return Objects.equals(generatedPayload, designAssistantAPIPayloadResponse.generatedPayload);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(generatedPayload);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DesignAssistantAPIPayloadResponseDTO {\n");
+    
+    sb.append("    generatedPayload: ").append(toIndentedString(generatedPayload)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/DesignAssistantChatQueryDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/DesignAssistantChatQueryDTO.java
@@ -1,0 +1,101 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class DesignAssistantChatQueryDTO   {
+  
+    private String text = null;
+    private String sessionId = null;
+
+  /**
+   **/
+  public DesignAssistantChatQueryDTO text(String text) {
+    this.text = text;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "create an API for a banking transaction", value = "")
+  @JsonProperty("text")
+  public String getText() {
+    return text;
+  }
+  public void setText(String text) {
+    this.text = text;
+  }
+
+  /**
+   **/
+  public DesignAssistantChatQueryDTO sessionId(String sessionId) {
+    this.sessionId = sessionId;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "1234567890", value = "")
+  @JsonProperty("session_id")
+  public String getSessionId() {
+    return sessionId;
+  }
+  public void setSessionId(String sessionId) {
+    this.sessionId = sessionId;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DesignAssistantChatQueryDTO designAssistantChatQuery = (DesignAssistantChatQueryDTO) o;
+    return Objects.equals(text, designAssistantChatQuery.text) &&
+        Objects.equals(sessionId, designAssistantChatQuery.sessionId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(text, sessionId);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DesignAssistantChatQueryDTO {\n");
+    
+    sb.append("    text: ").append(toIndentedString(text)).append("\n");
+    sb.append("    sessionId: ").append(toIndentedString(sessionId)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/DesignAssistantChatResponseDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/DesignAssistantChatResponseDTO.java
@@ -1,0 +1,223 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class DesignAssistantChatResponseDTO   {
+  
+    private String backendResponse = null;
+    private Boolean isSuggestions = null;
+    private String typeOfApi = null;
+    private String code = null;
+    private List<String> paths = new ArrayList<String>();
+    private String apiTypeSuggestion = null;
+    private String missingValues = null;
+    private String state = null;
+
+  /**
+   **/
+  public DesignAssistantChatResponseDTO backendResponse(String backendResponse) {
+    this.backendResponse = backendResponse;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("backendResponse")
+  public String getBackendResponse() {
+    return backendResponse;
+  }
+  public void setBackendResponse(String backendResponse) {
+    this.backendResponse = backendResponse;
+  }
+
+  /**
+   **/
+  public DesignAssistantChatResponseDTO isSuggestions(Boolean isSuggestions) {
+    this.isSuggestions = isSuggestions;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("isSuggestions")
+  public Boolean isIsSuggestions() {
+    return isSuggestions;
+  }
+  public void setIsSuggestions(Boolean isSuggestions) {
+    this.isSuggestions = isSuggestions;
+  }
+
+  /**
+   **/
+  public DesignAssistantChatResponseDTO typeOfApi(String typeOfApi) {
+    this.typeOfApi = typeOfApi;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "REST", value = "")
+  @JsonProperty("typeOfApi")
+  public String getTypeOfApi() {
+    return typeOfApi;
+  }
+  public void setTypeOfApi(String typeOfApi) {
+    this.typeOfApi = typeOfApi;
+  }
+
+  /**
+   **/
+  public DesignAssistantChatResponseDTO code(String code) {
+    this.code = code;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("code")
+  public String getCode() {
+    return code;
+  }
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  /**
+   **/
+  public DesignAssistantChatResponseDTO paths(List<String> paths) {
+    this.paths = paths;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "[]", value = "")
+  @JsonProperty("paths")
+  public List<String> getPaths() {
+    return paths;
+  }
+  public void setPaths(List<String> paths) {
+    this.paths = paths;
+  }
+
+  /**
+   **/
+  public DesignAssistantChatResponseDTO apiTypeSuggestion(String apiTypeSuggestion) {
+    this.apiTypeSuggestion = apiTypeSuggestion;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "This is suitable for CRUD operations in banking. Do you want to proceed?", value = "")
+  @JsonProperty("apiTypeSuggestion")
+  public String getApiTypeSuggestion() {
+    return apiTypeSuggestion;
+  }
+  public void setApiTypeSuggestion(String apiTypeSuggestion) {
+    this.apiTypeSuggestion = apiTypeSuggestion;
+  }
+
+  /**
+   **/
+  public DesignAssistantChatResponseDTO missingValues(String missingValues) {
+    this.missingValues = missingValues;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("missingValues")
+  public String getMissingValues() {
+    return missingValues;
+  }
+  public void setMissingValues(String missingValues) {
+    this.missingValues = missingValues;
+  }
+
+  /**
+   **/
+  public DesignAssistantChatResponseDTO state(String state) {
+    this.state = state;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "COMPLETE", value = "")
+  @JsonProperty("state")
+  public String getState() {
+    return state;
+  }
+  public void setState(String state) {
+    this.state = state;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DesignAssistantChatResponseDTO designAssistantChatResponse = (DesignAssistantChatResponseDTO) o;
+    return Objects.equals(backendResponse, designAssistantChatResponse.backendResponse) &&
+        Objects.equals(isSuggestions, designAssistantChatResponse.isSuggestions) &&
+        Objects.equals(typeOfApi, designAssistantChatResponse.typeOfApi) &&
+        Objects.equals(code, designAssistantChatResponse.code) &&
+        Objects.equals(paths, designAssistantChatResponse.paths) &&
+        Objects.equals(apiTypeSuggestion, designAssistantChatResponse.apiTypeSuggestion) &&
+        Objects.equals(missingValues, designAssistantChatResponse.missingValues) &&
+        Objects.equals(state, designAssistantChatResponse.state);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(backendResponse, isSuggestions, typeOfApi, code, paths, apiTypeSuggestion, missingValues, state);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DesignAssistantChatResponseDTO {\n");
+    
+    sb.append("    backendResponse: ").append(toIndentedString(backendResponse)).append("\n");
+    sb.append("    isSuggestions: ").append(toIndentedString(isSuggestions)).append("\n");
+    sb.append("    typeOfApi: ").append(toIndentedString(typeOfApi)).append("\n");
+    sb.append("    code: ").append(toIndentedString(code)).append("\n");
+    sb.append("    paths: ").append(toIndentedString(paths)).append("\n");
+    sb.append("    apiTypeSuggestion: ").append(toIndentedString(apiTypeSuggestion)).append("\n");
+    sb.append("    missingValues: ").append(toIndentedString(missingValues)).append("\n");
+    sb.append("    state: ").append(toIndentedString(state)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/DesignAssistantGenAPIPayloadDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/dto/DesignAssistantGenAPIPayloadDTO.java
@@ -1,0 +1,81 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class DesignAssistantGenAPIPayloadDTO   {
+  
+    private String sessionId = null;
+
+  /**
+   **/
+  public DesignAssistantGenAPIPayloadDTO sessionId(String sessionId) {
+    this.sessionId = sessionId;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "1234567890", value = "")
+  @JsonProperty("session_id")
+  public String getSessionId() {
+    return sessionId;
+  }
+  public void setSessionId(String sessionId) {
+    this.sessionId = sessionId;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DesignAssistantGenAPIPayloadDTO designAssistantGenAPIPayload = (DesignAssistantGenAPIPayloadDTO) o;
+    return Objects.equals(sessionId, designAssistantGenAPIPayload.sessionId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sessionId);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DesignAssistantGenAPIPayloadDTO {\n");
+    
+    sb.append("    sessionId: ").append(toIndentedString(sessionId)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/DesignAssistantApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/DesignAssistantApi.java
@@ -1,0 +1,77 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1;
+
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DesignAssistantAPIPayloadResponseDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DesignAssistantChatQueryDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DesignAssistantChatResponseDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DesignAssistantGenAPIPayloadDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.DesignAssistantApiService;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.impl.DesignAssistantApiServiceImpl;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.inject.Inject;
+
+import io.swagger.annotations.*;
+import java.io.InputStream;
+
+import org.apache.cxf.jaxrs.ext.MessageContext;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+
+import java.util.Map;
+import java.util.List;
+import javax.validation.constraints.*;
+@Path("/design-assistant")
+
+@Api(description = "the design-assistant API")
+
+
+
+
+public class DesignAssistantApi  {
+
+  @Context MessageContext securityContext;
+
+DesignAssistantApiService delegate = new DesignAssistantApiServiceImpl();
+
+
+    @POST
+    @Path("/generate-api-payload")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Create API Payload with API Design Assistant", notes = "Creates an API payload using the stored specification. ", response = DesignAssistantAPIPayloadResponseDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:api_create", description = "Create API"),
+            @AuthorizationScope(scope = "apim:api_manage", description = "Manage all API related operations")
+        })
+    }, tags={ "API Design Assistant",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "API payload successfully created.", response = DesignAssistantAPIPayloadResponseDTO.class),
+        @ApiResponse(code = 400, message = "Bad Request. Invalid request or validation error.", response = ErrorDTO.class),
+        @ApiResponse(code = 415, message = "Unsupported Media Type. The entity of the request was not in a supported format.", response = ErrorDTO.class) })
+    public Response designAssistantApiPayloadGen(@ApiParam(value = "Input for API payload creation" ,required=true) DesignAssistantGenAPIPayloadDTO designAssistantGenAPIPayloadDTO) throws APIManagementException{
+        return delegate.designAssistantApiPayloadGen(designAssistantGenAPIPayloadDTO, securityContext);
+    }
+
+    @POST
+    @Path("/chat")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Generate API Specifications with API Design Assistant", notes = "Generates API specifications based on natural language input.  Key features: - Converts text descriptions into structured API specifications - Provides QoS suggestions and other improvements - Supports session-based API generation ", response = DesignAssistantChatResponseDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:api_create", description = "Create API"),
+            @AuthorizationScope(scope = "apim:api_manage", description = "Manage all API related operations")
+        })
+    }, tags={ "API Design Assistant" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful API specification generation", response = DesignAssistantChatResponseDTO.class),
+        @ApiResponse(code = 400, message = "Bad Request. Invalid request or validation error.", response = ErrorDTO.class),
+        @ApiResponse(code = 415, message = "Unsupported Media Type. The entity of the request was not in a supported format.", response = ErrorDTO.class) })
+    public Response designAssistantChat(@ApiParam(value = "Input for API specification generation" ,required=true) DesignAssistantChatQueryDTO designAssistantChatQueryDTO) throws APIManagementException{
+        return delegate.designAssistantChat(designAssistantChatQueryDTO, securityContext);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/DesignAssistantApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/DesignAssistantApiService.java
@@ -1,0 +1,29 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1;
+
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.*;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.*;
+
+import org.apache.cxf.jaxrs.ext.MessageContext;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+
+import org.wso2.carbon.apimgt.api.APIManagementException;
+
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DesignAssistantAPIPayloadResponseDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DesignAssistantChatQueryDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DesignAssistantChatResponseDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DesignAssistantGenAPIPayloadDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.ErrorDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+
+
+public interface DesignAssistantApiService {
+      public Response designAssistantApiPayloadGen(DesignAssistantGenAPIPayloadDTO designAssistantGenAPIPayloadDTO, MessageContext messageContext) throws APIManagementException;
+      public Response designAssistantChat(DesignAssistantChatQueryDTO designAssistantChatQueryDTO, MessageContext messageContext) throws APIManagementException;
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/DesignAssistantApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/DesignAssistantApiServiceImpl.java
@@ -1,0 +1,105 @@
+package org.wso2.carbon.apimgt.rest.api.publisher.v1.impl;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.*;
+
+import org.apache.cxf.jaxrs.ext.MessageContext;
+
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DesignAssistantAPIPayloadResponseDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DesignAssistantChatQueryDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DesignAssistantChatResponseDTO;
+import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.DesignAssistantGenAPIPayloadDTO;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.io.InputStream;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class DesignAssistantApiServiceImpl implements DesignAssistantApiService {
+    public Response designAssistantApiPayloadGen(DesignAssistantGenAPIPayloadDTO designAssistantGenAPIPayloadDTO, MessageContext messageContext) {
+        String sessionId = designAssistantGenAPIPayloadDTO.getSessionId();
+        try {
+            String generatedPayload = sendSessionIdToPythonBackend(sessionId);
+            DesignAssistantAPIPayloadResponseDTO responseDTO = new DesignAssistantAPIPayloadResponseDTO();
+            responseDTO.setGeneratedPayload(generatedPayload);
+
+            return Response.ok(responseDTO).build();
+        } catch (Exception e) {
+            System.err.println("Failed to send Session Id to Python backend: " + e.getMessage());
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("Error processing request: " + e.getMessage())
+                    .build();
+        }
+    }
+
+    public String sendSessionIdToPythonBackend (String sessionId) throws URISyntaxException, IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonPayload = objectMapper.writeValueAsString(new GeneratePayloadRequest(sessionId));
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(new URI("http://localhost:8000/generate-api-payload"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(jsonPayload))
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        return response.body();
+    }
+
+    public Response designAssistantChat(DesignAssistantChatQueryDTO designAssistantChatQueryDTO, MessageContext messageContext) {
+        String text = designAssistantChatQueryDTO.getText();
+        String sessionId = designAssistantChatQueryDTO.getSessionId();
+        try {
+            String chatResponseJson = sendTextSessionIdToPythonBackend(text, sessionId);
+            ObjectMapper objectMapper = new ObjectMapper();
+            DesignAssistantChatResponseDTO responseDTO = objectMapper.readValue(chatResponseJson, DesignAssistantChatResponseDTO.class);
+
+            return Response.ok(responseDTO).build();
+        } catch (Exception e) {
+            System.err.println("Failed to send Session Id to Python backend: " + e.getMessage());
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("Error processing request: " + e.getMessage())
+                    .build();
+        }
+    }
+
+    public String sendTextSessionIdToPythonBackend (String text, String sessionId) throws URISyntaxException, IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonPayload = objectMapper.writeValueAsString(new ChatRequest(text, sessionId));
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(new URI("http://localhost:8000/chat"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(jsonPayload))
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        return response.body();
+    }
+
+    private static class GeneratePayloadRequest {
+        public String sessionId;
+
+        public GeneratePayloadRequest(String sessionId) {
+            this.sessionId = sessionId;
+        }
+    }
+
+    private static class ChatRequest {
+        public String text;
+        public String sessionId;
+
+        public ChatRequest(String text, String sessionId) {
+            this.text = text;
+            this.sessionId = sessionId;
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -301,7 +301,7 @@ paths:
             - apim:api_manage
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -X POST -H Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
+          source: 'curl -k -X POST -H Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"sessionId\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
       operationId: designAssistantChat
 
   ######################################################################
@@ -338,7 +338,7 @@ paths:
             - apim:api_manage
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/generate-api-payload"'
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"sessionId\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/generate-api-payload"'
       operationId: designAssistantApiPayloadGen
 
   ######################################################

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -262,9 +262,9 @@ paths:
           -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis"'
       operationId: createAPI
 
-  ######################################################
+  #######################################################
   # The "API Design Assistant - Chat" resource APIs
-  ######################################################
+  #######################################################
   /design-assistant/chat:
     post:
       tags:
@@ -301,7 +301,7 @@ paths:
             - apim:api_manage
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -X POST -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
+          source: 'curl -k -X POST -H Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
       operationId: designAssistantChat
 
   ######################################################################

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -263,6 +263,85 @@ paths:
       operationId: createAPI
 
   ######################################################
+  # The "API Design Assistant - Chat" resource APIs
+  ######################################################
+  /design-assistant/chat:
+    post:
+      tags:
+        - API Design Assistant
+      summary: Generate API Specifications with API Design Assistant
+      description: |
+        Generates API specifications based on natural language input.
+
+        Key features:
+        - Converts text descriptions into structured API specifications
+        - Provides QoS suggestions and other improvements
+        - Supports session-based API generation
+      requestBody:
+        description: Input for API specification generation
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DesignAssistantChatQuery'
+      responses:
+        200:
+          description: Successful API specification generation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DesignAssistantChatResponse'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        415:
+          $ref: '#/components/responses/UnsupportedMediaType'
+      security:
+        - OAuth2Security:
+            - apim:api_create
+            - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
+      operationId: designAssistantChat
+
+  ######################################################################
+  # The "API Design Assistant - Generate API Payloads" resource APIs
+  ######################################################################
+  /design-assistant/generate-api-payload:
+    post:
+      tags:
+        - API Design Assistant
+      summary: Create API Payload with API Design Assistant
+      description: |
+        Creates an API payload using the stored specification.
+      requestBody:
+        description: Input for API payload creation
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DesignAssistantGenAPIPayload'
+      responses:
+        200:
+          description: API payload successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DesignAssistantAPIPayloadResponse'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        415:
+          $ref: '#/components/responses/UnsupportedMediaType'
+      security:
+        - OAuth2Security:
+            - apim:api_create
+            - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/generate-api-payload"'
+      operationId: designAssistantApiPayloadGen
+
+  ######################################################
   # The "Individual API" resource APIs
   ######################################################
   /apis/{apiId}:
@@ -9735,6 +9814,52 @@ paths:
 
 components:
   schemas:
+    DesignAssistantChatQuery:
+      type: object
+      properties:
+        text:
+          type: string
+          example: create an API for a banking transaction
+        session_id:
+          type: string
+          example: 1234567890
+    DesignAssistantChatResponse:
+      type: object
+      properties:
+        backendResponse:
+          type: string
+        isSuggestions:
+          type: boolean
+          example: true
+        typeOfApi:
+          type: string
+          example: REST
+        code:
+          type: string
+        paths:
+          type: array
+          example: []
+          items:
+            type: string
+        apiTypeSuggestion:
+          type: string
+          example: This is suitable for CRUD operations in banking. Do you want to proceed?
+        missingValues:
+          type: string
+        state:
+          type: string
+          example: COMPLETE
+    DesignAssistantGenAPIPayload:
+      type: object
+      properties:
+        session_id:
+          type: string
+          example: 1234567890
+    DesignAssistantAPIPayloadResponse:
+      type: object
+      properties:
+        generated_payload:
+          type: string
     SequenceBackendList:
       title: Sequence Backend List
       type: object

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/beans.xml
@@ -38,6 +38,7 @@
             <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.GatewayPoliciesApi"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.WorkflowsApi"/>
             <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.LabelsApi"/>
+            <bean class="org.wso2.carbon.apimgt.rest.api.publisher.v1.DesignAssistantApi"/>
         </jaxrs:serviceBeans>
         <jaxrs:providers>
             <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/web.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/webapp/WEB-INF/web.xml
@@ -56,7 +56,8 @@
                 org.wso2.carbon.apimgt.rest.api.publisher.v1.WorkflowsApi,
                 org.wso2.carbon.apimgt.rest.api.publisher.v1.LlmProvidersApi,
                 org.wso2.carbon.apimgt.rest.api.publisher.v1.LabelsApi,
-                org.wso2.carbon.apimgt.rest.api.publisher.v1.OrganizationsApi
+                org.wso2.carbon.apimgt.rest.api.publisher.v1.OrganizationsApi,
+                org.wso2.carbon.apimgt.rest.api.publisher.v1.DesignAssistantApi
             </param-value>
         </init-param>
         <init-param>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
@@ -301,7 +301,7 @@ paths:
             - apim:api_manage
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -X POST -H Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
+          source: 'curl -k -X POST -H Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"sessionId\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
       operationId: designAssistantChat
 
   ######################################################################
@@ -338,7 +338,7 @@ paths:
             - apim:api_manage
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/generate-api-payload"'
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"sessionId\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/generate-api-payload"'
       operationId: designAssistantApiPayloadGen
 
   ######################################################

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
@@ -262,9 +262,9 @@ paths:
           -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis"'
       operationId: createAPI
 
-  ######################################################
+  #######################################################
   # The "API Design Assistant - Chat" resource APIs
-  ######################################################
+  #######################################################
   /design-assistant/chat:
     post:
       tags:
@@ -301,7 +301,7 @@ paths:
             - apim:api_manage
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -X POST -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
+          source: 'curl -k -X POST -H Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
       operationId: designAssistantChat
 
   ######################################################################
@@ -8624,12 +8624,12 @@ paths:
   /apis/{apiId}/labels:
     get:
       tags:
-        - API Labels
+          - API Labels
       summary: Get Labels of an API
       description: |
-        This operation can be used to get the labels of an API.
+          This operation can be used to get the labels of an API.
       parameters:
-        - $ref: '#/components/parameters/apiId'
+          - $ref: '#/components/parameters/apiId'
       responses:
         200:
           description: |
@@ -8642,14 +8642,14 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
       security:
-        - OAuth2Security:
-            - apim:api_view
-            - apim:api_create
-            - apim:api_manage
-            - apim:api_publish
+          - OAuth2Security:
+              - apim:api_view
+              - apim:api_create
+              - apim:api_manage
+              - apim:api_publish
       x-code-samples:
-        - lang: Curl
-          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          - lang: Curl
+            source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
             "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/labels"'
       operationId: getLabelsOfAPI
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/publisher-api.yaml
@@ -17,6 +17,7 @@ info:
   title: WSO2 API Manager - Publisher API
   description: |
     This document specifies a **RESTful API** for WSO2 **API Manager** - **Publisher**.
+    Please see [full OpenAPI Specification](https://raw.githubusercontent.com/wso2/carbon-apimgt/master/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml) of the API which is written using [OAS 3.0](http://swagger.io/) specification.
 
     # Authentication
     The Publisher REST API is protected using OAuth2 and access control is achieved through scopes. Before you start invoking
@@ -59,6 +60,9 @@ info:
     "tokenType": null
     }
     ```
+    Note that in a distributed deployment or IS as KM separated environment to invoke RESTful APIs (product APIs), users must generate tokens through API-M Control Plane's token endpoint.
+    The tokens generated using third party key managers, are to manage end-user authentication when accessing APIs.
+    
     Next you must use the above client id and secret to obtain the access token.
     We will be using the password grant type for this, you can use any grant type you desire.
     You also need to add the proper **scope** when getting the access token. All possible scopes for publisher REST API can be viewed in **OAuth2 Security** section
@@ -95,17 +99,17 @@ info:
     * Make sure you have an API Manager instance up and running.
     * Update the `basepath` parameter to match the hostname and port of the APIM instance.
 
-    [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/a09044034b5c3c1b01a9)
+    [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/32294946-7fbaad97-7fb9-43ae-b6f2-13b63f2867d7)
   contact:
     name: WSO2
-    url: http://wso2.com/products/api-manager/
+    url: https://wso2.com/api-manager/
     email: architecture@wso2.com
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: v3
+  version: v4
 servers:
-  - url: https://apis.wso2.com/api/am/publisher/v3
+  - url: https://apis.wso2.com/api/am/publisher/v4
 security:
   - OAuth2Security:
       - apim:api_view
@@ -126,8 +130,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
-        - $ref: '#/components/parameters/sortBy'
-        - $ref: '#/components/parameters/sortOrder'
         - $ref: '#/components/parameters/requestedTenant'
         - name: query
           in: query
@@ -146,8 +148,9 @@ paths:
             name:pizzashack version:v1 will match an API if the name of the API is pizzashack and version is v1.
 
             Supported attribute modifiers are [**version, context, name, status,
-            description, doc, provider**]
-
+            description, provider, api-category, tags, doc, contexttemplate,
+            lcstate, content, type, label, enablestore, thirdparty**]
+            
             If no advanced attribute modifier has been specified,  the API names containing
             the search term will be returned as a result.
 
@@ -191,9 +194,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis"'
-      x-examples:
-        $ref: docs/examples/apis/apis_get.yaml
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis"'
       operationId: getAllAPIs
 
     post:
@@ -258,10 +259,87 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v3/apis"'
-      x-examples:
-        $ref: docs/examples/apis/apis_post.yaml
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis"'
       operationId: createAPI
+
+  ######################################################
+  # The "API Design Assistant - Chat" resource APIs
+  ######################################################
+  /design-assistant/chat:
+    post:
+      tags:
+        - API Design Assistant
+      summary: Generate API Specifications with API Design Assistant
+      description: |
+        Generates API specifications based on natural language input.
+
+        Key features:
+        - Converts text descriptions into structured API specifications
+        - Provides QoS suggestions and other improvements
+        - Supports session-based API generation
+      requestBody:
+        description: Input for API specification generation
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DesignAssistantChatQuery'
+      responses:
+        200:
+          description: Successful API specification generation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DesignAssistantChatResponse'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        415:
+          $ref: '#/components/responses/UnsupportedMediaType'
+      security:
+        - OAuth2Security:
+            - apim:api_create
+            - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Content-Type: application/json" -d "{\"text\": \"create an API for a banking transaction.\", \"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/chat"'
+      operationId: designAssistantChat
+
+  ######################################################################
+  # The "API Design Assistant - Generate API Payloads" resource APIs
+  ######################################################################
+  /design-assistant/generate-api-payload:
+    post:
+      tags:
+        - API Design Assistant
+      summary: Create API Payload with API Design Assistant
+      description: |
+        Creates an API payload using the stored specification.
+      requestBody:
+        description: Input for API payload creation
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DesignAssistantGenAPIPayload'
+      responses:
+        200:
+          description: API payload successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DesignAssistantAPIPayloadResponse'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        415:
+          $ref: '#/components/responses/UnsupportedMediaType'
+      security:
+        - OAuth2Security:
+            - apim:api_create
+            - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d "{\"session_id\": \"1234567890\"}" "https://127.0.0.1:9443/api/am/publisher/v4/design-assistant/generate-api-payload"'
+      operationId: designAssistantApiPayloadGen
 
   ######################################################
   # The "Individual API" resource APIs
@@ -321,9 +399,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/7a2298c4-c905-403f-8fac-38c73301631f"'
-      x-examples:
-        $ref: docs/examples/apis/apis_id_get.yaml
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/7a2298c4-c905-403f-8fac-38c73301631f"'
       operationId: getAPI
 
     put:
@@ -392,7 +468,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/7a2298c4-c905-403f-8fac-38c73301631f"'
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/7a2298c4-c905-403f-8fac-38c73301631f"'
       operationId: updateAPI
 
     delete:
@@ -426,15 +502,15 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/7a2298c4-c905-403f-8fac-38c73301631f"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/7a2298c4-c905-403f-8fac-38c73301631f"'
       operationId: deleteAPI
 
   /apis/{apiId}/topics:
     put:
       tags:
         - APIs
-      summary: Update Topics
-      description: This operation can be used to update topics of an existing API.
+      summary: Update Topics of an Async API
+      description: This operation can be used to update topics of an existing async API.
       operationId: updateTopics
       parameters:
         - $ref: '#/components/parameters/apiId'
@@ -482,6 +558,201 @@ paths:
             - apim:api_create
             - apim:api_manage
             - apim:api_import_export
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          -H "Content-Type: application/json" -d @data.json
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/7a2298c4-c905-403f-8fac-38c73301631f/topics"'
+
+  /apis/{apiId}/sequence-backend/{type}/content:
+    get:
+      tags:
+        - APIs
+      summary: Get Sequence of Custom Backend
+      description: This operation can be used to get Sequence of the Custom Backend
+      operationId: getSequenceBackendContent
+      parameters:
+        - name: type
+          in: path
+          description: |
+            Type of the Endpoint.
+            SANDBOX or PRODUCTION
+          required: true
+          schema:
+            maxLength: 15
+            type: string
+        - $ref: '#/components/parameters/apiId'
+      responses:
+        200:
+          description: |
+            OK.
+            Requested API Custom Backend is returned
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/xml:
+              schema:
+                type: string
+                format: binary
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+      security:
+        - OAuth2Security:
+            - apim:api_view
+            - apim:api_manage
+            - apim:api_import_export
+            - apim:api_product_import_export
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/7a2298c4-c905-403f-8fac-38c73301631f/custom-backend/7a2298c4-c915-483f-8fac-38c73301631f/content"'
+
+  /apis/{apiId}/sequence-backend/{type}:
+    delete:
+      tags:
+        - APIs
+      summary: Delete Sequence Backend of the API
+      description: This operation can be used to remove the Sequence Backend of the API
+      operationId: sequenceBackendDelete
+      parameters:
+        - name: type
+          in: path
+          description: |
+            Type of the Endpoint.
+            SANDBOX or PRODUCTION
+          required: true
+          schema:
+            maxLength: 15
+            type: string
+        - $ref: '#/components/parameters/apiId'
+      responses:
+        200:
+          description: |
+            OK.
+            Resource successfully deleted.
+          content: { }
+        403:
+          $ref: '#/components/responses/Forbidden'
+        404:
+          $ref: '#/components/responses/NotFound'
+        409:
+          $ref: '#/components/responses/Conflict'
+        412:
+          $ref: '#/components/responses/PreconditionFailed'
+      security:
+        - OAuth2Security:
+            - apim:api_delete
+            - apim:api_manage
+            - apim:api_import_export
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/7a2298c4-c905-403f-8fac-38c73301631f/custom-backend/7a2298c4-c915-483f-8fac-38c73301631f"'
+
+  /apis/{apiId}/sequence-backend:
+    get:
+      tags:
+        - APIs
+      summary: Get Sequence Backends of the API
+      description: This operation can be used to get Sequence Backend data of the API
+      operationId: getSequenceBackendData
+      parameters:
+        - $ref: '#/components/parameters/apiId'
+      responses:
+        200:
+          description: |
+            OK.
+            Requested API Sequence Backend is returned
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SequenceBackendList'
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+      security:
+        - OAuth2Security:
+            - apim:api_view
+            - apim:api_manage
+            - apim:api_import_export
+            - apim:api_product_import_export
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/7a2298c4-c905-403f-8fac-38c73301631f/custom-backend/7a2298c4-c915-483f-8fac-38c73301631f"'
+    put:
+      tags:
+        - APIs
+      summary: Upload Sequence Sequence as the Endpoint of the API
+      description: This operation can be used to change the endpoint of the API to Sequence Backend
+      operationId: sequenceBackendUpdate
+      parameters:
+        - $ref: '#/components/parameters/apiId'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                sequence:
+                  type: string
+                  description: The sequence that needs to be uploaded.
+                  format: binary
+                type:
+                  type: string
+                  description: Type of the Endpoint
+      responses:
+        200:
+          description: |
+            OK.
+            Successful response with updated API object
+          headers:
+            Location:
+              description: |
+                The URL of the newly created resource.
+              schema:
+                type: string
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/API'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        404:
+          $ref: '#/components/responses/NotFound'
+        409:
+          $ref: '#/components/responses/Conflict'
+        412:
+          $ref: '#/components/responses/PreconditionFailed'
+      security:
+        - OAuth2Security:
+            - apim:api_create
+            - apim:api_manage
+            - apim:api_publish
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/7a2298c4-c905-403f-8fac-38c73301631f/custom-backend"'
+
 
   /apis/{apiId}/reimport-service:
     put:
@@ -523,7 +794,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/ecb5b300-422d-4ee8-88d2-364a0a122238/reimport-service"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/ecb5b300-422d-4ee8-88d2-364a0a122238/reimport-service"'
 
   /apis/{apiId}/swagger:
     get:
@@ -579,7 +850,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/7a2298c4-c905-403f-8fac-38c73301631f/swagger"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/7a2298c4-c905-403f-8fac-38c73301631f/swagger"'
       operationId: getAPISwagger
 
     put:
@@ -653,7 +924,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -F apiDefinition=@swagger.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/swagger"'
+          -F apiDefinition=@swagger.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/swagger"'
       operationId: updateAPISwagger
 
   /apis/{apiId}/generate-mock-scripts:
@@ -710,8 +981,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/7a2298c4-c905-403f-8fac-38c73301631f/generate-mock-scripts"'
-
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/7a2298c4-c905-403f-8fac-38c73301631f/generate-mock-scripts"'
 
   /apis/{apiId}/generated-mock-scripts:
     get:
@@ -766,7 +1036,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/7a2298c4-c905-403f-8fac-38c73301631f/generated-mock-scripts"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/7a2298c4-c905-403f-8fac-38c73301631f/generated-mock-scripts"'
 
   /apis/{apiId}/resource-policies:
     get:
@@ -836,7 +1106,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/2fd14eb8-b828-4013-b448-0739d2e76bf7/resource-policies?resourcePath=checkPhoneNumber&verb=post&sequenceType=in"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/2fd14eb8-b828-4013-b448-0739d2e76bf7/resource-policies?resourcePath=checkPhoneNumber&verb=post&sequenceType=in"'
       operationId: getAPIResourcePolicies
 
   /apis/{apiId}/resource-policies/{resourcePolicyId}:
@@ -895,7 +1165,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/2fd14eb8-b828-4013-b448-0739d2e76bf7/resource-policies/8efc32a4-c7f1-4bee-b860-b7566e2bc0d5"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/2fd14eb8-b828-4013-b448-0739d2e76bf7/resource-policies/8efc32a4-c7f1-4bee-b860-b7566e2bc0d5"'
       operationId: getAPIResourcePoliciesByPolicyId
 
     put:
@@ -962,7 +1232,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/2fd14eb8-b828-4013-b448-0739d2e76bf7/resource-policies/8efc32a4-c7f1-4bee-b860-b7566e2bc0d5"'
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/2fd14eb8-b828-4013-b448-0739d2e76bf7/resource-policies/8efc32a4-c7f1-4bee-b860-b7566e2bc0d5"'
       operationId: updateAPIResourcePoliciesByPolicyId
 
   /apis/{apiId}/thumbnail:
@@ -1015,7 +1285,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/2fd14eb8-b828-4013-b448-0739d2e76bf7/thumbnail"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/2fd14eb8-b828-4013-b448-0739d2e76bf7/thumbnail"'
       operationId: getAPIThumbnail
 
     put:
@@ -1086,7 +1356,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -F file=image.jpeg "https://127.0.0.1:9443/api/am/publisher/v3/apis/2fd14eb8-b828-4013-b448-0739d2e76bf7/thumbnail"'
+          -F file=@image.jpeg "https://127.0.0.1:9443/api/am/publisher/v4/apis/2fd14eb8-b828-4013-b448-0739d2e76bf7/thumbnail"'
 
   /apis/{apiId}/subscription-policies:
     get:
@@ -1102,6 +1372,8 @@ paths:
         - $ref: '#/components/parameters/apiId'
         - $ref: '#/components/parameters/requestedTenant'
         - $ref: '#/components/parameters/If-None-Match'
+        - $ref: '#/components/parameters/isAiApi'
+        - $ref: '#/components/parameters/organizationID'
       responses:
         200:
           description: |
@@ -1140,7 +1412,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/2fd14eb8-b828-4013-b448-0739d2e76bf7/subscription-policies"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/2fd14eb8-b828-4013-b448-0739d2e76bf7/subscription-policies"'
       operationId: getAPISubscriptionPolicies
 
   /apis/copy-api:
@@ -1197,9 +1469,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/copy-api?newVersion=2.0&defaultVersion=false&apiId=2fd14eb8-b828-4013-b448-0739d2e76bf7"'
-      x-examples:
-        $ref: docs/examples/apis/apis_copyapi.yaml#/post
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/copy-api?newVersion=2.0&defaultVersion=false&apiId=2fd14eb8-b828-4013-b448-0739d2e76bf7"'
       operationId: createNewAPIVersion
 
   /apis/change-lifecycle:
@@ -1240,7 +1510,7 @@ paths:
             2. **Requires re-subscription when publishing the API**: If you set this to true, users need to re subscribe to the API although they may have subscribed to an older version.
             You can specify additional checklist items by using an **"attribute:"** modifier.
             Eg: "Deprecate old versions after publishing the API:true" will deprecate older versions of a particular API when it is promoted to Published state from Created state. Multiple checklist items can be given in "attribute1:true, attribute2:false" format.
-            **Sample CURL :**  curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -X POST "https://localhost:9443/api/am/publisher/v3/apis/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish&lifecycleChecklist=Deprecate%20old%20versions%20after%20publishing%20the%20API%3Atrue,Requires%20re-subscription%20when%20publishing%20the%20API%3Afalse"
+            **Sample CURL :**  curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -X POST "https://localhost:9443/api/am/publisher/v4/apis/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish&lifecycleChecklist=Deprecate%20old%20versions%20after%20publishing%20the%20API%3Atrue,Requires%20re-subscription%20when%20publishing%20the%20API%3Afalse"
           schema:
             type: string
         - $ref: '#/components/parameters/apiId-Q'
@@ -1290,7 +1560,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish"'
       operationId: changeAPILifecycle
 
   /apis/{apiId}/lifecycle-history:
@@ -1339,7 +1609,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-history"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-history"'
       operationId: getAPILifecycleHistory
 
   /apis/{apiId}/lifecycle-state:
@@ -1396,7 +1666,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-state"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-state"'
       operationId: getAPILifecycleState
 
   /apis/{apiId}/lifecycle-state/pending-tasks:
@@ -1425,7 +1695,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-state/pending-tasks"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-state/pending-tasks"'
       operationId: deleteAPILifecycleStatePendingTasks
 
   ######################################################
@@ -1470,7 +1740,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions?query=deployed:true"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions?query=deployed:true"'
 
     #--------------------------------------------
     # Create a new API revision
@@ -1513,7 +1783,7 @@ paths:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
             -H "Content-Type: application/json" -d @data.json
-            "https://127.0.0.1:9443/api/am/publisher/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions"'
 
   ######################################################
   # The "API Revisions" individual resource API
@@ -1528,7 +1798,7 @@ paths:
         - API Revisions
       summary: Retrieve Revision
       description: |
-        Retrieve a revision of an API
+        Retrieve a revision of an API (This resource is not supported in the current release)
       operationId: getAPIRevision
       parameters:
         - $ref: '#/components/parameters/apiId'
@@ -1553,7 +1823,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions/e0824883-3e86-403a-aec1-22bbc454eb7c"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions/e0824883-3e86-403a-aec1-22bbc454eb7c"'
 
     #--------------------------------------------
     # Delete a revision
@@ -1592,7 +1862,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions/e0824883-3e86-403a-aec1-22bbc454eb7c"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions/e0824883-3e86-403a-aec1-22bbc454eb7c"'
 
   /apis/{apiId}/deployments:
     #--------------------------------------------
@@ -1627,7 +1897,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-                "https://127.0.0.1:9443/api/am/publisher/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/deployments"'
+                "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/deployments"'
 
   /apis/{apiId}/deployments/{deploymentId}:
     #--------------------------------------------
@@ -1668,7 +1938,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -d @data.json
-                "https://127.0.0.1:9443/api/am/publisher/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/deployments/UHJvZHVjdGlvbiBhbmQgU2FuZGJveA"'
+                "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/deployments/UHJvZHVjdGlvbiBhbmQgU2FuZGJveA"'
 
   /apis/{apiId}/deploy-revision:
     #--------------------------------------------
@@ -1714,8 +1984,8 @@ paths:
             - apim:api_publish
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/deploy-revision?revisionId=e0824883-3e86-403a-aec1-22bbc454eb7c"'
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d @data.json
+                "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/deploy-revision?revisionId=e0824883-3e86-403a-aec1-22bbc454eb7c"'
 
   /apis/{apiId}/undeploy-revision:
     #--------------------------------------------
@@ -1771,8 +2041,8 @@ paths:
             - apim:api_import_export
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-                "https://127.0.0.1:9443/api/am/publisher/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/undeploy-revision?revisionId=e0824883-3e86-403a-aec1-22bbc454eb7c"'
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d @data.json
+                "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/undeploy-revision?revisionId=e0824883-3e86-403a-aec1-22bbc454eb7c"'
 
   /apis/{apiId}/restore-revision:
 
@@ -1808,7 +2078,42 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/restore-revision?revisionId=e0824883-3e86-403a-aec1-22bbc454eb7c"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/restore-revision?revisionId=e0824883-3e86-403a-aec1-22bbc454eb7c"'
+
+  /apis/{apiId}/cancel-revision-workflow/{revisionId}/{envName}:
+    #--------------------------------------------------------
+    # Cancel a pending revision deployment workflow task given revision id and environment name
+    #--------------------------------------------------------
+    delete:
+      tags:
+        - API Revisions
+      summary: Delete Pending Revision Deployment Workflow Tasks
+      description: |
+        This operation can be used to remove pending revision deployment requests that are in pending state
+      parameters:
+        - $ref: '#/components/parameters/apiId'
+        - $ref: '#/components/parameters/revisionId'
+        - $ref: '#/components/parameters/envName'
+      responses:
+        200:
+          description: |
+            OK.
+            Revision deployment pending task removed successfully.
+          content: { }
+        404:
+          $ref: '#/components/responses/NotFound'
+        412:
+          $ref: '#/components/responses/PreconditionFailed'
+      security:
+        - OAuth2Security:
+            - apim:api_publish
+            - apim:api_manage
+            - apim:api_create
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/cancel-revision-workflow/e0824883-3e86-403a-aec1-22bbc454eb7c/Default"'
+      operationId: deleteAPIRevisionDeploymentPendingTask
 
   /apis/import-service:
     post:
@@ -1862,7 +2167,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/import-service?serviceKey=Pizzashack-1.0.0"'
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/import-service?serviceKey=Pizzashack-1.0.0"'
 
   /apis/{apiId}/comments:
     get:
@@ -1898,7 +2203,8 @@ paths:
             - apim:comment_manage
       x-code-samples:
         - lang: Curl
-          source: curl -k "https://localhost:9443/api/am/publisher/v1/apis/e93fb282-b456-48fc-8981-003fb89086ae/comments"
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://localhost:9443/api/am/publisher/v4/apis/e93fb282-b456-48fc-8981-003fb89086ae/comments"'
 
     post:
       tags:
@@ -1969,7 +2275,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization:Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://localhost:9443/api/am/publisher/v1/apis/e93fb282-b456-48fc-8981-003fb89086ae/comments"'
+          -H "Content-Type: application/json" -d @data.json "https://localhost:9443/api/am/publisher/v4/apis/e93fb282-b456-48fc-8981-003fb89086ae/comments"'
 
   /apis/{apiId}/comments/{commentId}:
     get:
@@ -2024,7 +2330,8 @@ paths:
             - apim:comment_manage
       x-code-samples:
         - lang: Curl
-          source: curl -k "https://localhost:9443/api/am/publisher/v1/apis/e93fb282-b456-48fc-8981-003fb89086ae/comments/d4cf1704-5d09-491c-bc48-4d19ce6ea9b4"
+          source: 'curl -k -H "Authorization:Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://localhost:9443/api/am/publisher/v4/apis/e93fb282-b456-48fc-8981-003fb89086ae/comments/d4cf1704-5d09-491c-bc48-4d19ce6ea9b4"'
 
     patch:
       tags:
@@ -2096,7 +2403,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PATCH -H "Authorization:Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://localhost:9443/api/am/publisher/v1/apis/e93fb282-b456-48fc-8981-003fb89086ae/comments/d4cf1704-5d09-491c-bc48-4d19ce6ea9b4"'
+          -H "Content-Type: application/json" -d @data.json "https://localhost:9443/api/am/publisher/v4/apis/e93fb282-b456-48fc-8981-003fb89086ae/comments/d4cf1704-5d09-491c-bc48-4d19ce6ea9b4"'
 
     delete:
       tags:
@@ -2136,7 +2443,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: curl -k -X DELETE -H "Authorization:Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://localhost:9443/api/am/publisher/v1/apis/e93fb282-b456-48fc-8981-003fb89086ae/comments/d4cf1704-5d09-491c-bc48-4d19ce6ea9b4"
+            "https://localhost:9443/api/am/publisher/v4/apis/e93fb282-b456-48fc-8981-003fb89086ae/comments/d4cf1704-5d09-491c-bc48-4d19ce6ea9b4"
 
   /apis/{apiId}/comments/{commentId}/replies:
     get:
@@ -2191,7 +2498,8 @@ paths:
             - apim:comment_manage
       x-code-samples:
         - lang: Curl
-          source: curl -k "https://localhost:9443/api/am/publisher/v1/apis/e93fb282-b456-48fc-8981-003fb89086ae/comments/d4cf1704-5d09-491c-bc48-4d19ce6ea9b4/replies"
+          source: 'curl -k -H "Authorization:Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://localhost:9443/api/am/publisher/v4/apis/e93fb282-b456-48fc-8981-003fb89086ae/comments/d4cf1704-5d09-491c-bc48-4d19ce6ea9b4/replies"'
 
   /apis/import-openapi:
     post:
@@ -2259,9 +2567,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -F file=@openapi.json -F additionalProperties=@data.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/import-openapi"'
-      x-examples:
-        $ref: docs/examples/apis/import_openapi_post.yaml
+          -F file=@openapi.json -F additionalProperties=@data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/import-openapi"'
 
   /apis/import-wsdl:
     post:
@@ -2287,11 +2593,11 @@ paths:
 
                     **Sample cURL to Upload WSDL File**
 
-                    curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -F file=@api.wsdl -F additionalProperties=@data.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/import-wsdl"
+                    curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -F file=@api.wsdl -F additionalProperties=@data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/import-wsdl"
 
                     **Sample cURL to Upload WSDL Archive**
 
-                    curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -F file="@wsdl.zip;type=application/zip" -F additionalProperties=@data.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/import-wsdl"
+                    curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -F file="@wsdl.zip;type=application/zip" -F additionalProperties=@data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/import-wsdl"
                   format: binary
                 url:
                   type: string
@@ -2349,9 +2655,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -F file=@api.wsdl -F additionalProperties=@data.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/import-wsdl"'
-      x-examples:
-        $ref: docs/examples/apis/wsdl/import_wsdl_post.yaml
+          -F file=@api.wsdl -F additionalProperties=@data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/import-wsdl"'
 
   /apis/import-graphql-schema:
     post:
@@ -2381,6 +2685,12 @@ paths:
                   type: string
                   description: Definition to uploads a file
                   format: binary
+                url:
+                  type: string
+                  description: Definition url
+                schema:
+                  type: string
+                  description: Definition schema
                 additionalProperties:
                   type: string
                   description: Additional attributes specified as a stringified JSON
@@ -2422,7 +2732,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -F file=@schema.graphql -F additionalProperties=@data.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/import-graphql-schema"'
+          -F file=@schema.graphql -F additionalProperties=@data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/import-graphql-schema"'
       operationId: importGraphQLSchema
 
   /apis/validate-openapi:
@@ -2484,9 +2794,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -F file=@openapi.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/validate-openapi"'
-      x-examples:
-        $ref: docs/examples/apis/validate_openapi_post.yaml
+          -F file=@openapi.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/validate-openapi"'
 
   /apis/validate-endpoint:
     post:
@@ -2505,6 +2813,7 @@ paths:
             type: string
         - name: apiId
           in: query
+          description: API ID consisting of the UUID of the API
           schema:
             type: string
       responses:
@@ -2533,7 +2842,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/validate-endpoint?apiId=e0824883-3e86-403a-aec1-22bbc454eb7c&endpointUrl=https%3A%2F%2Flocalhost%3A9443%2Fam%2Fsample%2Fpizzashack%2Fv1%2Fapi%2F"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/validate-endpoint?apiId=e0824883-3e86-403a-aec1-22bbc454eb7c&endpointUrl=https%3A%2F%2Flocalhost%3A9443%2Fam%2Fsample%2Fpizzashack%2Fv1%2Fapi%2F"'
 
   /apis/validate:
     post:
@@ -2585,9 +2894,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/validate?query=name%3Awso2"'
-      x-examples:
-        $ref: docs/examples/apis/apis_validate.yaml
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/validate?query=name%3Awso2"'
 
   /apis/validate-wsdl:
     post:
@@ -2636,9 +2943,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -F file=@api.wsdl "https://127.0.0.1:9443/api/am/publisher/v3/apis/validate-wsdl"'
-      x-examples:
-        $ref: docs/examples/apis/wsdl/validate_wsdl_post.yaml
+          -F file=@api.wsdl "https://127.0.0.1:9443/api/am/publisher/v4/apis/validate-wsdl"'
 
   /apis/validate-graphql-schema:
     post:
@@ -2647,17 +2952,26 @@ paths:
       summary: Validate a GraphQL SDL
       description: |
         This operation can be used to validate a graphQL definition and retrieve a summary.
+      parameters:
+        - name: useIntrospection
+          in: query
+          description: |
+            Specify whether to use Introspection to obtain the GraphQL Schema
+          schema:
+            type: boolean
+            default: false
       requestBody:
         content:
           multipart/form-data:
             schema:
-              required:
-                - file
               properties:
                 file:
                   type: string
                   description: Definition to upload as a file
                   format: binary
+                url:
+                  type: string
+                  description: Definition to upload using url
         required: true
       responses:
         200:
@@ -2685,7 +2999,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -F file=@schema.graphql "https://127.0.0.1:9443/api/am/publisher/v3/apis/validate-graphql-schema"'
+          -F file=@schema.graphql "https://127.0.0.1:9443/api/am/publisher/v4/apis/validate-graphql-schema"'
       operationId: validateGraphQLSchema
 
   /apis/{apiId}/graphql-schema:
@@ -2741,7 +3055,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/e0824883-3e86-403a-aec1-22bbc454eb7c/graphql-schema"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/e0824883-3e86-403a-aec1-22bbc454eb7c/graphql-schema"'
       operationId: getAPIGraphQLSchema
 
     put:
@@ -2806,8 +3120,8 @@ paths:
             - apim:api_manage
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -F schemaDefinition=@schema.graphql "https://127.0.0.1:9443/api/am/publisher/v3/apis/e0824883-3e86-403a-aec1-22bbc454eb7c/graphql-schema"'
+          source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          -F schemaDefinition=@schema.graphql "https://127.0.0.1:9443/api/am/publisher/v4/apis/e0824883-3e86-403a-aec1-22bbc454eb7c/graphql-schema"'
       operationId: updateAPIGraphQLSchema
 
   /apis/{apiId}/amznResourceNames:
@@ -2851,9 +3165,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/e0824883-3e86-403a-aec1-22bbc454eb7c/amznResourceNames"'
-      x-examples:
-        $ref: docs/examples/apis/apis_id_amznresourcenames_get.yaml
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/e0824883-3e86-403a-aec1-22bbc454eb7c/amznResourceNames"'
       operationId: getAmazonResourceNamesOfAPI
 
   /apis/{apiId}/monetize:
@@ -2891,7 +3203,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/monetize'
+          -H "Content-Type: application/json" -d @data.json https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/monetize'
       operationId: addAPIMonetization
 
   /apis/{apiId}/monetization:
@@ -2923,7 +3235,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/monetize"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/monetization"'
       operationId: getAPIMonetization
 
   /apis/{apiId}/revenue:
@@ -2974,7 +3286,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/revenue"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/revenue"'
       operationId: getAPIRevenue
 
   /apis/{apiId}/documents:
@@ -3026,7 +3338,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/e0824883-3e86-403a-aec1-22bbc454eb7c/documents"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/e0824883-3e86-403a-aec1-22bbc454eb7c/documents"'
       operationId: getAPIDocuments
 
     post:
@@ -3085,7 +3397,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents"'
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents"'
       operationId: addAPIDocument
 
   /apis/{apiId}/documents/{documentId}:
@@ -3143,7 +3455,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5"'
       operationId: getAPIDocumentByDocumentId
 
     put:
@@ -3209,7 +3521,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @doc.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5"'
+          -H "Content-Type: application/json" -d @doc.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5"'
       operationId: updateAPIDocument
 
     delete:
@@ -3240,7 +3552,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5"'
       operationId: deleteAPIDocument
 
   /apis/{apiId}/documents/{documentId}/content:
@@ -3256,7 +3568,7 @@ paths:
         1. **Inline type**:
            The content of the document will be retrieved in `text/plain` content type
 
-           _Sample cURL_ : `curl -k -H "Authorization:Bearer 579f0af4-37be-35c7-81a4-f1f1e9ee7c51" -F inlineContent=@"docs.txt" -X POST "https://localhost:9443/api/am/publisher/v3/apis/995a4972-3178-4b17-a374-756e0e19127c/documents/43c2bcce-60e7-405f-bc36-e39c0c5e189e/content`
+           _Sample cURL_ : `curl -k -H "Authorization:Bearer 579f0af4-37be-35c7-81a4-f1f1e9ee7c51" -F inlineContent=@"docs.txt" -X POST "https://localhost:9443/api/am/publisher/v4/apis/995a4972-3178-4b17-a374-756e0e19127c/documents/43c2bcce-60e7-405f-bc36-e39c0c5e189e/content`
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
@@ -3320,7 +3632,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5/content"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5/content"'
       operationId: getAPIDocumentContentByDocumentId
 
     post:
@@ -3397,7 +3709,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -F file=@sample.pdf "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5/content"'
+          -F file=@sample.pdf "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5/content"'
       operationId: addAPIDocumentContent
 
   /apis/{apiId}/documents/validate:
@@ -3438,9 +3750,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/validate?name=CalculatorDoc"'
-      x-examples:
-        $ref: docs/examples/apis/apis_id_document_validate.yaml
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/documents/validate?name=CalculatorDoc"'
 
   /apis/{apiId}/wsdl-info:
     get:
@@ -3473,9 +3783,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/wsdl-info"'
-      x-examples:
-        $ref: docs/examples/apis/wsdl/apiId_wsdl_info_get.yaml
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/wsdl-info"'
 
   /apis/{apiId}/wsdl:
     get:
@@ -3524,9 +3832,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/wsdl"'
-      x-examples:
-        $ref: docs/examples/apis/wsdl/apiId_wsdl_get.yaml
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/wsdl"'
 
     put:
       tags:
@@ -3560,13 +3866,13 @@ paths:
           headers:
             ETag:
               description: |
-                Entity Tag of the response resource. Used by caches, or in conditional requests (Will be supported in future).
+                Entity Tag of the response resource. Used by caches, or in conditional requests (This is not supported by WSO2 API Manager as of yet).
               schema:
                 type: string
             Last-Modified:
               description: |
                 Date and time the resource has been modifed the last time.
-                Used by caches, or in conditional requests (Will be supported in future).
+                Used by caches, or in conditional requests (This is not supported by WSO2 API Manager as of yet).
               schema:
                 type: string
             Location:
@@ -3594,18 +3900,16 @@ paths:
             - apim:api_manage
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -F file=@api.wsdl "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/wsdl"'
-      x-examples:
-        $ref: docs/examples/apis/wsdl/apiId_wsdl_put.yaml
+          source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          -F file=@api.wsdl "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/wsdl"'
 
   /apis/{apiId}/graphql-policies/complexity:
     get:
       tags:
         - GraphQL Policies
-      summary: Get the Complexity Related Details of an API
+      summary: Get the Complexity-Related Details of an API
       description: |
-        This operation can be used to retrieve complexity related details belonging to an API by providing the API id.
+        This operation can be used to retrieve complexity-related details belonging to an API by providing the API ID.
       parameters:
         - $ref: '#/components/parameters/apiId'
       responses:
@@ -3635,16 +3939,16 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/graphql-policies/complexity"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/graphql-policies/complexity"'
       operationId: getGraphQLPolicyComplexityOfAPI
 
 
     put:
       tags:
         - GraphQL Policies
-      summary: Update Complexity Related Details of an API
+      summary: Update Complexity-Related Details of an API
       description: |
-        This operation can be used to update complexity details belonging to an API by providing the id of the API.
+        This operation can be used to update complexity-related details belonging to an API by providing the API ID.
       parameters:
         - $ref: '#/components/parameters/apiId'
       requestBody:
@@ -3668,7 +3972,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/graphql-policies/complexity"'
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/graphql-policies/complexity"'
       operationId: updateGraphQLPolicyComplexityOfAPI
 
   /apis/{apiId}/graphql-policies/complexity/types:
@@ -3677,7 +3981,7 @@ paths:
         - GraphQL Policies
       summary: Retrieve Types and Fields of a GraphQL Schema
       description: |
-        This operation can be used to retrieve all types and fields of the GraphQL Schema by providing the API id.
+        This operation can be used to retrieve all types and fields of the GraphQL Schema by providing the API ID.
       parameters:
         - $ref: '#/components/parameters/apiId'
       responses:
@@ -3707,7 +4011,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/graphql-policies/complexity/types"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/graphql-policies/complexity/types"'
       operationId: getGraphQLPolicyComplexityTypesOfAPI
 
   /apis/{apiId}/resource-paths:
@@ -3716,7 +4020,7 @@ paths:
         - APIs
       summary: Get Resource Paths of an API
       description: |
-        This operation can be used to retrieve resource paths defined for a specific api.
+        This operation can be used to retrieve resource paths defined for a specific API.
       parameters:
         - $ref: '#/components/parameters/apiId'
         - $ref: '#/components/parameters/limit'
@@ -3765,8 +4069,36 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/resource-paths"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/resource-paths"'
       operationId: getAPIResourcePaths
+
+  /organizations:
+    get:
+      tags:
+        - Organizations
+      summary: Get all registered Organizations
+      description: |
+        Get all Registered Organizations
+      responses:
+        200:
+          description: |
+            OK.
+            Organizations returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationList'
+      security:
+        - OAuth2Security:
+            - apim:api_view
+            - apim:api_manage
+            - apim:api_import_export
+            - apim:api_product_import_export
+            - apim:publisher_organization_read
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/organizations"'
 
   /apis/{apiId}/auditapi:
     get:
@@ -3803,9 +4135,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/auditapi"'
-      x-examples:
-        $ref: "docs/examples/apis/apis_id_auditapi_get.yaml"
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/auditapi"'
       operationId: getAuditReportOfAPI
 
   /apis/{apiId}/external-stores:
@@ -3814,7 +4144,7 @@ paths:
         - External Stores
       summary: Get the List of External Stores to which an API is Published
       description: |
-        This operation can be used to retrieve a list of external stores which an API is published to by providing the id of the API.
+        This operation can be used to retrieve a list of external stores which an API is published to by providing the ID of the API.
       operationId: getAllPublishedExternalStoresByAPI
       parameters:
         - $ref: '#/components/parameters/apiId'
@@ -3850,9 +4180,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/external-stores"'
-      x-examples:
-        $ref: docs/examples/external-stores/external_stores.yaml#/getPublishedExternalStoresByAPI
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/external-stores"'
 
   /apis/{apiId}/publish-to-external-stores:
     post:
@@ -3880,13 +4208,13 @@ paths:
             ETag:
               description: |
                 Entity Tag of the blocked subscription.
-                Used by caches, or in conditional requests (Will be supported in future).
+                Used by caches, or in conditional requests (This is not supported by WSO2 API Manager as of yet).
               schema:
                 type: string
             Last-Modified:
               description: |
-                Date and time the subscription has been blocked.
-                Used by caches, or in conditional requests (Will be supported in future).
+                Date and time the subscription which was blocked.
+                Used by caches, or in conditional requests (This is not supported by WSO2 API Manager as of yet).
               schema:
                 type: string
           content:
@@ -3904,9 +4232,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/publish-to-external-stores?externalStoreId=Store123#"'
-      x-examples:
-        $ref: docs/examples/external-stores/external_stores.yaml#/publishToExternalStore
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/publish-to-external-stores?externalStoreId=Store123#"'
 
   /apis/{apiId}/generate-key:
     post:
@@ -3914,7 +4240,7 @@ paths:
         - APIs
       summary: Generate internal API Key to invoke APIS.
       description: |
-        This operation can be used to generate internal api key which used to invoke API.
+        This operation can be used to generate internal API key which used to invoke API.
       operationId: generateInternalAPIKey
       parameters:
         - $ref: '#/components/parameters/apiId'
@@ -3938,7 +4264,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/7a2298c4-c905-403f-8fac-38c73301631f/generate-key"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/7a2298c4-c905-403f-8fac-38c73301631f/generate-key"'
 
   /apis/export:
     get:
@@ -3989,7 +4315,7 @@ paths:
         - name: preserveStatus
           in: query
           description: |
-            Preserve API Status on export
+            Preserve API Status during export
           schema:
             type: boolean
         - name: latestRevision
@@ -4035,7 +4361,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/export?apiId=96077508-fd01-4fae-bc64-5de0e2baf43c&name=PizzaShackAPI&version=1.0&provider=admin&format=YAML"
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/export?apiId=96077508-fd01-4fae-bc64-5de0e2baf43c&name=PizzaShackAPI&version=1.0&provider=admin&format=YAML"
           > exportAPI.zip'
       operationId: exportAPI
 
@@ -4068,6 +4394,22 @@ paths:
           required: false
           schema:
             type: boolean
+        - name: preservePortalConfigurations
+          in: query
+          description: |
+            Preserve Portal Configurations. This is used to preserve the portal configurations of the API
+          required: false
+          schema:
+            type: boolean
+        - name: dryRun
+          in: query
+          description: |
+            Dry Run. This is used to validate the API without importing it
+          required: false
+          schema:
+            type: boolean
+            default: false
+        - $ref: '#/components/parameters/Accept'
       requestBody:
         content:
           multipart/form-data:
@@ -4077,13 +4419,21 @@ paths:
               properties:
                 file:
                   type: string
-                  description: Zip archive consisting on exported api configuration
+                  description: Zip archive consisting on exported API configuration
                   format: binary
       responses:
         200:
           description: |
             Created.
             API Imported Successfully.
+          content:
+            "text/plain":
+              schema:
+                type: string
+                example: API Imported Successfully
+            "application/json":
+              schema:
+                $ref: '#/components/schemas/ImportAPIResponse'
         403:
           $ref: '#/components/responses/Forbidden'
         404:
@@ -4099,7 +4449,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -F file=@admin-PizzaShackAPI-1.0.0.zip "https://127.0.0.1:9443/api/am/publisher/v3/apis/import?preserveProvider=false&overwrite=false"'
+          -F file=@admin-PizzaShackAPI-1.0.0.zip "https://127.0.0.1:9443/api/am/publisher/v4/apis/import?preserveProvider=false&overwrite=false"'
       operationId: importAPI
 
   ######################################################
@@ -4114,10 +4464,10 @@ paths:
         This operation can be used to retrieve a list of subscriptions of the user associated with the provided access token. This operation is capable of
 
         1. Retrieving all subscriptions for the user's APIs.
-        `GET https://127.0.0.1:9443/api/am/publisher/v3/subscriptions`
+        `GET https://127.0.0.1:9443/api/am/publisher/v4/subscriptions`
 
         2. Retrieving subscriptions for a specific API.
-        `GET https://127.0.0.1:9443/api/am/publisher/v3/subscriptions?apiId=c43a325c-260b-4302-81cb-768eafaa3aed`
+        `GET https://127.0.0.1:9443/api/am/publisher/v4/subscriptions?apiId=c43a325c-260b-4302-81cb-768eafaa3aed`
       parameters:
         - $ref: '#/components/parameters/apiId-Q-Opt'
         - $ref: '#/components/parameters/limit'
@@ -4165,7 +4515,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/subscriptions?apiId=96077508-fd01-4fae-bc64-5de0e2baf43c"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/subscriptions?apiId=96077508-fd01-4fae-bc64-5de0e2baf43c"'
       operationId: getSubscriptions
 
   ######################################################
@@ -4225,7 +4575,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/subscriptions/64eca60b-2e55-4c38-8603-e9e6bad7d809/usage"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/subscriptions/64eca60b-2e55-4c38-8603-e9e6bad7d809/usage"'
       operationId: getSubscriptionUsage
 
   /subscriptions/{subscriptionId}/subscriber-info:
@@ -4256,7 +4606,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/subscriptions/64eca60b-2e55-4c38-8603-e9e6bad7d809/subscriber-info"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/subscriptions/64eca60b-2e55-4c38-8603-e9e6bad7d809/subscriber-info"'
       operationId: getSubscriberInfoBySubscriptionId
 
   /subscriptions/block-subscription:
@@ -4314,7 +4664,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/subscriptions/block-subscription?subscriptionId=64eca60b-2e55-4c38-8603-e9e6bad7d809&blockState=PROD_ONLY_BLOCKED"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/subscriptions/block-subscription?subscriptionId=64eca60b-2e55-4c38-8603-e9e6bad7d809&blockState=PROD_ONLY_BLOCKED"'
       operationId: blockSubscription
 
   /subscriptions/unblock-subscription:
@@ -4359,9 +4709,47 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/subscriptions/unblock-subscription?subscriptionId=64eca60b-2e55-4c38-8603-e9e6bad7d809"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/subscriptions/unblock-subscription?subscriptionId=64eca60b-2e55-4c38-8603-e9e6bad7d809"'
       operationId: unBlockSubscription
 
+  /subscriptions/change-business-plan:
+    post:
+      tags:
+        - Subscriptions
+      summary: Change subscription business plan
+      description: |
+        This operation can be used to change the business plan of a subscription specifying the subscription Id and the business plan.
+      parameters:
+        - $ref: '#/components/parameters/subscriptionId-Q'
+        - name: businessPlan
+          in: query
+          description: |
+            The business plan to be assigned to the subscription.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/If-Match'
+      responses:
+        200:
+          description: |
+            OK.
+            Subscription business plan was changed successfully.
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        404:
+          $ref: '#/components/responses/NotFound'
+        409:
+          $ref: '#/components/responses/Conflict'
+      security:
+        - OAuth2Security:
+            - apim:subscription_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -X POST
+          "https://127.0.0.1:9443/api/am/publisher/v4/subscriptions/change-business-plan?subscriptionId=92c50632-012f-4739-b37d-baa23008c813&businessPlan=Silver"'
+      operationId: changeSubscriptionBusinessPlan
 
   ######################################################
   # The "Thorttling Tier Collection" resource APIs
@@ -4380,6 +4768,7 @@ paths:
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/policyLevel'
         - $ref: '#/components/parameters/If-None-Match'
+        - $ref: '#/components/parameters/isAiApi'
       responses:
         200:
           description: |
@@ -4415,7 +4804,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/throttling-policies/api"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/throttling-policies/api"'
 
   ######################################################
   # The "Subscription Throttling Based on Quota Type" resource APIs
@@ -4467,7 +4856,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/throttling-policies/subscription?tierQuotaType=RequestCountLimit"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/throttling-policies/streaming/subscription?limit=10&offset=0"'
 
   ######################################################
   # The "Individual Throttling Tier" resource APIs
@@ -4528,13 +4917,17 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/throttling-policies/api/Platinum"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/throttling-policies/api/Platinum"'
 
+  ######################################################
+  # The "Client Certificates" resource APIs (Deprecated)
+  ######################################################
   /apis/{apiId}/client-certificates:
     get:
       tags:
         - Client Certificates
       summary: Retrieve/ Search Uploaded Client Certificates
+      deprecated: true
       description: |
         This operation can be used to retrieve and search the uploaded client certificates.
       parameters:
@@ -4573,13 +4966,14 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates?alias=wso2carbon"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates?alias=wso2carbon"'
       operationId: getAPIClientCertificates
 
     post:
       tags:
         - Client Certificates
       summary: Upload a New Certificate
+      deprecated: true
       description: |
         This operation can be used to upload a new certificate for an endpoint.
       parameters:
@@ -4604,7 +4998,7 @@ paths:
                   description: Alias for the certificate
                 tier:
                   type: string
-                  description: api tier to which the certificate should be applied.
+                  description: API tier to which the certificate should be applied.
         required: true
       responses:
         200:
@@ -4639,12 +5033,13 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: multipart/form-data" -F certificate=@test.crt -F alias=wso2carbon
-          -F apiId=fea749dd-d548-4a8b-b308-34903b39a34b -F tier=Gold "https://127.0.0.1:9443/api/am/publisher/v3/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates"'
+          -H "Content-Type: multipart/form-data" -F certificate=@test.crt -F alias=wso2carbon -F tier=Gold
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates"'
       operationId: addAPIClientCertificate
 
   /apis/{apiId}/client-certificates/{alias}:
     get:
+      deprecated: true
       tags:
         - Client Certificates
       summary: Get the Certificate Information
@@ -4686,10 +5081,11 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates/wso2carbon"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates/wso2carbon"'
       operationId: getAPIClientCertificateByAlias
 
     put:
+      deprecated: true
       tags:
         - Client Certificates
       summary: Update a Certificate
@@ -4753,10 +5149,11 @@ paths:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
           -H "Content-Type: multipart/form-data" -F certificate=@test.crt -F alias=wso2carbon
-          -F apiId=fea749dd-d548-4a8b-b308-34903b39a34b -F tier=Gold "https://127.0.0.1:9443/api/am/publisher/v3/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates/wso2carbon"'
+          -F apiId=fea749dd-d548-4a8b-b308-34903b39a34b -F tier=Gold "https://127.0.0.1:9443/api/am/publisher/v4/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates/wso2carbon"'
       operationId: updateAPIClientCertificateByAlias
 
     delete:
+      deprecated: true
       tags:
         - Client Certificates
       summary: Delete a Certificate
@@ -4797,11 +5194,12 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates/wso2carbon"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates/wso2carbon"'
       operationId: deleteAPIClientCertificateByAlias
 
   /apis/{apiId}/client-certificates/{alias}/content:
     get:
+      deprecated: true
       tags:
         - Client Certificates
       summary: Download a Certificate
@@ -4840,8 +5238,344 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates/wso2carbon/content"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates/wso2carbon/content" > test.crt'
       operationId: getAPIClientCertificateContentByAlias
+
+  ######################################################
+  # The "Client Certificates" resource APIs (New)
+  ######################################################
+  /apis/{apiId}/client-certs/{keyType}:
+    parameters:
+      - in: path
+        name: keyType
+        schema:
+          type: string
+        required: true
+        description: Key type for the certificate
+    get:
+      tags:
+        - Client Certificates
+      summary: Retrieve/ Search Uploaded Client Certificates of a given key type
+      description: |
+        This operation can be used to retrieve and search the uploaded client certificates of a given key type.
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - name: alias
+          in: query
+          description: Alias for the client certificate
+          schema:
+            type: string
+        - $ref: '#/components/parameters/apiId'
+      responses:
+        200:
+          description: |
+            OK. Successful response with the list of matching certificate information in the body.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientCertificates'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:api_view
+            - apim:api_manage
+            - apim:client_certificates_view
+            - apim:client_certificates_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certs/PRODUCTION?alias=wso2carbon"'
+      operationId: getAPIClientCertificatesByKeyType
+    post:
+      tags:
+        - Client Certificates
+      summary: Upload a New Certificate of the given key type
+      description: |
+        This operation can be used to upload a new certificate for an endpoint of the given type.
+      parameters:
+        - $ref: '#/components/parameters/apiId'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - alias
+                - certificate
+                - tier
+              properties:
+                certificate:
+                  type: string
+                  description: The certificate that needs to be uploaded.
+                  format: binary
+                alias:
+                  maxLength: 30
+                  minLength: 1
+                  type: string
+                  description: Alias for the certificate
+                tier:
+                  type: string
+                  description: API tier to which the certificate should be applied.
+        required: true
+      responses:
+        200:
+          description: |
+            OK.
+            The Certificate added successfully.
+          headers:
+            Location:
+              description: |
+                The URL of the newly created resource.
+              schema:
+                type: string
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientCertMetadata'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:api_create
+            - apim:api_manage
+            - apim:client_certificates_add
+            - apim:client_certificates_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          -H "Content-Type: multipart/form-data" -F certificate=@test.crt -F alias=wso2carbon -F tier=Gold
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certs/PRODUCTION"'
+      operationId: addAPIClientCertificateOfGivenKeyType
+
+  /apis/{apiId}/client-certs/{keyType}/{alias}:
+    parameters:
+      - in: path
+        name: keyType
+        schema:
+          type: string
+        required: true
+        description: Key type for the certificate
+    get:
+      tags:
+        - Client Certificates
+      summary: Get the Certificate Information of a Given Key Type
+      description: |
+        This operation can be used to get the information about a certificate of a given key type.
+      parameters:
+        - name: alias
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/apiId'
+      responses:
+        200:
+          description: |
+            OK.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateInfo'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:api_view
+            - apim:api_manage
+            - apim:client_certificates_view
+            - apim:client_certificates_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certs/PRODUCTION/wso2carbon"'
+      operationId: getAPIClientCertificateByKeyTypeAndAlias
+
+    put:
+      tags:
+        - Client Certificates
+      summary: Update a Certificate of a Given Key Type
+      description: |
+        This operation can be used to update an uploaded certificate of a given key type.
+      parameters:
+        - name: alias
+          in: path
+          description: Alias for the certificate
+          required: true
+          schema:
+            maxLength: 30
+            minLength: 1
+            type: string
+        - $ref: '#/components/parameters/apiId'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                certificate:
+                  type: string
+                  description: The certificate that needs to be uploaded.
+                  format: binary
+                tier:
+                  type: string
+                  description: The tier of the certificate
+      responses:
+        200:
+          description: |
+            OK.
+            The Certificate updated successfully.
+          headers:
+            Location:
+              description: |
+                The URL of the newly created resource.
+              schema:
+                type: string
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientCertMetadata'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:api_create
+            - apim:api_manage
+            - apim:client_certificates_update
+            - apim:client_certificates_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          -H "Content-Type: multipart/form-data" -F certificate=@test.crt -F alias=wso2carbon
+          -F apiId=fea749dd-d548-4a8b-b308-34903b39a34b -F tier=Gold "https://127.0.0.1:9443/api/am/publisher/v4/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certs/PRODUCTION/wso2carbon"'
+      operationId: updateAPIClientCertificateByKeyTypeAndAlias
+
+    delete:
+      tags:
+        - Client Certificates
+      summary: Delete a Certificate of a Given Key Type
+      description: |
+        This operation can be used to delete an uploaded certificate of a given key type.
+      parameters:
+        - name: alias
+          in: path
+          description: |
+            The alias of the certificate that should be deleted.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/apiId'
+      responses:
+        200:
+          description: |
+            OK.
+            The Certificate deleted successfully.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content: { }
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:api_create
+            - apim:api_manage
+            - apim:client_certificates_update
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certificates/wso2carbon"'
+      operationId: deleteAPIClientCertificateByKeyTypeAndAlias
+
+  /apis/{apiId}/client-certs/{keyType}/{alias}/content:
+    get:
+      tags:
+        - Client Certificates
+      summary: Download a Certificate of Given Key Type
+      description: |
+        This operation can be used to download a certificate which matches the given alias and key type.
+      parameters:
+        - $ref: '#/components/parameters/apiId'
+        - name: alias
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: keyType
+          in: path
+          description: |
+            The key type of the certificate that should be deleted.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: |
+            OK.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content: {}
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:api_view
+            - apim:api_manage
+            - apim:client_certificates_view
+            - apim:client_certificates_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/client-certs/PRODUCTION/wso2carbon/content" > test.crt'
+      operationId: getAPIClientCertificateContentByKeyTypeAndAlias
 
   ######################################################
   # The "Certificate Management" resource APIs
@@ -4896,7 +5630,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/endpoint-certificates?alias=wso2carbon&endpoint=www.abc.com"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/endpoint-certificates?alias=wso2carbon&endpoint=www.abc.com"'
       operationId: getEndpointCertificates
 
     post:
@@ -4961,7 +5695,7 @@ paths:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
           -H "Content-Type: multipart/form-data" -F certificate=@test.crt -F alias=alias
-          -F "endpoint=endpoint=https://www.abc.com" "https://127.0.0.1:9443/api/am/publisher/v3/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/endpoint-certificates"'
+          -F endpoint=https://www.abc.com "https://127.0.0.1:9443/api/am/publisher/v4/endpoint-certificates"'
       operationId: addEndpointCertificate
 
   /endpoint-certificates/{alias}:
@@ -5006,7 +5740,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/endpoint-certificates/wso2carbon"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/endpoint-certificates/wso2carbon"'
       operationId: getEndpointCertificateByAlias
 
     put:
@@ -5071,7 +5805,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: multipart/form-data" -F certificate=@test.crt "https://127.0.0.1:9443/api/am/publisher/v3/apis/d48a3412-1b85-49be-99f4-b81a3722ae73/endpoint-certificates/wso2carbon"'
+          -H "Content-Type: multipart/form-data" -F certificate=@test.crt "https://127.0.0.1:9443/api/am/publisher/v4/endpoint-certificates/wso2carbon"'
       operationId: updateEndpointCertificateByAlias
 
     delete:
@@ -5115,7 +5849,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/endpoint-certificates/wso2carbon"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/endpoint-certificates/wso2carbon"'
       operationId: deleteEndpointCertificateByAlias
 
   /endpoint-certificates/{alias}/content:
@@ -5157,8 +5891,56 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/endpoint-certificates/wso2carbon/content"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/endpoint-certificates/wso2carbon/content" > test.crt'
       operationId: getEndpointCertificateContentByAlias
+
+  /endpoint-certificates/{alias}/usage:
+    get:
+      tags:
+        - Endpoint Certificates
+      summary: Retrieve all the APIs that use a given certificate by the alias
+      description: |
+        This operation can be used to retrieve/identify apis that use a known certificate.
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - name: alias
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: |
+            OK.
+            List of qualifying APIs is returned.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIMetadataList'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:api_view
+            - apim:api_manage
+            - apim:ep_certificates_view
+            - apim:ep_certificates_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+              "https://127.0.0.1:9443/api/am/publisher/v4/endpoint-certificates/wso2cert/usage"'
+      operationId: getCertificateUsageByAlias
 
   ######################################################
   # The "Content Search Results" resource APIs
@@ -5218,9 +6000,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/search?query=pizza"'
-      x-examples:
-        $ref: docs/examples/apis/search_get.yaml
+          "https://127.0.0.1:9443/api/am/publisher/v4/search?query=pizza"'
       operationId: search
 
   ######################################################
@@ -5278,7 +6058,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products?query=PizzaAPIProduct"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products?query=PizzaAPIProduct"'
       operationId: getAllAPIProducts
 
     post:
@@ -5331,7 +6111,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v3/api-products"'
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/api-products"'
       operationId: createAPIProduct
 
   ################################################################
@@ -5392,7 +6172,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/5bca47e1-8233-46a5-9295-525dca337f33"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/5bca47e1-8233-46a5-9295-525dca337f33"'
       operationId: getAPIProduct
 
     put:
@@ -5458,7 +6238,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v3/api-products/5bca47e1-8233-46a5-9295-525dca337f33"'
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/api-products/5bca47e1-8233-46a5-9295-525dca337f33"'
       operationId: updateAPIProduct
 
 
@@ -5491,7 +6271,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/5bca47e1-8233-46a5-9295-525dca337f33"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/5bca47e1-8233-46a5-9295-525dca337f33"'
       operationId: deleteAPIProduct
 
   /api-products/{apiProductId}/thumbnail:
@@ -5546,7 +6326,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/5bca47e1-8233-46a5-9295-525dca337f33/thumbnail"
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/5bca47e1-8233-46a5-9295-525dca337f33/thumbnail"
           > image.jpeg'
       operationId: getAPIProductThumbnail
 
@@ -5616,7 +6396,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: multipart/form-data" -F file=@image.jpeg "https://127.0.0.1:9443/api/am/publisher/v3/api-products/d48a3412-1b85-49be-99f4-b81a3722ae73/thumbnail"'
+          -H "Content-Type: multipart/form-data" -F file=@image.jpeg "https://127.0.0.1:9443/api/am/publisher/v4/api-products/d48a3412-1b85-49be-99f4-b81a3722ae73/thumbnail"'
       operationId: updateAPIProductThumbnail
 
   /api-products/{apiProductId}/swagger:
@@ -5670,7 +6450,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/5bca47e1-8233-46a5-9295-525dca337f33/swagger"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/5bca47e1-8233-46a5-9295-525dca337f33/swagger"'
       operationId: getAPIProductSwagger
 
   /api-products/{apiProductId}/is-outdated:
@@ -5732,7 +6512,7 @@ paths:
         - API Product Documents
       summary: Get a List of Documents of an API Product
       description: |
-        This operation can be used to retrive a list of documents belonging to an API Product by providing the id of the API Product.
+        This operation can be used to retrive a list of documents belonging to an API Product by providing the ID of the API Product.
       parameters:
         - $ref: '#/components/parameters/apiProductId'
         - $ref: '#/components/parameters/limit'
@@ -5776,7 +6556,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents"'
       operationId: getAPIProductDocuments
 
     post:
@@ -5832,7 +6612,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v3/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents"'
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents"'
       operationId: addAPIProductDocument
 
   /api-products/{apiProductId}/documents/{documentId}:
@@ -5891,7 +6671,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents/83312daf-0d8a-427b-8f72-12755b7901d3"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents/83312daf-0d8a-427b-8f72-12755b7901d3"'
       operationId: getAPIProductDocument
 
     put:
@@ -5956,7 +6736,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v3/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents/83312daf-0d8a-427b-8f72-12755b7901d3"'
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents/83312daf-0d8a-427b-8f72-12755b7901d3"'
       operationId: updateAPIProductDocument
 
     delete:
@@ -5986,7 +6766,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents/83312daf-0d8a-427b-8f72-12755b7901d3"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents/83312daf-0d8a-427b-8f72-12755b7901d3"'
       operationId: deleteAPIProductDocument
 
   /api-products/{apiProductId}/documents/{documentId}/content:
@@ -6002,7 +6782,7 @@ paths:
         1. **Inline type**:
            The content of the document will be retrieved in `text/plain` content type
 
-           _Sample cURL_ : `curl -k -H "Authorization:Bearer 579f0af4-37be-35c7-81a4-f1f1e9ee7c51" -F inlineContent=@"docs.txt" -X POST "https://localhost:9443/api/am/publisher/v3/apis/995a4972-3178-4b17-a374-756e0e19127c/documents/43c2bcce-60e7-405f-bc36-e39c0c5e189e/content`
+           _Sample cURL_ : `curl -k -H "Authorization:Bearer 579f0af4-37be-35c7-81a4-f1f1e9ee7c51" -F inlineContent=@"docs.txt" -X POST "https://localhost:9443/api/am/publisher/v4/apis/995a4972-3178-4b17-a374-756e0e19127c/documents/43c2bcce-60e7-405f-bc36-e39c0c5e189e/content`
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
@@ -6064,7 +6844,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents/83312daf-0d8a-427b-8f72-12755b7901d3/content"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents/83312daf-0d8a-427b-8f72-12755b7901d3/content"'
       operationId: getAPIProductDocumentContent
 
     post:
@@ -6139,7 +6919,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: multipart/form-data" -F file=@sample.pdf "https://127.0.0.1:9443/api/am/publisher/v3/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents/83312daf-0d8a-427b-8f72-12755b7901d3/content"'
+          -H "Content-Type: multipart/form-data" -F file=@sample.pdf "https://127.0.0.1:9443/api/am/publisher/v4/api-products/5bca47e1-8233-46a5-9295-525dca337f33/documents/83312daf-0d8a-427b-8f72-12755b7901d3/content"'
       operationId: addAPIProductDocumentContent
 
   ######################################################
@@ -6184,7 +6964,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v3/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions?query=deployed:true"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions?query=deployed:true"'
 
     #--------------------------------------------
     # Create a new API Product revision
@@ -6226,7 +7006,7 @@ paths:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
             -H "Content-Type: application/json" -d @data.json
-            "https://127.0.0.1:9443/api/am/publisher/v3/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions"'
 
   ######################################################
   # The "API Revisions" individual resource API Product
@@ -6241,7 +7021,7 @@ paths:
         - API Product Revisions
       summary: Retrieve Revision
       description: |
-        Retrieve a revision of an API Product
+        Retrieve a revision of an API Product (This resource is not supported at the moment)
       operationId: getAPIProductRevision
       parameters:
         - $ref: '#/components/parameters/apiProductId'
@@ -6266,7 +7046,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v3/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions/e0824883-3e86-403a-aec1-22bbc454eb7c"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions/e0824883-3e86-403a-aec1-22bbc454eb7c"'
 
     #--------------------------------------------
     # Delete a revision
@@ -6304,7 +7084,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v3/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions/e0824883-3e86-403a-aec1-22bbc454eb7c"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/revisions/e0824883-3e86-403a-aec1-22bbc454eb7c"'
 
   /api-products/{apiProductId}/deployments:
     #--------------------------------------------
@@ -6339,7 +7119,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-                "https://127.0.0.1:9443/api/am/publisher/v3/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/deployments"'
+                "https://127.0.0.1:9443/api/am/publisher/v4/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/deployments"'
 
   /api-products/{apiProductId}/deployments/{deploymentId}:
     #--------------------------------------------
@@ -6380,7 +7160,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -d @data.json
-                "https://127.0.0.1:9443/api/am/publisher/v3/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/deployments/UHJvZHVjdGlvbiBhbmQgU2FuZGJveA"'
+                "https://127.0.0.1:9443/api/am/publisher/v4/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/deployments/UHJvZHVjdGlvbiBhbmQgU2FuZGJveA"'
 
   /api-products/{apiProductId}/deploy-revision:
     #--------------------------------------------
@@ -6429,8 +7209,8 @@ paths:
             - apim:api_manage
       x-code-samples:
         - lang: Curl
-          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v3/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/deploy-revision?revisionId=e0824883-3e86-403a-aec1-22bbc454eb7c"'
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d @data.json
+            "https://127.0.0.1:9443/api/am/publisher/v4/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/deploy-revision?revisionId=e0824883-3e86-403a-aec1-22bbc454eb7c"'
 
   /api-products/{apiProductId}/undeploy-revision:
     #--------------------------------------------
@@ -6487,7 +7267,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-                "https://127.0.0.1:9443/api/am/publisher/v3/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/undeploy-revision?revisionId=e0824883-3e86-403a-aec1-22bbc454eb7c"'
+                "https://127.0.0.1:9443/api/am/publisher/v4/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/undeploy-revision?revisionId=e0824883-3e86-403a-aec1-22bbc454eb7c"'
 
   /api-products/{apiProductId}/restore-revision:
 
@@ -6523,7 +7303,61 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v3/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/restore-revision?revisionId=e0824883-3e86-403a-aec1-22bbc454eb7c"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/restore-revision?revisionId=e0824883-3e86-403a-aec1-22bbc454eb7c"'
+
+  /api-products/copy-api-products:
+    #--------------------------------------------------------
+    # Create new product version from the existing API Product
+    #--------------------------------------------------------
+    post:
+      tags:
+        - API Products
+      summary: Create a New API Product Version
+      description: |
+        This operation can be used to create a new version of an existing API Products. The new version is specified as `newVersion` query parameter. New API Product will be in `CREATED` state.
+      parameters:
+        - name: newVersion
+          in: query
+          description: Version of the new API Product.
+          required: true
+          schema:
+            maxLength: 30
+            type: string
+        - name: defaultVersion
+          in: query
+          description: Specifies whether new API Product should be added as default version.
+          schema:
+            type: boolean
+            default: false
+        - $ref: '#/components/parameters/apiProductId-Q'
+      responses:
+        201:
+          description: |
+            Created.
+            Successful response with the newly created API Product as entity in the body. Location header contains URL of newly created API Product.
+          headers:
+            Location:
+              description: |
+                The URL of the newly created API Product.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIProduct'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+      security:
+        - OAuth2Security:
+            - apim:api_publish
+            - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/copy-api-products?newVersion=2.0&defaultVersion=false&apiProductId=2fd14eb8-b828-4013-b448-0739d2e76bf7"'
+      operationId: createNewAPIProductVersion
 
   /api-products/export:
     get:
@@ -6606,7 +7440,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/export?name=LeasingAPIProduct&version=1.0.0&revisionNumber=2&provider=admin&format=YAML"
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/export?name=LeasingAPIProduct&version=1.0.0&revisionNumber=2&provider=admin&format=YAML"
           > exportAPIProduct.zip'
       operationId: exportAPIProduct
 
@@ -6682,7 +7516,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            -F file=@admin-PizzaShackAPIProduct.zip "https://127.0.0.1:9443/api/am/admin/v3/api-products/importt?preserveProvider=false&overwriteAPIProduct=false&overwriteAPIs=false&importAPIs=false"'
+            -F file=@admin-PizzaShackAPIProduct.zip "https://127.0.0.1:9443/api/am/publisher/v4/api-products/import?preserveProvider=false&overwriteAPIProduct=false&overwriteAPIs=false&importAPIs=false"'
       operationId: importAPIProduct
 
   ######################################################
@@ -6712,7 +7546,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -I -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/roles/SW50ZXJuYWwvcHVibGlzaGVyCQ"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/roles/SW50ZXJuYWwvcHVibGlzaGVyCQ"'
 
   /me/roles/{roleId}:
     head:
@@ -6737,7 +7571,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -I -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/me/roles/SW50ZXJuYWwvcHVibGlzaGVyCQ"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/me/roles/SW50ZXJuYWwvcHVibGlzaGVyCQ"'
 
   ######################################################
   # The "ExternalStore Collection" resource APIs
@@ -6768,7 +7602,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/external-stores"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/external-stores"'
 
   ######################################################
   # The Publisher settings resource APIs
@@ -6798,9 +7632,48 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/settings"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/settings"'
       operationId: getSettings
 
+  ######################################################
+  # The linter custom rules resource APIs
+  ######################################################
+  /linter-custom-rules:
+    get:
+      tags:
+        - Linter Custom Rules
+      summary: Get linter custom rules.
+      description: |
+        This operation can be used to get linter custom rules from tenant-config.
+      operationId: getLinterCustomRules
+      responses:
+        200:
+          description: |
+            OK.
+            Linter Custom Rules Retrieved Successfully.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: string
+        403:
+          $ref: '#/components/responses/Forbidden'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:api_view
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/linter-custom-rules"'
   ######################################################
   # The tenant resource APIs
   ######################################################
@@ -6854,7 +7727,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/tenants?state=active"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/tenants?state=active"'
 
   /tenants/{tenantDomain}:
     head:
@@ -6879,9 +7752,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -I -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/tenants/wso2.com"'
-      x-examples:
-        $ref: docs/examples/tenants/tenants.yaml
+          "https://127.0.0.1:9443/api/am/publisher/v4/tenants/wso2.com"'
 
   ######################################################
   # The "API Category Collection" resource API
@@ -6909,7 +7780,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-categories"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-categories"'
       operationId: getAllAPICategories
 
   ######################################################
@@ -6950,7 +7821,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/scopes"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/scopes"'
 
     post:
       tags:
@@ -6991,7 +7862,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v3/scopes"'
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/scopes"'
 
   /scopes/{scopeId}:
     get:
@@ -7027,7 +7898,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/scopes/01234567-0123-0123-0123-012345678901"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/scopes/01234567-0123-0123-0123-012345678901"'
 
     put:
       tags:
@@ -7070,7 +7941,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v3/scopes/01234567-0123-0123-0123-012345678901"'
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/scopes/01234567-0123-0123-0123-012345678901"'
 
     delete:
       tags:
@@ -7095,7 +7966,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/scopes/01234567-0123-0123-0123-012345678901"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/scopes/01234567-0123-0123-0123-012345678901"'
 
     head:
       tags:
@@ -7121,7 +7992,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -I -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/scopes/YXBpbTphcGlfdmlldw"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/scopes/YXBpbTphcGlfdmlldw"'
 
   /scopes/{scopeId}/usage:
     get:
@@ -7158,7 +8029,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/scopes/01234567-0123-0123-0123-012345678901/usage"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/scopes/01234567-0123-0123-0123-012345678901/usage"'
 
   ######################################################
   # The "Key Managers Collection" resource API
@@ -7187,7 +8058,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/key-managers"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/key-managers"'
       operationId: getAllKeyManagers
 
   /apis/validate-asyncapi:
@@ -7243,12 +8114,16 @@ paths:
         - OAuth2Security:
             - apim:api_create
             - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            -F file=@streetlights.yml "https://127.0.0.1:9443/api/am/publisher/v4/apis/validate-asyncapi"'
 
   /apis/import-asyncapi:
     post:
       tags:
         - APIs
-      summary: import an AsyncAPI Specification
+      summary: Import an AsyncAPI Specification
       description:
         This operation can be used to create and API from the AsyncAPI Specification. Provide either 'url' or 'file'
         to specify the definition.
@@ -7303,6 +8178,10 @@ paths:
         - OAuth2Security:
             - apim:api_create
             - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+                -F file=@streetlights.yml -F additionalProperties=@import-asyncapi.json "https://127.0.0.1:9443/api/am/publisher/v4/apis/import-asyncapi"'
 
   /apis/{apiId}/asyncapi:
     get:
@@ -7355,6 +8234,10 @@ paths:
             - apim:api_view
             - apim:api_manage
             - apim:api_definition_view
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/01234567-0123-0123-0123-012345678901/asyncapi"'
 
     put:
       tags:
@@ -7424,11 +8307,15 @@ paths:
         - OAuth2Security:
             - apim:api_create
             - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            -F file=@streetlights.yml "https://127.0.0.1:9443/api/am/publisher/v4/apis/01234567-0123-0123-0123-012345678901/asyncapi"'
   /apis/{apiId}/environments/{envId}/keys:
     get:
       tags:
         - APIs
-      summary: get environment specific API properties
+      summary: Get environment specific API properties
       description: |
         This operation can be used to retrieve environment specific API properties from an existing API.
       parameters:
@@ -7453,6 +8340,10 @@ paths:
         - OAuth2Security:
             - apim:api_create
             - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/01234567-0123-0123-0123-012345678901/environments/9b37ac57-78b9-4fac-b0d4-dc8f4b15c023/keys"'
     put:
       tags:
         - APIs
@@ -7487,6 +8378,10 @@ paths:
         - OAuth2Security:
             - apim:api_create
             - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d @data.json
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/01234567-0123-0123-0123-012345678901/environments/9b37ac57-78b9-4fac-b0d4-dc8f4b15c023/keys"'
   /apis/{apiId}/operation-policies:
     get:
       tags:
@@ -7533,7 +8428,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v2/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/operation-policies"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/operation-policies"'
 
     post:
       tags:
@@ -7599,8 +8494,8 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            -H "Content-Type: multipart/form-data" -F policySpecFile=@setHeader.yaml -F policyDefinitionFile=@setHeader.j2
-            "https://127.0.0.1:9443/api/am/publisher/v2/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/operation-policies"'
+            -H "Content-Type: multipart/form-data" -F policySpecFile=@setHeader.yaml -F synapsePolicyDefinitionFile=@setHeader.j2
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/operation-policies"'
 
 
   /apis/{apiId}/operation-policies/{operationPolicyId}:
@@ -7645,7 +8540,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v2/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a"'
 
     delete:
       tags:
@@ -7678,7 +8573,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v2/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a"'
 
   /apis/{apiId}/operation-policies/{operationPolicyId}/content:
     get:
@@ -7721,7 +8616,124 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v2/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a/content"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a/content"'
+
+  ######################################################
+  # API Labels APIs
+  ######################################################
+  /apis/{apiId}/labels:
+    get:
+      tags:
+        - API Labels
+      summary: Get Labels of an API
+      description: |
+        This operation can be used to get the labels of an API.
+      parameters:
+        - $ref: '#/components/parameters/apiId'
+      responses:
+        200:
+          description: |
+            OK.
+            Successful response with Label object list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LabelList'
+        404:
+          $ref: '#/components/responses/NotFound'
+      security:
+        - OAuth2Security:
+            - apim:api_view
+            - apim:api_create
+            - apim:api_manage
+            - apim:api_publish
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/96077508-fd01-4fae-bc64-5de0e2baf43c/labels"'
+      operationId: getLabelsOfAPI
+
+  /apis/{apiId}/attach-labels:
+    post:
+      tags:
+        - API Labels Attach
+      summary: Attach Labels to an API
+      description: |
+        This operation can be used to attach labels to an API.
+      parameters:
+        - $ref: '#/components/parameters/apiId'
+      requestBody:
+        description: |
+          List of labels to be attached to the API
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestLabelList'
+        required: true
+      responses:
+        200:
+          description: |
+            OK.
+            Successful response with updated Label object list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LabelList'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+      security:
+        - OAuth2Security:
+            - apim:api_create
+            - apim:api_manage
+            - apim:api_publish
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d @data.json
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/01234567-0123-0123-0123-012345678901/attach-labels"'
+      operationId: attachLabelsToAPI
+
+  /apis/{apiId}/detach-labels:
+    post:
+      tags:
+        - API Labels Detach
+      summary: Detach Labels from an API
+      description: |
+        This operation can be used to detach labels from an API.
+      parameters:
+        - $ref: '#/components/parameters/apiId'
+      requestBody:
+        description: |
+          List of labels to be detached from the API
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestLabelList'
+        required: true
+      responses:
+        200:
+          description: |
+            OK.
+            Successful response with updated Label object list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LabelList'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+      security:
+        - OAuth2Security:
+            - apim:api_create
+            - apim:api_manage
+            - apim:api_publish
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -H "Content-Type: application/json" -d @data.json
+            "https://127.0.0.1:9443/api/am/publisher/v4/apis/01234567-0123-0123-0123-012345678901/detach-labels"'
+      operationId: detachLabelsFromAPI
 
   ######################################################
   # LLM Providers resource APIs
@@ -7868,11 +8880,28 @@ paths:
         This operation provides you a list of all common operation policies that can be used by any API
       operationId: getAllCommonOperationPolicies
       parameters:
-        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/policyLimit'
         - $ref: '#/components/parameters/offset'
         - name: query
           in: query
-          description: -Not supported yet-
+          description: |
+            **Search condition**.
+
+            You can search in attributes by using an **"<attribute>:"** modifier.
+
+            Eg.
+            "name:addHeader" will match an API Policy if the provider of the API Policy contains "addHeader".
+            "version:"v1"" will match an API Policy if the provider of the API Policy contains "v1".
+
+            Also you can use combined modifiers
+            Eg.
+            name:addHeader&version:v1 will match an API Policy if the name of the API Policy is addHeader and version is v1.
+
+            Supported attribute modifiers are [**version, name**]
+            
+            If query attributes are provided, this returns all API policies available under the given limit.
+
+            Please note that you need to use encoded URL (URL encoding) if you are using a client which does not support URL encoding (such as curl)
           schema:
             type: string
       responses:
@@ -7897,11 +8926,11 @@ paths:
         - OAuth2Security:
             - apim:common_operation_policy_view
             - apim:common_operation_policy_manage
+            - apim:policies_import_export
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v2/operation-policies"'
-
+            "https://127.0.0.1:9443/api/am/publisher/v4/operation-policies"'
     post:
       tags:
         - Operation Policies
@@ -7961,8 +8990,101 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            -H "Content-Type: multipart/form-data" -F policySpecFile=@setHeader.yaml -F policyDefinitionFile=@setHeader.j2
-            "https://127.0.0.1:9443/api/am/publisher/v2/operation-policies"'
+            -H "Content-Type: multipart/form-data" -F policySpecFile=@setHeader.yaml -F synapsePolicyDefinitionFile=@setHeader.j2
+            "https://127.0.0.1:9443/api/am/publisher/v4/operation-policies"'
+
+  /operation-policies/export:
+    get:
+      tags:
+        - Import Export
+      summary: |
+        Export an API Policy by its name and version
+      description: |
+        This operation provides you to export a preferred common API policy
+      operationId: exportOperationPolicy
+      parameters:
+        - name: name
+          in: query
+          description: Policy name
+          schema:
+            type: string
+        - name: version
+          in: query
+          description: Version of the policy
+          schema:
+            type: string
+        - name: format
+          in: query
+          description: Format of the policy definition file
+          schema:
+            type: string
+      responses:
+        200:
+          description: |
+            OK.
+            Export Successful.
+          headers:
+            Content-Type:
+              description: The content type of the body.
+              schema:
+                type: string
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        403:
+          $ref: '#/components/responses/Forbidden'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+        404:
+          $ref: '#/components/responses/NotFound'
+      security:
+        - OAuth2Security:
+            - apim:policies_import_export
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://127.0.0.1:9443/api/am/publisher/v4/operation-policies/export?name=addHeader&version=v1"
+            > addHeader_v1.zip'
+
+  /operation-policies/import:
+    post:
+      tags:
+        - Import Export
+      summary: Import an API Policy
+      description: |
+        This operation can be used to import an API Policy.
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  description: Zip archive consisting on exported policy configuration
+                  format: binary
+      responses:
+        200:
+          description: |
+            Created.
+            Policy Imported Successfully.
+        403:
+          $ref: '#/components/responses/Forbidden'
+        409:
+          $ref: '#/components/responses/Conflict'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:policies_import_export
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          -F file=add_header_v1.zip "https://127.0.0.1:9443/api/am/publisher/v4/operation-policies/import"'
+      operationId: importOperationPolicy
 
   /operation-policies/{operationPolicyId}:
     get:
@@ -7999,10 +9121,11 @@ paths:
         - OAuth2Security:
             - apim:common_operation_policy_view
             - apim:common_operation_policy_manage
+            - apim:policies_import_export
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v2/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a"'
 
     delete:
       tags:
@@ -8028,10 +9151,11 @@ paths:
       security:
         - OAuth2Security:
             - apim:common_operation_policy_manage
+            - apim:policies_import_export
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-            "https://127.0.0.1:9443/api/am/publisher/v2/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a"'
+            "https://127.0.0.1:9443/api/am/publisher/v4/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a"'
 
   /operation-policies/{operationPolicyId}/content:
     get:
@@ -8070,7 +9194,276 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v2/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a/content"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/operation-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a/content"'
+
+  ######################################################
+  # The Gateway Policies API
+  ######################################################
+  /gateway-policies:
+    post:
+      tags:
+        - Gateway Policies
+      summary: Engage gateway policies to the request, response, fault flows
+      description: |
+        This operation can be used to apply gateway policies to the request, response, fault flows.
+      operationId: addGatewayPoliciesToFlows
+      requestBody:
+        description: Policy details object that needs to be added.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GatewayPolicyMappings'
+        required: true
+      responses:
+        201:
+          description: |
+            OK.
+            Policy mapping created successfully.
+          headers:
+            Location:
+              description: |
+                The URL of the created gateway policy mapping.
+              schema:
+                type: string
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GatewayPolicyMappingInfo'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:gateway_policy_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+              -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/gateway-policies"'
+
+    get:
+      tags:
+        - Gateway Policies
+      summary: |
+        Get all gateway policies mapping information
+      description: |
+        This operation provides you a list of all gateway policies mapping information.
+      operationId: getAllGatewayPolicies
+      parameters:
+        - $ref: '#/components/parameters/policyLimit'
+        - $ref: '#/components/parameters/offset'
+        - name: query
+          in: query
+          description: |
+            **Search condition**.
+
+            You can search in attributes by using an **"gatewayLabel:"** modifier.
+
+            Eg.
+            The entry "gatewayLabel:gateway1" will result in a match with a Gateway Policy Mapping only if the policy mapping is deployed on "gateway1".
+
+            If query attribute is provided, this returns the Gateway policy Mapping available under the given limit.
+
+            Please note that you need to use encoded URL (URL encoding) if you are using a client which does not support URL encoding (such as curl)
+          schema:
+            type: string
+      responses:
+        200:
+          description: |
+            OK.
+            List of gateway policies is returned.
+          headers:
+            Content-Type:
+              description: The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GatewayPolicyMappingDataList'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:gateway_policy_view
+            - apim:gateway_policy_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://127.0.0.1:9443/api/am/publisher/v4/gateway-policies"'
+
+  /gateway-policies/{gatewayPolicyMappingId}:
+    get:
+      tags:
+        - Gateway Policies
+      summary: Retrieve information of a selected gateway policy mapping
+      description: |
+        This operation can be used to retrieve information of a selected gateway policy mapping.
+      operationId: getGatewayPolicyMappingContentByPolicyMappingId
+      parameters:
+        - $ref: '#/components/parameters/gatewayPolicyMappingId'
+      responses:
+        200:
+          description: |
+            OK.
+            Gateway policy mapping information returned.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GatewayPolicyMappings'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:gateway_policy_view
+            - apim:gateway_policy_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/gateway-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a"'
+
+    delete:
+      tags:
+        - Gateway Policies
+      summary: Delete a gateway policy mapping
+      description: |
+        This operation can be used to delete an existing gateway policy mapping by providing the Id of the policy mapping.
+      operationId: deleteGatewayPolicyByPolicyId
+      parameters:
+        - $ref: '#/components/parameters/gatewayPolicyMappingId'
+      responses:
+        200:
+          description: |
+            OK.
+            Resource successfully deleted.
+          content: { }
+        403:
+          $ref: '#/components/responses/Forbidden'
+        404:
+          $ref: '#/components/responses/NotFound'
+        412:
+          $ref: '#/components/responses/PreconditionFailed'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:gateway_policy_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://127.0.0.1:9443/api/am/publisher/v4/gateway-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a"'
+
+    put:
+      tags:
+        - Gateway Policies
+      summary: Update gateway policies added to the request, response, fault flows
+      description: |
+        This operation can be used to update already added gateway policies to the request, response, fault flows.
+      operationId: updateGatewayPoliciesToFlows
+      parameters:
+        - $ref: '#/components/parameters/gatewayPolicyMappingId'
+      requestBody:
+        description: Policy details object that needs to be updated.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GatewayPolicyMappings'
+        required: true
+      responses:
+        200:
+          description: |
+            OK.
+            Policy mapping updated successfully.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GatewayPolicyMappings'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:gateway_policy_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X PUT -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+              -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/gateway-policies/f56eb8b4-128c-45aa-ad35-9c87a546261a"'
+
+  /gateway-policies/{gatewayPolicyMappingId}/deploy:
+    post:
+      tags:
+        - Gateway Policies
+      summary: Engage gateway policy mapping to the gateways
+      description: |
+        This operation can be used to engage gateway policy mapping to the gateway/s.
+      operationId: engageGlobalPolicy
+      parameters:
+        - $ref: '#/components/parameters/gatewayPolicyMappingId'
+      requestBody:
+        description: Policy details object that needs to be added.
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/GatewayPolicyDeployment'
+        required: true
+      responses:
+        200:
+          description: |
+            OK.
+            Gateway policy mapping engaged successfully.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GatewayPolicyDeployment'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:gateway_policy_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+              -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/publisher/v4/gateway-policies/deploy"'
 
   /api-products/change-lifecycle:
     post:
@@ -8113,7 +9506,7 @@ paths:
             2. **Requires re-subscription when publishing the API**: If you set this to true, users need to re subscribe to the API Products although they may have subscribed to an older version.
             You can specify additional checklist items by using an **"attribute:"** modifier.
             Eg: "Deprecate old versions after publishing the API:true" will deprecate older versions of a particular API Product when it is promoted to Published state from Created state. Multiple checklist items can be given in "attribute1:true, attribute2:false" format.
-            **Sample CURL :**  curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -X POST "https://localhost:9443/api/am/publisher/v3/api-products/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish&lifecycleChecklist=Deprecate%20old%20versions%20after%20publishing%20the%20API%3Atrue,Requires%20re-subscription%20when%20publishing%20the%20API%3Afalse"
+            **Sample CURL :**  curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8" -X POST "https://localhost:9443/api/am/publisher/v4/api-products/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish&lifecycleChecklist=Deprecate%20old%20versions%20after%20publishing%20the%20API%3Atrue,Requires%20re-subscription%20when%20publishing%20the%20API%3Afalse"
           schema:
             type: string
         - $ref: '#/components/parameters/apiProductId-Q'
@@ -8145,7 +9538,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/change-lifecycle?apiId=890a4f4d-09eb-4877-a323-57f6ce2ed79b&action=Publish"'
       operationId: changeAPIProductLifecycle
 
   /api-products/{apiProductId}/lifecycle-history:
@@ -8180,7 +9573,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-history"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-history"'
       operationId: getAPIProductLifecycleHistory
 
   /api-products/{apiProductId}/lifecycle-state:
@@ -8216,7 +9609,7 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-state"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-state"'
       operationId: getAPIProductLifecycleState
 
   /api-products/{apiProductId}/lifecycle-state/pending-tasks:
@@ -8247,10 +9640,259 @@ paths:
       x-code-samples:
         - lang: Curl
           source: 'curl -k -X DELETE -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
-          "https://127.0.0.1:9443/api/am/publisher/v3/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-state/pending-tasks"'
+          "https://127.0.0.1:9443/api/am/publisher/v4/api-products/890a4f4d-09eb-4877-a323-57f6ce2ed79b/lifecycle-state/pending-tasks"'
       operationId: deleteAPIProductLifecycleStatePendingTasks
+
+  ######################################################
+  # The "Workflow Collection" resource APIs
+  ######################################################
+  /workflows:
+    get:
+      tags:
+        - Workflow (Collection)
+      summary: |
+        Retrieve All Pending Workflow Processes
+      description: |
+        This operation can be used to retrieve list of workflow pending processes.
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/Accept'
+        - name: workflowType
+          in: query
+          description: |
+            We need to show the values of each workflow process separately .for that we use workflow type.
+            Workflow type can be AM_SUBSCRIPTION_CREATION, AM_SUBSCRIPTION_UPDATE.
+          schema:
+            type: string
+            enum:
+              - AM_SUBSCRIPTION_CREATION
+              - AM_SUBSCRIPTION_UPDATE
+      responses:
+        200:
+          description: |
+            OK.
+            Workflow pendding process list returned.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkflowList'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+      security:
+        - OAuth2Security:
+            - apim:subscription_approval_view
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/workflows"'
+  /workflows/{externalWorkflowRef}:
+    get:
+      tags:
+        - Workflows (Individual)
+      summary: |
+        Get Pending Workflow Details by External Workflow Reference
+      description: |
+        Using this operation, you can retrieve complete details of a pending workflow request that either belongs to application creation, application subscription, application registration, api state change, user self sign up.. You need to provide the External_Workflow_Reference of the workflow Request to retrive it.
+      parameters:
+        - name: externalWorkflowRef
+          in: path
+          description: |
+            from the externel workflow reference we decide what is the the pending request that the are requesting.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: |
+            OK.
+            Requested Workflow Pending is returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkflowInfo'
+        304:
+          description: |
+            Not Modified.
+            Empty body because the client has already the latest version of the requested resource.
+          content: {}
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+      security:
+        - OAuth2Security:
+            - apim:subscription_approval_view
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/admin/v4/workflows/c43a325c-260b-4302-81cb-768eafaa3aed"'
+
+  /workflows/update-workflow-status:
+    post:
+      tags:
+        - Workflows (Individual)
+      summary: Update Workflow Status
+      description: |
+        This operation can be used to approve or reject a workflow task.
+      parameters:
+        - $ref: '#/components/parameters/workflowReferenceId-Q'
+      requestBody:
+        description: |
+          Workflow event that need to be updated
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Workflow'
+        required: true
+      responses:
+        200:
+          description: |
+            OK.
+            Workflow request information is returned.
+          headers:
+            Content-Type:
+              description: |
+                The content type of the body.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workflow'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+      security:
+        - OAuth2Security:
+            - apim:subscription_approval_view
+            - apim:subscription_approval_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -X POST -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          -H "Content-Type: application/json" -d @data.json "https://127.0.0.1:9443/api/am/admin/v4/workflows/update-workflow-status?workflowReferenceId=56e3a170-a7a7-45f8-b051-7e43a58a67e1"'
+
+  ######################################################
+  # The "Label Collection" resource API
+  ######################################################
+  /labels:
+    get:
+      tags:
+        - Labels (Collection)
+      summary: Get all Labels
+      description: |
+        Get all Labels
+      responses:
+        200:
+          description: |
+            OK.
+            Labels returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LabelList'
+      security:
+        - OAuth2Security:
+            - apim:api_view
+            - apim:api_manage
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+          "https://127.0.0.1:9443/api/am/publisher/v4/labels"'
+      operationId: getAllLabels
+
 components:
   schemas:
+    DesignAssistantChatQuery:
+      type: object
+      properties:
+        text:
+          type: string
+          example: create an API for a banking transaction
+        session_id:
+          type: string
+          example: 1234567890
+    DesignAssistantChatResponse:
+      type: object
+      properties:
+        backendResponse:
+          type: string
+        isSuggestions:
+          type: boolean
+          example: true
+        typeOfApi:
+          type: string
+          example: REST
+        code:
+          type: string
+        paths:
+          type: array
+          example: []
+          items:
+            type: string
+        apiTypeSuggestion:
+          type: string
+          example: This is suitable for CRUD operations in banking. Do you want to proceed?
+        missingValues:
+          type: string
+        state:
+          type: string
+          example: COMPLETE
+    DesignAssistantGenAPIPayload:
+      type: object
+      properties:
+        session_id:
+          type: string
+          example: 1234567890
+    DesignAssistantAPIPayloadResponse:
+      type: object
+      properties:
+        generated_payload:
+          type: string
+    SequenceBackendList:
+      title: Sequence Backend List
+      type: object
+      properties:
+        count:
+          type: integer
+          description: |
+            Number of Sequence Backends returned.
+          example: 1
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/SequenceBackend'
+    SequenceBackend:
+      title: Sequence Backend
+      type: object
+      properties:
+        sequenceId:
+          type: string
+          readOnly: true
+          example: 943d3002-000c-42d3-a1b9-d6559f8a4d49
+        sequenceName:
+          type: string
+          readOnly: true
+          example: 943d3002-000c-42d3-a1b9-d6559f8a4d49-SANDBOX
+        sequenceType:
+          type: string
+          readOnly: true
+          example: SANDBOX
+        sequence:
+          type: string
+          format: binary
+          readOnly: true
     Comment:
       title: Comment
       required:
@@ -8338,7 +9980,21 @@ components:
             $ref: '#/components/schemas/APIInfo'
         pagination:
           $ref: '#/components/schemas/Pagination'
-
+    APIMetadataList:
+      title: API metadata List
+      type: object
+      properties:
+        count:
+          type: integer
+          description: |
+            Number of APIs returned.
+          example: 1
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/APIMetadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
     APIInfo:
       title: API Info object with basic API details.
       type: object
@@ -8390,6 +10046,12 @@ components:
         type:
           type: string
           example: HTTP
+        subtype:
+          type: string
+          description: Subtype of the API.
+          default: DEFAULT
+          example: AIAPI
+          readOnly: true
         audience:
           type: string
           description: The audience of the API. Accepted values are PUBLIC, SINGLE
@@ -8397,6 +10059,12 @@ components:
           enum:
             - PUBLIC
             - SINGLE
+        audiences:
+          type: array
+          description: The audiences of the API for jwt validation. Accepted values are any String values
+          items:
+            type: string
+            example: [ "aud1","aud2","aud3" ]
         lifeCycleStatus:
           type: string
           example: CREATED
@@ -8416,12 +10084,62 @@ components:
         updatedTime:
           type: string
           example : 2021-02-11 09:57:25
+        updatedBy:
+          type: string
+          example: wso2.system.user
         gatewayVendor:
           type: string
           example: wso2
+        gatewayType:
+          title: Field to identify gateway type.
+          type: string
+          description: Accepts one of the following. wso2/synapse, wso2/apk.
+          example: wso2/synapse
+          default: wso2/synapse
         advertiseOnly:
           type: boolean
           example: true
+        monetizedInfo:
+          type: boolean
+          example: true
+        businessOwner:
+          type: string
+          example: Business Owner
+        businessOwnerEmail:
+          type: string
+          example: businessowner@abc.com
+        TechnicalOwner:
+          type: string
+          example: Technical Owner
+        TechnicalOwnerEmail:
+          type: string
+          example: technicalowner@abc.com
+        egress:
+          type: boolean
+          description: Whether the API is EGRESS or not
+          default: false
+          example: true
+    APIMetadata:
+      title: API Info object with basic minimal API details.
+      type: object
+      properties:
+        id:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901
+        name:
+          type: string
+          example: CalculatorAPI
+        context:
+          type: string
+          example: CalculatorAPI
+        version:
+          type: string
+          example: 1.0.0
+        provider:
+          type: string
+          description: |
+            If the provider value is not given, the user invoking the API will be used as the provider.
+          example: admin
     Topic:
       title: Topic object
       required:
@@ -8442,9 +10160,9 @@ components:
           type: string
           example: PizzaShackAPI
         mode:
-          maxLength: 32766
+          maxLength: 20
           type: string
-          example: This is a simple API for Pizza Shack online pizza delivery store.
+          example: Pizza
         description:
           maxLength: 32766
           type: string
@@ -8464,6 +10182,108 @@ components:
             $ref: '#/components/schemas/Topic'
         pagination:
           $ref: '#/components/schemas/Pagination'
+    Workflow:
+      title: workflow
+      required:
+        - status
+      type: object
+      properties:
+        status:
+          type: string
+          description: |
+            This attribute declares whether this workflow task is approved or rejected.
+          example: APPROVED
+          enum:
+            - APPROVED
+            - REJECTED
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+          description: |
+            Custom attributes to complete the workflow task
+          example: {}
+        description:
+          type: string
+          example: Approve workflow request.
+    WorkflowList:
+      title: WorkflowList
+      type: object
+      properties:
+        count:
+          type: integer
+          description: |
+            Number of workflow processes returned.
+          example: 1
+        next:
+          type: string
+          description: |
+            Link to the next subset of resources qualified.
+            Empty if no more resources are to be returned.
+          example: /workflows?limit=1&offset=2&user=
+        previous:
+          type: string
+          description: |
+            Link to the previous subset of resources qualified.
+            Empty if current subset is the first subset returned.
+          example: /workflows?limit=1&offset=0&user=
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkflowInfo'
+    WorkflowInfo:
+      title: Workflow info object with basic workflow details
+      type: object
+      properties:
+        workflowType:
+          type: string
+          description: |
+            Type of the Workflow Request. It shows which type of request is it.
+          example: APPLICATION_CREATION
+          enum:
+            - APPLICATION_CREATION
+            - SUBSCRIPTION_CREATION
+            - USER_SIGNUP
+            - APPLICATION_REGISTRATION_PRODUCTION
+            - APPLICATION_REGISTRATION_SANDBOX
+            - APPLICATION_DELETION
+            - API_STATE
+            - API_PRODUCT_STATE
+            - SUBSCRIPTION_DELETION
+            - SUBSCRIPTION_UPDATE
+            - REVISION_DEPLOYMENT
+        workflowStatus:
+          type: string
+          description: |
+            Show the Status of the the workflow request whether it is approved or created.
+          example: APPROVED
+          enum:
+            - APPROVED
+            - CREATED
+        createdTime:
+          type: string
+          description: |
+            Time of the the workflow request created.
+          example: 2020-02-10 10:10:19.704
+        updatedTime:
+          type: string
+          description: |
+            Time of the the workflow request updated.
+          example: 2020-02-10 10:10:19.704
+        referenceId:
+          type: string
+          description: |
+            Workflow external reference is used to identify the workflow requests uniquely.
+          example: 5871244b-d6f3-466e-8995-8accd1e64303
+        properties:
+          type: object
+          properties: { }
+        description:
+          type: string
+          description: |
+            description is a message with basic details about the workflow request.
+          example: Approve application [APP1] creation request from application creator
+            - admin with throttling tier - 10MinPer
     API:
       title: API object
       required:
@@ -8479,7 +10299,6 @@ components:
           readOnly: true
           example: 01234567-0123-0123-0123-012345678901
         name:
-          maxLength: 60
           minLength: 1
           pattern: '(^[^~!@#;:%^*()+={}|\\<>"'',&$\[\]\/]*$)'
           type: string
@@ -8500,7 +10319,7 @@ components:
           pattern: '^[^~!@#;:%^*()+={}|\\<>"'',&/$\[\]\s+\/]+$'
           example: 1.0.0
         provider:
-          maxLength: 50
+          maxLength: 200
           type: string
           description: |
             If the provider value is not given user invoking the api will be used as the provider.
@@ -8544,6 +10363,9 @@ components:
         enableSchemaValidation:
           type: boolean
           example: false
+        enableSubscriberVerification:
+          type: boolean
+          example: false
         type:
           type: string
           description: The api creation type to be used. Accepted values are HTTP,
@@ -8567,6 +10389,12 @@ components:
           enum:
             - PUBLIC
             - SINGLE
+        audiences:
+          type: array
+          description: The audiences of the API for jwt validation. Accepted values are any String values
+          items:
+            type: string
+            example: [ "aud1","aud2","aud3" ]
         transport:
           type: array
           description: |
@@ -8595,6 +10423,13 @@ components:
           x-otherScopes:
             - apim:api_publish
             - apim:api_manage
+        organizationPolicies:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrganizationPolicies'
+          x-otherScopes:
+            - apim:api_publish
+            - apim:api_manage
         apiThrottlingPolicy:
           type: string
           description: The API level throttling policy selected for the particular
@@ -8610,6 +10445,12 @@ components:
             Name of the Authorization header used for invoking the API. If it is not set, Authorization header name specified
             in tenant or system level will be used.
           example: Authorization
+        apiKeyHeader:
+          type: string
+          pattern: '(^[^~!@#;:%^*()+={}|\\<>"'',&$\s+]*$)'
+          description: |
+            Name of the API key header used for invoking the API. If it is not set, default value `apiKey` will be used.
+          example: apiKey
         securityScheme:
           type: array
           description: |
@@ -8645,6 +10486,12 @@ components:
             - apim:api_manage
         visibleTenants:
           type: array
+          example: []
+          items:
+            type: string
+        visibleOrganizations:
+          type: array
+          description: The organizations that are able to access the API in Developer Portal
           example: []
           items:
             type: string
@@ -8762,10 +10609,10 @@ components:
               {
                 "endpoint_type": "http",
                 "sandbox_endpoints":       {
-                   "url": "https://localhost:9443/am/sample/pizzashack/v1/api/"
+                   "url": "https://localhost:9443/am/sample/pizzashack/v3/api/"
                 },
                 "production_endpoints":       {
-                   "url": "https://localhost:9443/am/sample/pizzashack/v1/api/"
+                   "url": "https://localhost:9443/am/sample/pizzashack/v3/api/"
                 }
               }
 
@@ -8777,22 +10624,22 @@ components:
                 "sessionManagement": "",
                 "sandbox_endpoints":       [
                             {
-                      "url": "https://localhost:9443/am/sample/pizzashack/v1/api/1"
+                      "url": "https://localhost:9443/am/sample/pizzashack/v3/api/1"
                    },
                             {
                       "endpoint_type": "http",
                       "template_not_supported": false,
-                      "url": "https://localhost:9443/am/sample/pizzashack/v1/api/2"
+                      "url": "https://localhost:9443/am/sample/pizzashack/v3/api/2"
                    }
                 ],
                 "production_endpoints":       [
                             {
-                      "url": "https://localhost:9443/am/sample/pizzashack/v1/api/3"
+                      "url": "https://localhost:9443/am/sample/pizzashack/v3/api/3"
                    },
                             {
                       "endpoint_type": "http",
                       "template_not_supported": false,
-                      "url": "https://localhost:9443/am/sample/pizzashack/v1/api/4"
+                      "url": "https://localhost:9443/am/sample/pizzashack/v3/api/4"
                    }
                 ],
                 "sessionTimeOut": "",
@@ -8806,21 +10653,21 @@ components:
                    {
                       "endpoint_type":"http",
                       "template_not_supported":false,
-                      "url":"https://localhost:9443/am/sample/pizzashack/v1/api/1"
+                      "url":"https://localhost:9443/am/sample/pizzashack/v3/api/1"
                    }
                 ],
                 "endpoint_type":"failover",
                 "sandbox_endpoints":{
-                   "url":"https://localhost:9443/am/sample/pizzashack/v1/api/2"
+                   "url":"https://localhost:9443/am/sample/pizzashack/v3/api/2"
                 },
                 "production_endpoints":{
-                   "url":"https://localhost:9443/am/sample/pizzashack/v1/api/3"
+                   "url":"https://localhost:9443/am/sample/pizzashack/v3/api/3"
                 },
                 "sandbox_failovers":[
                    {
                       "endpoint_type":"http",
                       "template_not_supported":false,
-                      "url":"https://localhost:9443/am/sample/pizzashack/v1/api/4"
+                      "url":"https://localhost:9443/am/sample/pizzashack/v3/api/4"
                    }
                 ]
               }
@@ -8845,7 +10692,7 @@ components:
               }
             
             `AWS Lambda as Endpoint`
-            
+
               {
                 "endpoint_type":"awslambda",
                 "access_method":"role-supplied|stored",
@@ -8860,9 +10707,9 @@ components:
           example:
             endpoint_type: http
             sandbox_endpoints:
-              url: https://localhost:9443/am/sample/pizzashack/v1/api/
+              url: https://localhost:9443/am/sample/pizzashack/v3/api/
             production_endpoints:
-              url: https://localhost:9443/am/sample/pizzashack/v1/api/
+              url: https://localhost:9443/am/sample/pizzashack/v3/api/
         endpointImplementationType:
           type: string
           example: INLINE
@@ -8954,8 +10801,9 @@ components:
           title: Field to identify gateway type.
           type: string
           description: The gateway type selected for the API policies. Accepts one of the
-            following. wso2/synapse, wso2/choreo-connect.
+            following. wso2/synapse, wso2/apk.
           example: wso2/synapse
+          default: wso2/synapse
         asyncTransportProtocols:
           type: array
           description: |
@@ -8965,6 +10813,11 @@ components:
             - https
           items:
             type: string
+        egress:
+          type: boolean
+          description: Whether the API is EGRESS or not
+          default: false
+          example: true
       x-scopes:
         - apim:api_create
         - apim:api_import_export
@@ -9052,7 +10905,15 @@ components:
           maxLength: 255
           minLength: 1
           type: string
-          example: default
+          example: Default
+        status:
+          type: string
+          example: CREATED
+          default: CREATED
+          enum:
+            - CREATED
+            - APPROVED
+            - REJECTED
         vhost:
           maxLength: 255
           minLength: 1
@@ -9063,6 +10924,7 @@ components:
         displayOnDevportal:
           type: boolean
           example: true
+          default: true
         deployedTime:
           readOnly: true
           type: string
@@ -9135,20 +10997,16 @@ components:
           description: |
             If the provider value is not given, the user invoking the API will be used as the provider.
           example: admin
+        version:
+          type: string
+          example: 1.0.0
         hasThumbnail:
           type: boolean
           example: true
         state:
           type: string
           description: |
-            State of the API product. Only published api products are visible on the Developer Portal
-          enum:
-            - CREATED
-            - PUBLISHED
-            - DEPRECATED
-            - RETIRED
-            - BLOCKED
-            - PROTOTYPED
+            State of the API product. Only published API products are visible on the Developer Portal
         securityScheme:
           type: array
           description: |
@@ -9161,6 +11019,32 @@ components:
         gatewayVendor:
           type: string
           example: wso2
+        audiences:
+          type: array
+          description: The audiences of the API product for jwt validation. Accepted values are any String values
+          items:
+            type: string
+            example: [ "aud1","aud2","aud3" ]
+        monetizedInfo:
+          type: boolean
+          example: true
+        businessOwner:
+          type: string
+          example: Business Owner
+        businessOwnerEmail:
+          type: string
+          example: businessowner@abc.com
+        TechnicalOwner:
+          type: string
+          example: Technical Owner
+        TechnicalOwnerEmail:
+          type: string
+          example: technicalowner@abc.com
+        egress:
+          type: boolean
+          description: Whether the APIProduct is EGRESS or not
+          default: false
+          example: true
     APIProduct:
       title: API Product object
       required:
@@ -9184,6 +11068,12 @@ components:
           minLength: 1
           type: string
           example: pizzaproduct
+        version:
+          maxLength: 30
+          minLength: 1
+          type: string
+          pattern: '^[^~!@#;:%^*()+={}|\\<>"'',&/$\[\]\s+\/]+$'
+          example: 1.0.0
         description:
           type: string
           description: A brief description about the API
@@ -9199,17 +11089,14 @@ components:
           example: false
         state:
           type: string
+          example: CREATED
           description: |
-            State of the API product. Only published api products are visible on the Developer Portal
+            State of the API product. Only published API products are visible on the Developer Portal
           default: CREATED
-          enum:
-            - CREATED
-            - PUBLISHED
-            - DEPRECATED
-            - RETIRED
-            - BLOCKED
-            - PROTOTYPED
         enableSchemaValidation:
+          type: boolean
+          example: false
+        isDefaultVersion:
           type: boolean
           example: false
         isRevision:
@@ -9309,6 +11196,11 @@ components:
             Name of the Authorization header used for invoking the API. If it is not set, Authorization header name specified
             in tenant or system level will be used.
           example: Authorization
+        apiKeyHeader:
+          type: string
+          description: |
+            Name of the API key header used for invoking the API. If it is not set, default value `apiKey` will be used.
+          example: ApiKey
         securityScheme:
           type: array
           description: |
@@ -9368,9 +11260,9 @@ components:
           $ref: '#/components/schemas/APICorsConfiguration'
         createdTime:
           type: string
-        lastUpdatedTimestamp:
-          type: string
         lastUpdatedTime:
+          type: string
+        lastUpdatedTimestamp:
           type: string
         gatewayVendor:
           title: field to identify gateway vendor
@@ -9411,6 +11303,17 @@ components:
         workflowStatus:
           type: string
           example: APPROVED
+        audiences:
+          type: array
+          description: The audiences of the API for jwt validation. Accepted values are any String values
+          items:
+            type: string
+            example: [ "aud1","aud2","aud3" ]
+        egress:
+          type: boolean
+          description: Whether the APIProduct is EGRESS or not
+          default: false
+          example: true
     ProductAPI:
       title: ProductAPI
       required:
@@ -9582,7 +11485,7 @@ components:
           readOnly: true
           example: 01234567-0123-0123-0123-012345678901
         name:
-          maxLength: 60
+          maxLength: 255
           minLength: 1
           type: string
           example: PizzaShackDoc
@@ -9771,6 +11674,24 @@ components:
             Unit of data allowed to be transfered. Allowed values are "KB", "MB" and "GB"
           type: string
           example: KB
+        totalTokenCount:
+          type: integer
+          description: |
+            Maximum number of total tokens which can be used within a provided unit time
+          format: int64
+          example: 1000
+        promptTokenCount:
+          type: integer
+          description: |
+            Maximum number of prompt tokens which can be used within a provided unit time
+          format: int64
+          example: 500
+        completionTokenCount:
+          type: integer
+          description: |
+            Maximum number of completion tokens which can be used within a provided unit time
+          format: int64
+          example: 600
         unitTime:
           type: integer
           format: int64
@@ -9793,6 +11714,7 @@ components:
           enum:
             - REQUESTCOUNT
             - BANDWIDTHVOLUME
+            - AIAPIQUOTA
           example: REQUESTCOUNT
         tierPlan:
           type: string
@@ -10236,7 +12158,12 @@ components:
           example: Default
         type:
           type: string
+          default: hybrid
           example: hybrid
+        gatewayType:
+          type: string
+          example: Regular
+          default: Regular
         serverUrl:
           type: string
           example: https://localhost:9443/services/
@@ -10430,10 +12357,59 @@ components:
           type: integer
           format: int64
           example: 1000
+        productionTimeUnit:
+          type: string
+          description: "Time unit for the production."
+          default: SECOND
+          enum:
+            - SECOND
+            - MINUTE
+            - HOUR
         sandbox:
           type: integer
           format: int64
           example: 1000
+        sandboxTimeUnit:
+          type: string
+          description: "Time unit for the sandbox."
+          default: SECOND
+          enum:
+            - SECOND
+            - MINUTE
+            - HOUR
+        tokenBasedThrottlingConfiguration:
+          type: object
+          required:
+            - isTokenBasedThrottlingEnabled
+          properties:
+            productionMaxPromptTokenCount:
+              type: integer
+              description: "Maximum prompt token count for production"
+              format: int64
+            productionMaxCompletionTokenCount:
+              type: integer
+              description: "Maximum completion token count for production"
+              format: int64
+            productionMaxTotalTokenCount:
+              type: integer
+              description: "Maximum total token count for production"
+              format: int64
+            sandboxMaxPromptTokenCount:
+              type: integer
+              description: "Maximum prompt token count for sandbox"
+              format: int64
+            sandboxMaxCompletionTokenCount:
+              type: integer
+              description: "Maximum completion token count for sandbox"
+              format: int64
+            sandboxMaxTotalTokenCount:
+              type: integer
+              description: "Maximum total token count for sandbox"
+              format: int64
+            isTokenBasedThrottlingEnabled:
+              type: boolean
+              default: false
+              description: "Whether token-based throttling is enabled"
     APIBusinessInformation:
       type: object
       properties:
@@ -10581,6 +12557,51 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Endpoint'
+    Organization:
+      title: Organization
+      required:
+        - organizationId
+      type: object
+      properties:
+        organizationId:
+          type: string
+          example: ece92bdc-e1e6-325c-b6f4-656208a041e9
+          readOnly: true
+          description: |
+            UUID of the organization.
+        externalOrganizationId:
+          type: string
+          example: ece92bdc-e1e6-325c-b6f4-656208a041e9
+          description: |
+            External id of the organization.
+        parentOrganizationId:
+          type: string
+          readOnly: true
+          example: ece92bdc-e1e6-325c-b6f4-656208a041e9
+          description: |
+            UUID of the parent organization if there is any.
+        displayName:
+          maxLength: 255
+          minLength: 1
+          type: string
+          example: My Organization
+        description:
+          maxLength: 1023
+          type: string
+          example: My Organization Description
+    OrganizationList:
+      title: Organization List
+      type: object
+      properties:
+        count:
+          type: integer
+          description: |
+            Number of Organizationa returned.
+          example: 1
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/Organization'
     Scope:
       title: Scope
       required:
@@ -10673,6 +12694,9 @@ components:
           description: |
             If the provider value is not given user invoking the api will be used as the provider.
           example: admin
+        revisionID:
+          type: string
+          example: Revision 1
         usedResourceList:
           type: array
           description: |
@@ -10738,6 +12762,8 @@ components:
           example: ""
         amznResourceTimeout:
           type: integer
+        amznResourceContentEncode:
+          type: boolean
         payloadSchema:
           type: string
           example: ""
@@ -10746,6 +12772,23 @@ components:
           example: ""
         operationPolicies:
           $ref: '#/components/schemas/APIOperationPolicies'
+    OrganizationPolicies:
+      title: Organization based Subscription Policies
+      type: object
+      required:
+        - organizationID
+      properties:
+        organizationID:
+          type: string
+          example: "36c87e00-57f0-4000-9f97-b379acc4e577"
+        organizationName:
+          type: string
+          example: "wso2"
+        policies:
+          type: array
+          example: ["Silver", "Gold", "Unlimited"]
+          items:
+            type: string
     ScopeList:
       title: Scope List
       type: object
@@ -11028,7 +13071,7 @@ components:
                 contains host/servers specified in the OpenAPI file/URL
               items:
                 type: string
-                example: https://localhost:9443/am/sample/pizzashack/v1/api/
+                example: https://localhost:9443/am/sample/pizzashack/v3/api/
           description: |
             API definition information
         errors:
@@ -11189,6 +13232,7 @@ components:
             - DOC
             - API
             - APIProduct
+            - DEFINITION
         transportType:
           type: string
           description: Accepted values are HTTP, WS, SOAPTOREST, GRAPHQL
@@ -11234,6 +13278,21 @@ components:
             hasThumbnail:
               type: boolean
               example: true
+            monetizedInfo:
+              type: boolean
+              example: true
+            businessOwner:
+              type: string
+              example: Business Owner
+            businessOwnerEmail:
+              type: string
+              example: businessowner@abc.com
+            TechnicalOwner:
+              type: string
+              example: Technical Owner
+            TechnicalOwnerEmail:
+              type: string
+              example: technicalowner@abc.com
     APIProductSearchResult:
       title: API Result
       allOf:
@@ -11268,6 +13327,25 @@ components:
             hasThumbnail:
               type: boolean
               example: true
+            monetizedInfo:
+              type: boolean
+              example: true
+            businessOwner:
+              type: string
+              example: Business Owner
+            businessOwnerEmail:
+              type: string
+              example: businessowner@abc.com
+            TechnicalOwner:
+              type: string
+              example: Technical Owner
+            TechnicalOwnerEmail:
+              type: string
+              example: technicalowner@abc.com
+            egress:
+              type: boolean
+              description: Whether the API is Egress or not
+              example: false
     APIMonetizationInfo:
       title: API monetization object
       required:
@@ -11339,6 +13417,38 @@ components:
               type: string
             associatedType:
               type: string
+    APIDefinitionSearchResult:
+      title: API Definition Search Result
+      allOf:
+        - $ref: '#/components/schemas/SearchResult'
+        - properties:
+            apiName:
+              type: string
+              description: The name of the associated API
+              example: TestAPI
+            apiVersion:
+              type: string
+              description: The version of the associated API
+              example: 1.0.0
+            apiContext:
+              type: string
+              description: The context of the associated API
+              example: /test
+            apiUUID:
+              type: string
+              description: The UUID of the associated API
+            apiProvider:
+              type: string
+              description: The provider name of the associated API
+              example: publisher
+            apiType:
+              type: string
+              description: The type of the associated API
+              example: REST
+            associatedType:
+              type: string
+              description: API or APIProduct
+              example: API
     MockResponsePayloadList:
       title: Mock Response Payload list
       type: object
@@ -11433,6 +13543,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Environment'
+        gatewayTypes:
+          type: array
+          example:
+            - Regular
+            - APK
+          items:
+            type: string
         scopes:
           type: array
           example:
@@ -11446,6 +13563,10 @@ components:
           example: []
           items:
             $ref: '#/components/schemas/MonetizationAttribute'
+        subscriberContactAttributes:
+          type: object
+          items:
+            $ref: '#/components/schemas/SubscriberContactAttribute'
         securityAuditProperties:
           type: object
           properties: {}
@@ -11459,6 +13580,18 @@ components:
           description: |
             Is Document Visibility configuration enabled
           example: false
+        portalConfigurationOnlyModeEnabled:
+          type: boolean
+          description: |
+            Is Portal Configuration Only Mode enabled
+          example: false
+          default: false
+        retryCallWithNewOAuthTokenEnabled:
+          type: boolean
+          description: |
+            Is Retry Call With New OAuth Token Enabled
+          example: true
+          default: true
         crossTenantSubscriptionEnabled:
           type: boolean
           description: |
@@ -11475,32 +13608,36 @@ components:
           type: string
           description: Authorization Header
           example: authorization
+        IsJWTEnabledForLoginTokens:
+          type: boolean
+          default: false
+        orgAccessControlEnabled:
+          type: boolean
+          description: |
+            Is Organization-based access control configuration enabled
+          example: true
         allowSubscriptionValidationDisabling:
           type: boolean
           description: |
             Allow subscription validation disabling for OAuth tokens
           default: true
         customProperties:
-            type: array
-            items:
-              type: object
-              properties:
-                name:
-                  type: string
-                  description: |
-                    Custom property name
-                  example: Department
-                description:
-                  type: string
-                  description: Description of custom property
-                  example: Relevant Department
-                required:
-                  type: boolean
-                  example: false
-        isAPIPoliciesEnabled:
-          type: boolean
-          description: Is API level policy support feature enabled
-          example: false
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: |
+                  Custom property name
+                example: Department
+              description:
+                type: string
+                description: Description of custom property
+                example: Relevant Department
+              required:
+                type: boolean
+                example: false
     SecurityAuditAttribute:
       title: SecurityAuditAttributeDTO
       type: object
@@ -11554,6 +13691,20 @@ components:
           description: |
             Link to the previous subset of resources qualified.
             Empty if current subset is the first subset returned.
+    #-----------------------------------------------------
+    # The Subscriber Contact resource
+    #-----------------------------------------------------
+    SubscriberContactAttribute:
+      title: Subscriber Contact attribute object
+      properties:
+        recipient:
+          type: string
+          description: |
+            recipient type of the email
+        delimiter:
+          type: string
+          description: |
+            delimiter to seperate the email address
     MonetizationAttribute:
       title: Monetization attribute object
       type: object
@@ -11726,8 +13877,8 @@ components:
       additionalProperties:
         type: string
       example:
-        productionEndpoint: https://localhost:9443/pizzashack/v1/api/
-        sandboxEndpoint: https://localhost:9443/pizzashack/v1/api/
+        productionEndpoint: https://localhost:9443/pizzashack/v3/api/
+        sandboxEndpoint: https://localhost:9443/pizzashack/v3/api/
     AsyncAPISpecificationValidationResponse:
       title: AsyncAPI Specification Validation Response
       required:
@@ -11770,7 +13921,7 @@ components:
                 contains host/servers specified in the AsyncAPI file/URL
               items:
                 type: string
-                example: "https://localhost:9443/am/sample/pizzashack/v1/api/"
+                example: "https://localhost:9443/am/sample/pizzashack/v3/api/"
             gatewayVendor:
               type: string
               example: wso2
@@ -11800,6 +13951,8 @@ components:
         policyVersion:
           type: string
           default: v1
+        policyType:
+          type: string
         policyId:
           type: string
         parameters:
@@ -11821,6 +13974,97 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OperationPolicy'
+    GatewayPolicyMappings:
+      title: Gateway Policy Mappings
+      type: object
+      required:
+        - policyMapping
+        - displayName
+      properties:
+        id:
+          type: string
+          example: 121223q41-24141-124124124-12414
+        policyMapping:
+          $ref: '#/components/schemas/APIOperationPolicies'
+        description:
+          type: string
+          description: A brief description about the policy mapping
+          example: Set header value to the request with item type and response header set with served server name
+        displayName:
+          type: string
+          description: Meaningful name to identify the policy mapping
+          example: item_type_setter
+        appliedGatewayLabels:
+          type: array
+          items:
+            type: string
+            example: gatewayLabel_1
+    GatewayPolicyMappingDeploymentInfo:
+      title: Gateway Policy Mapping and Deployment Information
+      type: object
+      properties:
+        id:
+          type: string
+          example: 121223q41-24141-124124124-12414
+        description:
+          type: string
+          description: A brief description about the policy mapping
+          example: Set header value to the request with item type and response header set with served server name
+        displayName:
+          type: string
+          description: Meaningful name to identify the policy mapping
+          example: item_type_setter
+        appliedGatewayLabels:
+          type: array
+          items:
+            type: string
+            example: gatewayLabel_1
+    GatewayPolicyMappingInfo:
+      title: Gateway Policy Mapping Information
+      type: object
+      properties:
+        id:
+          type: string
+          example: 121223q41-24141-124124124-12414
+        description:
+          type: string
+          description: A brief description about the policy mapping
+          example: Set header value to the request with item type and response header set with served server name
+        displayName:
+          type: string
+          description: Meaningful name to identify the policy mapping
+          example: item_type_setter
+    GatewayPolicyDeployment:
+      title: Details to map, deploy, undeploy policy mappings to gateways
+      required:
+        - gatewayLabel
+        - gatewayDeployment
+      type: object
+      properties:
+        gatewayLabel:
+          type: string
+          example: gatewayLabel_1
+        gatewayDeployment:
+          type: boolean
+          example: true
+        mappingUUID:
+          type: string
+          example: 01234567-0123-0123-0123-012345678901
+    GatewayPolicyMappingDataList:
+      title: Gateway Policy Mapping List
+      type: object
+      properties:
+        count:
+          type: integer
+          description: |
+            Number of gateway policy mappings returned.
+          example: 1
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/GatewayPolicyMappingDeploymentInfo'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
     GatewayEnvironmentProtocolURI:
       title: Gateway Environment protocols and URIs
       required:
@@ -11862,12 +14106,13 @@ components:
         name:
           type: string
           example: removeHeaderPolicy
-        displayName:
-          type: string
-          example: Remove Header Policy
         version:
           type: string
           example: v1
+          default: v1
+        displayName:
+          type: string
+          example: Remove Header Policy
         description:
           type: string
           example: With this policy, user can add a new header to the request
@@ -11934,6 +14179,64 @@ components:
           items:
             type: string
             example: ["GET","POST","PUT"]
+    ImportAPIResponse:
+      title: Import API Response
+      type: object
+      properties:
+        id:
+          type: string
+          description: |
+            UUID of the imported API
+          example: 01234567-0123-0123-0123-012345678901
+        revision:
+          type: string
+          description: |
+            Revision of the imported API
+          example: 1
+    Label:
+      title: Label
+      required:
+        - name
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+          example: d7cf8523-9180-4255-84fa-6cb171c1f779
+        name:
+          maxLength: 255
+          minLength: 1
+          type: string
+          example: Health
+        description:
+          maxLength: 1024
+          type: string
+          example: Health related APIs
+    RequestLabelList:
+      title: Label ID List for Request
+      type: object
+      properties:
+        labels:
+          type: array
+          description: List of label IDs.
+          items:
+            type: string
+            example: d7cf8523-9180-4255-84fa-6cb171c1f779
+    LabelList:
+      title: Label List
+      type: object
+      properties:
+        count:
+          type: integer
+          description: Number of labels returned.
+          example: 1
+        list:
+          type: array
+          description: List of labels.
+          items:
+            $ref: '#/components/schemas/Label'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
   responses:
     BadRequest:
       description: Bad Request. Invalid request or validation error.
@@ -12216,6 +14519,14 @@ components:
       required: true
       schema:
         type: string
+    gatewayPolicyMappingId:
+      name: gatewayPolicyMappingId
+      in: path
+      description: |
+        Gateway policy mapping Id
+      required: true
+      schema:
+        type: string
 
     # API Revision Identifier
     # Specified as part of the path expression
@@ -12228,6 +14539,17 @@ components:
       schema:
         type: string
 
+    # API Revision Environment
+    # Specified as part of the path expression
+    envName:
+      name: envName
+      in: path
+      description: |
+        Environment name of an Revision
+      required: true
+      schema:
+        type: string
+
     # API Revision Identifier
     # Specified as part of the query string
     revisionId-Q:
@@ -12235,6 +14557,14 @@ components:
       in: query
       description: |
         Revision ID of an API
+      schema:
+        type: string
+    workflowReferenceId-Q:
+      name: workflowReferenceId
+      in: query
+      description: |
+        Workflow reference id
+      required: true
       schema:
         type: string
     revisionNum-Q:
@@ -12298,6 +14628,13 @@ components:
       schema:
         type: integer
         default: 25
+    policyLimit:
+      name: limit
+      in: query
+      description: |
+        Maximum size of policy array to return.
+      schema:
+        type: integer
     Accept:
       name: Accept
       in: header
@@ -12306,6 +14643,21 @@ components:
       schema:
         type: string
         default: application/json
+    isAiApi:
+      name: isAiApi
+      in: query
+      description: |
+        Indicates the quota policy type to be AI API quota or not.
+      schema:
+        type: boolean
+        default: false
+    organizationID:
+      name: organizationID
+      in: query
+      description: |
+        Indicates the organization ID
+      schema:
+        type: string
     offset:
       name: offset
       in: query
@@ -12314,30 +14666,6 @@ components:
       schema:
         type: integer
         default: 0
-    sortBy:
-      name: sortBy
-      in: query
-      description: |
-        Criteria for sorting.
-      schema:
-        type: string
-        default: createdTime
-        enum:
-          - apiName
-          - version
-          - createdTime
-          - status
-    sortOrder:
-      name: sortOrder
-      in: query
-      description: |
-        Order of sorting(ascending/descending).
-      schema:
-        type: string
-        default: desc
-        enum:
-          - asc
-          - desc
     If-None-Match:
       name: If-None-Match
       in: header
@@ -12357,7 +14685,7 @@ components:
       name: scopeId
       in: path
       description: |
-        Scope name
+        Base64 URL encoded value of the scope name
       required: true
       schema:
         type: string
@@ -12469,6 +14797,7 @@ components:
           scopes:
             openid: Authorize access to user details
             apim:api_view: View API
+            apim:policies_import_export: Export and import policies related operations
             apim:api_create: Create API
             apim:api_delete: Delete API
             apim:api_publish: Publish API
@@ -12486,6 +14815,8 @@ components:
             apim:mediation_policy_manage: Update and delete mediation policies
             apim:common_operation_policy_view: View common operation policies
             apim:common_operation_policy_manage: Add, Update and Delete common operation policies
+            apim:gateway_policy_view: View gateway policies
+            apim:gateway_policy_manage: Add, Update and Delete gateway policies
             apim:client_certificates_view: View client certificates
             apim:client_certificates_add: Add client certificates
             apim:client_certificates_update: Update and delete client certificates
@@ -12509,4 +14840,10 @@ components:
             apim:tier_manage: View, update and delete throttling policies
             apim:api_list_view: View, Retrieve API list
             apim:api_definition_view: View, Retrieve API definition
+            apim:subscription_approval_view: Approve subscription creation requests
+            apim:subscription_approval_manage: Approve subscription update requests
             apim:llm_provider_read: Read LLM Providers
+            apim:publisher_organization_read: Read organization
+            apim:gov_policy_read: Retrieve governance policies
+            apim:gov_result_read: Retrieve governance results
+            apim:gov_rule_read: Retrieve governance rules


### PR DESCRIPTION
## Purpose
> Implements two new resources (Chat and Generate API Payload) for API Design Assistant.
> Related issue: https://github.com/wso2/api-manager/issues/3564

## Description
> This PR implements REST API resources for the API Design Assistant, enabling it to retrieve text and session IDs from the frontend, forward them to the LLM backend, receive the response, and seamlessly return it to the frontend UI.