### PR TITLE
Fix Invalid Characters Causing Issues for the Policy Names

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3233,6 +3233,7 @@ public final class APIConstants {
     public static final String OPERATION_POLICY_SUPPORTED_API_TYPE_SOAPTOREST = "SOAPTOREST";
     public static final String OPERATION_POLICY_SUPPORTED_API_TYPE_GRAPHQL = "GRAPHQL";
     public static final String DEFAULT_POLICY_VERSION = "v1";
+    public static final String POLICY_FILENAME_INVALID_CHARS_REGEX = "[\\/:*?\"<>|]";
 
 
     public static final String WSO2_GATEWAY_ENVIRONMENT = "wso2";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -260,7 +260,6 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
 
     private static final Log log = LogFactory.getLog(APIProviderImpl.class);
     private static final String ENDPOINT_CONFIG_SEARCH_TYPE_PREFIX  = "endpointConfig:";
-    private static final String INVALID_FILENAME_CHARS_REGEX = "[\\\\/:*?\"<>|]";
     private ServiceCatalogDAO serviceCatalogDAO = ServiceCatalogDAO.getInstance();
 
     private final String userNameWithoutChange;
@@ -1615,20 +1614,20 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (APIUtil.isSequenceDefined(api.getInSequence())) {
             Mediation inSequenceMediation = api.getInSequenceMediation();
             OperationPolicyData existingPolicy = getAPISpecificOperationPolicyByPolicyName(
-                    inSequenceMediation.getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                    inSequenceMediation.getName().replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""),
                     APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             String inFlowPolicyId;
             if (existingPolicy == null) {
-                OperationPolicyData inSeqPolicyData =
-                        APIUtil.getPolicyDataForMediationFlow(api, APIConstants.OPERATION_SEQUENCE_TYPE_REQUEST,
-                                organization);
-                inSeqPolicyData.getSpecification().setName(
-                        inSeqPolicyData.getSpecification().getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""));
+                OperationPolicyData inSeqPolicyData = APIUtil.getPolicyDataForMediationFlow(api,
+                        APIConstants.OPERATION_SEQUENCE_TYPE_REQUEST, organization);
+                inSeqPolicyData.getSpecification().setName(inSeqPolicyData.getSpecification().getName()
+                        .replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""));
                 inFlowPolicyId = addAPISpecificOperationPolicy(apiUUID, inSeqPolicyData, organization);
             } else {
                 inFlowPolicyId = existingPolicy.getPolicyId();
             }
-            clonedPoliciesMap.put(inSequenceMediation.getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+            clonedPoliciesMap.put(
+                    inSequenceMediation.getName().replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""),
                     inFlowPolicyId);
             api.setInSequence(null);
             api.setInSequenceMediation(null);
@@ -1637,20 +1636,21 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (APIUtil.isSequenceDefined(api.getOutSequence())) {
             Mediation outSequenceMediation = api.getOutSequenceMediation();
             OperationPolicyData existingPolicy = getAPISpecificOperationPolicyByPolicyName(
-                    outSequenceMediation.getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                    outSequenceMediation.getName().replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""),
                     APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             String outFlowPolicyId;
             if (existingPolicy == null) {
                 OperationPolicyData outSeqPolicyData =
                         APIUtil.getPolicyDataForMediationFlow(api, APIConstants.OPERATION_SEQUENCE_TYPE_RESPONSE,
                                 organization);
-                outSeqPolicyData.getSpecification().setName(
-                        outSeqPolicyData.getSpecification().getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""));
+                outSeqPolicyData.getSpecification().setName(outSeqPolicyData.getSpecification().getName()
+                        .replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""));
                 outFlowPolicyId = addAPISpecificOperationPolicy(apiUUID, outSeqPolicyData, organization);
             } else {
                 outFlowPolicyId = existingPolicy.getPolicyId();
             }
-            clonedPoliciesMap.put(outSequenceMediation.getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+            clonedPoliciesMap.put(
+                    outSequenceMediation.getName().replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""),
                     outFlowPolicyId);
             api.setOutSequence(null);
             api.setOutSequenceMediation(null);
