### PR TITLE
Fix Resident KM Handling of Migrated Apps with Neg Token Exp Times

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -237,67 +237,91 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
             additionalProperties = new Gson().fromJson((String) parameter, Map.class);
         }
         if (additionalProperties.containsKey(APIConstants.KeyManager.APPLICATION_ACCESS_TOKEN_EXPIRY_TIME)) {
-            Object expiryTimeObject =
-                    additionalProperties.get(APIConstants.KeyManager.APPLICATION_ACCESS_TOKEN_EXPIRY_TIME);
-            if (expiryTimeObject instanceof String) {
-                if (!APIConstants.KeyManager.NOT_APPLICABLE_VALUE.equals(expiryTimeObject)) {
-                    try {
+            Object expiryTimeObject = additionalProperties.get(APIConstants.KeyManager
+                    .APPLICATION_ACCESS_TOKEN_EXPIRY_TIME);
+            try {
+                if (expiryTimeObject instanceof String) {
+                    if (!APIConstants.KeyManager.NOT_APPLICABLE_VALUE.equals(expiryTimeObject)) {
                         long expiry = Long.parseLong((String) expiryTimeObject);
                         if (expiry < 0) {
                             throw new APIManagementException("Invalid application access token expiry time given for "
                                     + oauthClientName, ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
                         }
                         clientInfo.setApplicationAccessTokenLifeTime(expiry);
-                    } catch (NumberFormatException e) {
-                        // No need to throw as its due to not a number sent.
                     }
+                } else if (expiryTimeObject instanceof Number) {
+                    long expiry = ((Number) expiryTimeObject).longValue();
+                    if (expiry < 0) {
+                        throw new APIManagementException("Invalid application access token expiry time given for "
+                                + oauthClientName, ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
+                    }
+                    clientInfo.setApplicationAccessTokenLifeTime(expiry);
                 }
+            } catch (NumberFormatException e) {
+                // No need to throw as it's due to invalid number format.
+                log.debug("Invalid application access token expiry time given for " + oauthClientName, e);
             }
         }
+
         if (additionalProperties.containsKey(APIConstants.KeyManager.USER_ACCESS_TOKEN_EXPIRY_TIME)) {
-            Object expiryTimeObject =
-                    additionalProperties.get(APIConstants.KeyManager.USER_ACCESS_TOKEN_EXPIRY_TIME);
-            if (expiryTimeObject instanceof String) {
-                if (!APIConstants.KeyManager.NOT_APPLICABLE_VALUE.equals(expiryTimeObject)) {
-                    try {
+            Object expiryTimeObject = additionalProperties.get(APIConstants.KeyManager.USER_ACCESS_TOKEN_EXPIRY_TIME);
+            try {
+                if (expiryTimeObject instanceof String) {
+                    if (!APIConstants.KeyManager.NOT_APPLICABLE_VALUE.equals(expiryTimeObject)) {
                         long expiry = Long.parseLong((String) expiryTimeObject);
                         if (expiry < 0) {
                             throw new APIManagementException("Invalid user access token expiry time given for "
                                     + oauthClientName, ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
                         }
                         clientInfo.setUserAccessTokenLifeTime(expiry);
-                    } catch (NumberFormatException e) {
-                        // No need to throw as its due to not a number sent.
                     }
+                } else if (expiryTimeObject instanceof Number) {
+                    long expiry = ((Number) expiryTimeObject).longValue();
+                    if (expiry < 0) {
+                        throw new APIManagementException("Invalid user access token expiry time given for "
+                                + oauthClientName, ExceptionCodes.INVALID_APPLICATION_PROPERTIES);
+                    }
+                    clientInfo.setUserAccessTokenLifeTime(expiry);
                 }
+            } catch (NumberFormatException e) {
+                // No need to throw as it's due to a non-numeric value.
+                log.debug("Invalid user access token expiry time given for " + oauthClientName, e);
             }
         }
+
         if (additionalProperties.containsKey(APIConstants.KeyManager.REFRESH_TOKEN_EXPIRY_TIME)) {
-            Object expiryTimeObject =
-                    additionalProperties.get(APIConstants.KeyManager.REFRESH_TOKEN_EXPIRY_TIME);
-            if (expiryTimeObject instanceof String) {
-                if (!APIConstants.KeyManager.NOT_APPLICABLE_VALUE.equals(expiryTimeObject)) {
-                    try {
+            Object expiryTimeObject = additionalProperties.get(APIConstants.KeyManager.REFRESH_TOKEN_EXPIRY_TIME);
+            try {
+                if (expiryTimeObject instanceof String) {
+                    if (!APIConstants.KeyManager.NOT_APPLICABLE_VALUE.equals(expiryTimeObject)) {
                         long expiry = Long.parseLong((String) expiryTimeObject);
                         clientInfo.setRefreshTokenLifeTime(expiry);
-                    } catch (NumberFormatException e) {
-                        // No need to throw as its due to not a number sent.
                     }
+                } else if (expiryTimeObject instanceof Number) {
+                    long expiry = ((Number) expiryTimeObject).longValue();
+                    clientInfo.setRefreshTokenLifeTime(expiry);
                 }
+            } catch (NumberFormatException e) {
+                // No need to throw as it's due to a non-numeric value.
+                log.debug("Invalid refresh token expiry time given for " + oauthClientName, e);
             }
         }
+
         if (additionalProperties.containsKey(APIConstants.KeyManager.ID_TOKEN_EXPIRY_TIME)) {
-            Object expiryTimeObject =
-                    additionalProperties.get(APIConstants.KeyManager.ID_TOKEN_EXPIRY_TIME);
-            if (expiryTimeObject instanceof String) {
-                if (!APIConstants.KeyManager.NOT_APPLICABLE_VALUE.equals(expiryTimeObject)) {
-                    try {
+            Object expiryTimeObject = additionalProperties.get(APIConstants.KeyManager.ID_TOKEN_EXPIRY_TIME);
+            try {
+                if (expiryTimeObject instanceof String) {
+                    if (!APIConstants.KeyManager.NOT_APPLICABLE_VALUE.equals(expiryTimeObject)) {
                         long expiry = Long.parseLong((String) expiryTimeObject);
                         clientInfo.setIdTokenLifeTime(expiry);
-                    } catch (NumberFormatException e) {
-                        // No need to throw as its due to not a number sent.
                     }
+                } else if (expiryTimeObject instanceof Number) {
+                    long expiry = ((Number) expiryTimeObject).longValue();
+                    clientInfo.setIdTokenLifeTime(expiry);
                 }
+            } catch (NumberFormatException e) {
+                // No need to throw as it's due to a non-numeric value.
+                log.debug("Invalid ID token expiry time given for " + oauthClientName, e);
             }
         }
 
@@ -311,6 +335,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                         clientInfo.setPkceMandatory(pkceMandatory);
                     } catch (NumberFormatException e) {
                         // No need to throw as its due to not a number sent.
+                        log.debug("Invalid PKCE mandatory value given for " + oauthClientName, e);
                     }
                 }
             }
@@ -326,6 +351,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                         clientInfo.setPkceSupportPlain(pkceSupportPlain);
                     } catch (NumberFormatException e) {
                         // No need to throw as its due to not a number sent.
+                        log.debug("Invalid PKCE support plain value given for " + oauthClientName, e);
                     }
                 }
             }
@@ -341,6 +367,7 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
                         clientInfo.setBypassClientCredentials(bypassClientCredentials);
                     } catch (NumberFormatException e) {
                         // No need to throw as its due to not a number sent.
+                        log.debug("Invalid bypass client credentials value given for " + oauthClientName, e);
                     }
                 }
             }
@@ -690,12 +717,13 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
         oAuthApplicationInfo.addParameter(ApplicationConstants.OAUTH_CLIENT_NAME, appResponse.getClientName());
         Map<String, Object> additionalProperties = new HashMap<>();
         additionalProperties.put(APIConstants.KeyManager.APPLICATION_ACCESS_TOKEN_EXPIRY_TIME,
-                appResponse.getApplicationAccessTokenLifeTime());
+                sanitizeExpiryTime(appResponse.getApplicationAccessTokenLifeTime()));
         additionalProperties.put(APIConstants.KeyManager.USER_ACCESS_TOKEN_EXPIRY_TIME,
-                appResponse.getUserAccessTokenLifeTime());
+                sanitizeExpiryTime(appResponse.getUserAccessTokenLifeTime()));
         additionalProperties.put(APIConstants.KeyManager.REFRESH_TOKEN_EXPIRY_TIME,
-                appResponse.getRefreshTokenLifeTime());
-        additionalProperties.put(APIConstants.KeyManager.ID_TOKEN_EXPIRY_TIME, appResponse.getIdTokenLifeTime());
+                sanitizeExpiryTime(appResponse.getRefreshTokenLifeTime()));
+        additionalProperties.put(APIConstants.KeyManager.ID_TOKEN_EXPIRY_TIME,
+                sanitizeExpiryTime(appResponse.getIdTokenLifeTime()));
         additionalProperties.put(APIConstants.KeyManager.PKCE_MANDATORY, appResponse.getPkceMandatory());
         additionalProperties.put(APIConstants.KeyManager.PKCE_SUPPORT_PLAIN, appResponse.getPkceSupportPlain());
         additionalProperties.put(APIConstants.KeyManager.BYPASS_CLIENT_CREDENTIALS,
@@ -703,6 +731,20 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
 
         oAuthApplicationInfo.addParameter(APIConstants.JSON_ADDITIONAL_PROPERTIES, additionalProperties);
         return oAuthApplicationInfo;
+    }
+
+    /**
+     * This method is used to sanitize the expiry time values.
+     * If the value is -1, it will be set to Integer.MAX_VALUE - 1L
+     *
+     * @param expTimeValue Expiry time value
+     * @return Sanitized expiry time value
+     */
+    private Long sanitizeExpiryTime(Long expTimeValue) {
+        if (expTimeValue != null && expTimeValue == -1L) {
+            return Integer.MAX_VALUE - 1L;
+        }
+        return expTimeValue;
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImplTest.java
@@ -301,6 +301,76 @@ public class AMDefaultKeyManagerImplTest {
         Assert.assertEquals(APIConstants.DEFAULT_TOKEN_TYPE, tokenType);
     }
 
+    @Test
+    public void testApplicationInfoBuildWithNegativeExpiryTimes() throws Exception {
+        OAuthApplicationInfo oauthApplication = new OAuthApplicationInfo();
+        oauthApplication.setClientId("test");
+        oauthApplication.setTokenType(APIConstants.TOKEN_TYPE_OAUTH);
+
+        String customTokenType = "customTokenType";
+        ClientInfo clientInfo = new ClientInfo();
+        clientInfo.setTokenType(customTokenType);
+        clientInfo.setRefreshTokenLifeTime(-1L);
+        clientInfo.setUserAccessTokenLifeTime(-1L);
+        clientInfo.setApplicationAccessTokenLifeTime(-1L);
+        clientInfo.setIdTokenLifeTime(-1L);
+
+        Mockito.when(dcrClient.getApplication(java.util.Base64.getUrlEncoder().encodeToString(
+                oauthApplication.getClientId().getBytes(StandardCharsets.UTF_8)))).thenReturn(clientInfo);
+
+        OAuthApplicationInfo appInfo = Whitebox.invokeMethod(keyManager, "buildDTOFromClientInfo",
+                clientInfo, oauthApplication);
+        Map<String, Object> additionalProps = new HashMap<>();
+        Object additionalPropsObj = appInfo.getParameter(APIConstants.JSON_ADDITIONAL_PROPERTIES);
+        Assert.assertTrue(additionalPropsObj instanceof Map);
+
+        additionalProps = (Map<String, Object>) additionalPropsObj;
+        Assert.assertEquals(Integer.MAX_VALUE - 1L,
+                additionalProps.get(APIConstants.KeyManager.REFRESH_TOKEN_EXPIRY_TIME));
+        Assert.assertEquals(Integer.MAX_VALUE - 1L,
+                additionalProps.get(APIConstants.KeyManager.USER_ACCESS_TOKEN_EXPIRY_TIME));
+        Assert.assertEquals(Integer.MAX_VALUE - 1L,
+                additionalProps.get(APIConstants.KeyManager.APPLICATION_ACCESS_TOKEN_EXPIRY_TIME));
+        Assert.assertEquals(Integer.MAX_VALUE - 1L,
+                additionalProps.get(APIConstants.KeyManager.ID_TOKEN_EXPIRY_TIME));
+    }
+
+    @Test
+    public void testApplicationInfoBuildWithPositiveExpiryTimes() throws Exception {
+        OAuthApplicationInfo oauthApplication = new OAuthApplicationInfo();
+        oauthApplication.setClientId("test");
+        oauthApplication.setTokenType(APIConstants.TOKEN_TYPE_OAUTH);
+
+        String customTokenType = "customTokenType";
+        ClientInfo clientInfo = new ClientInfo();
+        clientInfo.setTokenType(customTokenType);
+        clientInfo.setRefreshTokenLifeTime(100L);
+        clientInfo.setUserAccessTokenLifeTime(100L);
+        clientInfo.setApplicationAccessTokenLifeTime(100L);
+        clientInfo.setIdTokenLifeTime(100L);
+
+        Mockito.when(dcrClient.getApplication(java.util.Base64.getUrlEncoder().encodeToString(
+                oauthApplication.getClientId().getBytes(StandardCharsets.UTF_8)))).thenReturn(clientInfo);
+
+        OAuthApplicationInfo appInfo = Whitebox.invokeMethod(keyManager, "buildDTOFromClientInfo",
+                clientInfo, oauthApplication);
+        Map<String, Object> additionalProps = new HashMap<>();
+        Object additionalPropsObj = appInfo.getParameter(APIConstants.JSON_ADDITIONAL_PROPERTIES);
+        Assert.assertTrue(additionalPropsObj instanceof Map);
+
+        additionalProps = (Map<String, Object>) additionalPropsObj;
+        Assert.assertEquals(100L,
+                additionalProps.get(APIConstants.KeyManager.REFRESH_TOKEN_EXPIRY_TIME));
+        Assert.assertEquals(100L,
+                additionalProps.get(APIConstants.KeyManager.USER_ACCESS_TOKEN_EXPIRY_TIME));
+        Assert.assertEquals(100L,
+                additionalProps.get(APIConstants.KeyManager.APPLICATION_ACCESS_TOKEN_EXPIRY_TIME));
+        Assert.assertEquals(100L,
+                additionalProps.get(APIConstants.KeyManager.ID_TOKEN_EXPIRY_TIME));
+
+
+    }
+
 //
 //    @Test
 //    public void testUpdateApplication() throws APIManagementException {


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/3894


### Improvements to token expiry time handling:

* Added the `sanitizeExpiryTime` method to handle negative expiry time values by converting them to `Integer.MAX_VALUE - 1L`. This ensures consistency when dealing with special cases like `-1L`. (`[components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.javaR736-R749](diffhunk://#diff-553f5114107240c43d507c1fc0dc0156ad38189d8301562953c0c888f8586f8fR736-R749)`)
* Updated the `buildDTOFromClientInfo` method to use the `sanitizeExpiryTime` method for all token expiry time fields (`APPLICATION_ACCESS_TOKEN_EXPIRY_TIME`, `USER_ACCESS_TOKEN_EXPIRY_TIME`, `REFRESH_TOKEN_EXPIRY_TIME`, and `ID_TOKEN_EXPIRY_TIME`). (`[components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.javaL693-R726](diffhunk://#diff-553f5114107240c43d507c1fc0dc0156ad38189d8301562953c0c888f8586f8fL693-R726)`)

### Enhanced error handling and logging:

* Added debug-level logging for invalid numeric values in token expiry times and other parameters (`PKCE_MANDATORY`, `PKCE_SUPPORT_PLAIN`, and `BYPASS_CLIENT_CREDENTIALS`). This provides better traceability for debugging issues. (`[[1]](diffhunk://#diff-553f5114107240c43d507c1fc0dc0156ad38189d8301562953c0c888f8586f8fL240-R324)`, `[[2]](diffhunk://#diff-553f5114107240c43d507c1fc0dc0156ad38189d8301562953c0c888f8586f8fR338)`, `[[3]](diffhunk://#diff-553f5114107240c43d507c1fc0dc0156ad38189d8301562953c0c888f8586f8fR354)`, `[[4]](diffhunk://#diff-553f5114107240c43d507c1fc0dc0156ad38189d8301562953c0c888f8586f8fR370)`)

### New unit tests:

* Added two new test cases, `testApplicationInfoBuildWithNegativeExpiryTimes` and `testApplicationInfoBuildWithPositiveExpiryTimes`, to validate the behavior of the `sanitizeExpiryTime` method and ensure correct handling of both negative and positive expiry time values. (`[components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImplTest.javaR304-R373](diffhunk://#diff-6d0778d233fb2a7f0c4d6e2516e83094f6a09a2d957b3bcccd12104bf8b7e004R304-R373)`)