### PR TITLE
Update the queries to get all valid webhook subscriptions.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -3845,16 +3845,12 @@ public class SQLConstants {
                         "APP.APPLICATION_TIER AS APPLICATION_TIER, " +
                         "SUBSCRIBER.USER_ID AS SUBSCRIBER, " +
                         "SUBSCRIBER.TENANT_ID AS TENANT_ID " +
-                        "FROM AM_WEBHOOKS_SUBSCRIPTION WH, " +
-                        "AM_API API, " +
-                        "AM_SUBSCRIPTION SUB, " +
-                        "AM_APPLICATION APP, " +
-                        "AM_SUBSCRIBER SUBSCRIBER " +
-                        "WHERE WH.EXPIRY_AT >= ? AND WH.TENANT_DOMAIN = ? " +
-                        "AND API.API_ID = SUB.API_ID " +
-                        "AND WH.APPLICATION_ID = SUB.APPLICATION_ID " +
-                        "AND API.API_UUID = WH.API_UUID " +
-                        "AND APP.SUBSCRIBER_ID = SUBSCRIBER.SUBSCRIBER_ID ";
+                        "FROM AM_WEBHOOKS_SUBSCRIPTION WH " +
+                        "JOIN AM_SUBSCRIPTION SUB ON WH.APPLICATION_ID = SUB.APPLICATION_ID " +
+                        "JOIN AM_API API ON API.API_ID = SUB.API_ID AND API.API_UUID = WH.API_UUID " +
+                        "JOIN AM_APPLICATION APP ON WH.APPLICATION_ID = APP.APPLICATION_ID " +
+                        "JOIN AM_SUBSCRIBER SUBSCRIBER ON APP.SUBSCRIBER_ID = SUBSCRIBER.SUBSCRIBER_ID " +
+                        "WHERE (WH.EXPIRY_AT >= ? OR WH.EXPIRY_AT = 0) AND WH.TENANT_DOMAIN = ? ";
 
         public static final String GET_ALL_VALID_SUBSCRIPTIONS_POSTGRE_SQL =
                 "SELECT WH.API_UUID AS API_UUID, " +
@@ -3871,16 +3867,12 @@ public class SQLConstants {
                         "APP.APPLICATION_TIER AS APPLICATION_TIER, " +
                         "SUBSCRIBER.USER_ID AS SUBSCRIBER, " +
                         "SUBSCRIBER.TENANT_ID AS TENANT_ID " +
-                        "FROM AM_WEBHOOKS_SUBSCRIPTION WH, " +
-                        "AM_API API, " +
-                        "AM_SUBSCRIPTION SUB, " +
-                        "AM_APPLICATION APP, " +
-                        "AM_SUBSCRIBER SUBSCRIBER " +
-                        "WHERE WH.EXPIRY_AT >= ? AND WH.TENANT_DOMAIN = ? " +
-                        "AND API.API_ID = SUB.API_ID " +
-                        "AND WH.APPLICATION_ID::integer = SUB.APPLICATION_ID " +
-                        "AND API.API_UUID = WH.API_UUID " +
-                        "AND APP.SUBSCRIBER_ID = SUBSCRIBER.SUBSCRIBER_ID ";
+                        "FROM AM_WEBHOOKS_SUBSCRIPTION WH " +
+                        "JOIN AM_SUBSCRIPTION SUB ON CAST(WH.APPLICATION_ID AS INTEGER) = SUB.APPLICATION_ID " +
+                        "JOIN AM_API API ON API.API_ID = SUB.API_ID AND API.API_UUID = WH.API_UUID " +
+                        "JOIN AM_APPLICATION APP ON CAST(WH.APPLICATION_ID AS INTEGER) = APP.APPLICATION_ID " +
+                        "JOIN AM_SUBSCRIBER SUBSCRIBER ON APP.SUBSCRIBER_ID = SUBSCRIBER.SUBSCRIBER_ID " +
+                        "WHERE (WH.EXPIRY_AT >= ? OR WH.EXPIRY_AT = 0) AND WH.TENANT_DOMAIN = ? ";
 
         public static final String UPDATE_DELIVERY_STATE =
                 "UPDATE AM_WEBHOOKS_SUBSCRIPTION SET DELIVERED_AT = ?, DELIVERY_STATE = ? WHERE API_UUID = ? AND " +


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/3809

Replace the cartesian products and the conditions with joins to fix the issue where the same result is returned multiple times.

Add a clause to include subscriptions with an expiry time of 0, since they never expire.