### PR TITLE
Fix GW ordering issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -3574,16 +3574,6 @@ public final class APIUtil {
                 }
             } else {
                 GatewayAgentConfiguration externalGatewayConfiguration = externalGatewayConnectorConfigurationMap.get(gatewayType);
-                // Case-insensitive fallback lookup for external gateway keys
-                if (externalGatewayConfiguration == null) {
-                    for (Map.Entry<String, GatewayAgentConfiguration> e
-                            : externalGatewayConnectorConfigurationMap.entrySet()) {
-                        if (e.getKey().equalsIgnoreCase(gatewayType)) {
-                            externalGatewayConfiguration = e.getValue();
-                            break;
-                        }
-                    }
-                }
                 
                 if (externalGatewayConfiguration != null) {
                     processExternalGatewayFeatureCatalogs(gatewayConfigsMap, apiData, externalGatewayConfiguration);


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/4023

With this PR, the Gateway types supported for each API Type will be processed in the order the gateway types appear in the deployment.toml config. The order the gw cards appear in the UI will also be the same.

