### PR TITLE
Fix scopes issue due to caching and add support to skip deploying throttle policies to TM

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2251,6 +2251,7 @@ public final class APIConstants {
         public static final String ENABLE_JWT_CLAIM_CONDITIONS = "EnableJWTClaimConditions";
         public static final String ENABLE_QUERY_PARAM_CONDITIONS = "EnableQueryParamConditions";
         public static final String SKIP_REDEPLOYING_POLICIES = "SkipRedeployingPolicies";
+        public static final String SKIP_DEPLOYING_POLICIES = "SkipDeployingPolicies";
         public static final String ENABLED = "Enabled";
         public static final String IS_THROTTLED = "isThrottled";
         public static final String THROTTLE_KEY = "throttleKey";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -17,6 +17,7 @@
 package org.wso2.carbon.apimgt.impl;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1407,8 +1408,8 @@ public class APIManagerConfiguration {
                     .getFirstChildWithName(new QName(APIConstants.AdvancedThrottleConstants
                             .SKIP_DEPLOYING_POLICIES));
             if (skipDeployingPoliciesElement != null) {
-                throttleProperties.setSkipDeployingPolicies(skipDeployingPoliciesElement
-                        .getText().split(APIConstants.DELEM_COMMA));
+                throttleProperties.setSkipDeployingPolicies(
+                        Arrays.asList(skipDeployingPoliciesElement.getText().split(APIConstants.DELEM_COMMA)));
             }
             OMElement enablePolicyDeployElement = throttleConfigurationElement
                     .getFirstChildWithName(new QName(APIConstants.AdvancedThrottleConstants.ENABLE_POLICY_DEPLOYMENT));

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -1402,6 +1402,14 @@ public class APIManagerConfiguration {
                 throttleProperties.setSkipRedeployingPolicies(skipRedeployingPoliciesElement
                         .getText().split(APIConstants.DELEM_COMMA));
             }
+            // Check skip deploy throttle policies
+            OMElement skipDeployingPoliciesElement = throttleConfigurationElement
+                    .getFirstChildWithName(new QName(APIConstants.AdvancedThrottleConstants
+                            .SKIP_DEPLOYING_POLICIES));
+            if (skipDeployingPoliciesElement != null) {
+                throttleProperties.setSkipDeployingPolicies(skipDeployingPoliciesElement
+                        .getText().split(APIConstants.DELEM_COMMA));
+            }
             OMElement enablePolicyDeployElement = throttleConfigurationElement
                     .getFirstChildWithName(new QName(APIConstants.AdvancedThrottleConstants.ENABLE_POLICY_DEPLOYMENT));
             if (enablePolicyDeployElement != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ThrottleProperties.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ThrottleProperties.java
@@ -16,7 +16,9 @@
 
 package org.wso2.carbon.apimgt.impl.dto;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -47,7 +49,7 @@ public class ThrottleProperties {
     private boolean enableJwtConditions = false;
     private boolean enableQueryParamConditions =false;
     private String[] skipRedeployingPolicies = new String[]{};
-    private String[] skipDeployingPolicies = new String[]{};
+    private List<String> skipDeployingPolicies = new ArrayList<>();
     private Map<String, Long> defaultThrottleTierLimits = new HashMap<String, Long>();
     private boolean enablePolicyRecreate;
     private TrafficManager trafficManager;
@@ -642,11 +644,11 @@ public class ThrottleProperties {
     public void setSkipRedeployingPolicies(String[] skipRedeployingPolicies) {
         this.skipRedeployingPolicies = skipRedeployingPolicies;
     }
-    public String[] getSkipDeployingPolicies() {
+    public List<String>  getSkipDeployingPolicies() {
         return skipDeployingPolicies;
     }
 
-    public void setSkipDeployingPolicies(String[] skipDeployingPolicies) {
+    public void setSkipDeployingPolicies(List<String> skipDeployingPolicies) {
         this.skipDeployingPolicies = skipDeployingPolicies;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ThrottleProperties.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ThrottleProperties.java
@@ -47,6 +47,7 @@ public class ThrottleProperties {
     private boolean enableJwtConditions = false;
     private boolean enableQueryParamConditions =false;
     private String[] skipRedeployingPolicies = new String[]{};
+    private String[] skipDeployingPolicies = new String[]{};
     private Map<String, Long> defaultThrottleTierLimits = new HashMap<String, Long>();
     private boolean enablePolicyRecreate;
     private TrafficManager trafficManager;
@@ -640,6 +641,13 @@ public class ThrottleProperties {
 
     public void setSkipRedeployingPolicies(String[] skipRedeployingPolicies) {
         this.skipRedeployingPolicies = skipRedeployingPolicies;
+    }
+    public String[] getSkipDeployingPolicies() {
+        return skipDeployingPolicies;
+    }
+
+    public void setSkipDeployingPolicies(String[] skipDeployingPolicies) {
+        this.skipDeployingPolicies = skipDeployingPolicies;
     }
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SystemScopesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SystemScopesApiServiceImpl.java
@@ -11,6 +11,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.impl.APIAdminImpl;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.caching.CacheProvider;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
 import org.apache.cxf.jaxrs.ext.MessageContext;
@@ -78,8 +79,9 @@ public class SystemScopesApiServiceImpl implements SystemScopesApiService {
             throws APIManagementException {
         JSONObject newScopeRoleJson = SystemScopesMappingUtil.createJsonObjectOfScopeMapping(body);
         APIUtil.updateTenantConfOfRoleScopeMapping(newScopeRoleJson, RestApiCommonUtil.getLoggedInUsername());
-        Map<String, String> scopeRoleMapping = APIUtil.getRESTAPIScopesForTenantWithoutRoleMappings(MultitenantUtils
-                .getTenantDomain(RestApiCommonUtil.getLoggedInUsername()));
+        String tenantDomain = MultitenantUtils.getTenantDomain(RestApiCommonUtil.getLoggedInUsername());
+        CacheProvider.getRESTAPIScopeCache().remove(tenantDomain);
+        Map<String, String> scopeRoleMapping = APIUtil.getRESTAPIScopesForTenantWithoutRoleMappings(tenantDomain);
         ScopeListDTO scopeListDTO = SystemScopesMappingUtil.fromScopeListToScopeListDTO(scopeRoleMapping);
         APIUtil.logAuditMessage(APIConstants.AuditLogConstants.ROLES_FOR_SCOPE, APIConstants.AuditLogConstants.ROLES_FOR_SCOPE_INFO,
                 APIConstants.AuditLogConstants.UPDATED, RestApiCommonUtil.getLoggedInUsername());

--- a/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/src/main/java/org/wso2/carbon/apimgt/throttle/policy/deployer/utils/PolicyUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/src/main/java/org/wso2/carbon/apimgt/throttle/policy/deployer/utils/PolicyUtil.java
@@ -49,7 +49,6 @@ import org.wso2.carbon.event.processor.core.exception.ExecutionPlanConfiguration
 import org.wso2.carbon.event.processor.core.exception.ExecutionPlanDependencyValidationException;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +73,12 @@ public class PolicyUtil {
         }
         EventProcessorService eventProcessorService =
                 ServiceReferenceHolder.getInstance().getEventProcessorService();
+        APIManagerConfiguration apiManagerConfiguration =
+                ServiceReferenceHolder.getInstance().getAPIMConfiguration();
+        List<String> skipPolicyNames = new ArrayList<>();
+        if (apiManagerConfiguration.getThrottleProperties().getSkipDeployingPolicies() != null) {
+            skipPolicyNames = apiManagerConfiguration.getThrottleProperties().getSkipDeployingPolicies();
+        }
         ThrottlePolicyTemplateBuilder policyTemplateBuilder = new ThrottlePolicyTemplateBuilder();
 
         Map<String, String> policiesToDeploy = new HashMap<>();
@@ -86,25 +91,33 @@ public class PolicyUtil {
             String policyFile;
             String policyString;
             if (Policy.PolicyType.SUBSCRIPTION.equals(policy.getType()) && policy instanceof SubscriptionPolicy) {
-                // Add Subscription policy
-                policyFile = String.join(APIConstants.DELEM_UNDERSCORE,
-                        policy.getTenantDomain(), PolicyConstants.POLICY_LEVEL_SUB, policy.getName());
-                policyString = policyTemplateBuilder.getThrottlePolicyForSubscriptionLevel((SubscriptionPolicy) policy);
-                policiesToDeploy.put(policyFile, policyString);
+                policyFile = String.join(APIConstants.DELEM_UNDERSCORE, policy.getTenantDomain(),
+                        PolicyConstants.POLICY_LEVEL_SUB, policy.getName());
+                if (shouldDeployPolicy(policyFile, skipPolicyNames)) {
+                    // Add Subscription policy
+                    policyString = policyTemplateBuilder.getThrottlePolicyForSubscriptionLevel(
+                            (SubscriptionPolicy) policy);
+                    policiesToDeploy.put(policyFile, policyString);
+                }
             } else if (Policy.PolicyType.APPLICATION.equals(policy.getType()) && policy instanceof ApplicationPolicy) {
-                // Add Application policy
-                policyFile = String.join(APIConstants.DELEM_UNDERSCORE,
-                        policy.getTenantDomain(), PolicyConstants.POLICY_LEVEL_APP, policy.getName());
-                policyString = policyTemplateBuilder.getThrottlePolicyForAppLevel((ApplicationPolicy) policy);
-                policiesToDeploy.put(policyFile, policyString);
+                policyFile = String.join(APIConstants.DELEM_UNDERSCORE, policy.getTenantDomain(),
+                        PolicyConstants.POLICY_LEVEL_APP, policy.getName());
+                if (shouldDeployPolicy(policyFile, skipPolicyNames)) {
+                    // Add Application policy
+                    policyString = policyTemplateBuilder.getThrottlePolicyForAppLevel((ApplicationPolicy) policy);
+                    policiesToDeploy.put(policyFile, policyString);
+                }
             } else if (Policy.PolicyType.API.equals(policy.getType()) && policy instanceof ApiPolicy) {
-                // Add API policy
-                policiesToDeploy = policyTemplateBuilder.getThrottlePolicyForAPILevel((ApiPolicy) policy);
-                String defaultPolicy = policyTemplateBuilder.getThrottlePolicyForAPILevelDefault((ApiPolicy) policy);
-                policyFile = String.join(APIConstants.DELEM_UNDERSCORE,
-                        policy.getTenantDomain(), PolicyConstants.POLICY_LEVEL_RESOURCE, policy.getName());
-                String defaultPolicyName = policyFile + APIConstants.THROTTLE_POLICY_DEFAULT;
-                policiesToDeploy.put(defaultPolicyName, defaultPolicy);
+                policyFile = String.join(APIConstants.DELEM_UNDERSCORE, policy.getTenantDomain(),
+                        PolicyConstants.POLICY_LEVEL_RESOURCE, policy.getName());
+                if (shouldDeployPolicy(policyFile, skipPolicyNames)) {
+                    // Add API policy
+                    policiesToDeploy = policyTemplateBuilder.getThrottlePolicyForAPILevel((ApiPolicy) policy);
+                    String defaultPolicy = policyTemplateBuilder.getThrottlePolicyForAPILevelDefault(
+                            (ApiPolicy) policy);
+                    String defaultPolicyName = policyFile + APIConstants.THROTTLE_POLICY_DEFAULT;
+                    policiesToDeploy.put(defaultPolicyName, defaultPolicy);
+                }
                 if (policyEvent instanceof APIPolicyEvent) {
                     List<Integer> deletedConditionGroupIds =
                             ((APIPolicyEvent) policyEvent).getDeletedConditionGroupIds();
@@ -117,12 +130,14 @@ public class PolicyUtil {
                     }
                 }
             } else if (Policy.PolicyType.GLOBAL.equals(policy.getType()) && policy instanceof GlobalPolicy) {
-                // Add Global policy
-                GlobalPolicy globalPolicy = (GlobalPolicy) policy;
                 policyFile = String.join(APIConstants.DELEM_UNDERSCORE,
                         PolicyConstants.POLICY_LEVEL_GLOBAL, policy.getName());
-                policyString = policyTemplateBuilder.getThrottlePolicyForGlobalLevel(globalPolicy);
-                policiesToDeploy.put(policyFile, policyString);
+                if (shouldDeployPolicy(policyFile, skipPolicyNames)) {
+                    // Add Global policy
+                    GlobalPolicy globalPolicy = (GlobalPolicy) policy;
+                    policyString = policyTemplateBuilder.getThrottlePolicyForGlobalLevel(globalPolicy);
+                    policiesToDeploy.put(policyFile, policyString);
+                }
             }
 
             // Undeploy removed policies
@@ -157,13 +172,7 @@ public class PolicyUtil {
      * Deploy all the throttle policies retrieved from the database in the Traffic Manager.
      */
     public static void deployAllPolicies() {
-        APIManagerConfiguration apiManagerConfiguration =
-                ServiceReferenceHolder.getInstance().getAPIMConfiguration();
         PolicyRetriever policyRetriever = new PolicyRetriever();
-        List<String> skipPolicyNames = new ArrayList<>();
-        if (apiManagerConfiguration.getThrottleProperties().getSkipDeployingPolicies() != null) {
-            skipPolicyNames = Arrays.asList(apiManagerConfiguration.getThrottleProperties().getSkipDeployingPolicies());
-        }
         try {
             // Deploy all the policies retrieved from the database
             SubscriptionPolicyList subscriptionPolicies = new SubscriptionPolicyList();
@@ -176,10 +185,7 @@ public class PolicyUtil {
             // Undeploy all existing policies
             undeployAllPolicies();
             for (SubscriptionPolicy subscriptionPolicy : subscriptionPolicies.getList()) {
-                String policyFileName = subscriptionPolicy.getTenantDomain() + "_" + PolicyConstants.POLICY_LEVEL_SUB +
-                        "_" + subscriptionPolicy.getName();
-                if (shouldDeployPolicy(policyFileName, skipPolicyNames) &&
-                        !(APIConstants.UNLIMITED_TIER.equalsIgnoreCase(subscriptionPolicy.getName())
+                if (!(APIConstants.UNLIMITED_TIER.equalsIgnoreCase(subscriptionPolicy.getName())
                         || APIConstants.DEFAULT_SUB_POLICY_ASYNC_UNLIMITED.
                         equalsIgnoreCase(subscriptionPolicy.getName())
                         || APIConstants.DEFAULT_SUB_POLICY_ASYNC_WH_UNLIMITED.
@@ -188,27 +194,17 @@ public class PolicyUtil {
                 }
             }
             for (ApplicationPolicy applicationPolicy : applicationPolicies.getList()) {
-                String policyFileName = applicationPolicy.getTenantDomain() + "_" + PolicyConstants.POLICY_LEVEL_APP +
-                        "_" + applicationPolicy.getName();
-                if (shouldDeployPolicy(policyFileName, skipPolicyNames) &&
-                        !APIConstants.UNLIMITED_TIER.equalsIgnoreCase(applicationPolicy.getName())) {
+                if (!APIConstants.UNLIMITED_TIER.equalsIgnoreCase(applicationPolicy.getName())) {
                     deployPolicy(applicationPolicy, null);
                 }
             }
             for (ApiPolicy apiPolicy : apiPolicies.getList()) {
-                String policyFileName = apiPolicy.getTenantDomain() + "_" + PolicyConstants.POLICY_LEVEL_API +
-                        "_" + apiPolicy.getName();
-                if (shouldDeployPolicy(policyFileName, skipPolicyNames) &&
-                        !APIConstants.UNLIMITED_TIER.equalsIgnoreCase(apiPolicy.getName())) {
+                if (!APIConstants.UNLIMITED_TIER.equalsIgnoreCase(apiPolicy.getName())) {
                     deployPolicy(apiPolicy, null);
                 }
             }
             for (GlobalPolicy globalPolicy : globalPolicies.getList()) {
-                String policyFileName = globalPolicy.getTenantDomain() + "_" + PolicyConstants.POLICY_LEVEL_GLOBAL +
-                        "_" + globalPolicy.getName();
-                if (shouldDeployPolicy(policyFileName, skipPolicyNames)) {
-                    deployPolicy(globalPolicy, null);
-                }
+                deployPolicy(globalPolicy, null);
             }
         } catch (ThrottlePolicyDeployerException e) {
             log.error("Error in retrieving throttle policies", e);


### PR DESCRIPTION
### Purpose
To enhance code changes added with https://github.com/wso2/carbon-apimgt/pull/13190 to fix scope issues caused by caching and to support skipping the deployment of throttle policies to TM.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/4028
Fixes: https://github.com/wso2/api-manager/issues/4018

### Code Changes Summary by Copilot:
This pull request introduces a new feature to allow skipping the deployment of specific throttle policies in the API Manager. The changes span multiple files, adding a new configuration option, updating data structures, and modifying the policy deployment logic to respect the new setting.

### Enhancements to Throttle Policy Management:

* **New Configuration Option**: Added a constant `SKIP_DEPLOYING_POLICIES` in `AdvancedThrottleConstants` to represent the new configuration for skipping specific throttle policies during deployment. (`APIConstants.java`, [components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.javaR2254](diffhunk://#diff-53180db9d61eccf226f337dec15f32bb7e951677a1e8b930daef9c9c30828d17R2254))
* **Throttle Properties Update**: Introduced a new `List<String>` field `skipDeployingPolicies` in `ThrottleProperties` to store the list of policies to skip and added corresponding getter and setter methods. (`ThrottleProperties.java`, [[1]](diffhunk://#diff-a04e8b4492c0577c724c416632bf6f28543e0525e7c2ccb5c6ba533af13dd53eR52) [[2]](diffhunk://#diff-a04e8b4492c0577c724c416632bf6f28543e0525e7c2ccb5c6ba533af13dd53eR647-R653)
* **Configuration Parsing**: Updated `setThrottleProperties` in `APIManagerConfiguration` to parse the new `SKIP_DEPLOYING_POLICIES` configuration and populate `skipDeployingPolicies`. (`APIManagerConfiguration.java`, [components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.javaR1406-R1413](diffhunk://#diff-6ad5a30e0da551268318842e70c7a6e235b4e71a5985b57b662723142c8d9ff9R1406-R1413))

### Policy Deployment Logic:

* **Policy Deployment Check**: Modified the `deployPolicy` method in `PolicyUtil` to skip deploying policies listed in `skipDeployingPolicies`. Introduced a helper method `shouldDeployPolicy` to encapsulate this logic. (`PolicyUtil.java`, [[1]](diffhunk://#diff-825173eb15c2e94d27db10a3ffd3e2c1f2d2a81e1ef863a6e7aadc6ff8056631R76-R81) [[2]](diffhunk://#diff-825173eb15c2e94d27db10a3ffd3e2c1f2d2a81e1ef863a6e7aadc6ff8056631R94-R120) [[3]](diffhunk://#diff-825173eb15c2e94d27db10a3ffd3e2c1f2d2a81e1ef863a6e7aadc6ff8056631L119-R141) [[4]](diffhunk://#diff-825173eb15c2e94d27db10a3ffd3e2c1f2d2a81e1ef863a6e7aadc6ff8056631R214-R227)

### Cache Management for Scopes:

* **Scope Cache Update**: Enhanced `updateRolesForScope` in `SystemScopesApiServiceImpl` to clear the REST API scope cache for the tenant before updating role-scope mappings. (`SystemScopesApiServiceImpl.java`, [components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SystemScopesApiServiceImpl.javaL81-R84](diffhunk://#diff-40b14de7a86289d48ef554c49ab5d55d355e7ad29bc16959aea609a49bee19c4L81-R84))

These changes collectively improve the flexibility and efficiency of throttle policy management in the API Manager by allowing selective deployment and ensuring cache consistency for scope updates.