### PR TITLE
Add ability to access API properties from WebSocket handlers

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/gateway/GatewayAPIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/gateway/GatewayAPIDTO.java
@@ -22,7 +22,9 @@ package org.wso2.carbon.apimgt.api.gateway;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This Contains the API Related data to deploy in Gateway.
@@ -51,6 +53,7 @@ public class GatewayAPIDTO implements Serializable {
     private CredentialDto[] credentialsToBeAdd ;
     private String[] credentialsToBeRemove;
     private List<String> keyManagers = new ArrayList<>();
+    private Map<String, String> additionalProperties = new HashMap<>();
     public String getName() {
 
         return name;
@@ -243,5 +246,13 @@ public class GatewayAPIDTO implements Serializable {
 
     public void setRevision(String revision) {
         this.revision = revision;
+    }
+
+    public Map<String, String> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    public void setAdditionalProperties(Map<String, String> additionalProperties) {
+        this.additionalProperties = additionalProperties;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/DataHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/DataHolder.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 public class DataHolder {
     private static final Log log  = LogFactory.getLog(DataHolder.class);
     private static final DataHolder Instance = new DataHolder();
-    private Map<String, List<String>> apiToCertificatesMap = new HashMap();
+    private Map<String, List<String>> apiToCertificatesMap = new HashMap<>();
     private Map<String, String> googleAnalyticsConfigMap = new HashMap<>();
     private Map<String, GraphQLSchemaDTO> apiToGraphQLSchemaDTOMap = new HashMap<>();
     private Map<String, List<String>> apiToKeyManagersMap = new HashMap<>();
@@ -424,4 +424,22 @@ public class DataHolder {
         DataHolder.gatewayRegistrationResponse = gatewayRegistrationResponse;
     }
 
+    /**
+     * Update API properties, revision ID, and deployment status in subscription data store
+     *
+     * @param gatewayAPIDTO Gateway API DTO containing additional properties and other info
+     */
+    public void updateAPIPropertiesFromGatewayDTO(GatewayAPIDTO gatewayAPIDTO) {
+        Map<String, API> apiMap = tenantAPIMap.get(gatewayAPIDTO.getTenantDomain());
+        if (apiMap != null) {
+            API api = apiMap.get(gatewayAPIDTO.getApiContext());
+            if (api != null) {
+                api.setApiProperties(gatewayAPIDTO.getAdditionalProperties());
+                if (log.isDebugEnabled()) {
+                    log.debug("Updated API properties for API: " + api.getName() + " (Context: " + api.getContext() +
+                            ")");
+                }
+            }
+        }
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/SubscriptionDataStore.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/SubscriptionDataStore.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.apimgt.keymgt.model;
 
+import org.wso2.carbon.apimgt.api.gateway.GatewayAPIDTO;
 import org.wso2.carbon.apimgt.impl.notifier.events.DeployAPIInGatewayEvent;
 import org.wso2.carbon.apimgt.keymgt.model.entity.API;
 import org.wso2.carbon.apimgt.keymgt.model.entity.ApiPolicy;
@@ -218,5 +219,7 @@ public interface SubscriptionDataStore {
     List<ApplicationKeyMapping> getKeyMappingByApplicationId(int applicationId);
 
     void destroy();
+
+    void updateAPIPropertiesFromGatewayDTO(GatewayAPIDTO gatewayAPIDTO);
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/entity/API.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/entity/API.java
@@ -23,7 +23,9 @@ import org.wso2.carbon.apimgt.api.model.subscription.CacheableEntity;
 import org.wso2.carbon.apimgt.api.model.subscription.URLMapping;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Entity for keeping API related information.
@@ -44,6 +46,7 @@ public class API implements CacheableEntity<String> {
     private boolean isDefaultVersion = false;
     private String securityScheme;
     private String revisionId;
+    private Map<String, String> apiProperties = new HashMap<>();
     private List<OperationPolicy> apiPolicies = new ArrayList<>();
     private boolean isSubscriptionValidationDisabled = false;
     private Boolean isEgress = null;
@@ -363,5 +366,13 @@ public class API implements CacheableEntity<String> {
 
     public void setSubtype(String subtype) {
         this.subtype = subtype;
+    }
+
+    public Map<String, String> getApiProperties() {
+        return apiProperties;
+    }
+
+    public void setApiProperties(Map<String, String> apiProperties) {
+        this.apiProperties = apiProperties;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
@@ -859,6 +859,7 @@ public class TemplateBuilderUtil {
         productAPIDto.setVersion(id.getVersion());
         productAPIDto.setTenantDomain(tenantDomain);
         productAPIDto.setKeyManagers(Collections.singletonList(APIConstants.KeyManager.API_LEVEL_ALL_KEY_MANAGERS));
+        productAPIDto.setAdditionalProperties(toStringMap(apiProduct.getAdditionalProperties()));
         String definition = apiProduct.getDefinition();
         productAPIDto.setLocalEntriesToBeRemove(GatewayUtils.addStringToList(apiProduct.getUuid(),
                 productAPIDto.getLocalEntriesToBeRemove()));
@@ -971,6 +972,7 @@ public class TemplateBuilderUtil {
         gatewayAPIDTO.setApiContext(api.getContext());
         gatewayAPIDTO.setTenantDomain(tenantDomain);
         gatewayAPIDTO.setKeyManagers(api.getKeyManagers());
+        gatewayAPIDTO.setAdditionalProperties(toStringMap(api.getAdditionalProperties()));
 
         String definition;
         boolean isGraphQLSubscriptionAPI = false;
@@ -1121,6 +1123,25 @@ public class TemplateBuilderUtil {
         }
         setSecureVaultPropertyToBeAdded(null, api, gatewayAPIDTO);
         return gatewayAPIDTO;
+    }
+    
+    /**
+     * Converts a JSONObject to a Map<String, String>.
+     *
+     * @param json the JSONObject to convert
+     * @return a map of string key-value pairs
+     */
+    private static Map<String, String> toStringMap(JSONObject json) {
+        Map<String, String> map = new HashMap<>();
+        if (json != null) {
+            for (Object keyObj : json.keySet()) {
+                String key = keyObj.toString();
+                Object valueObj = json.get(key);
+                String value = valueObj != null ? valueObj.toString() : null;
+                map.put(key, value);
+            }
+        }
+        return map;
     }
 
     private static void addEndpointsSequence(String type, List<SimplifiedEndpoint> endpoints,


### PR DESCRIPTION
### 🔧 Purpose

This PR enables access to custom API properties from WebSocket handlers, allowing the implementation of dynamic authentication flows via a custom authentication handler.

---

### ✅ Summary of Changes

- Introduced a new field for custom API properties in the gateway API DTO and API entity.
- Updated the API deployment flow to synchronize these properties across gateway components and the subscription data store.
- Modified the template builder to extract and set custom properties from the API definition.

---

### 📌 Use Case

WebSocket handlers can now access API-level custom properties at runtime.  
This allows implementers to:
- Inject conditional logic into custom authentication handlers
- Drive different authentication flows based on per-API configuration (e.g., enabling JWT, mutual TLS, API key, etc.)

### Related Issues
- [api-manage#3986](https://github.com/wso2/api-manager/issues/3986)