### PR TITLE
ci: Use Maven 3.6.4 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           java-version: 11.0.16+8
           distribution: 'temurin'
+          maven-version: '3.6.4'
       - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
@@ -81,6 +82,7 @@ jobs:
         with:
           java-version: 11.0.16+8
           distribution: 'temurin'
+          maven-version: '3.6.4'
       - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
@@ -146,6 +148,7 @@ jobs:
         with:
           java-version: 11.0.16+8
           distribution: 'temurin'
+          maven-version: '3.6.4'
       - uses: actions/setup-node@v3
         with:
           node-version: '14.x'


### PR DESCRIPTION
Updated the .github/workflows/main.yml file to specify Maven version 3.6.4 for all jobs. This ensures a consistent build environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI pipeline to use Maven version 3.6.4 for all build and test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->