### PR TITLE
Remove trialing `/` in resource during operation policy aggregation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -11484,6 +11484,20 @@ public final class APIUtil {
     }
 
     /**
+     * Removes all trailing slashes from the given URL string.
+     *
+     * @param url the URL string to process
+     * @return the URL string without trailing slashes; returns the original string if no trailing slashes are present
+     * @throws NullPointerException if the input URL is null
+     */
+    public static String trimTrailingSlashes(String url) {
+        while (url.endsWith("/")) {
+            url = url.substring(0, url.length() - 1);
+        }
+        return url;
+    }
+
+    /**
      * Get available tiers for organizations as a string.
      *
      * @param api API object

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
@@ -48,6 +48,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.wso2.carbon.apimgt.impl.utils.APIUtil.trimTrailingSlashes;
+
 /**
  * This class used to generate Synapse Artifact.
  */
@@ -154,6 +156,7 @@ public class SynapsePolicyAggregator {
 
         Map<String, Object> caseMap = new HashMap<>();
         String uriTemplateString = template.getUriTemplate();
+        uriTemplateString = trimTrailingSlashes(uriTemplateString);
         String method = template.getHTTPVerb();
         String key = method + "_" + uriTemplateString.replaceAll("[\\W]", "\\\\$0");
 


### PR DESCRIPTION
## Purpose
The current implementation does not handle trailing `/` in resources during operation policy aggregation, causing failures when enforcing an operation policies on such resources.
Ex: `/menu/`

This PR introduces functionality to properly handle and remove trailing `/` during operation policy aggregation, ensuring correct policy enforcement.

## Issue
https://github.com/wso2/api-manager/issues/3624