### PR TITLE
Fix subscriber null issue when importing application

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIManager.java
@@ -279,6 +279,15 @@ public interface APIManager {
     void addSubscriber(String username, String groupingId) throws APIManagementException;
 
     /**
+     * Creates a new subscriber without default application given the username and the grouping Id
+     *
+     * @param username   Username of the subscriber to be added
+     * @param groupingId - the groupId to which the subscriber belongs to
+     * @throws org.wso2.carbon.apimgt.api.APIManagementException if failed add subscriber
+     */
+    void addSubscriberOnly(String username, String groupingId) throws APIManagementException;
+
+    /**
      * Updates the details of the given subscriber.
      *
      * @param subscriber The subscriber to be updated

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -630,6 +630,26 @@ public abstract class AbstractAPIManager implements APIManager {
         }
     }
 
+    public void addSubscriberOnly(String username, String groupingId)
+            throws APIManagementException {
+
+        Subscriber subscriber = new Subscriber(username);
+        subscriber.setSubscribedDate(new Date());
+        try {
+            int tenantId = getTenantManager()
+                    .getTenantId(getTenantDomain(username));
+            subscriber.setEmail(StringUtils.EMPTY);
+            subscriber.setTenantId(tenantId);
+            apiMgtDAO.addSubscriber(subscriber, groupingId);
+        } catch (APIManagementException e) {
+            String msg = "Error while adding the subscriber " + subscriber.getName();
+            throw new APIManagementException(msg, e);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            String msg = "Error while adding the subscriber " + subscriber.getName();
+            throw new APIManagementException(msg, e);
+        }
+    }
+
     protected String getTenantDomain(String username) {
 
         return MultitenantUtils.getTenantDomain(username);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
@@ -248,6 +248,10 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
                 ImportUtils.validateOwner(username, applicationGroupId, apiConsumer);
             }
 
+            // This is to handle if the subscriber hasn't logged into the APIM Devportal
+            // and not available in the AM_SUBSCRIBER table
+            ImportUtils.validateSubscriber(ownerId, applicationGroupId, apiConsumer);
+
             String organization = RestApiUtil.getValidatedOrganization(messageContext);
             OrganizationInfo orgInfo = RestApiUtil.getOrganizationInfo(messageContext);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/utils/ImportUtils.java
@@ -118,6 +118,26 @@ public class ImportUtils {
     }
 
     /**
+     * Check whether a provided userId corresponds to a valid consumer of the store and subscribe if valid
+     *
+     * @param userId      Username of the Owner
+     * @param groupId     The groupId to which the target subscriber belongs to
+     * @param apiConsumer API Consumer
+     * @throws APIManagementException if an error occurs while checking the validity of user
+     */
+    public static void validateSubscriber(String userId, String groupId, APIConsumer apiConsumer)
+            throws APIManagementException {
+        Subscriber subscriber = apiConsumer.getSubscriber(userId);
+        try {
+            if (subscriber == null && !APIUtil.isPermissionCheckDisabled()) {
+                apiConsumer.addSubscriberOnly(userId, groupId);
+            }
+        } catch (APIManagementException e) {
+            throw new APIManagementException("Provided Application Owner is Invalid", e);
+        }
+    }
+
+    /**
      * This extracts information for creating an APIKey from an OAuthApplication
      *
      * @param applicationKeyDto Application Key DTO


### PR DESCRIPTION
### Purpose
> A Null Pointer Exception occurs when the application owner (subscriber) has never logged into the Developer Portal and trying to import applications using the APICTL.
Related Issue : https://github.com/wso2/api-manager/issues/3817

### Goals
> Allow importing application importing when the application owner (subscriber) has never logged in the dev portal before.

### Implementation
> Add the application owner (subscriber) to the AM_SUBSCRIBER table if the subscriber not yet available when importing applications. 