### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2064,24 +2064,24 @@
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
 
-        <carbon.analytics.common.version>5.3.25</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.9.29-alpha</carbon.kernel.version>
+        <carbon.kernel.version>4.9.29</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
 
-        <carbon.commons.version>4.9.11</carbon.commons.version>
+        <carbon.commons.version>4.9.18</carbon.commons.version>
 
-        <carbon.registry.version>4.8.43</carbon.registry.version>
-        <carbon.mediation.version>4.7.255</carbon.mediation.version>
+        <carbon.registry.version>4.8.48</carbon.registry.version>
+        <carbon.mediation.version>4.7.257</carbon.mediation.version>
 
         <mongodb.driver.version>4.1.0</mongodb.driver.version>
 
         <!-- Carbon Identity versions -->
-        <carbon.identity.version>5.25.729</carbon.identity.version>
+        <carbon.identity.version>5.25.731</carbon.identity.version>
         <carbon.identity.governance.version>1.8.109</carbon.identity.governance.version>
-        <carbon.identity-inbound-auth-oauth.version>6.13.34</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version>6.13.35</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-oauth2-grant-jwt.version>2.2.4</carbon.identity-oauth2-grant-jwt.version>
         <carbon.identity-user-ws.version>5.7.6</carbon.identity-user-ws.version>
         <carbon.identity-data-publisher-application-authentication.version>5.6.8</carbon.identity-data-publisher-application-authentication.version>
@@ -2093,12 +2093,12 @@
         <graphql.java.version>19.11.wso2v1</graphql.java.version>
         <graphql.java.version.range>[19.0,20.0)</graphql.java.version.range>
 
-        <carbon.governance.version>4.8.34</carbon.governance.version>
-        <carbon.deployment.version>4.11.19</carbon.deployment.version>
-        <carbon.multitenancy.version>4.9.36</carbon.multitenancy.version>
+        <carbon.governance.version>4.8.37</carbon.governance.version>
+        <carbon.deployment.version>4.11.22</carbon.deployment.version>
+        <carbon.multitenancy.version>4.9.41</carbon.multitenancy.version>
         <wso2-uri-templates.version>1.6.5</wso2-uri-templates.version>
         <apimserver.version>1.10.0</apimserver.version>
-        <siddhi.version>3.2.14</siddhi.version>
+        <siddhi.version>3.2.15</siddhi.version>
 
         <carbon.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.registry.imp.pkg.version>
         <commons.logging.imp.pkg.version>[1.2.0, 1.3.0)</commons.logging.imp.pkg.version>
@@ -2154,7 +2154,7 @@
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
 
         <!-- Misc Versions -->
-        <synapse.version>4.0.0-wso2v240</synapse.version>
+        <synapse.version>4.0.0-wso2v245</synapse.version>
         <orbit.version.json>3.0.0.wso2v7</orbit.version.json>
 
         <!-- orbit httpmime versions-->
@@ -2220,10 +2220,10 @@
         <rule.validator.version>1.0.1</rule.validator.version>
 
         <!-- apache cxf version -->
-        <cxf.version>3.6.5</cxf.version>
+        <cxf.version>3.6.8</cxf.version>
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <!-- apache pdfbox version -->
-        <event.processor.version>2.3.15</event.processor.version>
+        <event.processor.version>2.3.17</event.processor.version>
         <pdfbox.version>3.0.1</pdfbox.version>
         <pdfbox.io.version>3.0.1.wso2v1</pdfbox.io.version>
         <swagger.inflector.version>1.0.16.wso2v1</swagger.inflector.version>
@@ -2240,8 +2240,8 @@
         <fasterxml.jackson.version>2.17.2</fasterxml.jackson.version>
         <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
         <javax.inject.version>1</javax.inject.version>
-        <carbon.broker.version>3.3.35</carbon.broker.version>
-        <andes.version>3.3.33</andes.version>
+        <carbon.broker.version>3.3.38</carbon.broker.version>
+        <andes.version>3.3.36</andes.version>
         <waffle-jna.version>1.6.wso2v7</waffle-jna.version>
         <version.snake.yaml>2.2</version.snake.yaml>
         <wsdl4j.version>1.6.3.wso2v3</wsdl4j.version>
