### PR TITLE
Upgrade netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2047,7 +2047,7 @@
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
 
-        <carbon.analytics.common.version><LATEST_RELEASE_VERSION></carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.19</carbon.analytics.common.version>
 
         <!-- Carbon kernel version -->
         <carbon.kernel.version>4.9.28-beta</carbon.kernel.version>
@@ -2057,12 +2057,12 @@
         <carbon.commons.version>4.9.11</carbon.commons.version>
 
         <carbon.registry.version>4.8.43</carbon.registry.version>
-        <carbon.mediation.version><LATEST_RELEASE_VERSION></carbon.mediation.version>
+        <carbon.mediation.version>4.7.245</carbon.mediation.version>
 
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 
         <!-- Carbon Identity versions -->
-        <carbon.identity.version><LATEST_RELEASE_VERSION></carbon.identity.version>
+        <carbon.identity.version>5.25.723</carbon.identity.version>
         <carbon.identity.governance.version>1.8.108</carbon.identity.governance.version>
         <carbon.identity-inbound-auth-oauth.version>6.13.25</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-oauth2-grant-jwt.version>2.2.4</carbon.identity-oauth2-grant-jwt.version>
@@ -2137,7 +2137,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version><LATEST_RELEASE_VERSION></synapse.version>
+        <synapse.version>4.0.0-wso2v218</synapse.version>
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 
         <!-- orbit httpmime versions-->

--- a/pom.xml
+++ b/pom.xml
@@ -2064,7 +2064,7 @@
         <!-- Carbon Identity versions -->
         <carbon.identity.version>5.25.723</carbon.identity.version>
         <carbon.identity.governance.version>1.8.108</carbon.identity.governance.version>
-        <carbon.identity-inbound-auth-oauth.version>6.13.25</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version>6.13.26</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-oauth2-grant-jwt.version>2.2.4</carbon.identity-oauth2-grant-jwt.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
         <carbon.identity-data-publisher-application-authentication.version>5.6.8</carbon.identity-data-publisher-application-authentication.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2057,7 +2057,7 @@
         <carbon.commons.version>4.9.11</carbon.commons.version>
 
         <carbon.registry.version>4.8.43</carbon.registry.version>
-        <carbon.mediation.version>4.7.228</carbon.mediation.version>
+        <carbon.mediation.version>4.7.244</carbon.mediation.version>
 
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 
@@ -2137,7 +2137,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>4.0.0-wso2v186</synapse.version>
+        <synapse.version>4.0.0-wso2v216</synapse.version>
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 
         <!-- orbit httpmime versions-->

--- a/pom.xml
+++ b/pom.xml
@@ -2047,7 +2047,7 @@
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
 
-        <carbon.analytics.common.version>5.3.17</carbon.analytics.common.version>
+        <carbon.analytics.common.version><LATEST_RELEASE_VERSION></carbon.analytics.common.version>
 
         <!-- Carbon kernel version -->
         <carbon.kernel.version>4.9.28-beta</carbon.kernel.version>
@@ -2057,12 +2057,12 @@
         <carbon.commons.version>4.9.11</carbon.commons.version>
 
         <carbon.registry.version>4.8.43</carbon.registry.version>
-        <carbon.mediation.version>4.7.244</carbon.mediation.version>
+        <carbon.mediation.version><LATEST_RELEASE_VERSION></carbon.mediation.version>
 
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 
         <!-- Carbon Identity versions -->
-        <carbon.identity.version>5.25.722</carbon.identity.version>
+        <carbon.identity.version><LATEST_RELEASE_VERSION></carbon.identity.version>
         <carbon.identity.governance.version>1.8.108</carbon.identity.governance.version>
         <carbon.identity-inbound-auth-oauth.version>6.13.25</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-oauth2-grant-jwt.version>2.2.4</carbon.identity-oauth2-grant-jwt.version>
@@ -2137,7 +2137,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>4.0.0-wso2v216</synapse.version>
+        <synapse.version><LATEST_RELEASE_VERSION></synapse.version>
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 
         <!-- orbit httpmime versions-->
@@ -2174,7 +2174,8 @@
         <httpcomponents.version>4.5.10</httpcomponents.version>
         <commons-codec.version>1.16.0</commons-codec.version>
         <com.nimbusds.wso2.version>9.37.3.wso2v1</com.nimbusds.wso2.version>
-        <json-smart.version>2.5.0</json-smart.version>
+        <json-smart.version>2.5.2</json-smart.version>
+        <org.apache.velocity.version>2.3</org.apache.velocity.version>
         <org.slf4j.version>2.0.12</org.slf4j.version>
         <slf4j.api.version>2.0.12</slf4j.api.version>
         <spring-web.version>5.3.23</spring-web.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2175,7 +2175,6 @@
         <commons-codec.version>1.16.0</commons-codec.version>
         <com.nimbusds.wso2.version>9.37.3.wso2v1</com.nimbusds.wso2.version>
         <json-smart.version>2.5.2</json-smart.version>
-        <org.apache.velocity.version>2.3</org.apache.velocity.version>
         <org.slf4j.version>2.0.12</org.slf4j.version>
         <slf4j.api.version>2.0.12</slf4j.api.version>
         <spring-web.version>5.3.23</spring-web.version>


### PR DESCRIPTION
## io.netty Upgrade
### Purpose
Upgrades carbon mediation and synapse versions to bump the io.netty version from 4.1.117.Final to non-vulnerable 4.1.118.Final.

#### Related PRs:
transport-http: https://github.com/wso2/transport-http/pull/475
synapse: https://github.com/wso2/wso2-synapse/pull/2333
carbon-mediation: https://github.com/wso2/carbon-mediation/pull/1763
product-apim: https://github.com/wso2/product-apim/pull/13688


## Json-smart Upgrade

### Purpose
To upgrade json-smart version from 2.5.0 to the non-vulnerable 2.5.2 version.

#### Related PRs:

Identity-inbound-auth-oauth: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2730
Carbon-identity-framework: https://github.com/wso2/carbon-identity-framework/pull/6543
Identity-inbound-auth-openid: https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/109
Identity-outbound-auth-oidc: https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/199
Carbon-mediation: https://github.com/wso2/carbon-mediation/pull/1767
Carbon-analytics-common: https://github.com/wso2/carbon-analytics-common/pull/862
Product-apim: https://github.com/wso2/product-apim/pull/13688