### PR TITLE
Make transport cleanup configurable

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -180,6 +180,7 @@ public class APIMgtGatewayConstants {
     public static final String OAUTH_ENDPOINT_INSTANCE = "oauth.instance";
     public static final String VALIDATED_X509_CERT = "ValidatedX509Cert";
     public static final String RESOURCE_SPAN = "API:Resource";
+    public static final String AUTO_TRANSPORT_OPERATION_CLEANUP = "autoTransportOperationCleanUp";
 
     /**
      * Web-sub related properties

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthCredentialValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/basicauth/BasicAuthCredentialValidator.java
@@ -27,6 +27,7 @@ import org.apache.synapse.MessageContext;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.RESTConstants;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.MethodStats;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APIKeyValidator;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityConstants;
@@ -94,6 +95,11 @@ public class BasicAuthCredentialValidator {
             Options options = client.getOptions();
             options.setCallTransportCleanup(true);
             options.setManageSession(true);
+            if (System.getProperty(APIMgtGatewayConstants.AUTO_TRANSPORT_OPERATION_CLEANUP) != null) {
+                options.setProperty(ServiceClient.AUTO_OPERATION_CLEANUP,
+                        Boolean.parseBoolean(
+                                System.getProperty(APIMgtGatewayConstants.AUTO_TRANSPORT_OPERATION_CLEANUP)));
+            }
             CarbonUtils.setBasicAccessSecurityHeaders(username, password, client);
         } catch (AxisFault axisFault) {
             throw new APISecurityException(APISecurityConstants.API_AUTH_GENERAL_ERROR, axisFault.getMessage(), axisFault);


### PR DESCRIPTION
Fix: https://github.com/wso2/api-manager/issues/3806

Make the auto-cleanup process configurable by introducing a system property, `autoTransportOperationCleanUp`. You can control whether to enable the auto-cleanup process when starting the API-M. Setting this property to false will disable the auto-cleanup mechanism.

ex. ./wso2server.sh -DautoTransportOperationCleanUp=false