@@ -1659,21 +1659,21 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (APIUtil.isSequenceDefined(api.getFaultSequence())) {
             Mediation faultSequenceMediation = api.getFaultSequenceMediation();
             OperationPolicyData existingPolicy = getAPISpecificOperationPolicyByPolicyName(
-                    faultSequenceMediation.getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                    faultSequenceMediation.getName().replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""),
                     APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             String faultFlowPolicyId;
             if (existingPolicy == null) {
-                OperationPolicyData faultSeqPolicyData =
-                        APIUtil.getPolicyDataForMediationFlow(api, APIConstants.OPERATION_SEQUENCE_TYPE_FAULT,
-                                organization);
-                faultSeqPolicyData.getSpecification().setName(
-                        faultSeqPolicyData.getSpecification().getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""));
+                OperationPolicyData faultSeqPolicyData = APIUtil.getPolicyDataForMediationFlow(api,
+                        APIConstants.OPERATION_SEQUENCE_TYPE_FAULT, organization);
+                faultSeqPolicyData.getSpecification().setName(faultSeqPolicyData.getSpecification().getName()
+                        .replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""));
                 faultFlowPolicyId = addAPISpecificOperationPolicy(apiUUID, faultSeqPolicyData, organization);
             } else {
                 faultFlowPolicyId = existingPolicy.getPolicyId();
             }
 
-            clonedPoliciesMap.put(faultSequenceMediation.getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+            clonedPoliciesMap.put(
+                    faultSequenceMediation.getName().replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""),
                     faultFlowPolicyId);
             api.setFaultSequence(null);
             api.setFaultSequenceMediation(null);
@@ -1701,9 +1701,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     policy.setPolicyId(clonedPoliciesMap.get(policy.getPolicyName()));
                     policyUpdated = true;
                 } else if (clonedPoliciesMap.containsKey(
-                        policy.getPolicyName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""))) {
-                    policy.setPolicyId(
-                            clonedPoliciesMap.get(policy.getPolicyName().replaceAll(INVALID_FILENAME_CHARS_REGEX, "")));
+                        policy.getPolicyName().replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""))) {
+                    policy.setPolicyId(clonedPoliciesMap.get(
+                            policy.getPolicyName().replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, "")));
                     policyUpdated = true;
                 }
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1861,7 +1861,6 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         List<OperationPolicy> validatedPolicies = new ArrayList<>();
         for (OperationPolicy policy : apiPoliciesList) {
             String policyId = policy.getPolicyId();
-            policy.setPolicyName(policy.getPolicyName().replaceAll(POLICY_NAME_REGEX, ""));
             if (policyId != null) {
                 // First check the API specific operation policy list
                 OperationPolicyData policyData =
@@ -8150,7 +8149,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         }
         return gatewayPolicyDeploymentMapForResponse;
     }
-    
+
     @Override
     public void updateSoapToRestSequences(String organization, String apiId, List<SOAPToRestSequence> sequences)
             throws APIManagementException {
@@ -8159,7 +8158,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             apiPersistenceInstance.updateSoapToRestSequences(org, apiId, sequences);
         } catch (APIPersistenceException e) {
             throw new APIManagementException("Error while sequences to the api  " + apiId, e);
-        }        
+        }
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -260,6 +260,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
 
     private static final Log log = LogFactory.getLog(APIProviderImpl.class);
     private static final String ENDPOINT_CONFIG_SEARCH_TYPE_PREFIX  = "endpointConfig:";
+    private static final String POLICY_NAME_REGEX = "[^a-zA-Z0-9]";
     private ServiceCatalogDAO serviceCatalogDAO = ServiceCatalogDAO.getInstance();
 
     private final String userNameWithoutChange;
@@ -1614,18 +1615,20 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (APIUtil.isSequenceDefined(api.getInSequence())) {
             Mediation inSequenceMediation = api.getInSequenceMediation();
             OperationPolicyData existingPolicy = getAPISpecificOperationPolicyByPolicyName(
-                    inSequenceMediation.getName(), APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null,
-                    organization, false);
+                    inSequenceMediation.getName().replaceAll(POLICY_NAME_REGEX, ""), APIConstants.DEFAULT_POLICY_VERSION,
+                    api.getUuid(), null, organization, false);
             String inFlowPolicyId;
             if (existingPolicy == null) {
                 OperationPolicyData inSeqPolicyData =
                         APIUtil.getPolicyDataForMediationFlow(api, APIConstants.OPERATION_SEQUENCE_TYPE_REQUEST,
                                 organization);
+                inSeqPolicyData.getSpecification()
+                        .setName(inSeqPolicyData.getSpecification().getName().replaceAll(POLICY_NAME_REGEX, ""));
                 inFlowPolicyId = addAPISpecificOperationPolicy(apiUUID, inSeqPolicyData, organization);
             } else {
                 inFlowPolicyId = existingPolicy.getPolicyId();
             }
