### PR TITLE
Introduce a config to continue backend JWT generation on user claim retrieval failure

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/jwt/JWTValidator.java
@@ -427,7 +427,7 @@ public class JWTValidator {
         return endUserToken;
     }
 
-    private void includeUserStoreClaimsIntoClaims(JWTInfoDto jwtInfoDto) {
+    private void includeUserStoreClaimsIntoClaims(JWTInfoDto jwtInfoDto) throws JWTGeneratorException {
 
         JWTInfoDto localJWTInfoDto = new JWTInfoDto(jwtInfoDto);
         Map<String, String> userClaimsFromKeyManager = getUserClaimsFromKeyManager(localJWTInfoDto);
@@ -859,7 +859,7 @@ public class JWTValidator {
 
         return CacheProvider.getGatewayJWTTokenCache();
     }
-    private Map<String, String> getUserClaimsFromKeyManager(JWTInfoDto jwtInfoDto) {
+    private Map<String, String> getUserClaimsFromKeyManager(JWTInfoDto jwtInfoDto) throws JWTGeneratorException {
 
         if (jwtConfigurationDto.isEnableUserClaimRetrievalFromUserStore()) {
             String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
@@ -881,7 +881,11 @@ public class JWTValidator {
                     try {
                         return keyManagerInstance.getUserClaims(jwtInfoDto.getEndUser(), properties);
                     } catch (APIManagementException e) {
-                        log.error("Error while retrieving User claims from Key Manager ", e);
+                        if (jwtConfigurationDto.isContinueOnClaimRetrievalFailure()) {
+                            log.error("Error while retrieving User Claims from Key Manager ", e);
+                        } else {
+                            throw new JWTGeneratorException("Error while retrieving User Claims from Key Manager", e);
+                        }
                     }
                 }
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/APIKeyValidatorClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/APIKeyValidatorClient.java
@@ -56,7 +56,7 @@ public class APIKeyValidatorClient {
         } catch (APIKeyMgtException | APIManagementException e) {
             log.error("Error while retrieving data from datastore", e);
             throw new APISecurityException(APISecurityConstants.API_AUTH_GENERAL_ERROR,
-                    "Error while retrieving data from datastore", e);
+                    e.getMessage(), e);
         }
 
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/WSAPIKeyDataStore.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/keys/WSAPIKeyDataStore.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.gateway.MethodStats;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityException;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dto.APIKeyValidationInfoDTO;
 import org.wso2.carbon.apimgt.keymgt.model.entity.Scope;
 import org.wso2.carbon.apimgt.keymgt.service.TokenValidationContext;
@@ -53,6 +54,10 @@ public class WSAPIKeyDataStore implements APIKeyDataStore {
             return client.getAPIKeyData(context, apiVersion, apiKey, requiredAuthenticationLevel,
                     matchingResource, httpVerb, tenantDomain, keyManagers);
         } catch (APISecurityException ex) {
+            if (ex.getMessage().equalsIgnoreCase(APIConstants.JWT_GENERATION_ERROR)) {
+                throw new APISecurityException(ex.getErrorCode(),
+                        APISecurityConstants.API_AUTH_GENERAL_ERROR_MESSAGE, ex);
+            }
             throw new APISecurityException(ex.getErrorCode(),
                     "Resource forbidden", ex);
         } catch (Exception e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1913,6 +1913,8 @@ public final class APIConstants {
     public static final String MSG_TIER_RET_ERROR = "Error while retrieving API tiers from registry";
     public static final String MSG_MALFORMED_XML_ERROR = "Malformed XML found in the API tier policy resource";
 
+    public static final String JWT_GENERATION_ERROR = "Error occurred while generating JWT";
+
     //Doc search related constants
 
     public static final String PUBLISHER_CLIENT = "Publisher";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -676,6 +676,7 @@ public final class APIConstants {
     public static final String VALUE = "value";
     public static final String GATEWAY_INTROSPECT_CACHE_NAME = "GatewayIntrospectCache";
     public static final String ENABLE_USER_CLAIMS_RETRIEVAL_FROM_KEY_MANAGER = "EnableUserClaimRetrievalFromKeyManager";
+    public static final String CONTINUE_ON_CLAIM_RETRIEVAL_FAILURE = "ContinueOnClaimRetrievalFailure";
 
     public static final String DELEM_COLON = ":";
     public static final String DELEM_COMMA = ",";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -1845,6 +1845,12 @@ public class APIManagerConfiguration {
                         }
                     }
                 }
+                OMElement continueOnCustomClaimRetrievalFailureElement =
+                        omElement.getFirstChildWithName(new QName(APIConstants.CONTINUE_ON_CLAIM_RETRIEVAL_FAILURE));
+                if (continueOnCustomClaimRetrievalFailureElement != null) {
+                    jwtConfigurationDto.setContinueOnClaimRetrievalFailure(
+                            Boolean.parseBoolean(continueOnCustomClaimRetrievalFailureElement.getText()));
+                }
                 OMElement enableBase64PaddingElement = gatewayJWTConfigurationElement.getFirstChildWithName(
                         new QName(APIConstants.ENABLE_BASE64_PADDING));
                 if (enableBase64PaddingElement != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ExtendedJWTConfigurationDto.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ExtendedJWTConfigurationDto.java
@@ -6,6 +6,7 @@ public class ExtendedJWTConfigurationDto extends JWTConfigurationDto {
     private String jwtGeneratorImplClass = "org.wso2.carbon.apimgt.keymgt.token.JWTGenerator";
     private String claimRetrieverImplClass;
     private boolean tenantBasedSigningEnabled;
+    private boolean continueOnClaimRetrievalFailure;
     private boolean enableUserClaimRetrievalFromUserStore;
     private boolean isBindFederatedUserClaims;
     private boolean isJWKSApiEnabled;
@@ -48,6 +49,14 @@ public class ExtendedJWTConfigurationDto extends JWTConfigurationDto {
     public boolean isEnableUserClaimRetrievalFromUserStore() {
 
         return enableUserClaimRetrievalFromUserStore;
+    }
+
+    public boolean isContinueOnClaimRetrievalFailure() {
+        return continueOnClaimRetrievalFailure;
+    }
+
+    public void setContinueOnClaimRetrievalFailure(boolean continueOnClaimRetrievalFailure) {
+        this.continueOnClaimRetrievalFailure = continueOnClaimRetrievalFailure;
     }
 
     public boolean isBindFederatedUserClaims() {

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/AbstractKeyValidationHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/AbstractKeyValidationHandler.java
@@ -133,17 +133,20 @@ public abstract class AbstractKeyValidationHandler implements KeyValidationHandl
     @Override
     public boolean generateConsumerToken(TokenValidationContext validationContext) throws APIKeyMgtException {
 
-
+        String jwt;
         try {
-            String jwt = getCachedJWTToken(validationContext);
-            validationContext.getValidationInfoDTO().setEndUserToken(jwt);
-            return true;
-
+            jwt = getCachedJWTToken(validationContext);
         } catch (APIManagementException e) {
-            log.error("Error occurred while generating JWT. ", e);
+            if (!(ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration()
+                    .getJwtConfigurationDto().isContinueOnClaimRetrievalFailure())) {
+                throw new APIKeyMgtException("Error occurred while generating JWT", e);
+            } else {
+                log.error("Error occurred while generating JWT. ", e);
+                return false;
+            }
         }
-
-        return false;
+        validationContext.getValidationInfoDTO().setEndUserToken(jwt);
+        return true;
     }
 
     private String getCachedJWTToken(TokenValidationContext validationContext) throws APIManagementException {

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/AbstractKeyValidationHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/handlers/AbstractKeyValidationHandler.java
@@ -133,16 +133,15 @@ public abstract class AbstractKeyValidationHandler implements KeyValidationHandl
     @Override
     public boolean generateConsumerToken(TokenValidationContext validationContext) throws APIKeyMgtException {
 
-        String jwt;
+        String jwt = null;
         try {
             jwt = getCachedJWTToken(validationContext);
         } catch (APIManagementException e) {
             if (!(ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration()
                     .getJwtConfigurationDto().isContinueOnClaimRetrievalFailure())) {
-                throw new APIKeyMgtException("Error occurred while generating JWT", e);
+                throw new APIKeyMgtException(APIConstants.JWT_GENERATION_ERROR, e);
             } else {
                 log.error("Error occurred while generating JWT. ", e);
-                return false;
             }
         }
         validationContext.getValidationInfoDTO().setEndUserToken(jwt);

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -32,6 +32,7 @@
   "apim.jwt.encode_x5t_without_padding": false,
   "apim.jwt.enable_tenant_based_signing": false,
   "apim.jwt.gateway_generator.enable_claim_retrieval": false,
+  "apim.jwt.continue_on_claim_retrieval_failure": true,
   "apim.jwt.binding_federated_user_claims": false,
   "apim.hashing.hashing_algorithm": "SHA-256",
   "apim.cache.gateway_token.enable": true,

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -86,6 +86,8 @@
         <!-- This parameter specifies which implementation should be used for generating the Token. For URL safe JWT
              Token generation the implementation is provided in URLSafeJWTGenerator -->
         <!--<JWTGeneratorImpl>org.wso2.carbon.apimgt.keymgt.token.URLSafeJWTGenerator</JWTGeneratorImpl>-->
+        <ContinueOnClaimRetrievalFailure>{{apim.jwt.continue_on_claim_retrieval_failure}}</ContinueOnClaimRetrievalFailure>
+
        {% if apim.jwt.enable_tenant_based_signing is defined %}
         <EnableTenantBasedSigning>{{apim.jwt.enable_tenant_based_signing}}</EnableTenantBasedSigning>
         {% endif %}


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/3816

### Config
```apim.jwt.continue_on_claim_retrieval_failure``` was newly introduced. This is true by default.
Following is a sample usage : 
```
[apim.jwt]
enable = true
enable_user_claims = true
gateway_generator.enable_claim_retrieval=true
continue_on_claim_retrieval_failure = false

```
### Response Codes
When the config enabled,
invocations providing JWT token when exception is thrown during user claim retrieval. (HTTP status code - 401): 
```{
  "code": "900900",
  "message": "Unclassified Authentication Failure",
  "description": "Unclassified Authentication Failure"
}
```

Invocations providing Opaque token : 
```
{
  "code": "900900",
  "message": "Unclassified Authentication Failure",
  "description": "Resource forbidden"
}
```
