### PR TITLE
Fix sort issue in application listing for postgreSQL

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantPostgreSQL.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantPostgreSQL.java
@@ -53,7 +53,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And " +
                     "    LOWER (NAME) like LOWER (?)" +
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 offset ? limit ? ";
 
 
@@ -86,7 +86,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And "+
                     "    LOWER (NAME) like LOWER (?)"+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 offset ? limit ? ";
 
     public static final String GET_APPLICATIONS_PREFIX_CASESENSITVE_WITH_MULTIGROUPID =
@@ -123,7 +123,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And "+
                     "    LOWER (NAME) like LOWER (?)" +
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 offset ? limit ? ";
 
 
@@ -162,7 +162,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And " +
                     "    LOWER (NAME) like LOWER (?)"+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 offset ? limit ? ";
 
 
@@ -195,7 +195,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And "+
                     "    LOWER (NAME) like LOWER (?)"+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 offset ? limit ? ";
 
     public static final String GET_APPLICATIONS_PREFIX_NONE_CASESENSITVE =
@@ -227,7 +227,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And "+
                     "    LOWER (NAME) like LOWER (?)"+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 offset ? limit ? ";
 
     public static final String GET_APPLICATIONS_PREFIX_CASESENSITVE_WITH_ORGSHARING =
@@ -259,7 +259,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And "+
                     "    LOWER (NAME) like LOWER (?)"+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 offset ? limit ? ";
 
     public static final String GET_APPLICATIONS_PREFIX_NONE_CASESENSITVE_WITH_ORGSHARING =
@@ -291,7 +291,7 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And "+
                     "    LOWER (NAME) like LOWER (?)"+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) " +
                     " ORDER BY $1 $2 offset ? limit ? ";
 
     public static final String GET_APPLICATIONS_BY_TENANT_ID =

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantPostgreSQL.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantPostgreSQL.java
@@ -53,10 +53,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And " +
                     "    LOWER (NAME) like LOWER (?)" +
-                    " ORDER BY $1 $2 " +
-                    " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
-                    " ORDER BY $1 $2 ";
+                    " ORDER BY $1 $2 offset ? limit ? ";
 
 
     public static final String GET_APPLICATIONS_PREFIX_NONE_CASESENSITVE_WITHGROUPID =
@@ -88,10 +86,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And "+
                     "    LOWER (NAME) like LOWER (?)"+
-                    " ORDER BY $1 $2 " +
-                    " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
-                    " ORDER BY $1 $2 ";
+                    " ORDER BY $1 $2 offset ? limit ? ";
 
     public static final String GET_APPLICATIONS_PREFIX_CASESENSITVE_WITH_MULTIGROUPID =
             "select distinct x.*,bl.ENABLED from (" +
@@ -127,10 +123,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And "+
                     "    LOWER (NAME) like LOWER (?)" +
-                    " ORDER BY $1 $2 " +
-                    " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
-                    " ORDER BY $1 $2 ";
+                    " ORDER BY $1 $2 offset ? limit ? ";
 
 
     public static final String GET_APPLICATIONS_PREFIX_NONE_CASESENSITVE_WITH_MULTIGROUPID =
@@ -168,10 +162,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And " +
                     "    LOWER (NAME) like LOWER (?)"+
-                    " ORDER BY $1 $2 " +
-                    " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
-                    " ORDER BY $1 $2 ";
+                    " ORDER BY $1 $2 offset ? limit ? ";
 
 
     public static final String GET_APPLICATIONS_PREFIX_CASESENSITVE =
@@ -203,10 +195,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And "+
                     "    LOWER (NAME) like LOWER (?)"+
-                    " ORDER BY $1 $2 " +
-                    " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
-                    " ORDER BY $1 $2 ";
+                    " ORDER BY $1 $2 offset ? limit ? ";
 
     public static final String GET_APPLICATIONS_PREFIX_NONE_CASESENSITVE =
             "select distinct x.*,bl.ENABLED from (" +
@@ -237,10 +227,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And "+
                     "    LOWER (NAME) like LOWER (?)"+
