### PR TITLE
Add Dynamic Endpoint support for websocket

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/WebSocketExtensionHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/WebSocketExtensionHandler.java
@@ -80,11 +80,6 @@ public class WebSocketExtensionHandler extends AbstractHandler {
                     handleResourceNotFound(messageContext, Arrays.asList(allAPIResources));
                     return false;
                 }
-                if (selectedResource == null) {
-                    onResourceNotFoundError(messageContext, HttpStatus.SC_NOT_FOUND,
-                            APIMgtGatewayConstants.RESOURCE_NOT_FOUND_ERROR_MSG);
-                    return false;
-                }
             }
 
             String resourceString = selectedResource.getDispatcherHelper().getString();

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/WebSocketExtensionHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/WebSocketExtensionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/WebSocketExtensionHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/ext/WebSocketExtensionHandler.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.handlers.ext;
+
+import org.apache.axis2.addressing.EndpointReference;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpStatus;
+import org.apache.synapse.Mediator;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.api.API;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.rest.AbstractHandler;
+import org.apache.synapse.rest.RESTConstants;
+import org.apache.synapse.rest.RESTUtils;
+import org.apache.synapse.api.Resource;
+import org.apache.synapse.api.dispatch.RESTDispatcher;
+import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
+import org.wso2.carbon.apimgt.gateway.MethodStats;
+import org.wso2.carbon.apimgt.gateway.handlers.Utils;
+import org.wso2.carbon.apimgt.gateway.handlers.streaming.websocket.WebSocketApiConstants;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class handles WebSocket requests in the inbound flow of the API Gateway. It identifies the API and resource,
+ * sets the sub-request path, and performs request mediation for handshake requests.
+ */
+public class WebSocketExtensionHandler extends AbstractHandler {
+
+    private static final Log log = LogFactory.getLog(WebSocketExtensionHandler.class);
+    private static final String DIRECTION_IN = "In";
+
+    @MethodStats
+    public boolean handleRequest(MessageContext messageContext) {
+        try {
+            API selectedApi = Utils.getSelectedAPI(messageContext);
+            Resource selectedResource = null;
+            Utils.setSubRequestPath(selectedApi, messageContext);
+
+            if (selectedApi != null) {
+                Resource[] allAPIResources = selectedApi.getResources();
+                Set<Resource> acceptableResources = new LinkedHashSet<>(Arrays.asList(allAPIResources));
+                if (!acceptableResources.isEmpty()) {
+                    for (RESTDispatcher dispatcher : RESTUtils.getDispatchers()) {
+                        Resource resource = dispatcher.findResource(messageContext, acceptableResources);
+                        if (resource != null) {
+                            selectedResource = resource;
+                            if (selectedResource.getDispatcherHelper()
+                                    .getString() != null && !selectedResource.getDispatcherHelper().getString()
+                                    .contains("/*")) {
+                                break;
+                            }
+                        }
+                    }
+                    if (selectedResource == null) {
+                        handleResourceNotFound(messageContext, Arrays.asList(allAPIResources));
+                        return false;
+                    }
+                } else {
+                    handleResourceNotFound(messageContext, Arrays.asList(allAPIResources));
+                    return false;
+                }
+                if (selectedResource == null) {
+                    onResourceNotFoundError(messageContext, HttpStatus.SC_NOT_FOUND,
+                            APIMgtGatewayConstants.RESOURCE_NOT_FOUND_ERROR_MSG);
+                    return false;
+                }
+            }
+
+            String resourceString = selectedResource.getDispatcherHelper().getString();
+            messageContext.setProperty(APIConstants.API_ELECTED_RESOURCE, resourceString);
+            if (!Boolean.TRUE.equals(messageContext.getProperty(WebSocketApiConstants.SOURCE_HANDSHAKE_PRESENT))) {
+                // For websocket frames, set the 'To header' to be used in dynamic endpoint scenarios and pass without mediation
+                Axis2MessageContext axis2MsgCtx = (Axis2MessageContext) messageContext;
+                org.apache.axis2.context.MessageContext axis2Ctx = axis2MsgCtx.getAxis2MessageContext();
+                axis2Ctx.getOptions().setTo(new EndpointReference(
+                        (String) axis2MsgCtx.getProperty(WebSocketApiConstants.TARGET_ENDPOINT_ADDRESS)));
+                return true;
+            } else {
+                // For WebSocket handshakes, handle the request mediation
+                return mediate(messageContext);
+            }
+        } catch (Exception e) {
+            log.error("Error occurred while identifying the resource in WebSocketTopicDispatcher", e);
+            throw e;
+        }
+    }
+
+    @MethodStats
+    public boolean mediate(MessageContext messageContext) {
+        try {
+            Map localRegistry = messageContext.getConfiguration().getLocalRegistry();
+            String apiName = (String) messageContext.getProperty(RESTConstants.SYNAPSE_REST_API);
+            Object sequence = localRegistry.get(apiName + "--" + DIRECTION_IN);
+            if (sequence instanceof Mediator) {
+                return ((Mediator) sequence).mediate(messageContext);
+            }
+            return true;
+        } catch (Exception e) {
+            log.error("Error during post-request processing", e);
+            throw e;
+        }
+    }
+
+    @Override
+    public boolean handleResponse(MessageContext messageContext) {
+        return true;
+    }
+
+    private void handleResourceNotFound(MessageContext messageContext, List<Resource> allAPIResources) {
+        Resource uriMatchingResource = null;
+        for (RESTDispatcher dispatcher : RESTUtils.getDispatchers()) {
+            uriMatchingResource = dispatcher.findResource(messageContext, allAPIResources);
+            if (uriMatchingResource != null) {
+                onResourceNotFoundError(messageContext, HttpStatus.SC_METHOD_NOT_ALLOWED,
+                        APIMgtGatewayConstants.METHOD_NOT_FOUND_ERROR_MSG);
+                return;
+            }
+        }
+        onResourceNotFoundError(messageContext, HttpStatus.SC_NOT_FOUND,
+                APIMgtGatewayConstants.RESOURCE_NOT_FOUND_ERROR_MSG);
+    }
+
+    private void onResourceNotFoundError(MessageContext messageContext, int statusCode, String errorMessage) {
+        messageContext.setProperty(APIConstants.CUSTOM_HTTP_STATUS_CODE, statusCode);
+        messageContext.setProperty(APIConstants.CUSTOM_ERROR_CODE, statusCode);
+        messageContext.setProperty(APIConstants.CUSTOM_ERROR_MESSAGE, errorMessage);
+        Mediator resourceMisMatchedSequence = messageContext.getSequence(RESTConstants.NO_MATCHING_RESOURCE_HANDLER);
+        if (resourceMisMatchedSequence != null) {
+            resourceMisMatchedSequence.mediate(messageContext);
+        }
+    }
+
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketApiConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/websocket/WebSocketApiConstants.java
@@ -29,6 +29,8 @@ public class WebSocketApiConstants {
     public static final String URL_SEPARATOR = "/";
     public static final String DEFAULT_RESOURCE_NAME = "/_default_resource_of_api_";
     public static final String WS_SSL_CHANNEL_HANDLER_NAME = "ssl";
+    public static final String SOURCE_HANDSHAKE_PRESENT = "websocket.source.handshake.present";
+    public static final String TARGET_ENDPOINT_ADDRESS = "ENDPOINT_ADDRESS";
 
     //Constants for Websocket frame error codes and messages
     public static class FrameErrorConstants {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1828,7 +1828,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
      */
     private void validateAPIPolicyParameters(API api, String tenantDomain) throws APIManagementException {
 
-        if (APIConstants.API_TYPE_WS.equals(api.getType()) || APIConstants.API_TYPE_SSE.equals(api.getType())
+        if (APIConstants.API_TYPE_SSE.equals(api.getType())
                 || APIConstants.API_TYPE_WEBSUB.equals(api.getType())) {
             if (log.isDebugEnabled()) {
                 log.debug("Operation policies are not allowed for " + api.getType() + " APIs");

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/gatewayFeatureCatalog/synapse-gateway-feature-catalog.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/gatewayFeatureCatalog/synapse-gateway-feature-catalog.json
@@ -59,7 +59,8 @@
         "loadBalanceAndFailoverConfigurations",
         "endpointSecurity",
         "typePRODUCTION",
-        "typeSANDBOX"
+        "typeSANDBOX",
+        "ws"
       ],
       "endpointSecurity": [
         "basicAuth",

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/operationPolicy/operation-policy-specification-schema.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/operationPolicy/operation-policy-specification-schema.json
@@ -58,7 +58,8 @@
               "HTTP",
               "SOAP",
               "SOAPTOREST",
-              "GRAPHQL"
+              "GRAPHQL",
+              "WS"
             ]
           },
           {
@@ -70,7 +71,8 @@
                   "HTTP",
                   "SOAP",
                   "SOAPTOREST",
-                  "GRAPHQL"
+                  "GRAPHQL",
+                  "WS"
                 ]
               },
               "subType": {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapsePolicyAggregator.java
@@ -90,6 +90,11 @@ public class SynapsePolicyAggregator {
         String operationPolicyTemplate = FileUtil.readFileToString(POLICY_SEQUENCE_TEMPLATE_LOCATION)
                 .replace("\\", ""); //Removing escape characters from the template
         configMap.put("sequence_name", sequenceName);
+
+        if (api != null) {
+            configMap.put("api_type", api.getType());
+        }
+
         if (APIConstants.OPERATION_SEQUENCE_TYPE_FAULT.equals(flow)) {
             configMap.put("fault_sequence", true);
         }
@@ -153,7 +158,14 @@ public class SynapsePolicyAggregator {
         String uriTemplateString = template.getUriTemplate();
         uriTemplateString = trimTrailingSlashes(uriTemplateString);
         String method = template.getHTTPVerb();
-        String key = method + "_" + uriTemplateString.replaceAll("[\\W]", "\\\\$0");
+        String key;
+        if (APIConstants.HTTP_VERB_SUBSCRIBE.equalsIgnoreCase(
+                method) || APIConstants.HTTP_VERB_PUBLISH.equalsIgnoreCase(method)) {
+            // For WebSocket APIs, ignore the method
+            key = uriTemplateString.replaceAll("[\\W]", "\\\\$0");
+        } else {
+            key = method + "_" + uriTemplateString.replaceAll("[\\W]", "\\\\$0");
+        }
 
         // This will replace & with &amp; for query params
         key = StringEscapeUtils.escapeXml(StringEscapeUtils.unescapeXml(key));

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
@@ -354,6 +354,11 @@ public class TemplateBuilderUtil {
             }
         }
 
+        if (APIConstants.APITransportType.WS.toString().equals(api.getType())) {
+            vtb.addHandler("org.wso2.carbon.apimgt.gateway.handlers.ext.WebSocketExtensionHandler",
+                    Collections.emptyMap());
+        }
+
         return vtb;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -1694,6 +1694,13 @@ public class PublisherCommonUtils {
         boolean isValidSandboxUrl = true;
         if (api.getEndpointConfig() != null) {
             Map endpointConfig = (Map) api.getEndpointConfig();
+
+            // Skip validation if endpoint type is default to support dynamic endpoints
+            String endpointType = (String) endpointConfig.get(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE);
+            if (APIConstants.ENDPOINT_TYPE_DEFAULT.equalsIgnoreCase(endpointType)) {
+                return true;
+            }
+
             if (endpointConfig.containsKey(APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS)) {
                 String prodEndpointUrl = String.valueOf(((Map) endpointConfig.get(
                         APIConstants.ENDPOINT_PRODUCTION_ENDPOINTS)).get(APIConstants.API_DATA_URL));
@@ -1708,8 +1715,10 @@ public class PublisherCommonUtils {
                         || sandboxEndpointUrl.startsWith(APIConstants.WSS_PROTOCOL_URL_PREFIX);
                 containsEndpoint = true;
             }
+            return containsEndpoint && isValidProdUrl && isValidSandboxUrl;
+        } else {
+            return true;
         }
-        return containsEndpoint && isValidProdUrl && isValidSandboxUrl;
     }
 
     /**
@@ -2205,6 +2214,8 @@ public class PublisherCommonUtils {
         if (uriTemplates == null || uriTemplates.isEmpty()) {
             throw new APIManagementException(ExceptionCodes.NO_RESOURCES_FOUND);
         }
+        //set existing operation policies to URI templates
+        apiProvider.setOperationPoliciesToURITemplates(apiId, uriTemplates);
         existingAPI.setUriTemplates(uriTemplates);
 
         // Update ws uri mapping

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/AsyncApiParser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/AsyncApiParser.java
@@ -1938,7 +1938,7 @@ public class AsyncApiParser extends APIDefinition {
         aaiDocument.info = aaiDocument.createInfo();
         aaiDocument.info.title = api.getId().getName();
         aaiDocument.info.version = api.getId().getVersion();
-        if (!APISpecParserConstants.API_TYPE_WEBSUB.equals(api.getType())) {
+        if (!APISpecParserConstants.API_TYPE_WEBSUB.equals(api.getType()) && !APISpecParserConstants.API_TYPE_WS.equals(api.getType())) {
             JSONObject endpointConfig = new JSONObject(api.getEndpointConfig());
 
             if (endpointConfig.has(APISpecParserConstants.ENDPOINT_PRODUCTION_ENDPOINTS)) {


### PR DESCRIPTION
### Purpose
This PR introduces dynamic endpoint support for WebSocket APIs, allowing users to define dynamic endpoints through a policy, similar to other API types.

### Implementation Approach
Onboarded WebSocket as a new supported API type for operation policies.
Introduced a new handler for message mediation in WebSocket APIs and integrated it into the Synapse API configuration.
Enabled setting operation-level policies during API update calls for WebSocket APIs.
Implemented support for the default endpoint type in WebSocket APIs by skipping endpoint validation.

Fixes:
https://github.com/wso2/api-manager/issues/3893