### PR TITLE
Fix case sensitive user roles for publisher access control

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -338,6 +338,8 @@ public final class APIUtil {
 
     private static boolean isContextCacheInitialized = false;
 
+    private static final String caseSensitiveCheckEnabled = System.getProperty(APIConstants.CASE_SENSITIVE_CHECK_PATH);
+
     public static final String DISABLE_ROLE_VALIDATION_AT_SCOPE_CREATION = "disableRoleValidationAtScopeCreation";
 
     public static final String DISABLE_API_CONTEXT_VALIDATION = "disableApiContextValidation";
@@ -7704,11 +7706,16 @@ public final class APIUtil {
      * @return true if the Array contains the role specified.
      */
     public static boolean compareRoleList(String[] userRoleList, String accessControlRole) {
-
         if (userRoleList != null) {
             for (String userRole : userRoleList) {
-                if (userRole.equalsIgnoreCase(accessControlRole)) {
-                    return true;
+                if (Boolean.parseBoolean(caseSensitiveCheckEnabled)) {
+                    if (userRole.equals(accessControlRole)) {
+                        return true;
+                    }
+                } else {
+                    if (userRole.equalsIgnoreCase(accessControlRole)) {
+                        return true;
+                    }
                 }
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -193,6 +193,7 @@ public class APIMappingUtil {
     private static final String EMPTY_STRING = "";
 
     private static String migrationEnabled = System.getProperty(APIConstants.MIGRATE);
+    private static String caseSensitiveCheckEnabled = System.getProperty(APIConstants.CASE_SENSITIVE_CHECK_PATH);
 
     public static API fromDTOtoAPI(APIDTO dto, String provider) throws APIManagementException {
 
@@ -395,7 +396,12 @@ public class APIMappingUtil {
             model.setAccessControl(APIConstants.NO_ACCESS_CONTROL);
             model.setAccessControlRoles("null");
         } else {
-            model.setAccessControlRoles(StringUtils.join(accessControlRoles, ',').toLowerCase());
+            String roles = StringUtils.join(accessControlRoles, ',');
+            if (Boolean.parseBoolean(caseSensitiveCheckEnabled)) {
+                model.setAccessControlRoles(roles);
+            } else {
+                model.setAccessControlRoles(roles.toLowerCase());
+            }
             model.setAccessControl(APIConstants.API_RESTRICTED_VISIBILITY);
         }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/APIMappingUtil.java
@@ -397,6 +397,9 @@ public class APIMappingUtil {
             model.setAccessControlRoles("null");
         } else {
             String roles = StringUtils.join(accessControlRoles, ',');
+            if (log.isDebugEnabled()) {
+                log.debug("Setting access control roles for API: " + apiId);
+            }
             if (Boolean.parseBoolean(caseSensitiveCheckEnabled)) {
                 model.setAccessControlRoles(roles);
             } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -2018,6 +2018,9 @@ public class PublisherCommonUtils {
                 String roleString = String.join(",", inputRoles);
                 if (userRoleList != null) {
                     for (String inputRole : inputRoles) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Checking role: " + inputRole + " against user roles");
+                        }
                         if (!isMatched && APIUtil.compareRoleList(userRoleList, inputRole)) {
                             isMatched = true;
                         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -2007,12 +2007,10 @@ public class PublisherCommonUtils {
 
         String userName = RestApiCommonUtil.getLoggedInUsername();
         boolean isMatched = false;
-        String[] userRoleList = null;
+        String[] userRoleList = APIUtil.getListOfRoles(userName);
 
         if (APIUtil.hasPermission(userName, APIConstants.Permissions.APIM_ADMIN)) {
             isMatched = true;
-        } else {
-            userRoleList = APIUtil.getListOfRoles(userName);
         }
         if (inputRoles != null && !inputRoles.isEmpty()) {
             if (Boolean.parseBoolean(System.getProperty(APIConstants.CASE_SENSITIVE_CHECK_PATH))) {
@@ -2020,7 +2018,7 @@ public class PublisherCommonUtils {
                 String roleString = String.join(",", inputRoles);
                 if (userRoleList != null) {
                     for (String inputRole : inputRoles) {
-                        if (!isMatched && userRoleList != null && APIUtil.compareRoleList(userRoleList, inputRole)) {
+                        if (!isMatched && APIUtil.compareRoleList(userRoleList, inputRole)) {
                             isMatched = true;
                         }
                     }


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/4080

The following issues are resolved:

The error occurring when a user with admin permissions tries to add a role from the publisher portal for an API is now fixed.
When a role with capital letters is created from the publisher portal and added to an API, the API can now be successfully updated with no errors.