### PR TITLE
Fix issue in gw configs in settings call

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -3549,15 +3549,13 @@ public final class APIUtil {
 
         // Process OOTB supported external gateway types first to ensure correct order in publisher UI
         if (externalGatewayConnectorConfigurationMap.containsKey(APIConstants.EXTERNAL_AWS_GATEWAY)) {
-            processExternalGatewayFeatureCatalogs(gatewayConfigsMap, apiData, externalGatewayConnectorConfigurationMap.
-                    get(APIConstants.EXTERNAL_AWS_GATEWAY));
+            processExternalGatewayFeatureCatalogs(gatewayConfigsMap, apiData,
+                    externalGatewayConnectorConfigurationMap.get(APIConstants.EXTERNAL_AWS_GATEWAY));
         }
 
-        externalGatewayConnectorConfigurationMap.forEach((gatewayName, gatewayConfiguration) -> {
-            if (!APIConstants.EXTERNAL_AWS_GATEWAY.equals(gatewayName)) {
-                processExternalGatewayFeatureCatalogs(gatewayConfigsMap, apiData, gatewayConfiguration);
-            }
-        });
+        externalGatewayConnectorConfigurationMap.entrySet().stream()
+            .filter(entry -> !APIConstants.EXTERNAL_AWS_GATEWAY.equals(entry.getKey()))
+            .forEach(entry -> processExternalGatewayFeatureCatalogs(gatewayConfigsMap, apiData, entry.getValue()));
 
         GatewayFeatureCatalog gatewayFeatureCatalog = new GatewayFeatureCatalog();
         gatewayFeatureCatalog.setApiTypes(apiData);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -3549,12 +3549,14 @@ public final class APIUtil {
 
         // Process OOTB supported external gateway types first to ensure correct order in publisher UI
         if (externalGatewayConnectorConfigurationMap.containsKey(APIConstants.EXTERNAL_AWS_GATEWAY)) {
-            processExternalGatewayFeatureCatalogs(gatewayConfigsMap, apiData, externalGatewayConnectorConfigurationMap.get(APIConstants.EXTERNAL_AWS_GATEWAY));
-            externalGatewayConnectorConfigurationMap.remove(APIConstants.EXTERNAL_AWS_GATEWAY);
+            processExternalGatewayFeatureCatalogs(gatewayConfigsMap, apiData, externalGatewayConnectorConfigurationMap.
+                    get(APIConstants.EXTERNAL_AWS_GATEWAY));
         }
 
         externalGatewayConnectorConfigurationMap.forEach((gatewayName, gatewayConfiguration) -> {
-            processExternalGatewayFeatureCatalogs(gatewayConfigsMap, apiData, gatewayConfiguration);
+            if (!APIConstants.EXTERNAL_AWS_GATEWAY.equals(gatewayName)) {
+                processExternalGatewayFeatureCatalogs(gatewayConfigsMap, apiData, gatewayConfiguration);
+            }
         });
 
         GatewayFeatureCatalog gatewayFeatureCatalog = new GatewayFeatureCatalog();


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/4023

This PR fixes below issue,

1. Fetch publisher settings by invoking api/am/publisher/v4/settings twice
2. From the second settings call onwards AWS gw type will be dropped from the gatewayFeatureCatalog.apiTypes.rest

The reason for above behaviour was the removal of AWS gw from externalGatewayConnectorConfigurationMap of ServiceReferenceHolder in PR [1].

[1]. https://github.com/wso2/carbon-apimgt/pull/13115