-            clonedPoliciesMap.put(inSequenceMediation.getName(), inFlowPolicyId);
+            clonedPoliciesMap.put(inSequenceMediation.getName().replaceAll(POLICY_NAME_REGEX, ""), inFlowPolicyId);
             api.setInSequence(null);
             api.setInSequenceMediation(null);
         }
@@ -1633,18 +1636,20 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (APIUtil.isSequenceDefined(api.getOutSequence())) {
             Mediation outSequenceMediation = api.getOutSequenceMediation();
             OperationPolicyData existingPolicy = getAPISpecificOperationPolicyByPolicyName(
-                    outSequenceMediation.getName(), APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null,
-                    organization, false);
+                    outSequenceMediation.getName().replaceAll(POLICY_NAME_REGEX, ""), APIConstants.DEFAULT_POLICY_VERSION,
+                    api.getUuid(), null, organization, false);
             String outFlowPolicyId;
             if (existingPolicy == null) {
                 OperationPolicyData outSeqPolicyData =
                         APIUtil.getPolicyDataForMediationFlow(api, APIConstants.OPERATION_SEQUENCE_TYPE_RESPONSE,
                                 organization);
+                outSeqPolicyData.getSpecification()
+                        .setName(outSeqPolicyData.getSpecification().getName().replaceAll(POLICY_NAME_REGEX, ""));
                 outFlowPolicyId = addAPISpecificOperationPolicy(apiUUID, outSeqPolicyData, organization);
             } else {
                 outFlowPolicyId = existingPolicy.getPolicyId();
             }
-            clonedPoliciesMap.put(outSequenceMediation.getName(), outFlowPolicyId);
+            clonedPoliciesMap.put(outSequenceMediation.getName().replaceAll(POLICY_NAME_REGEX, ""), outFlowPolicyId);
             api.setOutSequence(null);
             api.setOutSequenceMediation(null);
         }
@@ -1652,19 +1657,21 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (APIUtil.isSequenceDefined(api.getFaultSequence())) {
             Mediation faultSequenceMediation = api.getFaultSequenceMediation();
             OperationPolicyData existingPolicy = getAPISpecificOperationPolicyByPolicyName(
-                    faultSequenceMediation.getName(), APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null,
-                    organization, false);
+                    faultSequenceMediation.getName().replaceAll(POLICY_NAME_REGEX, ""),
+                    APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             String faultFlowPolicyId;
             if (existingPolicy == null) {
                 OperationPolicyData faultSeqPolicyData =
                         APIUtil.getPolicyDataForMediationFlow(api, APIConstants.OPERATION_SEQUENCE_TYPE_FAULT,
                                 organization);
+                faultSeqPolicyData.getSpecification()
+                        .setName(faultSeqPolicyData.getSpecification().getName().replaceAll(POLICY_NAME_REGEX, ""));
                 faultFlowPolicyId = addAPISpecificOperationPolicy(apiUUID, faultSeqPolicyData, organization);
             } else {
                 faultFlowPolicyId = existingPolicy.getPolicyId();
             }
 
-            clonedPoliciesMap.put(faultSequenceMediation.getName(), faultFlowPolicyId);
+            clonedPoliciesMap.put(faultSequenceMediation.getName().replaceAll(POLICY_NAME_REGEX, ""), faultFlowPolicyId);
             api.setFaultSequence(null);
             api.setFaultSequenceMediation(null);
         }
