### PR TITLE
Handle scheduling interval being 0

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.federated.gateway/src/main/java/org/wso2/carbon/federated/gateway/FederatedAPIDiscoveryRunner.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.federated.gateway/src/main/java/org/wso2/carbon/federated/gateway/FederatedAPIDiscoveryRunner.java
@@ -97,9 +97,9 @@ public class FederatedAPIDiscoveryRunner implements FederatedAPIDiscoveryService
                     federatedAPIDiscovery = (FederatedAPIDiscovery)
                             Class.forName(gatewayConfiguration.getDiscoveryImplementation())
                                     .getDeclaredConstructor().newInstance();
-                    federatedAPIDiscovery.init(environment, organization);
                     log.info("Initializing federated API discovery for environment: " + environment.getName()
-                                    + " and organization: " + organization);
+                            + " and organization: " + organization);
+                    federatedAPIDiscovery.init(environment, organization);
                     String taskKey = environment.getName() + DELEM_COLON + organization;
                     ScheduledFuture<?> scheduledFuture = scheduledDiscoveryTasks.get(taskKey);
                     // Cancel existing task if one exists


### PR DESCRIPTION
This PR handles the scenario where the scheduling interval for API discovery is configured 0 from Admin portal. If a user specifies this value as 0, the scheduling will be disabled.