### PR TITLE
Create Unique ID of Certificate from Subject DN

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/CertificateMgtUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/CertificateMgtUtils.java
@@ -622,7 +622,7 @@ public class CertificateMgtUtils {
             while (serverCert.available() > 0) {
                 Certificate generatedCertificate = cf.generateCertificate(serverCert);
                 X509Certificate x509Certificate = (X509Certificate) generatedCertificate;
-                uniqueIdentifier = x509Certificate.getSerialNumber() + "_" + x509Certificate.getIssuerDN();
+                uniqueIdentifier = x509Certificate.getSerialNumber() + "_" + x509Certificate.getSubjectDN();
                 uniqueIdentifier = uniqueIdentifier.replaceAll(",", "#").replaceAll("\"", "'")
                         .replaceAll("&(?!amp;)", "&amp;")
                         .replaceAll("<", "&lt;").replaceAll(">", "&gt;");


### PR DESCRIPTION
### Purpose
- Create Unique ID of Certificate from Subject DN instead of Issuer DN
- Related Issue: https://github.com/wso2/api-manager/issues/3854