### PR TITLE
Fix HttpClient to use updated SSLContext at runtime for newly uploaded certificates

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/configdto/HttpClientConfigurationDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/configdto/HttpClientConfigurationDTO.java
@@ -17,11 +17,8 @@
  */
 package org.wso2.carbon.apimgt.common.gateway.configdto;
 
-import org.apache.http.ssl.SSLContexts;
-
 import java.util.Arrays;
 import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
 
 /**
  * Configuration related to Http Clients within gateway.
@@ -38,7 +35,6 @@ public class HttpClientConfigurationDTO {
     private char[] proxyPassword = new char[]{};
     private String[] nonProxyHosts = new String[]{};
     private String proxyProtocol;
-    private SSLContext sslContext;
     private HostnameVerifier hostnameVerifier;
 
     public HostnameVerifier getHostnameVerifier() {
@@ -84,10 +80,6 @@ public class HttpClientConfigurationDTO {
         return proxyProtocol;
     }
 
-    public SSLContext getSslContext() {
-        return sslContext;
-    }
-
     public int getConnectionTimeout() {
         return connectionTimeout;
     }
@@ -107,7 +99,6 @@ public class HttpClientConfigurationDTO {
         private char[] proxyPassword = new char[]{};
         private String[] nonProxyHosts = new String[]{};
         private String proxyProtocol;
-        private SSLContext sslContext;
         private HostnameVerifier hostnameVerifier;
 
         public Builder withConnectionParams(int connectionLimit, int maximumConnectionsPerRoute,
@@ -131,13 +122,7 @@ public class HttpClientConfigurationDTO {
             return this;
         }
 
-        public Builder withSSLContext(SSLContext sslContext) {
-            this.sslContext = sslContext;
-            return this;
-        }
-
-        public Builder withSSLContext(SSLContext sslContext, HostnameVerifier hostnameVerifier) {
-            this.sslContext = sslContext;
+        public Builder withHostnameVerifier(HostnameVerifier hostnameVerifier) {
             this.hostnameVerifier = hostnameVerifier;
             return this;
         }
@@ -155,11 +140,6 @@ public class HttpClientConfigurationDTO {
             configuration.proxyProtocol = this.proxyProtocol;
             configuration.nonProxyHosts = this.nonProxyHosts;
             configuration.hostnameVerifier = this.hostnameVerifier;
-            if (this.sslContext != null) {
-                configuration.sslContext = this.sslContext;
-            } else {
-                configuration.sslContext = SSLContexts.createDefault();
-            }
             return configuration;
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/CommonAPIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/src/main/java/org/wso2/carbon/apimgt/common/gateway/util/CommonAPIUtil.java
@@ -57,10 +57,9 @@ public class CommonAPIUtil {
     private static final HostnameVerifier browserHostNameVerifier = new BrowserHostnameVerifier();
 
     private static PoolingHttpClientConnectionManager getPoolingHttpClientConnectionManager(
-            HttpClientConfigurationDTO clientConfiguration) {
+            SSLContext sslContext, HostnameVerifier hostnameVerifier) {
 
-        SSLConnectionSocketFactory socketFactory = createSocketFactory(clientConfiguration.getSslContext(),
-                clientConfiguration.getHostnameVerifier());
+        SSLConnectionSocketFactory socketFactory = createSocketFactory(sslContext, hostnameVerifier);
         Registry<ConnectionSocketFactory> socketFactoryRegistry =
                     RegistryBuilder.<ConnectionSocketFactory>create()
                             .register(HTTP_PROTOCOL, PlainConnectionSocketFactory.getSocketFactory())
@@ -78,9 +77,12 @@ public class CommonAPIUtil {
      * Return a http client instance
      *
      * @param protocol - service endpoint protocol http/https
+     * @param clientConfiguration HTTP client configuration for connection pooling, proxy, timeouts
+     * @param sslContext SSL context to be used for HTTPS connections
      * @return {@link HttpClient} with all proxy, TLS, ConnectionPooling related configurations
      */
-    public static HttpClient getHttpClient(String protocol, HttpClientConfigurationDTO clientConfiguration) {
+    public static HttpClient getHttpClient(String protocol, HttpClientConfigurationDTO clientConfiguration,
+                                          SSLContext sslContext) {
 
         int maxTotal = clientConfiguration.getConnectionLimit();
         int defaultMaxPerRoute = clientConfiguration.getMaximumConnectionsPerRoute();
@@ -98,7 +100,8 @@ public class CommonAPIUtil {
             protocol = proxyProtocol;
         }
 
-        PoolingHttpClientConnectionManager pool = getPoolingHttpClientConnectionManager(clientConfiguration);
+        PoolingHttpClientConnectionManager pool = getPoolingHttpClientConnectionManager(sslContext,
+                clientConfiguration.getHostnameVerifier());
 
         pool.setMaxTotal(maxTotal);
         pool.setDefaultMaxPerRoute(defaultMaxPerRoute);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
@@ -1047,19 +1047,6 @@ public class APIManagerComponent {
                     nonProxyHosts);
         }
 
-        SSLContext sslContext = null;
-        try {
-            KeyStore trustStore = ServiceReferenceHolder.getInstance().getTrustStore();
-            sslContext = SSLContexts.custom().loadTrustMaterial(trustStore, null).build();
-        } catch ( KeyStoreException e) {
-            log.error("Failed to read from Key Store", e);
-        } catch (
-                NoSuchAlgorithmException e) {
-            log.error("Failed to load Key Store.", e);
-        } catch (
-                KeyManagementException e) {
-            log.error("Failed to load key from Key Store" , e);
-        }
         String hostnameVerifierOption = System.getProperty(HOST_NAME_VERIFIER);
         HostnameVerifier hostnameVerifier;
         switch(hostnameVerifierOption) {
@@ -1084,7 +1071,7 @@ public class APIManagerComponent {
         }
         configuration.setHttpClientConfiguration(builder
                 .withConnectionParams(maxTotal, defaultMaxPerRoute, connectionTimeout)
-                .withSSLContext(sslContext, hostnameVerifier).build());
+                .withHostnameVerifier(hostnameVerifier).build());
     }
 
     void initializeAPIDiscoveryTasks(String organization) {


### PR DESCRIPTION
This change addresses an issue introduced in PR #11577 (commit 12b242eb1d5944fe29ecec969980cee37c9e3ff2) where SSLContext was eagerly initialised at component startup; after #11577, SSLContext was loaded once during component initialization, preventing dynamic truststore updates from propagating to the HttpClient, so newly uploaded certificates were not picked up until the server was restarted, which caused HEAD requests in the Publisher portal endpoint try-out to fail even after uploading the required certificate unless the server was restarted. The fix refactors getHttpClient to avoid relying on a one-time, startup-initialized SSLContext and ensures that getHttpClient uses the current trust material by creating the HttpClient with an SSLContext that reflects the latest certificates (e.g., by building it at client creation time and/or refreshing when truststore content changes), so runtime certificate updates take effect immediately and restore the pre-#11577 behavior where new certificates are usable without a restart.