### PR TITLE
Add configurations for sequential failover from beginning

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -140,6 +140,7 @@
   "apim.throttling.jms.java_naming_factory_initial": "org.wso2.andes.jndi.PropertiesFileInitialContextFactory",
   "apim.throttling.enable_policy_deployment": true,
   "apim.throttling.enable_policy_recreation_on_startup": true,
+  "apim.throttling.sequential_failover_from_beginning": "false",
   "server.mode": "single",
   "apim.workflow.enable": "false",
   "apim.workflow.service_url": "https://localhost:9445/bpmn",

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1163,6 +1163,7 @@
                 {% else %}
                 <connectionfactory.TopicConnectionFactory>amqp://${admin.username}:${admin.password}@clientid/carbon?brokerlist='tcp://${carbon.local.ip}:${jms.port}'</connectionfactory.TopicConnectionFactory>
                 {% endif %}
+                <SequentialFailoverFromBeginning>{{apim.throttling.sequential_failover_from_beginning}}</SequentialFailoverFromBeginning>
             </JMSConnectionParameters>
         </JMSConnectionDetails>
 
@@ -1619,6 +1620,7 @@
              {% else %}
              <connectionfactory.TopicConnectionFactory>amqp://${admin.username}:${admin.password}@clientid/carbon?brokerlist='tcp://${carbon.local.ip}:${jms.port}?{% if apim.throttling.jms.ssl is defined %}ssl='{{apim.throttling.jms.ssl}}'{% endif %}'</connectionfactory.TopicConnectionFactory>
              {% endif %}
+             <SequentialFailoverFromBeginning>{{apim.throttling.sequential_failover_from_beginning}}</SequentialFailoverFromBeginning>
          </EventReceiverConfiguration>
      </EventHubConfigurations>
 


### PR DESCRIPTION
### Purpose

Add required configurations for adding support for sequential failover from beginning in [1]

[1] https://github.com/wso2/andes/pull/1066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option to control sequential failover behavior for API throttling, ensuring that failover does not restart from the beginning.
  - Enhanced system configuration for handling JMS connections and event processing, allowing for more precise management of failover scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->