### PR TITLE
Fix XML Schema validation not working for Soap APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -471,7 +471,13 @@ public class GatewayUtils {
             bufferedInputStream = new BufferedInputStream(pipe.getInputStream());
         }
         inputStreamMap = new HashMap<>();
-        String contentType = axis2MC.getProperty(ThreatProtectorConstants.CONTENT_TYPE).toString();
+        String contentType;
+        Object contentTypeObject = axis2MC.getProperty(ThreatProtectorConstants.CONTENT_TYPE);
+        if (contentTypeObject != null) {
+            contentType = contentTypeObject.toString();
+        } else {
+            contentType = axis2MC.getProperty(ThreatProtectorConstants.SOAP_CONTENT_TYPE).toString();
+        }
 
         if (bufferedInputStream != null) {
             bufferedInputStream.mark(0);


### PR DESCRIPTION
### Purpose:
Fix the error in XML Schema Validation for Soap APIs, which occurs due to the incorrect retrieval of the Content-Type property. For Soap APIs, this is retrieved as null.

For Rest APIs Content-Type is correctly retrieved and therefore the XML validation works as expected.

### Approach:
Modified the code to get the correct property for Content-Type when it is null.

Fix: https://github.com/wso2/api-manager/issues/3596