### PR TITLE
Update default policy loading logic to check against full policy set

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/util/APIMGovernanceUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/util/APIMGovernanceUtil.java
@@ -193,7 +193,8 @@ public class APIMGovernanceUtil {
         PolicyManager policyManager = new PolicyManager();
         try {
             // Fetch existing policies for the organization
-            Map<String, String> existingPolicies = policyManager.getOrganizationWidePolicies(organization);
+            List<APIMGovernancePolicy> existingPolicies = policyManager.getGovernancePolicies(organization)
+                    .getGovernancePolicyList();
 
             // Define the path to default policies
             String pathToPolicies = CarbonUtils.getCarbonHome() + File.separator
@@ -209,7 +210,9 @@ public class APIMGovernanceUtil {
                         APIMDefaultGovPolicy defaultPolicy = mapper.readValue(file, APIMDefaultGovPolicy.class);
 
                         // Add policy if it doesn't already exist
-                        if (!existingPolicies.containsValue(defaultPolicy.getName())) {
+                        boolean policyExists = existingPolicies.stream()
+                                .anyMatch(policy -> defaultPolicy.getName().equals(policy.getName()));
+                        if (!policyExists) {
                             log.info("Adding default policy: " + defaultPolicy.getName());
                             APIMGovernancePolicy policy = getGovPolicyFromDefaultGovPolicy(defaultPolicy, organization);
                             APIMGovernancePolicy createdPolicy = policyManager.createGovernancePolicy(organization,


### PR DESCRIPTION
## Description
This PR fixes an issue that occurs during APIM server startup when a default policy already exists in the database with the same name but is marked as non-global (`IS_GLOBAL = 0`).

During migration (e.g., from APIM 4.2.0 to 4.5.0), users are instructed to disable default policies by setting the `labels` field in policy YAML files to an empty list (`[]`). This causes the policy to be created in the database **without** the `GLOBAL` label and with the `IS_GLOBAL` flag set to `false`.

At the next server startup:

- The server checks only for existing global policies (`IS_GLOBAL = 1`)
- Since the previously created policy is not global, it is **not detected**
- The server attempts to re-create the policy
- This fails with a `Policy already exists` error due to a name conflict

## Approach

Replaced the call to `getOrganizationWidePolicies()` (which only returns global policies) with `getGovernancePolicies()`, which fetches **all** policies for the organization, regardless of the `IS_GLOBAL` flag.

This ensures that any existing policy with the same name is detected before attempting creation, thus preventing the exception being thrown.

## Related Issue:

Resolves: https://github.com/wso2/api-manager/issues/3950