@@ -1854,6 +1861,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         List<OperationPolicy> validatedPolicies = new ArrayList<>();
         for (OperationPolicy policy : apiPoliciesList) {
             String policyId = policy.getPolicyId();
+            policy.setPolicyName(policy.getPolicyName().replaceAll(POLICY_NAME_REGEX, ""));
             if (policyId != null) {
                 // First check the API specific operation policy list
                 OperationPolicyData policyData =

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -260,7 +260,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
 
     private static final Log log = LogFactory.getLog(APIProviderImpl.class);
     private static final String ENDPOINT_CONFIG_SEARCH_TYPE_PREFIX  = "endpointConfig:";
-    private static final String POLICY_NAME_REGEX = "[^a-zA-Z0-9]";
+    private static final String INVALID_FILENAME_CHARS_REGEX = "[\\\\/:*?\"<>|]";
     private ServiceCatalogDAO serviceCatalogDAO = ServiceCatalogDAO.getInstance();
 
     private final String userNameWithoutChange;
@@ -1615,20 +1615,21 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (APIUtil.isSequenceDefined(api.getInSequence())) {
             Mediation inSequenceMediation = api.getInSequenceMediation();
             OperationPolicyData existingPolicy = getAPISpecificOperationPolicyByPolicyName(
-                    inSequenceMediation.getName().replaceAll(POLICY_NAME_REGEX, ""), APIConstants.DEFAULT_POLICY_VERSION,
-                    api.getUuid(), null, organization, false);
+                    inSequenceMediation.getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                    APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             String inFlowPolicyId;
             if (existingPolicy == null) {
                 OperationPolicyData inSeqPolicyData =
                         APIUtil.getPolicyDataForMediationFlow(api, APIConstants.OPERATION_SEQUENCE_TYPE_REQUEST,
                                 organization);
-                inSeqPolicyData.getSpecification()
-                        .setName(inSeqPolicyData.getSpecification().getName().replaceAll(POLICY_NAME_REGEX, ""));
+                inSeqPolicyData.getSpecification().setName(
+                        inSeqPolicyData.getSpecification().getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""));
                 inFlowPolicyId = addAPISpecificOperationPolicy(apiUUID, inSeqPolicyData, organization);
             } else {
                 inFlowPolicyId = existingPolicy.getPolicyId();
             }
-            clonedPoliciesMap.put(inSequenceMediation.getName().replaceAll(POLICY_NAME_REGEX, ""), inFlowPolicyId);
+            clonedPoliciesMap.put(inSequenceMediation.getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                    inFlowPolicyId);
             api.setInSequence(null);
             api.setInSequenceMediation(null);
         }
@@ -1636,20 +1637,21 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (APIUtil.isSequenceDefined(api.getOutSequence())) {
             Mediation outSequenceMediation = api.getOutSequenceMediation();
             OperationPolicyData existingPolicy = getAPISpecificOperationPolicyByPolicyName(
-                    outSequenceMediation.getName().replaceAll(POLICY_NAME_REGEX, ""), APIConstants.DEFAULT_POLICY_VERSION,
-                    api.getUuid(), null, organization, false);
+                    outSequenceMediation.getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                    APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             String outFlowPolicyId;
             if (existingPolicy == null) {
                 OperationPolicyData outSeqPolicyData =
                         APIUtil.getPolicyDataForMediationFlow(api, APIConstants.OPERATION_SEQUENCE_TYPE_RESPONSE,
                                 organization);
-                outSeqPolicyData.getSpecification()
-                        .setName(outSeqPolicyData.getSpecification().getName().replaceAll(POLICY_NAME_REGEX, ""));
+                outSeqPolicyData.getSpecification().setName(
+                        outSeqPolicyData.getSpecification().getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""));
                 outFlowPolicyId = addAPISpecificOperationPolicy(apiUUID, outSeqPolicyData, organization);
             } else {
                 outFlowPolicyId = existingPolicy.getPolicyId();
             }
-            clonedPoliciesMap.put(outSequenceMediation.getName().replaceAll(POLICY_NAME_REGEX, ""), outFlowPolicyId);
+            clonedPoliciesMap.put(outSequenceMediation.getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                    outFlowPolicyId);
             api.setOutSequence(null);
             api.setOutSequenceMediation(null);
         }
@@ -1657,21 +1659,22 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (APIUtil.isSequenceDefined(api.getFaultSequence())) {
             Mediation faultSequenceMediation = api.getFaultSequenceMediation();
             OperationPolicyData existingPolicy = getAPISpecificOperationPolicyByPolicyName(
-                    faultSequenceMediation.getName().replaceAll(POLICY_NAME_REGEX, ""),
+                    faultSequenceMediation.getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
                     APIConstants.DEFAULT_POLICY_VERSION, api.getUuid(), null, organization, false);
             String faultFlowPolicyId;
             if (existingPolicy == null) {
                 OperationPolicyData faultSeqPolicyData =
                         APIUtil.getPolicyDataForMediationFlow(api, APIConstants.OPERATION_SEQUENCE_TYPE_FAULT,
                                 organization);
-                faultSeqPolicyData.getSpecification()
-                        .setName(faultSeqPolicyData.getSpecification().getName().replaceAll(POLICY_NAME_REGEX, ""));
+                faultSeqPolicyData.getSpecification().setName(
+                        faultSeqPolicyData.getSpecification().getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""));
                 faultFlowPolicyId = addAPISpecificOperationPolicy(apiUUID, faultSeqPolicyData, organization);
             } else {
                 faultFlowPolicyId = existingPolicy.getPolicyId();
             }
 
