### PR TITLE
Support secret custom params in endpoint security config

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1520,6 +1520,9 @@ public final class APIConstants {
         public static final String ENDPOINT_SECURITY_ENABLED = "enabled";
         public static final String ENDPOINT_SECURITY_USERNAME = "username";
 
+        public static final String CUSTOM_PARAMETERS_SECURED = "secured";
+        public static final String CUSTOM_PARAMETERS_VALUE = "value";
+
         private OAuthConstants() {
 
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIControllerUtil.java
@@ -430,6 +430,25 @@ public class APIControllerUtil {
                     ExceptionCodes.ERROR_READING_PARAMS_FILE);
         }
 
+        // Validate custom parameters
+        if (endpointSecurityDetails.has(APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS)) {
+            JsonElement customParamsElement = endpointSecurityDetails.get(
+                    APIConstants.OAuthConstants.OAUTH_CUSTOM_PARAMETERS);
+            if (customParamsElement != null && !customParamsElement.isJsonNull()) {
+                JsonObject customParams = customParamsElement.getAsJsonObject();
+                for (Map.Entry<String, JsonElement> entry : customParams.entrySet()) {
+                    JsonElement value = entry.getValue();
+                    if (value != null && value.isJsonObject() && !value.getAsJsonObject()
+                            .has(APIConstants.OAuthConstants.CUSTOM_PARAMETERS_VALUE)) {
+                        throw new APIManagementException(
+                                "Error parsing custom parameters. Parameter '"
+                                        + entry.getKey() + "' has invalid format.",
+                                ExceptionCodes.ERROR_READING_PARAMS_FILE);
+                    }
+                }
+            }
+        }
+
         if (!endpointSecurityDetails.has(APIConstants.OAuthConstants.OAUTH_CLIENT_ID)
                 || endpointSecurityDetails.get(APIConstants.OAuthConstants.OAUTH_CLIENT_ID) == null
                 || endpointSecurityDetails.get(APIConstants.OAuthConstants.OAUTH_CLIENT_ID).isJsonNull()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -250,6 +250,10 @@ public class ApisApiServiceImpl implements ApisApiService {
             String errorMessage = "Error while encrypting the secret key of API : " + body.getProvider() + "-" +
                     body.getName() + "-" + body.getVersion() + " - " + e.getMessage();
             RestApiUtil.handleInternalServerError(errorMessage, e, log);
+        } catch (ParseException e){
+            String errorMessage = "Error while parsing the endpoint configuration of API : " + body.getProvider() +
+                    "-" + body.getName() + "-" + body.getVersion() + " - " + e.getMessage();
+            RestApiUtil.handleInternalServerError(errorMessage, e, log);
         }
         return null;
     }
@@ -3272,7 +3276,8 @@ public class ApisApiServiceImpl implements ApisApiService {
             // OAuth 2.0 backend protection: API Key and API Secret encryption
             PublisherCommonUtils
                     .encryptEndpointSecurityOAuthCredentials(endpointConfig, CryptoUtil.getDefaultCryptoUtil(),
-                            StringUtils.EMPTY, StringUtils.EMPTY, apiDTOFromProperties);
+                            StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY,
+                            apiDTOFromProperties);
             PublisherCommonUtils
                     .encryptEndpointSecurityApiKeyCredentials(endpointConfig, CryptoUtil.getDefaultCryptoUtil(),
                             StringUtils.EMPTY, StringUtils.EMPTY, apiDTOFromProperties);
@@ -3296,6 +3301,9 @@ public class ApisApiServiceImpl implements ApisApiService {
                             + apiDTOFromProperties.getName() + "-" + apiDTOFromProperties.getVersion();
             throw new APIManagementException(errorMessage, e,
                     ExceptionCodes.from(ExceptionCodes.ENDPOINT_SECURITY_CRYPTO_EXCEPTION, errorMessage));
+        } catch (ParseException e) {
+            String errorMessage = "Error while parsing the endpoint configuration";
+            throw new APIManagementException(errorMessage, e);
         }
         return null;
     }


### PR DESCRIPTION
## Purpose
Fixing https://github.com/wso2/api-manager/issues/3842

## Goals
Allowing users to add secret custom parameters to the endpoint security (OAuth) of an API

## Approach
Supported an extended version of custom parameter objects:
- Now the `customParameters` array of the endpoint security support the following formats:
```
customParameters:
    key1: val1
    key2:
       value: val2
       secured: true
```

- Implemented the secret value hiding logic
  - Create/Update logic:
      - If a value comes from the payload, use the `encryptAndBase64encode` function to encrypt before saving to the registry
      - If the value in payload is empty string `""`, it will preserve the existing value
  - Retrieval Logic:
      - In the response payload, the value of the parameter will be empty string `""` if a value already stored in the db

## Related PRs
[1] Frontend PR: https://github.com/wso2/apim-apps/pull/1017


