### PR TITLE
test: add null and edge case tests for APIUtil.isValidTenantDomain

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilTest.java
@@ -2182,4 +2182,13 @@ public class APIUtilTest {
         fileName = "test1.pdf";
         Assert.assertFalse("PDF type should not be allowed", APIUtil.isSupportedFileType(fileName));
     }
+    
+    @Test
+        public void testIsValidTenantDomain_NullOrEdgeCases() {
+        assertFalse(APIUtil.isValidTenantDomain(null));
+        assertFalse(APIUtil.isValidTenantDomain(""));
+        assertFalse(APIUtil.isValidTenantDomain("a@b.c"));   // invalid
+        assertTrue(APIUtil.isValidTenantDomain("sub.domain.com"));
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIUtilTest.java
@@ -2184,11 +2184,19 @@ public class APIUtilTest {
     }
     
     @Test
-        public void testIsValidTenantDomain_NullOrEdgeCases() {
+    public void testIsValidTenantDomain_NullOrEdgeCases() {
         assertFalse(APIUtil.isValidTenantDomain(null));
         assertFalse(APIUtil.isValidTenantDomain(""));
         assertFalse(APIUtil.isValidTenantDomain("a@b.c"));   // invalid
         assertTrue(APIUtil.isValidTenantDomain("sub.domain.com"));
+        
+        // Add more test cases for valid and invalid tenant domains
+        assertTrue(APIUtil.isValidTenantDomain("example.com"));
+        assertTrue(APIUtil.isValidTenantDomain("sub1.sub2.example.com"));
+        assertFalse(APIUtil.isValidTenantDomain("sub_domain.com"));
+        assertFalse(APIUtil.isValidTenantDomain("sub.-domain.com"));
+        assertFalse(APIUtil.isValidTenantDomain("sub.domain-.com"));
+        assertFalse(APIUtil.isValidTenantDomain("sub..domain.com"));
+        assertFalse(APIUtil.isValidTenantDomain("sub.domain.com."));
     }
-
 }


### PR DESCRIPTION
This adds additional test cases for APIUtil.isValidTenantDomain() to cover:
- null input
- empty string
- invalid formats (with '@')
- valid multi-subdomain
