### PR TITLE
Include the WSDL url when mapping APIDTO to API

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -508,6 +508,10 @@ public class APIMappingUtil {
             model.setGatewayVendor(dto.getGatewayVendor());
         }
 
+        if (dto.getWsdlUrl() != null) {
+            model.setWsdlUrl(dto.getWsdlUrl());
+        }
+
         if (dto.getAsyncTransportProtocols() != null) {
             String asyncTransports = StringUtils.join(dto.getAsyncTransportProtocols(), ',');
             model.setAsyncTransportProtocols(asyncTransports);


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/3928

## Goals
Preventing the wsdl url being null when it is used in the velocity template

## Approach
Set the `wsdlUrl` within the `fromDTOtoAPI` itself.

(Note:  In other scenarios, such as adding or updating an API, the `wsdlUrl` is set separately after the `fromDTOtoAPI` mapping is completed. As a result, following this fix, the value will be overwritten with the same value in those flows. This redundancy can be removed if necessary.)

