### PR TITLE
Update Spectral Linter Rulesets and Other Gov Bug Fixes

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.governance.api/src/main/java/org/wso2/carbon/apimgt/governance/api/service/APIMGovernanceService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.api/src/main/java/org/wso2/carbon/apimgt/governance/api/service/APIMGovernanceService.java
@@ -23,7 +23,10 @@ import org.wso2.carbon.apimgt.governance.api.model.APIMGovernableState;
 import org.wso2.carbon.apimgt.governance.api.model.ArtifactComplianceDryRunInfo;
 import org.wso2.carbon.apimgt.governance.api.model.ArtifactComplianceInfo;
 import org.wso2.carbon.apimgt.governance.api.model.ArtifactType;
+import org.wso2.carbon.apimgt.governance.api.model.ExtendedArtifactType;
+import org.wso2.carbon.apimgt.governance.api.model.RuleCategory;
 import org.wso2.carbon.apimgt.governance.api.model.RuleType;
+import org.wso2.carbon.apimgt.governance.api.model.Ruleset;
 
 import java.util.List;
 import java.util.Map;
@@ -118,4 +121,34 @@ public interface APIMGovernanceService {
      */
     void clearArtifactComplianceInfo(String artifactRefId, ArtifactType artifactType, String organization)
             throws APIMGovernanceException;
+
+
+    /**
+     * Get applicable rulesets for the artifact
+     *
+     * @param artifactRefId Artifact Reference ID (ID of artifact on APIM side)
+     * @param artifactType  Artifact type (ArtifactType.API)
+     * @param ruleType      Rule type (RuleType.API_DEFINITION)
+     * @param ruleCategory  Rule category (RuleCategory.SPECTRAL)
+     * @param organization  Organization
+     * @return List of Rulesets
+     * @throws APIMGovernanceException If an error occurs while getting the applicable rulesets
+     */
+    List<Ruleset> getApplicableRulesetsForArtifact(String artifactRefId, ArtifactType artifactType,
+                                                   RuleType ruleType, RuleCategory ruleCategory,
+                                                   String organization) throws APIMGovernanceException;
+
+    /**
+     * Get applicable rulesets by extended artifact type
+     *
+     * @param extendedArtifactType Extended artifact type (ExtendedArtifactType.REST_API)
+     * @param ruleType             Rule type (RuleType.API_DEFINITION)
+     * @param ruleCategory         Rule category (RuleCategory.SPECTRAL)
+     * @param organization         Organization
+     * @return List of Rulesets
+     * @throws APIMGovernanceException If an error occurs while getting the applicable rulesets
+     */
+    List<Ruleset> getApplicableRulesetsByExtendedArtifactType(ExtendedArtifactType extendedArtifactType,
+                                                              RuleType ruleType, RuleCategory ruleCategory,
+                                                              String organization) throws APIMGovernanceException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/PolicyManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/PolicyManager.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.apimgt.governance.impl;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.governance.api.error.APIMGovExceptionCodes;
 import org.wso2.carbon.apimgt.governance.api.error.APIMGovernanceException;
 import org.wso2.carbon.apimgt.governance.api.model.APIMGovernableState;
@@ -33,6 +35,7 @@ import org.wso2.carbon.apimgt.governance.impl.dao.impl.GovernancePolicyMgtDAOImp
 import org.wso2.carbon.apimgt.governance.impl.util.APIMGovernanceUtil;
 import org.wso2.carbon.apimgt.governance.impl.util.AuditLogger;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +47,7 @@ import java.util.regex.Pattern;
  */
 public class PolicyManager {
 
+    private static final Log log = LogFactory.getLog(PolicyManager.class);
     private final GovernancePolicyMgtDAO policyMgtDAO;
 
     public PolicyManager() {
@@ -251,7 +255,8 @@ public class PolicyManager {
     public List<Ruleset> getRulesetsWithContentByPolicyId(String policyId, String organization)
             throws APIMGovernanceException {
         if (policyMgtDAO.getGovernancePolicyByID(policyId, organization) == null) {
-            throw new APIMGovernanceException(APIMGovExceptionCodes.POLICY_NOT_FOUND, policyId);
+            log.warn("Policy not found for ID: " + policyId);
+            return new ArrayList<>();
         }
         return policyMgtDAO.getRulesetsWithContentByPolicyId(policyId, organization);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/PolicyManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/PolicyManager.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.apimgt.governance.api.model.APIMGovernanceActionType;
 import org.wso2.carbon.apimgt.governance.api.model.APIMGovernancePolicy;
 import org.wso2.carbon.apimgt.governance.api.model.APIMGovernancePolicyList;
 import org.wso2.carbon.apimgt.governance.api.model.RuleSeverity;
+import org.wso2.carbon.apimgt.governance.api.model.Ruleset;
 import org.wso2.carbon.apimgt.governance.api.model.RulesetInfo;
 import org.wso2.carbon.apimgt.governance.impl.dao.GovernancePolicyMgtDAO;
 import org.wso2.carbon.apimgt.governance.impl.dao.impl.GovernancePolicyMgtDAOImpl;
@@ -237,6 +238,22 @@ public class PolicyManager {
             throw new APIMGovernanceException(APIMGovExceptionCodes.POLICY_NOT_FOUND, policyId);
         }
         return policyMgtDAO.getRulesetsByPolicyId(policyId, organization);
+    }
+
+    /**
+     * Get the list of rulesets with content for a given policy
+     *
+     * @param policyId     Policy ID
+     * @param organization Organization
+     * @return List of rulesets with content
+     * @throws APIMGovernanceException If an error occurs while getting the rulesets
+     */
+    public List<Ruleset> getRulesetsWithContentByPolicyId(String policyId, String organization)
+            throws APIMGovernanceException {
+        if (policyMgtDAO.getGovernancePolicyByID(policyId, organization) == null) {
+            throw new APIMGovernanceException(APIMGovExceptionCodes.POLICY_NOT_FOUND, policyId);
+        }
+        return policyMgtDAO.getRulesetsWithContentByPolicyId(policyId, organization);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/main/java/org/wso2/carbon/apimgt/governance/rest/api/util/APIMGovernanceExceptionMapper.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/main/java/org/wso2/carbon/apimgt/governance/rest/api/util/APIMGovernanceExceptionMapper.java
@@ -24,16 +24,16 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.governance.api.error.APIMGovernanceException;
 import org.wso2.carbon.apimgt.governance.api.error.ErrorHandler;
 import org.wso2.carbon.apimgt.governance.rest.api.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.util.exception.GlobalThrowableMapper;
 
 import java.util.List;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 
 /**
  * This is the custom exception mapper for Governance.
  */
-public class APIMGovernanceExceptionMapper implements ExceptionMapper<Throwable> {
+public class APIMGovernanceExceptionMapper extends GlobalThrowableMapper {
 
     private static final Log log = LogFactory.getLog(APIMGovernanceExceptionMapper.class);
 
@@ -88,6 +88,6 @@ public class APIMGovernanceExceptionMapper implements ExceptionMapper<Throwable>
                         .build();
             }
         }
-        return null;
+        return super.toResponse(e);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/main/webapp/WEB-INF/beans.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/main/webapp/WEB-INF/beans.xml
@@ -38,12 +38,11 @@
         </jaxrs:serviceBeans>
         <jaxrs:providers>
             <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
-            <bean class="org.wso2.carbon.apimgt.governance.rest.api.util.APIMGovernanceExceptionMapper,"/>
-            <bean class="org.wso2.carbon.apimgt.rest.api.util.exception.GlobalThrowableMapper"/>
+            <bean class="org.wso2.carbon.apimgt.governance.rest.api.util.APIMGovernanceExceptionMapper"/>
             <ref bean="cors-filter"/>
         </jaxrs:providers>
         <jaxrs:properties>
-            <!-- This is added to catch interceptor level exceptions in GlobalThrowableMapper. -->
+            <!-- This is added to catch interceptor level exceptions in APIMGovernanceExceptionMapper. -->
             <entry key="map.cxf.interceptor.fault" value="true"/>
             <!-- This is added to restrict the size of attachments sent through the requests. -->
             <entry key="attachment-max-size" value="#{systemProperties['rest.api.admin.attachment.max.size'] != null ?

--- a/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/main/webapp/WEB-INF/web.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/src/main/webapp/WEB-INF/web.xml
@@ -50,7 +50,6 @@
             <param-value>
                 com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider,
                 org.wso2.carbon.apimgt.governance.rest.api.util.APIMGovernanceExceptionMapper,
-                org.wso2.carbon.apimgt.rest.api.util.exception.GlobalThrowableMapper,
                 org.apache.cxf.rs.security.cors.CrossOriginResourceSharingFilter(allowHeaders=Authorization
                 allowHeaders=X-WSO2-Tenant allowHeaders=content-type exposeHeaders=Content-Disposition
                 allowCredentials=true allowOrigins={systemProperties['rest.api.admin.allowed.origins']})

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/publisher-api.yaml
@@ -7675,6 +7675,17 @@ paths:
       description: |
         This operation can be used to get linter custom rules from tenant-config.
       operationId: getLinterCustomRules
+      parameters:
+        - name: apiId
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: apiType
+          in: query
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: |

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/LinterCustomRulesApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/LinterCustomRulesApi.java
@@ -49,7 +49,7 @@ LinterCustomRulesApiService delegate = new LinterCustomRulesApiServiceImpl();
         @ApiResponse(code = 403, message = "Forbidden. The request must be conditional but no condition has been specified.", response = ErrorDTO.class),
         @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
         @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
-    public Response getLinterCustomRules() throws APIManagementException{
-        return delegate.getLinterCustomRules(securityContext);
+    public Response getLinterCustomRules( @ApiParam(value = "")  @QueryParam("apiId") String apiId,  @ApiParam(value = "")  @QueryParam("apiType") String apiType) throws APIManagementException{
+        return delegate.getLinterCustomRules(apiId, apiType, securityContext);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/LinterCustomRulesApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/LinterCustomRulesApiService.java
@@ -20,5 +20,5 @@ import javax.ws.rs.core.SecurityContext;
 
 
 public interface LinterCustomRulesApiService {
-      public Response getLinterCustomRules(MessageContext messageContext) throws APIManagementException;
+      public Response getLinterCustomRules(String apiId, String apiType, MessageContext messageContext) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml
@@ -7675,6 +7675,17 @@ paths:
       description: |
         This operation can be used to get linter custom rules from tenant-config.
       operationId: getLinterCustomRules
+      parameters:
+        - name: apiId
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: apiType
+          in: query
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: |

--- a/features/apimgt/org.wso2.carbon.apimgt.governance.feature/src/main/resources/default-rulesets/wso2_rest_api_design_guidelines.yaml
+++ b/features/apimgt/org.wso2.carbon.apimgt.governance.feature/src/main/resources/default-rulesets/wso2_rest_api_design_guidelines.yaml
@@ -163,7 +163,7 @@ rulesetContent:
         - formats:
             - oas2
             - oas3
-            - oas3.0
+            - oas3_0
           given:
             - "$..[?(@ && @.type=='array')]"
 


### PR DESCRIPTION
## Purpose

This pull request introduces several new methods and changes to the API management governance service to support the retrieval of applicable rulesets for artifacts. Additionally, it updates the linter custom rules API to include parameters for filtering by API ID and API type.

These changes enhance the flexibility and functionality of the API management governance service by allowing more granular control and retrieval of rulesets based on specific artifact and API details.