### PR TITLE
Add guardrail_fault to allowed error sequences

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -809,7 +809,12 @@ public enum ExceptionCodes implements ErrorHandler {
     API_ENDPOINT_URL_INVALID(902049, "Endpoint URL is invalid", 400,
             "Endpoint URL is invalid"),
     INVALID_MEDIA_TYPE_VALIDATION(902050, "Invalid or mismatched media type detected.", 415,
-            "File extension '%s' does not match detected MIME type '%s'");
+            "File extension '%s' does not match detected MIME type '%s'"),
+
+    // Guardrail related codes
+    GUARDRAIL_VIOLATION(900514, "Guardrail intervened.", 446,
+            "Guardrail constraint violation detected.");
+
     private final long errorCode;
     private final String errorMessage;
     private final int httpStatusCode;

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1714,6 +1714,7 @@
             <Sequence>_cors_request_handler_.xml</Sequence>
             <Sequence>dispatchSeq.xml</Sequence>
             <Sequence>fault.xml</Sequence>
+            <Sequence>guardrail_fault.xml</Sequence>
             <Sequence>_graphql_failure_handler_.xml</Sequence>
             <Sequence>main.xml</Sequence>
             <Sequence>outDispatchSeq.xml</Sequence>


### PR DESCRIPTION
## Purpose 
Add `guardrail_fault` to allowed error sequences.

## Issue
https://github.com/wso2/api-manager/issues/4067