### PR TITLE
Process gateway artifacts asynchronously with a custom thread pool

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
@@ -242,6 +242,10 @@ public class InMemoryAPIDeployer {
                     PrivilegedCarbonContext.startTenantFlow();
                     PrivilegedCarbonContext.getThreadLocalCarbonContext()
                             .setTenantDomain(tenantDomain, true);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Retrieving all artifacts for the gateway with the labels: " + labelString +
+                                " for tenant: " + tenantDomain);
+                    }
                     List<String> gatewayRuntimeArtifacts = ServiceReferenceHolder.getInstance().getArtifactRetriever()
                             .retrieveAllArtifacts(encodedString, tenantDomain);
                     if (gatewayRuntimeArtifacts.isEmpty()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/InMemoryAPIDeployer.java
@@ -248,7 +248,10 @@ public class InMemoryAPIDeployer {
                     }
                     List<String> gatewayRuntimeArtifacts = ServiceReferenceHolder.getInstance().getArtifactRetriever()
                             .retrieveAllArtifacts(encodedString, tenantDomain);
+                    log.info("Retrieved " + gatewayRuntimeArtifacts.size() + " artifacts for deployment");
                     if (gatewayRuntimeArtifacts.isEmpty()) {
+                        log.warn("No artifacts found for gateway labels: " + labelString +
+                                " in tenant: " + tenantDomain);
                         return true;
                     }
                     if (redeployChangedAPIs) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3215,7 +3215,7 @@ public final class APIConstants {
         public static final String GATEWAY_INSTRUCTION_REMOVE = "Remove";
         public static final String GATEWAY_INSTRUCTION_ANY = "ANY";
         public static final String SYNAPSE_ATTRIBUTES = "/synapse-attributes";
-        public static final String GATEAY_SYNAPSE_ARTIFACTS = "/runtime-artifacts";
+        public static final String GATEWAY_SYNAPSE_ARTIFACTS = "/runtime-artifacts";
         public static final String GATEWAY_POLICY_SYNAPSE_ARTIFACTS = "/gateway-policy-artifacts";
         public static final String DATA_SOURCE_NAME = "DataSourceName";
         public static final String DATA_RETRIEVAL_MODE = "DataRetrievalMode";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/DBRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/gatewayartifactsynchronizer/DBRetriever.java
@@ -79,7 +79,7 @@ public class DBRetriever implements ArtifactRetriever {
         try {
             String encodedGatewayLabel = URLEncoder.encode(gatewayLabel, APIConstants.DigestAuthConstants.CHARSET);
             encodedGatewayLabel = encodedGatewayLabel.replace("\\+", "%20");
-            String path = APIConstants.GatewayArtifactSynchronizer.GATEAY_SYNAPSE_ARTIFACTS + "?apiId=" + apiId +
+            String path = APIConstants.GatewayArtifactSynchronizer.GATEWAY_SYNAPSE_ARTIFACTS + "?apiId=" + apiId +
                     "&gatewayLabel=" + encodedGatewayLabel + "&type=Synapse";
             String endpoint = baseURL + path;
             try (CloseableHttpResponse httpResponse = invokeService(endpoint, tenantDomain)) {
@@ -125,7 +125,7 @@ public class DBRetriever implements ArtifactRetriever {
         List<String> gatewayRuntimeArtifactsArray = new ArrayList<>();
         try {
             String endcodedgatewayLabel = URLEncoder.encode(label, APIConstants.DigestAuthConstants.CHARSET);
-            String path = APIConstants.GatewayArtifactSynchronizer.GATEAY_SYNAPSE_ARTIFACTS
+            String path = APIConstants.GatewayArtifactSynchronizer.GATEWAY_SYNAPSE_ARTIFACTS
                     + "?gatewayLabel=" + endcodedgatewayLabel + "&type=Synapse";
             String endpoint = baseURL + path;
             try (CloseableHttpResponse httpResponse = invokeService(endpoint,tenantDomain)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapseArtifactGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/SynapseArtifactGenerator.java
@@ -23,7 +23,10 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.gateway.GatewayAPIDTO;
@@ -50,6 +53,7 @@ import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.APIProductDTO;
 import org.wso2.carbon.apimgt.rest.api.publisher.v1.dto.MCPServerDTO;
 import org.wso2.carbon.apimgt.spec.parser.definitions.GraphQLSchemaDefinition;
 import org.wso2.carbon.apimgt.spec.parser.definitions.OAS3Parser;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -57,6 +61,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 
@@ -73,99 +84,281 @@ public class SynapseArtifactGenerator implements GatewayArtifactGenerator {
     private static final Log log = LogFactory.getLog(SynapseArtifactGenerator.class);
     private static final String GATEWAY_EXT_SEQUENCE_PREFIX = "WSO2AMGW--Ext";
 
+    // Thread pool configuration
+    private static final int CORE_POOL_SIZE = 10;
+    private static final int MAX_POOL_SIZE = 50;
+    private static final long KEEP_ALIVE_TIME_MS = 60000L;
+    private static final int QUEUE_CAPACITY = 1000;
+
+    private ThreadPoolExecutor artifactThreadPoolExecutor;
+
+    /**
+     * OSGi component activation method
+     */
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+        log.info("Initializing SynapseArtifactGenerator thread pool executor");
+
+        this.artifactThreadPoolExecutor = new ThreadPoolExecutor(
+                CORE_POOL_SIZE,
+                MAX_POOL_SIZE,
+                KEEP_ALIVE_TIME_MS,
+                TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<>(QUEUE_CAPACITY),
+                new ThreadFactory() {
+                    private final AtomicInteger count = new AtomicInteger(1);
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread t = new Thread(r, "SynapseArtifact-" + count.getAndIncrement());
+                        t.setDaemon(false);
+                        return t;
+                    }
+                },
+                new ThreadPoolExecutor.CallerRunsPolicy() { // Handle rejection gracefully
+                    @Override
+                    public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+                        log.warn("Thread pool queue full, executing task in caller thread");
+                        super.rejectedExecution(r, executor);
+                    }
+                }
+        );
+
+        log.info("SynapseArtifactGenerator thread pool initialized: core=" + CORE_POOL_SIZE +
+                ", max=" + MAX_POOL_SIZE + ", queue=" + QUEUE_CAPACITY);
+    }
+
+    /**
+     * OSGi component deactivation method
+     */
+    @Deactivate
+    protected void deactivate(ComponentContext componentContext) {
+        log.info("Deactivating SynapseArtifactGenerator component");
+
+        if (artifactThreadPoolExecutor != null) {
+            log.info("Shutting down SynapseArtifactGenerator thread pool...");
+
+            // Shutdown the executor service
+            artifactThreadPoolExecutor.shutdown();
+
+            try {
+                // Wait for existing tasks to complete within a timeout
+                if (!artifactThreadPoolExecutor.awaitTermination(60, TimeUnit.SECONDS)) {
+                    log.warn("Thread pool did not terminate gracefully within the timeout, forcing shutdown");
+                    artifactThreadPoolExecutor.shutdownNow();
+
+                    // Wait for tasks to respond to being cancelled
+                    if (!artifactThreadPoolExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
+                        log.error("Thread pool did not terminate after forced shutdown");
+                    }
+                }
+                log.info("SynapseArtifactGenerator thread pool shutdown completed");
+            } catch (InterruptedException ie) {
+                log.error("Thread pool shutdown was interrupted", ie);
+                artifactThreadPoolExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static class ProcessingResult {
+        String apiId;
+        String name;
+        String content;
+        boolean success = false;
+        String errorMessage;
+        Exception exception;
+    }
+
     @Override
     public RuntimeArtifactDto generateGatewayArtifact(List<APIRuntimeArtifactDto> apiRuntimeArtifactDtoList)
             throws APIManagementException {
 
         RuntimeArtifactDto runtimeArtifactDto = new RuntimeArtifactDto();
         List<String> synapseArtifacts = new ArrayList<>();
-        for (APIRuntimeArtifactDto runTimeArtifact : apiRuntimeArtifactDtoList) {
-            if (runTimeArtifact.isFile()) {
-                String tenantDomain = runTimeArtifact.getTenantDomain();
-                String label = runTimeArtifact.getLabel();
-                Environment environment = APIUtil.getEnvironments(tenantDomain).get(label);
-                GatewayAPIDTO gatewayAPIDTO = null;
-                if (environment != null) {
-                    try (InputStream artifact = (InputStream) runTimeArtifact.getArtifact()) {
-                        File baseDirectory = CommonUtil.createTempDirectory(null);
-                        try {
-                            String extractedFolderPath =
-                                    ImportUtils.getArchivePathOfExtractedDirectory(baseDirectory.getAbsolutePath(),
-                                            artifact);
-                            if (APIConstants.API_PRODUCT.equals(runTimeArtifact.getType())) {
-                                APIProductDTO apiProductDTO = ImportUtils.retrieveAPIProductDto(extractedFolderPath);
-                                apiProductDTO.setId(runTimeArtifact.getApiId());
-                                APIProduct apiProduct = APIMappingUtil.fromDTOtoAPIProduct(apiProductDTO,
-                                        apiProductDTO.getProvider());
-                                String openApiDefinition = ImportUtils.loadSwaggerFile(extractedFolderPath);
-                                apiProduct.setDefinition(openApiDefinition);
-                                gatewayAPIDTO = TemplateBuilderUtil.retrieveGatewayAPIDto(apiProduct, environment,
-                                        tenantDomain, extractedFolderPath, openApiDefinition);
-                            } else if (APIConstants.API_TYPE_MCP.equals(runTimeArtifact.getType())) {
-                                MCPServerDTO mcpServerDTO = ImportUtils.retrievedMCPDto(extractedFolderPath);
-                                API api = APIMappingUtil.fromMCPServerDTOtoAPI(mcpServerDTO,
-                                        mcpServerDTO.getProvider());
-                                String openApiDefinition = ImportUtils.loadSwaggerFile(extractedFolderPath);
-                                api.setSwaggerDefinition(openApiDefinition);
-                                APIDTO apidto = APIMappingUtil.fromAPItoDTO(api);
-                                gatewayAPIDTO = TemplateBuilderUtil.retrieveGatewayAPIDto(api, environment,
-                                        tenantDomain, apidto, extractedFolderPath, openApiDefinition);
-                            } else {
-                                APIDTO apidto = ImportUtils.retrievedAPIDto(extractedFolderPath);
-                                API api = APIMappingUtil.fromDTOtoAPI(apidto, apidto.getProvider());
-                                api.setUUID(apidto.getId());
-                                if (APIConstants.APITransportType.GRAPHQL.toString().equals(api.getType())) {
-                                    APIDefinition parser = new OAS3Parser();
-                                    SwaggerData swaggerData = new SwaggerData(api);
-                                    String apiDefinition = parser.generateAPIDefinition(swaggerData);
-                                    api.setSwaggerDefinition(apiDefinition);
-                                    GraphqlComplexityInfo graphqlComplexityInfo = APIUtil.getComplexityDetails(api);
-                                    String graphqlSchema = ImportUtils.loadGraphqlSDLFile(extractedFolderPath);
-                                    api.setGraphQLSchema(graphqlSchema);
-                                    GraphQLSchemaDefinition graphQLSchemaDefinition = new GraphQLSchemaDefinition();
-                                    graphqlSchema = graphQLSchemaDefinition.buildSchemaWithAdditionalInfo(api,
-                                            graphqlComplexityInfo);
-                                    api.setGraphQLSchema(graphqlSchema);
-                                    gatewayAPIDTO = TemplateBuilderUtil.retrieveGatewayAPIDto(api, environment,
-                                            tenantDomain, apidto, extractedFolderPath);
-                                } else if (api.getType() != null
-                                        && (APIConstants.APITransportType.HTTP.toString().equals(api.getType())
-                                        || APIConstants.API_TYPE_SOAP.equals(api.getType())
-                                        || APIConstants.API_TYPE_SOAPTOREST.equals(api.getType())
-                                        || APIConstants.APITransportType.WEBHOOK.toString().equals(api.getType())
-                                        || APIConstants.API_TYPE_MCP.equals(api.getType()))) {
-                                    String openApiDefinition = ImportUtils.loadSwaggerFile(extractedFolderPath);
-                                    api.setSwaggerDefinition(openApiDefinition);
-                                    gatewayAPIDTO = TemplateBuilderUtil.retrieveGatewayAPIDto(api, environment,
-                                            tenantDomain, apidto, extractedFolderPath, openApiDefinition);
-                                } else if (api.getType() != null &&
-                                        (APIConstants.APITransportType.WS.toString().equals(api.getType()) ||
-                                                APIConstants.APITransportType.SSE.toString().equals(api.getType()) ||
-                                                APIConstants.APITransportType.WEBSUB.toString()
-                                                        .equals(api.getType()))) {
-                                    String asyncApiDefinition =
-                                            ImportUtils.loadAsyncApiDefinitionFromFile(extractedFolderPath);
-                                    api.setAsyncApiDefinition(asyncApiDefinition);
-                                    gatewayAPIDTO = TemplateBuilderUtil.retrieveGatewayAPIDtoForStreamingAPI(api,
-                                            environment, tenantDomain, apidto, extractedFolderPath);
-                                }
-                            }
-                            if (gatewayAPIDTO != null) {
-                                gatewayAPIDTO.setRevision(runTimeArtifact.getRevision());
-                                String content = new Gson().toJson(gatewayAPIDTO);
-                                synapseArtifacts.add(content);
-                            }
-                        } finally {
-                            FileUtils.deleteQuietly(baseDirectory);
-                        }
-                    } catch (Exception e) {
-                        // only do error since we need to continue for other apis
+        List<String> failedApis = new ArrayList<>();
 
-                        log.error("Error while creating Synapse configurations", e);
+        // Capture the tenant context
+        String currentTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        String currentUsername = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+        int currentTenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+
+        List<CompletableFuture<ProcessingResult>> futures = apiRuntimeArtifactDtoList.stream()
+            .map(runTimeArtifact ->  CompletableFuture.supplyAsync(() -> {
+                // Set the Carbon context in the async thread
+                PrivilegedCarbonContext.startTenantFlow();
+                try {
+                    PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+                    carbonContext.setTenantDomain(currentTenantDomain);
+                    carbonContext.setUsername(currentUsername);
+                    carbonContext.setTenantId(currentTenantId);
+
+                    ProcessingResult result = new ProcessingResult();
+                    result.apiId = runTimeArtifact.getApiId();
+                    result.name = runTimeArtifact.getName();
+
+                    if (runTimeArtifact.isFile()) {
+                        String tenantDomain = runTimeArtifact.getTenantDomain();
+                        String label = runTimeArtifact.getLabel();
+                        Environment environment = null;
+                        // TODO prevent environment not found scenarios
+                        try {
+                            environment = APIUtil.getEnvironments(tenantDomain).get(label);
+                        } catch (APIManagementException e) {
+                            result.success = false;
+                            result.errorMessage = "Failed to get environment for tenant: " + tenantDomain +
+                                    ", error: " + e.getMessage();
+                            result.exception = e;
+                            log.error("Error getting environment for API: " + result.name +
+                                    " (" + result.apiId + ") in tenant: " + tenantDomain, e);
+                            return result;
+                        }
+                        GatewayAPIDTO gatewayAPIDTO = null;
+                        if (environment != null) {
+                            try (InputStream artifact = (InputStream) runTimeArtifact.getArtifact()) {
+                                File baseDirectory = CommonUtil.createTempDirectory(null);
+                                try {
+                                    String extractedFolderPath = ImportUtils.getArchivePathOfExtractedDirectory(
+                                            baseDirectory.getAbsolutePath(), artifact);
+                                    if (APIConstants.API_PRODUCT.equals(runTimeArtifact.getType())) {
+                                        APIProductDTO apiProductDTO = ImportUtils.retrieveAPIProductDto(
+                                                extractedFolderPath);
+                                        apiProductDTO.setId(runTimeArtifact.getApiId());
+                                        APIProduct apiProduct = APIMappingUtil.fromDTOtoAPIProduct(apiProductDTO,
+                                                apiProductDTO.getProvider());
+                                        String openApiDefinition = ImportUtils.loadSwaggerFile(extractedFolderPath);
+                                        apiProduct.setDefinition(openApiDefinition);
+                                        gatewayAPIDTO = TemplateBuilderUtil.retrieveGatewayAPIDto(apiProduct,
+                                                environment, tenantDomain, extractedFolderPath, openApiDefinition);
+                                    } else if (APIConstants.API_TYPE_MCP.equals(runTimeArtifact.getType())) {
+                                        MCPServerDTO mcpServerDTO = ImportUtils.retrievedMCPDto(
+                                                extractedFolderPath);
+                                        API api = APIMappingUtil.fromMCPServerDTOtoAPI(mcpServerDTO,
+                                                mcpServerDTO.getProvider());
+                                        String openApiDefinition = ImportUtils.loadSwaggerFile(extractedFolderPath);
+                                        api.setSwaggerDefinition(openApiDefinition);
+                                        APIDTO apidto = APIMappingUtil.fromAPItoDTO(api);
+                                        gatewayAPIDTO = TemplateBuilderUtil.retrieveGatewayAPIDto(api, environment,
+                                                tenantDomain, apidto, extractedFolderPath, openApiDefinition);
+                                    } else {
+                                        APIDTO apidto = ImportUtils.retrievedAPIDto(extractedFolderPath);
+                                        API api = APIMappingUtil.fromDTOtoAPI(apidto, apidto.getProvider());
+                                        api.setUUID(apidto.getId());
+                                        if (APIConstants.APITransportType.GRAPHQL.toString()
+                                                .equals(api.getType())) {
+                                            APIDefinition parser = new OAS3Parser();
+                                            SwaggerData swaggerData = new SwaggerData(api);
+                                            String apiDefinition = parser.generateAPIDefinition(swaggerData);
+                                            api.setSwaggerDefinition(apiDefinition);
+                                            GraphqlComplexityInfo graphqlComplexityInfo = APIUtil
+                                                    .getComplexityDetails(api);
+                                            String graphqlSchema = ImportUtils.loadGraphqlSDLFile(
+                                                    extractedFolderPath);
+                                            api.setGraphQLSchema(graphqlSchema);
+                                            GraphQLSchemaDefinition graphQLSchemaDefinition = new
+                                                    GraphQLSchemaDefinition();
+                                            graphqlSchema = graphQLSchemaDefinition.buildSchemaWithAdditionalInfo(
+                                                    api, graphqlComplexityInfo);
+                                            api.setGraphQLSchema(graphqlSchema);
+                                            gatewayAPIDTO = TemplateBuilderUtil.retrieveGatewayAPIDto(api,
+                                                    environment, tenantDomain, apidto, extractedFolderPath);
+                                        } else if (api.getType() != null && (APIConstants.APITransportType.HTTP
+                                                .toString().equals(api.getType()) || APIConstants.API_TYPE_SOAP
+                                                .equals(api.getType()) || APIConstants.API_TYPE_SOAPTOREST
+                                                .equals(api.getType()) || APIConstants.APITransportType.WEBHOOK
+                                                .toString().equals(api.getType()) || APIConstants.API_TYPE_MCP
+                                                .equals(api.getType()))) {
+                                            String openApiDefinition = ImportUtils.loadSwaggerFile(
+                                                    extractedFolderPath);
+                                            api.setSwaggerDefinition(openApiDefinition);
+                                            gatewayAPIDTO = TemplateBuilderUtil.retrieveGatewayAPIDto(api,
+                                                    environment, tenantDomain, apidto, extractedFolderPath,
+                                                    openApiDefinition);
+                                        } else if (api.getType() != null
+                                                && (APIConstants.APITransportType.WS.toString().equals(
+                                                        api.getType())
+                                                || APIConstants.APITransportType.SSE.toString().equals(
+                                                        api.getType())
+                                                || APIConstants.APITransportType.WEBSUB.toString().equals(
+                                                        api.getType()))) {
+                                            String asyncApiDefinition = ImportUtils.loadAsyncApiDefinitionFromFile(
+                                                    extractedFolderPath);
+                                            api.setAsyncApiDefinition(asyncApiDefinition);
+                                            gatewayAPIDTO = TemplateBuilderUtil
+                                                    .retrieveGatewayAPIDtoForStreamingAPI(api, environment,
+                                                            tenantDomain, apidto, extractedFolderPath);
+                                        }
+                                    }
+                                    if (gatewayAPIDTO != null) {
+                                        gatewayAPIDTO.setRevision(runTimeArtifact.getRevision());
+                                        result.content = new Gson().toJson(gatewayAPIDTO);
+                                        result.success = true;
+                                    } else {
+                                        result.success = false;
+                                        result.errorMessage = "GatewayAPIDTO is null";
+                                    }
+                                } finally {
+                                    FileUtils.deleteQuietly(baseDirectory);
+                                }
+                            } catch (Exception e) {
+                                // only do error since we need to continue for other apis
+                                result.success = false;
+                                result.errorMessage = "Error while creating Synapse configurations: " +
+                                        e.getMessage();
+                                result.exception = e;
+                                log.error("Error while creating Synapse configurations for API: " +
+                                        result.name + " (" + result.apiId + ")", e);
+                            }
+                        } else {
+                            result.success = false;
+                            result.errorMessage = "Environment not found for tenant: " + tenantDomain +
+                                    ", label: " + label;
+                        }
+                    } else {
+                        result.success = false;
+                        result.errorMessage = "Runtime artifact is not a file";
                     }
+                    return result;
+                } finally {
+                    PrivilegedCarbonContext.endTenantFlow();
+                }
+                }, artifactThreadPoolExecutor)).collect(Collectors.toList());
+
+        // Wait for all tasks to complete
+        CompletableFuture<Void> allFutures = CompletableFuture.allOf(
+                futures.toArray(new CompletableFuture[0]));
+
+        try {
+            // Collect results of all completed tasks
+            allFutures.get();
+            for (int i = 0; i < futures.size(); i++) {
+                try {
+                    ProcessingResult result = futures.get(i).get();
+                    if (result.success && result.content != null) {
+                        synapseArtifacts.add(result.content);
+                    } else {
+                        failedApis.add(result.name + " (" + result.apiId + "): " + result.errorMessage);
+                        log.warn("Failed to process API " + result.name +
+                                " (" + result.apiId + "): " + result.errorMessage);
+                    }
+                } catch (Exception ex) {
+                    APIRuntimeArtifactDto originalArtifact = apiRuntimeArtifactDtoList.get(i);
+                    failedApis.add(originalArtifact.getName() + " (" + originalArtifact.getApiId() + "): "
+                            + ex.getMessage());
+                    log.error("Error collecting result for API: " + originalArtifact.getName() +
+                            " (" + originalArtifact.getApiId() + ") ", ex);
                 }
             }
+
+        } catch (Exception e) {
+            log.error("Unexpected error while waiting for artifact generation", e);
+            throw new APIManagementException("Failed to process runtime artifacts", e);
         }
+
+        if (!failedApis.isEmpty()) {
+            log.warn("Error while creating Synapse configurations for APIs " +
+                    String.join(", ", failedApis));
+        }
+
         runtimeArtifactDto.setFile(false);
         runtimeArtifactDto.setArtifact(synapseArtifacts);
         return runtimeArtifactDto;


### PR DESCRIPTION
## Description

Refactored `SynapseArtifactGenerator.generateGatewayArtifact()` to process API runtime artifacts asynchronously, improving performance for bulk operations while maintaining thread-safety and proper error handling.

## Related Issue
Fix: https://github.com/wso2/api-manager/issues/4012

## Approach
Implemented parallel processing using `CompletableFuture` with a `custom thread pool` while preserving the original method signature and behavior.

## Performance Improvement Summary

Carried out 10 APIM clustered setup startups, first half without the improvement and the rest with the async improvement (with a `custom thread pool`).

- Total APIs deployed per run: 1,500

- **Time Reduction:** 37s (21.5% faster)
- **Throughput Increase:** 2.39 APIs/second (27.2% improvement)
-  **Standard deviation:** 3.75 s (Very consistent runtimes)
- **Most Consistent:** Async implementation shows less variance between runs

<img width="1190" height="789" alt="image" src="https://github.com/user-attachments/assets/c52db73b-7c21-4147-b71a-85c55b0a1a07" /> <br>
 
| Metric | Sync Implementation | Async Implementation | Improvement |
|--------|-------------------|---------------------|-------------|
| **Average Runtime** | 2m 51s (171.03s) | 2m 14s (134.33s) | **21.5% faster** |
| **Average Throughput** | 8.80 APIs/sec | 11.19 API/sec | **27.2% higher** |