### PR TITLE
Fix Empty Body Issue and Ensure JSON Payload is Sent as String

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
@@ -141,24 +141,18 @@ public class AWSLambdaMediator extends AbstractMediator {
 
             String body = "{}";
             if (JsonUtil.hasAJsonPayload(axis2MessageContext)) {
-                String jsonPayload = JsonUtil.jsonPayloadToString(axis2MessageContext);
-                if (!isContentEncodingEnabled) {
-                    payload.add(BODY_PARAMETER, new JsonParser().parse(body).getAsJsonObject());
-                } else {
-                    payload.addProperty(BODY_PARAMETER, Base64.encodeBase64String(jsonPayload.getBytes()));
+                body = JsonUtil.jsonPayloadToString(axis2MessageContext);
+                if (isContentEncodingEnabled) {
+                    body = Base64.encodeBase64String(body.getBytes());
                 }
             } else {
                 String multipartContent = extractFormDataContent(axis2MessageContext);
                 if (StringUtils.isNotEmpty(multipartContent)) {
                     body = isContentEncodingEnabled ? Base64.encodeBase64String(multipartContent.getBytes()) :
                             multipartContent;
-                    payload.addProperty(BODY_PARAMETER, body);
-                } else {
-                    // If the request does not have a payload(as either a json payload or multipart content),
-                    // set an empty JSON object as the payload
-                    payload.add(BODY_PARAMETER, new JsonParser().parse(body).getAsJsonObject());
                 }
             }
+            payload.addProperty(BODY_PARAMETER, body);
             payload.addProperty(IS_BASE64_ENCODED_PARAMETER, isContentEncodingEnabled);
 
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Purpose

> - Fix the issue of sending an empty body when a JSON payload is available and ensure that the body is sent as a JSON string instead of a JSON object.
> - Fixes:
>   - https://github.com/wso2/api-manager/issues/3376
>   - https://github.com/wso2/api-manager/issues/3414

### Approach

> - Update the code to correctly send the JSON payload instead of an empty body and ensure the body is always sent as a string rather than a JSON object.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the handling of request payload bodies by simplifying how content types (e.g., JSON and multipart data) are processed. This update ensures that the correct body content is consistently included, resulting in improved reliability and predictable request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->