### PR TITLE
Remove specific headers from transport headers

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/webhooks/SubscriberInfoLoader.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/webhooks/SubscriberInfoLoader.java
@@ -81,6 +81,9 @@ public class SubscriberInfoLoader extends AbstractMediator {
 
     private void removeSignatureHeaderFromTransportHeaders(MessageContext messageContext) {
         String signatureHeaderName = (String) messageContext.getProperty(APIConstants.Webhooks.SIGNATURE_HEADER_NAME_PROPERTY);
+        if (log.isDebugEnabled()) {
+            log.debug("Removing signature header: " + signatureHeaderName);
+        }
         if (signatureHeaderName != null && !signatureHeaderName.isEmpty()) {
             org.apache.axis2.context.MessageContext axisCtx = ((Axis2MessageContext) messageContext).
                     getAxis2MessageContext();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2903,6 +2903,7 @@ public final class APIConstants {
         public static final String HUB_MODE_QUERY_PARAM = "hub.mode";
         public static final String HUB_LEASE_SECONDS_QUERY_PARAM = "hub.lease_seconds";
         public static final String TOPIC_QUERY_PARAM = "topic";
+        public static final String SIGNATURE_HEADER_NAME_PROPERTY = "signature_header_name";
         public static final String SUBSCRIBERS_LIST_PROPERTY = "SUBSCRIBERS_LIST";
         public static final String SUBSCRIBERS_COUNT_PROPERTY = "SUBSCRIBERS_COUNT";
         public static final String SUBSCRIBER_CALLBACK_PROPERTY = "SUBSCRIBER_CALLBACK";


### PR DESCRIPTION
The changes are as follows:

-  A parameter containing the signature header name configured in the publisher is set as a property
- This value is then read and the headers that start with that value are removed before being forwarded to the callback URL

Related issue: https://github.com/wso2/api-manager/issues/3962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of webhook signature headers to enhance message processing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->