### PR TITLE
Fix Missing Certificate Error for HEAD Requests in Active-Active Deployment

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3579,6 +3579,9 @@ public final class APIConstants {
         public static final String TOKEN_VALIDATION_CONFIG = "TokenValidation";
         public static final String ENFORCE_JWT_TYPE_HEADER_VALIDATION = "EnforceTypeHeaderValidation";
     }
+
+    // Constants related to the Certificate Management
+    public static final String ENABLE_CERTIFICATE_MANAGEMENT_EVENT_LISTENING = "EnableCertificateManagementEventListening";
     
     // For Organization access control Configuration
     public static final String ORG_BASED_ACCESS_CONTROL = "OrganizationBasedAccessControl";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -4468,6 +4468,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     tenantDomain, alias, endpoint);
             certificateEvent.setTenantId(tenantId);
             APIUtil.sendNotification(certificateEvent, APIConstants.NotifierType.CERTIFICATE.name());
+            if (log.isDebugEnabled()) {
+                log.debug("Certificate event sent for alias: " + alias + " in tenant: " + tenantDomain);
+            }
         } catch (UserStoreException e) {
             handleException("Error while reading tenant information", e);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -4466,6 +4466,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             CertificateEvent certificateEvent = new CertificateEvent(UUID.randomUUID().toString(),
                     System.currentTimeMillis(), APIConstants.EventType.ENDPOINT_CERTIFICATE_ADD.toString(),
                     tenantDomain, alias, endpoint);
+            certificateEvent.setTenantId(tenantId);
             APIUtil.sendNotification(certificateEvent, APIConstants.NotifierType.CERTIFICATE.name());
         } catch (UserStoreException e) {
             handleException("Error while reading tenant information", e);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/certificatemgt/PeerNodeCertificateManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/certificatemgt/PeerNodeCertificateManager.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com/).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.certificatemgt;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.dto.CertificateMetadataDTO;
