### PR TITLE
Add changes to resolve gw server URL from vhosts

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
@@ -112,6 +112,7 @@ public class InMemoryAPIDeployer {
                 DataHolder.getInstance().addKeyManagerToAPIMapping(apiId, gatewayAPIDTO.getKeyManagers());
                 DataHolder.getInstance().addAPIMetaData(gatewayEvent);
                 DataHolder.getInstance().markAPIAsDeployed(gatewayAPIDTO);
+                DataHolder.getInstance().populateVhosts(gatewayAPIDTO);
                 syncAPIPropertiesAcrossComponents(gatewayAPIDTO);
                 if (log.isDebugEnabled()) {
                     log.debug("API with " + apiId + " is deployed in gateway with the labels " + String.join(",",
@@ -149,6 +150,7 @@ public class InMemoryAPIDeployer {
                 addDeployedGraphqlQLToAPI(gatewayAPIDTO);
                 DataHolder.getInstance().addKeyManagerToAPIMapping(apiId, gatewayAPIDTO.getKeyManagers());
                 DataHolder.getInstance().markAPIAsDeployed(gatewayAPIDTO);
+                DataHolder.getInstance().populateVhosts(gatewayAPIDTO);
                 syncAPIPropertiesAcrossComponents(gatewayAPIDTO);
                 if (log.isDebugEnabled()) {
                     log.debug("API with " + apiId + " is deployed in gateway with the labels " + String.join(",",
@@ -353,6 +355,7 @@ public class InMemoryAPIDeployer {
         DataHolder.getInstance().addKeyManagerToAPIMapping(gatewayAPIDTO.getApiId(),
                 gatewayAPIDTO.getKeyManagers());
         DataHolder.getInstance().markAPIAsDeployed(gatewayAPIDTO);
+        DataHolder.getInstance().populateVhosts(gatewayAPIDTO);
     }
 
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/DataHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/DataHolder.java
@@ -255,6 +255,19 @@ public class DataHolder {
         }
     }
 
+    public void populateVhosts(GatewayAPIDTO gatewayAPIDTO) {
+        Map<String, API> apiMap = tenantAPIMap.get(gatewayAPIDTO.getTenantDomain());
+        if (apiMap != null) {
+            API api = apiMap.get(gatewayAPIDTO.getApiContext());
+            if (api != null) {
+                api.setVhosts(gatewayAPIDTO.getVhosts());
+                if (log.isDebugEnabled()) {
+                    log.debug("Populated vhosts info for API : " + api.getApiName());
+                }
+            }
+        }
+    }
+
     public Map<String, Map<String, API>> getTenantAPIMap() {
         return tenantAPIMap;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/McpMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/McpMediator.java
@@ -33,6 +33,7 @@ import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractMediator;
 import org.apache.synapse.rest.RESTConstants;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.wso2.carbon.apimgt.api.model.VHost;
 import org.wso2.carbon.apimgt.api.model.subscription.URLMapping;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.dto.OAuthProtectedResourceDTO;
@@ -174,14 +175,9 @@ public class McpMediator extends AbstractMediator implements ManagedLifecycle {
             log.error("Multiple Key Managers found for MCP Server: " + matchedAPI.getUuid() + ".");
             skipAuthServersAttribute = true;
         }
-        // We need to adjust this to support vhost instead of constructing the URL here
         String contextPath = (String) messageContext.getProperty(RESTConstants.REST_API_CONTEXT);
-        String hostAddress = APIUtil.getHostAddress();
-        String serverURL = APIConstants.HTTPS_PROTOCOL + APIConstants.URL_SCHEME_SEPARATOR + hostAddress;
-        if ("localhost".equals(hostAddress)) {
-            serverURL += ":";
-            serverURL += (8243  + APIUtil.getPortOffset());
-        }
+        String serverURL = MCPUtils.getGatewayServerURL(null, contextPath);
+
         String resourceURL = serverURL + contextPath + APIMgtGatewayConstants.MCP_RESOURCE;
         oAuthProtectedResourceDTO.setResource(resourceURL);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/entity/API.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/model/entity/API.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.apimgt.keymgt.model.entity;
 
 import org.wso2.carbon.apimgt.api.model.OperationPolicy;
+import org.wso2.carbon.apimgt.api.model.VHost;
 import org.wso2.carbon.apimgt.api.model.subscription.CacheableEntity;
 import org.wso2.carbon.apimgt.api.model.subscription.URLMapping;
 
@@ -51,6 +52,7 @@ public class API implements CacheableEntity<String> {
     private boolean isSubscriptionValidationDisabled = false;
     private Boolean isEgress = null;
     private String subtype = null;
+    private List<VHost> vhosts = new ArrayList<>();
 
     public API() {
     }
@@ -374,5 +376,13 @@ public class API implements CacheableEntity<String> {
 
     public void setApiProperties(Map<String, String> apiProperties) {
         this.apiProperties = apiProperties;
+    }
+
+    public List<VHost> getVhosts() {
+        return vhosts;
+    }
+
+    public void setVhosts(List<VHost> vhosts) {
+        this.vhosts = vhosts;
     }
 }


### PR DESCRIPTION
$subject

When deploying an API to GW,
 - Dataholder API instance is updated with vhost info
 - In MCPMediator and APIAuthentication handler, resolves the gw URL using the vhosts of the gw and the host header value passed in with the request.
   - if a host header is available, we first check whether that host is available in the gw vhost list.
   - if above fails to populate a gwURL, the first vhost in the vhost list is picked.