### PR TITLE
Migrate Lambda mediator to AWS SDK 2.x

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -310,7 +310,7 @@
             <version>${graphql.java.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.com.amazonaws</groupId>
+            <groupId>org.wso2.orbit.software.amazon.awssdk</groupId>
             <artifactId>awslambda</artifactId>
         </dependency>
         <dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -490,7 +490,10 @@
                             org.wso2.carbon.apimgt.tracing.*; version="${carbon.apimgt.imp.pkg.version}",
                             org.wso2.orbit.re2j.*; version="${re2j.version}",
                             graphql.*; version="${graphql.java.version.range}",
-                            com.amazonaws.*; version="${com.amazonaws.version}",
+                            software.amazon.awssdk.services.sts.*; version="${org.wso2.orbit.com.amazonaws.version.range}"; resolution:=optional,
+                            software.amazon.awssdk.services.lambda.*; version="${org.wso2.orbit.com.amazonaws.version.range}"; resolution:=optional,
+                            software.amazon.awssdk.core.*; version="${org.wso2.orbit.com.amazonaws.version.range}"; resolution:=optional,
+                            software.amazon.awssdk.awscore.*; version="${org.wso2.orbit.com.amazonaws.version.range}"; resolution:=optional,
                             org.apache.servicemix.bundles.jedis.*; version="${servicemix.bundles.jedis.version}",
                             com.nimbusds.jwt.*,
                             org.apache.commons.codec.*,
@@ -501,8 +504,29 @@
                             javax.annotation;version=0.0.0;resolution:=optional,
                             *;resolution:=optional
                         </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>set-system-properties</goal>
+                        </goals>
+                        <configuration>
+                            <properties>
+                                <property>
+                                    <name>org.aspectj.weaver.openarchives</name>
+                                    <value>1500</value>
+                                </property>
+                            </properties>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -311,7 +311,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.software.amazon.awssdk</groupId>
-            <artifactId>awslambda</artifactId>
+            <artifactId>aws-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
@@ -17,25 +17,6 @@
  */
 package org.wso2.carbon.apimgt.gateway.mediators;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.SdkClientException;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.BasicSessionCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.lambda.AWSLambda;
-import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
-import com.amazonaws.services.lambda.model.InvocationType;
-import com.amazonaws.services.lambda.model.InvokeRequest;
-import com.amazonaws.services.lambda.model.InvokeResult;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
-import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
-import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
-import com.amazonaws.services.securitytoken.model.Credentials;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.axiom.om.OMElement;
@@ -58,10 +39,29 @@ import org.wso2.carbon.apimgt.gateway.handlers.analytics.Constants;
 import org.wso2.carbon.apimgt.gateway.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.gateway.utils.redis.RedisCacheUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import software.amazon.awssdk.auth.credentials.*;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvocationType;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeMap;
@@ -79,7 +79,7 @@ public class AWSLambdaMediator extends AbstractMediator {
     private String roleArn = "";
     private String roleSessionName = "";
     private String roleRegion = "";
-    private int resourceTimeout = APIConstants.AWS_DEFAULT_CONNECTION_TIMEOUT;
+    private Duration resourceTimeout = Duration.ofMillis(APIConstants.AWS_DEFAULT_CONNECTION_TIMEOUT);
     private boolean isContentEncodingEnabled = false;
     private static final String PATH_PARAMETERS = "pathParameters";
     private static final String QUERY_STRING_PARAMETERS = "queryStringParameters";
@@ -165,15 +165,15 @@ public class AWSLambdaMediator extends AbstractMediator {
                 log.debug("Passing the payload " + payload.toString() + " to AWS Lambda function with resource name "
                         + resourceName);
             }
-            InvokeResult invokeResult = invokeLambda(payload.toString());
+            InvokeResponse invokeResult = invokeLambda(payload.toString());
 
             if (invokeResult != null) {
                 if (log.isDebugEnabled()) {
                     log.debug("AWS Lambda function: " + resourceName + " is invoked successfully.");
                 }
-                JsonUtil.getNewJsonPayload(axis2MessageContext, new String(invokeResult.getPayload().array()),
+                JsonUtil.getNewJsonPayload(axis2MessageContext, new String(invokeResult.payload().asByteArray(), StandardCharsets.UTF_8),
                         true, true);
-                axis2MessageContext.setProperty(APIMgtGatewayConstants.HTTP_SC, invokeResult.getStatusCode());
+                axis2MessageContext.setProperty(APIMgtGatewayConstants.HTTP_SC, invokeResult.statusCode());
                 axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_MESSAGE_TYPE, APIConstants.APPLICATION_JSON_MEDIA_TYPE);
                 axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_CONTENT_TYPE, APIConstants.APPLICATION_JSON_MEDIA_TYPE);
                 axis2MessageContext.removeProperty(APIConstants.NO_ENTITY_BODY);
@@ -198,39 +198,39 @@ public class AWSLambdaMediator extends AbstractMediator {
      * @param payload - input parameters to pass to AWS Lambda function as a JSONString
      * @return InvokeResult
      */
-    private InvokeResult invokeLambda(String payload) {
+    private InvokeResponse invokeLambda(String payload) {
         try {
             // Validate resource timeout and set client configuration
-            if (resourceTimeout < 1000 || resourceTimeout > 900000) {
+            if (resourceTimeout.toMillis() < 1000 || resourceTimeout.toMillis() > 900000) {
                 setResourceTimeout(APIConstants.AWS_DEFAULT_CONNECTION_TIMEOUT);
             }
-            ClientConfiguration clientConfig = new ClientConfiguration();
-            clientConfig.setSocketTimeout(resourceTimeout);
+            ClientOverrideConfiguration clientConfig = ClientOverrideConfiguration.builder()
+                    .apiCallTimeout(resourceTimeout).build();
 
-            AWSLambda awsLambdaClient;
+            LambdaClient awsLambdaClient;
             if (StringUtils.isEmpty(accessKey) && StringUtils.isEmpty(secretKey)) {
                 if (log.isDebugEnabled()) {
                     log.debug("Using temporary credentials supplied by the IAM role attached to AWS instance");
                 }
                 if (StringUtils.isEmpty(roleArn) && StringUtils.isEmpty(roleSessionName)
                         && StringUtils.isEmpty(roleRegion)) {
-                    awsLambdaClient = AWSLambdaClientBuilder.standard()
-                            .withCredentials(DefaultAWSCredentialsProviderChain.getInstance())
-                            .withClientConfiguration(clientConfig)
+                    awsLambdaClient = LambdaClient.builder()
+                            .credentialsProvider(DefaultCredentialsProvider.create())
+                            .httpClientBuilder(ApacheHttpClient.builder())
+                            .overrideConfiguration(clientConfig)
                             .build();
                 } else if (StringUtils.isNotEmpty(roleArn) && StringUtils.isNotEmpty(roleSessionName)
                         && StringUtils.isNotEmpty(roleRegion)) {
+                    Region region = new DefaultAwsRegionProviderChain().getRegion();
                     Credentials sessionCredentials = getSessionCredentials(
-                            DefaultAWSCredentialsProviderChain.getInstance(), roleArn, roleSessionName,
-                            String.valueOf(Regions.getCurrentRegion()));
-                    BasicSessionCredentials basicSessionCredentials = new BasicSessionCredentials(
-                            sessionCredentials.getAccessKeyId(),
-                            sessionCredentials.getSecretAccessKey(),
-                            sessionCredentials.getSessionToken());
-                    awsLambdaClient = AWSLambdaClientBuilder.standard()
-                            .withCredentials(new AWSStaticCredentialsProvider(basicSessionCredentials))
-                            .withClientConfiguration(clientConfig)
-                            .withRegion(roleRegion)
+                            DefaultCredentialsProvider.create(), roleArn, roleSessionName,
+                            String.valueOf(region));
+                    AwsSessionCredentials basicSessionCredentials = AwsSessionCredentials.create(sessionCredentials.accessKeyId(), sessionCredentials.secretAccessKey(), sessionCredentials.sessionToken());
+                    awsLambdaClient = LambdaClient.builder()
+                                    .credentialsProvider(StaticCredentialsProvider.create(basicSessionCredentials))
+                                    .httpClientBuilder(ApacheHttpClient.builder())
+                                    .overrideConfiguration(clientConfig)
+                            .region(Region.of(roleRegion))
                             .build();
                 } else {
                     log.error("Missing AWS STS configurations");
@@ -241,26 +241,25 @@ public class AWSLambdaMediator extends AbstractMediator {
                 if (log.isDebugEnabled()) {
                     log.debug("Using user given stored credentials");
                 }
-                BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+                AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
                 if (StringUtils.isEmpty(roleArn) && StringUtils.isEmpty(roleSessionName)
                         && StringUtils.isEmpty(roleRegion)) {
-                    awsLambdaClient = AWSLambdaClientBuilder.standard()
-                            .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-                            .withClientConfiguration(clientConfig)
-                            .withRegion(region)
+                    awsLambdaClient = LambdaClient.builder()
+                                    .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                                    .httpClientBuilder(ApacheHttpClient.builder())
+                                    .overrideConfiguration(clientConfig)
+                            .region(Region.of(region))
                             .build();
                 } else if (StringUtils.isNotEmpty(roleArn) && StringUtils.isNotEmpty(roleSessionName)
                         && StringUtils.isNotEmpty(roleRegion)) {
                     Credentials sessionCredentials = getSessionCredentials(
-                            new AWSStaticCredentialsProvider(awsCredentials), roleArn, roleSessionName, region);
-                    BasicSessionCredentials basicSessionCredentials = new BasicSessionCredentials(
-                            sessionCredentials.getAccessKeyId(),
-                            sessionCredentials.getSecretAccessKey(),
-                            sessionCredentials.getSessionToken());
-                    awsLambdaClient = AWSLambdaClientBuilder.standard()
-                            .withCredentials(new AWSStaticCredentialsProvider(basicSessionCredentials))
-                            .withClientConfiguration(clientConfig)
-                            .withRegion(roleRegion)
+                            StaticCredentialsProvider.create(awsCredentials), roleArn, roleSessionName, region);
+                    AwsSessionCredentials basicSessionCredentials = AwsSessionCredentials.create(sessionCredentials.accessKeyId(), sessionCredentials.secretAccessKey(), sessionCredentials.sessionToken());
+                    awsLambdaClient = LambdaClient.builder()
+                                    .credentialsProvider(StaticCredentialsProvider.create(basicSessionCredentials))
+                                    .httpClientBuilder(ApacheHttpClient.builder())
+                                    .overrideConfiguration(clientConfig)
+                            .region(Region.of(roleRegion))
                             .build();
                 } else {
                     log.error("Missing AWS STS configurations");
@@ -270,20 +269,22 @@ public class AWSLambdaMediator extends AbstractMediator {
                 log.error("Missing AWS Credentials");
                 return null;
             }
-            InvokeRequest invokeRequest = new InvokeRequest()
-                    .withFunctionName(resourceName)
-                    .withPayload(payload)
-                    .withInvocationType(InvocationType.RequestResponse)
-                    .withSdkClientExecutionTimeout(resourceTimeout);
+
+            SdkBytes payloadBytes = SdkBytes.fromUtf8String(payload);
+            InvokeRequest invokeRequest = InvokeRequest.builder()
+                    .functionName(resourceName)
+                    .payload(payloadBytes)
+                    .invocationType(InvocationType.REQUEST_RESPONSE)
+                    .build();
             return awsLambdaClient.invoke(invokeRequest);
-        } catch (SdkClientException e) {
+        } catch (SdkClientException | URISyntaxException e) {
             log.error("Error while invoking the lambda function", e);
         }
         return null;
     }
 
-    private Credentials getSessionCredentials(AWSCredentialsProvider credentialsProvider, String roleArn,
-                                              String roleSessionName, String region) {
+    private Credentials getSessionCredentials(AwsCredentialsProvider credentialsProvider, String roleArn,
+                                              String roleSessionName, String region) throws URISyntaxException {
         Credentials sessionCredentials = null;
         if (ServiceReferenceHolder.getInstance().isRedisEnabled()) {
             Object previousCredentialsObject = new RedisCacheUtils(ServiceReferenceHolder.getInstance().getRedisPool())
@@ -295,30 +296,30 @@ public class AWSLambdaMediator extends AbstractMediator {
             sessionCredentials = CredentialsCache.getInstance().getCredentialsMap().get(roleSessionName);
         }
         if (sessionCredentials != null) {
-            long expirationTime = sessionCredentials.getExpiration().getTime();
+            long expirationTime = sessionCredentials.expiration().toEpochMilli();
             long currentTime = System.currentTimeMillis();
             long timeDifference = expirationTime - currentTime;
             if (timeDifference > 1000) {
                 return sessionCredentials;
             }
         }
-        AWSSecurityTokenService awsSTSClient;
+        StsClient awsSTSClient;
         if (StringUtils.isEmpty(region)) {
-            awsSTSClient = AWSSecurityTokenServiceClientBuilder.standard()
-                    .withCredentials(credentialsProvider)
+            awsSTSClient = StsClient.builder()
+                    .credentialsProvider(credentialsProvider)
                     .build();
         } else {
-            awsSTSClient = AWSSecurityTokenServiceClientBuilder.standard()
-                    .withCredentials(credentialsProvider)
-                    .withEndpointConfiguration(new EndpointConfiguration("https://sts." + region + ".amazonaws.com",
-                            region))
+            awsSTSClient = StsClient.builder()
+                    .credentialsProvider(credentialsProvider)
+                    .endpointOverride(new URI("https://sts." + region + ".amazonaws.com"))
                     .build();
         }
-        AssumeRoleRequest roleRequest = new AssumeRoleRequest()
-                .withRoleArn(roleArn)
-                .withRoleSessionName(roleSessionName);
-        AssumeRoleResult assumeRoleResult = awsSTSClient.assumeRole(roleRequest);
-        sessionCredentials = assumeRoleResult.getCredentials();
+        AssumeRoleRequest roleRequest = AssumeRoleRequest.builder()
+                .roleArn(roleArn)
+                .roleSessionName(roleSessionName)
+                .build();
+        AssumeRoleResponse assumeRoleResult = awsSTSClient.assumeRole(roleRequest);
+        sessionCredentials = assumeRoleResult.credentials();
         if (ServiceReferenceHolder.getInstance().isRedisEnabled()) {
             new RedisCacheUtils(ServiceReferenceHolder.getInstance().getRedisPool())
                     .addObject(roleSessionName, sessionCredentials);
@@ -416,7 +417,7 @@ public class AWSLambdaMediator extends AbstractMediator {
     }
 
     public int getResourceTimeout() {
-        return resourceTimeout;
+        return (int) resourceTimeout.toMillis();
     }
 
     public void setAccessKey(String accessKey) {
@@ -448,7 +449,7 @@ public class AWSLambdaMediator extends AbstractMediator {
     }
 
     public void setResourceTimeout(int resourceTimeout) {
-        this.resourceTimeout = resourceTimeout;
+        this.resourceTimeout = Duration.ofMillis(resourceTimeout);
     }
 
     public void setIsContentEncodingEnabled(boolean isContentEncodingEnabled) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/CredentialsCache.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/CredentialsCache.java
@@ -17,7 +17,7 @@
  */
 package org.wso2.carbon.apimgt.gateway.mediators;
 
-import com.amazonaws.services.securitytoken.model.Credentials;
+import software.amazon.awssdk.services.sts.model.Credentials;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -406,7 +406,7 @@
             <artifactId>velocity-engine-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.com.amazonaws</groupId>
+            <groupId>org.wso2.orbit.software.amazon.awssdk</groupId>
             <artifactId>awslambda</artifactId>
         </dependency>
         <dependency>
@@ -579,7 +579,7 @@
                             javax.servlet.resources;version="${javax.servlet.imp.pkg.version}",
                             org.eclipse.equinox.http.helper,
                             com.google.gson,
-                            com.amazonaws.*; version="${com.amazonaws.version}",
+                            software.amazon.awssdk.*; version="${com.amazonaws.version}",
                             org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.commons.io.*;version="${import.package.version.commons.io}",
                             org.apache.commons.codec.*;version="${import.package.version.commons.codec}",

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -579,7 +579,10 @@
                             javax.servlet.resources;version="${javax.servlet.imp.pkg.version}",
                             org.eclipse.equinox.http.helper,
                             com.google.gson,
-                            software.amazon.awssdk.*; version="${com.amazonaws.version}",
+                            software.amazon.awssdk.services.sts.*; version="${org.wso2.orbit.com.amazonaws.version.range}"; resolution:=optional,
+                            software.amazon.awssdk.services.lambda.*; version="${org.wso2.orbit.com.amazonaws.version.range}"; resolution:=optional,
+                            software.amazon.awssdk.core.*; version="${org.wso2.orbit.com.amazonaws.version.range}"; resolution:=optional,
+                            software.amazon.awssdk.awscore.*; version="${org.wso2.orbit.com.amazonaws.version.range}"; resolution:=optional,
                             org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.commons.io.*;version="${import.package.version.commons.io}",
                             org.apache.commons.codec.*;version="${import.package.version.commons.codec}",
@@ -654,7 +657,26 @@
                     <target>9</target>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>set-system-properties</goal>
+                        </goals>
+                        <configuration>
+                            <properties>
+                                <property>
+                                    <name>org.aspectj.weaver.openarchives</name>
+                                    <value>${org.aspectj.weaver.openarchives.limit}</value>
+                                </property>
+                            </properties>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -407,7 +407,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.software.amazon.awssdk</groupId>
-            <artifactId>awslambda</artifactId>
+            <artifactId>aws-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.apimgt.rest.api.publisher.v1.impl;
 
-import com.amazonaws.SdkClientException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
@@ -83,6 +82,7 @@ import org.wso2.carbon.apimgt.rest.api.util.exception.BadRequestException;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.core.util.CryptoUtil;
+import software.amazon.awssdk.core.exception.SdkClientException;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -1096,6 +1096,9 @@ public class ApisApiServiceImpl implements ApisApiService {
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
         } catch (CryptoException e) {
             String errorMessage = "Error while decrypting the secret key of the API: " + apiId;
+            RestApiUtil.handleInternalServerError(errorMessage, e, log);
+        } catch (URISyntaxException e) {
+            String errorMessage = "Error while parsing sts endpoint URI: " + apiId;
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
         } catch (APIManagementException e) {
             String errorMessage = "Error while retrieving the API: " + apiId;

--- a/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
@@ -179,6 +179,10 @@
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-httpclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.software.amazon.awssdk</groupId>
+            <artifactId>awslambda</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -287,7 +291,7 @@
                                 <bundleDef>org.wso2.orbit.graphQL:graphQL:${graphql.java.version}</bundleDef>
                                 <bundleDef>org.wso2.wsdl4j:wsdl4j.wso2:${wsdl4j.version}</bundleDef>
                                 <bundleDef>
-                                    org.wso2.orbit.com.amazonaws:awslambda:${org.wso2.orbit.com.amazonaws.version}
+                                    org.wso2.orbit.software.amazon.awssdk:awslambda:${org.wso2.orbit.com.amazonaws.version}
                                 </bundleDef>
                                 <bundleDef>
                                     com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${fasterxml.jackson.version}

--- a/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.gateway.feature/pom.xml
@@ -181,7 +181,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.software.amazon.awssdk</groupId>
-            <artifactId>awslambda</artifactId>
+            <artifactId>aws-core</artifactId>
         </dependency>
     </dependencies>
 
@@ -291,7 +291,7 @@
                                 <bundleDef>org.wso2.orbit.graphQL:graphQL:${graphql.java.version}</bundleDef>
                                 <bundleDef>org.wso2.wsdl4j:wsdl4j.wso2:${wsdl4j.version}</bundleDef>
                                 <bundleDef>
-                                    org.wso2.orbit.software.amazon.awssdk:awslambda:${org.wso2.orbit.com.amazonaws.version}
+                                    org.wso2.orbit.software.amazon.awssdk:aws-core:${org.wso2.orbit.com.amazonaws.version}
                                 </bundleDef>
                                 <bundleDef>
                                     com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${fasterxml.jackson.version}

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
@@ -108,7 +108,7 @@
             <artifactId>swagger-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.com.amazonaws</groupId>
+            <groupId>org.wso2.orbit.software.amazon.awssdk</groupId>
             <artifactId>awslambda</artifactId>
         </dependency>
         <dependency>
@@ -284,7 +284,7 @@
                                 <bundleDef>org.wso2.orbit.com.squareup.okio:okio:${okio.wso2.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.com.squareup.okhttp:okhttp:${okhttp.wso2.version}</bundleDef>
                                 <bundleDef>
-                                    org.wso2.orbit.com.amazonaws:awslambda:${org.wso2.orbit.com.amazonaws.version}
+                                    org.wso2.orbit.software.amazon.awssdk:awslambda:${org.wso2.orbit.com.amazonaws.version}
                                 </bundleDef>
                                 <bundleDef>
                                     com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${fasterxml.jackson.version}

--- a/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.feature/pom.xml
@@ -109,7 +109,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.software.amazon.awssdk</groupId>
-            <artifactId>awslambda</artifactId>
+            <artifactId>aws-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.mediation</groupId>
@@ -284,7 +284,7 @@
                                 <bundleDef>org.wso2.orbit.com.squareup.okio:okio:${okio.wso2.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.com.squareup.okhttp:okhttp:${okhttp.wso2.version}</bundleDef>
                                 <bundleDef>
-                                    org.wso2.orbit.software.amazon.awssdk:awslambda:${org.wso2.orbit.com.amazonaws.version}
+                                    org.wso2.orbit.software.amazon.awssdk:aws-core:${org.wso2.orbit.com.amazonaws.version}
                                 </bundleDef>
                                 <bundleDef>
                                     com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${fasterxml.jackson.version}

--- a/pom.xml
+++ b/pom.xml
@@ -1796,7 +1796,7 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.wso2.orbit.com.amazonaws</groupId>
+                <groupId>org.wso2.orbit.software.amazon.awssdk</groupId>
                 <artifactId>awslambda</artifactId>
                 <version>${org.wso2.orbit.com.amazonaws.version}</version>
             </dependency>
@@ -2281,8 +2281,8 @@
         <import.package.version.commons.io>[2.4.0,3.0.0)</import.package.version.commons.io>
         <import.package.version.commons.codec>[1.14.0,3.0.0)</import.package.version.commons.codec>
 
-        <com.amazonaws.version>1.12.671</com.amazonaws.version>
-        <org.wso2.orbit.com.amazonaws.version>1.12.671.wso2v1</org.wso2.orbit.com.amazonaws.version>
+        <com.amazonaws.version>2.30.22</com.amazonaws.version>
+        <org.wso2.orbit.com.amazonaws.version>2.30.22.wso2v1</org.wso2.orbit.com.amazonaws.version>
 
         <zipkin.version>2.27.1</zipkin.version>
         <okhttp.wso2.version>4.12.0.wso2v1</okhttp.wso2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2281,8 +2281,8 @@
         <import.package.version.commons.io>[2.4.0,3.0.0)</import.package.version.commons.io>
         <import.package.version.commons.codec>[1.14.0,3.0.0)</import.package.version.commons.codec>
 
-        <com.amazonaws.version>2.30.22</com.amazonaws.version>
         <org.wso2.orbit.com.amazonaws.version>2.30.22.wso2v1</org.wso2.orbit.com.amazonaws.version>
+        <org.wso2.orbit.com.amazonaws.version.range>[2.20, 2.50]</org.wso2.orbit.com.amazonaws.version.range>
 
         <zipkin.version>2.27.1</zipkin.version>
         <okhttp.wso2.version>4.12.0.wso2v1</okhttp.wso2.version>
@@ -2300,6 +2300,7 @@
         <org.wso2.orbit.atlassian.oai.version>2.12.1.wso2v2</org.wso2.orbit.atlassian.oai.version>
         <maven.spotbugsplugin.exclude.file>${project.parent.basedir}/../../spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>
         <skip.aspectj>false</skip.aspectj>
+        <org.aspectj.weaver.openarchives.limit>1500</org.aspectj.weaver.openarchives.limit>
         <javax.jms.version>2.0.1</javax.jms.version>
         <com.damnhandy.version>2.1.6</com.damnhandy.version>
         <damnhandy.version>${com.damnhandy.version}.wso2v2</damnhandy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1797,7 +1797,7 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.orbit.software.amazon.awssdk</groupId>
-                <artifactId>awslambda</artifactId>
+                <artifactId>aws-core</artifactId>
                 <version>${org.wso2.orbit.com.amazonaws.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
This PR update AWS Lambda Mediator code to use AWS SDK 2.x.