### PR TITLE
Add MCP GW fixes

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/mcp/McpInitHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/mcp/McpInitHandler.java
@@ -19,12 +19,19 @@
 package org.wso2.carbon.apimgt.gateway.handlers.mcp;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
+import org.apache.axis2.Constants;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpStatus;
 import org.apache.synapse.ManagedLifecycle;
+import org.apache.synapse.Mediator;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
@@ -34,11 +41,17 @@ import org.wso2.carbon.apimgt.api.model.APIOperationMapping;
 import org.wso2.carbon.apimgt.api.model.BackendOperation;
 import org.wso2.carbon.apimgt.api.model.BackendOperationMapping;
 import org.wso2.carbon.apimgt.api.model.subscription.URLMapping;
+import org.wso2.carbon.apimgt.common.gateway.constants.GraphQLConstants;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.exception.McpException;
+import org.wso2.carbon.apimgt.gateway.handlers.Utils;
+import org.wso2.carbon.apimgt.gateway.mcp.request.MCPRequestDeserializer;
 import org.wso2.carbon.apimgt.gateway.mcp.request.Params;
 import org.wso2.carbon.apimgt.gateway.mcp.request.McpRequest;
+import org.wso2.carbon.apimgt.gateway.mcp.response.McpResponse;
+import org.wso2.carbon.apimgt.gateway.mcp.response.McpResponseDto;
 import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
+import org.wso2.carbon.apimgt.gateway.utils.MCPPayloadGenerator;
 import org.wso2.carbon.apimgt.gateway.utils.MCPUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.keymgt.model.entity.API;
@@ -77,7 +90,9 @@ public class McpInitHandler extends AbstractHandler implements ManagedLifecycle 
                 messageContext.setProperty(APIMgtGatewayConstants.MCP_NO_AUTH_REQUEST, isNoAuthMCPRequest);
             }
         } catch (McpException e) {
-            log.error("Error in MCP handleRequest flow", e);
+            log.error(e.getData().toString(), e);
+            MCPUtils.handleMCPFailure(messageContext, new McpResponseDto(e.getErrorMessage(), e.getErrorCode(), null));
+            return false;
         }
         return true;
     }
