### PR TITLE
Fix API Export-Import Error Due to Migrated Mediation Policies and Fix Gateway Vendor Retrieval for "Null" vendor

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1520,7 +1520,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     }
                 }
             } catch (MediationPolicyPersistenceException e) {
-                throw new APIManagementException("Error while loading medation policies", e);
+                throw new APIManagementException("Error while loading mediation policies", e);
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -1232,7 +1232,7 @@ public abstract class AbstractAPIManager implements APIManager {
         int internalId = apiMgtDAO.getAPIID(currentApiUuid);
         apiId.setId(internalId);
         apiMgtDAO.setServiceStatusInfoToAPI(api, internalId);
-        if (api.getGatewayVendor() == null) {
+        if (api.getGatewayVendor() == null || "null".equals(api.getGatewayVendor())) {
             String gatewayVendor = apiMgtDAO.getGatewayVendorByAPIUUID(uuid);
             if (gatewayVendor == null) {
                 gatewayVendor = APIConstants.WSO2_GATEWAY_ENVIRONMENT;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10962,11 +10962,16 @@ public final class APIUtil {
 
     /**
      * Replaces wso2/apk gateway vendor type as wso2 after retrieving from db.
+     * For synapse gateway type it returns as "wso2"
+     * For other types it returns as "external"
      *
      * @param gatewayVendor Gateway vendor type
      * @return wso2 gateway vendor type
      */
     public static String handleGatewayVendorRetrieval(String gatewayVendor) {
+        if (gatewayVendor == null) {
+            return null; // Return null to handle this scenario while populating API information
+        }
         if (APIConstants.WSO2_APK_GATEWAY.equals(gatewayVendor) ||
                 APIConstants.WSO2_GATEWAY_ENVIRONMENT.equals(gatewayVendor)) {
             return APIConstants.WSO2_GATEWAY_ENVIRONMENT;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -86,6 +86,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -264,6 +265,9 @@ public class ExportUtils {
             }
             addClientCertificatesToArchive(archivePath, apiIdentifier, tenantId, apiProvider, exportFormat,
                     organization);
+        }
+        if (apiDtoToReturn.getMediationPolicies() != null && !apiDtoToReturn.getMediationPolicies().isEmpty()) {
+            apiDtoToReturn.setMediationPolicies(Collections.emptyList());
         }
         addAPIMetaInformationToArchive(archivePath, apiDtoToReturn, exportFormat, apiProvider, apiIdentifier,
                 organization, currentApiUuid);
@@ -763,13 +767,41 @@ public class ExportUtils {
                     String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
                             policy.getPolicyVersion(), policy.getPolicyType());
                     if (!exportedPolicies.contains(policyFileName)) {
-                        OperationPolicyData policyData =
-                                apiProvider.getAPISpecificOperationPolicyByPolicyId(policy.getPolicyId(),
-                                        currentApiUuid, tenantDomain, true);
-                        if (policyData != null) {
-                            exportPolicyData(policyFileName, policyData, archivePath, exportFormat);
-                            exportedPolicies.add(policy.getPolicyName() + "_" + policy.getPolicyVersion() + "_" +
-                                    policy.getPolicyType());
+                        OperationPolicyData policyData;
+                        if (policy.getPolicyId() != null) {
+                            policyData = apiProvider.getAPISpecificOperationPolicyByPolicyId(policy.getPolicyId(),
+                                            currentApiUuid, tenantDomain, true);
+                            if (policyData != null) {
+                                exportPolicyData(policyFileName, policyData, archivePath, exportFormat);
+                                exportedPolicies.add(policy.getPolicyName() + "_" + policy.getPolicyVersion() + "_" +
+                                        policy.getPolicyType());
+                            }
+                        } else {
+                            // This path is to handle migrated APIs with mediation policies attached
+                            // These are considered as API policies by default
+                            policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
+                                    policy.getPolicyVersion(), ImportExportConstants.POLICY_TYPE_API);
+                            if (APIUtil.isSequenceDefined(api.getInSequence())
+                                    || APIUtil.isSequenceDefined(api.getOutSequence())
+                                    || APIUtil.isSequenceDefined(api.getFaultSequence())) {
+                                if (log.isDebugEnabled()) {
+                                    log.debug("Mediation policy " + policy.getPolicyName()
+                                            + " will be converted to an operation policy");
+                                }
+                                if (!mediationPoliciesLoaded) {
+                                    apiProvider.loadMediationPoliciesToAPI(api, tenantDomain);
+                                    mediationPoliciesLoaded = true;
+                                }
+                            }
+
+                            policyData = APIUtil.getPolicyDataForMediationFlow(api,
+                                    policy.getDirection(), tenantDomain);
+
+                            if (policyData != null) {
+                                exportPolicyData(policyFileName, policyData, archivePath, exportFormat);
+                                exportedPolicies.add(policy.getPolicyName() + "_" + policy.getPolicyVersion() + "_"
+                                        + ImportExportConstants.POLICY_TYPE_API);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Description
This PR fixes the below problems.
- Fixes an export-import related issue on the migrated APIs from 3.2.0 to 4.x. Migrated APIs consist of mediation sequences and they were not properly handled to populate API level policies while exporting them (These migrated APIs are not SAVED)
- When update an API from the management console it set the gatewayVendor to null and later this null scenario handled when populating API object by getting the vendor from the DB.

Resolves https://github.com/wso2/api-manager/issues/3855