### PR TITLE
Add log PR comment analyzer

### DIFF
--- a/.github/workflows/log-pr-comment-analyzer.yml
+++ b/.github/workflows/log-pr-comment-analyzer.yml
@@ -1,0 +1,49 @@
+name: Notify Merged PR to AI Log Agent
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  find-pr-details:
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.pr.outputs.url }}
+    steps:
+      - name: Get merged PR info
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commitSha = context.sha;
+
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 10
+            });
+
+            const mergedPr = prs.data.find(pr =>
+              pr.merge_commit_sha === commitSha
+            );
+
+            if (!mergedPr) {
+              core.setFailed("No merged PR found for this commit.");
+              return;
+            }
+
+            core.info(`Found merged PR: ${mergedPr.html_url} (#${mergedPr.number})`);
+            core.setOutput("url", mergedPr.html_url);
+  invoke-ai-log-agent:
+    name: Invoke AI Log Agent
+    needs: find-pr-details
+    uses: wso2/wso2-organization-templates/.github/workflows/log-pr-comment-analyzer.yml@main
+    with:
+      prUrl: ${{ needs.find-pr-details.outputs.url }}
+    secrets:
+      clientId: ${{ secrets.AI_LOG_AGENT_CLIENT_ID }}
+      clientSecret: ${{ secrets.AI_LOG_AGENT_CLIENT_SECRET }}

--- a/.github/workflows/pr-reviewer-for-logs.yml
+++ b/.github/workflows/pr-reviewer-for-logs.yml
@@ -8,8 +8,6 @@ jobs:
   call-template:
     uses: wso2/wso2-organization-templates/.github/workflows/pr-reviewer.yml@main
     with:
-      reviewEndpoint: ${{ vars.AI_LOG_AGENT_REVIEW_ENDPOINT }}
-      tokenUrl: ${{ vars.AI_LOG_AGENT_TOKEN_URL }}
       prUrl: ${{ github.event.pull_request.html_url }}
     secrets:
       clientId: ${{ secrets.AI_LOG_AGENT_CLIENT_ID }}


### PR DESCRIPTION
This will introduce new git action on PR merge to analyze the status of the added comments by AI Log Agent

This pull request introduces a new GitHub Actions workflow to notify an AI Log Agent about merged pull requests and modifies an existing workflow by removing unused parameters. The changes aim to enhance automation and simplify the configuration of workflows.

### New Workflow Addition:

* [`.github/workflows/log-pr-comment-analyzer.yml`](diffhunk://#diff-ab8d1c48027cc34c29131aba70591bf017d962b7657dddf6c2910a7166fb1482R1-R49): Added a new workflow named "Notify Merged PR to AI Log Agent." This workflow triggers on pushes to the `master` branch, retrieves details of the merged pull request, and invokes the AI Log Agent with the PR URL.

### Workflow Simplification:

* [`.github/workflows/pr-reviewer-for-logs.yml`](diffhunk://#diff-293a18629002f26c7e80049a10b2ac5ff294715d69002ac614062a751e5d1dbdL11-L12): Removed unused parameters `reviewEndpoint` and `tokenUrl` from the "call-template" job, simplifying the workflow configuration.