### PR TITLE
Enable custom analytics for webhook APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/webhook/WebhooksAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/webhook/WebhooksAnalyticsDataProvider.java
@@ -19,19 +19,32 @@ package org.wso2.carbon.apimgt.gateway.handlers.streaming.webhook;
 
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.rest.RESTConstants;
+import org.wso2.carbon.apimgt.common.analytics.collectors.AnalyticsCustomDataProvider;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Operation;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Target;
+import org.wso2.carbon.apimgt.common.gateway.constants.JWTConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.analytics.Constants;
 import org.wso2.carbon.apimgt.gateway.handlers.streaming.AsyncAnalyticsDataProvider;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class WebhooksAnalyticsDataProvider extends AsyncAnalyticsDataProvider {
 
     private MessageContext messageContext;
+    private AnalyticsCustomDataProvider analyticsCustomDataProvider;
 
     public WebhooksAnalyticsDataProvider(MessageContext messageContext) {
         super(messageContext);
         this.messageContext = messageContext;
+    }
+
+    public WebhooksAnalyticsDataProvider(MessageContext messageContext,
+                                         AnalyticsCustomDataProvider analyticsCustomDataProvider) {
+        super(messageContext);
+        this.messageContext = messageContext;
+        this.analyticsCustomDataProvider = analyticsCustomDataProvider;
     }
 
     @Override
@@ -62,6 +75,26 @@ public class WebhooksAnalyticsDataProvider extends AsyncAnalyticsDataProvider {
         target.setDestination(endpointAddress);
         target.setTargetResponseCode(targetResponseCode);
         return target;
+    }
+
+    public Map<String, Object> getProperties() {
+        Map<String, Object> customProperties;
+
+        if (analyticsCustomDataProvider != null) {
+            customProperties = analyticsCustomDataProvider.getCustomProperties(messageContext);
+        } else {
+            customProperties = new HashMap<>();
+        }
+        customProperties.put(Constants.API_CONTEXT_KEY, getApiContext());
+        return customProperties;
+    }
+
+    private String getApiContext() {
+
+        if (messageContext.getPropertyKeySet().contains(JWTConstants.REST_API_CONTEXT)) {
+            return (String) messageContext.getProperty(JWTConstants.REST_API_CONTEXT);
+        }
+        return null;
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/WebhooksUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/WebhooksUtils.java
@@ -34,6 +34,7 @@ import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.RESTConstants;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.wso2.carbon.apimgt.common.analytics.collectors.AnalyticsCustomDataProvider;
 import org.wso2.carbon.apimgt.common.analytics.collectors.impl.GenericRequestDataCollector;
 import org.wso2.carbon.apimgt.common.analytics.exceptions.AnalyticsException;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
@@ -231,7 +232,14 @@ public class WebhooksUtils {
         org.apache.axis2.context.MessageContext axisCtx =
                 ((Axis2MessageContext) messageContext).getAxis2MessageContext();
         axisCtx.setProperty(PassThroughConstants.SYNAPSE_ARTIFACT_TYPE, APIConstants.API_TYPE_WEBSUB);
-        WebhooksAnalyticsDataProvider provider = new WebhooksAnalyticsDataProvider(messageContext);
+        AnalyticsCustomDataProvider analyticsCustomDataProvider = ServiceReferenceHolder.getInstance()
+                .getAnalyticsCustomDataProvider();
+        WebhooksAnalyticsDataProvider provider;
+        if (analyticsCustomDataProvider != null) {
+            provider = new WebhooksAnalyticsDataProvider(messageContext, analyticsCustomDataProvider);
+        } else {
+            provider = new WebhooksAnalyticsDataProvider(messageContext);
+        }
         GenericRequestDataCollector dataCollector = new GenericRequestDataCollector(provider);
         try {
             dataCollector.collectData();


### PR DESCRIPTION
### Purpose
> Publishing custom analytics data is only available for Synapse APIs. This PR extends this support to webhook APIs.
Related Issue: https://github.com/wso2/api-manager/issues/3887

### Goals
> Enable publishing custom analytics for webhook APIs in both successful and faulty flows.

### Approach
> A new constructor is added to WebhooksAnalyticsDataProvider to accept an AnalyticsCustomDataProvider, allowing injection of custom analytics logic.
A new method getProperties() is implemented to extract custom properties from the injected provider, and additionally append the api.context.
In WebhooksUtils, check for the availability of an AnalyticsCustomDataProvider via the ServiceReferenceHolder and initializes the provider accordingly.