### PR TITLE
[Gov Feature Branch] Fix Codestyle Issue and Policy Status Minor Bug 

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/main/java/org/wso2/carbon/apimgt/governance/rest/api/util/ComplianceAPIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/main/java/org/wso2/carbon/apimgt/governance/rest/api/util/ComplianceAPIUtil.java
@@ -227,15 +227,20 @@ public class ComplianceAPIUtil {
             rulesetValidationResults.add(resultDTO);
         }
 
-        // If all rulesets are passed, set the policy adherence status to passed
-        if (rulesetValidationResults.stream().allMatch(
-                rulesetValidationResultDTO -> (rulesetValidationResultDTO.getStatus() ==
-                        RulesetValidationResultWithoutRulesDTO.StatusEnum.PASSED) ||
-                        (rulesetValidationResultDTO.getStatus() ==
-                                RulesetValidationResultWithoutRulesDTO.StatusEnum.UNAPPLIED))) {
-            policyAdherenceWithRulesetsDTO.setStatus(PolicyAdherenceWithRulesetsDTO.StatusEnum.FOLLOWED);
-        } else {
+        /* If one of the rulesets is violated, set the policy adherence status to violated
+         * If all rulesets are un applied policy adherence status to unapplied
+         *
+         * Else policy adherence status to followed
+         * passed, set the policy adherence status to followed
+         */
+        if (rulesetValidationResults.stream().anyMatch(dto -> dto.getStatus()
+                == RulesetValidationResultWithoutRulesDTO.StatusEnum.FAILED)) {
             policyAdherenceWithRulesetsDTO.setStatus(PolicyAdherenceWithRulesetsDTO.StatusEnum.VIOLATED);
+        } else if (rulesetValidationResults.stream().allMatch(dto -> dto.getStatus()
+                == RulesetValidationResultWithoutRulesDTO.StatusEnum.UNAPPLIED)) {
+            policyAdherenceWithRulesetsDTO.setStatus(PolicyAdherenceWithRulesetsDTO.StatusEnum.UNAPPLIED);
+        } else {
+            policyAdherenceWithRulesetsDTO.setStatus(PolicyAdherenceWithRulesetsDTO.StatusEnum.FOLLOWED);
         }
 
         policyAdherenceWithRulesetsDTO.setRulesetValidationResults(rulesetValidationResults);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -93,7 +93,6 @@ import org.wso2.carbon.apimgt.governance.api.model.APIMGovernableState;
 import org.wso2.carbon.apimgt.governance.api.model.ArtifactComplianceDryRunInfo;
 import org.wso2.carbon.apimgt.governance.api.model.ArtifactComplianceInfo;
 import org.wso2.carbon.apimgt.governance.api.model.ArtifactType;
-import org.wso2.carbon.apimgt.governance.api.model.ExtendedArtifactType;
 import org.wso2.carbon.apimgt.governance.api.model.RuleType;
 import org.wso2.carbon.apimgt.governance.api.model.RuleViolation;
 import org.wso2.carbon.apimgt.governance.api.service.APIMGovernanceService;


### PR DESCRIPTION
## Purpose
This pull request includes updates to the policy adherence logic and cleanup of unused imports. The most important changes include modifying the logic for setting policy adherence status and removing an unused import from `PublisherCommonUtils`.

Improvements to policy adherence logic:

* [`components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/main/java/org/wso2/carbon/apimgt/governance/rest/api/util/ComplianceAPIUtil.java`](diffhunk://#diff-57636ef562217be418d5dcbd0e9df2e9b7bbaf1ed69f8d0cd40c71df3d9eb7d3L230-R243): Modified the logic to set the policy adherence status based on the ruleset validation results. The new logic checks if any ruleset is violated, if all rulesets are unapplied, or otherwise sets the status to followed.

Codebase cleanup:

* [`components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java`](diffhunk://#diff-4c57ff2f60dc5bf7fe19d7008754c116c4eac15e13b64ed376bfb827f811d05eL96): Removed the unused import `ExtendedArtifactType`.