### PR TITLE
[B2B] Add improvements to organization based subscription policies

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OrganizationTiers.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/OrganizationTiers.java
@@ -27,6 +27,14 @@ public class OrganizationTiers {
     private String organizationID;
     private Set<Tier> tiers;
 
+    public OrganizationTiers() {
+    }
+
+    public OrganizationTiers(String organizationID, Set<Tier> tiers) {
+        this.organizationID = organizationID;
+        this.tiers = tiers;
+    }
+
     public String getOrganizationID() {
         return organizationID;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -81,6 +81,7 @@ import org.wso2.carbon.apimgt.api.model.Label;
 import org.wso2.carbon.apimgt.api.model.LifeCycleEvent;
 import org.wso2.carbon.apimgt.api.model.OperationPolicy;
 import org.wso2.carbon.apimgt.api.model.OrganizationInfo;
+import org.wso2.carbon.apimgt.api.model.OrganizationTiers;
 import org.wso2.carbon.apimgt.api.model.ResourceFile;
 import org.wso2.carbon.apimgt.api.model.SOAPToRestSequence;
 import org.wso2.carbon.apimgt.api.model.ServiceEntry;
@@ -268,6 +269,14 @@ public class PublisherCommonUtils {
                 visibleOrgs = visibleOrgs + "," + orginfo.getOrganizationId();
                 apiToUpdate.setVisibleOrganizations(visibleOrgs);
             }
+            OrganizationTiers parentOrgTiers = new OrganizationTiers(orginfo.getOrganizationId(),
+                    apiToUpdate.getAvailableTiers());
+            Set<OrganizationTiers> currentOrganizationTiers = apiToUpdate.getAvailableTiersForOrganizations();
+            if (currentOrganizationTiers == null) {
+                currentOrganizationTiers = new HashSet<>();
+            }
+            currentOrganizationTiers.add(parentOrgTiers);
+            apiToUpdate.setAvailableTiersForOrganizations(currentOrganizationTiers);
         }
         
         apiProvider.updateAPI(apiToUpdate, originalAPI);
@@ -279,6 +288,13 @@ public class PublisherCommonUtils {
             String visibleOrgs = StringUtils.join(orgList, ',');
             apiUpdated.setVisibleOrganizations(visibleOrgs);
         }
+        // Remove parentOrgTiers from OrganizationTiers list
+        Set<OrganizationTiers> updatedOrganizationTiers = apiUpdated.getAvailableTiersForOrganizations();
+        if (updatedOrganizationTiers != null) {
+            updatedOrganizationTiers.removeIf(tier -> tier.getOrganizationID().equals(orginfo.getOrganizationId()));
+            apiUpdated.setAvailableTiersForOrganizations(updatedOrganizationTiers);
+        }
+
         if (apiUpdated != null && !StringUtils.isEmpty(apiUpdated.getEndpointConfig())) {
             JsonObject endpointConfig = JsonParser.parseString(apiUpdated.getEndpointConfig()).getAsJsonObject();
             if (!APIConstants.ENDPOINT_TYPE_SEQUENCE.equals(
@@ -1432,6 +1448,14 @@ public class PublisherCommonUtils {
                 visibleOrgs = visibleOrgs + "," + orgInfo.getOrganizationId();
                 apiToAdd.setVisibleOrganizations(visibleOrgs);
             }
+            OrganizationTiers parentOrgTiers = new OrganizationTiers(orgInfo.getOrganizationId(),
+                    apiToAdd.getAvailableTiers());
+            Set<OrganizationTiers> currentOrganizationTiers = apiToAdd.getAvailableTiersForOrganizations();
+            if (currentOrganizationTiers == null) {
+                currentOrganizationTiers = new HashSet<>();
+            }
+            currentOrganizationTiers.add(parentOrgTiers);
+            apiToAdd.setAvailableTiersForOrganizations(currentOrganizationTiers);
         }
 
         //adding the api
@@ -1444,6 +1468,12 @@ public class PublisherCommonUtils {
         }
         apiProvider.addAPI(apiToAdd);
         checkGovernanceComplianceAsync(apiToAdd.getUuid(), APIMGovernableState.API_CREATE, artifactType, organization);
+        // Remove parentOrgTiers from OrganizationTiers list
+        Set<OrganizationTiers> updatedOrganizationTiers = apiToAdd.getAvailableTiersForOrganizations();
+        if (updatedOrganizationTiers != null) {
+            updatedOrganizationTiers.removeIf(tier -> tier.getOrganizationID().equals(orgInfo.getOrganizationId()));
+            apiToAdd.setAvailableTiersForOrganizations(updatedOrganizationTiers);
+        }
         return apiToAdd;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -578,24 +578,28 @@ public class PublisherCommonUtils {
                         ExceptionCodes.TIER_NAME_INVALID);
             }
         }
+
+        boolean isSubscriptionValidationDisablingEnabled
+                = tiersFromDTO.contains(APIConstants.DEFAULT_SUB_POLICY_SUBSCRIPTIONLESS)
+                || tiersFromDTO.contains(APIConstants.DEFAULT_SUB_POLICY_ASYNC_SUBSCRIPTIONLESS);
         // Organization based subscription policies
         if (APIUtil.isOrganizationAccessControlEnabled()) {
             for (OrganizationPoliciesDTO organizationPoliciesDTO : organizationPoliciesDTOs) {
                 List<String> organizationTiersFromDTO = organizationPoliciesDTO.getPolicies();
-
-                // Remove the subscriptionless tier if other tiers are available.
-                if (organizationTiersFromDTO != null && organizationTiersFromDTO.size() > 1) {
-                    String tierToDrop = null;
-                    for (String tier : organizationTiersFromDTO) {
-                        if (tier.contains(APIConstants.DEFAULT_SUB_POLICY_SUBSCRIPTIONLESS)) {
-                            tierToDrop = tier;
-                            break;
-                        }
-                    }
-                    if (tierToDrop != null) {
-                        organizationTiersFromDTO.remove(tierToDrop);
-                        organizationPoliciesDTO.setPolicies(tiersFromDTO);
-                    }
+                if (isSubscriptionValidationDisablingEnabled) {
+                    /* If subscription validation is disabled for root organization
+                    it should be disabled for shared organizations */
+                    organizationTiersFromDTO = tiersFromDTO;
+                    organizationPoliciesDTO.setPolicies(organizationTiersFromDTO);
+                } else if (organizationTiersFromDTO.contains(APIConstants.DEFAULT_SUB_POLICY_SUBSCRIPTIONLESS)
+                        || organizationTiersFromDTO.contains(APIConstants.DEFAULT_SUB_POLICY_ASYNC_SUBSCRIPTIONLESS)) {
+                    /* If subscription validation is enabled for root organization
+                    it should not be disabled for shared organizations */
+                    organizationTiersFromDTO = tiersFromDTO;
+                    organizationPoliciesDTO.setPolicies(organizationTiersFromDTO);
+                    log.warn("Subscription validation can not be disabled for the organization with ID: "
+                            + organizationPoliciesDTO.getOrganizationID()
+                            + ". Therefore root organization subscription policies will be assigned.");
                 }
                 boolean conditionForOrganization = (
                         (organizationTiersFromDTO == null || organizationTiersFromDTO.isEmpty() && !(
@@ -613,15 +617,9 @@ public class PublisherCommonUtils {
                             throw new APIManagementException("A tier should be defined if the API is not in CREATED "
                                     + "or PROTOTYPED state", ExceptionCodes.TIER_CANNOT_BE_NULL);
                         } else if (apiSecurity.contains(APIConstants.DEFAULT_API_SECURITY_OAUTH2)) {
-                            // Internally set the default tier when no tiers are defined in order to support
-                            // subscription validation disabling for OAuth2 secured APIs
+                            // Use the root organization tiers if no tiers are set
                             if (organizationTiersFromDTO != null && organizationTiersFromDTO.isEmpty()) {
-                                if (isAsyncAPI) {
-                                    organizationTiersFromDTO.add(
-                                            APIConstants.DEFAULT_SUB_POLICY_ASYNC_SUBSCRIPTIONLESS);
-                                } else {
-                                    organizationTiersFromDTO.add(APIConstants.DEFAULT_SUB_POLICY_SUBSCRIPTIONLESS);
-                                }
+                                organizationTiersFromDTO = tiersFromDTO;
                                 organizationPoliciesDTO.setPolicies(organizationTiersFromDTO);
                             }
                         }
@@ -635,6 +633,7 @@ public class PublisherCommonUtils {
                     }
                 }
             }
+            apiDtoToUpdate.setOrganizationPolicies(organizationPoliciesDTOs);
         }
 
         if (apiDtoToUpdate.getAccessControlRoles() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -269,6 +269,12 @@ public class ApisApiServiceImpl implements ApisApiService {
                 newOrgList.add(APIConstants.VISIBLE_ORG_NONE);
             }
             apiToReturn.setVisibleOrganizations(newOrgList);
+            // Remove parent organization policies the OrganizationPoliciesDTO List
+            List<OrganizationPoliciesDTO> organizationPolicies = apiToReturn.getOrganizationPolicies();
+            if (organizationPolicies != null) {
+                organizationPolicies.removeIf(tier -> tier.getOrganizationID().equals(organizationInfo.getOrganizationId()));
+                apiToReturn.setOrganizationPolicies(organizationPolicies);
+            }
         }
 
         return Response.ok().entity(apiToReturn).build();


### PR DESCRIPTION
### Purpose

- Resolves https://github.com/wso2/api-manager/issues/3610
- Add implementation to work with subscription validation disabling feature

### Description

- Store root organization's subscription policies with its organization ID in the registry
- Add backend changes for default behaviour with subscription validation disabling feature
   - When root organization  has subscription validation disabled, it will be disabled for other shared organization's as well
   - When root organization needs subscription validation
      - If there are subscription policies defined for a shared organization it will be used
      - If it is not assigned root organization's subscription policies will be used for that organization