### PR TITLE
Fix JWT assertion not generated for client credentials grant with opaque tokens

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyValidationService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/service/APIKeyValidationService.java
@@ -173,7 +173,10 @@ public class APIKeyValidationService {
         log.debug("State after calling validateScopes... " + state);
 
         if (state && APIKeyMgtDataHolder.isJwtGenerationEnabled() &&
-                validationContext.getValidationInfoDTO().getEndUserName() != null && !validationContext.isCacheHit()) {
+                (validationContext.getValidationInfoDTO().getEndUserName() != null ||
+                        (validationContext.getTokenInfo() != null &&
+                                validationContext.getTokenInfo().isApplicationToken())) &&
+                !validationContext.isCacheHit()) {
             Timer timer5 = MetricManager.timer(org.wso2.carbon.metrics.manager.Level.INFO, MetricManager.name(
                     APIConstants.METRICS_PREFIX, this.getClass().getSimpleName(), "GENERATE_JWT"));
             Timer.Context timerContext5 = timer5.start();


### PR DESCRIPTION
**Summary**

Fixes an issue where `X-JWT-ASSERTION` is not generated for opaque tokens when using the **client credentials grant type** in IS 7. Since the application owner concept is removed in IS 7, `endUserName` is `null`, which skips JWT generation.

The fix updates the condition to allow JWT generation if the token is an **application token**, even when `endUserName` is missing.

**Related Issue**  
[wso2/api-manager#3882](https://github.com/wso2/api-manager/issues/3882)