### PR TITLE
[Governance] Rename Default Ruleset, Policy and Fix Mssql Bug

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/APIGovernanceHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/APIGovernanceHandler.java
@@ -425,7 +425,7 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
                 return Files.readAllBytes(apiProject.toPath());
             } catch (APIManagementException | APIImportExportException | IOException e) {
                 throw new APIMGovernanceException(APIMGovExceptionCodes.ERROR_WHILE_GETTING_APIM_PROJECT, e,
-                        apiId);
+                        apiId, organization);
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/dao/constants/SQLConstants.java
@@ -302,7 +302,6 @@ public class SQLConstants {
                     "    WHERE GA.ARTIFACT_REF_ID = ? " +
                     "    AND GA.ARTIFACT_TYPE = ? " +
                     "    AND GA.ORGANIZATION = ? " +
-                    "    LIMIT 1" +
                     ")";
 
 

--- a/features/apimgt/org.wso2.carbon.apimgt.governance.feature/src/main/resources/default-policies/wso2_api_mgt_best_practices.yaml
+++ b/features/apimgt/org.wso2.carbon.apimgt.governance.feature/src/main/resources/default-policies/wso2_api_mgt_best_practices.yaml
@@ -5,13 +5,13 @@
 # herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
 # You may not alter or remove any copyright or other notice from copies of this content.
 
-name : WSO2 API Best Practices
-description: This policy enforces a set of best practices recommended by WSO2 for APIs on the WSO2 API Manager. This by default includes the WSO2 API Design Guidelines and WSO2 Style Guidelines.
+name: WSO2 API Management Best Practices
+description: This policy enforces a set of best practices recommended by WSO2 for APIs on the WSO2 API Manager.
 labels:
   - GLOBAL
 governableStates:
   - API_CREATE
   - API_UPDATE
 rulesetNames:
-  - WSO2 Rest API Design Guidelines
+  - WSO2 REST API Design Guidelines
   - WSO2 API Management Guidelines

--- a/features/apimgt/org.wso2.carbon.apimgt.governance.feature/src/main/resources/default-rulesets/wso2_rest_api_design_guidelines.yaml
+++ b/features/apimgt/org.wso2.carbon.apimgt.governance.feature/src/main/resources/default-rulesets/wso2_rest_api_design_guidelines.yaml
@@ -5,7 +5,7 @@
 # herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
 # You may not alter or remove any copyright or other notice from copies of this content.
 
-name: WSO2 Rest API Design Guidelines
+name: WSO2 REST API Design Guidelines
 description: >-
   A set of guidelines focused on enforcing uniformity in API style, including
   naming conventions, formatting, and documentation to ensure clarity and


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/api-manager/issues/3650

This pull request includes changes to improve naming consistency and remove unnecessary SQL constraints. The most important changes include renaming a YAML file and updating policy descriptions to ensure uniformity.

Improvements to naming consistency:

* [`features/apimgt/org.wso2.carbon.apimgt.governance.feature/src/main/resources/default-policies/wso2_api_mgt_best_practices.yaml`](diffhunk://#diff-92338162d33d48117f63b047181a9577c23af9348f285d214f2544330f39d8c8L8-R16): Renamed from `wso2_api_best_practices.yaml` and updated the policy name and description to reflect "WSO2 API Management Best Practices" and "WSO2 REST API Design Guidelines".
* [`features/apimgt/org.wso2.carbon.apimgt.governance.feature/src/main/resources/default-rulesets/wso2_rest_api_design_guidelines.yaml`](diffhunk://#diff-b40de1c36267962f22e34a595552bee0c06be6d9e5d35c8f71f86ea1b5182001L8-R8): Updated the ruleset name to "WSO2 REST API Design Guidelines" for consistency.

Codebase simplification:

* [`components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/dao/constants/SQLConstants.java`](diffhunk://#diff-ff52be4ac1cc716c3fd6bf5ade918a35aa37bab7a812206a98a93d51e387c4b0L305): Removed the unnecessary `LIMIT 1` constraint from the SQL query.