### PR TITLE
Fix incorrect gateway URL port (-1) in Dev Portal when custom tenant URL is used with HTTP-only APIs.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -3599,10 +3599,21 @@ APIConstants.AuditLogConstants.DELETED, this.username);
         String organization = api.getOrganization();
         if (!domains.isEmpty()) {
             String customUrl = domains.get(APIConstants.CUSTOM_URL);
-            if (customUrl.startsWith(APIConstants.HTTP_PROTOCOL_URL_PREFIX)) {
-                hostsWithSchemes.put(APIConstants.HTTP_PROTOCOL, customUrl);
-            } else {
-                hostsWithSchemes.put(APIConstants.HTTPS_PROTOCOL, customUrl);
+            if (customUrl != null) {
+                boolean isHttp = customUrl.startsWith(APIConstants.HTTP_PROTOCOL_URL_PREFIX);
+                boolean isHttps = customUrl.startsWith(APIConstants.HTTPS_PROTOCOL_URL_PREFIX);
+
+                if (!isHttp && !isHttps) {
+                    hostsWithSchemes.put(APIConstants.HTTP_PROTOCOL, customUrl);
+                    hostsWithSchemes.put(APIConstants.HTTPS_PROTOCOL, customUrl);
+                } else {
+                    if (isHttp) {
+                        hostsWithSchemes.put(APIConstants.HTTP_PROTOCOL, customUrl);
+                    }
+                    if (isHttps) {
+                        hostsWithSchemes.put(APIConstants.HTTPS_PROTOCOL, customUrl);
+                    }
+                }
             }
         } else {
             Map<String, Environment> allEnvironments = APIUtil.getEnvironments(organization);


### PR DESCRIPTION
###  Scenario

This issue occurs when:
- A tenant has a **custom gateway domain** configured (e.g., via registry path `/customurl/api-cloud/...`)
- An API is created under that tenant with **only HTTP transport enabled**

As a result:
- The Dev Portal shows a incorrect gateway URL like `http://example.com:-1/context/version`
- The **Try Out** page fails to load because the Swagger API call returns incomplete server details (missing gateway URLs)

###  Fix

- Fixes the `-1` port issue by correctly setting the port.
- Fixes Swagger server URL generation by determining the correct transport protocol (HTTP or HTTPS) based on the API’s transport level security.

Related Issue: [wso2/api-manager#3819](https://github.com/wso2/api-manager/issues/3819)