### PR TITLE
Refactor key manager configuration retrieval to check kmId early

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/definitions/OAS2Parser.java
@@ -1464,12 +1464,12 @@ public class OAS2Parser extends APIDefinition {
 
         KeyManagerConfigurationDTO keyManagerConfigurationDTO = null;
         try {
-            if (!StringUtils.isEmpty(kmId)) {
+            if (StringUtils.isNotEmpty(kmId)) {
                 String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
                 APIAdmin apiAdmin = new APIAdminImpl();
                 keyManagerConfigurationDTO = apiAdmin.getKeyManagerConfigurationById(tenantDomain, kmId);
-                if (keyManagerConfigurationDTO == null || (StringUtils.isEmpty(kmId) && !Objects.equals(
-                        keyManagerConfigurationDTO.getType(), APIConstants.KeyManager.DEFAULT_KEY_MANAGER_TYPE))) {
+                // If the key manager is not found by ID, try to get the default key manager.
+                if (keyManagerConfigurationDTO == null) {
                     keyManagerConfigurationDTO = apiAdmin.getKeyManagerConfigurationByName(tenantDomain,
                             APIConstants.KeyManager.DEFAULT_KEY_MANAGER);
                 }


### PR DESCRIPTION
### Purpose
This PR refactors the key manager configuration retrieval logic by moving the check for an empty or null kmId to the start of the method. This change prevents unnecessary calls to getKeyManagerConfigurationById when kmId is empty or null.

Previously, the code attempted to fetch a key manager configuration by kmId even when kmId was empty or null, relying on fallback logic afterward. This refactoring:

- Avoids redundant calls.
- Makes the intent clearer by explicitly handling empty kmId cases upfront.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/3970