### PR TITLE
Fix API not being updated with disabled key managers

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1161,7 +1161,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
 
         Map<String, KeyManagerDto> tenantKeyManagers = KeyManagerHolder.getGlobalAndTenantKeyManagers(tenantDomain);
         Set<String> disabledKeyManagers = KeyManagerHolder.getDisabledTenantKeyManagerNames(tenantDomain);
-        log.debug("Validating key managers for API: " + api.getId().getApiName());
+        if (log.isDebugEnabled()) {
+            log.debug("Validating key managers for API: " + api.getId().getApiName());
+        }
         List<String> configuredMissingKeyManagers = new ArrayList<>();
         for (String keyManager : api.getKeyManagers()) {
             if (!APIConstants.KeyManager.API_LEVEL_ALL_KEY_MANAGERS.equals(keyManager)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1160,7 +1160,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     private void validateKeyManagers(API api) throws APIManagementException {
 
         Map<String, KeyManagerDto> tenantKeyManagers = KeyManagerHolder.getGlobalAndTenantKeyManagers(tenantDomain);
-        HashSet<String> disabledKeyManagers = KeyManagerHolder.getDisabledKeyManagers();
+        Set<String> disabledKeyManagers = KeyManagerHolder.getDisabledTenantKeyManagerNames(tenantDomain);
+        log.debug("Validating key managers for API: " + api.getId().getApiName());
         List<String> configuredMissingKeyManagers = new ArrayList<>();
         for (String keyManager : api.getKeyManagers()) {
             if (!APIConstants.KeyManager.API_LEVEL_ALL_KEY_MANAGERS.equals(keyManager)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1160,7 +1160,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     private void validateKeyManagers(API api) throws APIManagementException {
 
         Map<String, KeyManagerDto> tenantKeyManagers = KeyManagerHolder.getGlobalAndTenantKeyManagers(tenantDomain);
-
+        HashSet<String> disabledKeyManagers = KeyManagerHolder.getDisabledKeyManagers();
         List<String> configuredMissingKeyManagers = new ArrayList<>();
         for (String keyManager : api.getKeyManagers()) {
             if (!APIConstants.KeyManager.API_LEVEL_ALL_KEY_MANAGERS.equals(keyManager)) {
@@ -1177,6 +1177,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 }
             }
         }
+        configuredMissingKeyManagers.removeAll(disabledKeyManagers);
         if (!configuredMissingKeyManagers.isEmpty()) {
             throw new APIManagementException(
                     "Key Manager(s) Not found :" + String.join(" , ", configuredMissingKeyManagers),

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/factory/KeyManagerHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/factory/KeyManagerHolder.java
@@ -357,11 +357,13 @@ public class KeyManagerHolder {
     }
 
     public static void removeDisabledKeyManager(String name, String organization) {
-        Set<String> disabledKeyManagerNames = getDisabledTenantKeyManagerNames(organization);
-        if (disabledKeyManagerNames.contains(name)) {
-            disabledKeyManagerNames = new HashSet<>(disabledKeyManagerNames);
-            disabledKeyManagerNames.remove(name);
-        }
-        disabledOrganizationWiseMap.put(organization, disabledKeyManagerNames);
+        disabledOrganizationWiseMap.compute(organization, (org, currentSet) -> {
+            if (currentSet == null || !currentSet.contains(name)) {
+                return currentSet;
+            }
+            Set<String> newSet = new HashSet<>(currentSet);
+            newSet.remove(name);
+            return newSet.isEmpty() ? null : newSet;
+        });
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/factory/KeyManagerHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/factory/KeyManagerHolder.java
@@ -351,18 +351,14 @@ public class KeyManagerHolder {
 
     public static void addDisabledKeyManager(String name, String organization) {
         Set<String> disabledKeyManagerNames = getDisabledTenantKeyManagerNames(organization);
-        if (disabledKeyManagerNames == null) {
-            disabledKeyManagerNames = new HashSet<>();
-        } else {
-            disabledKeyManagerNames = new HashSet<>(disabledKeyManagerNames);
-        }
+        disabledKeyManagerNames = new HashSet<>(disabledKeyManagerNames);
         disabledKeyManagerNames.add(name);
         disabledOrganizationWiseMap.put(organization, disabledKeyManagerNames);
     }
 
     public static void removeDisabledKeyManager(String name, String organization) {
         Set<String> disabledKeyManagerNames = getDisabledTenantKeyManagerNames(organization);
-        if (disabledKeyManagerNames != null && disabledKeyManagerNames.contains(name)) {
+        if (disabledKeyManagerNames.contains(name)) {
             disabledKeyManagerNames = new HashSet<>(disabledKeyManagerNames);
             disabledKeyManagerNames.remove(name);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/keymgt/KeyManagerConfigurationService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/keymgt/KeyManagerConfigurationService.java
@@ -32,4 +32,6 @@ public interface KeyManagerConfigurationService {
             throws APIManagementException;
 
     void removeKeyManagerConfiguration(String tenantDomain, String name) throws APIManagementException;
+    
+    void updateDisabledKeyManagers(String name) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/keymgt/KeyManagerConfigurationService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/keymgt/KeyManagerConfigurationService.java
@@ -33,5 +33,5 @@ public interface KeyManagerConfigurationService {
 
     void removeKeyManagerConfiguration(String tenantDomain, String name) throws APIManagementException;
     
-    void updateDisabledKeyManagers(String name) throws APIManagementException;
+    void updateDisabledKeyManagers(String name, String organization) throws APIManagementException;
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/keymgt/KeyManagerConfigurationServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/keymgt/KeyManagerConfigurationServiceImpl.java
@@ -35,6 +35,11 @@ public class KeyManagerConfigurationServiceImpl implements KeyManagerConfigurati
         }
 
     }
+    
+    @Override
+    public void updateDisabledKeyManagers(String name) throws APIManagementException {
+        KeyManagerHolder.addDisabledKeyManager(name);
+    }
 
     @Override
     public void updateKeyManagerConfiguration(String organization, String name, String type,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/keymgt/KeyManagerConfigurationServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/keymgt/KeyManagerConfigurationServiceImpl.java
@@ -37,8 +37,8 @@ public class KeyManagerConfigurationServiceImpl implements KeyManagerConfigurati
     }
     
     @Override
-    public void updateDisabledKeyManagers(String name) throws APIManagementException {
-        KeyManagerHolder.addDisabledKeyManager(name);
+    public void updateDisabledKeyManagers(String name, String organization) throws APIManagementException {
+        KeyManagerHolder.addDisabledKeyManager(name, organization);
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/loader/KeyManagerConfigurationDataRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/loader/KeyManagerConfigurationDataRetriever.java
@@ -81,6 +81,16 @@ public class KeyManagerConfigurationDataRetriever extends TimerTask {
                                                     keyManagerConfiguration.getName() +
                                                     " in tenant " + resolvedKeyManagerConfiguration.getTenantDomain(), e);
                                         }
+                                    } else {
+                                        try {
+                                            ServiceReferenceHolder.getInstance().getKeyManagerConfigurationService()
+                                                    .updateDisabledKeyManagers(keyManagerConfiguration.getName());
+                                        } catch (APIManagementException e) {
+                                            log.error(
+                                                    "Error while configuring disabled Key Managers " + 
+                                                            keyManagerConfiguration.getName() + " in tenant " + tenantDomain,
+                                                    e);
+                                        }
                                     }
                                 }
                                 retry = false;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/loader/KeyManagerConfigurationDataRetriever.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/loader/KeyManagerConfigurationDataRetriever.java
@@ -84,12 +84,13 @@ public class KeyManagerConfigurationDataRetriever extends TimerTask {
                                     } else {
                                         try {
                                             ServiceReferenceHolder.getInstance().getKeyManagerConfigurationService()
-                                                    .updateDisabledKeyManagers(keyManagerConfiguration.getName());
+                                                    .updateDisabledKeyManagers(
+                                                            keyManagerConfiguration.getName(),
+                                                            tenantDomain);
                                         } catch (APIManagementException e) {
-                                            log.error(
-                                                    "Error while configuring disabled Key Managers " + 
-                                                            keyManagerConfiguration.getName() + " in tenant " + tenantDomain,
-                                                    e);
+                                            log.error("Error while configuring disabled Key Manager " +
+                                                    keyManagerConfiguration.getName() +
+                                                    " in tenant " + tenantDomain, e);
                                         }
                                     }
                                 }


### PR DESCRIPTION
This pull request introduces enhancements to the management of disabled Key Managers within the API Manager implementation. Tracks disabled Key Managers and excludes from validation checks in API runtime configurations.

**Key Manager Disabled State Tracking and Handling:**

* Added a `disabledKeyManagers` `HashSet` to `KeyManagerHolder` to track disabled Key Managers globally, with methods to add, remove, and retrieve disabled Key Managers. 

* Modified the API validation logic in `APIProviderImpl` to exclude disabled Key Managers from the list of missing Key Managers, preventing errors when a Key Manager is intentionally disabled.

**Service Interface and Implementation Updates:**

* Extended the `KeyManagerConfigurationService` interface and its implementation to include a method for updating disabled Key Managers, allowing external components to mark Key Managers as disabled via the service layer
**Key Manager Configuration Data Loading:**

* Updated `KeyManagerConfigurationDataRetriever` to call the new service method for marking Key Managers as disabled during configuration loading, ensuring disabled Key Managers are registered correctly on startup or configuration changes.

