### PR TITLE
Resolve Database Inconsistency for APP_ATTRIBUTE in Oracle 19c

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -15988,8 +15988,9 @@ public class ApiMgtDAO {
             ps.setInt(1, applicationId);
             rs = ps.executeQuery();
             while (rs.next()) {
+                String appAttribute = rs.getString("APP_ATTRIBUTE");
                 applicationAttributes.put(rs.getString("NAME"),
-                        rs.getString("APP_ATTRIBUTE"));
+                        (appAttribute != null) ? appAttribute : "");
             }
 
         } catch (SQLException e) {


### PR DESCRIPTION
### Purpose

This PR addresses a **JWTTest failure** encountered during integration testing when using **Oracle 19c** as the database. The failure occurs due to a discrepancy in how **Oracle 19c** handles empty values compared to other databases.

- **Resolves**: [wso2/api-manager/issues/3846](https://github.com/wso2/api-manager/issues/3846)

### Approach

- **Issue with Oracle 19c**: In Oracle, when an optional attribute has an empty value, the `APP_ATTRIBUTE` column is stored as `NULL`. This contrasts with other databases, which return an empty string (`""`) when the value is empty.

- **Impact**: The difference in handling empty values between Oracle and other databases causes inconsistencies in the returned response, leading to test failures during integration.

- **Solution**:
  - A validation step was added to check if the `APP_ATTRIBUTE` value is `NULL`. If so, it is set to an empty string (`""`).
  - This ensures consistent behavior across different database types and resolves the issue by standardizing the response.

By implementing this change, we can ensure **database consistency** and eliminate the discrepancies between Oracle and other databases.

### Test Cases

- The issue has been validated and resolved for Oracle 19c, and **failed integration tests have passed** successfully after the fix.

### Conclusion

This change improves database consistency across different database platforms (Oracle and others), ensuring a stable and predictable response during JWT tests.
