### PR TITLE
Add jackson-dataformat-cbor to the throttle policy deployer feature

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer.feature/pom.xml
@@ -103,6 +103,9 @@
                                 </bundleDef>
                                 <bundleDef>org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.common.gateway:${carbon.apimgt.version}</bundleDef>
                                 <bundleDef>org.apache.httpcomponents.wso2:httpcore</bundleDef>
+                                <bundleDef>
+                                    com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${fasterxml.jackson.version}
+                                </bundleDef>
                             </bundles>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Purpose

This PR adds jackson-dataformat-cbor dependency as a bundle to be packed to the traffic manager product. 