### PR TITLE
Add mandatory property validation to API import flow

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -122,6 +122,7 @@ public enum ExceptionCodes implements ErrorHandler {
     CANNOT_CREATE_API_VERSION(900362, "New API Version cannot be created from a different provider", 409, "Initial provider of an API must be preserved in all versions of that API"),
     INTERNAL_ERROR_WHILE_UPDATING_API(900363, "Internal Server Error occurred while updating the API", 500, "Internal Server Error. '%s'"),
     ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES(903010, "Error while updating required properties", 400, "Error while updating required properties."),
+    ERROR_WHILE_VALIDATING_MANDATORY_PROPERTIES(903015, "Error while validating required properties", 400, "Error while validating required properties."),
 
     //Lifecycle related codes
     API_UPDATE_FORBIDDEN_PER_LC(900380, "Insufficient permission to update the API", 403,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -3343,21 +3343,6 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             boolean isApiProduct = apiTypeWrapper.isAPIProduct();
             String workflowType;
 
-            if (!apiTypeWrapper.isAPIProduct()){
-                // validate custom API properties
-                if (StringUtils.equals(action, APIConstants.LC_PUBLISH_LC_STATE)) {
-                    org.json.simple.JSONArray customProperties = APIUtil.getCustomProperties(this.tenantDomain);
-                    List<String> errorProperties = APIUtil.validateMandatoryProperties(customProperties,
-                            apiTypeWrapper.getApi().getAdditionalProperties());
-
-                    if (!errorProperties.isEmpty()) {
-                        String errorString = " : " + String.join(", ", errorProperties);
-                        throw new APIManagementException(errorString, ExceptionCodes.from(ExceptionCodes
-                                .ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES));
-                    }
-                }
-            }
-
             if (isApiProduct) {
                 APIProduct apiProduct = apiTypeWrapper.getApiProduct();
                 providerName = apiProduct.getId().getProviderName();
@@ -3370,6 +3355,19 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 apiOrApiProductId = apiMgtDAO.getAPIProductId(apiTypeWrapper.getApiProduct().getId());
                 workflowType = WorkflowConstants.WF_TYPE_AM_API_PRODUCT_STATE;
             } else {
+                // validate mandatory API properties
+                if (StringUtils.equals(action, APIConstants.LC_PUBLISH_LC_STATE)) {
+                    org.json.simple.JSONArray customProperties = APIUtil.getCustomProperties(this.tenantDomain);
+                    List<String> errorProperties = APIUtil.validateMandatoryProperties(customProperties,
+                            apiTypeWrapper.getApi().getAdditionalProperties());
+
+                    if (!errorProperties.isEmpty()) {
+                        String errorString = " : " + String.join(", ", errorProperties);
+                        throw new APIManagementException(errorString, ExceptionCodes.from(ExceptionCodes
+                                .ERROR_WHILE_VALIDATING_MANDATORY_PROPERTIES));
+                    }
+                }
+
                 API api = apiTypeWrapper.getApi();
                 providerName = api.getId().getProviderName();
                 apiName = api.getId().getApiName();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -3343,6 +3343,21 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             boolean isApiProduct = apiTypeWrapper.isAPIProduct();
             String workflowType;
 
+            if (!apiTypeWrapper.isAPIProduct()){
+                // validate custom API properties
+                if (StringUtils.equals(action, APIConstants.LC_PUBLISH_LC_STATE)) {
+                    org.json.simple.JSONArray customProperties = APIUtil.getCustomProperties(this.tenantDomain);
+                    List<String> errorProperties = APIUtil.validateMandatoryProperties(customProperties,
+                            apiTypeWrapper.getApi().getAdditionalProperties());
+
+                    if (!errorProperties.isEmpty()) {
+                        String errorString = " : " + String.join(", ", errorProperties);
+                        throw new APIManagementException(errorString, ExceptionCodes.from(ExceptionCodes
+                                .ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES));
+                    }
+                }
+            }
+
             if (isApiProduct) {
                 APIProduct apiProduct = apiTypeWrapper.getApiProduct();
                 providerName = apiProduct.getId().getProviderName();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -11620,7 +11620,7 @@ public final class APIUtil {
     /**
      * This method is used to validate the mandatory custom properties of an API
      *
-     * @param customProperties custom properties of the API
+     * @param customProperties        custom properties of the API
      * @param additionalPropertiesMap additional properties to validate
      * @return list of erroneous property names. returns an empty array if there are no errors.
      */

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3670,8 +3670,6 @@ public class ApisApiServiceImpl implements ApisApiService {
             } else if (isAuthorizationFailure(e)) {
                 RestApiUtil.handleAuthorizationFailure(
                         "Authorization failure while updating the lifecycle of API " + apiId, e, log);
-            } else if (e.getErrorHandler().getErrorCode() == ExceptionCodes.ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES.getErrorCode()) {
-                RestApiUtil.handleBadRequest(e.getErrorHandler().getErrorDescription() + " on API " + apiId, e, log);
             } else {
                 throw e;
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -975,7 +975,7 @@ public class ApisApiServiceImpl implements ApisApiService {
             }
 
             // validate custom properties
-            org.json.simple.JSONArray customProperties = APIUtil.getCustomProperties(username);
+            org.json.simple.JSONArray customProperties = APIUtil.getCustomProperties(organization);
             List<String> errorProperties = PublisherCommonUtils.validateMandatoryProperties(customProperties, body);
             if (!errorProperties.isEmpty()) {
                 String errorString = " : " + String.join(", ", errorProperties);
@@ -3670,6 +3670,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             } else if (isAuthorizationFailure(e)) {
                 RestApiUtil.handleAuthorizationFailure(
                         "Authorization failure while updating the lifecycle of API " + apiId, e, log);
+            } else if (e.getErrorHandler().getErrorCode() == ExceptionCodes.ERROR_WHILE_UPDATING_MANDATORY_PROPERTIES.getErrorCode()) {
+                RestApiUtil.handleBadRequest(e.getErrorHandler().getErrorDescription() + " on API " + apiId, e, log);
             } else {
                 throw e;
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/SettingsApiServiceImpl.java
@@ -56,7 +56,7 @@ public class SettingsApiServiceImpl implements SettingsApiService {
             SettingsDTO settingsDTO = settingsMappingUtil.fromSettingstoDTO(isUserAvailable, organization);
             settingsDTO.setScopes(getScopeList());
             settingsDTO.setGatewayTypes(APIUtil.getGatewayTypes());
-            settingsDTO.setCustomProperties(APIUtil.getCustomProperties(username));
+            settingsDTO.setCustomProperties(APIUtil.getCustomProperties(organization));
             return Response.ok().entity(settingsDTO).build();
         } catch (APIManagementException | IOException e) {
             String errorMessage = "Error while retrieving Publisher Settings";


### PR DESCRIPTION
### Purpose
Adds mandatory API property validation when importing an API to the Publisher Portal.
Previously, mandatory properties were only validated when updating an API.

Ensures mandatory property validation happens at the rest api level when changing the lifecycle status to Publish. Previously, this was only validated from the UI.

### Approach
Validated mandatory properties when updating an API's lifecycle status to Publish.
This ensures that mandatory properties are validated when both importing and changing lifecycle status.

Related public issue: https://github.com/wso2/api-manager/issues/3568