@@ -123,7 +138,8 @@ public class McpInitHandler extends AbstractHandler implements ManagedLifecycle 
             if (JsonUtil.hasAJsonPayload(axis2MC)) {
                 messageBody = JsonUtil.jsonPayloadToString(axis2MC);
 
-                Gson gson = new Gson();
+                Gson gson = new GsonBuilder().registerTypeAdapter(McpRequest.class, new MCPRequestDeserializer())
+                        .create();
                 McpRequest request = gson.fromJson(messageBody, McpRequest.class);
                 if (!MCPUtils.validateRequest(request)) {
                     throw new McpException(APIConstants.MCP.RpcConstants.INVALID_REQUEST_CODE,
@@ -178,13 +194,13 @@ public class McpInitHandler extends AbstractHandler implements ManagedLifecycle 
             case APIConstants.MCP.METHOD_INITIALIZE:
             case APIConstants.MCP.METHOD_PING:
             case APIConstants.MCP.METHOD_NOTIFICATION_INITIALIZED:
+            case APIConstants.MCP.METHOD_RESOURCES_LIST:
+            case APIConstants.MCP.METHOD_RESOURCE_TEMPLATE_LIST:
+            case APIConstants.MCP.METHOD_PROMPTS_LIST:
                 return true;
 
             case APIConstants.MCP.METHOD_TOOL_LIST:
             case APIConstants.MCP.METHOD_TOOL_CALL:
-            case APIConstants.MCP.METHOD_RESOURCES_LIST:
-            case APIConstants.MCP.METHOD_RESOURCE_TEMPLATE_LIST:
-            case APIConstants.MCP.METHOD_PROMPTS_LIST:
                 return false;
 
             default:

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/mcp/McpInitHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/mcp/McpInitHandler.java
@@ -90,7 +90,7 @@ public class McpInitHandler extends AbstractHandler implements ManagedLifecycle 
                 messageContext.setProperty(APIMgtGatewayConstants.MCP_NO_AUTH_REQUEST, isNoAuthMCPRequest);
             }
         } catch (McpException e) {
-            log.error(e.getData().toString(), e);
+            log.error("MCP init failed: " + String.valueOf(e.getData()), e);
             MCPUtils.handleMCPFailure(messageContext, new McpResponseDto(e.getErrorMessage(), e.getErrorCode(), null));
             return false;
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/InternalAPIKeyAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/InternalAPIKeyAuthenticator.java
@@ -185,7 +185,7 @@ public class InternalAPIKeyAuthenticator implements Authenticator {
                         log.debug("Internal Key not found in the cache.");
                     }
                     isVerified =
-                            GatewayUtils.verifyTokenSignature(signedJWT, alias) && !org.wso2.carbon.apimgt.gateway.utils.GatewayUtils.isJwtTokenExpired(payload);
+                            GatewayUtils.verifyTokenSignature(signedJWT, alias) && !GatewayUtils.isJwtTokenExpired(payload);
                     // Add token to tenant token cache
                     if (isVerified) {
                         getGatewayInternalKeyCache().put(tokenIdentifier, tenantDomain);
@@ -284,7 +284,11 @@ public class InternalAPIKeyAuthenticator implements Authenticator {
             if (internalKey != null) {
                 //Remove InternalKey header from the request except for MCP existing_API subtype
                 API matchedAPI = GatewayUtils.getAPI(mCtx);
-                if (matchedAPI != null && !APIConstants.API_SUBTYPE_EXISTING_API.equals(matchedAPI.getSubtype())) {
+                if (matchedAPI != null && !APIConstants.API_TYPE_MCP.equals(matchedAPI.getApiType()) &&
+                        !APIConstants.API_SUBTYPE_EXISTING_API.equals(matchedAPI.getSubtype())) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Removing Internal Key header from request for API: " + matchedAPI.getName());
+                    }
                     headers.remove(securityParam);
                 }
                 return internalKey.trim();

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/InternalAPIKeyAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/InternalAPIKeyAuthenticator.java
@@ -185,7 +185,7 @@ public class InternalAPIKeyAuthenticator implements Authenticator {
                         log.debug("Internal Key not found in the cache.");
                     }
                     isVerified =
-                            GatewayUtils.verifyTokenSignature(signedJWT, alias) && !GatewayUtils.isJwtTokenExpired(payload);
+                            GatewayUtils.verifyTokenSignature(signedJWT, alias) && !org.wso2.carbon.apimgt.gateway.utils.GatewayUtils.isJwtTokenExpired(payload);
                     // Add token to tenant token cache
                     if (isVerified) {
                         getGatewayInternalKeyCache().put(tokenIdentifier, tenantDomain);
@@ -282,8 +282,11 @@ public class InternalAPIKeyAuthenticator implements Authenticator {
         if (headers != null) {
             internalKey = (String) headers.get(securityParam);
             if (internalKey != null) {
-                //Remove InternalKey header from the request
-                headers.remove(securityParam);
+                //Remove InternalKey header from the request except for MCP existing_API subtype
+                API matchedAPI = GatewayUtils.getAPI(mCtx);
+                if (matchedAPI != null && !APIConstants.API_SUBTYPE_EXISTING_API.equals(matchedAPI.getSubtype())) {
+                    headers.remove(securityParam);
+                }
                 return internalKey.trim();
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mcp/request/MCPRequestDeserializer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mcp/request/MCPRequestDeserializer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.gateway.mcp.request;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+
+import java.lang.reflect.Type;
+
+/**
+ * This class is used to deserialize a JSON element into a McpRequest object.
+ * It implements the JsonDeserializer interface from the Gson library.
+ * A custom deserializer was required to handle the id field, which can be either a string or an integer.
+ */
+
+public class MCPRequestDeserializer implements com.google.gson.JsonDeserializer<McpRequest> {
+
+    /**
+     * Deserialize a JSON element into a McpRequest object.
+     *
+     * @param json The JSON element to deserialize.
+     * @param typeOfT The type of the object to deserialize into.
+     * @param context The deserialization context.
+     * @return A McpRequest object.
+     * @throws JsonParseException If the JSON is not in the expected format.
+     */
+
+    @Override
+    public McpRequest deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        JsonObject obj = json.getAsJsonObject();
+        McpRequest mcpRequest = new McpRequest(null);
+
+        // Requests MUST include a string or integer ID (2025-06-18 spec)
+        JsonElement idElement = obj.get("id");
+        if (idElement != null && idElement.isJsonPrimitive()) {
+            JsonPrimitive prim = idElement.getAsJsonPrimitive();
+            if (prim.isString()) {
+                mcpRequest.setId(prim.getAsString());
+            } else if (prim.isNumber()) {
+                int val = prim.getAsInt();
+                mcpRequest.setId(val);
+            }
+        }
+
+        // Let Gson handle the rest (name, etc.)
+        mcpRequest.setMethod(context.deserialize(obj.get("method"), String.class));
+        mcpRequest.setParams(context.deserialize(obj.get("params"), Params.class));
+
+        return mcpRequest;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mcp/request/MCPRequestDeserializer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mcp/request/MCPRequestDeserializer.java
@@ -23,6 +23,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.lang.reflect.Type;
 
@@ -33,6 +35,7 @@ import java.lang.reflect.Type;
  */
 
 public class MCPRequestDeserializer implements com.google.gson.JsonDeserializer<McpRequest> {
+    private static final Log log = LogFactory.getLog(MCPRequestDeserializer.class);
 
     /**
      * Deserialize a JSON element into a McpRequest object.
@@ -47,6 +50,10 @@ public class MCPRequestDeserializer implements com.google.gson.JsonDeserializer<
     @Override
     public McpRequest deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
             throws JsonParseException {
+        if (log.isDebugEnabled()) {
+            log.debug("Starting deserialization of McpRequest");
+        }
+
         JsonObject obj = json.getAsJsonObject();
         McpRequest mcpRequest = new McpRequest(null);
 
@@ -56,15 +63,29 @@ public class MCPRequestDeserializer implements com.google.gson.JsonDeserializer<
             JsonPrimitive prim = idElement.getAsJsonPrimitive();
             if (prim.isString()) {
                 mcpRequest.setId(prim.getAsString());
+                if (log.isDebugEnabled()) {
+                    log.debug("Set string ID: " + prim.getAsString());
+                }
             } else if (prim.isNumber()) {
-                int val = prim.getAsInt();
+                long val = prim.getAsLong();
                 mcpRequest.setId(val);
+                if (log.isDebugEnabled()) {
+                    log.debug("Set integer ID: " + val);
+                }
+            }
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("ID element is missing in McpRequest");
             }
         }
 
-        // Let Gson handle the rest (name, etc.)
+        // Let Gson handle the rest
         mcpRequest.setMethod(context.deserialize(obj.get("method"), String.class));
         mcpRequest.setParams(context.deserialize(obj.get("params"), Params.class));
+
+        if (log.isDebugEnabled()) {
+            log.debug("Successfully deserialized McpRequest with method: " + mcpRequest.getMethod());
+        }
 
         return mcpRequest;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mcp/request/McpRequest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mcp/request/McpRequest.java
@@ -23,7 +23,7 @@ import com.google.gson.annotations.SerializedName;
 import org.wso2.carbon.apimgt.impl.APIConstants.MCP;
 
 /**
- * This class is used to represent the response for the MCP.
+ * This class is used to represent the MCP request.
  */
 public class McpRequest {
     @SerializedName("jsonrpc")

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mcp/request/McpRequestProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mcp/request/McpRequestProcessor.java
@@ -18,19 +18,33 @@
 
 package org.wso2.carbon.apimgt.gateway.mcp.request;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.wso2.carbon.apimgt.gateway.mcp.response.McpResponseDto;
 import org.wso2.carbon.apimgt.gateway.utils.MCPUtils;
 import org.wso2.carbon.apimgt.keymgt.model.entity.API;
 
 public class McpRequestProcessor {
+    private static final Log log = LogFactory.getLog(McpRequestProcessor.class);
 
     public static McpResponseDto processRequest(MessageContext messageContext, API matchedMcpApi,
                                                 McpRequest requestBody) {
 
-        // Todo: check subtype, implement MCP Server option
+        if (log.isDebugEnabled()) {
+            log.debug("Processing MCP request: " + requestBody.getMethod() + " for API: " +
+                    matchedMcpApi.getName() + "-" + matchedMcpApi.getVersion());
+        }
+
         String method = requestBody.getMethod();
-        return MCPUtils.processInternalRequest(messageContext, matchedMcpApi, requestBody, method);
+        McpResponseDto dto = MCPUtils.processInternalRequest(messageContext, matchedMcpApi, requestBody, method);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Successfully processed MCP request: " + requestBody.getMethod() + " for API: " +
+                    matchedMcpApi.getName() + "-" + matchedMcpApi.getVersion());
+        }
+
+        return dto;
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mcp/response/InitializeResult.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mcp/response/InitializeResult.java
@@ -34,60 +34,9 @@ public class InitializeResult {
     public ServerInfo serverInfo;
 
     public static class Capabilities {
-        @SerializedName("logging")
-        public Map<String, Object> logging;
-
-        @SerializedName("prompts")
-        public Prompts prompts;
-
-        @SerializedName("resources")
-        public Resources resources;
 
         @SerializedName("tools")
         public Tools tools;
-
-        @SerializedName("completions")
-        public Map<String, Object> completions;
-
-        @SerializedName("experimental")
-        public Map<String, Object> experimental;
-
-        public static class Prompts {
-            @SerializedName("listChanged")
-            public Boolean listChanged;
-
-            public Boolean getListChanged() {
-                return listChanged;
-            }
-
-            public void setListChanged(Boolean listChanged) {
-                this.listChanged = listChanged;
-            }
-        }
-
-        public static class Resources {
-            @SerializedName("subscribe")
-            public Boolean subscribe;
-
-            @SerializedName("listChanged")
-            public Boolean listChanged;
-
-            public Boolean getSubscribe() {
-                return subscribe;
-            }
-
-            public void setSubscribe(Boolean subscribe) {
-                this.subscribe = subscribe;
-            }
-
-            public Boolean getListChanged() {
-                return listChanged;
-            }
-
-            public void setListChanged(Boolean listChanged) {
-                this.listChanged = listChanged;
-            }
-        }
 
         public static class Tools {
             @SerializedName("listChanged")
@@ -102,52 +51,12 @@ public class InitializeResult {
             }
         }
 
-        public Map<String, Object> getLogging() {
-            return logging;
-        }
-
-        public void setLogging(Map<String, Object> logging) {
-            this.logging = logging;
-        }
-
-        public Prompts getPrompts() {
-            return prompts;
-        }
-
-        public void setPrompts(Prompts prompts) {
-            this.prompts = prompts;
-        }
-
-        public Resources getResources() {
-            return resources;
-        }
-
-        public void setResources(Resources resources) {
-            this.resources = resources;
-        }
-
         public Tools getTools() {
             return tools;
         }
 
         public void setTools(Tools tools) {
             this.tools = tools;
-        }
-
-        public Map<String, Object> getCompletions() {
-            return completions;
-        }
-
-        public void setCompletions(Map<String, Object> completions) {
-            this.completions = completions;
-        }
-
-        public Map<String, Object> getExperimental() {
-            return experimental;
-        }
-
-        public void setExperimental(Map<String, Object> experimental) {
-            this.experimental = experimental;
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mcp/response/ToolListResult.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mcp/response/ToolListResult.java
@@ -27,23 +27,12 @@ public class ToolListResult {
     @SerializedName("tools")
     public List<ToolInfo> tools;
 
-    @SerializedName("nextCursor")
-    public String nextCursor;
-
     public List<ToolInfo> getTools() {
         return tools;
     }
 
     public void setTools(List<ToolInfo> tools) {
         this.tools = tools;
-    }
-
-    public String getNextCursor() {
-        return nextCursor;
-    }
-
-    public void setNextCursor(String nextCursor) {
-        this.nextCursor = nextCursor;
     }
 
     public static class ToolInfo {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/McpMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/McpMediator.java
@@ -43,6 +43,7 @@ import org.wso2.carbon.apimgt.gateway.mcp.request.McpRequestProcessor;
 import org.wso2.carbon.apimgt.gateway.mcp.response.McpResponseDto;
 import org.wso2.carbon.apimgt.gateway.utils.GatewayUtils;
 import org.wso2.carbon.apimgt.gateway.utils.MCPPayloadGenerator;
+import org.wso2.carbon.apimgt.gateway.utils.MCPUtils;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dto.KeyManagerDto;
 import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
@@ -122,6 +123,7 @@ public class McpMediator extends AbstractMediator implements ManagedLifecycle {
                 handleMcpResponse(messageContext);
             } catch (McpException e) {
                 log.error("Error while handling MCP response", e);
+                MCPUtils.handleMCPFailure(messageContext, new McpResponseDto(e.getErrorMessage(), e.getErrorCode(), null));
                 return false;
             }
         }
@@ -136,7 +138,7 @@ public class McpMediator extends AbstractMediator implements ManagedLifecycle {
 
         McpResponseDto mcpResponse = McpRequestProcessor.processRequest(messageContext, matchedAPI, requestBody);
         if (APIConstants.MCP.METHOD_INITIALIZE.equals(mcpMethod) || APIConstants.MCP.METHOD_TOOL_LIST.equals(mcpMethod)
-            || APIConstants.MCP.METHOD_PING.equals(mcpMethod)) {
+            || APIConstants.MCP.METHOD_PING.equals(mcpMethod) || APIConstants.MCP.METHOD_PROMPTS_LIST.equals(mcpMethod)) {
             messageContext.setProperty(MCP_PROCESSED, "true");
             if (mcpResponse != null) {
                 try {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/MCPPayloadGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/MCPPayloadGenerator.java
@@ -79,19 +79,6 @@ public class MCPPayloadGenerator {
         InitializeResult.Capabilities.Tools tools = new InitializeResult.Capabilities.Tools();
         tools.setListChanged(toolListChangeNotified);
         capabilities.setTools(tools);
-        capabilities.setLogging(new HashMap<>());
-
-        InitializeResult.Capabilities.Resources resources = new InitializeResult.Capabilities.Resources();
-        resources.setSubscribe(false); // Resources are not supported at the moment
-        resources.setListChanged(false); // Resources are not supported at the moment
-        capabilities.setResources(resources);
-
-        InitializeResult.Capabilities.Prompts prompts = new InitializeResult.Capabilities.Prompts();
-        prompts.setListChanged(false); // Prompts are not supported at the moment
-        capabilities.setPrompts(prompts);
-
-        capabilities.setCompletions(new HashMap<>());
-        capabilities.setExperimental(new HashMap<>());
         return capabilities;
     }
 
@@ -136,7 +123,6 @@ public class MCPPayloadGenerator {
             toolInfoList.add(tool);
         }
         toolListResult.setTools(toolInfoList);
-        toolListResult.setNextCursor(""); // No pagination support in this implementation
         toolListResponse.setResult(toolListResult);
         return gson.toJson(toolListResponse);
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/MCPUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/MCPUtils.java
@@ -28,7 +28,10 @@ import org.apache.axis2.Constants;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpStatus;
+import org.apache.synapse.Mediator;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.commons.json.JsonUtil;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.wso2.carbon.apimgt.api.model.APIOperationMapping;
@@ -38,6 +41,7 @@ import org.wso2.carbon.apimgt.api.model.subscription.URLMapping;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.exception.McpException;
 import org.wso2.carbon.apimgt.gateway.exception.McpExceptionWithId;
+import org.wso2.carbon.apimgt.gateway.handlers.Utils;
 import org.wso2.carbon.apimgt.gateway.mcp.Param;
 import org.wso2.carbon.apimgt.gateway.mcp.SchemaMapping;
 import org.wso2.carbon.apimgt.gateway.mcp.request.McpRequest;
@@ -72,7 +76,7 @@ public class MCPUtils {
         }
         if (!APIConstants.MCP.ALLOWED_METHODS.contains(method)) {
             throw new McpException(APIConstants.MCP.RpcConstants.METHOD_NOT_FOUND_CODE,
-                    APIConstants.MCP.RpcConstants.METHOD_NOT_FOUND_MESSAGE, "Method not found");
+                    APIConstants.MCP.RpcConstants.METHOD_NOT_FOUND_MESSAGE, method + " Method not found");
         }
 
         Object id = request.getId();
@@ -243,7 +247,7 @@ public class MCPUtils {
                 processRequestBody(messageContext, schemaMapping, mcpRequest);
 
                 //set received id to msg context
-                messageContext.setProperty("RECEIVED_MCP_ID", id.toString());
+                messageContext.setProperty("RECEIVED_MCP_ID", id);
             }
         } else {
             throw new McpException(APIConstants.MCP.RpcConstants.INTERNAL_ERROR_CODE,
@@ -456,6 +460,23 @@ public class MCPUtils {
     private static void throwMissingMethodError() throws McpException {
         throw new McpException(APIConstants.MCP.RpcConstants.INVALID_REQUEST_CODE,
                 APIConstants.MCP.RpcConstants.INVALID_REQUEST_MESSAGE, "Missing method field");
+    }
+
+    /**
+     * This method handles failures
+     *
+     * @param messageContext    message context of the request
+     * @param responseDto      payload of the error
+     */
+    public static void handleMCPFailure(MessageContext messageContext, McpResponseDto responseDto) {
+        messageContext.setProperty("MCP_ID", null);
+        messageContext.setProperty(SynapseConstants.ERROR_MESSAGE, responseDto.getResponse());
+        messageContext.setProperty("MCP_ERROR_CODE", responseDto.getStatusCode());
+        Mediator sequence = messageContext.getSequence(APIConstants.MCP.MCP_FAILURE_HANDLER);
+        if (sequence != null && !sequence.mediate(messageContext)) {
+            return;
+        }
+        Utils.sendFault(messageContext, HttpStatus.SC_OK);
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/MCPUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/utils/MCPUtils.java
@@ -76,7 +76,7 @@ public class MCPUtils {
         }
         if (!APIConstants.MCP.ALLOWED_METHODS.contains(method)) {
             throw new McpException(APIConstants.MCP.RpcConstants.METHOD_NOT_FOUND_CODE,
-                    APIConstants.MCP.RpcConstants.METHOD_NOT_FOUND_MESSAGE, method + " Method not found");
+                    APIConstants.MCP.RpcConstants.METHOD_NOT_FOUND_MESSAGE, "Method " + method + " not found");
         }
 
         Object id = request.getId();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3682,7 +3682,7 @@ public final class APIConstants {
         public static final String HEADER_ACCEPT = "Accept";
         public static final String HEADER_MCP_SESSION_ID = "Mcp-Session-Id";
         public static final String ACCEPT_JSON_AND_SSE = "application/json, text/event-stream";
-        public static final String MCP_FAILURE_HANDLER = "_mcp_failure_handler";
+        public static final String MCP_FAILURE_HANDLER = "_mcp_failure_handler_";
 
         // JSON keys used in payloads
         public static final String CAPABILITIES_KEY = "capabilities";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3682,6 +3682,7 @@ public final class APIConstants {
         public static final String HEADER_ACCEPT = "Accept";
         public static final String HEADER_MCP_SESSION_ID = "Mcp-Session-Id";
         public static final String ACCEPT_JSON_AND_SSE = "application/json, text/event-stream";
+        public static final String MCP_FAILURE_HANDLER = "_mcp_failure_handler";
 
         // JSON keys used in payloads
         public static final String CAPABILITIES_KEY = "capabilities";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -61,6 +61,7 @@ import org.wso2.carbon.apimgt.api.model.APIDefinitionContentSearchResult;
 import org.wso2.carbon.apimgt.api.model.APIEndpointInfo;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIInfo;
+import org.wso2.carbon.apimgt.api.model.APIOperationMapping;
 import org.wso2.carbon.apimgt.api.model.APIProduct;
 import org.wso2.carbon.apimgt.api.model.APIProductIdentifier;
 import org.wso2.carbon.apimgt.api.model.APIProductResource;
@@ -7680,11 +7681,31 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             throw new APIMgtResourceNotFoundException("Couldn't retrieve existing API with ID: "
                     + apiId, ExceptionCodes.from(ExceptionCodes.API_NOT_FOUND, apiId));
         }
+        List<SubscribedApiDTO> subscribedApiDTOList = new ArrayList<>();
         SubscribedApiDTO subscribedApiInfo = new SubscribedApiDTO();
         subscribedApiInfo.setName(apiInfo.getName());
         subscribedApiInfo.setContext(apiInfo.getContext());
         subscribedApiInfo.setPublisher(apiInfo.getProvider());
         subscribedApiInfo.setVersion(apiInfo.getVersion());
+        subscribedApiDTOList.add(subscribedApiInfo);
+
+        if (StringUtils.equals(apiInfo.getApiType(), APIConstants.API_TYPE_MCP) &&
+                StringUtils.equals(apiInfo.getApiSubtype(), APIConstants.API_SUBTYPE_EXISTING_API) ) {
+            API mcpAPI = getAPIbyUUID(apiId, organization);
+            Set<URITemplate> uriTemplates = mcpAPI.getUriTemplates();
+            if (uriTemplates != null && !uriTemplates.isEmpty()) {
+                //fetch any uri template to get the underlying API details
+                URITemplate template = uriTemplates.iterator().next();
+                APIOperationMapping apiOperationMapping = template.getAPIOperationMapping();
+
+                SubscribedApiDTO backendApiInfo = new SubscribedApiDTO();
+                backendApiInfo.setName(apiOperationMapping.getApiName());
+                backendApiInfo.setContext(apiOperationMapping.getApiContext());
+                backendApiInfo.setVersion(apiOperationMapping.getApiVersion());
+                subscribedApiDTOList.add(backendApiInfo);
+            }
+        }
+
         JwtTokenInfoDTO jwtTokenInfoDTO = new JwtTokenInfoDTO();
         jwtTokenInfoDTO.setEndUserName(username);
         jwtTokenInfoDTO.setKeyType(APIConstants.API_KEY_TYPE_PRODUCTION);
@@ -7705,7 +7726,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 }
             }
         }
-        jwtTokenInfoDTO.setSubscribedApiDTOList(Arrays.asList(subscribedApiInfo));
+        jwtTokenInfoDTO.setSubscribedApiDTOList(subscribedApiDTOList);
         jwtTokenInfoDTO.setExpirationTime(60000l);
         jwtTokenInfoDTO.setAudience(Arrays.asList(apiId));
         ApiKeyGenerator apiKeyGenerator = new InternalAPIKeyGenerator();

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1846,6 +1846,7 @@
             <Sequence>fault.xml</Sequence>
             <Sequence>guardrail_fault.xml</Sequence>
             <Sequence>_graphql_failure_handler_.xml</Sequence>
+            <Sequence>_mcp_failure_handler_.xml</Sequence>
             <Sequence>main.xml</Sequence>
             <Sequence>outDispatchSeq.xml</Sequence>
             <Sequence>_production_key_error_.xml</Sequence>


### PR DESCRIPTION
This PR,

- removes unsupported capabilities from init response
- Fixes issue with MCP jsonrpc ID field being converted to a double string
- introduces a ` _mcp_failure_handler_` sequence : product-apim change https://github.com/wso2/product-apim/pull/13820
- fixes issue with invoking EXISTING_API subtype MCPs via internal-key Authentication : fixes https://github.com/wso2/api-manager/issues/4127
- fixes issues while calling MCP tools via an MCP client  : fixes https://github.com/wso2/api-manager/issues/4156