### PR TITLE
Fix APIM Product Creation Bug with `allOf`

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java
@@ -884,6 +884,11 @@ public class OASParserUtil {
         if (os.getProperties() != null) {
             for (String propertyName : os.getProperties().keySet()) {
                 Schema propertySchema = os.getProperties().get(propertyName);
+
+                if (propertySchema.get$ref() != null) {
+                    references.add(propertySchema.get$ref());
+                }
+
                 if (propertySchema instanceof ComposedSchema) {
                     ComposedSchema cs = (ComposedSchema) propertySchema;
                     if (cs.getAllOf() != null) {


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/api-manager/issues/3453

This pull request includes an important change to the `OASParserUtil.java` file that enhances the handling of schema references in the `addSchemaOfSchema` method.

Enhancements to schema reference handling:

* [`components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OASParserUtil.java`](diffhunk://#diff-8a21aa587423ad2248a05927197442d9f98436f3997c52a507cd530c213258a8R887-R891): Added logic to check if a property schema has a `$ref` and, if so, add it to the `references` list. This ensures that all schema references are properly collected.