### PR TITLE
API Gateway Federation bug fixes and improvements

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -7336,7 +7336,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         } catch (WorkflowException ex) {
             log.warn("Unable to delete Revision Deployment Workflow", ex);
         }
-        removeFromGateway(api, new HashSet<>(apiRevisionDeployments), Collections.emptySet());
+        if (!api.isInitiatedFromGateway()) {
+            removeFromGateway(api, new HashSet<>(apiRevisionDeployments), Collections.emptySet());
+        }
         apiMgtDAO.removeAPIRevisionDeployment(apiRevisionId, apiRevisionDeployments);
         GatewayArtifactsMgtDAO.getInstance().removePublishedGatewayLabels(apiId, apiRevisionId, environmentsToRemove);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/notifier/ExternalGatewayNotifier.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/notifier/ExternalGatewayNotifier.java
@@ -112,7 +112,7 @@ public class ExternalGatewayNotifier extends DeployAPIInGatewayNotifier {
                 }
             }
         } catch (APIManagementException e) {
-            throw new NotifierException(e.getMessage());
+            throw new NotifierException(e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
These fixes will,

1. Check if an API is initiated from the gateway before undeploying from the gateway.
2. Send the exception object when Federated API deployment fails and an exception is thrown.