### PR TITLE
Sanitize Key Manager Configs before adding and updating KM

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -718,6 +718,7 @@ public class APIAdminImpl implements APIAdmin {
         }
         if (!KeyManagerConfiguration.TokenType.valueOf(keyManagerConfigurationDTO.getTokenType().toUpperCase())
                 .equals(KeyManagerConfiguration.TokenType.EXCHANGED)) {
+            sanitizeKeyManagerConfiguration(keyManagerConfigurationDTO);
             validateKeyManagerConfiguration(keyManagerConfigurationDTO);
             validateKeyManagerEndpointConfiguration(keyManagerConfigurationDTO);
         }
@@ -939,6 +940,7 @@ public class APIAdminImpl implements APIAdmin {
             throws APIManagementException {
         if (!KeyManagerConfiguration.TokenType.valueOf(keyManagerConfigurationDTO.getTokenType().toUpperCase())
                 .equals(KeyManagerConfiguration.TokenType.EXCHANGED)) {
+            sanitizeKeyManagerConfiguration(keyManagerConfigurationDTO);
             validateKeyManagerConfiguration(keyManagerConfigurationDTO);
             validateKeyManagerEndpointConfiguration(keyManagerConfigurationDTO);
         }
@@ -1444,6 +1446,16 @@ public class APIAdminImpl implements APIAdmin {
                     ExceptionCodes.from(ExceptionCodes.LABEL_NOT_FOUND, labelID));
         }
         return labelsDAO.getMappedApisForLabel(labelID);
+    }
+
+    private void sanitizeKeyManagerConfiguration(KeyManagerConfigurationDTO keyManagerConfigurationDTO) {
+        if (keyManagerConfigurationDTO != null && keyManagerConfigurationDTO.getAdditionalProperties() != null) {
+            for (Map.Entry<String, Object> entry : keyManagerConfigurationDTO.getAdditionalProperties().entrySet()) {
+                if (entry.getValue() instanceof String) {
+                    entry.setValue(((String) entry.getValue()).trim());
+                }
+            }
+        }
     }
 
     private void validateKeyManagerConfiguration(KeyManagerConfigurationDTO keyManagerConfigurationDTO)


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/3903

Whitespace sanitization should be added to the Key Manager configs in the add and update flows. Otherwise backend will try to call wrong endpoints with leading or trailing whitespaces.