### PR TITLE
Bump synapse version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2137,7 +2137,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>4.0.0-wso2v218</synapse.version>
+        <synapse.version>4.0.0-wso2v221</synapse.version>
         <orbit.version.json>3.0.0.wso2v1</orbit.version.json>
 
         <!-- orbit httpmime versions-->


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/3772

Currently when invoking SSE APIs an error log is written `Throttle object cannot be null`. 

In Synapse, parts of the request context is passed to the response once we configure it in `passthrough-http.properties`, including the above `throttle_dto`. But after reading this file, the list of properties allowed to be passed from the request to the response was dropped. A fix was sent to wso2-synapse that will successfully pass the defined properties from the request to the response.

This fix will make APIM use the fixed version of wso2-synapse.