### PR TITLE
Fix Issue with Writing AI API-Related Properties to apim_metrics.log

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -428,12 +428,12 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
         org.apache.axis2.context.MessageContext axis2MessageContext =
                 ((Axis2MessageContext) messageContext).getAxis2MessageContext();
 
-        if (messageContext.getProperty("AI_API_RESPONSE_METADATA") != null) {
+        if (messageContext.getProperty(AIAPIConstants.AI_API_RESPONSE_METADATA) != null) {
             Object requestStartTimeObj = messageContext.getProperty(Constants.REQUEST_START_TIME_PROPERTY);
             long requestStartTime = requestStartTimeObj == null ? 0L : (long) requestStartTimeObj;
             int requestStartHour = getHourByUTC(requestStartTime);
             getAiAnalyticsData(
-                    (Map) messageContext.getProperty("AI_API_RESPONSE_METADATA"),
+                    (Map) messageContext.getProperty(AIAPIConstants.AI_API_RESPONSE_METADATA),
                     requestStartHour,
                     customProperties
             );

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -428,12 +428,12 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
         org.apache.axis2.context.MessageContext axis2MessageContext =
                 ((Axis2MessageContext) messageContext).getAxis2MessageContext();
 
-        if (axis2MessageContext.getProperty(AIAPIConstants.AI_API_RESPONSE_METADATA) != null) {
+        if (messageContext.getProperty("AI_API_RESPONSE_METADATA") != null) {
             Object requestStartTimeObj = messageContext.getProperty(Constants.REQUEST_START_TIME_PROPERTY);
             long requestStartTime = requestStartTimeObj == null ? 0L : (long) requestStartTimeObj;
             int requestStartHour = getHourByUTC(requestStartTime);
             getAiAnalyticsData(
-                    (Map) axis2MessageContext.getProperty(AIAPIConstants.AI_API_RESPONSE_METADATA),
+                    (Map) messageContext.getProperty("AI_API_RESPONSE_METADATA"),
                     requestStartHour,
                     customProperties
             );


### PR DESCRIPTION
## Purpose  

> AI API-related analytics are not presented in analytics dashboards because AI API-related properties are not written to `apim_metrics.log`. The issue was that the properties were accessed through `axis2MessageContext`, but they are no longer available there.  
>  
> Resolves: https://github.com/wso2/api-manager/issues/3700  

## Approach  

> AI API-related properties are available in `messageContext`. Hence, the code has been updated to access the properties from `messageContext` instead of `axis2MessageContext`.  