-                    " ORDER BY $1 $2 " +
-                    " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
-                    " ORDER BY $1 $2 ";
+                    " ORDER BY $1 $2 offset ? limit ? ";
 
     public static final String GET_APPLICATIONS_PREFIX_CASESENSITVE_WITH_ORGSHARING =
             "select distinct x.*,bl.ENABLED from (" +
@@ -271,10 +259,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And "+
                     "    LOWER (NAME) like LOWER (?)"+
-                    " ORDER BY $1 $2 " +
-                    " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
-                    " ORDER BY $1 $2 ";
+                    " ORDER BY $1 $2 offset ? limit ? ";
 
     public static final String GET_APPLICATIONS_PREFIX_NONE_CASESENSITVE_WITH_ORGSHARING =
             "select distinct x.*,bl.ENABLED from (" +
@@ -305,10 +291,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "   APP.ORGANIZATION = ? " +
                     " And "+
                     "    LOWER (NAME) like LOWER (?)"+
-                    " ORDER BY $1 $2 " +
-                    " offset ? limit  ? "+
                     " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
-                    " ORDER BY $1 $2 ";
+                    " ORDER BY $1 $2 offset ? limit ? ";
 
     public static final String GET_APPLICATIONS_BY_TENANT_ID =
                     "   SELECT " +

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantPostgreSQL.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstantPostgreSQL.java
@@ -55,7 +55,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "    LOWER (NAME) like LOWER (?)" +
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " ORDER BY $1 $2 ";
 
 
     public static final String GET_APPLICATIONS_PREFIX_NONE_CASESENSITVE_WITHGROUPID =
@@ -89,7 +90,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "    LOWER (NAME) like LOWER (?)"+
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " ORDER BY $1 $2 ";
 
     public static final String GET_APPLICATIONS_PREFIX_CASESENSITVE_WITH_MULTIGROUPID =
             "select distinct x.*,bl.ENABLED from (" +
@@ -127,7 +129,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "    LOWER (NAME) like LOWER (?)" +
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " ORDER BY $1 $2 ";
 
 
     public static final String GET_APPLICATIONS_PREFIX_NONE_CASESENSITVE_WITH_MULTIGROUPID =
@@ -167,7 +170,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "    LOWER (NAME) like LOWER (?)"+
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " ORDER BY $1 $2 ";
 
 
     public static final String GET_APPLICATIONS_PREFIX_CASESENSITVE =
@@ -201,7 +205,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "    LOWER (NAME) like LOWER (?)"+
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " ORDER BY $1 $2 ";
 
     public static final String GET_APPLICATIONS_PREFIX_NONE_CASESENSITVE =
             "select distinct x.*,bl.ENABLED from (" +
@@ -234,7 +239,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "    LOWER (NAME) like LOWER (?)"+
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " ORDER BY $1 $2 ";
 
     public static final String GET_APPLICATIONS_PREFIX_CASESENSITVE_WITH_ORGSHARING =
             "select distinct x.*,bl.ENABLED from (" +
@@ -267,7 +273,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "    LOWER (NAME) like LOWER (?)"+
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " ORDER BY $1 $2 ";
 
     public static final String GET_APPLICATIONS_PREFIX_NONE_CASESENSITVE_WITH_ORGSHARING =
             "select distinct x.*,bl.ENABLED from (" +
@@ -300,7 +307,8 @@ public class SQLConstantPostgreSQL extends SQLConstants{
                     "    LOWER (NAME) like LOWER (?)"+
                     " ORDER BY $1 $2 " +
                     " offset ? limit  ? "+
-                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) ";
+                    " )x left join AM_BLOCK_CONDITIONS bl on  ( bl.TYPE = 'APPLICATION' AND bl.BLOCK_CONDITION = concat(concat(x.USER_ID,':'),x.name)) "+
+                    " ORDER BY $1 $2 ";
 
     public static final String GET_APPLICATIONS_BY_TENANT_ID =
                     "   SELECT " +


### PR DESCRIPTION
### Purpose
This PR fixes the issue where applications in the Dev Portal are always shown in created order, ignoring the selected sort option (e.g., by name, owner, or policy). This happens only when the db type is postgreSQL.

### Approach
Applied an `ORDER BY` clause at the outermost query level to ensure the chosen sorting option is reflected in the results.