### PR TITLE
Add vhosts to the runtime artifact response

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/gateway/GatewayAPIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/gateway/GatewayAPIDTO.java
@@ -20,6 +20,10 @@
 
 package org.wso2.carbon.apimgt.api.gateway;
 
+import org.wso2.carbon.apimgt.api.model.VHost;
+
+import org.wso2.carbon.apimgt.api.model.VHost;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -54,6 +58,8 @@ public class GatewayAPIDTO implements Serializable {
     private String[] credentialsToBeRemove;
     private List<String> keyManagers = new ArrayList<>();
     private Map<String, String> additionalProperties = new HashMap<>();
+    private List<VHost> vhosts = new ArrayList<>();
+
     public String getName() {
 
         return name;
@@ -254,5 +260,13 @@ public class GatewayAPIDTO implements Serializable {
 
     public void setAdditionalProperties(Map<String, String> additionalProperties) {
         this.additionalProperties = additionalProperties;
+    }
+
+    public List<VHost> getVhosts() {
+        return vhosts;
+    }
+
+    public void setVhosts(List<VHost> vhosts) {
+        this.vhosts = vhosts;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/gateway/GatewayAPIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/gateway/GatewayAPIDTO.java
@@ -22,8 +22,6 @@ package org.wso2.carbon.apimgt.api.gateway;
 
 import org.wso2.carbon.apimgt.api.model.VHost;
 
-import org.wso2.carbon.apimgt.api.model.VHost;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
@@ -21,13 +21,17 @@ import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.UsedByMigrationClient;
 
+import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
 
 /**
  * This class represent an Virtual Host
  */
-public class VHost {
+public class VHost implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     // host name from the http endpoint
     private String host;
     private String httpContext = "";

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/TemplateBuilderUtil.java
@@ -860,6 +860,7 @@ public class TemplateBuilderUtil {
         productAPIDto.setTenantDomain(tenantDomain);
         productAPIDto.setKeyManagers(Collections.singletonList(APIConstants.KeyManager.API_LEVEL_ALL_KEY_MANAGERS));
         productAPIDto.setAdditionalProperties(toStringMap(apiProduct.getAdditionalProperties()));
+        productAPIDto.setVhosts(environment.getVhosts());
         String definition = apiProduct.getDefinition();
         productAPIDto.setLocalEntriesToBeRemove(GatewayUtils.addStringToList(apiProduct.getUuid(),
                 productAPIDto.getLocalEntriesToBeRemove()));
@@ -973,6 +974,7 @@ public class TemplateBuilderUtil {
         gatewayAPIDTO.setTenantDomain(tenantDomain);
         gatewayAPIDTO.setKeyManagers(api.getKeyManagers());
         gatewayAPIDTO.setAdditionalProperties(toStringMap(api.getAdditionalProperties()));
+        gatewayAPIDTO.setVhosts(environment.getVhosts());
 
         String definition;
         boolean isGraphQLSubscriptionAPI = false;
@@ -1124,7 +1126,7 @@ public class TemplateBuilderUtil {
         setSecureVaultPropertyToBeAdded(null, api, gatewayAPIDTO);
         return gatewayAPIDTO;
     }
-    
+
     /**
      * Converts a JSONObject to a Map<String, String>.
      *


### PR DESCRIPTION
Adding Vhost details to the runtime artifact response to serve oauth protected resource metadata responses and WWW-Authenticate headers for MCP Servers