### PR TITLE
Implement asynchronous processing of Synapse artifacts with custom thread pool

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
@@ -242,6 +242,10 @@ public class InMemoryAPIDeployer {
                     PrivilegedCarbonContext.startTenantFlow();
                     PrivilegedCarbonContext.getThreadLocalCarbonContext()
                             .setTenantDomain(tenantDomain, true);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Retrieving all artifacts for the gateway with the labels: " + labelString +
+                                " for tenant: " + tenantDomain);
+                    }
                     List<String> gatewayRuntimeArtifacts = ServiceReferenceHolder.getInstance().getArtifactRetriever()
                             .retrieveAllArtifacts(encodedString, tenantDomain);
                     if (gatewayRuntimeArtifacts.isEmpty()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3215,7 +3215,7 @@ public final class APIConstants {
         public static final String GATEWAY_INSTRUCTION_REMOVE = "Remove";
         public static final String GATEWAY_INSTRUCTION_ANY = "ANY";
         public static final String SYNAPSE_ATTRIBUTES = "/synapse-attributes";
-        public static final String GATEAY_SYNAPSE_ARTIFACTS = "/runtime-artifacts";
+        public static final String GATEWAY_SYNAPSE_ARTIFACTS = "/runtime-artifacts";
         public static final String GATEWAY_POLICY_SYNAPSE_ARTIFACTS = "/gateway-policy-artifacts";
         public static final String DATA_SOURCE_NAME = "DataSourceName";
         public static final String DATA_RETRIEVAL_MODE = "DataRetrievalMode";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/DBRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/DBRetriever.java
@@ -79,7 +79,7 @@ public class DBRetriever implements ArtifactRetriever {
         try {
             String encodedGatewayLabel = URLEncoder.encode(gatewayLabel, APIConstants.DigestAuthConstants.CHARSET);
             encodedGatewayLabel = encodedGatewayLabel.replace("\\+", "%20");
-            String path = APIConstants.GatewayArtifactSynchronizer.GATEAY_SYNAPSE_ARTIFACTS + "?apiId=" + apiId +
+            String path = APIConstants.GatewayArtifactSynchronizer.GATEWAY_SYNAPSE_ARTIFACTS + "?apiId=" + apiId +
                     "&gatewayLabel=" + encodedGatewayLabel + "&type=Synapse";
             String endpoint = baseURL + path;
             try (CloseableHttpResponse httpResponse = invokeService(endpoint, tenantDomain)) {
@@ -125,7 +125,7 @@ public class DBRetriever implements ArtifactRetriever {
         List<String> gatewayRuntimeArtifactsArray = new ArrayList<>();
         try {
             String endcodedgatewayLabel = URLEncoder.encode(label, APIConstants.DigestAuthConstants.CHARSET);
-            String path = APIConstants.GatewayArtifactSynchronizer.GATEAY_SYNAPSE_ARTIFACTS
+            String path = APIConstants.GatewayArtifactSynchronizer.GATEWAY_SYNAPSE_ARTIFACTS
                     + "?gatewayLabel=" + endcodedgatewayLabel + "&type=Synapse";
             String endpoint = baseURL + path;
             try (CloseableHttpResponse httpResponse = invokeService(endpoint,tenantDomain)) {


### PR DESCRIPTION
## Description
Refactored `SynapseArtifactGenerator.generateGatewayArtifact()` to process API runtime artifacts asynchronously.

## Approach
Implemented parallel processing using a `custom thread pool` along with  `ConcurrentLinkedQueue` while preserving the original method signature and behavior:

## Performance Test Summary
Carried out 10 APIM clustered setup startups, first half without the improvement and the rest with the async implementation using a `custom thread pool` along with  `ConcurrentLinkedQueue`

<img width="1189" height="789" alt="image" src="https://github.com/user-attachments/assets/d10b6104-0b04-484e-ad2e-7508f2af4c93" />

**Summary:**

No significant improvement can be seen:

| Metric | Sync Implementation | Async Implementation | Improvement |
|--------|-------------------|---------------------|-------------|
| **Average Runtime** | 2m 51s (171.03s) | 2m 35s (155s) | **9% faster** |
| **Average Throughput** | 8.80 APIs/sec | 9.7 API/sec | **10% higher** |