@@ -2273,7 +2273,7 @@
         <swagger3.core.version>2.2.20</swagger3.core.version>
         <javax.enterprise.version>2.0</javax.enterprise.version>
         <jaeger.client.version>1.8.0.wso2v1</jaeger.client.version>
-        <zipkin.sender.okhttp3.version>2.17.2.wso2v1</zipkin.sender.okhttp3.version>
+        <zipkin.sender.okhttp3.version>2.17.2.wso2v2</zipkin.sender.okhttp3.version>
         <zipkin.reporter.version>2.17.2</zipkin.reporter.version>
         <zipkin.reporter.version.range>[2.17,4)</zipkin.reporter.version.range>
         <brave.opentracing.version>0.32.0</brave.opentracing.version>
@@ -2292,7 +2292,7 @@
         <apache.felix.version>1.0.0</apache.felix.version>
         <maven.scr.plugin.version>1.26.0</maven.scr.plugin.version>
         <org.json.version.range>[3.0.0,4.0.0)</org.json.version.range>
-        <pax.logging.api.version>2.2.1-wso2v2</pax.logging.api.version>
+        <pax.logging.api.version>2.3.0-wso2v1</pax.logging.api.version>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <import.package.version.commons.io>[2.4.0,3.0.0)</import.package.version.commons.io>
         <import.package.version.commons.codec>[1.14.0,3.0.0)</import.package.version.commons.codec>
@@ -2301,8 +2301,8 @@
         <org.wso2.orbit.com.amazonaws.version.range>[2.20, 2.50]</org.wso2.orbit.com.amazonaws.version.range>
 
         <zipkin.version>2.27.1</zipkin.version>
-        <okhttp.wso2.version>4.12.0.wso2v1</okhttp.wso2.version>
-        <okio.wso2.version>3.6.0.wso2v1</okio.wso2.version>
+        <okhttp.wso2.version>4.12.0.wso2v4</okhttp.wso2.version>
+        <okio.wso2.version>3.16.0.wso2v1</okio.wso2.version>
 
         <openfeign.version>13.2.1</openfeign.version>
         <maven.spotbugsplugin.version>4.8.2.0</maven.spotbugsplugin.version>
@@ -2321,7 +2321,7 @@
         <com.damnhandy.version>2.1.6</com.damnhandy.version>
         <damnhandy.version>${com.damnhandy.version}.wso2v2</damnhandy.version>
         <javax.annotation.verion>1.3.2</javax.annotation.verion>
-        <log4j2.version>2.17.1</log4j2.version>
+        <log4j2.version>2.24.3</log4j2.version>
         <jinjava.version>2.7.2</jinjava.version>
         <h2.orbit.version>2.3.232.wso2v1</h2.orbit.version>
         <tomcat.version>9.0.108</tomcat.version>


### PR DESCRIPTION
## Purpose

This PR adds the following dependency upgrades:

- carbon-analytics-common: 5.3.25 to 5.3.27
- carbon-kernel: 4.9.29-alpha to 4.9.29
- carbon-commons: 4.9.11 to 4.9.18
- carbon-registry: 4.8.43 to 4.8.48
- carbon-mediation: 4.7.255 to 4.7.257
- carbon-identity-framework: 5.25.729 to 5.25.731
- identity-inbound-auth-oauth: 6.13.34 to 6.13.35
- carbon-governance: 4.8.34 to 4.8.37
- carbon-deployment: 4.11.19 to 4.11.22
- carbon-multitenancy: 4.9.36 to 4.9.41
- siddhi: 3.2.14 to 3.2.15
- synapse: 4.0.0-wso2v240 to 4.0.0-wso2v245
- cxf: 3.6.5 to 3.6.8
- carbon-event-processor: 2.3.15 to 2.3.17
- carbon-business-messaging: 3.3.35 to 3.3.38
- andes: 3.3.33 to 3.3.36
- zipkin-sender-okhttp3: 2.17.2.wso2v1 to 2.17.2.wso2v2
- pax-logging: 2.2.1-wso2v2 to 2.3.0-wso2v1
- okhttp: 4.12.0.wso2v1 to 4.12.0.wso2v4
- okio: 3.6.0.wso2v1 to 3.16.0.wso2v1
- log4j2: 2.17.1 to 2.24.3