### PR TITLE
Restrict OAuth key deletion to application owner only

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/impl/ApplicationsApiServiceImpl.java
@@ -1314,6 +1314,13 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
         try {
             APIConsumer apiConsumer = APIManagerFactory.getInstance().getAPIConsumer(username);
             Application application = apiConsumer.getLightweightApplicationByUUID(applicationId);
+            if (application == null) {
+                RestApiUtil.handleResourceNotFoundError(RestApiConstants.RESOURCE_APPLICATION, applicationId, log);
+            }
+            // Only the application owner can delete OAuth keys
+            if (!RestAPIStoreUtils.isUserOwnerOfApplication(application)) {
+                RestApiUtil.handleAuthorizationFailure(RestApiConstants.RESOURCE_APPLICATION, applicationId, log);
+            }
             boolean result = apiConsumer.removalKeys(application, keyMappingId, xWSO2Tenant);
             if (result) {
                 return Response.ok().build();


### PR DESCRIPTION
This PR ensures that only the application owner can delete OAuth keys for an application. Previously, any user in the organization could delete these keys. Now, the DELETE endpoint checks ownership and returns a 403 Forbidden if the user is not the owner, matching the behavior of key generation and update.

**Related issue:** [wso2/api-manager/issues#3919](https://github.com/wso2/api-manager/issues/3919)