+import org.wso2.carbon.apimgt.impl.certificatemgt.exceptions.CertificateManagementException;
+import org.wso2.carbon.apimgt.impl.dao.CertificateMgtDAO;
+import org.wso2.carbon.apimgt.impl.utils.CertificateMgtUtils;
+
+/**
+ * This class is responsible for managing certificates for peer nodes in a specific context(Active-Active Deployment).
+ *
+ * NOTE: This class is designed for use only within this specific implementation. Do not reuse or adapt this class or
+ * its methods for any other contexts or implementations.
+ */
+public class PeerNodeCertificateManager {
+
+    private static final Log log = LogFactory.getLog(PeerNodeCertificateManager.class);
+    private static final PeerNodeCertificateManager instance = new PeerNodeCertificateManager();
+
+    private PeerNodeCertificateManager() {
+    }
+
+    public static PeerNodeCertificateManager getInstance() {
+        return instance;
+    }
+
+    /**
+     * Adds the certificate to the trust stores of peer nodes.
+     *
+     * This method is invoked when the ENDPOINT_CERTIFICATE_ADD event is received by a peer node. It ensures that the
+     * certificate is added to the trust stores of the peer nodes.
+     *
+     * NOTE: This method is designed for use only within this specific implementation. Do not reuse or adapt this method
+     * for any other contexts or implementations.
+     *
+     * @param alias    The alias of the certificate.
+     * @param endpoint The endpoint associated with the certificate.
+     * @param tenantId The tenant identifier.
+     */
+    public void addCertificateToPeerNode(String alias, String endpoint, int tenantId) {
+
+        try {
+            CertificateMetadataDTO certificateMetadataDTO = CertificateMgtDAO.getInstance().getCertificate(alias,
+                    endpoint, tenantId);
+            ResponseCode responseCode = CertificateMgtUtils.getInstance().addCertificateToTrustStore(certificateMetadataDTO.
+                    getCertificate(), certificateMetadataDTO.getAlias());
+            if (responseCode == ResponseCode.INTERNAL_SERVER_ERROR) {
+                log.error("Error adding the certificate to Publisher trust store.");
+            } else if (responseCode == ResponseCode.SUCCESS) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Certificate is successfully added to the Publisher client Trust Store with Alias '"
+                            + alias + "'");
+                }
+            }
+        } catch (CertificateManagementException e) {
+            log.error("Error when fetching certificate metadata for alias " + alias + " from database.", e);
+        }
+    }
+
+    /**
+     * Deletes the certificate from the trust stores of peer nodes.
+     *
+     * This method is invoked when the ENDPOINT_CERTIFICATE_REMOVE event is received by a peer node. It ensures that
+     * the certificate identified by the provided alias is removed from the trust stores of the peer nodes.
+     *
+     * NOTE: This method is designed for use only within this specific implementation. Do not reuse or adapt this method
+     * for any other contexts or implementations.
+     *
+     * @param alias The alias of the certificate to be removed.
+     */
+    public void deleteCertificateFromPeerNode(String alias) {
+
+        ResponseCode responseCode = CertificateMgtUtils.getInstance().removeCertificateFromTrustStore(alias);
+        if (responseCode == ResponseCode.INTERNAL_SERVER_ERROR) {
+            log.error("Error removing the Certificate from the trust store.");
+        } else if (responseCode == ResponseCode.SUCCESS) {
+            if (log.isDebugEnabled()) {
+                log.debug("Certificate is successfully removed from the Publisher Trust Store with Alias '"
+                        + alias + "'");
+            }
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/main/java/org/wso2/carbon/apimgt/jms/listener/utils/CertificateManagerJMSMessageListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/main/java/org/wso2/carbon/apimgt/jms/listener/utils/CertificateManagerJMSMessageListener.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com/).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.jms.listener.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.certificatemgt.PeerNodeCertificateManager;
+import org.wso2.carbon.apimgt.impl.notifier.events.CertificateEvent;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * This class listens for and processes JMS messages related to certificate management, performing actions based on the
+ * message content and type.
+ */
+public class CertificateManagerJMSMessageListener implements MessageListener {
+
+    private static final Log log = LogFactory.getLog(CertificateManagerJMSMessageListener.class);
+
+    /**
+     * Handles incoming JMS messages and processes them based on their content and type. This method is triggered
+     * whenever a message is received by the JMS Event Receiver.
+     *
+     * @param message The message received from the JMS topic.
+     */
+    @Override
+    public void onMessage(Message message) {
+
+        try {
+            if (message != null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Event received in JMS Event Receiver - " + message);
+                }
+                Topic jmsDestination = (Topic) message.getJMSDestination();
+                if (message instanceof TextMessage) {
+                    String textMessage = ((TextMessage) message).getText();
+                    JsonNode payloadData = new ObjectMapper().readTree(textMessage).path(APIConstants.EVENT_PAYLOAD).
+                            path(APIConstants.EVENT_PAYLOAD_DATA);
+
+                    if (APIConstants.TopicNames.TOPIC_NOTIFICATION.equalsIgnoreCase(jmsDestination.getTopicName())) {
+                        if (payloadData.get(APIConstants.EVENT_TYPE).asText() != null) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Event received from the topic of " + jmsDestination.getTopicName());
+                            }
+                            handleNotificationMessage(payloadData.get(APIConstants.EVENT_TYPE).asText(),
+                                    payloadData.get(APIConstants.EVENT_PAYLOAD).asText());
+                        }
+                    }
+                } else {
+                    log.warn("Event dropped due to unsupported message type " + message.getClass());
+                }
+            } else {
+                log.warn("Dropping the empty/null event received through jms receiver");
+            }
+        } catch (JMSException | JsonProcessingException e) {
+            log.error("JMSException occurred when processing the received message ", e);
+        }
+    }
+
+    /**
+     * Handles a notification message by decoding the event payload and performing appropriate actions based on the
+     * event type.
+     *
+     * @param eventType    The type of the event.
+     * @param encodedEvent The Base64-encoded event payload containing event details.
+     */
+    private void handleNotificationMessage(String eventType, String encodedEvent) {
+
+        byte[] eventDecoded = Base64.decodeBase64(encodedEvent);
+        String eventJson = new String(eventDecoded, StandardCharsets.UTF_8);
+
+        if (APIConstants.EventType.ENDPOINT_CERTIFICATE_ADD.toString().equals(eventType)) {
+            CertificateEvent certificateEvent = new Gson().fromJson(eventJson, CertificateEvent.class);
+            PeerNodeCertificateManager.getInstance().addCertificateToPeerNode(certificateEvent.getAlias(),
+                    certificateEvent.getEndpoint(), certificateEvent.getTenantId());
+        } else if (APIConstants.EventType.ENDPOINT_CERTIFICATE_REMOVE.toString().equals(eventType)) {
+            CertificateEvent certificateEvent = new Gson().fromJson(eventJson, CertificateEvent.class);
+            PeerNodeCertificateManager.getInstance().deleteCertificateFromPeerNode(certificateEvent.getAlias());
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/main/java/org/wso2/carbon/apimgt/jms/listener/utils/JMSListenerStartupShutdownListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/main/java/org/wso2/carbon/apimgt/jms/listener/utils/JMSListenerStartupShutdownListener.java
@@ -64,9 +64,17 @@ public class JMSListenerStartupShutdownListener implements ServerStartupObserver
     @Override
     public void completedServerStartup() {
 
+        APIManagerConfiguration apimConfiguration = ServiceReferenceHolder.getInstance().getAPIMConfiguration();
+        if (apimConfiguration != null) {
+            if (Boolean.parseBoolean(apimConfiguration.getFirstProperty(APIConstants.
+                    ENABLE_CERTIFICATE_MANAGEMENT_EVENT_LISTENING))) {
+                jmsTransportHandlerForEventHub.subscribeForJmsEvents(APIConstants.TopicNames.TOPIC_NOTIFICATION,
+                        new CertificateManagerJMSMessageListener());
+            }
+        }
+
         String migrationEnabled = System.getProperty(APIConstants.MIGRATE);
         if (migrationEnabled == null) {
-            APIManagerConfiguration apimConfiguration = ServiceReferenceHolder.getInstance().getAPIMConfiguration();
             if (apimConfiguration != null) {
                 String enableKeyManagerRetrieval =
                         apimConfiguration.getFirstProperty(APIConstants.ENABLE_KEY_MANAGER_RETRIVAL);

--- a/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/main/java/org/wso2/carbon/apimgt/jms/listener/utils/JMSListenerStartupShutdownListener.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.jms.listener/src/main/java/org/wso2/carbon/apimgt/jms/listener/utils/JMSListenerStartupShutdownListener.java
@@ -68,6 +68,7 @@ public class JMSListenerStartupShutdownListener implements ServerStartupObserver
         if (apimConfiguration != null) {
             if (Boolean.parseBoolean(apimConfiguration.getFirstProperty(APIConstants.
                     ENABLE_CERTIFICATE_MANAGEMENT_EVENT_LISTENING))) {
+                log.info("Certificate management event listening is enabled. Subscribing to notification topic.");
                 jmsTransportHandlerForEventHub.subscribeForJmsEvents(APIConstants.TopicNames.TOPIC_NOTIFICATION,
                         new CertificateManagerJMSMessageListener());
             }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -247,5 +247,6 @@
   "apim.gateway_notification.registration.retry_duration": "10000",
   "apim.gateway_notification.registration.retry_progression_factor": "2.0",
   "apim.gateway_notification.cleanup.expiry_time": "120",
-  "apim.gateway_notification.cleanup.data_retention_period": "2629800"
+  "apim.gateway_notification.cleanup.data_retention_period": "2629800",
+  "apim.certificate_manager.events_enabled": true
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1982,4 +1982,6 @@
               <DataRetentionPeriodSeconds>{{apim.gateway_notification.cleanup.data_retention_period}}</DataRetentionPeriodSeconds>
           </GatewayCleanup>
       </GatewayNotificationConfiguration>
+
+      <EnableCertificateManagementEventListening>{{apim.certificate_manager.events_enabled}}</EnableCertificateManagementEventListening>
 </APIManager>


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/3388

This PR resolves the "missing certificate" error encountered when sending HEAD requests to verify HTTPS endpoints in an Active-Active Deployment configuration.

Solution:
A CP-to-CP event mechanism has been introduced to address this issue and add the missing certificates to the peer nodes upon receiving the events.