### PR TITLE
Fix multiple issues in devportal unified search

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -4507,6 +4507,7 @@ APIConstants.AuditLogConstants.DELETED, this.username);
                                 docItem.getApiVersion()));
                         api.setUuid(docItem.getApiUUID());
                         api.setDisplayName(docItem.getApiDisplayName());
+                        api.setType(docItem.getAssociatedType());
                         docMap.put(doc, api);
                     } else if (item instanceof APIDefSearchContent) {
                         APIDefSearchContent definitionItem = (APIDefSearchContent) item;

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -1898,6 +1898,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
                             String apiArtifactId = apiResource.getUUID();
                             DevPortalAPI devAPI;
                             if (apiArtifactId != null) {
+                                log.debug("Processing artifact for document search: " + apiArtifactId);
                                 GenericArtifact apiArtifact = apiArtifactManager.getGenericArtifact(apiArtifactId);
                                 String associatedType;
                                 if (apiArtifact.getAttribute(APIConstants.API_OVERVIEW_TYPE)

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -1939,11 +1939,10 @@ public class RegistryPersistenceImpl implements APIPersistence {
                                 DevPortalSearchContent content = new DevPortalSearchContent();
                                 content.setContext(devAPI.getContext());
                                 String associatedType;
-                                if (apiArtifact.getAttribute(APIConstants.API_OVERVIEW_TYPE)
-                                        .equals(APIConstants.AuditLogConstants.API_PRODUCT)) {
+                                String artifactType = apiArtifact.getAttribute(APIConstants.API_OVERVIEW_TYPE);
+                                if (artifactType.equals(APIConstants.API_PRODUCT)) {
                                     associatedType = APIConstants.API_PRODUCT;
-                                } else if (apiArtifact.getAttribute(APIConstants.API_OVERVIEW_TYPE)
-                                        .equals(APIConstants.MCP)){
+                                } else if (artifactType.equals(APIConstants.MCP)){
                                     associatedType = APIConstants.MCP;
                                 } else {
                                     associatedType = APIConstants.API;

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -1709,17 +1709,17 @@ public class RegistryPersistenceImpl implements APIPersistence {
                             PublisherAPI pubAPI;
                             if (apiArtifactId != null) {
                                 GenericArtifact apiArtifact = apiArtifactManager.getGenericArtifact(apiArtifactId);
-                                String accociatedType;
+                                String associatedType;
                                 if (apiArtifact.getAttribute(APIConstants.API_OVERVIEW_TYPE).
                                         equals(APIConstants.AuditLogConstants.API_PRODUCT)) {
                                     //associatedAPIProduct = APIUtil.getAPIProduct(apiArtifact, registry);
-                                    accociatedType = APIConstants.API_PRODUCT;
+                                    associatedType = APIConstants.API_PRODUCT;
                                 } else if (apiArtifact.getAttribute(APIConstants.API_OVERVIEW_TYPE)
                                         .equals(APIConstants.MCP)){
-                                    accociatedType = APIConstants.MCP;
+                                    associatedType = APIConstants.MCP;
                                 } else {
                                     //associatedAPI = APIUtil.getAPI(apiArtifact, registry);
-                                    accociatedType = APIConstants.API;
+                                    associatedType = APIConstants.API;
                                 }
                                 pubAPI = RegistryPersistenceUtil.getAPIForSearch(apiArtifact);
                                 docSearch.setApiName(pubAPI.getApiName());
@@ -1727,7 +1727,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
                                 docSearch.setApiProvider(pubAPI.getProviderName());
                                 docSearch.setApiVersion(pubAPI.getVersion());
                                 docSearch.setApiUUID(pubAPI.getId());
-                                docSearch.setAssociatedType(accociatedType);
+                                docSearch.setAssociatedType(associatedType);
                                 docSearch.setDocType(doc.getType());
                                 docSearch.setId(doc.getId());
                                 docSearch.setSourceType(doc.getSourceType());
@@ -1899,6 +1899,13 @@ public class RegistryPersistenceImpl implements APIPersistence {
                             DevPortalAPI devAPI;
                             if (apiArtifactId != null) {
                                 GenericArtifact apiArtifact = apiArtifactManager.getGenericArtifact(apiArtifactId);
+                                String associatedType;
+                                if (apiArtifact.getAttribute(APIConstants.API_OVERVIEW_TYPE)
+                                        .equals(APIConstants.MCP)){
+                                    associatedType = APIConstants.MCP;
+                                } else {
+                                    associatedType = APIConstants.API;
+                                }
                                 devAPI = RegistryPersistenceUtil.getDevPortalAPIForSearch(apiArtifact);
                                 devAPI.setVisibility(apiArtifact.getAttribute(APIConstants.API_OVERVIEW_VISIBILITY));
                                 docSearch.setApiName(devAPI.getApiName());
@@ -1906,6 +1913,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
                                 docSearch.setApiProvider(devAPI.getProviderName());
                                 docSearch.setApiVersion(devAPI.getVersion());
                                 docSearch.setApiUUID(devAPI.getId());
+                                docSearch.setAssociatedType(associatedType);
                                 docSearch.setDocType(doc.getType());
                                 docSearch.setId(doc.getId());
                                 docSearch.setSourceType(doc.getSourceType());

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -1956,6 +1956,7 @@ public class RegistryPersistenceImpl implements APIPersistence {
                                 content.setTechnicalOwnerEmail(devAPI.getTechnicalOwnerEmail());
                                 content.setMonetizationStatus(devAPI.getMonetizationStatus());
                                 content.setAdvertiseOnly(devAPI.isAdvertiseOnly());
+                                content.setTransportType(devAPI.getType());
 
                                 contentData.add(content);
                             } else {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/devportal-api.yaml
@@ -6386,6 +6386,8 @@ components:
               example: admin
             apiUUID:
               type: string
+            associatedType:
+              type: string
     APIDefinitionSearchResult:
       title: API Definition Search Result
       allOf:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/DocumentSearchResultAllOfDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/DocumentSearchResultAllOfDTO.java
@@ -132,6 +132,7 @@ return null;
     private String apiVersion = null;
     private String apiProvider = null;
     private String apiUUID = null;
+    private String associatedType = null;
 
   /**
    **/
@@ -323,6 +324,23 @@ return null;
     this.apiUUID = apiUUID;
   }
 
+  /**
+   **/
+  public DocumentSearchResultAllOfDTO associatedType(String associatedType) {
+    this.associatedType = associatedType;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("associatedType")
+  public String getAssociatedType() {
+    return associatedType;
+  }
+  public void setAssociatedType(String associatedType) {
+    this.associatedType = associatedType;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -343,12 +361,13 @@ return null;
         Objects.equals(apiDisplayName, documentSearchResultAllOf.apiDisplayName) &&
         Objects.equals(apiVersion, documentSearchResultAllOf.apiVersion) &&
         Objects.equals(apiProvider, documentSearchResultAllOf.apiProvider) &&
-        Objects.equals(apiUUID, documentSearchResultAllOf.apiUUID);
+        Objects.equals(apiUUID, documentSearchResultAllOf.apiUUID) &&
+        Objects.equals(associatedType, documentSearchResultAllOf.associatedType);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(docType, summary, sourceType, sourceUrl, otherTypeName, visibility, apiName, apiDisplayName, apiVersion, apiProvider, apiUUID);
+    return Objects.hash(docType, summary, sourceType, sourceUrl, otherTypeName, visibility, apiName, apiDisplayName, apiVersion, apiProvider, apiUUID, associatedType);
   }
 
   @Override
@@ -367,6 +386,7 @@ return null;
     sb.append("    apiVersion: ").append(toIndentedString(apiVersion)).append("\n");
     sb.append("    apiProvider: ").append(toIndentedString(apiProvider)).append("\n");
     sb.append("    apiUUID: ").append(toIndentedString(apiUUID)).append("\n");
+    sb.append("    associatedType: ").append(toIndentedString(associatedType)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/DocumentSearchResultDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/store/v1/dto/DocumentSearchResultDTO.java
@@ -134,6 +134,7 @@ return null;
     private String apiVersion = null;
     private String apiProvider = null;
     private String apiUUID = null;
+    private String associatedType = null;
 
   /**
    **/
@@ -325,6 +326,23 @@ return null;
     this.apiUUID = apiUUID;
   }
 
+  /**
+   **/
+  public DocumentSearchResultDTO associatedType(String associatedType) {
+    this.associatedType = associatedType;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("associatedType")
+  public String getAssociatedType() {
+    return associatedType;
+  }
+  public void setAssociatedType(String associatedType) {
+    this.associatedType = associatedType;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -345,12 +363,13 @@ return null;
         Objects.equals(apiDisplayName, documentSearchResult.apiDisplayName) &&
         Objects.equals(apiVersion, documentSearchResult.apiVersion) &&
         Objects.equals(apiProvider, documentSearchResult.apiProvider) &&
-        Objects.equals(apiUUID, documentSearchResult.apiUUID);
+        Objects.equals(apiUUID, documentSearchResult.apiUUID) &&
+        Objects.equals(associatedType, documentSearchResult.associatedType);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(docType, summary, sourceType, sourceUrl, otherTypeName, visibility, apiName, apiDisplayName, apiVersion, apiProvider, apiUUID);
+    return Objects.hash(docType, summary, sourceType, sourceUrl, otherTypeName, visibility, apiName, apiDisplayName, apiVersion, apiProvider, apiUUID, associatedType);
   }
 
   @Override
@@ -369,6 +388,7 @@ return null;
     sb.append("    apiVersion: ").append(toIndentedString(apiVersion)).append("\n");
     sb.append("    apiProvider: ").append(toIndentedString(apiProvider)).append("\n");
     sb.append("    apiUUID: ").append(toIndentedString(apiUUID)).append("\n");
+    sb.append("    associatedType: ").append(toIndentedString(associatedType)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SearchResultMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/SearchResultMappingUtil.java
@@ -150,6 +150,7 @@ public class SearchResultMappingUtil {
         docResultDTO.setApiVersion(apiId.getVersion());
         docResultDTO.setApiProvider(apiId.getProviderName());
         docResultDTO.setApiUUID(api.getUUID());
+        docResultDTO.setAssociatedType(api.getType());
         return docResultDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/resources/devportal-api.yaml
@@ -6386,6 +6386,8 @@ components:
               example: admin
             apiUUID:
               type: string
+            associatedType:
+              type: string
     APIDefinitionSearchResult:
       title: API Definition Search Result
       allOf:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/devportal-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/src/main/resources/devportal-api.yaml
@@ -5776,6 +5776,8 @@ components:
               example: admin
             apiUUID:
               type: string
+            associatedType:
+              type: string
     CommenterInfo:
       type: object
       properties:


### PR DESCRIPTION
### Purpose
Fixing multiple issues in devportal unified search
1. `transportType` being incorrect. It was returning the default value for all artifacts which is `HTTP`
2. `associatedType` being undefined in unified search `DOC` results

Fixes https://github.com/wso2/api-manager/issues/4191 in devportal side

### Approach
- Corrected the `transportType` in devportal unified search result by setting the value.
- Included `associatedType` in devportal unified search doc results

### Note
Original PR: https://github.com/wso2/carbon-apimgt/pull/13350