### PR TITLE
Introduce New Configuration to Govern Binding Federated User Claims in Backend JWT Generation when using Opaque Tokens

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -465,6 +465,7 @@ public final class APIConstants {
     public static final String JWT_DECODING = "JWTDecoding";
     public static final String ENABLE_USER_CLAIMS = "EnableUserClaims";
     public static final String BINDING_FEDERATED_USER_CLAIMS = "EnableBindingFederatedUserClaims";
+    public static final String BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE = "EnableBindingFederatedUserClaimsForOpaque";
     public static final String TOKEN_GENERATOR_IMPL = "JWTGeneratorImpl";
     public static final String ENABLE_JWT_GENERATION = "EnableJWTGeneration";
     public static final String Enable_JWKS_API = "EnableJWKSApi";
@@ -3051,7 +3052,6 @@ public final class APIConstants {
         public static final String AUTH_CODE = "authCode";
         public static final String CLAIM_DIALECT = "dialect";
         public static final String BINDING_FEDERATED_USER_CLAIMS = "bindFederatedUserClaims";
-        public static final String BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE = "bindFederatedUserClaims.opaqueToken.enable";
         public static final String DEFAULT_KEY_MANAGER_OPENID_CONNECT_DISCOVERY_ENDPOINT = "/oauth2/token/.well-known/openid-configuration";
         public static final String DEFAULT_JWKS_ENDPOINT = "/oauth2/jwks";
         public static final String PRODUCTION_TOKEN_ENDPOINT = "production_token_endpoint";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3051,6 +3051,7 @@ public final class APIConstants {
         public static final String AUTH_CODE = "authCode";
         public static final String CLAIM_DIALECT = "dialect";
         public static final String BINDING_FEDERATED_USER_CLAIMS = "bindFederatedUserClaims";
+        public static final String BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE = "bindFederatedUserClaims.opaqueToken.enable";
         public static final String DEFAULT_KEY_MANAGER_OPENID_CONNECT_DISCOVERY_ENDPOINT = "/oauth2/token/.well-known/openid-configuration";
         public static final String DEFAULT_JWKS_ENDPOINT = "/oauth2/jwks";
         public static final String PRODUCTION_TOKEN_ENDPOINT = "production_token_endpoint";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -2157,7 +2157,7 @@ public class APIManagerConfiguration {
                     }
                     OMElement claimRetrievalElement =
                             configurationElement.getFirstChildWithName(new QName(APIConstants.ENABLE_USER_CLAIMS_RETRIEVAL_FROM_KEY_MANAGER));
-                    if (claimRetrievalElement != null) {
+                    if (claimRetrievalElement != null || jwtUserClaimsElement != null) {
                         jwtConfigurationDto.setEnableUserClaimRetrievalFromUserStore(Boolean.parseBoolean(claimRetrievalElement.getText()));
                         OMElement isBindFederatedUserClaims =
                                 omElement.getFirstChildWithName(new QName(APIConstants.BINDING_FEDERATED_USER_CLAIMS));

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -2167,6 +2167,14 @@ public class APIManagerConfiguration {
                         } else {
                             jwtConfigurationDto.setBindFederatedUserClaims(true);
                         }
+                        OMElement isBindFederatedUserClaimsForOpaque =
+                                omElement.getFirstChildWithName(new QName(APIConstants.BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE));
+                        if (isBindFederatedUserClaimsForOpaque != null) {
+                            jwtConfigurationDto.setBindFederatedUserClaimsForOpaque(
+                                    Boolean.parseBoolean(isBindFederatedUserClaimsForOpaque.getText()));
+                        } else {
+                            jwtConfigurationDto.setBindFederatedUserClaimsForOpaque(false);
+                        }
                     }
                 }
                 OMElement enableBase64PaddingElement = gatewayJWTConfigurationElement.getFirstChildWithName(

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ExtendedJWTConfigurationDto.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ExtendedJWTConfigurationDto.java
@@ -8,6 +8,7 @@ public class ExtendedJWTConfigurationDto extends JWTConfigurationDto {
     private boolean tenantBasedSigningEnabled;
     private boolean enableUserClaimRetrievalFromUserStore;
     private boolean isBindFederatedUserClaims;
+    private boolean isBindFederatedUserClaimsForOpaque;
     private boolean isJWKSApiEnabled;
 
     public String getClaimRetrieverImplClass() {
@@ -66,5 +67,13 @@ public class ExtendedJWTConfigurationDto extends JWTConfigurationDto {
 
     public void setJWKSApiEnabled(boolean JWKSApiEnabled) {
         this.isJWKSApiEnabled = JWKSApiEnabled;
+    }
+
+    public boolean isBindFederatedUserClaimsForOpaque() {
+        return isBindFederatedUserClaimsForOpaque;
+    }
+
+    public void setBindFederatedUserClaimsForOpaque(boolean bindFederatedUserClaimsForOpaque) {
+        isBindFederatedUserClaimsForOpaque = bindFederatedUserClaimsForOpaque;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/JWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/JWTGenerator.java
@@ -55,6 +55,9 @@ public class JWTGenerator extends AbstractJWTGenerator {
 
     private static final Log log = LogFactory.getLog(JWTGenerator.class);
     private static final String OIDC_DIALECT_URI = "http://wso2.org/oidc/claim";
+    private static final boolean BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE =
+            Boolean.parseBoolean(System.getProperty(APIConstants.KeyManager.BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE,
+                    "false"));
 
     @Override
     public Map<String, String> populateStandardClaims(TokenValidationContext validationContext)
@@ -188,7 +191,8 @@ public class JWTGenerator extends AbstractJWTGenerator {
 
     private Map<String, String> getClaimsFromKeyManager(String username, String accessToken, int tenantId,
                                                         String dialectURI, String keyManager,
-                                                        boolean isBindFederatedUserClaims) throws APIManagementException {
+                                                        boolean isBindFederatedUserClaims)
+            throws APIManagementException {
 
         Map<String, Object> properties = new HashMap<>();
         if (accessToken != null) {
@@ -196,7 +200,9 @@ public class JWTGenerator extends AbstractJWTGenerator {
         }
         if (!StringUtils.isEmpty(dialectURI)) {
             properties.put(APIConstants.KeyManager.CLAIM_DIALECT, dialectURI);
-            properties.put(APIConstants.KeyManager.BINDING_FEDERATED_USER_CLAIMS, isBindFederatedUserClaims);
+            if (isBindFederatedUserClaims && BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE) {
+                properties.put(APIConstants.KeyManager.BINDING_FEDERATED_USER_CLAIMS, true);
+            }
             KeyManager keymanager = KeyManagerHolder
                     .getKeyManagerInstance(APIUtil.getTenantDomainFromTenantId(tenantId), keyManager);
             if (keymanager != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/JWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/JWTGenerator.java
@@ -189,6 +189,26 @@ public class JWTGenerator extends AbstractJWTGenerator {
         return new HashMap<>();
     }
 
+    /**
+     * Retrieves user claims from the Key Manager for a given user and tenant context.
+     *
+     * This method communicates with the configured Key Manager to obtain claims associated
+     * with the specified user.
+     *
+     * @param username                   The username of the user whose claims are to be retrieved.
+     * @param accessToken                The access token associated with the user (can be {@code null}).
+     * @param tenantId                   The tenant ID corresponding to the user.
+     * @param dialectURI                 The claim dialect URI used to format the claims.
+     * @param keyManager                 The name of the configured Key Manager.
+     * @param isBindFederatedUserClaims A flag indicating whether federated user claims should be bound.
+     *                                   This is used in combination with the system-level
+     *                                   {@code BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE} flag.
+     *
+     * @return A map of user claims if successfully retrieved from the Key Manager;
+     *         {@code null} if no claims are available or retrieval fails.
+     *
+     * @throws APIManagementException If an error occurs while retrieving claims from the Key Manager.
+     */
     private Map<String, String> getClaimsFromKeyManager(String username, String accessToken, int tenantId,
                                                         String dialectURI, String keyManager,
                                                         boolean isBindFederatedUserClaims)

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/JWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/JWTGenerator.java
@@ -55,9 +55,6 @@ public class JWTGenerator extends AbstractJWTGenerator {
 
     private static final Log log = LogFactory.getLog(JWTGenerator.class);
     private static final String OIDC_DIALECT_URI = "http://wso2.org/oidc/claim";
-    private static final boolean BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE =
-            Boolean.parseBoolean(System.getProperty(APIConstants.KeyManager.BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE,
-                    "false"));
 
     @Override
     public Map<String, String> populateStandardClaims(TokenValidationContext validationContext)
@@ -160,7 +157,7 @@ public class JWTGenerator extends AbstractJWTGenerator {
         APIManagerConfiguration apiManagerConfiguration =
                 ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration();
         ExtendedJWTConfigurationDto jwtConfigurationDto = apiManagerConfiguration.getJwtConfigurationDto();
-        boolean isBindFederatedUserClaims = jwtConfigurationDto.isBindFederatedUserClaims();
+        boolean isBindFederatedUserClaims = jwtConfigurationDto.isBindFederatedUserClaimsForOpaque();
         if (apiManagerConfiguration.isJWTClaimCacheEnabled()) {
             String cacheKey = username.concat("_").concat(String.valueOf(tenantId));
             Object claims = CacheProvider.getJWTClaimCache().get(cacheKey);
@@ -196,13 +193,11 @@ public class JWTGenerator extends AbstractJWTGenerator {
      * with the specified user.
      *
      * @param username                   The username of the user whose claims are to be retrieved.
-     * @param accessToken                The access token associated with the user (can be {@code null}).
+     * @param accessToken                The access token associated with the user.
      * @param tenantId                   The tenant ID corresponding to the user.
      * @param dialectURI                 The claim dialect URI used to format the claims.
      * @param keyManager                 The name of the configured Key Manager.
      * @param isBindFederatedUserClaims  A flag indicating whether federated user claims should be bound.
-     *                                   This is used in combination with the system-level
-     *                                   {@code BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE} flag.
      *
      * @return A map of user claims if successfully retrieved from the Key Manager;
      *         {@code null} if no claims are available or retrieval fails.
@@ -220,9 +215,7 @@ public class JWTGenerator extends AbstractJWTGenerator {
         }
         if (!StringUtils.isEmpty(dialectURI)) {
             properties.put(APIConstants.KeyManager.CLAIM_DIALECT, dialectURI);
-            if (isBindFederatedUserClaims && BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE) {
-                properties.put(APIConstants.KeyManager.BINDING_FEDERATED_USER_CLAIMS, true);
-            }
+            properties.put(APIConstants.KeyManager.BINDING_FEDERATED_USER_CLAIMS, isBindFederatedUserClaims);
             KeyManager keymanager = KeyManagerHolder
                     .getKeyManagerInstance(APIUtil.getTenantDomainFromTenantId(tenantId), keyManager);
             if (keymanager != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/JWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/JWTGenerator.java
@@ -200,7 +200,7 @@ public class JWTGenerator extends AbstractJWTGenerator {
      * @param tenantId                   The tenant ID corresponding to the user.
      * @param dialectURI                 The claim dialect URI used to format the claims.
      * @param keyManager                 The name of the configured Key Manager.
-     * @param isBindFederatedUserClaims A flag indicating whether federated user claims should be bound.
+     * @param isBindFederatedUserClaims  A flag indicating whether federated user claims should be bound.
      *                                   This is used in combination with the system-level
      *                                   {@code BINDING_FEDERATED_USER_CLAIMS_FOR_OPAQUE} flag.
      *

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -32,7 +32,6 @@
   "apim.jwt.encode_x5t_without_padding": false,
   "apim.jwt.enable_tenant_based_signing": false,
   "apim.jwt.gateway_generator.enable_claim_retrieval": false,
-  "apim.jwt.binding_federated_user_claims": false,
   "apim.hashing.hashing_algorithm": "SHA-256",
   "apim.cache.gateway_token.enable": true,
   "apim.cache.resource.enable": true,

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -50,6 +50,9 @@
         {% if apim.jwt.binding_federated_user_claims is defined %}
         <EnableBindingFederatedUserClaims>{{apim.jwt.binding_federated_user_claims}}</EnableBindingFederatedUserClaims>
         {% endif %}
+        {% if apim.jwt.binding_federated_user_claims_for_opaque is defined %}
+        <EnableBindingFederatedUserClaimsForOpaque>{{apim.jwt.binding_federated_user_claims_for_opaque}}</EnableBindingFederatedUserClaimsForOpaque>
+        {% endif %}
         {% if apim.jwt.enable_user_claims %}
         <ClaimsRetrieverImplClass>{{apim.jwt.claims_extractor_impl}}</ClaimsRetrieverImplClass>
         {% else %}

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -47,7 +47,7 @@
              jwt token, he needs to enable this parameter.
              The DefaultClaimsRetriever class adds user claims from the default carbon user store. -->
         <EnableUserClaims>{{apim.jwt.enable_user_claims}}</EnableUserClaims>
-        {% if apim.jwt.binding_federated_user_claims %}
+        {% if apim.jwt.binding_federated_user_claims is defined %}
         <EnableBindingFederatedUserClaims>{{apim.jwt.binding_federated_user_claims}}</EnableBindingFederatedUserClaims>
         {% endif %}
         {% if apim.jwt.enable_user_claims %}


### PR DESCRIPTION
### Purpose
- Introduce new configuration to govern binding federated user claims in backend JWT generation when using opaque tokens
- Related public issue: https://github.com/wso2/api-manager/issues/3911

### Approach
- Introduced a new configuration as below (`binding_federated_user_claims_for_opaque`) to govern the behaviour of binding federated claims in backend JWT generation when using opaque tokens. 
- The default value of this configuration will be false which means federated user claims will not be included in the generated backend JWT
```
[apim.jwt]
enable = true
enable_user_claims = true
binding_federated_user_claims_for_opaque = true
```