### PR TITLE
Resolve revoke token cleanup issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -509,6 +509,7 @@ public final class APIConstants {
     public static final String HASH_TOKENS_ON_PERSISTENCE = OAUTH_CONFIGS + "EnableTokenHashMode";
     public static final String TOKEN_ENDPOINT_CONTEXT = OAUTH_CONFIGS + "TokenEndPointName";
     public static final String REVOKE_ENDPOINT_CONTEXT = OAUTH_CONFIGS + "RevokeEndpointName";
+    public static final String ENABLE_REVOKE_TOKEN_CLEANUP = OAUTH_CONFIGS + "EnableRevokeTokenCleanup";
     public static final String DEFAULT_MODIFIED_ENDPOINT_PASSWORD = "*****"; //5 stars
     public static final String REGISTRY_HIDDEN_ENDPOINT_PROPERTY = "registry.HiddenEpProperty";
     public static final String OVERVIEW_ELEMENT = "overview";

--- a/components/apimgt/org.wso2.carbon.apimgt.notification/src/main/java/org/wso2/carbon/apimgt/notification/AbstractKeyManagerEventHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.notification/src/main/java/org/wso2/carbon/apimgt/notification/AbstractKeyManagerEventHandler.java
@@ -22,7 +22,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.Application;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.keymgt.ExpiredJWTCleaner;
 import org.wso2.carbon.apimgt.impl.keymgt.KeyManagerEventHandler;
 import org.wso2.carbon.apimgt.impl.publishers.RevocationRequestPublisher;
@@ -65,10 +67,18 @@ public abstract class AbstractKeyManagerEventHandler implements KeyManagerEventH
             properties.put(APIConstants.NotificationEvent.ORG_ID, orgId);
         }
         revocationRequestPublisher.publishRevocationEvents(tokenRevocationEvent.getAccessToken(), properties);
-        // Cleanup expired revoked tokens from db.
-        Runnable expiredJWTCleaner = new ExpiredJWTCleaner();
-        Thread cleanupThread = new Thread(expiredJWTCleaner);
-        cleanupThread.start();
+        APIManagerConfiguration config = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                .getAPIManagerConfiguration();
+
+        String isRevokeTokenCleanupEnabled = config.getFirstProperty(APIConstants.ENABLE_REVOKE_TOKEN_CLEANUP);
+
+        if (Boolean.parseBoolean(isRevokeTokenCleanupEnabled)) {
+            // Cleanup expired revoked tokens from db.
+            Runnable expiredJWTCleaner = new ExpiredJWTCleaner();
+            Thread cleanupThread = new Thread(expiredJWTCleaner);
+            cleanupThread.start();
+        }
+
         return true;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.notification/src/test/java/org/wso2/carbon/apimgt/notification/AbstractKeyManagerEventHandlerTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.notification/src/test/java/org/wso2/carbon/apimgt/notification/AbstractKeyManagerEventHandlerTest.java
@@ -27,7 +27,11 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.api.model.Application;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.publishers.RevocationRequestPublisher;
 import org.wso2.carbon.apimgt.notification.event.TokenRevocationEvent;
 
@@ -39,7 +43,8 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ AbstractKeyManagerEventHandler.class, ApiMgtDAO.class, RevocationRequestPublisher.class })
+@PrepareForTest({ AbstractKeyManagerEventHandler.class, ApiMgtDAO.class, RevocationRequestPublisher.class,
+        ServiceReferenceHolder.class })
 public class AbstractKeyManagerEventHandlerTest {
 
     @Test
@@ -65,6 +70,18 @@ public class AbstractKeyManagerEventHandlerTest {
         PowerMockito.mockStatic(ApiMgtDAO.class);
         PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
         when(apiMgtDAO.getApplicationByClientId(tokenRevocationEvent.getConsumerKey())).thenReturn(application);
+
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        APIManagerConfigurationService apiManagerConfigurationService = Mockito.mock(
+                APIManagerConfigurationService.class);
+        APIManagerConfiguration apiManagerConfiguration = Mockito.mock(APIManagerConfiguration.class);
+        Mockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService())
+                .thenReturn(apiManagerConfigurationService);
+        Mockito.when(apiManagerConfigurationService.getAPIManagerConfiguration()).thenReturn(apiManagerConfiguration);
+        Mockito.when(apiManagerConfiguration.getFirstProperty(APIConstants.ENABLE_REVOKE_TOKEN_CLEANUP))
+                .thenReturn("true");
 
         DefaultKeyManagerEventHandlerImpl defaultKeyManagerEventHandler = new DefaultKeyManagerEventHandlerImpl();
         Boolean result = defaultKeyManagerEventHandler.handleTokenRevocationEvent(tokenRevocationEvent);

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -79,6 +79,7 @@
   "apim.oauth_config.revoke_endpoint": "https://localhost:${mgt.transport.https.port}/oauth2/revoke",
   "apim.oauth_config.enable_token_encryption": false,
   "apim.oauth_config.enable_token_hashing": false,
+  "apim.oauth_config.enable_revoke_token_cleanup": true,
   "apim.oauth_config.enable_certificate_bound_access_token": false,
   "apim.oauth_config.allowed_scopes": [
     "^device_.*",

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -535,6 +535,7 @@
         org.wso2.carbon.identity.oauth.tokenprocessor.HashingPersistenceProcessor and change the value of
         <EnableClientSecretHash> to true in the identity.xml -->
         <EnableTokenHashMode>{{apim.oauth_config.enable_token_hashing}}</EnableTokenHashMode>
+        <EnableRevokeTokenCleanup>{{apim.oauth_config.enable_revoke_token_cleanup}}</EnableRevokeTokenCleanup>
         <!-- Whether to validate certificate bound access tokens-->
         <EnableCertificateBoundAccessToken>{{apim.oauth_config.enable_certificate_bound_access_token}}</EnableCertificateBoundAccessToken>
 


### PR DESCRIPTION
### Purpose

- Introduced a configurable option to enable or disable revoke token cleanup functionality in API Manager.
- This enhancement addresses the need for making token cleanup optional, based on deployment requirements.
- Fix: [api-manager/issues/#3900](https://github.com/wso2/api-manager/issues/3900)

### Approach

- Introduced a new configuration flag in `deployment.toml` under the `[apim.oauth_config]` section.
- The revoke token cleanup functionality is now conditionally executed based on the value of this flag.

### Configuration Instructions

To **disable** the revoke token cleanup functionality add below configuration to `deployment.toml`
```
[apim.oauth_config]
enable_revoke_token_cleanup = false
```

