### PR TITLE
Handle Ruleset Severity `null` Scenario

### DIFF
--- a/components/governance/org.wso2.carbon.apimgt.governance.engine/src/main/java/org/wso2/carbon/apimgt/governance/engine/SpectralValidationEngine.java
+++ b/components/governance/org.wso2.carbon.apimgt.governance.engine/src/main/java/org/wso2/carbon/apimgt/governance/engine/SpectralValidationEngine.java
@@ -123,8 +123,8 @@ public class SpectralValidationEngine implements ValidationEngine {
                 }
 
                 String severityString = (String) ruleDetails.get("severity");
-                RuleSeverity severity = RuleSeverity.fromString(severityString);
-                severity = severity == null ? RuleSeverity.WARN : severity;
+                RuleSeverity severity = severityString == null ? RuleSeverity.WARN :
+                        RuleSeverity.fromString(severityString);
 
                 ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
 


### PR DESCRIPTION
## Purpose

This pull request includes a change to the `extractRulesFromRuleset` method in the `SpectralValidationEngine.java` file. The change simplifies the assignment of the `severity` variable by combining the null check and the `fromString` method call into a single line.

* Simplified the assignment of the `severity` variable by combining the null check and the `fromString` method call in the `extractRulesFromRuleset` method in `SpectralValidationEngine.java`.