### PR TITLE
Fix Analytics Throttle Event Publishing and responseSize Calculation in WebSocket Messages

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/FaultyRequestDataCollector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/FaultyRequestDataCollector.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.apimgt.common.analytics.exceptions.DataNotFoundException;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.API;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Event;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.MetaInfo;
+import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Operation;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Target;
 
 /**
@@ -83,6 +84,7 @@ public class FaultyRequestDataCollector extends CommonRequestDataCollector imple
         API api = provider.getApi();
         Target target = new Target();
         target.setTargetResponseCode(Constants.UNKNOWN_INT_VALUE);
+        Operation operation = provider.getOperation();
         MetaInfo metaInfo = provider.getMetaInfo();
         String userIp = provider.getEndUserIP();
         if (userIp == null) {
@@ -93,6 +95,7 @@ public class FaultyRequestDataCollector extends CommonRequestDataCollector imple
         event.setTarget(target);
         event.setProxyResponseCode(provider.getProxyResponseCode());
         event.setRequestTimestamp(offsetDateTime);
+        event.setOperation(operation);
         event.setMetaInfo(metaInfo);
         event.setUserIp(userIp);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java
@@ -126,7 +126,6 @@ public class WebsocketHandler extends CombinedChannelDuplexHandler<WebsocketInbo
                     log.debug(channelId + " -- Websocket API request [outbound] : Sending Outbound Websocket frame." +
                             ctx.channel().toString());
                 }
-                outboundHandler().write(ctx, msg, promise);
                 if (APIUtil.isAnalyticsEnabled()) {
                     WebSocketUtils.setApiPropertyToChannel(ctx, Constants.BACKEND_END_TIME_PROPERTY,
                             System.currentTimeMillis());
@@ -135,6 +134,7 @@ public class WebsocketHandler extends CombinedChannelDuplexHandler<WebsocketInbo
                                 ((TextWebSocketFrame) msg).text().length());
                     }
                 }
+                outboundHandler().write(ctx, msg, promise);
                 // publish analytics events if analytics is enabled
                 publishSubscribeEvent(ctx);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -594,8 +594,8 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
         }
     }
 
-    public int getResponseSize() {
-        int responseSize = 0;
+    public long getResponseSize() {
+        long responseSize = 0L;
         if (buildResponseMessage == null) {
             Map<String,String> configs = APIManagerConfiguration.getAnalyticsProperties();
             if (configs.containsKey(Constants.BUILD_RESPONSE_MESSAGE_CONFIG)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketAnalyticsDataProvider.java
@@ -322,8 +322,7 @@ public class WebSocketAnalyticsDataProvider implements AnalyticsDataProvider {
         }
         customProperties.put(Constants.API_USER_NAME_KEY, getUserName());
         customProperties.put(Constants.API_CONTEXT_KEY, getApiContext());
-        customProperties.put(Constants.RESPONSE_SIZE,
-                WebSocketUtils.getPropertyFromChannel(Constants.RESPONSE_SIZE, ctx));
+        customProperties.put(Constants.RESPONSE_SIZE, getResponseSize());
         return customProperties;
     }
     
@@ -373,5 +372,10 @@ public class WebSocketAnalyticsDataProvider implements AnalyticsDataProvider {
                 (long) WebSocketUtils.getPropertyFromChannel(Constants.BACKEND_START_TIME_PROPERTY, ctx) == 0 &&
                         WebSocketUtils.getPropertyFromChannel(Constants.REQUEST_START_TIME_PROPERTY, ctx) != null &&
                         WebSocketUtils.getPropertyFromChannel(Constants.REQUEST_END_TIME_PROPERTY, ctx) != null);
+    }
+
+    private long getResponseSize() {
+        Object responseSize = WebSocketUtils.getPropertyFromChannel(Constants.RESPONSE_SIZE, ctx);
+        return responseSize == null ? 0L : ((Number) responseSize).longValue();
     }
 }


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/api-manager/issues/3811
This pull request includes several changes to enhance the analytics data collection and processing in the API management gateway. The most important changes include adding a new `Operation` field to the `FaultyRequestDataCollector`, fixing the order of method calls in `WebsocketHandler`, and updating the response size data type and retrieval method.

Enhancements to analytics data collection:

* [`components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/FaultyRequestDataCollector.java`](diffhunk://#diff-c3b3b1646fc318a345bf8564513fd8f2ffc9d4c2243537ed0fc0d81ecf74191dR35): Added `Operation` field to the `Event` object to capture more detailed analytics data. [[1]](diffhunk://#diff-c3b3b1646fc318a345bf8564513fd8f2ffc9d4c2243537ed0fc0d81ecf74191dR35) [[2]](diffhunk://#diff-c3b3b1646fc318a345bf8564513fd8f2ffc9d4c2243537ed0fc0d81ecf74191dR87) [[3]](diffhunk://#diff-c3b3b1646fc318a345bf8564513fd8f2ffc9d4c2243537ed0fc0d81ecf74191dR98)

Bug fixes and improvements:

* [`components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/WebsocketHandler.java`](diffhunk://#diff-2c214d8b50f0d187c7d79f4579a772835a57f83c02802470b7477707b40c3ad3L129): Fixed the order of `outboundHandler().write` method call to ensure proper handling of outbound WebSocket frames. [[1]](diffhunk://#diff-2c214d8b50f0d187c7d79f4579a772835a57f83c02802470b7477707b40c3ad3L129) [[2]](diffhunk://#diff-2c214d8b50f0d187c7d79f4579a772835a57f83c02802470b7477707b40c3ad3R137)
* [`components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java`](diffhunk://#diff-9aa5ba13d787ed6cb131be88887fc3c7da66f86cf235cfa4abcbe06ba389a9c4L597-R598): Changed the return type of `getResponseSize` from `int` to `long` to handle larger response sizes.
* [`components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketAnalyticsDataProvider.java`](diffhunk://#diff-7fb93260a287896107a724a21d157ce83e68cc9d62a264c06262b3530be45a88L325-R325): Updated the method to retrieve response size directly using a new `getResponseSize` method. [[1]](diffhunk://#diff-7fb93260a287896107a724a21d157ce83e68cc9d62a264c06262b3530be45a88L325-R325) [[2]](diffhunk://#diff-7fb93260a287896107a724a21d157ce83e68cc9d62a264c06262b3530be45a88R376-R380)