### PR TITLE
Implement a New Cache for User Schemas

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/TenantServiceCreator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/TenantServiceCreator.java
@@ -198,6 +198,7 @@ public class TenantServiceCreator extends AbstractAxis2ConfigurationContextObser
         CacheProvider.createRecommendationsCache();
         CacheProvider.createParsedSignJWTCache();
         CacheProvider.createJWTClaimCache();
+        CacheProvider.createUserSchemaCache();
         CacheProvider.createInvalidGatewayApiKeyCache();
         CacheProvider.createGatewayInternalKeyCache();
         CacheProvider.createGatewayInternalKeyDataCache();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -815,6 +815,8 @@ public final class APIConstants {
     public static final String KEY_MANAGER_TOKEN_CACHE = CACHE_CONFIGS + "EnableKeyManagerTokenCache";
     public static final String TOKEN_CACHE_EXPIRY = CACHE_CONFIGS + "TokenCacheExpiry";
     public static final String REST_API_TOKEN_CACHE_ENABLED = CACHE_CONFIGS + "EnableRESTAPITokenCache";
+    public static final String USER_SCHEMA_CACHE_ENABLED = CACHE_CONFIGS + "UserSchemaCacheEnabled";
+    public static final String USER_SCHEMA_CACHE_EXPIRY = CACHE_CONFIGS + "UserSchemaCacheExpiry";
     public static final String REST_API_TOKEN_CACHE_EXPIRY = CACHE_CONFIGS + "RESTAPITokenCacheExpiry";
     public static final String REST_API_CACHE_CONTROL_HEADERS_ENABLED = CACHE_CONFIGS
             + "EnableRESTAPICacheControlHeaders";
@@ -1206,6 +1208,7 @@ public final class APIConstants {
     public static final String REST_API_TOKEN_CACHE_NAME = "RESTAPITokenCache";
     public static final String REST_API_INVALID_TOKEN_CACHE_NAME = "RESTAPIInvalidTokenCache";
     public static final String GATEWAY_JWT_TOKEN_CACHE = "GatewayJWTTokenCache";
+    public static final String USER_SCHEMA_CACHE = "UserSchemaCache";
 
     public static final String KEY_CACHE_NAME = "keyCache";
     public static final String API_CONTEXT_CACHE = "apiContextCache";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/caching/CacheProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/caching/CacheProvider.java
@@ -108,6 +108,16 @@ public class CacheProvider {
         return getCache(APIConstants.GATEWAY_JWT_TOKEN_CACHE);
     }
 
+    /**
+     * @return User Schema Cache
+     */
+    public static Cache getUserSchemaCache() {
+        return getCache(APIConstants.USER_SCHEMA_CACHE);
+    }
+
+    /**
+     * @return Gateway JWT Claim Cache
+     */
     public static Cache getJWTClaimCache() {
         return getCache(APIConstants.CLAIMS_APIM_CACHE);
     }
@@ -513,6 +523,23 @@ public class CacheProvider {
     }
 
     /**
+     * Create and return the Schema Cache for Gateway JWT Tokens
+     */
+    public static Cache createUserSchemaCache() {
+
+        String userSchemaCacheExpiry =
+                getApiManagerConfiguration().getFirstProperty(APIConstants.USER_SCHEMA_CACHE_EXPIRY);
+        if (userSchemaCacheExpiry != null) {
+            return getCache(APIConstants.API_MANAGER_CACHE_MANAGER, APIConstants.USER_SCHEMA_CACHE,
+                    Long.parseLong(userSchemaCacheExpiry), Long.parseLong(userSchemaCacheExpiry));
+        } else {
+            long defaultCacheTimeout = getDefaultCacheTimeout();
+            return getCache(APIConstants.API_MANAGER_CACHE_MANAGER, APIConstants.USER_SCHEMA_CACHE,
+                    defaultCacheTimeout, defaultCacheTimeout);
+        }
+    }
+
+    /**
      * Create and return the JWT Claim Cache
      */
     public static Cache createJWTClaimCache() {
@@ -587,6 +614,8 @@ public class CacheProvider {
                 createRESTAPIInvalidTokenCache().getName());
         Caching.getCacheManager(APIConstants.API_MANAGER_CACHE_MANAGER).removeCache(CacheProvider.
                 getGatewayJWTTokenCache().getName());
+        Caching.getCacheManager(APIConstants.API_MANAGER_CACHE_MANAGER).removeCache(CacheProvider.
+                getUserSchemaCache().getName());
         Caching.getCacheManager(APIConstants.API_MANAGER_CACHE_MANAGER).removeCache(CacheProvider.
                 getGatewayApiKeyCache().getName());
         Caching.getCacheManager(APIConstants.API_MANAGER_CACHE_MANAGER).removeCache(CacheProvider.

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/factory/KeyManagerHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/factory/KeyManagerHolder.java
@@ -84,8 +84,12 @@ public class KeyManagerHolder {
                     .getAPIManagerConfigurationService().getAPIManagerConfiguration();
             String defaultKeyManagerType = apiManagerConfiguration
                     .getFirstProperty(APIConstants.DEFAULT_KEY_MANAGER_TYPE);
+            boolean isUserSchemaCacheEnabled = Boolean.parseBoolean(
+                    apiManagerConfiguration.getFirstProperty(APIConstants.USER_SCHEMA_CACHE_ENABLED));
             KeyManagerConnectorConfiguration keyManagerConnectorConfiguration = ServiceReferenceHolder.getInstance()
                     .getKeyManagerConnectorConfiguration(type);
+            keyManagerConfiguration.addParameter(APIConstants.USER_SCHEMA_CACHE_ENABLED,
+                    isUserSchemaCacheEnabled);
             if (keyManagerConnectorConfiguration != null) {
                 if (StringUtils.isNotEmpty(keyManagerConnectorConfiguration.getImplementation())) {
                     try {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
@@ -317,6 +317,7 @@ public class APIManagerComponent {
             CacheProvider.createGatewayBasicAuthResourceCache();
             CacheProvider.createGatewayUsernameCache();
             CacheProvider.createIntrospectionCache();
+            CacheProvider.createUserSchemaCache();
             if(configuration.isJWTClaimCacheEnabled()){
                 CacheProvider.createJWTClaimCache();
             }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -339,6 +339,10 @@
           as 'false' to completely disable JWTClaimCache.
          -->
         <EnableJWTClaimCache>{{apim.cache.jwt_claim.enable}}</EnableJWTClaimCache>
+        <UserSchemaCacheEnabled>{{apim.cache.user_schema.enable}}</UserSchemaCacheEnabled>
+        {% if apim.cache.user_schema.expiry_time is defined %}
+        <UserSchemaCacheExpiry>{{apim.cache.user_schema.expiry_time}}</UserSchemaCacheExpiry>
+        {% endif %}
     </CacheConfigurations>
 
     <!--


### PR DESCRIPTION
### Description
This PR introduced a new cache to keep the user schema-related data to use to all users whenever they need get claims from the key managers.

- Resolves https://github.com/wso2/api-manager/issues/4020