### PR TITLE
Catch `OMException` type exception during operation policy migration

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/GlobalMediationPolicyImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/GlobalMediationPolicyImpl.java
@@ -2,6 +2,7 @@ package org.wso2.carbon.apimgt.impl;
 
 import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMException;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -98,13 +99,15 @@ public class GlobalMediationPolicyImpl {
                                     mediation.setType(resourceType);
                                     //Add mediation to the mediation list
                                     mediationList.add(mediation);
-                                } catch (XMLStreamException e) {
+                                } catch (XMLStreamException | OMException e) {
                                     //If any exception been caught flow may continue with the next mediation policy
                                     log.error("Error occurred while getting omElement out of " +
                                             "mediation content from " + sequence, e);
                                 } catch (IOException e) {
                                     log.error("Error occurred while converting resource " +
                                             "contentStream in to string in " + sequence, e);
+                                } catch (Exception e) {
+                                    log.error("An unexpected error occurred during mediation in " + sequence, e);
                                 }
                             }
                         }


### PR DESCRIPTION
## Purpose
In the previous implementation of operation policy migration, `OMException` was not handled, causing the API save functionality to be interrupted when encountering a corrupt mediation policy in the `in`, `out`, or `fault` directories. This occurred even if the corrupted policy was not assigned to the API.

This PR addresses the issue by logging a message when a corrupted mediation policy is detected, preventing it from disrupting the API save process. The details of the corrupted policy will be recorded in the logs.

<img width="1510" alt="Screenshot 2025-02-19 at 14 43 51" src="https://github.com/user-attachments/assets/49cef314-1b05-4394-8450-5ccdae8bac91" />

```
[2025-02-19 14:24:57,804] ERROR - GlobalMediationPolicyImpl Error occurred while getting omElement out of mediation content from /apimgt/customsequences/in/authorization_pipeline.xml
org.apache.axiom.om.OMException: com.ctc.wstx.exc.WstxUnexpectedCharException: Unexpected character 'l' (code 108) in prolog; expected '<'
 at [row,col {unknown-source}]: [1,1]
	at org.apache.axiom.om.impl.builder.StAXOMBuilder.next(StAXOMBuilder.java:296) ~[axiom_1.2.11.wso2v25.jar:?]
	at org.apache.axiom.om.impl.llom.OMDocumentImpl.getOMDocumentElement(OMDocumentImpl.java:109) ~[axiom_1.2.11.wso2v25.jar:?]
	at org.apache.axiom.om.impl.builder.StAXOMBuilder.getDocumentElement(StAXOMBuilder.java:570) ~[axiom_1.2.11.wso2v25.jar:?]
	at org.apache.axiom.om.impl.builder.StAXOMBuilder.getDocumentElement(StAXOMBuilder.java:566) ~[axiom_1.2.11.wso2v25.jar:?]
	at org.apache.axiom.om.util.AXIOMUtil.stringToOM(AXIOMUtil.java:55) ~[axiom_1.2.11.wso2v25.jar:?]
	at org.apache.axiom.om.util.AXIOMUtil.stringToOM(AXIOMUtil.java:39) ~[axiom_1.2.11.wso2v25.jar:?]
	at org.wso2.carbon.apimgt.impl.GlobalMediationPolicyImpl.getAllGlobalMediationPolicies_aroundBody0(GlobalMediationPolicyImpl.java:92) ~[org.wso2.carbon.apimgt.impl-9.28.116.284-SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.GlobalMediationPolicyImpl.getAllGlobalMediationPolicies(GlobalMediationPolicyImpl.java:1) ~[org.wso2.carbon.apimgt.impl-9.28.116.284-SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.APIProviderImpl.loadMediationPoliciesToAPI_aroundBody66(APIProviderImpl.java:1200) ~[org.wso2.carbon.apimgt.impl-9.28.116.284-SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.APIProviderImpl.loadMediationPoliciesToAPI(APIProviderImpl.java:1) ~[org.wso2.carbon.apimgt.impl-9.28.116.284-SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.UserAwareAPIProvider.loadMediationPoliciesToAPI(UserAwareAPIProvider.java:1) ~[org.wso2.carbon.apimgt.impl-9.28.116.284-SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.APIProviderImpl.migrateMediationPoliciesOfAPI_aroundBody72(APIProviderImpl.java:1395) ~[org.wso2.carbon.apimgt.impl-9.28.116.284-SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.APIProviderImpl.migrateMediationPoliciesOfAPI(APIProviderImpl.java:1) ~[org.wso2.carbon.apimgt.impl-9.28.116.284-SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.APIProviderImpl.updateAPI_aroundBody54(APIProviderImpl.java:838) ~[org.wso2.carbon.apimgt.impl-9.28.116.284-SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.APIProviderImpl.updateAPI(APIProviderImpl.java:1) ~[org.wso2.carbon.apimgt.impl-9.28.116.284-SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.UserAwareAPIProvider.updateAPI(UserAwareAPIProvider.java:1) ~[org.wso2.carbon.apimgt.impl-9.28.116.284-SNAPSHOT.jar:?]
```

In a case where the API is assigned with the corrupted mediation policy, the save process of the API will fail.

<img width="1510" alt="Screenshot 2025-02-19 at 14 35 24" src="https://github.com/user-attachments/assets/4ac18c69-05b1-4cfd-925c-412ded6c368b" />

## Issue
https://github.com/wso2/api-manager/issues/3576