### PR TITLE
Fix Formatting Issue of SQL Query

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -2760,7 +2760,7 @@ public class SQLConstants {
     public static final String DELETE_ENVIRONMENT_SQL = "DELETE FROM AM_GATEWAY_ENVIRONMENT WHERE UUID = ?";
 
     public static final String UPDATE_ENVIRONMENT_SQL = "UPDATE AM_GATEWAY_ENVIRONMENT " +
-            "SET DISPLAY_NAME = ?, DESCRIPTION = ?, CONFIGURATION = ?" +
+            "SET DISPLAY_NAME = ?, DESCRIPTION = ?, CONFIGURATION = ? " +
             "WHERE UUID = ?";
 
     public static final String ADD_API_EXTERNAL_API_MAPPING_SQL = "INSERT INTO AM_API_EXTERNAL_API_MAPPING " +


### PR DESCRIPTION
### Purpose
- There is a issue as follows due to improper formatting of a SQL query when running with Postgres DB
```
org.postgresql.util.PSQLException: ERROR: trailing junk after parameter at or near "$3WHERE"
```
- This PR fix the formatting issue of the SQL query