### PR TITLE
Make Authorization and apikey headers case-insensitive in WebSocket APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/InboundWebSocketProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/InboundWebSocketProcessor.java
@@ -67,6 +67,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -117,16 +118,14 @@ public class InboundWebSocketProcessor {
             if (isOauthAuthentication(req, inboundMessageContext)) {
                 inboundMessageContext.setAuthenticator(new OAuthAuthenticator());
                 setRequestHeaders(req, inboundMessageContext);
-                inboundMessageContext.getRequestHeaders().put(WebsocketUtil.authorizationHeader, req.headers()
-                        .get(WebsocketUtil.authorizationHeader));
+                setOrReplaceRequestHeaderIgnoreCase(WebsocketUtil.authorizationHeader, req, inboundMessageContext);
                 inboundProcessorResponseDTO =
                         handshakeProcessor.processHandshake(inboundMessageContext);
                 setRequestHeaders(req, inboundMessageContext);
             } else if (isAPIKeyAuthentication(req, inboundMessageContext)) {
                 inboundMessageContext.setAuthenticator(new ApiKeyAuthenticator());
                 setRequestHeaders(req, inboundMessageContext);
-                inboundMessageContext.getRequestHeaders().put(APIConstants.API_KEY_HEADER_QUERY_PARAM, req.headers()
-                        .get(APIConstants.API_KEY_HEADER_QUERY_PARAM));
+                setOrReplaceRequestHeaderIgnoreCase(APIConstants.API_KEY_HEADER_QUERY_PARAM, req, inboundMessageContext);
                 inboundProcessorResponseDTO =
                         handshakeProcessor.processHandshake(inboundMessageContext);
                 setRequestHeaders(req, inboundMessageContext);
@@ -226,7 +225,12 @@ public class InboundWebSocketProcessor {
     private boolean isOauthAuthentication(FullHttpRequest req, InboundMessageContext inboundMessageContext)
             throws APISecurityException {
 
-        if (!inboundMessageContext.getRequestHeaders().containsKey(WebsocketUtil.authorizationHeader)) {
+        boolean containsAuthorizationHeader = inboundMessageContext.getRequestHeaders()
+                .keySet()
+                .stream()
+                .anyMatch(key -> key.equalsIgnoreCase(WebsocketUtil.authorizationHeader));
+
+        if (!containsAuthorizationHeader) {
             QueryStringDecoder decoder = new QueryStringDecoder(inboundMessageContext.getFullRequestPath());
             Map<String, List<String>> requestMap = decoder.parameters();
             if (requestMap.containsKey(APIConstants.AUTHORIZATION_QUERY_PARAM_DEFAULT) && requestMap.get(APIConstants.
@@ -255,7 +259,12 @@ public class InboundWebSocketProcessor {
     private boolean isAPIKeyAuthentication(FullHttpRequest req, InboundMessageContext inboundMessageContext)
             throws APISecurityException {
 
-        if (!inboundMessageContext.getRequestHeaders().containsKey(APIConstants.API_KEY_HEADER_QUERY_PARAM)) {
+        boolean containsAuthorizationHeader = inboundMessageContext.getRequestHeaders()
+                .keySet()
+                .stream()
+                .anyMatch(key -> key.equalsIgnoreCase(APIConstants.API_KEY_HEADER_QUERY_PARAM));
+
+        if (!containsAuthorizationHeader) {
             QueryStringDecoder decoder = new QueryStringDecoder(inboundMessageContext.getFullRequestPath());
             Map<String, List<String>> requestMap = decoder.parameters();
             if (requestMap.containsKey(APIConstants.API_KEY_HEADER_QUERY_PARAM) && requestMap.get(APIConstants.
@@ -482,5 +491,23 @@ public class InboundWebSocketProcessor {
             request.headers().remove(header);
         }
         inboundMessageContext.setHeadersToRemove(new ArrayList<>());
+    }
+
+    /**
+     * Sets or replaces a request header in InboundMessageContext matching the header key case-insensitively.
+     *
+     * @param headerKey             Header key to set or replace
+     * @param request               Handshake request
+     * @param inboundMessageContext InboundMessageContext
+     */
+    private static void setOrReplaceRequestHeaderIgnoreCase(String headerKey, FullHttpRequest request,
+                                                            InboundMessageContext inboundMessageContext) {
+        Optional<String> existingKey = inboundMessageContext.getRequestHeaders().keySet()
+                .stream()
+                .filter(key -> key.equalsIgnoreCase(headerKey))
+                .findFirst();
+
+        existingKey.ifPresent(inboundMessageContext.getRequestHeaders()::remove);
+        inboundMessageContext.getRequestHeaders().put(headerKey, request.headers().get(headerKey));
     }
 }


### PR DESCRIPTION
### Purpose
> Publishing custom analytics data is only available for Synapse APIs. This PR extends this support to webhook APIs.
Related Issue: https://github.com/wso2/api-manager/issues/3897

### Goals
> Enable publishing custom analytics for webhook APIs in both successful and faulty flows.

### Approach
> A new constructor is added to WebhooksAnalyticsDataProvider to accept an AnalyticsCustomDataProvider, allowing injection of custom analytics logic.
A new method getProperties() is implemented to extract custom properties from the injected provider, and additionally append the api.context [1].
In WebhooksUtils, check for the availability of an AnalyticsCustomDataProvider via the ServiceReferenceHolder and initializes the provider accordingly.
[1] https://github.com/wso2-enterprise/wso2-apim-internal/issues/9437#issuecomment-2865882603