### PR TITLE
 Fix Null Pointer Exception for Application Created and Updated values from database

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -4290,8 +4290,10 @@ public class ApiMgtDAO {
                 application.setIsBlackListed(rs.getBoolean("ENABLED"));
                 application.setOwner(rs.getString("CREATED_BY"));
                 application.setTokenType(rs.getString("TOKEN_TYPE"));
-                application.setLastUpdatedTime(String.valueOf(rs.getTimestamp("APP_UPDATED_TIME").getTime()));
-                application.setCreatedTime(String.valueOf(rs.getTimestamp("APP_CREATED_TIME").getTime()));
+                Timestamp updated_time = rs.getTimestamp("APP_UPDATED_TIME");
+                application.setLastUpdatedTime(updated_time == null ? null : String.valueOf(updated_time.getTime()));
+                Timestamp createdTime = rs.getTimestamp("APP_CREATED_TIME");
+                application.setCreatedTime(createdTime == null ? null : String.valueOf(createdTime.getTime()));
 
                 if (multiGroupAppSharingEnabled) {
                     setGroupIdInApplication(connection, application);
@@ -6585,8 +6587,10 @@ public class ApiMgtDAO {
                 application.setGroupId(rs.getString("GROUP_ID"));
                 application.setOwner(rs.getString("CREATED_BY"));
                 application.setTokenType(rs.getString("TOKEN_TYPE"));
-                application.setLastUpdatedTime(String.valueOf(rs.getTimestamp("UPDATED_TIME").getTime()));
-                application.setCreatedTime(String.valueOf(rs.getTimestamp("CREATED_TIME").getTime()));
+                Timestamp updated_time = rs.getTimestamp("UPDATED_TIME");
+                application.setLastUpdatedTime(updated_time == null ? null : String.valueOf(updated_time.getTime()));
+                Timestamp createdTime = rs.getTimestamp("CREATED_TIME");
+                application.setCreatedTime(createdTime == null ? null : String.valueOf(createdTime.getTime()));
 
                 if (multiGroupAppSharingEnabled) {
                     setGroupIdInApplication(connection, application);
@@ -6659,8 +6663,10 @@ public class ApiMgtDAO {
                 application.setTokenType(rs.getString("TOKEN_TYPE"));
                 application.setOrganization(rs.getString("ORGANIZATION"));
                 subscriber.setId(rs.getInt("SUBSCRIBER_ID"));
-                application.setLastUpdatedTime(String.valueOf(rs.getTimestamp("UPDATED_TIME").getTime()));
-                application.setCreatedTime(String.valueOf(rs.getTimestamp("CREATED_TIME").getTime()));
+                Timestamp updated_time = rs.getTimestamp("UPDATED_TIME");
+                application.setLastUpdatedTime(updated_time == null ? null : String.valueOf(updated_time.getTime()));
+                Timestamp createdTime = rs.getTimestamp("CREATED_TIME");
+                application.setCreatedTime(createdTime == null ? null : String.valueOf(createdTime.getTime()));
 
                 String tenantDomain = MultitenantUtils.getTenantDomain(subscriberName);
                 Map<String, Map<String, OAuthApplicationInfo>>
@@ -6816,8 +6822,10 @@ public class ApiMgtDAO {
                 application.setUUID(rs.getString("UUID"));
                 application.setTier(rs.getString("APPLICATION_TIER"));
                 subscriber.setId(rs.getInt("SUBSCRIBER_ID"));
-                application.setLastUpdatedTime(String.valueOf(rs.getTimestamp("UPDATED_TIME").getTime()));
-                application.setCreatedTime(String.valueOf(rs.getTimestamp("CREATED_TIME").getTime()));
+                Timestamp updated_time = rs.getTimestamp("UPDATED_TIME");
+                application.setLastUpdatedTime(updated_time == null ? null : String.valueOf(updated_time.getTime()));
+                Timestamp createdTime = rs.getTimestamp("CREATED_TIME");
+                application.setCreatedTime(createdTime == null ? null : String.valueOf(createdTime.getTime()));
 
                 String tenantDomain = MultitenantUtils.getTenantDomain(subscriberName);
                 Map<String, Map<String, OAuthApplicationInfo>>
@@ -6891,8 +6899,6 @@ public class ApiMgtDAO {
                 application.setOrganization(rs.getString("ORGANIZATION"));
                 application.setSharedOrganization(rs.getString("SHARED_ORGANIZATION"));
                 subscriber.setId(rs.getInt("SUBSCRIBER_ID"));
-                application.setLastUpdatedTime(String.valueOf(rs.getTimestamp("UPDATED_TIME").getTime()));
-                application.setCreatedTime(String.valueOf(rs.getTimestamp("CREATED_TIME").getTime()));
                 if (multiGroupAppSharingEnabled) {
                     if (application.getGroupId() == null || application.getGroupId().isEmpty()) {
                         application.setGroupId(getGroupId(connection, application.getId()));
@@ -15204,8 +15210,10 @@ public class ApiMgtDAO {
                 application.setTokenType(rs.getString("TOKEN_TYPE"));
                 application.setKeyType(rs.getString("KEY_TYPE"));
                 application.setOrganization(rs.getString("ORGANIZATION"));
-                application.setLastUpdatedTime(String.valueOf(rs.getTimestamp("UPDATED_TIME").getTime()));
-                application.setCreatedTime(String.valueOf(rs.getTimestamp("CREATED_TIME").getTime()));
+                Timestamp updated_time = rs.getTimestamp("UPDATED_TIME");
+                application.setLastUpdatedTime(updated_time == null ? null : String.valueOf(updated_time.getTime()));
+                Timestamp createdTime = rs.getTimestamp("CREATED_TIME");
+                application.setCreatedTime(createdTime == null ? null : String.valueOf(createdTime.getTime()));
 
                 if (multiGroupAppSharingEnabled) {
                     if (application.getGroupId() == null || application.getGroupId().isEmpty()) {


### PR DESCRIPTION
Ensures that `null` database values for creation and update times are handled gracefully. Previously, the code assumed timestamps were always present, which could lead to `NullPointerException`s if they were missing. Now, the code checks for `null` before converting timestamps, setting the corresponding fields to `null` when necessary.

Fixes https://github.com/wso2/api-manager/issues/4216