### PR TITLE
Fix missing default CORS configuration value

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/CORSConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/CORSConfiguration.java
@@ -79,6 +79,8 @@ public class CORSConfiguration {
     public void setAccessControlAllowMethods(List<String> accessControlAllowMethods) {
         this.accessControlAllowMethods = accessControlAllowMethods;
     }
+    
+    @com.fasterxml.jackson.annotation.JsonIgnore
     public boolean isEmpty() {
         return (accessControlAllowOrigins == null || accessControlAllowOrigins.isEmpty()) &&
                 (accessControlAllowHeaders == null || accessControlAllowHeaders.isEmpty()) &&

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/CORSConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/CORSConfiguration.java
@@ -79,4 +79,11 @@ public class CORSConfiguration {
     public void setAccessControlAllowMethods(List<String> accessControlAllowMethods) {
         this.accessControlAllowMethods = accessControlAllowMethods;
     }
+    public boolean isEmpty() {
+        return (accessControlAllowOrigins == null || accessControlAllowOrigins.isEmpty()) &&
+                (accessControlAllowHeaders == null || accessControlAllowHeaders.isEmpty()) &&
+                (accessControlAllowMethods == null || accessControlAllowMethods.isEmpty()) &&
+                !accessControlAllowCredentials &&
+                !corsConfigurationEnabled;
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
@@ -2454,7 +2454,7 @@ public class OAS3Parser extends APIDefinition {
         }
         //Setup CORSConfigurations
         CORSConfiguration corsConfiguration = OASParserUtil.getCorsConfigFromSwagger(extensions);
-        if (corsConfiguration != null) {
+        if (corsConfiguration != null && !corsConfiguration.isEmpty()) {
             api.setCorsConfiguration(corsConfiguration);
         }
         //Setup Response cache enabling

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
@@ -2456,6 +2456,9 @@ public class OAS3Parser extends APIDefinition {
         CORSConfiguration corsConfiguration = OASParserUtil.getCorsConfigFromSwagger(extensions);
         if (corsConfiguration != null && !corsConfiguration.isEmpty()) {
             api.setCorsConfiguration(corsConfiguration);
+            if (log.isDebugEnabled()) {
+                log.debug("Adding CORS Configuration to the API");
+            }
         }
         //Setup Response cache enabling
         boolean responseCacheEnable = OASParserUtil.getResponseCacheFromSwagger(extensions);


### PR DESCRIPTION
This pull request introduces an improvement to how CORS configuration is handled when parsing OpenAPI specifications. The main change ensures that only non-empty CORS configurations are set on the API object

CORS configuration handling:

Added an isEmpty() method to the CORSConfiguration class to check if all fields are unset or empty.
Updated the logic in OAS3Parser so that api.setCorsConfiguration() is only called if the CORS configuration is not empty, avoiding the assignment of default or empty configurations.

Fixes https://github.com/wso2/api-manager/issues/4140