### PR TITLE
Fix the issue of deploying APIs with reserved API names

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/GatewayUtils.java
@@ -553,12 +553,12 @@ public class GatewayUtils {
 
     public static String getQualifiedApiName(String apiName, String version) {
 
-        return APIConstants.API_NAME_CONSTANT_PREFIX + "--" + apiName + ":v" + version;
+        return APIConstants.SYNAPSE_API_NAME_PREFIX + "--" + apiName + ":v" + version;
     }
 
     public static String getQualifiedDefaultApiName(String apiName) {
 
-        return APIConstants.API_NAME_CONSTANT_PREFIX + "--" + apiName;
+        return APIConstants.SYNAPSE_API_NAME_PREFIX + "--" + apiName;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdminTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/test/java/org/wso2/carbon/apimgt/gateway/service/APIGatewayAdminTest.java
@@ -36,8 +36,8 @@ public class APIGatewayAdminTest {
     String version = "1.0.0";
     String config = "abcdef";
     String tenantDomain = "carbon.super";
-    String apiName = APIConstants.API_NAME_CONSTANT_PREFIX + "--" + name + ":v" + version;
-    String apiDefaultName = APIConstants.API_NAME_CONSTANT_PREFIX + "--" + name;
+    String apiName = APIConstants.SYNAPSE_API_NAME_PREFIX + "--" + name + ":v" + version;
+    String apiDefaultName = APIConstants.SYNAPSE_API_NAME_PREFIX + "--" + name;
 
     @Test
     public void addApiForTenant() throws Exception {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3366,5 +3366,5 @@ public final class APIConstants {
         public static final String SCHEDULER_TASK_CLEANUP_INTERVAL = "TaskCleanupIntervalMinutes";
     }
 
-    public static final String API_NAME_CONSTANT_PREFIX = "prod";
+    public static final String SYNAPSE_API_NAME_PREFIX = "prod";
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -4655,7 +4655,7 @@ public final class APIUtil {
      */
     public static String getSequenceExtensionName(API api) {
 
-        return APIConstants.API_NAME_CONSTANT_PREFIX + "--" + api.getId().getApiName() + ":v" + api.getId().getVersion();
+        return APIConstants.SYNAPSE_API_NAME_PREFIX + "--" + api.getId().getApiName() + ":v" + api.getId().getVersion();
     }
 
     /**
@@ -4689,7 +4689,7 @@ public final class APIUtil {
      */
     public static String getSequenceExtensionName(String name, String version) {
 
-        return APIConstants.API_NAME_CONSTANT_PREFIX + "--" + name + ":v" + version;
+        return APIConstants.SYNAPSE_API_NAME_PREFIX + "--" + name + ":v" + version;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/template/APIConfigContext.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/template/APIConfigContext.java
@@ -157,11 +157,11 @@ public class APIConfigContext extends ConfigContext {
     }
 
     public String getAPIName(API api) {
-        return APIConstants.API_NAME_CONSTANT_PREFIX + "--" + api.getId().getApiName();
+        return APIConstants.SYNAPSE_API_NAME_PREFIX + "--" + api.getId().getApiName();
     }
 
     public String getAPIProductName(APIProduct product) {
-        return APIConstants.API_NAME_CONSTANT_PREFIX + "--" + product.getId().getName();
+        return APIConstants.SYNAPSE_API_NAME_PREFIX + "--" + product.getId().getName();
     }
 
     /**


### PR DESCRIPTION
### Purpose

This pull request fixes the issue where deploying APIs fails due to the use of internally reserved API names. To address this, we have introduced a new constant value (`prod--`)  that serves as a prefix appended to API names during deployment. 

- Related Issue: https://github.com/wso2/api-manager/issues/3920