### PR TITLE
Fix Accept header case preservation to prevent schema validation bypass

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
@@ -185,6 +185,7 @@ public class APIMgtLatencyStatsHandler extends AbstractHandler {
         List<Parameter> headerParameters = parameters.stream()
                 .filter(param -> param.getIn().equalsIgnoreCase("header"))
                 .filter(param -> !param.getName().equalsIgnoreCase(Headers.CONTENT_TYPE)) // Ignore content-type header
+                .filter(param -> !param.getName().equalsIgnoreCase(Headers.ACCEPT)) // Ignore accept header
                 .collect(Collectors.toList());
         List<Parameter> modifiedHeaderParameters = headerParameters.stream()
                 .map(APIMgtLatencyStatsHandler::replaceLowerCaseHeaderName).collect(Collectors.toList());

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/model/OpenAPIRequest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/model/OpenAPIRequest.java
@@ -93,10 +93,13 @@ public class OpenAPIRequest implements Request {
         //Set transport headers
         for (Map.Entry<String, Collection<String>> header : headerMap.entrySet()) {
             String headerKey = header.getKey();
+            if (headerKey == null) {
+                continue; // Skip null keys
+            }
             String value = header.getValue().iterator().next();
-            if (headerKey.equalsIgnoreCase(Headers.CONTENT_TYPE)) {
+            if (Headers.CONTENT_TYPE.equalsIgnoreCase(headerKey)) {
                 headerKey = Headers.CONTENT_TYPE;
-            } else if (headerKey.equalsIgnoreCase(Headers.ACCEPT)) {
+            } else if (Headers.ACCEPT.equalsIgnoreCase(headerKey)) {
                 headerKey = Headers.ACCEPT;
             } else {
                 headerKey = headerKey.toLowerCase(Locale.ROOT);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/model/OpenAPIRequest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/model/OpenAPIRequest.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.apimgt.gateway.handlers.security.model;
 
+import com.atlassian.oai.validator.model.Headers;
 import com.atlassian.oai.validator.model.Request;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
@@ -90,12 +91,16 @@ public class OpenAPIRequest implements Request {
                 .stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> Collections.singleton(entry.getValue())));
         //Set transport headers
-        String contentTypeHeader = "content-type";
         for (Map.Entry<String, Collection<String>> header : headerMap.entrySet()) {
             String headerKey = header.getKey();
-            String value =  header.getValue().iterator().next();
-            headerKey = headerKey.equalsIgnoreCase(contentTypeHeader) ?
-                    "Content-Type" : headerKey.toLowerCase(Locale.ROOT);
+            String value = header.getValue().iterator().next();
+            if (headerKey.equalsIgnoreCase(Headers.CONTENT_TYPE)) {
+                headerKey = Headers.CONTENT_TYPE;
+            } else if (headerKey.equalsIgnoreCase(Headers.ACCEPT)) {
+                headerKey = Headers.ACCEPT;
+            } else {
+                headerKey = headerKey.toLowerCase(Locale.ROOT);
+            }
             headers.put(headerKey, value);
         }
         String apiResource = "/";


### PR DESCRIPTION
### Problem
Schema validation was being skipped for Accept headers because they were lowercased to "accept" but the Atlassian validator expects "Accept".

### Solution
Preserve Accept header case (like Content-Type) in both:
- `OpenAPIRequest.java` - request header processing
- `APIMgtLatencyStatsHandler.java` - OpenAPI spec processing

### Impact
- Accept header validation now works correctly when schema validation is enabled for an API
- Invalid Accept headers are rejected

### Related Issue
https://github.com/wso2/api-manager/issues/3987