### PR TITLE
Use Internal Key to invoke APIs via MCP Servers

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -19,6 +19,11 @@
 
 package org.wso2.carbon.apimgt.gateway;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 public class APIMgtGatewayConstants {
 
     public static final String CONSUMER_KEY = "api.ut.consumerKey";
@@ -214,5 +219,22 @@ public class APIMgtGatewayConstants {
     public static final String MCP_RESOURCE= "/mcp";
     public static final String MCP_WELL_KNOWN_RESOURCE = "/.well-known/oauth-protected-resource";
     public static final String MCP_AUTH_CLAIM = "MCP_AUTHENTICATED";
+
+    /**
+     * JWT Claim related Constants
+     */
+    public static final Set<String> STANDARD_JWT_CLAIMS = Collections.unmodifiableSet(new HashSet<>(
+            Arrays.asList("sub", "iss", "aud", "exp", "iat", "jti", "azp", "nbf", "scope", "scp", "aut")));
+    public static final String SUBSCRIBER_CLAIM = "subscriber";
+    public static final String APPLICATION_ID_CLAIM = "applicationid";
+    public static final String APPLICATION_NAME_CLAIM = "applicationname";
+    public static final String APPLICATION_TIER_CLAIM = "applicationtier";
+    public static final String TIER_CLAIM = "tier";
+    public static final String APPLICATION_UUID_CLAIM = "applicationUUId";
+    public static final String KEY_TYPE_CLAIM = "keytype";
+    public static final String END_USER_CLAIM = "enduser";
+    public static final String END_USER_TENANT_ID_CLAIM = "enduserTenantId";
+    public static final String TOKEN_TYPE_CLAIM = "token_type";
+
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -213,5 +213,6 @@ public class APIMgtGatewayConstants {
     public static final String MCP_NO_AUTH_REQUEST = "MCP_NO_AUTH_REQUEST";
     public static final String MCP_RESOURCE= "/mcp";
     public static final String MCP_WELL_KNOWN_RESOURCE = "/.well-known/oauth-protected-resource";
+    public static final String MCP_AUTHENTICATED = "MCP_AUTHENTICATED";
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -213,6 +213,6 @@ public class APIMgtGatewayConstants {
     public static final String MCP_NO_AUTH_REQUEST = "MCP_NO_AUTH_REQUEST";
     public static final String MCP_RESOURCE= "/mcp";
     public static final String MCP_WELL_KNOWN_RESOURCE = "/.well-known/oauth-protected-resource";
-    public static final String MCP_AUTHENTICATED = "MCP_AUTHENTICATED";
+    public static final String MCP_AUTH_CLAIM = "MCP_AUTHENTICATED";
 }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/APIMgtGatewayConstants.java
@@ -219,7 +219,7 @@ public class APIMgtGatewayConstants {
     public static final String MCP_RESOURCE= "/mcp";
     public static final String MCP_WELL_KNOWN_RESOURCE = "/.well-known/oauth-protected-resource";
     public static final String MCP_AUTH_CLAIM = "MCP_AUTHENTICATED";
-
+    public static final Long MCP_AUTH_TOKEN_EXPIRATION_TIME = 6000L;
     /**
      * JWT Claim related Constants
      */

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APISecurityUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APISecurityUtils.java
@@ -16,11 +16,14 @@
 
 package org.wso2.carbon.apimgt.gateway.handlers.security;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 
 import java.util.Map;
+
+import static org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants.INTERNAL_KEY;
 
 public class APISecurityUtils {
 
@@ -46,10 +49,18 @@ public class APISecurityUtils {
         if (authContext.getIssuer() != null) {
             synCtx.setProperty(APIConstants.KeyManager.ISSUER, authContext.getIssuer());
         }
-        if (contextHeader != null && authContext.getCallerToken() != null) {
+        boolean isSetCallerToken = contextHeader != null && authContext.getCallerToken() != null;
+        boolean isSetMcpUpstreamToken = StringUtils.isNotBlank(authContext.getMcpUpstreamToken());
+
+        if (isSetCallerToken || isSetMcpUpstreamToken) {
             Map transportHeaders = (Map) ((Axis2MessageContext) synCtx).getAxis2MessageContext()
                     .getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
-            transportHeaders.put(contextHeader, authContext.getCallerToken());
+            if (isSetCallerToken) {
+                transportHeaders.put(contextHeader, authContext.getCallerToken());
+            }
+            if (isSetMcpUpstreamToken) {
+                transportHeaders.put(INTERNAL_KEY, authContext.getMcpUpstreamToken());
+            }
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APISecurityUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APISecurityUtils.java
@@ -19,11 +19,10 @@ package org.wso2.carbon.apimgt.gateway.handlers.security;
 import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 
 import java.util.Map;
-
-import static org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants.INTERNAL_KEY;
 
 public class APISecurityUtils {
 
@@ -59,7 +58,7 @@ public class APISecurityUtils {
                 transportHeaders.put(contextHeader, authContext.getCallerToken());
             }
             if (isSetMcpUpstreamToken) {
-                transportHeaders.put(INTERNAL_KEY, authContext.getMcpUpstreamToken());
+                transportHeaders.put(APIMgtGatewayConstants.INTERNAL_KEY, authContext.getMcpUpstreamToken());
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APISecurityUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/APISecurityUtils.java
@@ -48,7 +48,8 @@ public class APISecurityUtils {
         if (authContext.getIssuer() != null) {
             synCtx.setProperty(APIConstants.KeyManager.ISSUER, authContext.getIssuer());
         }
-        boolean isSetCallerToken = contextHeader != null && authContext.getCallerToken() != null;
+        boolean isSetCallerToken = StringUtils.isNotBlank(contextHeader)
+                && StringUtils.isNotBlank(authContext.getCallerToken());
         boolean isSetMcpUpstreamToken = StringUtils.isNotBlank(authContext.getMcpUpstreamToken());
 
         if (isSetCallerToken || isSetMcpUpstreamToken) {

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/AuthenticationContext.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/AuthenticationContext.java
@@ -57,6 +57,7 @@ public class AuthenticationContext {
     private int graphQLMaxComplexity;
     private String accessToken;
     private Set<String> applicationGroupIds;
+    private String mcpUpstreamToken;
 
     public List<String> getRequestTokenScopes() {
         return requestTokenScopes;
@@ -318,5 +319,13 @@ public class AuthenticationContext {
 
     public void setApplicationGroupIds(Set<String> applicationGroupIds) {
         this.applicationGroupIds = applicationGroupIds;
+    }
+
+    public String getMcpUpstreamToken() {
+        return mcpUpstreamToken;
+    }
+
+    public void setMcpUpstreamToken(String mcpUpstreamToken) {
+        this.mcpUpstreamToken = mcpUpstreamToken;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/InternalAPIKeyAuthenticator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/authenticator/InternalAPIKeyAuthenticator.java
@@ -32,6 +32,9 @@ import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.rest.RESTConstants;
 import org.wso2.carbon.apimgt.common.gateway.dto.JWTConfigurationDto;
+import org.wso2.carbon.apimgt.common.gateway.dto.JWTInfoDto;
+import org.wso2.carbon.apimgt.common.gateway.dto.JWTValidationInfo;
+import org.wso2.carbon.apimgt.common.gateway.jwtgenerator.AbstractAPIMgtGatewayJWTGenerator;
 import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.dto.JWTTokenPayloadInfo;
 import org.wso2.carbon.apimgt.gateway.handlers.security.APISecurityConstants;
@@ -49,14 +52,23 @@ import org.wso2.carbon.apimgt.impl.caching.CacheProvider;
 import org.wso2.carbon.apimgt.impl.dto.ExtendedJWTConfigurationDto;
 import org.wso2.carbon.apimgt.impl.dto.VerbInfoDTO;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.impl.utils.JWTUtil;
+import org.wso2.carbon.apimgt.impl.utils.SigningUtil;
 import org.wso2.carbon.apimgt.keymgt.model.entity.API;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import javax.cache.Cache;
 
 /**
@@ -68,6 +80,10 @@ public class InternalAPIKeyAuthenticator implements Authenticator {
 
     private String securityParam;
     private boolean jwtGenerationEnabled;
+    private boolean isGatewayTokenCacheEnabled;
+    private ExtendedJWTConfigurationDto jwtConfigurationDto;
+    private AbstractAPIMgtGatewayJWTGenerator apiMgtGatewayJWTGenerator;
+    private static volatile long ttl = -1L;
 
     public InternalAPIKeyAuthenticator(String securityParam) {
         this.securityParam = securityParam;
@@ -75,9 +91,10 @@ public class InternalAPIKeyAuthenticator implements Authenticator {
 
     @Override
     public void init(SynapseEnvironment env) {
-        ExtendedJWTConfigurationDto jwtConfigurationDto =
+        jwtConfigurationDto =
                 ServiceReferenceHolder.getInstance().getAPIManagerConfiguration().getJwtConfigurationDto();
         jwtGenerationEnabled = jwtConfigurationDto.isEnabled();
+        isGatewayTokenCacheEnabled = GatewayUtils.isGatewayTokenCacheEnabled();
     }
 
     @Override
@@ -253,16 +270,21 @@ public class InternalAPIKeyAuthenticator implements Authenticator {
                         log.debug("Internal Key authentication successful.");
                     }
 
+                    String endUserToken = null;
+                    if (jwtGenerationEnabled && StringUtils.isNotBlank(mcpAuthClaim)
+                            && Boolean.parseBoolean(mcpAuthClaim)) {
+                        ensureJwtGeneratorInitialized();
+                        JWTInfoDto jwtInfoDto = buildJWTInfoForInternalKey(payload, retrievedApi, synCtx);
+                        endUserToken = generateAndRetrieveJWTToken(tokenIdentifier, jwtInfoDto);
+                    }
+
                     AuthenticationContext authenticationContext = GatewayUtils
                             .generateAuthenticationContext(tokenIdentifier, payload, api, retrievedApi.getApiTier());
-                    if (jwtGenerationEnabled) {
-                        String callerToken =
-                                (String) ((Map) ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty(
-                                        APIMgtGatewayConstants.TRANSPORT_HEADERS)).get(getContextHeader());
-                        if (StringUtils.isNotEmpty(callerToken)) {
-                            authenticationContext.setCallerToken(callerToken);
-                        }
+
+                    if (StringUtils.isNotEmpty(endUserToken)) {
+                        authenticationContext.setCallerToken(endUserToken);
                     }
+
                     APISecurityUtils.setAuthenticationContext(synCtx, authenticationContext,
                             jwtGenerationEnabled ? getContextHeader() : null);
                     synCtx.setProperty(APIMgtGatewayConstants.END_USER_NAME, authenticationContext.getUsername());
@@ -290,6 +312,201 @@ public class InternalAPIKeyAuthenticator implements Authenticator {
         }
         return new AuthenticationResponse(false, true, false, APISecurityConstants.API_AUTH_GENERAL_ERROR,
                 APISecurityConstants.API_AUTH_GENERAL_ERROR_MESSAGE);
+    }
+
+    private void ensureJwtGeneratorInitialized() {
+
+        if (apiMgtGatewayJWTGenerator != null && jwtConfigurationDto.getPublicCert() != null) {
+            return;
+        }
+        String tenantDomain = GatewayUtils.getTenantDomain();
+        try {
+            if (jwtConfigurationDto.isTenantBasedSigningEnabled()) {
+                int tenantId = APIUtil.getTenantIdFromTenantDomain(tenantDomain);
+                jwtConfigurationDto.setPublicCert(SigningUtil.getPublicCertificate(tenantId));
+                jwtConfigurationDto.setPrivateKey(SigningUtil.getSigningKey(tenantId));
+            } else {
+                jwtConfigurationDto.setPublicCert(ServiceReferenceHolder.getInstance().getPublicCert());
+                jwtConfigurationDto.setPrivateKey(ServiceReferenceHolder.getInstance().getPrivateKey());
+            }
+            jwtConfigurationDto.setTtl(getTtl());
+
+            apiMgtGatewayJWTGenerator =
+                    ServiceReferenceHolder.getInstance().getApiMgtGatewayJWTGenerator()
+                            .get(jwtConfigurationDto.getGatewayJWTGeneratorImpl());
+            apiMgtGatewayJWTGenerator.setJWTConfigurationDto(jwtConfigurationDto);
+        } catch (Exception e) {
+            log.error("Failed initializing gateway JWT generator for InternalKey flow", e);
+        }
+    }
+
+    private JWTInfoDto buildJWTInfoForInternalKey(JWTClaimsSet payload, API matchedAPI, MessageContext synCtx) {
+        JWTInfoDto dto = new JWTInfoDto();
+
+        // API meta
+        String apiContext = (String) synCtx.getProperty(RESTConstants.REST_API_CONTEXT);
+        String apiVersion = (String) synCtx.getProperty(RESTConstants.SYNAPSE_REST_API_VERSION);
+        dto.setApiContext(apiContext);
+        dto.setVersion(apiVersion);
+        dto.setApiName(matchedAPI != null ? matchedAPI.getName() : null);
+
+        String dialect = jwtConfigurationDto.getConsumerDialectUri();
+        if (dialect == null || dialect.isEmpty() || "/".equals(dialect)) {
+            dialect = APIConstants.DEFAULT_CARBON_DIALECT + "/";
+        } else if (!dialect.endsWith("/")) {
+            dialect = dialect + "/";
+        }
+
+        Object subscriberObj = payload.getClaim(dialect + APIMgtGatewayConstants.SUBSCRIBER_CLAIM);
+        if (subscriberObj instanceof String && StringUtils.isNotBlank((String) subscriberObj)) {
+            dto.setSubscriber((String) subscriberObj);
+        }
+
+        Object applicationIdObj = payload.getClaim(dialect + APIMgtGatewayConstants.APPLICATION_ID_CLAIM);
+        if (applicationIdObj instanceof String && StringUtils.isNotBlank((String) applicationIdObj)) {
+            dto.setApplicationId((String) applicationIdObj);
+        }
+
+        Object appNameObj = payload.getClaim(dialect + APIMgtGatewayConstants.APPLICATION_NAME_CLAIM);
+        if (appNameObj instanceof String && StringUtils.isNotBlank((String) appNameObj)) {
+            dto.setApplicationName((String) appNameObj);
+        }
+
+        Object appTierObj = payload.getClaim(dialect + APIMgtGatewayConstants.APPLICATION_TIER_CLAIM);
+        if (appTierObj instanceof String && StringUtils.isNotBlank((String) appTierObj)) {
+            dto.setApplicationTier((String) appTierObj);
+        }
+
+        Object tierObj = payload.getClaim(dialect + APIMgtGatewayConstants.TIER_CLAIM);
+        if (tierObj instanceof String && StringUtils.isNotBlank((String) tierObj)) {
+            dto.setSubscriptionTier((String) tierObj);
+        }
+
+        Object appUuidObj = payload.getClaim(dialect + APIMgtGatewayConstants.APPLICATION_UUID_CLAIM);
+        if (appUuidObj instanceof String && StringUtils.isNotBlank((String) appUuidObj)) {
+            dto.setApplicationUUId((String) appUuidObj);
+        }
+
+        Object keyTypeObj = payload.getClaim(dialect + APIMgtGatewayConstants.KEY_TYPE_CLAIM);
+        if (keyTypeObj instanceof String && StringUtils.isNotBlank((String) keyTypeObj)) {
+            dto.setKeyType((String) keyTypeObj);
+        }
+
+        Object endUserObj = payload.getClaim(dialect + APIMgtGatewayConstants.END_USER_CLAIM);
+        if (endUserObj instanceof String && StringUtils.isNotBlank((String) endUserObj)) {
+            dto.setEndUser((String) endUserObj);
+        }
+
+        Object endUserTenantIdObj = payload.getClaim(dialect + APIMgtGatewayConstants.END_USER_TENANT_ID_CLAIM);
+        if (endUserTenantIdObj instanceof Number) {
+            dto.setEndUserTenantId(((Number) endUserTenantIdObj).intValue());
+        }
+
+        // Build JWTValidationInfo to carry scopes & claims (generator reads from here)
+        JWTValidationInfo vi = new JWTValidationInfo();
+        vi.setValid(true);
+        Map<String, Object> claims = new HashMap<>();
+        Set<String> exclude = new HashSet<>(APIMgtGatewayConstants.STANDARD_JWT_CLAIMS);
+        exclude.addAll(Arrays.asList(
+                APIMgtGatewayConstants.MCP_AUTH_CLAIM,
+                APIMgtGatewayConstants.TOKEN_TYPE_CLAIM,
+                APIMgtGatewayConstants.KEY_TYPE_CLAIM,
+                dialect + APIMgtGatewayConstants.SUBSCRIBER_CLAIM,
+                dialect + APIMgtGatewayConstants.APPLICATION_ID_CLAIM,
+                dialect + APIMgtGatewayConstants.APPLICATION_NAME_CLAIM,
+                dialect + APIMgtGatewayConstants.APPLICATION_TIER_CLAIM,
+                dialect + APIMgtGatewayConstants.TIER_CLAIM,
+                dialect + APIMgtGatewayConstants.APPLICATION_UUID_CLAIM,
+                dialect + APIMgtGatewayConstants.KEY_TYPE_CLAIM,
+                dialect + APIMgtGatewayConstants.END_USER_CLAIM,
+                dialect + APIMgtGatewayConstants.END_USER_TENANT_ID_CLAIM
+        ));
+        for (Map.Entry<String, Object> e : payload.getClaims().entrySet()) {
+            String k = e.getKey();
+            Object v = e.getValue();
+            if (k != null && v != null && !exclude.contains(k)) {
+                claims.putIfAbsent(k, v);
+            }
+        }
+        vi.setClaims(claims);
+        long nowMs = System.currentTimeMillis();
+        long expMs = (payload.getExpirationTime() != null) ?
+                payload.getExpirationTime().getTime() : nowMs + (getTtl() * 1000L);
+        vi.setExpiryTime(expMs);
+
+        dto.setJwtValidationInfo(vi);
+        return dto;
+    }
+
+    private String generateAndRetrieveJWTToken(String tokenSignature, JWTInfoDto jwtInfoDto) {
+        String jwt = null;
+        boolean valid = false;
+        String cacheKey = jwtInfoDto.getApiContext() + ":" + jwtInfoDto.getVersion() + ":" + tokenSignature;
+
+        if (isGatewayTokenCacheEnabled) {
+            Object cached = CacheProvider.getGatewayJWTTokenCache().get(cacheKey);
+            if (cached instanceof String) {
+                jwt = (String) cached;
+                long skewMs = getTimeStampSkewInSeconds() * 1000L;
+                valid = JWTUtil.isJWTValid(jwt, jwtConfigurationDto.getJwtDecoding(), skewMs);
+                if (!valid) {
+                    CacheProvider.getGatewayJWTTokenCache().remove(cacheKey);
+                    jwt = null;
+                }
+            }
+        }
+        if (jwt == null) {
+            try {
+                jwt = apiMgtGatewayJWTGenerator.generateToken(jwtInfoDto);
+                if (isGatewayTokenCacheEnabled) {
+                    CacheProvider.getGatewayJWTTokenCache().put(cacheKey, jwt);
+                }
+            } catch (Exception e) {
+                log.error("Error generating backend JWT for InternalKey (MCP)", e);
+                return null;
+            }
+        }
+        return jwt;
+    }
+
+    private long getTtl() {
+        if (ttl != -1) {
+            return ttl;
+        }
+        synchronized (AbstractAPIMgtGatewayJWTGenerator.class) {
+            if (ttl != -1) {
+                return ttl;
+            }
+            APIManagerConfiguration config = org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder.getInstance().
+                    getAPIManagerConfigurationService().getAPIManagerConfiguration();
+
+            String gwTokenCacheConfig = config.getFirstProperty(APIConstants.GATEWAY_TOKEN_CACHE_ENABLED);
+            boolean isGWTokenCacheEnabled = Boolean.parseBoolean(gwTokenCacheConfig);
+
+            if (isGWTokenCacheEnabled) {
+                String apimKeyCacheExpiry = config.getFirstProperty(APIConstants.TOKEN_CACHE_EXPIRY);
+
+                if (apimKeyCacheExpiry != null) {
+                    ttl = Long.parseLong(apimKeyCacheExpiry);
+                } else {
+                    ttl = Long.valueOf(900);
+                }
+            } else {
+                String ttlValue = config.getFirstProperty(APIConstants.JWT_EXPIRY_TIME);
+                if (ttlValue != null) {
+                    ttl = Long.parseLong(ttlValue);
+                } else {
+                    //15 * 60 (convert 15 minutes to seconds)
+                    ttl = Long.valueOf(900);
+                }
+            }
+            return ttl;
+        }
+    }
+
+    protected long getTimeStampSkewInSeconds() {
+
+        return OAuthServerConfiguration.getInstance().getTimeStampSkewInSeconds();
     }
 
     private String extractInternalKey(MessageContext mCtx) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2575,6 +2575,9 @@ public final class APIConstants {
         public static final String DECODING_ALGORITHM_BASE64URL = "base64url";
         public static final String APP_DOMAIN = "app_td";
         public static final String USER_DOMAIN = "user_td";
+        public static final Set<String> RESERVED_CLAIMS = Set.of(
+                "sub","iss","aud","exp","iat","jti","azp","nbf","scope","scp","aut"
+        );
     }
 
     public static final String SIGNATURE_ALGORITHM_RS256 = "RS256";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3707,6 +3707,8 @@ public final class APIConstants {
         // SSE parsing
         public static final String SSE_DATA_PREFIX = "data:";
 
+        public static final String MCP_AUTH_CLAIM = "MCP_AUTHENTICATED";
+
         /**
          * This class contains constants used for RPC processing
          */

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/JwtTokenInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/JwtTokenInfoDTO.java
@@ -44,6 +44,7 @@ public class JwtTokenInfoDTO implements Serializable {
     private Map<String, SubscriptionPolicyDTO> subscriptionPolicyDTOList = new HashMap<String, SubscriptionPolicyDTO>();
     private String permittedIP;
     private String permittedReferer;
+    private Map<String, String> customClaims = new HashMap<>();
 
     public String getPermittedIP() {
         return permittedIP;
@@ -155,6 +156,14 @@ public class JwtTokenInfoDTO implements Serializable {
 
     public void setConsumerKey(String consumerKey) {
         this.consumerKey = consumerKey;
+    }
+
+    public Map<String, String> getCustomClaims() {
+        return customClaims;
+    }
+
+    public void setCustomClaims(Map<String, String> customClaims) {
+        this.customClaims = customClaims;
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/JwtTokenInfoDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/JwtTokenInfoDTO.java
@@ -163,7 +163,8 @@ public class JwtTokenInfoDTO implements Serializable {
     }
 
     public void setCustomClaims(Map<String, String> customClaims) {
-        this.customClaims = customClaims;
+
+        this.customClaims = (customClaims != null) ? new HashMap<>(customClaims) : new HashMap<>();
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/InternalAPIKeyGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/InternalAPIKeyGenerator.java
@@ -65,8 +65,10 @@ public class InternalAPIKeyGenerator implements ApiKeyGenerator {
         if (expireIn != -1) {
             jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.EXPIRY_TIME, expireIn);
         }
-        jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.SUBSCRIBED_APIS,
-                jwtTokenInfoDTO.getSubscribedApiDTOList());
+        if (!jwtTokenInfoDTO.getSubscribedApiDTOList().isEmpty()) {
+            jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.SUBSCRIBED_APIS,
+                    jwtTokenInfoDTO.getSubscribedApiDTOList());
+        }
         jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.KEY_TYPE, jwtTokenInfoDTO.getKeyType());
         jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.TOKEN_TYPE,
                 APIConstants.JwtTokenConstants.INTERNAL_KEY_TOKEN_TYPE);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/InternalAPIKeyGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/InternalAPIKeyGenerator.java
@@ -77,9 +77,7 @@ public class InternalAPIKeyGenerator implements ApiKeyGenerator {
         for (Map.Entry<String, String> entry : jwtTokenInfoDTO.getCustomClaims().entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
-            if (APIConstants.MCP.MCP_AUTH_CLAIM.equals(key)) {
-                jwtClaimsSetBuilder.claim(key, value);
-            }
+            jwtClaimsSetBuilder.claim(key, value);
         }
         return jwtClaimsSetBuilder.build();
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/InternalAPIKeyGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/InternalAPIKeyGenerator.java
@@ -66,7 +66,8 @@ public class InternalAPIKeyGenerator implements ApiKeyGenerator {
         if (expireIn != -1) {
             jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.EXPIRY_TIME, expireIn);
         }
-        if (!jwtTokenInfoDTO.getSubscribedApiDTOList().isEmpty()) {
+        if (jwtTokenInfoDTO.getSubscribedApiDTOList() != null &&
+                !jwtTokenInfoDTO.getSubscribedApiDTOList().isEmpty()) {
             jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.SUBSCRIBED_APIS,
                     jwtTokenInfoDTO.getSubscribedApiDTOList());
         }
@@ -74,10 +75,15 @@ public class InternalAPIKeyGenerator implements ApiKeyGenerator {
         jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.TOKEN_TYPE,
                 APIConstants.JwtTokenConstants.INTERNAL_KEY_TOKEN_TYPE);
 
-        for (Map.Entry<String, String> entry : jwtTokenInfoDTO.getCustomClaims().entrySet()) {
-            String key = entry.getKey();
-            String value = entry.getValue();
-            jwtClaimsSetBuilder.claim(key, value);
+        Map<String, String> custom = jwtTokenInfoDTO.getCustomClaims();
+        if (custom != null) {
+            for (Map.Entry<String, String> entry : custom.entrySet()) {
+                String key = entry.getKey();
+                if (APIConstants.JwtTokenConstants.RESERVED_CLAIMS.contains(key)) {
+                    continue;
+                }
+                jwtClaimsSetBuilder.claim(key, entry.getValue());
+            }
         }
         return jwtClaimsSetBuilder.build();
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/InternalAPIKeyGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/token/InternalAPIKeyGenerator.java
@@ -18,6 +18,7 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.security.PrivateKey;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -72,6 +73,14 @@ public class InternalAPIKeyGenerator implements ApiKeyGenerator {
         jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.KEY_TYPE, jwtTokenInfoDTO.getKeyType());
         jwtClaimsSetBuilder.claim(APIConstants.JwtTokenConstants.TOKEN_TYPE,
                 APIConstants.JwtTokenConstants.INTERNAL_KEY_TOKEN_TYPE);
+
+        for (Map.Entry<String, String> entry : jwtTokenInfoDTO.getCustomClaims().entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (APIConstants.MCP.MCP_AUTH_CLAIM.equals(key)) {
+                jwtClaimsSetBuilder.claim(key, value);
+            }
+        }
         return jwtClaimsSetBuilder.build();
     }
 


### PR DESCRIPTION
Propagates authenticated context from the MCP auth layer to the API layer by generating and injecting an Internal Key for upstream calls. When an MCP Server has already authenticated the request, we skip subscription validation for the API.