### PR TITLE
extend-monetization-phase3

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/pom.xml
@@ -55,6 +55,10 @@
             <groupId>org.wso2.orbit.graphQL</groupId>
             <artifactId>graphQL</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.common.analytics</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/AnalyticsforMonetization.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/AnalyticsforMonetization.java
@@ -1,0 +1,14 @@
+package org.wso2.carbon.apimgt.api.model;
+
+import org.wso2.carbon.apimgt.common.analytics.exceptions.AnalyticsException;
+
+public interface AnalyticsforMonetization {
+    /**
+     * Gets Usage Data from Analytics Provider
+     *
+     * @param monetizationUsagePublishInfo monetization publish info
+     * @return usage data from analytics provider
+     * @throws AnalyticsException if the action failed
+     */
+    Object getUsageData(MonetizationUsagePublishInfo monetizationUsagePublishInfo) throws AnalyticsException;
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/MonetizationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/MonetizationDTO.java
@@ -6,23 +6,19 @@ public class MonetizationDTO {
 
     Long currentTimestamp;
     String apiUuid;
-    String apiName;
-    String apiVersion;
     String tenantDomain;
     String applicationName;
     String applicationOwner;
-    HashMap<String, Object> customAttributes;
+    HashMap<String, Object> properties;
     Long requestCount;
 
-    public MonetizationDTO(Long currentTimestamp, String apiUuid, String apiName, String apiVersion, String tenantDomain, String applicationName, String applicationOwner, HashMap<String, Object> customAttributes, Long requestCount) {
+    public MonetizationDTO(Long currentTimestamp, String apiUuid, String tenantDomain, String applicationName, String applicationOwner, HashMap<String, Object> properties, Long requestCount) {
         this.currentTimestamp = currentTimestamp;
         this.apiUuid = apiUuid;
-        this.apiName = apiName;
-        this.apiVersion = apiVersion;
         this.tenantDomain = tenantDomain;
         this.applicationName = applicationName;
         this.applicationOwner = applicationOwner;
-        this.customAttributes = customAttributes;
+        this.properties = properties;
         this.requestCount = requestCount;
     }
 
@@ -40,22 +36,6 @@ public class MonetizationDTO {
 
     public void setApiUuid(String apiUuid) {
         this.apiUuid = apiUuid;
-    }
-
-    public String getApiName() {
-        return apiName;
-    }
-
-    public void setApiName(String apiName) {
-        this.apiName = apiName;
-    }
-
-    public String getApiVersion() {
-        return apiVersion;
-    }
-
-    public void setApiVersion(String apiVersion) {
-        this.apiVersion = apiVersion;
     }
 
     public String getTenantDomain() {
@@ -82,12 +62,12 @@ public class MonetizationDTO {
         this.applicationOwner = applicationOwner;
     }
 
-    public HashMap<String, Object> getCustomAttributes() {
-        return customAttributes;
+    public HashMap<String, Object> getProperties() {
+        return properties;
     }
 
-    public void setCustomAttributes(HashMap<String, Object> customAttributes) {
-        this.customAttributes = customAttributes;
+    public void setProperties(HashMap<String, Object> properties) {
+        this.properties = properties;
     }
 
     public Long getRequestCount() {

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/MonetizationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/MonetizationDTO.java
@@ -2,7 +2,7 @@ package org.wso2.carbon.apimgt.api.model;
 
 import java.util.HashMap;
 
-public class MonetizationUsageInfo {
+public class MonetizationDTO {
 
     Long currentTimestamp;
     String apiUuid;
@@ -14,7 +14,7 @@ public class MonetizationUsageInfo {
     HashMap<String, Object> customAttributes;
     Long requestCount;
 
-    public MonetizationUsageInfo(Long currentTimestamp, String apiUuid, String apiName, String apiVersion, String tenantDomain, String applicationName, String applicationOwner, HashMap<String, Object> customAttributes, Long requestCount) {
+    public MonetizationDTO(Long currentTimestamp, String apiUuid, String apiName, String apiVersion, String tenantDomain, String applicationName, String applicationOwner, HashMap<String, Object> customAttributes, Long requestCount) {
         this.currentTimestamp = currentTimestamp;
         this.apiUuid = apiUuid;
         this.apiName = apiName;

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/MonetizationUsageInfo.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/MonetizationUsageInfo.java
@@ -1,0 +1,100 @@
+package org.wso2.carbon.apimgt.api.model;
+
+import java.util.HashMap;
+
+public class MonetizationUsageInfo {
+
+    Long currentTimestamp;
+    String apiUuid;
+    String apiName;
+    String apiVersion;
+    String tenantDomain;
+    String applicationName;
+    String applicationOwner;
+    HashMap<String, Object> customAttributes;
+    Long requestCount;
+
+    public MonetizationUsageInfo(Long currentTimestamp, String apiUuid, String apiName, String apiVersion, String tenantDomain, String applicationName, String applicationOwner, HashMap<String, Object> customAttributes, Long requestCount) {
+        this.currentTimestamp = currentTimestamp;
+        this.apiUuid = apiUuid;
+        this.apiName = apiName;
+        this.apiVersion = apiVersion;
+        this.tenantDomain = tenantDomain;
+        this.applicationName = applicationName;
+        this.applicationOwner = applicationOwner;
+        this.customAttributes = customAttributes;
+        this.requestCount = requestCount;
+    }
+
+    public Long getCurrentTimestamp() {
+        return currentTimestamp;
+    }
+
+    public void setCurrentTimestamp(Long currentTimestamp) {
+        this.currentTimestamp = currentTimestamp;
+    }
+
+    public String getApiUuid() {
+        return apiUuid;
+    }
+
+    public void setApiUuid(String apiUuid) {
+        this.apiUuid = apiUuid;
+    }
+
+    public String getApiName() {
+        return apiName;
+    }
+
+    public void setApiName(String apiName) {
+        this.apiName = apiName;
+    }
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    public String getTenantDomain() {
+        return tenantDomain;
+    }
+
+    public void setTenantDomain(String tenantDomain) {
+        this.tenantDomain = tenantDomain;
+    }
+
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    public void setApplicationName(String applicationName) {
+        this.applicationName = applicationName;
+    }
+
+    public String getApplicationOwner() {
+        return applicationOwner;
+    }
+
+    public void setApplicationOwner(String applicationOwner) {
+        this.applicationOwner = applicationOwner;
+    }
+
+    public HashMap<String, Object> getCustomAttributes() {
+        return customAttributes;
+    }
+
+    public void setCustomAttributes(HashMap<String, Object> customAttributes) {
+        this.customAttributes = customAttributes;
+    }
+
+    public Long getRequestCount() {
+        return requestCount;
+    }
+
+    public void setRequestCount(Long requestCount) {
+        this.requestCount = requestCount;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -908,37 +908,23 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 workflowDTO.setApplicationName(applicationName);
                 workflowDTO.setApplicationId(application.getId());
                 workflowDTO.setSubscriber(userId);
-
-                Tier tier = null;
-                Set<Tier> policies = Collections.emptySet();
-                if (!isApiProduct) {
-                    policies = api.getAvailableTiers();
-                } else {
-                    policies = product.getAvailableTiers();
-                }
-
-                for (Tier policy : policies) {
-                    if (policy.getName() != null && (policy.getName()).equals(workflowDTO.getTierName())) {
-                        tier = policy;
-                    }
-                }
-                boolean isMonetizationEnabled = false;
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.API_UUID, apiUUID);
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.TIER_NAME, workflowDTO.getTierName());
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.SUBSCRIBER, userId);
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APINAME, identifier.getName());
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APIVERSION, identifier.getVersion());
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APICONTEXT, identifier.getVersion());
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APIPROVIDER, identifier.getProviderName());
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APPLICATIONNAME, applicationName);
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APPLICATIONID, String.valueOf(application.getId()));
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.REQUESTED_TIER_NAME, identifier.getTier());
 
                 if (api != null) {
-                    isMonetizationEnabled = api.getMonetizationStatus();
-                    //check whether monetization is enabled for API and tier plan is commercial
-                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
-                        subscriptionImpl.monetizeSubscription(workflowDTO, api);
-                    }
                     workflowResponse = addSubscriptionWFExecutor.execute(workflowDTO);
                 } else {
-                    isMonetizationEnabled = product.getMonetizationStatus();
-                    //check whether monetization is enabled for API and tier plan is commercial
-                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
-                        subscriptionImpl.monetizeSubscription(workflowDTO, product);
-                    }
                     workflowResponse = addSubscriptionWFExecutor.execute(workflowDTO);
                 }
+
             } catch (WorkflowException e) {
                 //If the workflow execution fails, roll back transaction by removing the subscription entry.
                 apiMgtDAO.removeSubscriptionById(subscriptionId);
@@ -1096,37 +1082,23 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 workflowDTO.setApplicationName(application.getName());
                 workflowDTO.setApplicationId(application.getId());
                 workflowDTO.setSubscriber(userId);
-
-                Tier tier = null;
-                Set<Tier> policies = Collections.emptySet();
-                if (!isApiProduct) {
-                    policies = api.getAvailableTiers();
-                } else {
-                    policies = product.getAvailableTiers();
-                }
-
-                for (Tier policy : policies) {
-                    if (policy.getName() != null && (policy.getName()).equals(workflowDTO.getTierName())) {
-                        tier = policy;
-                    }
-                }
-                boolean isMonetizationEnabled = false;
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.API_UUID, apiUUId);
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.TIER_NAME, workflowDTO.getTierName());
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.SUBSCRIBER, userId);
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APINAME, identifier.getName());
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APIVERSION, identifier.getVersion());
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APICONTEXT, identifier.getVersion());
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APIPROVIDER, identifier.getProviderName());
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APPLICATIONNAME, application.getName());
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APPLICATIONID, String.valueOf(application.getId()));
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.REQUESTED_TIER_NAME, identifier.getTier());
 
                 if (api != null) {
-                    isMonetizationEnabled = api.getMonetizationStatus();
-                    //check whether monetization is enabled for API and tier plan is commercial
-                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
-                        subscriptionImpl.monetizeSubscription(workflowDTO, api);
-                    }
                     workflowResponse = updateSubscriptionWFExecutor.execute(workflowDTO);
                 } else {
-                    isMonetizationEnabled = product.getMonetizationStatus();
-                    //check whether monetization is enabled for API and tier plan is commercial
-                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
-                        subscriptionImpl.monetizeSubscription(workflowDTO, product);
-                    }
                     workflowResponse = updateSubscriptionWFExecutor.execute(workflowDTO);
                 }
