### PR TITLE
Fix product test failure

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -202,8 +202,7 @@ public class APIAdminImpl implements APIAdmin {
         validateForUniqueVhostNames(environment);
         Environment environmentToStore =  new Environment(environment);
         encryptGatewayConfigurationValues(null, environmentToStore);
-        apiMgtDAO.addEnvironment(tenantDomain, environmentToStore);
-        return environment;
+        return apiMgtDAO.addEnvironment(tenantDomain, environmentToStore);
     }
 
     @Override


### PR DESCRIPTION
Fixes a product apim test failure introduced with https://github.com/wso2/carbon-apimgt/pull/13006/files

- Have to return the added environment object back, otherwise the ID field will be empty.