### PR TITLE
Bump APIM version constant to 4.6.0

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/importexport/ImportExportConstants.java
@@ -204,7 +204,7 @@ public final class ImportExportConstants {
 
     public static final String TYPE_POLICY_SPECIFICATION = "operation_policy_specification";
 
-    public static final String APIM_VERSION = "v4.5.0";
+    public static final String APIM_VERSION = "v4.6.0";
 
     public static final String ENDPOINT_CONFIG = "endpointConfig";
 


### PR DESCRIPTION
This PR bumps the APIM version constant to 4.6.0 for the APICTL use cases.