### PR TITLE
Add a new resource to get the overview markdown content of an API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
@@ -231,6 +231,17 @@ public interface APIManager {
             throws APIManagementException;
 
     /**
+     * Get the markdown overview documentation Content by api id
+     *
+     * @param apiId         ID of the API
+     * @param organization  Identifier of an organization
+     * @return DocumentationContent
+     * @throws APIManagementException if failed to get Documentation
+     */
+    DocumentationContent getMarkdownOverviewContent(String apiId, String organization)
+            throws APIManagementException;
+
+    /**
      * Returns the GraphqlComplexityInfo object for a given API ID
      *
      * @param  apiId UUID of the API

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/API.java
@@ -145,6 +145,8 @@ public class API implements Serializable {
     private String implementation = "ENDPOINT";
 
     private String monetizationCategory;
+
+    private Boolean isMarkdownOverview;
     
     private List<SOAPToRestSequence> soapToRestSequences;
 
@@ -1402,6 +1404,14 @@ public class API implements Serializable {
 
     public void setTestKey(String testKey) {
         this.testKey = testKey;
+    }
+
+    public Boolean isMarkdownOverview() {
+        return isMarkdownOverview;
+    }
+
+    public void setMarkdownOverview(Boolean isMarkdownOverview) {
+        this.isMarkdownOverview = isMarkdownOverview;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/APIProduct.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/APIProduct.java
@@ -65,6 +65,7 @@ public class APIProduct implements Serializable {
     private JSONObject monetizationProperties = new JSONObject();
     private boolean isMonetizationEnabled = false;
     private String versionTimestamp;
+    private Boolean isMarkdownOverview;
 
     /**
      * API security at the gateway level.
@@ -715,5 +716,13 @@ public class APIProduct implements Serializable {
 
     public void setEgress(int egress) {
         isEgress = egress;
+    }
+
+    public Boolean isMarkdownOverview() {
+        return isMarkdownOverview;
+    }
+
+    public void setMarkdownOverview(Boolean isMarkdownOverview) {
+        this.isMarkdownOverview = isMarkdownOverview;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -4415,6 +4415,14 @@ APIConstants.AuditLogConstants.DELETED, this.username);
     }
 
     @Override
+    public DocumentationContent getMarkdownOverviewContent(String apiId, String organization)
+            throws APIManagementException {
+
+        checkAPIVisibilityRestriction(apiId, organization);
+        return super.getMarkdownOverviewContent(apiId, organization);
+    }
+
+    @Override
     public String getAsyncAPIDefinitionForLabel(Identifier apiId, String labelName) throws APIManagementException {
         String updatedDefinition = null;
         Map<String, String> hostsWithSchemes;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -3960,6 +3960,14 @@ APIConstants.AuditLogConstants.DELETED, this.username);
                 checkVisibilityPermission(userNameWithoutChange, devPortalApi.getVisibility(),
                         devPortalApi.getVisibleRoles(), devPortalApi.getPublisherAccessControl(),
                         devPortalApi.getPublisherAccessControlRoles());
+                List<Documentation> existingDocs = getAllDocumentation(uuid, organization);
+                devPortalApi.setMarkdownOverview(false);
+                for (Documentation doc : existingDocs) {
+                    if (doc.getOtherTypeName() != null && doc.getOtherTypeName().equals("_overview")) {
+                        devPortalApi.setMarkdownOverview(true);
+                        break;
+                    }
+                }
                 if (APIConstants.API_PRODUCT.equalsIgnoreCase(devPortalApi.getType())) {
                     APIProduct apiProduct = APIMapper.INSTANCE.toApiProduct(devPortalApi);
                     apiProduct.setID(new APIProductIdentifier(devPortalApi.getProviderName(),

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -498,6 +498,23 @@ public abstract class AbstractAPIManager implements APIManager {
         }
     }
 
+    @Override
+    public DocumentationContent getMarkdownOverviewContent(String apiId, String organization)
+            throws APIManagementException {
+
+        try {
+            DocumentSearchResult result = apiPersistenceInstance
+                    .searchDocumentation(new Organization(organization), apiId, 0, 0,
+                    "other:_overview", null);
+            if (result == null || result.getDocumentationList() == null || result.getDocumentationList().isEmpty()) {
+                return null;
+            }
+            return getDocumentationContent(apiId, result.getDocumentationList().get(0).getId(), organization);
+        } catch (DocumentationPersistenceException e) {
+            throw new APIManagementException("Error while retrieving document content ", e);
+        }
+    }
+
     public GraphqlComplexityInfo getComplexityDetails(String uuid) throws APIManagementException {
 
         return apiMgtDAO.getComplexityDetails(uuid);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIConsumerImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIConsumerImplTest.java
@@ -37,24 +37,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.WorkflowStatus;
 import org.wso2.carbon.apimgt.api.dto.KeyManagerConfigurationDTO;
-import org.wso2.carbon.apimgt.api.model.API;
-import org.wso2.carbon.apimgt.api.model.APIIdentifier;
-import org.wso2.carbon.apimgt.api.model.APIKey;
-import org.wso2.carbon.apimgt.api.model.APIRating;
-import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
-import org.wso2.carbon.apimgt.api.model.AccessTokenRequest;
-import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
-import org.wso2.carbon.apimgt.api.model.Application;
-import org.wso2.carbon.apimgt.api.model.Comment;
-import org.wso2.carbon.apimgt.api.model.KeyManager;
-import org.wso2.carbon.apimgt.api.model.KeyManagerConfiguration;
-import org.wso2.carbon.apimgt.api.model.OAuthAppRequest;
-import org.wso2.carbon.apimgt.api.model.OAuthApplicationInfo;
-import org.wso2.carbon.apimgt.api.model.Scope;
-import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
-import org.wso2.carbon.apimgt.api.model.Subscriber;
-import org.wso2.carbon.apimgt.api.model.SubscriptionResponse;
-import org.wso2.carbon.apimgt.api.model.Tier;
+import org.wso2.carbon.apimgt.api.model.*;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
@@ -1008,5 +991,22 @@ public class APIConsumerImplTest {
         assertNotNull(apiKeySet);
         assertEquals(apiKeySet.size(), 2);
         assertNotNull(apiKeySet.iterator().next().getAccessToken());
+    }
+
+    @Test
+    public void testGetMarkdownOverviewContent() throws Exception {
+        String apiId = "api123";
+        String organization = "wso2";
+        DocumentationContent mockContent = new DocumentationContent();
+
+        APIConsumerImpl apiConsumer = PowerMockito.spy(new APIConsumerImplWrapper());
+
+        PowerMockito.doNothing().when(apiConsumer).checkAPIVisibilityRestriction(apiId, organization);
+        PowerMockito.doReturn(mockContent).when(apiConsumer, "getMarkdownOverviewContent", apiId, organization);
+
+        DocumentationContent result = apiConsumer.getMarkdownOverviewContent(apiId, organization);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(mockContent, result);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AbstractAPIManagerTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AbstractAPIManagerTestCase.java
@@ -257,6 +257,36 @@ public class AbstractAPIManagerTestCase {
 
     }
 
+    @Test
+    public void testGetMarkdownOverviewContent() throws Exception {
+        String apiId = "sample-api-id";
+        String organization = "sample-org";
+
+        AbstractAPIManager abstractAPIManager = new AbstractAPIManagerWrapper(apiPersistenceInstance);
+
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        ServiceReferenceHolder sh = Mockito.mock(ServiceReferenceHolder.class);
+        APIManagerConfigurationService amConfigService = Mockito.mock(APIManagerConfigurationService.class);
+        APIManagerConfiguration amConfig = Mockito.mock(APIManagerConfiguration.class);
+
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(sh);
+        PowerMockito.when(sh.getAPIManagerConfigurationService()).thenReturn(amConfigService);
+        PowerMockito.when(amConfigService.getAPIManagerConfiguration()).thenReturn(amConfig);
+
+        DocumentSearchResult searchResult = Mockito.mock(DocumentSearchResult.class);
+        Mockito.when(searchResult.getDocumentationList()).thenReturn(Collections.emptyList());
+        Mockito.when(apiPersistenceInstance.searchDocumentation(
+                Mockito.any(Organization.class),
+                Mockito.eq(apiId),
+                Mockito.eq(0),
+                Mockito.eq(0),
+                Mockito.eq("other:_overview"),
+                Mockito.isNull()
+        )).thenReturn(searchResult);
+
+        DocumentationContent result = abstractAPIManager.getMarkdownOverviewContent(apiId, organization);
+        Assert.assertNull(result);
+    }
 
     @Test
     public void testIsContextExist() throws APIManagementException {

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2812,6 +2812,13 @@ public class RegistryPersistenceImpl implements APIPersistence {
                                     if (doc.getName().equalsIgnoreCase(requestedDocName)) {
                                         documentationList.add(doc);
                                     }
+                                }
+                                else if (searchQuery.toLowerCase().startsWith("other:")) {
+                                    String requestedDocOtherTypeName = searchQuery.split(":")[1];
+                                    if (doc.getOtherTypeName() != null
+                                            && doc.getOtherTypeName().equalsIgnoreCase(requestedDocOtherTypeName)) {
+                                        documentationList.add(doc);
+                                    }
                                 } else {
                                     log.warn("Document search not implemented for the query " + searchQuery);
                                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/DevPortalAPI.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/dto/DevPortalAPI.java
@@ -68,6 +68,7 @@ public class DevPortalAPI extends DevPortalAPIInfo {
     private String asyncTransportProtocols;
     private String publisherAccessControl;
     private String publisherAccessControlRoles;
+    private Boolean isMarkdownOverview;
 
     public String getContextTemplate() {
         return contextTemplate;
@@ -357,6 +358,14 @@ public class DevPortalAPI extends DevPortalAPIInfo {
         this.asyncTransportProtocols = asyncTransportProtocols;
     }
 
+    public Boolean isMarkdownOverview() {
+        return isMarkdownOverview;
+    }
+
+    public void setMarkdownOverview(Boolean isMarkdownOverview) {
+        this.isMarkdownOverview = isMarkdownOverview;
+    }
+
     @Override
     public String toString() {
         return "DevPortalAPI [status=" + status + ", isDefaultVersion=" + isDefaultVersion + ", description="
@@ -375,7 +384,7 @@ public class DevPortalAPI extends DevPortalAPIInfo {
                 + ", type=" + type + ", advertisedOnly=" + advertisedOnly + ", swaggerDefinition=" + swaggerDefinition
                 + ", contextTemplate=" + contextTemplate + ", apiSecurity=" + apiSecurity + ", visibility=" + visibility
                 + ", visibleRoles=" + visibleRoles + ", gatewayVendor=" + gatewayVendor + ", asyncTransportProtocols="
-                + asyncTransportProtocols + "]";
+                + asyncTransportProtocols + ", isMarkdownOverview=" + isMarkdownOverview + "]";
     }
 
     public String getApiSecurity() {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
@@ -836,6 +836,60 @@ paths:
         - lang: Curl
           source: curl -k "https://localhost:9443/api/am/devportal/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5/content"
 
+  /apis/{apiId}/markdown-content:
+    get:
+      tags:
+        - APIs
+      summary: |
+        Get the Content of the API Overview Markdown Document
+      description: |
+        This operation can be used to retrieve the overview markdown document content of an API. You need to provide the Id of the API to retrieve it.
+
+        The content of the document will be retrieved in `text/plain` content type
+
+        `X-WSO2-Tenant` header can be used to retrieve the content of the overview markdown document of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.
+
+        **NOTE:**
+        * This operation does not require an Authorization header by default. But in order to see a restricted API's overview markdown document content, you need to provide Authorization header.
+      operationId: getMarkdownContentOfAPI
+      parameters:
+        - $ref: '#/components/parameters/apiId'
+        - $ref: '#/components/parameters/requestedTenant'
+        - $ref: '#/components/parameters/If-None-Match'
+      responses:
+        200:
+          description: |
+            OK.
+            Inline content returned.
+          headers:
+            ETag:
+              description: |
+                Entity Tag of the response resource.
+                Used by caches, or in conditional requests.
+              schema:
+                type: string
+            Last-Modified:
+              description: |
+                Date and time the resource has been modified the last time.
+                Used by caches, or in conditional requests.
+              schema:
+                type: string
+          content: { }
+        304:
+          description: |
+            Not Modified.
+            Empty body because the client has already the latest version of the requested resource.
+          content: { }
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+      security:
+        - OAuth2Security: [ ]
+      x-code-samples:
+        - lang: Curl
+          source: curl -k "https://localhost:9443/api/am/devportal/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/markdown-content"
+
   /apis/{apiId}/thumbnail:
     get:
       tags:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
@@ -4133,6 +4133,9 @@ components:
           description: |
             If the provider value is not given user invoking the api will be used as the provider.
           example: admin
+        isMarkdownOverview:
+          type: boolean
+          example: true
         apiDefinition:
           type: string
           description: |

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApisApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApisApi.java
@@ -480,6 +480,24 @@ ApisApiService delegate = new ApisApiServiceImpl();
     }
 
     @GET
+    @Path("/{apiId}/markdown-content")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get the Content of the API Overview Markdown Document ", notes = "This operation can be used to retrieve the overview markdown document content of an API. You need to provide the Id of the API to retrieve it.  The content of the document will be retrieved in `text/plain` content type  `X-WSO2-Tenant` header can be used to retrieve the content of the overview markdown document of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.  **NOTE:** * This operation does not require an Authorization header by default. But in order to see a restricted API's overview markdown document content, you need to provide Authorization header. ", response = Void.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            
+        })
+    }, tags={ "APIs",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Inline content returned. ", response = Void.class),
+        @ApiResponse(code = 304, message = "Not Modified. Empty body because the client has already the latest version of the requested resource. ", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
+        @ApiResponse(code = 406, message = "Not Acceptable. The requested media type is not supported.", response = ErrorDTO.class) })
+    public Response getMarkdownContentOfAPI(@ApiParam(value = "**API ID** consisting of the **UUID** of the API. ",required=true) @PathParam("apiId") String apiId,  @ApiParam(value = "For cross-tenant invocations, this is used to specify the tenant domain, where the resource need to be   retrieved from. " )@HeaderParam("X-WSO2-Tenant") String xWSO2Tenant,  @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved variant of the resourec. " )@HeaderParam("If-None-Match") String ifNoneMatch) throws APIManagementException{
+        return delegate.getMarkdownContentOfAPI(apiId, xWSO2Tenant, ifNoneMatch, securityContext);
+    }
+
+    @GET
     @Path("/{apiId}/comments/{commentId}/replies")
     
     @Produces({ "application/json" })

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApisApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/ApisApiService.java
@@ -60,6 +60,7 @@ public interface ApisApiService {
       public Response editCommentOfAPI(String commentId, String apiId, PatchRequestBodyDTO patchRequestBodyDTO, MessageContext messageContext) throws APIManagementException;
       public Response getAllCommentsOfAPI(String apiId, String xWSO2Tenant, Integer limit, Integer offset, Boolean includeCommenterInfo, MessageContext messageContext) throws APIManagementException;
       public Response getCommentOfAPI(String commentId, String apiId, String xWSO2Tenant, String ifNoneMatch, Boolean includeCommenterInfo, Integer replyLimit, Integer replyOffset, MessageContext messageContext) throws APIManagementException;
+      public Response getMarkdownContentOfAPI(String apiId, String xWSO2Tenant, String ifNoneMatch, MessageContext messageContext) throws APIManagementException;
       public Response getRepliesOfComment(String commentId, String apiId, String xWSO2Tenant, Integer limit, Integer offset, String ifNoneMatch, Boolean includeCommenterInfo, MessageContext messageContext) throws APIManagementException;
       public Response getWSDLOfAPI(String apiId, String environmentName, String ifNoneMatch, String xWSO2Tenant, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/APIDTO.java
@@ -36,6 +36,7 @@ public class APIDTO   {
     private String context = null;
     private String version = null;
     private String provider = null;
+    private Boolean isMarkdownOverview = null;
     private String apiDefinition = null;
     private String wsdlUri = null;
     private String lifeCycleStatus = null;
@@ -178,6 +179,23 @@ public class APIDTO   {
   }
   public void setProvider(String provider) {
     this.provider = provider;
+  }
+
+  /**
+   **/
+  public APIDTO isMarkdownOverview(Boolean isMarkdownOverview) {
+    this.isMarkdownOverview = isMarkdownOverview;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "true", value = "")
+  @JsonProperty("isMarkdownOverview")
+  public Boolean isIsMarkdownOverview() {
+    return isMarkdownOverview;
+  }
+  public void setIsMarkdownOverview(Boolean isMarkdownOverview) {
+    this.isMarkdownOverview = isMarkdownOverview;
   }
 
   /**
@@ -751,6 +769,7 @@ public class APIDTO   {
         Objects.equals(context, API.context) &&
         Objects.equals(version, API.version) &&
         Objects.equals(provider, API.provider) &&
+        Objects.equals(isMarkdownOverview, API.isMarkdownOverview) &&
         Objects.equals(apiDefinition, API.apiDefinition) &&
         Objects.equals(wsdlUri, API.wsdlUri) &&
         Objects.equals(lifeCycleStatus, API.lifeCycleStatus) &&
@@ -786,7 +805,7 @@ public class APIDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, description, context, version, provider, apiDefinition, wsdlUri, lifeCycleStatus, isDefaultVersion, type, transport, operations, authorizationHeader, apiKeyHeader, securityScheme, tags, tiers, hasThumbnail, additionalProperties, monetization, endpointURLs, businessInformation, environmentList, scopes, avgRating, subscriptions, advertiseInfo, isSubscriptionAvailable, categories, keyManagers, createdTime, lastUpdatedTime, gatewayVendor, asyncTransportProtocols, egress, subtype);
+    return Objects.hash(id, name, description, context, version, provider, isMarkdownOverview, apiDefinition, wsdlUri, lifeCycleStatus, isDefaultVersion, type, transport, operations, authorizationHeader, apiKeyHeader, securityScheme, tags, tiers, hasThumbnail, additionalProperties, monetization, endpointURLs, businessInformation, environmentList, scopes, avgRating, subscriptions, advertiseInfo, isSubscriptionAvailable, categories, keyManagers, createdTime, lastUpdatedTime, gatewayVendor, asyncTransportProtocols, egress, subtype);
   }
 
   @Override
@@ -800,6 +819,7 @@ public class APIDTO   {
     sb.append("    context: ").append(toIndentedString(context)).append("\n");
     sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
+    sb.append("    isMarkdownOverview: ").append(toIndentedString(isMarkdownOverview)).append("\n");
     sb.append("    apiDefinition: ").append(toIndentedString(apiDefinition)).append("\n");
     sb.append("    wsdlUri: ").append(toIndentedString(wsdlUri)).append("\n");
     sb.append("    lifeCycleStatus: ").append(toIndentedString(lifeCycleStatus)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApisApiServiceImpl.java
@@ -1218,6 +1218,33 @@ public class ApisApiServiceImpl implements ApisApiService {
         return null;
     }
 
+    @Override
+    public Response getMarkdownContentOfAPI(String apiId, String xWSO2Tenant, String ifNoneMatch,
+                                            MessageContext messageContext) throws APIManagementException {
+        try {
+            String organization = RestApiUtil.getValidatedOrganization(messageContext);
+            APIConsumer apiConsumer = RestApiCommonUtil.getLoggedInUserConsumer();
+
+            DocumentationContent docContent = apiConsumer.getMarkdownOverviewContent(apiId, organization);
+            if (docContent == null) {
+                RestApiUtil.handleResourceNotFoundError(RestApiConstants.RESOURCE_DOCUMENTATION, "");
+                return null;
+            }
+            String content = docContent.getTextContent();
+            return Response.ok(content)
+                    .header(RestApiConstants.HEADER_CONTENT_TYPE, APIConstants.DOCUMENTATION_INLINE_CONTENT_TYPE)
+                    .build();
+        } catch (APIManagementException e) {
+            if (RestApiUtil.isDueToResourceNotFound(e)) {
+                RestApiUtil.handleResourceNotFoundError(RestApiConstants.RESOURCE_API, apiId, e, log);
+            } else {
+                String errorMessage = "Error while retrieving overview markdown document of the API " + apiId;
+                RestApiUtil.handleInternalServerError(errorMessage, e, log);
+            }
+        }
+        return null;
+    }
+
     /**
      * To check whether a particular exception is due to access control restriction.
      *

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -101,6 +101,7 @@ public class APIMappingUtil {
         dto.setSubtype(model.getSubtype());
         dto.setAvgRating(String.valueOf(model.getRating()));
         dto.setEgress(model.isEgress() == 1);
+        dto.setIsMarkdownOverview(model.isMarkdownOverview());
 
         Set<Scope> scopes = model.getScopes();
         Map<String, ScopeInfoDTO> uniqueScope = new HashMap<>();
@@ -305,6 +306,7 @@ public class APIMappingUtil {
         dto.setType(model.getType());
         dto.setAvgRating(String.valueOf(model.getRating()));
         dto.setEgress(model.isEgress() == 1);
+        dto.setIsMarkdownOverview(model.isMarkdownOverview());
 
         /* todo: created and last updated times
         if (null != model.getLastUpdated()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -836,6 +836,60 @@ paths:
         - lang: Curl
           source: curl -k "https://localhost:9443/api/am/devportal/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/documents/0bcb7f05-599d-4e1a-adce-5cb89bfe58d5/content"
 
+  /apis/{apiId}/markdown-content:
+    get:
+      tags:
+        - APIs
+      summary: |
+        Get the Content of the API Overview Markdown Document
+      description: |
+        This operation can be used to retrieve the overview markdown document content of an API. You need to provide the Id of the API to retrieve it.
+
+        The content of the document will be retrieved in `text/plain` content type
+
+        `X-WSO2-Tenant` header can be used to retrieve the content of the overview markdown document of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.
+
+        **NOTE:**
+        * This operation does not require an Authorization header by default. But in order to see a restricted API's overview markdown document content, you need to provide Authorization header.
+      operationId: getMarkdownContentOfAPI
+      parameters:
+        - $ref: '#/components/parameters/apiId'
+        - $ref: '#/components/parameters/requestedTenant'
+        - $ref: '#/components/parameters/If-None-Match'
+      responses:
+        200:
+          description: |
+            OK.
+            Inline content returned.
+          headers:
+            ETag:
+              description: |
+                Entity Tag of the response resource.
+                Used by caches, or in conditional requests.
+              schema:
+                type: string
+            Last-Modified:
+              description: |
+                Date and time the resource has been modified the last time.
+                Used by caches, or in conditional requests.
+              schema:
+                type: string
+          content: { }
+        304:
+          description: |
+            Not Modified.
+            Empty body because the client has already the latest version of the requested resource.
+          content: { }
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+      security:
+        - OAuth2Security: [ ]
+      x-code-samples:
+        - lang: Curl
+          source: curl -k "https://localhost:9443/api/am/devportal/v3/apis/890a4f4d-09eb-4877-a323-57f6ce2ed79b/markdown-content"
+
   /apis/{apiId}/thumbnail:
     get:
       tags:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -4133,6 +4133,9 @@ components:
           description: |
             If the provider value is not given user invoking the api will be used as the provider.
           example: admin
+        isMarkdownOverview:
+          type: boolean
+          example: true
         apiDefinition:
           type: string
           description: |

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -739,6 +739,10 @@
                 <HTTPMethods>GET,HEAD</HTTPMethods>
             </AllowedURI>
             <AllowedURI>
+                <URI>/api/am/devportal/{version}/apis/{apiId}/markdown-content</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </AllowedURI>
+            <AllowedURI>
                 <URI>/api/am/devportal/{version}/apis/{apiId}/swagger</URI>
                 <HTTPMethods>GET,HEAD</HTTPMethods>
             </AllowedURI>
@@ -800,6 +804,10 @@
             </AllowedURI>
             <AllowedURI>
                 <URI>/api/am/devportal/{version}/api-products/{apiId}</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </AllowedURI>
+            <AllowedURI>
+                <URI>/api/am/devportal/{version}/api-products/{apiId}/markdown-content</URI>
                 <HTTPMethods>GET,HEAD</HTTPMethods>
             </AllowedURI>
             <AllowedURI>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
@@ -455,6 +455,10 @@
                 <HTTPMethods>GET,HEAD</HTTPMethods>
             </AllowedURI>
             <AllowedURI>
+                <URI>/api/am/store/{version}/apis/{apiId}/markdown-content</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </AllowedURI>
+            <AllowedURI>
                 <URI>/api/am/store/{version}/apis/{apiId}/swagger</URI>
                 <HTTPMethods>GET,HEAD</HTTPMethods>
             </AllowedURI>
@@ -512,6 +516,10 @@
             </AllowedURI>
             <AllowedURI>
                 <URI>/api/am/store/{version}/api-products/{apiProductId}</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </AllowedURI>
+            <AllowedURI>
+                <URI>/api/am/store/{version}/api-products/{apiProductId}/markdown-content</URI>
                 <HTTPMethods>GET,HEAD</HTTPMethods>
             </AllowedURI>
             <AllowedURI>


### PR DESCRIPTION
### Purpose

A new resource `/apis/{apiId}/markdown-content` is created to fetch the overview markdown content of an API.

In the current implementation, to obtain the markdown content, the `documentId` related to the overview document needs to be known. So, at least **three** APIs should be called, including the **GET** `/apis/{apiId}` API, to fetch the markdown content.

From the new resource, we can directly obtain the markdown content if `isMarkdownOverview` is `true` in the **GET** `/apis/{apiId}` API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced API documentation with Markdown overview support, enabling retrieval of markdown-formatted content for API details.
  - New endpoints allow users to directly access API and API product markdown content with proper response handling.
  - API models now indicate the availability of Markdown documentation, improving content discovery.
  - Configuration updates ensure seamless, secure access to these new functionalities.

- **Tests**
  - Added unit tests to verify the correct functionality of markdown content retrieval and endpoint responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->