### PR TITLE
Fix get subscription pagination issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -21673,7 +21673,7 @@ public class ApiMgtDAO {
             try (ResultSet result = ps.executeQuery()) {
                 int index = 0;
                 while (result.next()) {
-                    if (index >= offset && index < limit) {
+                    if (index >= offset && index < (limit + offset)) {
                         String apiType = result.getString("TYPE");
 
                         if (APIConstants.API_PRODUCT.equalsIgnoreCase(apiType)) {
@@ -21696,7 +21696,7 @@ public class ApiMgtDAO {
                             subscribedAPIs.add(subscribedAPI);
                         }
 
-                        if (index == limit - 1) {
+                        if (index == limit + offset - 1) {
                             break;
                         }
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SubscriptionMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SubscriptionMappingUtil.java
@@ -155,15 +155,10 @@ public class SubscriptionMappingUtil {
             subscriptionListDTO.setList(subscriptionDTOs);
         }
 
-        //identifying the proper start and end indexes
-        int size = subscriptions.size();
-        int start = offset < size && offset >= 0 ? offset : Integer.MAX_VALUE;
-        int end = offset + limit - 1 <= size - 1 ? offset + limit - 1 : size - 1;
-
-        for (int i = start; i <= end; i++) {
+        for (SubscribedAPI subscribedAPI : subscriptions) {
             try {
-                SubscribedAPI subscription = subscriptions.get(i);
-                subscriptionDTOs.add(fromSubscriptionToDTO(subscription, organization));
+                SubscriptionDTO subscriptionDTO = fromSubscriptionToDTO(subscribedAPI, organization);
+                subscriptionDTOs.add(subscriptionDTO);
             } catch (APIManagementException e) {
                 log.error("Error while obtaining api metadata", e);
             }


### PR DESCRIPTION
### Purpose

- When retrieving subscriptions using the below API call with the specified offset and limit, the resulting response differs from the expected response.

```
https://localhost:9443/api/am/devportal/v3/subscriptions?applicationId=e3839d4b-f82c-40d0-a0d2-451e03daa7a7&limit=2&offset=2
```

- Related issue: [wso2/api-manager/issues#4072](https://github.com/wso2/api-manager/issues/4072)