### PR TITLE
Resolve secure-vault secrets in analytics properties in the configs.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -398,6 +398,7 @@ public class APIManagerConfiguration {
                     OMElement propertyElem = (OMElement) analyticsPropertiesIterator.next();
                     String name = propertyElem.getAttributeValue(new QName("name"));
                     String value = propertyElem.getText();
+                    value = MiscellaneousUtil.resolve(value, secretResolver);
                     if ("keystore_location".equals(name) || "truststore_location".equals(name)) {
                         analyticsProps.put(name, APIUtil.replaceSystemProperty(value));
                     } else {


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/3927

APIM Configurations analytics properties that require secrets to be resolved from the secure-vault, like the following, will now work as expected.
```
[apim.analytics]
properties.'stream.processor.rest.api.password' = "$secret{admin_password}"

[secrets]
admin_password = .......
```