### PR TITLE
Fix invocation issue for migrated APIs with mTLS

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -3231,12 +3231,16 @@ public class ImportUtils {
         String jsonContent = null;
         // try loading file as YAML
         if (CommonUtil.checkFileExistence(pathToYamlFile)) {
-            log.debug("Found client certificate file " + pathToYamlFile);
+            if (log.isDebugEnabled()) {
+                log.debug("Found client certificate file " + pathToYamlFile);
+            }
             String yamlContent = FileUtils.readFileToString(new File(pathToYamlFile));
             jsonContent = CommonUtil.yamlToJson(yamlContent);
         } else if (CommonUtil.checkFileExistence(pathToJsonFile)) {
             // load as a json fallback
-            log.debug("Found client certificate file " + pathToJsonFile);
+            if (log.isDebugEnabled()) {
+                log.debug("Found client certificate file " + pathToJsonFile);
+            }
             jsonContent = FileUtils.readFileToString(new File(pathToJsonFile));
         }
         return jsonContent;


### PR DESCRIPTION
This PR fixes an issue where a migrated API cannot be invoked when it has mTLS enabled.

The issue was caused by a difference in folder structures for APIs with mTLS before and after the migration. With this fix, the flow will fall back to the legacy folder structure in order to check whether any client certificates are available for the API and will add them as the PRODUCTION certificates to the truststore in order to comply with the new implementation.

Related issue: https://github.com/wso2/api-manager/issues/4209