### PR TITLE
Add topic validation for webhook APIs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/webhook/WebhookApiHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/streaming/webhook/WebhookApiHandler.java
@@ -36,9 +36,12 @@ import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.RESTConstants;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.wso2.carbon.apimgt.api.model.subscription.URLMapping;
 import org.wso2.carbon.apimgt.gateway.handlers.Utils;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler;
+import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.keymgt.model.entity.API;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 
 import javax.xml.stream.XMLStreamException;
@@ -107,6 +110,8 @@ public class WebhookApiHandler extends APIAuthenticationHandler {
                     setProperty(Constants.Configuration.HTTP_METHOD, httpVerb);
             return authenticationResolved;
         } else {
+            boolean isValidTopic = validateTopic(synCtx);
+            synCtx.setProperty(APIConstants.TOPIC_VALIDITY, String.valueOf(isValidTopic));
             org.apache.axis2.context.MessageContext axisMsgContext = ((Axis2MessageContext) synCtx).
                     getAxis2MessageContext();
             try {
@@ -129,6 +134,56 @@ public class WebhookApiHandler extends APIAuthenticationHandler {
                 return false;
             }
         }
+    }
+
+    public boolean validateTopic(MessageContext messageContext) {
+        if (log.isDebugEnabled()) {
+            log.debug("Validating topic for webhook event");
+        }
+        String urlQueryParams = (String) ((Axis2MessageContext) messageContext).getAxis2MessageContext()
+                .getProperty(APIConstants.TRANSPORT_URL_IN);
+        
+        if (urlQueryParams == null) {
+            log.debug("URL query parameters not found in the request");
+            return false;
+        }
+
+        List<NameValuePair> queryParameters;
+        try {
+            queryParameters = URLEncodedUtils.parse(new URI(urlQueryParams), StandardCharsets.UTF_8.name());
+        } catch (URISyntaxException e) {
+            log.error("Error parsing URI for topic validation: " + e.getMessage());
+            return false;
+        }
+        String topicName = null;
+        for (NameValuePair nvPair : queryParameters) {
+            if (APIConstants.Webhooks.TOPIC_QUERY_PARAM.equals(nvPair.getName())) {
+                topicName = nvPair.getValue();
+                break;
+            }
+        }
+
+        if (topicName == null || topicName.isEmpty()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Invalid topic name in the request");
+            }
+            return false;
+        }
+
+        API api = GatewayUtils.getAPI(messageContext);
+        if (api != null) {
+            for (URLMapping mapping : api.getUrlMappings()) {
+                if (topicName.equals(mapping.getUrlPattern())) {
+                    log.info("Valid topic found for webhook event");
+                    return true;
+                }
+            }
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Topic validation failed for webhook event");
+        }
+        return false;
     }
 
     private String getContentType(org.apache.axis2.context.MessageContext axisMsgContext) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2583,6 +2583,7 @@ public final class APIConstants {
     public static final String RECOMMENDATIONS_CACHE_KEY = "Recommendations";
     public static final String LAST_UPDATED_CACHE_KEY = "LastUpdated";
 
+    public static final String TOPIC_VALIDITY = "TOPIC_VALIDITY";
     public static final String CLONED_ITERATION_INDEX_PROPERTY = "CLONED_ITERATION_INDEX";
     public static final String TENANT_DOMAIN_INFO_PROPERTY = "tenant.info.domain";
     public static final String TENANT_ID_INFO_PROPERTY = "tenant.info.id";


### PR DESCRIPTION
## Purpose
When a topic is included in the webhook request, it will be validated first and a 404 error will be returned if the topic is invalid.
Related PR: https://github.com/wso2/product-apim/pull/13783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved validation for webhook topic parameters in streaming API requests, ensuring only valid topics are processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->