### PR TITLE
Ensure Organization Validation When Changing Application Ownership

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ApplicationsApiServiceImpl.java
@@ -220,11 +220,6 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
         return null;
     }
 
-    private static String[] getGroupIds(String loginInfoString) throws APIManagementException {
-        String groupingExtractorClass = APIUtil.getRESTApiGroupingExtractorImplementation();
-        return APIUtil.getGroupIdsFromExtractor(loginInfoString, groupingExtractorClass);
-    }
-
     private boolean isSameOrganization(String[] oldUserOrg, String[] newUserOrg) {
 
         return Arrays.stream(oldUserOrg)
@@ -236,6 +231,9 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
         userConfig.put("user", user);
         userConfig.put("isSuperTenant", tenantDomain.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME));
         String userConfigJSONString = userConfig.toJSONString();
-        return getGroupIds(userConfigJSONString);
+
+        String groupingExtractorClass = APIUtil.getRESTApiGroupingExtractorImplementation();
+
+        return APIUtil.getGroupIdsFromExtractor(userConfigJSONString, groupingExtractorClass);
     }
 }


### PR DESCRIPTION
### Purpose

- This PR addresses the issue where user organization validation was missing when changing application ownership.
- Resolves: https://github.com/wso2/api-manager/issues/3751

### Approach

When updating the application owner via the Admin Portal, the system now retrieves the organizations of both the existing owner and the new user. Ownership update will proceed only if **they share at least one common organization**; otherwise, an error response will be returned.