### PR TITLE
Set the fullRequestPath of the inboundMessageContext after the default version is resolved in the request in InboundWebsocketProcessor.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/InboundWebSocketProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/InboundWebSocketProcessor.java
@@ -104,6 +104,9 @@ public class InboundWebSocketProcessor {
             setUris(req, inboundMessageContext);
             InboundWebsocketProcessorUtil.setTenantDomainToContext(inboundMessageContext);
             setMatchingResource(ctx, req, inboundMessageContext);
+            // This needs to be called after setMatchingResource() to correctly set the fullRequestPath when invoking
+            // with authorization as a query parameter
+            setUris(req, inboundMessageContext);
             String userAgent = req.headers().get(HttpHeaders.USER_AGENT);
 
             // '-' is used for empty values to avoid possible errors in DAS side.


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/3905

### Description
By default, the following flow occurs when the default version of a websocket API is invoked without the version, with authorization as a query parameter. (`wscat -c "ws://localhost:9099/notifications?access_token=<token>"`)

1. The URI of the request is set as the `fullRequestPath` of the `inboundMessageContext` via `setUris()`. The URI of the request currently does not contain the version, hence the `fullRequestPath` of the `inboundMessageContext` also does not.
2. `setMatchingResource()` is called, which will add the version to the URI of the request.
3. `isOauthAuthentication()` is called. Which will set the authorization query parameter value as a request header.
4. The URI of the request (which now contains the version after step 2) is then replaced with the `fullRequestPath` of the `inboundMessageContext`, which does not contain the version.

Since the request does not contain the version now, an exception is thrown from `netty` during the handshake.

### Fix
An additional call to `setUris()` is made after `setMatchingResource()`, which will set the correct `fullRequestPath` with the version to the `inboundMessageContext`.