### PR TITLE
Add apikey to endpoint security type validation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -3079,8 +3079,10 @@ public final class APIUtil {
             if (!APIConstants.ENDPOINT_SECURITY_TYPE_NONE.equalsIgnoreCase(type) &&
                     !APIConstants.ENDPOINT_SECURITY_TYPE_BASIC.equalsIgnoreCase(type) &&
                     !APIConstants.ENDPOINT_SECURITY_TYPE_DIGEST.equalsIgnoreCase(type) &&
-                    !APIConstants.ENDPOINT_SECURITY_TYPE_OAUTH.equalsIgnoreCase(type)) {
-                ErrorHandler errorHandler = ExceptionCodes.from(ExceptionCodes.INVALID_ENDPOINT_SECURITY_CONFIG, environment);
+                    !APIConstants.ENDPOINT_SECURITY_TYPE_OAUTH.equalsIgnoreCase(type) &&
+                    !APIConstants.ENDPOINT_SECURITY_TYPE_API_KEY.equalsIgnoreCase(type)) {
+                ErrorHandler errorHandler = ExceptionCodes.from(ExceptionCodes.INVALID_ENDPOINT_SECURITY_CONFIG,
+                        environment);
                 throw new APIManagementException(
                         "Invalid endpoint security type '" + type + "' in '" + environment + "' configuration.",
                         errorHandler);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -3076,11 +3076,14 @@ public final class APIUtil {
         Object typeObj = securityConfig.get(APIConstants.ENDPOINT_SECURITY_TYPE);
         if (typeObj instanceof String) {
             String type = (String) typeObj;
-            if (!APIConstants.ENDPOINT_SECURITY_TYPE_NONE.equalsIgnoreCase(type) &&
-                    !APIConstants.ENDPOINT_SECURITY_TYPE_BASIC.equalsIgnoreCase(type) &&
-                    !APIConstants.ENDPOINT_SECURITY_TYPE_DIGEST.equalsIgnoreCase(type) &&
-                    !APIConstants.ENDPOINT_SECURITY_TYPE_OAUTH.equalsIgnoreCase(type) &&
-                    !APIConstants.ENDPOINT_SECURITY_TYPE_API_KEY.equalsIgnoreCase(type)) {
+            Set<String> validTypes = Set.of(
+                    APIConstants.ENDPOINT_SECURITY_TYPE_NONE,
+                    APIConstants.ENDPOINT_SECURITY_TYPE_BASIC,
+                    APIConstants.ENDPOINT_SECURITY_TYPE_DIGEST,
+                    APIConstants.ENDPOINT_SECURITY_TYPE_OAUTH,
+                    APIConstants.ENDPOINT_SECURITY_TYPE_API_KEY
+            );
+            if (validTypes.stream().noneMatch(type::equalsIgnoreCase)) {
                 ErrorHandler errorHandler = ExceptionCodes.from(ExceptionCodes.INVALID_ENDPOINT_SECURITY_CONFIG,
                         environment);
                 throw new APIManagementException(


### PR DESCRIPTION
### Purpose

This PR adds `apikey` type to the endpoint security type validation logic introduced by [1].

1. https://github.com/wso2/carbon-apimgt/pull/12829