+
             } catch (WorkflowException e) {
                 throw new APIManagementException("Could not execute Workflow", e);
             } finally {
@@ -1295,12 +1267,23 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             workflowDTO.setCallbackUrl(removeSubscriptionWFExecutor.getCallbackURL());
             workflowDTO.setApplicationId(applicationId);
             workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.API_ID, String.valueOf(identifier.getId()));
+            workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.TIER_NAME, workflowDTO.getTierName());
+            workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.SUBSCRIBER, userId);
+            workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APINAME, identifier.getName());
+            workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APIVERSION, identifier.getVersion());
+            workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APICONTEXT, identifier.getVersion());
+            workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APIPROVIDER, identifier.getProviderName());
+            workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APPLICATIONNAME, applicationName);
+            workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APPLICATIONID, String.valueOf(applicationId));
+            workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.REQUESTED_TIER_NAME, identifier.getTier());
 
             String status = null;
             if (apiIdentifier != null) {
                 status = apiMgtDAO.getSubscriptionStatus(apiIdentifier.getUUID(), applicationId);
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.API_UUID, apiIdentifier.getUUID());
             } else if (apiProdIdentifier != null) {
                 status = apiMgtDAO.getSubscriptionStatus(apiProdIdentifier.getUUID(), applicationId);
+                workflowDTO.setMetadata(WorkflowConstants.PayloadConstants.API_UUID, apiProdIdentifier.getUUID());
             }
 
             String subId = null;
@@ -1356,41 +1339,12 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             workflowDTO.setCreatedTime(System.currentTimeMillis());
             workflowDTO.setExternalWorkflowReference(removeSubscriptionWFExecutor.generateUUID());
 
-            Tier tier = null;
             if (api != null) {
-                Set<Tier> policies = api.getAvailableTiers();
-                Iterator<Tier> iterator = policies.iterator();
-                boolean isPolicyAllowed = false;
-                while (iterator.hasNext()) {
-                    Tier policy = iterator.next();
-                    if (policy.getName() != null && (policy.getName()).equals(workflowDTO.getTierName())) {
-                        tier = policy;
-                    }
-                }
-            } else if (product != null) {
-                Set<Tier> policies = product.getAvailableTiers();
-                Iterator<Tier> iterator = policies.iterator();
-                boolean isPolicyAllowed = false;
-                while (iterator.hasNext()) {
-                    Tier policy = iterator.next();
-                    if (policy.getName() != null && (policy.getName()).equals(workflowDTO.getTierName())) {
-                        tier = policy;
-                    }
-                }
-            }
-            if (api != null) {
-                //check whether monetization is enabled for API and tier plan is commercial
-                if (api.getMonetizationStatus() && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
-                    subscriptionImpl.deleteMonetizedSubscription(workflowDTO, api);
-                }
                 removeSubscriptionWFExecutor.execute(workflowDTO);
             } else if (product != null) {
-                //check whether monetization is enabled for API product and tier plan is commercial
-                if (product.getMonetizationStatus() && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
-                    subscriptionImpl.deleteMonetizedSubscription(workflowDTO, product);
-                }
                 removeSubscriptionWFExecutor.execute(workflowDTO);
             }
+
             JSONObject subsLogObject = new JSONObject();
             subsLogObject.put(APIConstants.AuditLogConstants.API_NAME, identifier.getName());
             subsLogObject.put(APIConstants.AuditLogConstants.PROVIDER, identifier.getProviderName());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -101,7 +101,9 @@ import org.wso2.carbon.apimgt.impl.dto.TierPermissionDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
 import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.monetization.AbstractMonetization;
 import org.wso2.carbon.apimgt.impl.monetization.DefaultMonetizationImpl;
+import org.wso2.carbon.apimgt.impl.monetization.MonetizationSubscription;
 import org.wso2.carbon.apimgt.impl.notifier.events.ApplicationEvent;
 import org.wso2.carbon.apimgt.impl.notifier.events.ApplicationPolicyResetEvent;
 import org.wso2.carbon.apimgt.impl.notifier.events.ApplicationRegistrationEvent;
@@ -184,6 +186,8 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
 
     private static final Log log = LogFactory.getLog(APIConsumerImpl.class);
     private RecommendationEnvironment recommendationEnvironment;
+    private AbstractMonetization monetizationImpl = (AbstractMonetization) getMonetizationImplClass();
+    private MonetizationSubscription subscriptionImpl = monetizationImpl.getMonetizationSubscriptionClass();
 
     private static final Log audit = CarbonConstants.AUDIT_LOG;
     public static final char COLON_CHAR = ':';
@@ -924,18 +928,16 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                     isMonetizationEnabled = api.getMonetizationStatus();
                     //check whether monetization is enabled for API and tier plan is commercial
                     if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
-                        workflowResponse = addSubscriptionWFExecutor.monetizeSubscription(workflowDTO, api);
-                    } else {
-                        workflowResponse = addSubscriptionWFExecutor.execute(workflowDTO);
+                        subscriptionImpl.monetizeSubscription(workflowDTO, api);
                     }
+                    workflowResponse = addSubscriptionWFExecutor.execute(workflowDTO);
                 } else {
                     isMonetizationEnabled = product.getMonetizationStatus();
                     //check whether monetization is enabled for API and tier plan is commercial
                     if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
-                        workflowResponse = addSubscriptionWFExecutor.monetizeSubscription(workflowDTO, product);
-                    } else {
-                        workflowResponse = addSubscriptionWFExecutor.execute(workflowDTO);
+                        subscriptionImpl.monetizeSubscription(workflowDTO, product);
                     }
+                    workflowResponse = addSubscriptionWFExecutor.execute(workflowDTO);
                 }
             } catch (WorkflowException e) {
                 //If the workflow execution fails, roll back transaction by removing the subscription entry.
@@ -1114,18 +1116,16 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                     isMonetizationEnabled = api.getMonetizationStatus();
                     //check whether monetization is enabled for API and tier plan is commercial
                     if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
-                        workflowResponse = updateSubscriptionWFExecutor.monetizeSubscription(workflowDTO, api);
-                    } else {
-                        workflowResponse = updateSubscriptionWFExecutor.execute(workflowDTO);
+                        subscriptionImpl.monetizeSubscription(workflowDTO, api);
                     }