-            clonedPoliciesMap.put(faultSequenceMediation.getName().replaceAll(POLICY_NAME_REGEX, ""), faultFlowPolicyId);
+            clonedPoliciesMap.put(faultSequenceMediation.getName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                    faultFlowPolicyId);
             api.setFaultSequence(null);
             api.setFaultSequenceMediation(null);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1700,6 +1700,11 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 if (clonedPoliciesMap.containsKey(policy.getPolicyName())) {
                     policy.setPolicyId(clonedPoliciesMap.get(policy.getPolicyName()));
                     policyUpdated = true;
+                } else if (clonedPoliciesMap.containsKey(
+                        policy.getPolicyName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""))) {
+                    policy.setPolicyId(
+                            clonedPoliciesMap.get(policy.getPolicyName().replaceAll(INVALID_FILENAME_CHARS_REGEX, "")));
+                    policyUpdated = true;
                 }
             }
         }
@@ -1881,6 +1886,10 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
 
                     boolean isPolicyNameMatch = policyData.getSpecification().getName().equals(policy.getPolicyName())
                             || (policyData.getSpecification().getName()).equals(policy.getPolicyName() + "_imported");
+                    if (!isPolicyNameMatch) {
+                        isPolicyNameMatch = policyData.getSpecification().getDisplayName().equals(policy.getPolicyName())
+                                || (policyData.getSpecification().getDisplayName()).equals(policy.getPolicyName() + "_imported");
+                    }
                     if (!isPolicyNameMatch || !policyData.getSpecification().getVersion()
                                     .equals(policy.getPolicyVersion())) {
                         throw new APIManagementException("Applied policy " + policy.getPolicyName()

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
@@ -57,6 +57,7 @@ import org.wso2.carbon.apimgt.api.model.DocumentationType;
 import org.wso2.carbon.apimgt.api.model.KeyManager;
 import org.wso2.carbon.apimgt.api.model.OperationPolicy;
 import org.wso2.carbon.apimgt.api.model.OperationPolicyData;
+import org.wso2.carbon.apimgt.api.model.OperationPolicySpecification;
 import org.wso2.carbon.apimgt.api.model.SubscribedAPI;
 import org.wso2.carbon.apimgt.api.model.Subscriber;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
@@ -1489,6 +1490,12 @@ public class APIProviderImplTest {
 
         OperationPolicyData policyData = new OperationPolicyData();
         policyData.setPolicyId("11111");
+        OperationPolicySpecification policySpecification = new OperationPolicySpecification();
+        policySpecification.setCategory(OperationPolicySpecification.PolicyCategory.Mediation);
+        policySpecification.setName("in-policy");
+        policySpecification.setDisplayName("in-policy");
+        policySpecification.setDescription("This is a mediation policy migrated to an operation policy.");
+        policyData.setSpecification(policySpecification);
 
         PowerMockito.when(apiPersistenceInstance.getAllMediationPolicies(any(Organization.class), any(String.class))).thenReturn(localPolicies);
         PowerMockito.when(apiPersistenceInstance.getMediationPolicy(any(Organization.class), any(String.class), any(String.class))).thenReturn(mediationPolicy);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
@@ -193,11 +193,20 @@ public class SynapsePolicyAggregator {
                         policy.getPolicyVersion(), policy.getPolicyType());
                 OperationPolicySpecification policySpecification = ImportUtils
                         .getOperationPolicySpecificationFromFile(policyDirectory, policyFileName);
+                if (policySpecification == null) {
+                    policySpecification = ImportUtils.getOperationPolicySpecificationFromFile(policyDirectory,
+                            policyFileName.replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""));
+                }
                 if (policySpecification.getSupportedGateways()
                         .contains(APIConstants.OPERATION_POLICY_SUPPORTED_GATEWAY_SYNAPSE)) {
                     OperationPolicyDefinition policyDefinition =
                             APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory, policyFileName,
                                     APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
+                    if (policyDefinition == null) {
+                        policyDefinition = APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
+                                policyFileName.replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""),
+                                APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
+                    }
                     if (policyDefinition != null) {
                         try {
                             String renderedTemplate =

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -92,8 +92,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.wso2.carbon.apimgt.impl.APIConstants.API_DATA_PRODUCTION_ENDPOINTS;
 import static org.wso2.carbon.apimgt.impl.APIConstants.API_DATA_SANDBOX_ENDPOINTS;
@@ -110,7 +108,6 @@ public class ExportUtils {
     private static final String OUT = "out";
     private static final String SOAPTOREST = "SoapToRest";
     private static String migrationEnabled = System.getProperty(APIConstants.MIGRATE);
-    private static final Pattern pattern = Pattern.compile(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX);
 
     /**
      * Validate name, version and provider before exporting an API/API Product.
@@ -767,14 +764,10 @@ public class ExportUtils {
 
             if (api.getApiPolicies() != null && !api.getApiPolicies().isEmpty()) {
                 for (OperationPolicy policy : api.getApiPolicies()) {
-                    String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
+                    String sanitizedPolicyName = policy.getPolicyName()
+                            .replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, "");
+                    String policyFileName = APIUtil.getOperationPolicyFileName(sanitizedPolicyName,
                             policy.getPolicyVersion(), policy.getPolicyType());
-                    Matcher matcher = pattern.matcher(policy.getPolicyName());
-                    if (matcher.find()) {
-                        policyFileName = APIUtil.getOperationPolicyFileName(
-                                policy.getPolicyName().replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""),
-                                policy.getPolicyVersion(), policy.getPolicyType());
-                    }
                     if (!exportedPolicies.contains(policyFileName)) {
                         OperationPolicyData policyData;
                         if (policy.getPolicyId() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -109,7 +109,7 @@ public class ExportUtils {
     private static final String IN = "in";
     private static final String OUT = "out";
     private static final String SOAPTOREST = "SoapToRest";
-    private static final String POLICY_NAME_REGEX = "[^a-zA-Z0-9]";
+    private static final String INVALID_FILENAME_CHARS_REGEX = "[\\\\/:*?\"<>|]";
     private static String migrationEnabled = System.getProperty(APIConstants.MIGRATE);
 
     /**
@@ -769,12 +769,12 @@ public class ExportUtils {
                 for (OperationPolicy policy : api.getApiPolicies()) {
                     String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
                             policy.getPolicyVersion(), policy.getPolicyType());
-                    Pattern pattern = Pattern.compile(POLICY_NAME_REGEX);
+                    Pattern pattern = Pattern.compile(INVALID_FILENAME_CHARS_REGEX);
                     Matcher matcher = pattern.matcher(policy.getPolicyName());
                     if (matcher.find()) {
                         policyFileName = APIUtil.getOperationPolicyFileName(
-                                policy.getPolicyName().replaceAll(POLICY_NAME_REGEX, ""), policy.getPolicyVersion(),
-                                policy.getPolicyType());
+                                policy.getPolicyName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                                policy.getPolicyVersion(), policy.getPolicyType());
                     }
                     if (!exportedPolicies.contains(policyFileName)) {
                         OperationPolicyData policyData;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -109,8 +109,8 @@ public class ExportUtils {
     private static final String IN = "in";
     private static final String OUT = "out";
     private static final String SOAPTOREST = "SoapToRest";
-    private static final String INVALID_FILENAME_CHARS_REGEX = "[\\\\/:*?\"<>|]";
     private static String migrationEnabled = System.getProperty(APIConstants.MIGRATE);
+    private static final Pattern pattern = Pattern.compile(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX);
 
     /**
      * Validate name, version and provider before exporting an API/API Product.
@@ -769,11 +769,10 @@ public class ExportUtils {
                 for (OperationPolicy policy : api.getApiPolicies()) {
                     String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
                             policy.getPolicyVersion(), policy.getPolicyType());
-                    Pattern pattern = Pattern.compile(INVALID_FILENAME_CHARS_REGEX);
                     Matcher matcher = pattern.matcher(policy.getPolicyName());
                     if (matcher.find()) {
                         policyFileName = APIUtil.getOperationPolicyFileName(
-                                policy.getPolicyName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                                policy.getPolicyName().replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""),
                                 policy.getPolicyVersion(), policy.getPolicyType());
                     }
                     if (!exportedPolicies.contains(policyFileName)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -722,9 +722,10 @@ public class ExportUtils {
                         if (!exportedPolicies.contains(policy.getPolicyName() + "_" + policy.getPolicyVersion() + "_" +
                                 policy.getPolicyType())) {
                             if (policy.getPolicyId() != null) {
-                                String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
+                                String sanitizedPolicyName = policy.getPolicyName()
+                                        .replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, "");
+                                String policyFileName = APIUtil.getOperationPolicyFileName(sanitizedPolicyName,
                                         policy.getPolicyVersion(), policy.getPolicyType());
-
                                 OperationPolicyData policyData =
                                         apiProvider.getAPISpecificOperationPolicyByPolicyId(policy.getPolicyId(),
                                                 currentApiUuid, tenantDomain, true);
@@ -736,7 +737,9 @@ public class ExportUtils {
                             } else {
                                 // This path is to handle migrated APIs with mediation policies attached
                                 // These are considered as API policies by default
-                                String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
+                                String sanitizedPolicyName = policy.getPolicyName()
+                                        .replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, "");
+                                String policyFileName = APIUtil.getOperationPolicyFileName(sanitizedPolicyName,
                                         policy.getPolicyVersion(), ImportExportConstants.POLICY_TYPE_API);
                                 if (APIUtil.isSequenceDefined(api.getInSequence())
                                         || APIUtil.isSequenceDefined(api.getOutSequence())

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -92,6 +92,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.wso2.carbon.apimgt.impl.APIConstants.API_DATA_PRODUCTION_ENDPOINTS;
 import static org.wso2.carbon.apimgt.impl.APIConstants.API_DATA_SANDBOX_ENDPOINTS;
@@ -107,6 +109,7 @@ public class ExportUtils {
     private static final String IN = "in";
     private static final String OUT = "out";
     private static final String SOAPTOREST = "SoapToRest";
+    private static final String POLICY_NAME_REGEX = "[^a-zA-Z0-9]";
     private static String migrationEnabled = System.getProperty(APIConstants.MIGRATE);
 
     /**
@@ -766,6 +769,13 @@ public class ExportUtils {
                 for (OperationPolicy policy : api.getApiPolicies()) {
                     String policyFileName = APIUtil.getOperationPolicyFileName(policy.getPolicyName(),
                             policy.getPolicyVersion(), policy.getPolicyType());
+                    Pattern pattern = Pattern.compile(POLICY_NAME_REGEX);
+                    Matcher matcher = pattern.matcher(policy.getPolicyName());
+                    if (matcher.find()) {
+                        policyFileName = APIUtil.getOperationPolicyFileName(
+                                policy.getPolicyName().replaceAll(POLICY_NAME_REGEX, ""), policy.getPolicyVersion(),
+                                policy.getPolicyType());
+                    }
                     if (!exportedPolicies.contains(policyFileName)) {
                         OperationPolicyData policyData;
                         if (policy.getPolicyId() != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -141,6 +141,7 @@ public class ImportUtils {
     public static final String OUT = "out";
     private static final Log log = LogFactory.getLog(ImportUtils.class);
     private static final String SOAPTOREST = "SoapToRest";
+    private static final String INVALID_FILENAME_CHARS_REGEX = "[\\\\/:*?\"<>|]";
 
     public static APIDTO getImportAPIDto(String extractedFolderPath, APIDTO importedApiDTO, Boolean preserveProvider,
                                          String userName) throws APIManagementException {
@@ -713,9 +714,9 @@ public class ImportUtils {
         if (policySpec == null) {
             // As the last option, we check whether the policy is updated with the policy file,
             // which has a name containing no special characters in the API project.
-            policySpec = getOperationPolicySpecificationFromFile(policyDirectory,
-                    APIUtil.getOperationPolicyFileName(appliedPolicy.getPolicyName().replaceAll("[^a-zA-Z0-9]", ""),
-                            appliedPolicy.getPolicyVersion(), policyType));
+            policySpec = getOperationPolicySpecificationFromFile(policyDirectory, APIUtil.getOperationPolicyFileName(
+                    appliedPolicy.getPolicyName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                    appliedPolicy.getPolicyVersion(), policyType));
         }
 
         if (policySpec != null) {
@@ -914,7 +915,7 @@ public class ImportUtils {
                     if (policySpec == null) {
                         policySpec = getOperationPolicySpecificationFromFile(policyDirectory,
                                 APIUtil.getOperationPolicyFileName(
-                                        policy.getPolicyName().replaceAll("[^a-zA-Z0-9]", ""),
+                                        policy.getPolicyName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
                                         policy.getPolicyVersion(), policyType));
                     }
                     if (policySpec != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -710,6 +710,14 @@ public class ImportUtils {
             }
         }
 
+        if (policySpec == null) {
+            // As the last option, we check whether the policy is updated with the policy file,
+            // which has a name containing no special characters in the API project.
+            policySpec = getOperationPolicySpecificationFromFile(policyDirectory,
+                    APIUtil.getOperationPolicyFileName(appliedPolicy.getPolicyName().replaceAll("[^a-zA-Z0-9]", ""),
+                            appliedPolicy.getPolicyVersion(), policyType));
+        }
+
         if (policySpec != null) {
             // if a policy specification is found, we need to validate the policy applied parameters.
             provider.validateAppliedPolicyWithSpecification(policySpec, appliedPolicy, apiType);
@@ -903,6 +911,12 @@ public class ImportUtils {
                 if (!importedPolicies.containsKey(policyFileName)) {
                     OperationPolicySpecification policySpec =
                             getOperationPolicySpecificationFromFile(policyDirectory, policyFileName);
+                    if (policySpec == null) {
+                        policySpec = getOperationPolicySpecificationFromFile(policyDirectory,
+                                APIUtil.getOperationPolicyFileName(
+                                        policy.getPolicyName().replaceAll("[^a-zA-Z0-9]", ""),
+                                        policy.getPolicyVersion(), policyType));
+                    }
                     if (policySpec != null) {
                         OperationPolicyData operationPolicyData = new OperationPolicyData();
                         operationPolicyData.setSpecification(policySpec);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -931,6 +931,18 @@ public class ImportUtils {
                             synapseDefinition = APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
                                     policyFileName, APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION_XML);
                         }
+                        // If the policy definition is still null, definition name is checked after removal of special
+                        // characters
+                        if (synapseDefinition == null) {
+                            String sanitizedPolicyName = policyFileName
+                                    .replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, "");
+                            synapseDefinition = APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
+                                    sanitizedPolicyName, APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION);
+                            if (synapseDefinition == null) {
+                                synapseDefinition = APIUtil.getOperationPolicyDefinitionFromFile(policyDirectory,
+                                        sanitizedPolicyName, APIConstants.SYNAPSE_POLICY_DEFINITION_EXTENSION_XML);
+                            }
+                        }
                         if (synapseDefinition != null) {
                             synapseDefinition.setGatewayType(OperationPolicyDefinition.GatewayType.Synapse);
                             operationPolicyData.setSynapsePolicyDefinition(synapseDefinition);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -141,7 +141,6 @@ public class ImportUtils {
     public static final String OUT = "out";
     private static final Log log = LogFactory.getLog(ImportUtils.class);
     private static final String SOAPTOREST = "SoapToRest";
-    private static final String INVALID_FILENAME_CHARS_REGEX = "[\\\\/:*?\"<>|]";
 
     public static APIDTO getImportAPIDto(String extractedFolderPath, APIDTO importedApiDTO, Boolean preserveProvider,
                                          String userName) throws APIManagementException {
@@ -715,7 +714,7 @@ public class ImportUtils {
             // As the last option, we check whether the policy is updated with the policy file,
             // which has a name containing no special characters in the API project.
             policySpec = getOperationPolicySpecificationFromFile(policyDirectory, APIUtil.getOperationPolicyFileName(
-                    appliedPolicy.getPolicyName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                    appliedPolicy.getPolicyName().replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""),
                     appliedPolicy.getPolicyVersion(), policyType));
         }
 
@@ -914,8 +913,8 @@ public class ImportUtils {
                             getOperationPolicySpecificationFromFile(policyDirectory, policyFileName);
                     if (policySpec == null) {
                         policySpec = getOperationPolicySpecificationFromFile(policyDirectory,
-                                APIUtil.getOperationPolicyFileName(
-                                        policy.getPolicyName().replaceAll(INVALID_FILENAME_CHARS_REGEX, ""),
+                                APIUtil.getOperationPolicyFileName(policy.getPolicyName()
+                                                .replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, ""),
                                         policy.getPolicyVersion(), policyType));
                     }
                     if (policySpec != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -300,13 +300,14 @@ public class RestApiPublisherUtils {
 
         File exportFolder = null;
         try {
-            exportFolder = CommonUtil.createTempDirectoryFromName(policyData.getSpecification().getName()
-                    + "_" +policyData.getSpecification().getVersion());
+            String sanitizedPolicyName = policyData.getSpecification().getName()
+                    .replaceAll(APIConstants.POLICY_FILENAME_INVALID_CHARS_REGEX, "");
+            exportFolder = CommonUtil.createTempDirectoryFromName(sanitizedPolicyName + "_" +
+                    policyData.getSpecification().getVersion());
             String exportAPIBasePath = exportFolder.toString();
-            String archivePath =
-                    exportAPIBasePath.concat(File.separator + policyData.getSpecification().getName());
+            String archivePath = exportAPIBasePath.concat(File.separator + sanitizedPolicyName);
             CommonUtil.createDirectory(archivePath);
-            String policyName = archivePath + File.separator + policyData.getSpecification().getName();
+            String policyName = archivePath + File.separator + sanitizedPolicyName;
             if (policyData.getSpecification() != null) {
                 if (format.equalsIgnoreCase(ExportFormat.YAML.name())) {
                     CommonUtil.writeDtoToFile(policyName, ExportFormat.YAML,


### PR DESCRIPTION
### Purpose

This PR resolve issues caused by invalid characters in policy names for migrated mediation policies in distributions from APIM 3.x.x versions.

Fixes https://github.com/wso2/api-manager/issues/3776

### Approach

Policy names are sanitized in the API and policy import/export flows.