### PR TITLE
Include token and token invalid reason in the message context

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/JWTValidationInfo.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/dto/JWTValidationInfo.java
@@ -43,6 +43,7 @@ public class JWTValidationInfo implements Serializable {
     private String rawPayload;
     private String keyManager;
     private Boolean isAppToken;
+    private boolean isExpired = false;
 
     public JWTValidationInfo() {
 
@@ -192,5 +193,13 @@ public class JWTValidationInfo implements Serializable {
     public void setKeyManager(String keyManager) {
 
         this.keyManager = keyManager;
+    }
+
+    public boolean isExpired() {
+        return isExpired;
+    }
+
+    public void setExpired(boolean expired) {
+        isExpired = expired;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -44,6 +44,8 @@ public class APIMgtGatewayConstants {
     public static final String X_FORWARDED_FOR = "X-Forwarded-For";
     public static final String REQUEST_RECEIVED_TIME = "wso2statistics.request.received.time";
     public static final String AUTHORIZATION = "Authorization";
+    public static final String ACCESS_TOKEN = "ACCESS_TOKEN";
+    public static final String ACCESS_TOKEN_INVALID_REASON = "ACCESS_TOKEN_INVALID_REASON";
     public static final String REVOKED_ACCESS_TOKEN = "RevokedAccessToken";
     public static final String DEACTIVATED_ACCESS_TOKEN = "DeactivatedAccessToken";
     public static final String SCOPES = "Scopes";
@@ -199,5 +201,7 @@ public class APIMgtGatewayConstants {
     public static final String ACCESS_GRANT_CLAIM_NAME = "grantVerificationClaim";
     public static final String ACCESS_GRANT_CLAIM_VALUE = "grantVerificationClaimValue";
     public static final String SHOULD_ALLOW_ACCESS_VALIDATION = "shouldAllowValidation";
+
+    public static final String INCLUDE_TOKEN_INFO_IN_MSG_CTX= "includeTokenInfoInMsgCtx";
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APIKeyValidator.java
@@ -169,6 +169,7 @@ public class APIKeyValidator {
                         getGatewayTokenCache().remove(apiKey);
                         // Put into invalid token cache
                         getInvalidTokenCache().put(apiKey, cachedToken);
+                        info.setExpired(true);
                     }
                     if (info.getEndUserToken() == null) {
                         return info;

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/oauth/OAuthAuthenticator.java
@@ -306,7 +306,7 @@ public class OAuthAuthenticator implements Authenticator {
                 }
             }
             if (includeTokenInfoInMsgCtx) {
-                synCtx.setProperty(APIMgtGatewayConstants.ACCESS_TOKEN_INVALID_REASON, "Access Token invalid");
+                synCtx.setProperty(APIMgtGatewayConstants.ACCESS_TOKEN_INVALID_REASON, "Access token invalid");
             }
             return new AuthenticationResponse(false, isMandatory, true,
                     APISecurityConstants.API_AUTH_MISSING_CREDENTIALS, "Required OAuth credentials not provided");

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/APIKeyValidationInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/APIKeyValidationInfoDTO.java
@@ -72,6 +72,7 @@ public class APIKeyValidationInfoDTO implements Serializable {
     private String applicationUUID;
     private Set<String> applicationGroupIds = new HashSet<>();
     private Map<String, String> appAttributes;
+    private boolean isExpired = false;
 
     public List<String> getThrottlingDataList() {
         return throttlingDataList;
@@ -414,6 +415,14 @@ public class APIKeyValidationInfoDTO implements Serializable {
     public void setAppAttributes(Map<String, String> appAttributes) {
 
         this.appAttributes = appAttributes;
+    }
+
+    public boolean isExpired() {
+        return isExpired;
+    }
+
+    public void setExpired(boolean expired) {
+        isExpired = expired;
     }
 }
 


### PR DESCRIPTION
### Add Token Info to Message Context on Invalid/Expired Tokens

This PR introduces support for adding token details and invalidation reasons to the Synapse Message Context when a token is **invalid** or **expired**.

🔧 **Enabled via:**
Set the system property `-DincludeTokenInfoInMsgCtx=true` to activate this feature. By default this is disabled.

📌 **Adds context properties:**

* `ACCESS_TOKEN`: Raw token from the request
* `ACCESS_TOKEN_INVALID_REASON`: Reason for token rejection ("Access token expired" or "Access token invalid")

✅ Useful for debugging, logging, or custom mediation flows.

Issue: https://github.com/wso2/api-manager/issues/3881

---

✅ The following scenarios were tested and confirmed to work as expected for **both JWT and Opaque tokens**:

1. **Empty token** – `ACCESS_TOKEN_INVALID_REASON`: "Access token invalid"
2. **Incorrect token** – `ACCESS_TOKEN_INVALID_REASON`: "Access token invalid"
3. **Revoked token** – `ACCESS_TOKEN_INVALID_REASON`: "Access token invalid"
4. **Unsubscribed token** – `ACCESS_TOKEN_INVALID_REASON`: "Access token invalid"
5. **Invalid scopes token** -  `ACCESS_TOKEN_INVALID_REASON`: "Access token invalid"
6. **Expired token** – `ACCESS_TOKEN_INVALID_REASON`: "Access token expired"

---