### PR TITLE
Fix Sandbox API Key requests returning Production Response for API Products

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/template/APIConfigContext.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/template/APIConfigContext.java
@@ -138,6 +138,18 @@ public class APIConfigContext extends ConfigContext {
         } else {
             context.put("apiIsOauthProtected", Boolean.FALSE);
         }
+        // if API is secured with api_Key
+        if (apiSecurity != null && apiSecurity.contains(APIConstants.API_SECURITY_API_KEY)) {
+            context.put("apiIsApiKeyProtected", Boolean.TRUE);
+        } else {
+            context.put("apiIsApiKeyProtected", Boolean.FALSE);
+        }
+        // if API is secured with basic_auth
+        if (apiSecurity != null && apiSecurity.contains(APIConstants.API_SECURITY_BASIC_AUTH)) {
+            context.put("apiIsBasicAuthProtected", Boolean.TRUE);
+        } else {
+            context.put("apiIsBasicAuthProtected", Boolean.FALSE);
+        }
         if (apiProduct.isEnabledSchemaValidation()) {
             context.put("enableSchemaValidation", Boolean.TRUE);
         } else {


### PR DESCRIPTION
### Issue

When an **API Product** is secured using **API Key** or **Basic Auth** (without OAuth2), requests made with a **sandbox API key** were incorrectly routed to the **production endpoint**. 

### Root Cause

Certain velocity context properties, specifically `apiIsApiKeyProtected` and `apiIsBasicAuthProtected`, were **not set** during the API Product deployment process. These properties are essential for rendering the Synapse configuration with correct routing logic.

As a result, API Products using only API Key or Basic Auth lacked the conditional filters in their Synapse configs, causing all requests—regardless of the key type—to route to production.

### Solution

Added the missing velocity context properties (`apiIsApiKeyProtected`, `apiIsBasicAuthProtected`) to ensure the Synapse configuration includes the correct conditional routing logic based on the security scheme.

### Impact

- Fixes incorrect endpoint routing for API Products using API Key or Basic Auth.
- Enables proper sandbox testing with sandbox API keys.

### Files Modified

- `APIConfigContext.java` (publisher v1 common)

### Testing

- Verified sandbox API key requests are now routed to sandbox endpoints.
- Confirmed production API key requests still function as expected.

### Related Issue

- [api-manager#3955](https://github.com/wso2/api-manager/issues/3955)