+                    workflowResponse = updateSubscriptionWFExecutor.execute(workflowDTO);
                 } else {
                     isMonetizationEnabled = product.getMonetizationStatus();
                     //check whether monetization is enabled for API and tier plan is commercial
                     if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
-                        workflowResponse = updateSubscriptionWFExecutor.monetizeSubscription(workflowDTO, product);
-                    } else {
-                        workflowResponse = updateSubscriptionWFExecutor.execute(workflowDTO);
+                        subscriptionImpl.monetizeSubscription(workflowDTO, product);
                     }
+                    workflowResponse = updateSubscriptionWFExecutor.execute(workflowDTO);
                 }
             } catch (WorkflowException e) {
                 throw new APIManagementException("Could not execute Workflow", e);
@@ -1381,17 +1381,15 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             if (api != null) {
                 //check whether monetization is enabled for API and tier plan is commercial
                 if (api.getMonetizationStatus() && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
-                    removeSubscriptionWFExecutor.deleteMonetizedSubscription(workflowDTO, api);
-                } else {
-                    removeSubscriptionWFExecutor.execute(workflowDTO);
+                    subscriptionImpl.deleteMonetizedSubscription(workflowDTO, api);
                 }
+                removeSubscriptionWFExecutor.execute(workflowDTO);
             } else if (product != null) {
                 //check whether monetization is enabled for API product and tier plan is commercial
                 if (product.getMonetizationStatus() && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
-                    removeSubscriptionWFExecutor.deleteMonetizedSubscription(workflowDTO, product);
-                } else {
-                    removeSubscriptionWFExecutor.execute(workflowDTO);
+                    subscriptionImpl.deleteMonetizedSubscription(workflowDTO, product);
                 }
+                removeSubscriptionWFExecutor.execute(workflowDTO);
             }
             JSONObject subsLogObject = new JSONObject();
             subsLogObject.put(APIConstants.AuditLogConstants.API_NAME, identifier.getName());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -403,6 +403,9 @@ public class APIManagerConfiguration {
                 OMElement enablePolicy = element.getFirstChildWithName(new QName("PolicyEnabled"));
                 analyticsProps.put("policyEnabled", enablePolicy.getText());
 
+                OMElement analyticsImplementation = element.getFirstChildWithName(new QName("AnalyticsImpl"));
+                analyticsProps.put("analyticsImpl", analyticsImplementation.getText());
+
                 analyticsProperties = analyticsProps;
             } else if ("PersistenceConfigs".equals(localName)) {
                 OMElement properties = element.getFirstChildWithName(new QName("Properties"));

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/analytics/DefaultAnalyticsImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/analytics/DefaultAnalyticsImpl.java
@@ -1,0 +1,12 @@
+package org.wso2.carbon.apimgt.impl.analytics;
+
+import org.wso2.carbon.apimgt.api.model.AnalyticsforMonetization;
+import org.wso2.carbon.apimgt.api.model.MonetizationUsagePublishInfo;
+import org.wso2.carbon.apimgt.common.analytics.exceptions.AnalyticsException;
+
+public class DefaultAnalyticsImpl implements AnalyticsforMonetization {
+    @Override
+    public Object getUsageData(MonetizationUsagePublishInfo monetizationUsagePublishInfo) throws AnalyticsException {
+        return new Object();
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/monetization/AbstractMonetization.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/monetization/AbstractMonetization.java
@@ -1,0 +1,85 @@
+package org.wso2.carbon.apimgt.impl.monetization;
+
+import org.wso2.carbon.apimgt.api.MonetizationException;
+import org.wso2.carbon.apimgt.api.model.AnalyticsforMonetization;
+import org.wso2.carbon.apimgt.api.model.Monetization;
+import org.wso2.carbon.apimgt.api.model.MonetizationUsagePublishInfo;
+import org.wso2.carbon.apimgt.common.analytics.exceptions.AnalyticsException;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Constructor;
+
+import java.util.Map;
+
+/**
+ * Abstract class for monetization, implements Monetization interface
+ */
+
+public abstract class AbstractMonetization implements Monetization {
+
+    private AnalyticsforMonetization analyticsClass;
+    private APIManagerConfiguration configuration = new APIManagerConfiguration();
+    public static final String ANALYTICS_IMPL = "analyticsImpl";
+
+    @Override
+    public boolean publishMonetizationUsageRecords(MonetizationUsagePublishInfo monetizationUsagePublishInfo) throws MonetizationException {
+        Object usageData = monetizationAnalyticsDataProvider(monetizationUsagePublishInfo);
+        return publishUsageData(usageData, monetizationUsagePublishInfo);
+    }
+
+    /**
+     * Publish the usageData to the billing engine
+     *
+     * @return true if the job is successful, and false otherwise
+     * @throws MonetizationException if failed to publish usageData
+     */
+    public abstract boolean publishUsageData(Object usageData, MonetizationUsagePublishInfo monetizationUsagePublishInfo) throws MonetizationException;
+
+    /**
+     * Returns an instance of the MonetizationSusbscription class
+     *
+     * @return MonetizationSubscription
+     */
+    public abstract MonetizationSubscription getMonetizationSubscriptionClass();
+
+    /**
+     * Gets Usage Data from Analytics Provider
+     *
+     * @param monetizationUsagePublishInfo monetization publish info
+     * @return usage data from analytics provider
+     * @throws AnalyticsException if the action failed
+     */
+    public Object monetizationAnalyticsDataProvider(MonetizationUsagePublishInfo monetizationUsagePublishInfo) throws MonetizationException{
+        Map<String,String> configs = configuration.getAnalyticsProperties();
+        String className;
+        if (configs.containsKey(ANALYTICS_IMPL) && !configs.get(ANALYTICS_IMPL).isEmpty()) {
+            className = configs.get(ANALYTICS_IMPL);
+        } else {
+            className = "org.wso2.am.analytics.retriever.choreo.ChoreoAnalyticsforMonetizationImpl";
+        }
+        String message;
+        try {
+            Class<?> callingClass = APIUtil.getClassForName(className);
+            Constructor<?> cons = callingClass.getConstructors()[0];
+            analyticsClass = (AnalyticsforMonetization) cons.newInstance();;
+            return analyticsClass.getUsageData(monetizationUsagePublishInfo);
+        }  catch (ClassNotFoundException e) {
+            message = "The specified class was not found";
+            throw new MonetizationException(message, e);
+        } catch (InvocationTargetException | AnalyticsException e) {
+            message = "Error fetching usage data";
+            throw new MonetizationException(message, e);
+        } catch (InstantiationException e) {
+            message = "Error creating class instance";
+            throw new MonetizationException(message, e);
+        } catch (IllegalAccessException e) {
+            message = "Error getting class access";
+            throw new MonetizationException(message, e);
+        } catch (ClassCastException e) {
+            message = "Error getting child class";
+            throw new MonetizationException(message, e);
+        } //handling of possible exceptions
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/monetization/AbstractMonetization.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/monetization/AbstractMonetization.java
@@ -49,7 +49,7 @@ public abstract class AbstractMonetization implements Monetization {
      *
      * @param monetizationUsagePublishInfo monetization publish info
      * @return usage data from analytics provider
-     * @throws AnalyticsException if the action failed
+     * @throws MonetizationException if the action failed
      */
     public Object monetizationAnalyticsDataProvider(MonetizationUsagePublishInfo monetizationUsagePublishInfo) throws MonetizationException{
         Map<String,String> configs = configuration.getAnalyticsProperties();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/monetization/DefaultMonetizationImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/monetization/DefaultMonetizationImpl.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
-public class DefaultMonetizationImpl implements Monetization {
+public class DefaultMonetizationImpl extends AbstractMonetization {
 
     @Override
     public boolean createBillingPlan(SubscriptionPolicy subPolicy) throws MonetizationException {
@@ -106,6 +106,16 @@ public class DefaultMonetizationImpl implements Monetization {
             throw new MonetizationException("Failed to update the monetization usage publish info", e);
         }
         return true;
+    }
+
+    @Override
+    public boolean publishUsageData(Object usageData, MonetizationUsagePublishInfo monetizationUsagePublishInfo) throws MonetizationException {
+        return true;
+    }
+
+    @Override
+    public MonetizationSubscription getMonetizationSubscriptionClass() {
+        return new DefaultMonetizationSubscriptionImpl();
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/monetization/DefaultMonetizationSubscriptionImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/monetization/DefaultMonetizationSubscriptionImpl.java
@@ -1,0 +1,29 @@
+package org.wso2.carbon.apimgt.impl.monetization;
+
+import org.wso2.carbon.apimgt.api.dto.WorkflowDTO;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIProduct;
+import org.wso2.carbon.apimgt.impl.workflow.WorkflowException;
+
+public class DefaultMonetizationSubscriptionImpl implements MonetizationSubscription{
+
+    @Override
+    public void monetizeSubscription(WorkflowDTO workflowDTO, API api) throws WorkflowException {
+
+    }
+
+    @Override
+    public void monetizeSubscription(org.wso2.carbon.apimgt.impl.dto.WorkflowDTO workflowDTO, APIProduct apiProduct) throws WorkflowException {
+
+    }
+
+    @Override
+    public void deleteMonetizedSubscription(org.wso2.carbon.apimgt.impl.dto.WorkflowDTO workflowDTO, API api) throws WorkflowException {
+
+    }
+
+    @Override
+    public void deleteMonetizedSubscription(org.wso2.carbon.apimgt.impl.dto.WorkflowDTO workflowDTO, APIProduct apiProduct) throws WorkflowException {
+
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/monetization/MonetizationSubscription.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/monetization/MonetizationSubscription.java
@@ -1,0 +1,48 @@
+package org.wso2.carbon.apimgt.impl.monetization;
+
+import org.wso2.carbon.apimgt.api.dto.WorkflowDTO;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIProduct;
+import org.wso2.carbon.apimgt.impl.workflow.WorkflowException;
+
+public interface MonetizationSubscription {
+
+    /**
+     * Implements monetization logic in workflow.
+     *
+     * @param workflowDTO - The WorkflowDTO which contains workflow contextual information related to the workflow.
+     * @param api - The API that is being subscribed to
+     * @throws WorkflowException - Thrown when the workflow execution was not fully performed.
+     */
+    public void monetizeSubscription(WorkflowDTO workflowDTO, API api) throws WorkflowException;
+
+    /**
+     * This method executes monetization related functions in the subscription creation workflow
+     *
+     * @param workflowDTO The WorkflowDTO which contains workflow contextual information related to the workflow
+     * @param apiProduct - API product to which the subscription relates to
+     * @throws WorkflowException Thrown when the workflow execution was not fully performed
+     */
+    public void monetizeSubscription(org.wso2.carbon.apimgt.impl.dto.WorkflowDTO workflowDTO, APIProduct apiProduct)
+            throws WorkflowException;
+
+    /**
+     * This method executes monetization related functions in the subscription deletion workflow
+     *
+     * @param workflowDTO The WorkflowDTO which contains workflow contextual information related to the workflow
+     * @param api - The API that is being subscribed to
+     * @throws WorkflowException Thrown when the workflow execution was not fully performed
+     */
+    public void deleteMonetizedSubscription(org.wso2.carbon.apimgt.impl.dto.WorkflowDTO workflowDTO, API api) throws WorkflowException;
+
+    /**
+     * This method executes monetization related functions in the subscription deletion workflow
+     *
+     * @param workflowDTO The WorkflowDTO which contains workflow contextual information related to the workflow
+     * @param apiProduct - API product to which the subscription relates to
+     * @throws WorkflowException Thrown when the workflow execution was not fully performed
+     */
+    public void deleteMonetizedSubscription(org.wso2.carbon.apimgt.impl.dto.WorkflowDTO workflowDTO, APIProduct apiProduct)
+            throws WorkflowException;
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionCreationApprovalWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionCreationApprovalWorkflowExecutor.java
@@ -21,17 +21,23 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.WorkflowResponse;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIProduct;
+import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
+import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
+import org.wso2.carbon.apimgt.impl.monetization.AbstractMonetization;
+import org.wso2.carbon.apimgt.impl.monetization.MonetizationSubscription;
 
 import java.util.List;
 
 /**
  * Approval workflow for API Subscription.
  */
-public class SubscriptionCreationApprovalWorkflowExecutor extends WorkflowExecutor {
+public class SubscriptionCreationApprovalWorkflowExecutor extends SubscriptionWorkflowExecutor {
 
     private static final Log log = LogFactory.getLog(SubscriptionCreationApprovalWorkflowExecutor.class);
 
@@ -43,6 +49,19 @@ public class SubscriptionCreationApprovalWorkflowExecutor extends WorkflowExecut
     @Override
     public List<WorkflowDTO> getWorkflowDetails(String workflowStatus) throws WorkflowException {
         return null;
+    }
+
+    /**
+     * Returns an instance of MonetizationSubscription to be called within complete for adding or removing monetized subscriptions
+     *
+     * @return an instance of MonetizationSubscription
+     * @throws APIManagementException due to it calling the getMonetizationImplClass method
+     */
+    @Override
+    public MonetizationSubscription getMonetizationSubscriptionClass() throws APIManagementException {
+        AbstractMonetization monetizationImpl = (AbstractMonetization) super.getMonetizationImplClass();
+        MonetizationSubscription subscriptionImpl = monetizationImpl.getMonetizationSubscriptionClass();
+        return subscriptionImpl;
     }
 
     /**
@@ -85,11 +104,34 @@ public class SubscriptionCreationApprovalWorkflowExecutor extends WorkflowExecut
             log.debug(logMessage);
         }
 
+        API api = null;
+        APIProduct product = null;
+
         if (WorkflowStatus.APPROVED.equals(workflowDTO.getStatus())) {
             ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();
             try {
                 apiMgtDAO.updateSubscriptionStatus(Integer.parseInt(workflowDTO.getWorkflowReference()),
                         APIConstants.SubscriptionStatus.UNBLOCKED);
+
+                ApiTypeWrapper apiTypeWrapper = getAPIorAPIProductwithWorkflowDTO(workflowDTO);
+                Tier tier = getAPIorAPIProductTier(apiTypeWrapper, workflowDTO);
+                boolean isApiProduct = apiTypeWrapper.isAPIProduct();
+                boolean isMonetizationEnabled = false;
+                MonetizationSubscription subscriptionImpl = getMonetizationSubscriptionClass();
+                if (isApiProduct) {
+                    product = apiTypeWrapper.getApiProduct();
+                    isMonetizationEnabled = product.getMonetizationStatus();
+                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                        subscriptionImpl.monetizeSubscription(workflowDTO, product);
+                    }
+                } else {
+                    api = apiTypeWrapper.getApi();
+                    isMonetizationEnabled = api.getMonetizationStatus();
+                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                        subscriptionImpl.monetizeSubscription(workflowDTO, api);
+                    }
+                }
+
             } catch (APIManagementException e) {
                 log.error("Could not complete subscription creation workflow", e);
                 throw new WorkflowException("Could not complete subscription creation workflow", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionCreationSimpleWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionCreationSimpleWorkflowExecutor.java
@@ -59,25 +59,6 @@ public class SubscriptionCreationSimpleWorkflowExecutor extends WorkflowExecutor
     }
 
     /**
-     * This method is responsible for creating monetuzation logic and returns the execute method.
-     *
-     * @param workflowDTO The WorkflowDTO which contains workflow contextual information related to the workflow
-     * @return workflow response to the caller by returning the execute() method
-     * @throws WorkflowException
-     */
-    @Override
-    public WorkflowResponse monetizeSubscription(WorkflowDTO workflowDTO, API api) throws WorkflowException {
-        // implemetation is not provided in this version
-        return execute(workflowDTO);
-    }
-
-    @Override
-    public WorkflowResponse monetizeSubscription(WorkflowDTO workflowDTO, APIProduct apiProduct) throws WorkflowException {
-        // implementation is not provided in this version
-        return execute(workflowDTO);
-    }
-
-    /**
      * This method completes subscription creation simple workflow and return workflow response back to the caller
      *
      * @param workflowDTO The WorkflowDTO which contains workflow contextual information related to the workflow

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionCreationSimpleWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionCreationSimpleWorkflowExecutor.java
@@ -24,14 +24,18 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.WorkflowResponse;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIProduct;
+import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
+import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
+import org.wso2.carbon.apimgt.impl.monetization.AbstractMonetization;
+import org.wso2.carbon.apimgt.impl.monetization.MonetizationSubscription;
 
 import java.util.List;
 
-public class SubscriptionCreationSimpleWorkflowExecutor extends WorkflowExecutor {
+public class SubscriptionCreationSimpleWorkflowExecutor extends SubscriptionWorkflowExecutor {
 
     private static final Log log = LogFactory.getLog(SubscriptionCreationSimpleWorkflowExecutor.class);
 
@@ -43,6 +47,19 @@ public class SubscriptionCreationSimpleWorkflowExecutor extends WorkflowExecutor
     @Override
     public List<WorkflowDTO> getWorkflowDetails(String workflowStatus) throws WorkflowException {
         return null;
+    }
+
+    /**
+     * Returns an instance of MonetizationSubscription to be called within complete for adding or removing monetized subscriptions
+     *
+     * @return an instance of MonetizationSubscription
+     * @throws APIManagementException due to it calling the getMonetizationImplClass method
+     */
+    @Override
+    public MonetizationSubscription getMonetizationSubscriptionClass() throws APIManagementException {
+        AbstractMonetization monetizationImpl = (AbstractMonetization) super.getMonetizationImplClass();
+        MonetizationSubscription subscriptionImpl = monetizationImpl.getMonetizationSubscriptionClass();
+        return subscriptionImpl;
     }
 
     /**
@@ -81,9 +98,33 @@ public class SubscriptionCreationSimpleWorkflowExecutor extends WorkflowExecutor
         workflowDTO.setUpdatedTime(System.currentTimeMillis());
         super.complete(workflowDTO);
         ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();
+
+        API api = null;
+        APIProduct product = null;
+
         try {
             apiMgtDAO.updateSubscriptionStatus(Integer.parseInt(workflowDTO.getWorkflowReference()),
                     APIConstants.SubscriptionStatus.UNBLOCKED);
+
+            ApiTypeWrapper apiTypeWrapper = getAPIorAPIProductwithWorkflowDTO(workflowDTO);
+            Tier tier = getAPIorAPIProductTier(apiTypeWrapper, workflowDTO);
+            boolean isApiProduct = apiTypeWrapper.isAPIProduct();
+            boolean isMonetizationEnabled = false;
+            MonetizationSubscription subscriptionImpl = getMonetizationSubscriptionClass();
+            if (isApiProduct) {
+                product = apiTypeWrapper.getApiProduct();
+                isMonetizationEnabled = product.getMonetizationStatus();
+                if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                    subscriptionImpl.monetizeSubscription(workflowDTO, product);
+                }
+            } else {
+                api = apiTypeWrapper.getApi();
+                isMonetizationEnabled = api.getMonetizationStatus();
+                if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                    subscriptionImpl.monetizeSubscription(workflowDTO, api);
+                }
+            }
+
         } catch (APIManagementException e) {
             log.error("Could not complete subscription creation workflow", e);
             throw new WorkflowException("Could not complete subscription creation workflow", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionCreationSimpleWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionCreationSimpleWorkflowExecutor.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIProduct;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
 
 import java.util.List;
@@ -53,8 +54,17 @@ public class SubscriptionCreationSimpleWorkflowExecutor extends WorkflowExecutor
      */
     @Override
     public WorkflowResponse execute(WorkflowDTO workflowDTO) throws WorkflowException {
+
+        SubscriptionWorkflowDTO subsWorkflowDTO = (SubscriptionWorkflowDTO) workflowDTO;
+        workflowDTO.setProperties("apiName", subsWorkflowDTO.getApiName());
+        workflowDTO.setProperties("apiVersion", subsWorkflowDTO.getApiVersion());
+        workflowDTO.setProperties("subscriber", subsWorkflowDTO.getSubscriber());
+        workflowDTO.setProperties("applicationName", subsWorkflowDTO.getApplicationName());
+        super.execute(workflowDTO);
+
         workflowDTO.setStatus(WorkflowStatus.APPROVED);
         WorkflowResponse workflowResponse = complete(workflowDTO);
+
         return workflowResponse;
     }
 
@@ -67,6 +77,9 @@ public class SubscriptionCreationSimpleWorkflowExecutor extends WorkflowExecutor
      */
     @Override
     public WorkflowResponse complete(WorkflowDTO workflowDTO) throws WorkflowException {
+
+        workflowDTO.setUpdatedTime(System.currentTimeMillis());
+        super.complete(workflowDTO);
         ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();
         try {
             apiMgtDAO.updateSubscriptionStatus(Integer.parseInt(workflowDTO.getWorkflowReference()),

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionCreationWSWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionCreationWSWorkflowExecutor.java
@@ -30,17 +30,23 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.WorkflowResponse;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIProduct;
+import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
+import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.monetization.AbstractMonetization;
+import org.wso2.carbon.apimgt.impl.monetization.MonetizationSubscription;
 
 import javax.xml.stream.XMLStreamException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SubscriptionCreationWSWorkflowExecutor extends WorkflowExecutor {
+public class SubscriptionCreationWSWorkflowExecutor extends SubscriptionWorkflowExecutor {
     private static final Log log = LogFactory.getLog(SubscriptionCreationWSWorkflowExecutor.class);
     private String serviceEndpoint;
     private String username;
@@ -55,6 +61,19 @@ public class SubscriptionCreationWSWorkflowExecutor extends WorkflowExecutor {
     @Override
     public List<WorkflowDTO> getWorkflowDetails(String workflowStatus) throws WorkflowException {
         return null;
+    }
+
+    /**
+     * Returns an instance of MonetizationSubscription to be called within complete for adding or removing monetized subscriptions
+     *
+     * @return an instance of MonetizationSubscription
+     * @throws APIManagementException due to it calling the getMonetizationImplClass method
+     */
+    @Override
+    public MonetizationSubscription getMonetizationSubscriptionClass() throws APIManagementException {
+        AbstractMonetization monetizationImpl = (AbstractMonetization) super.getMonetizationImplClass();
+        MonetizationSubscription subscriptionImpl = monetizationImpl.getMonetizationSubscriptionClass();
+        return subscriptionImpl;
     }
 
     /**
@@ -116,9 +135,31 @@ public class SubscriptionCreationWSWorkflowExecutor extends WorkflowExecutor {
 
         if (WorkflowStatus.APPROVED.equals(workflowDTO.getStatus())) {
             ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();
+            API api = null;
+            APIProduct product = null;
             try {
                 apiMgtDAO.updateSubscriptionStatus(Integer.parseInt(workflowDTO.getWorkflowReference()),
                         APIConstants.SubscriptionStatus.UNBLOCKED);
+
+                ApiTypeWrapper apiTypeWrapper = getAPIorAPIProductwithWorkflowDTO(workflowDTO);
+                Tier tier = getAPIorAPIProductTier(apiTypeWrapper, workflowDTO);
+                boolean isApiProduct = apiTypeWrapper.isAPIProduct();
+                boolean isMonetizationEnabled = false;
+                MonetizationSubscription subscriptionImpl = getMonetizationSubscriptionClass();
+                if (isApiProduct) {
+                    product = apiTypeWrapper.getApiProduct();
+                    isMonetizationEnabled = product.getMonetizationStatus();
+                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                        subscriptionImpl.monetizeSubscription(workflowDTO, product);
+                    }
+                } else {
+                    api = apiTypeWrapper.getApi();
+                    isMonetizationEnabled = api.getMonetizationStatus();
+                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                        subscriptionImpl.monetizeSubscription(workflowDTO, api);
+                    }
+                }
+
             } catch (APIManagementException e) {
                 log.error("Could not complete subscription creation workflow", e);
                 throw new WorkflowException("Could not complete subscription creation workflow", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionApprovalWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionApprovalWorkflowExecutor.java
@@ -21,14 +21,18 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.WorkflowResponse;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIProduct;
+import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
+import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
+import org.wso2.carbon.apimgt.impl.monetization.AbstractMonetization;
+import org.wso2.carbon.apimgt.impl.monetization.MonetizationSubscription;
 
 import java.util.*;
 
-public class SubscriptionDeletionApprovalWorkflowExecutor extends WorkflowExecutor {
+public class SubscriptionDeletionApprovalWorkflowExecutor extends SubscriptionWorkflowExecutor {
 
     private static final Log log = LogFactory.getLog(SubscriptionDeletionApprovalWorkflowExecutor.class);
 
@@ -36,6 +40,19 @@ public class SubscriptionDeletionApprovalWorkflowExecutor extends WorkflowExecut
     public String getWorkflowType() {
 
         return WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_DELETION;
+    }
+
+    /**
+     * Returns an instance of MonetizationSubscription to be called within complete for adding or removing monetized subscriptions
+     *
+     * @return an instance of MonetizationSubscription
+     * @throws APIManagementException due to it calling the getMonetizationImplClass method
+     */
+    @Override
+    public MonetizationSubscription getMonetizationSubscriptionClass() throws APIManagementException {
+        AbstractMonetization monetizationImpl = (AbstractMonetization) super.getMonetizationImplClass();
+        MonetizationSubscription subscriptionImpl = monetizationImpl.getMonetizationSubscriptionClass();
+        return subscriptionImpl;
     }
 
     @Override
@@ -66,12 +83,34 @@ public class SubscriptionDeletionApprovalWorkflowExecutor extends WorkflowExecut
         ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();
         SubscriptionWorkflowDTO subWorkflowDTO = (SubscriptionWorkflowDTO) workflowDTO;
         String errorMsg = null;
+        API api = null;
+        APIProduct product = null;
 
         super.complete(subWorkflowDTO);
 
         if (WorkflowStatus.APPROVED.equals(subWorkflowDTO.getStatus())) {
             try {
                 apiMgtDAO.removeSubscriptionById(Integer.parseInt(subWorkflowDTO.getWorkflowReference()));
+
+                ApiTypeWrapper apiTypeWrapper = getAPIorAPIProductwithWorkflowDTO(workflowDTO);
+                Tier tier = getAPIorAPIProductTier(apiTypeWrapper, workflowDTO);
+                boolean isApiProduct = apiTypeWrapper.isAPIProduct();
+                boolean isMonetizationEnabled = false;
+                MonetizationSubscription subscriptionImpl = getMonetizationSubscriptionClass();
+                if (isApiProduct) {
+                    product = apiTypeWrapper.getApiProduct();
+                    isMonetizationEnabled = product.getMonetizationStatus();
+                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                        subscriptionImpl.deleteMonetizedSubscription(workflowDTO, product);
+                    }
+                } else {
+                    api = apiTypeWrapper.getApi();
+                    isMonetizationEnabled = api.getMonetizationStatus();
+                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                        subscriptionImpl.deleteMonetizedSubscription(workflowDTO, api);
+                    }
+                }
+
             } catch (APIManagementException e) {
                 errorMsg = "Could not complete subscription deletion workflow for api: " + subWorkflowDTO.getApiName();
                 throw new WorkflowException(errorMsg, e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionApprovalWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionApprovalWorkflowExecutor.java
@@ -99,18 +99,6 @@ public class SubscriptionDeletionApprovalWorkflowExecutor extends WorkflowExecut
     }
 
     @Override
-    public WorkflowResponse deleteMonetizedSubscription(WorkflowDTO workflowDTO, API api) throws WorkflowException {
-        // implementation is not provided in this version
-        return execute(workflowDTO);
-    }
-
-    @Override
-    public WorkflowResponse deleteMonetizedSubscription(WorkflowDTO workflowDTO, APIProduct apiProduct) throws WorkflowException {
-        // implementation is not provided in this version
-        return execute(workflowDTO);
-    }
-
-    @Override
     public void cleanUpPendingTask(String workflowExtRef) throws WorkflowException {
 
         String errorMsg;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionSimpleWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionSimpleWorkflowExecutor.java
@@ -20,19 +20,20 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.WorkflowResponse;
-import org.wso2.carbon.apimgt.api.model.API;
-import org.wso2.carbon.apimgt.api.model.APIIdentifier;
-import org.wso2.carbon.apimgt.api.model.APIProduct;
+import org.wso2.carbon.apimgt.api.model.*;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
+import org.wso2.carbon.apimgt.impl.monetization.AbstractMonetization;
+import org.wso2.carbon.apimgt.impl.monetization.MonetizationSubscription;
 
 import java.util.List;
 
 /**
  * Simple workflow executor for subscription delete action
  */
-public class SubscriptionDeletionSimpleWorkflowExecutor extends WorkflowExecutor {
+public class SubscriptionDeletionSimpleWorkflowExecutor extends SubscriptionWorkflowExecutor {
     private static final Log log = LogFactory.getLog(SubscriptionDeletionSimpleWorkflowExecutor.class);
 
     @Override
@@ -47,6 +48,19 @@ public class SubscriptionDeletionSimpleWorkflowExecutor extends WorkflowExecutor
         return null;
     }
 
+    /**
+     * Returns an instance of MonetizationSubscription to be called within complete for adding or removing monetized subscriptions
+     *
+     * @return an instance of MonetizationSubscription
+     * @throws APIManagementException due to it calling the getMonetizationImplClass method
+     */
+    @Override
+    public MonetizationSubscription getMonetizationSubscriptionClass() throws APIManagementException {
+        AbstractMonetization monetizationImpl = (AbstractMonetization) super.getMonetizationImplClass();
+        MonetizationSubscription subscriptionImpl = monetizationImpl.getMonetizationSubscriptionClass();
+        return subscriptionImpl;
+    }
+
     @Override
     public WorkflowResponse execute(WorkflowDTO workflowDTO) throws WorkflowException {
         workflowDTO.setStatus(WorkflowStatus.APPROVED);
@@ -59,12 +73,34 @@ public class SubscriptionDeletionSimpleWorkflowExecutor extends WorkflowExecutor
         ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();
         SubscriptionWorkflowDTO subWorkflowDTO = (SubscriptionWorkflowDTO) workflowDTO;
         String errorMsg = null;
+        API api = null;
+        APIProduct product = null;
 
         try {
             APIIdentifier identifier = new APIIdentifier(subWorkflowDTO.getApiProvider(),
                     subWorkflowDTO.getApiName(), subWorkflowDTO.getApiVersion());
             identifier.setId(Integer.parseInt(subWorkflowDTO.getMetadata(WorkflowConstants.PayloadConstants.API_ID)));
             apiMgtDAO.removeSubscription(identifier, ((SubscriptionWorkflowDTO) workflowDTO).getApplicationId());
+
+            ApiTypeWrapper apiTypeWrapper = getAPIorAPIProductwithWorkflowDTO(workflowDTO);
+            Tier tier = getAPIorAPIProductTier(apiTypeWrapper, workflowDTO);
+            boolean isApiProduct = apiTypeWrapper.isAPIProduct();
+            boolean isMonetizationEnabled = false;
+            MonetizationSubscription subscriptionImpl = getMonetizationSubscriptionClass();
+            if (isApiProduct) {
+                product = apiTypeWrapper.getApiProduct();
+                isMonetizationEnabled = product.getMonetizationStatus();
+                if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                    subscriptionImpl.deleteMonetizedSubscription(workflowDTO, product);
+                }
+            } else {
+                api = apiTypeWrapper.getApi();
+                isMonetizationEnabled = api.getMonetizationStatus();
+                if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                    subscriptionImpl.deleteMonetizedSubscription(workflowDTO, api);
+                }
+            }
+
         } catch (APIManagementException e) {
             errorMsg = "Could not complete subscription deletion workflow for api: " + subWorkflowDTO.getApiName();
             throw new WorkflowException(errorMsg, e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionSimpleWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionSimpleWorkflowExecutor.java
@@ -54,25 +54,6 @@ public class SubscriptionDeletionSimpleWorkflowExecutor extends WorkflowExecutor
         return new GeneralWorkflowResponse();
     }
 
-    /**
-     * This method is responsible for deleting the monetized subscription and returns the execute method.
-     *
-     * @param workflowDTO The WorkflowDTO which contains workflow contextual information related to the workflow
-     * @return workflow response to the caller by returning the execute() method
-     * @throws WorkflowException
-     */
-    @Override
-    public WorkflowResponse deleteMonetizedSubscription(WorkflowDTO workflowDTO, API api) throws WorkflowException {
-        // implementation is not provided in this version
-        return execute(workflowDTO);
-    }
-
-    @Override
-    public WorkflowResponse deleteMonetizedSubscription(WorkflowDTO workflowDTO, APIProduct apiProduct) throws WorkflowException {
-        // implementation is not provided in this version
-        return execute(workflowDTO);
-    }
-
     @Override
     public WorkflowResponse complete(WorkflowDTO workflowDTO) throws WorkflowException {
         ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionUpdateApprovalWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionUpdateApprovalWorkflowExecutor.java
@@ -21,17 +21,23 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.WorkflowResponse;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIProduct;
+import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
+import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
+import org.wso2.carbon.apimgt.impl.monetization.AbstractMonetization;
+import org.wso2.carbon.apimgt.impl.monetization.MonetizationSubscription;
 
 import java.util.List;
 
 /**
  * Approval workflow for API Subscription Tier Update.
  */
-public class SubscriptionUpdateApprovalWorkflowExecutor extends WorkflowExecutor {
+public class SubscriptionUpdateApprovalWorkflowExecutor extends SubscriptionWorkflowExecutor {
 
     private static final Log log = LogFactory.getLog(SubscriptionUpdateApprovalWorkflowExecutor.class);
 
@@ -43,6 +49,19 @@ public class SubscriptionUpdateApprovalWorkflowExecutor extends WorkflowExecutor
     @Override
     public List<WorkflowDTO> getWorkflowDetails(String workflowStatus) throws WorkflowException {
         return null;
+    }
+
+    /**
+     * Returns an instance of MonetizationSubscription to be called within complete for adding or removing monetized subscriptions
+     *
+     * @return an instance of MonetizationSubscription
+     * @throws APIManagementException due to it calling the getMonetizationImplClass method
+     */
+    @Override
+    public MonetizationSubscription getMonetizationSubscriptionClass() throws APIManagementException {
+        AbstractMonetization monetizationImpl = (AbstractMonetization) super.getMonetizationImplClass();
+        MonetizationSubscription subscriptionImpl = monetizationImpl.getMonetizationSubscriptionClass();
+        return subscriptionImpl;
     }
 
     /**
@@ -89,9 +108,31 @@ public class SubscriptionUpdateApprovalWorkflowExecutor extends WorkflowExecutor
         SubscriptionWorkflowDTO subscriptionWorkflowDTO = (SubscriptionWorkflowDTO) workflowDTO;
         if (WorkflowStatus.APPROVED.equals(workflowDTO.getStatus())) {
             ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();
+            API api = null;
+            APIProduct product = null;
             try {
                 apiMgtDAO.updateSubscriptionStatusAndTier(Integer.parseInt(subscriptionWorkflowDTO.getWorkflowReference()),
                         APIConstants.SubscriptionStatus.UNBLOCKED);
+
+                ApiTypeWrapper apiTypeWrapper = getAPIorAPIProductwithWorkflowDTO(workflowDTO);
+                Tier tier = getAPIorAPIProductTier(apiTypeWrapper, workflowDTO);
+                boolean isApiProduct = apiTypeWrapper.isAPIProduct();
+                boolean isMonetizationEnabled = false;
+                MonetizationSubscription subscriptionImpl = getMonetizationSubscriptionClass();
+                if (isApiProduct) {
+                    product = apiTypeWrapper.getApiProduct();
+                    isMonetizationEnabled = product.getMonetizationStatus();
+                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                        subscriptionImpl.monetizeSubscription(workflowDTO, product);
+                    }
+                } else {
+                    api = apiTypeWrapper.getApi();
+                    isMonetizationEnabled = api.getMonetizationStatus();
+                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                        subscriptionImpl.monetizeSubscription(workflowDTO, api);
+                    }
+                }
+
             } catch (APIManagementException e) {
                 log.error("Could not complete subscription update workflow", e);
                 throw new WorkflowException("Could not complete subscription update workflow", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionUpdateSimpleWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionUpdateSimpleWorkflowExecutor.java
@@ -60,25 +60,6 @@ public class SubscriptionUpdateSimpleWorkflowExecutor extends WorkflowExecutor {
     }
 
     /**
-     * This method is responsible for updating monetization logic and returns the execute method.
-     *
-     * @param workflowDTO The WorkflowDTO which contains workflow contextual information related to the workflow
-     * @return workflow response to the caller by returning the execute() method
-     * @throws WorkflowException
-     */
-    @Override
-    public WorkflowResponse monetizeSubscription(WorkflowDTO workflowDTO, API api) throws WorkflowException {
-        // implementation is not provided in this version
-        return execute(workflowDTO);
-    }
-
-    @Override
-    public WorkflowResponse monetizeSubscription(WorkflowDTO workflowDTO, APIProduct apiProduct) throws WorkflowException {
-        // implementation is not provided in this version
-        return execute(workflowDTO);
-    }
-
-    /**
      * This method completes subscription update simple workflow and return workflow response back to the caller
      *
      * @param workflowDTO The WorkflowDTO which contains workflow contextual information related to the workflow

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionUpdateWSWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionUpdateWSWorkflowExecutor.java
@@ -30,17 +30,23 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.WorkflowResponse;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIProduct;
+import org.wso2.carbon.apimgt.api.model.ApiTypeWrapper;
+import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
 import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.monetization.AbstractMonetization;
+import org.wso2.carbon.apimgt.impl.monetization.MonetizationSubscription;
 
 import javax.xml.stream.XMLStreamException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SubscriptionUpdateWSWorkflowExecutor extends WorkflowExecutor {
+public class SubscriptionUpdateWSWorkflowExecutor extends SubscriptionWorkflowExecutor {
     private static final Log log = LogFactory.getLog(SubscriptionUpdateWSWorkflowExecutor.class);
     private String serviceEndpoint;
     private String username;
@@ -55,6 +61,19 @@ public class SubscriptionUpdateWSWorkflowExecutor extends WorkflowExecutor {
     @Override
     public List<WorkflowDTO> getWorkflowDetails(String workflowStatus) throws WorkflowException {
         return null;
+    }
+
+    /**
+     * Returns an instance of MonetizationSubscription to be called within complete for adding or removing monetized subscriptions
+     *
+     * @return an instance of MonetizationSubscription
+     * @throws APIManagementException due to it calling the getMonetizationImplClass method
+     */
+    @Override
+    public MonetizationSubscription getMonetizationSubscriptionClass() throws APIManagementException {
+        AbstractMonetization monetizationImpl = (AbstractMonetization) super.getMonetizationImplClass();
+        MonetizationSubscription subscriptionImpl = monetizationImpl.getMonetizationSubscriptionClass();
+        return subscriptionImpl;
     }
 
     /**
@@ -116,9 +135,31 @@ public class SubscriptionUpdateWSWorkflowExecutor extends WorkflowExecutor {
 
         if (WorkflowStatus.APPROVED.equals(workflowDTO.getStatus())) {
             ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();
+            API api = null;
+            APIProduct product = null;
             try {
                 apiMgtDAO.updateSubscriptionStatus(Integer.parseInt(workflowDTO.getWorkflowReference()),
                         APIConstants.SubscriptionStatus.UNBLOCKED);
+
+                ApiTypeWrapper apiTypeWrapper = getAPIorAPIProductwithWorkflowDTO(workflowDTO);
+                Tier tier = getAPIorAPIProductTier(apiTypeWrapper, workflowDTO);
+                boolean isApiProduct = apiTypeWrapper.isAPIProduct();
+                boolean isMonetizationEnabled = false;
+                MonetizationSubscription subscriptionImpl = getMonetizationSubscriptionClass();
+                if (isApiProduct) {
+                    product = apiTypeWrapper.getApiProduct();
+                    isMonetizationEnabled = product.getMonetizationStatus();
+                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                        subscriptionImpl.monetizeSubscription(workflowDTO, product);
+                    }
+                } else {
+                    api = apiTypeWrapper.getApi();
+                    isMonetizationEnabled = api.getMonetizationStatus();
+                    if (isMonetizationEnabled && APIConstants.COMMERCIAL_TIER_PLAN.equals(tier.getTierPlan())) {
+                        subscriptionImpl.monetizeSubscription(workflowDTO, api);
+                    }
+                }
+
             } catch (APIManagementException e) {
                 log.error("Could not complete subscription update workflow", e);
                 throw new WorkflowException("Could not complete subscription update workflow", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionWorkflowExecutor.java
@@ -1,0 +1,125 @@
+package org.wso2.carbon.apimgt.impl.workflow;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.APIProvider;
+import org.wso2.carbon.apimgt.api.model.*;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerFactory;
+import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.dto.WorkflowDTO;
+import org.wso2.carbon.apimgt.impl.monetization.DefaultMonetizationImpl;
+import org.wso2.carbon.apimgt.impl.monetization.MonetizationSubscription;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This is the class that should be extended by each Subscription workflow implementation.
+ */
+public abstract class SubscriptionWorkflowExecutor extends WorkflowExecutor{
+
+    private static final Log log = LogFactory.getLog(SubscriptionWorkflowExecutor.class);
+
+    @Override
+    public String getWorkflowType() {
+        return "SUBSCRIPTION_SUPER";
+    }
+
+    @Override
+    public List<WorkflowDTO> getWorkflowDetails(String workflowStatus) throws WorkflowException {
+        return null;
+    }
+
+    /**
+     * Returns an instance of AbstractMonetization to be called within getMonetizationSubscriptionClass
+     *
+     * @return an instance of AbstractMonetization
+     * @throws APIManagementException if the action fails
+     */
+    public Monetization getMonetizationImplClass() throws APIManagementException {
+
+        APIManagerConfiguration configuration = org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder.
+                getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration();
+        Monetization monetizationImpl = null;
+        if (configuration == null) {
+            log.error("API Manager configuration is not initialized.");
+        } else {
+            String monetizationImplClass = configuration.getMonetizationConfigurationDto().getMonetizationImpl();
+            if (monetizationImplClass == null) {
+                monetizationImpl = new DefaultMonetizationImpl();
+            } else {
+                try {
+                    monetizationImpl = (Monetization) APIUtil.getClassInstance(monetizationImplClass);
+                } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+                    APIUtil.handleException("Failed to load monetization implementation class.", e);
+                }
+            }
+        }
+        return monetizationImpl;
+    }
+
+    /**
+     * Returns an instance of MonetizationSubscription to be called within complete for adding or removing monetized subscriptions
+     *
+     * @return an instance of MonetizationSubscription
+     * @throws APIManagementException due to it calling the getMonetizationImplClass method
+     */
+    public abstract MonetizationSubscription getMonetizationSubscriptionClass() throws APIManagementException;
+
+    /**
+     * Returns an instance of ApiTypeWrapper that contains either an instance of API or APIProduct to be used for monetized subscriptions
+     *
+     * @return an instance of ApiTypeWrapper
+     */
+    public ApiTypeWrapper getAPIorAPIProductwithWorkflowDTO(WorkflowDTO workflowDTO){
+        ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();
+        String UUID = workflowDTO.getMetadata(WorkflowConstants.PayloadConstants.API_UUID);
+        String tenantDomain;
+        String apiProviderName;
+        String apiName;
+        String apiVersion;
+        APIProvider apiProvider;
+        try {
+            tenantDomain = workflowDTO.getTenantDomain();
+            apiName = workflowDTO.getMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APINAME);
+            apiVersion = workflowDTO.getMetadata(WorkflowConstants.PayloadConstants.VARIABLE_APIVERSION);;
+            apiProviderName = apiMgtDAO.getAPIProviderByNameAndVersion(apiName, apiVersion, tenantDomain);
+            apiProvider = APIManagerFactory.getInstance().getAPIProvider(apiProviderName);
+            ApiTypeWrapper apiTypeWrapper = apiProvider.getAPIorAPIProductByUUID(UUID, tenantDomain);
+            return apiTypeWrapper;
+        } catch (APIManagementException e) {
+            log.error("An error occurred while retrieving API or API Product with UUID: " + UUID, e);
+        }
+        return null;
+    }
+
+    public Tier getAPIorAPIProductTier(ApiTypeWrapper apiTypeWrapper, WorkflowDTO workflowDTO){
+        API api = null;
+        APIProduct product = null;
+        String tierName = null;
+        boolean isApiProduct = apiTypeWrapper.isAPIProduct();
+        if (isApiProduct) {
+            product = apiTypeWrapper.getApiProduct();
+        } else {
+            api = apiTypeWrapper.getApi();
+        }
+        Tier tier = null;
+        tierName = workflowDTO.getMetadata(WorkflowConstants.PayloadConstants.TIER_NAME);
+        Set<Tier> policies = Collections.emptySet();
+        if (!isApiProduct) {
+            policies = api.getAvailableTiers();
+        } else {
+            policies = product.getAvailableTiers();
+        }
+        for (Tier policy : policies) {
+            if (policy.getName() != null && (policy.getName()).equals(tierName)) {
+                tier = policy;
+            }
+        }
+        return tier;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/WorkflowConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/WorkflowConstants.java
@@ -130,16 +130,23 @@ public class WorkflowConstants {
         public static final String VARIABLE_CLIENTSECRET = "clientSecret";
         public static final String VARIABLE_SCOPE = "scope";
         public static final String VARIABLE_TOKENAPI = "tokenAPI";
-        public static final String VARIABLE_APISTATE = "apiCurrentState";
+        public static final String VARIABLE_APISTATE = "apiCurrezntState";
         public static final String VARIABLE_API_LC_ACTION = "apiLCAction";
         public static final String VARIABLE_APINAME = "apiName";
+        public static final String VARIABLE_APPLICATIONNAME = "applicationName";
+        public static final String VARIABLE_APPLICATIONID = "applicationId";
         public static final String VARIABLE_APIVERSION = "apiVersion";
         public static final String VARIABLE_APIPROVIDER = "apiProvider";
+        public static final String VARIABLE_APICONTEXT = "apiContext";
         public static final String VARIABLE_CALLBACKURL = "callbackUrl";
         public static final String VARIABLE_WFREF = "wfReference";
         public static final String VARIABLE_INVOKER = "invoker";
+        public static final String TIER_NAME = "tierName";
+        public static final String REQUESTED_TIER_NAME = "requestedTierName";
 
         public static final String API_ID = "apiId";
+        public static final String API_UUID = "apiUUID";
+        public static final String SUBSCRIBER = "subscriber";
         
         public static final String DATA = "data";
         public static final String ID = "id";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/WorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/WorkflowExecutor.java
@@ -63,36 +63,6 @@ public abstract class WorkflowExecutor implements Serializable {
     }
 
     /**
-     * Implements monetization logic in workflow.
-     *
-     * @param workflowDTO - The WorkflowDTO which contains workflow contextual information related to the workflow.
-     * @throws WorkflowException - Thrown when the workflow execution was not fully performed.
-     */
-    public WorkflowResponse monetizeSubscription(WorkflowDTO workflowDTO, API api) throws WorkflowException {
-        return new GeneralWorkflowResponse();
-    }
-
-    public WorkflowResponse monetizeSubscription(WorkflowDTO workflowDTO, APIProduct apiProduct)
-            throws WorkflowException {
-        return new GeneralWorkflowResponse();
-    }
-
-    /**
-     * Implements monetization deletion logic in workflow.
-     *
-     * @param workflowDTO - The WorkflowDTO which contains workflow contextual information related to the workflow.
-     * @throws WorkflowException - Thrown when the workflow execution was not fully performed.
-     */
-    public WorkflowResponse deleteMonetizedSubscription(WorkflowDTO workflowDTO, API api) throws WorkflowException {
-        return new GeneralWorkflowResponse();
-    }
-
-    public WorkflowResponse deleteMonetizedSubscription(WorkflowDTO workflowDTO, APIProduct apiProduct)
-            throws WorkflowException {
-        return new GeneralWorkflowResponse();
-    }
-
-    /**
      * Implements the workflow completion logic.
      *
      * @param workflowDTO - The WorkflowDTO which contains workflow contextual information related to the workflow.

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -337,9 +337,11 @@
 
         <PolicyEnabled>{{apim.analytics.enablePolicy}}</PolicyEnabled>
 
+        <AnalyticsImpl>{{apim.analytics.analytics_impl}}</AnalyticsImpl>
+
         <Type>{{apim.analytics.type}}</Type>
 
-        <AuthToken>{{apim.analytics.auth_token}}</AuthToken>
+        <AuthToken>{{apim.analytics.auth_token}}</AuthToken>]
 
         {% if apim.analytics.response_schema_name is defined %}
         <ResponseSchemaName>{{apim.analytics.response_schema_name}}</ResponseSchemaName>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/config/api-manager.xml
@@ -175,6 +175,8 @@
 
         <AuthToken></AuthToken>
 
+        <AnalyticsImpl></AnalyticsImpl>
+
         <!-- Event publisher implementation -->
         <!-- <ReporterClass></ReporterClass> -->
 


### PR DESCRIPTION
# Purpose
To separate the adding and removing of monetized subscriptions logic from the billing engine

# Goals
Allows the subscriptions workflows to be more modular and customizable by allowing the interchange of different workflow classes

![Untitled-2025-05-15-0024](https://github.com/user-attachments/assets/d5fae774-6842-40b7-bd6a-6dd8d2528142)


# Approach
Move the monetized subscription logic to a seperate class where they will be called be a the monetizationImpl class