### PR TITLE
Improved webhook delivery traceability through detailed fault and debug logging

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/WebhooksUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/WebhooksUtils.java
@@ -124,14 +124,26 @@ public class WebhooksUtils {
      */
     public static String generateAPIKey(MessageContext messageContext, String tenantDomain)
             throws DataNotFoundException {
+        return generateAPI(messageContext, tenantDomain).getUuid();
+    }
+
+    /**
+     * Generates an API object based on the provided message context and tenant domain.
+     *
+     * @param messageContext The message context containing properties such as API context and version.
+     * @param tenantDomain   The tenant domain to retrieve the subscription store.
+     * @return The API object corresponding to the given context and version.
+     * @throws DataNotFoundException If the API information cannot be found for the given context and version.
+     */
+    public static API generateAPI(MessageContext messageContext, String tenantDomain) throws DataNotFoundException {
         String context = (String) messageContext.getProperty(RESTConstants.REST_API_CONTEXT);
         String apiVersion = (String) messageContext.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION);
-        API api = SubscriptionDataHolder.getInstance().getTenantSubscriptionStore(tenantDomain).
-                getApiByContextAndVersion(context, apiVersion);
+        API api = SubscriptionDataHolder.getInstance().getTenantSubscriptionStore(tenantDomain)
+                .getApiByContextAndVersion(context, apiVersion);
         if (api == null) {
             throw new DataNotFoundException("Error occurred when getting API information");
         }
-        return api.getUuid();
+        return api;
     }
 
     /**


### PR DESCRIPTION
## Summary

Improves WebSub delivery traceability in the WSO2 API Manager gateway by introducing detailed logging for both successful and failed delivery attempts. These enhancements support better troubleshooting and issue correlation.

---

## Key Changes

### Java Mediator Logging
- Added debug logs in `DeliveryStatusUpdater`.
- Captures status, HTTP code, callback URL, topic, tenant domain, app ID, API UUID, and API name.
- Logs are shown when debug is enabled.

### Synapse Fault Sequence Logging
- Added always-on `<log>` mediator in `webhooksFaultSequence.xml`.
- Logs failed deliveries with key metadata regardless of log level.

---

## Related Issue

Fixes: [#3874](https://github.com/wso2/api-manager/issues/3874) – WebSub delivery logging and traceability improvements