### PR TITLE
Sort MCP tools alphabetically

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -165,6 +165,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -3549,6 +3550,8 @@ public class APIMappingUtil {
             MCPServerOperationDTO operationsDTO = getMCPServerOperationFromURITemplate(uriTemplate);
             operationsDTOList.add(operationsDTO);
         }
+        operationsDTOList.sort(Comparator.comparing(MCPServerOperationDTO::getTarget,
+                Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
         return operationsDTOList;
     }
 


### PR DESCRIPTION
$subject

Currently MCP tools returns in a random manner which cause the order of the tools to change with every request. This fix sort the tools alphabetically. 