### PR TITLE
Remove API_TYPE from WHERE clause of API Product queries.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5845,7 +5845,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         try {
             Organization org = new Organization(organization);
             PublisherAPIProduct publisherAPIProduct = apiPersistenceInstance.getPublisherAPIProduct(org, uuid);
-            if (publisherAPIProduct != null) {
+            if (publisherAPIProduct != null && APIConstants.API_PRODUCT.equalsIgnoreCase(publisherAPIProduct.getType())) {
                 APIProduct product = APIProductMapper.INSTANCE.toApiProduct(publisherAPIProduct);
                 product.setID(new APIProductIdentifier(publisherAPIProduct.getProviderName(),
                         publisherAPIProduct.getApiProductName(), publisherAPIProduct.getVersion(), uuid));

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -1381,10 +1381,10 @@ public class SQLConstants {
 
     public static final String GET_API_PRODUCT_ID_SQL =
             "SELECT API_ID FROM AM_API WHERE API_PROVIDER = ? AND API_NAME = ? "
-                    + "AND API_VERSION = ? AND API_TYPE = '" + APIConstants.API_PRODUCT + "'";
+                    + "AND API_VERSION = ?";
 
     public static final String GET_API_PRODUCT_SQL =
-            "SELECT API_ID, API_TIER FROM AM_API WHERE API_UUID = ? AND API_TYPE = '" + APIConstants.API_PRODUCT + "'";
+            "SELECT API_ID, API_TIER FROM AM_API WHERE API_UUID = ?";
 
     public static final String GET_AUDIT_UUID_SQL =
             "SELECT MAP.AUDIT_UUID FROM AM_SECURITY_AUDIT_UUID_MAPPING MAP WHERE MAP.API_ID = ?";
@@ -2845,8 +2845,7 @@ public class SQLConstants {
             "DELETE FROM AM_API_AI_CONFIGURATION WHERE API_UUID = ?";
 
     public static final String DELETE_API_PRODUCT_SQL =
-            "DELETE FROM AM_API WHERE API_PROVIDER = ? AND API_NAME = ? AND API_VERSION = ? AND API_TYPE = '"
-                    + APIConstants.API_PRODUCT + "'";
+            "DELETE FROM AM_API WHERE API_PROVIDER = ? AND API_NAME = ? AND API_VERSION = ?";
 
     public static final String UPDATE_PRODUCT_SQL =
             " UPDATE AM_API " +
@@ -2857,11 +2856,11 @@ public class SQLConstants {
             "   GATEWAY_VENDOR=?," +
             "   SUB_VALIDATION=?" +
             " WHERE" +
-            "   API_NAME=? AND API_PROVIDER=? AND API_VERSION=? AND API_TYPE='" + APIConstants.API_PRODUCT +"'";
+            "   API_NAME=? AND API_PROVIDER=? AND API_VERSION=?";
 
     public static final String GET_PRODUCT_ID =
             "SELECT API_ID FROM AM_API WHERE API_NAME = ? AND API_PROVIDER = ? AND "
-            + "API_VERSION = ? AND API_TYPE='" + APIConstants.API_PRODUCT +"'";
+            + "API_VERSION = ?";
 
     public static final String GET_URL_TEMPLATES_FOR_API =
             "SELECT URL_PATTERN , URL_MAPPING_ID, HTTP_METHOD FROM AM_API API , AM_API_URL_MAPPING URL "


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/3912

`API_TYPE` is not required to uniquely identify an API Product. So it can be removed from all API Product related queries, which will solve this migration related issue.

But there is a new issue being introduced by this fix. An intruder can update/delete APIs by calling the API Product REST APIs, since we removed the filter from the queries. This is fixed by adding checks that cover all the methods in the `ApiProductsApiServiceImpl.java` file.

- A new check is introduced to the `getAPIProductbyUUID` method, which will check whether the API Artifact retrieved by the Product ID is indeed an API Product. If it's not, an exception is thrown (ResourceNotFound)
- Most of the methods in the above file call the `getAPIProductbyUUID` method, so they are protected by this scenario.
- Some of the methods call `getAPIProductIdentifierFromUUID`, which in turn calls `getAPIProductbyUUID` so they are protected as well.
- For the other methods that retrieve an API Product using a UUID, a call to `getAPIProductbyUUID` is introduced, which will not impact the flow in any way, other than throwing an exception if the `Product ID` is not a UUID of an API Product.