### PR TITLE
API Deletion aws not properly happen due to event failure

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -2899,6 +2899,18 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     "delete event publishing to gateways");
             isError = true;
         }
+        // Delete event publishing to gateways
+        if (api != null && apiId != -1) {
+            APIEvent apiEvent = new APIEvent(UUID.randomUUID().toString(), System.currentTimeMillis(),
+                    APIConstants.EventType.API_DELETE.name(), tenantId, organization, api.getId().getApiName(), apiId,
+                    api.getUuid(), api.getId().getVersion(), api.getType(), api.getContext(),
+                    APIUtil.replaceEmailDomainBack(api.getId().getProviderName()),
+                    api.getStatus(), api.getApiSecurity(), api.getStatus(), api.getVisibility(), api.getVisibleRoles());
+            APIUtil.sendNotification(apiEvent, APIConstants.NotifierType.API.name());
+        } else {
+            log.debug("Event has not published to gateways due to API id has failed to retrieve from DB for API "
+                    + apiUuid + " on organization " + organization);
+        }
 
         // DB delete operations
         if (!isError && api != null) {
@@ -2996,18 +3008,6 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             }
         }
 
-        // Delete event publishing to gateways
-        if (api != null && apiId != -1) {
-            APIEvent apiEvent = new APIEvent(UUID.randomUUID().toString(), System.currentTimeMillis(),
-                    APIConstants.EventType.API_DELETE.name(), tenantId, organization, api.getId().getApiName(), apiId,
-                    api.getUuid(), api.getId().getVersion(), api.getType(), api.getContext(),
-                    APIUtil.replaceEmailDomainBack(api.getId().getProviderName()),
-                    api.getStatus(), api.getApiSecurity(), api.getStatus(), api.getVisibility(), api.getVisibleRoles());
-            APIUtil.sendNotification(apiEvent, APIConstants.NotifierType.API.name());
-        } else {
-            log.debug("Event has not published to gateways due to API id has failed to retrieve from DB for API "
-                    + apiUuid + " on organization " + organization);
-        }
 
         // Logging audit message for API delete
         if (api != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -368,7 +368,7 @@ public class ApiMgtDAO {
         // only check if using CEP based throttling.
         ResultSet resultSet = null;
         PreparedStatement ps = null;
-        String sqlQuery = SQLConstants.ThrottleSQLConstants.IS_ANY_POLICY_CONTENT_AWARE_SQL;
+        String sqlQuery = ThrottleSQLConstants.IS_ANY_POLICY_CONTENT_AWARE_SQL;
 
         try {
             String dbProdName = conn.getMetaData().getDatabaseProductName();
@@ -654,7 +654,7 @@ public class ApiMgtDAO {
                 subscriber.setId(subscriberId);
                 subscriber.setTenantId(rs.getInt("TENANT_ID"));
                 subscriber.setEmail(rs.getString("EMAIL_ADDRESS"));
-                subscriber.setSubscribedDate(new java.util.Date(rs.getTimestamp("DATE_SUBSCRIBED").getTime()));
+                subscriber.setSubscribedDate(new Date(rs.getTimestamp("DATE_SUBSCRIBED").getTime()));
                 return subscriber;
             }
         } catch (SQLException e) {
@@ -2825,7 +2825,7 @@ public class ApiMgtDAO {
      * @param apiUUID      UUID of the API
      * @param organization Organization of the API
      * @return All subscriptions of a given API
-     * @throws org.wso2.carbon.apimgt.api.APIManagementException
+     * @throws APIManagementException
      */
     public long getNoOfSubscriptionsOfAPI(String apiUUID, String organization)
             throws APIManagementException {
@@ -14640,7 +14640,7 @@ public class ApiMgtDAO {
                 query = ThrottleSQLConstants.GET_BLOCK_CONDITIONS_BY_TYPE_AND_EXACT_VALUE_SQL;
                 conditionValue = conditionValue.substring(1, conditionValue.length() - 1);
             } else {
-                query = SQLConstants.ThrottleSQLConstants.GET_BLOCK_CONDITIONS_BY_TYPE_AND_VALUE_SQL;
+                query = ThrottleSQLConstants.GET_BLOCK_CONDITIONS_BY_TYPE_AND_VALUE_SQL;
             }
             connection = APIMgtDBUtil.getConnection();
             selectPreparedStatement = connection.prepareStatement(query);
@@ -23147,6 +23147,31 @@ public class ApiMgtDAO {
         } catch (SQLException e) {
             handleException("Failed to delete all metadata (incl. revisions) for API: " + apiUuid, e);
         }
+    }
+
+    public Map<String, String> getApiExternalApiMappingReferences(String apiId) throws APIManagementException {
+        Map<String, String> references = new HashMap<>();
+        try (Connection connection = APIMgtDBUtil.getConnection();
+             PreparedStatement statement =
+                     connection.prepareStatement(SQLConstants.GET_REFERENCE_ARTIFACTS_SQL)) {
+            statement.setString(1, apiId);
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    String reference = "";
+                    try (InputStream referenceArtifactStream = resultSet.getBinaryStream("REFERENCE_ARTIFACT")) {
+                        if (referenceArtifactStream != null) {
+                            reference = IOUtils.toString(referenceArtifactStream, StandardCharsets.UTF_8);
+                        }
+                    }
+                    String environmentName = resultSet.getString("NAME");
+                    references.put(environmentName, reference);
+                }
+            }
+        } catch (SQLException | IOException e) {
+            handleException("Failed to fetch API - External API mapping for the API ID: " + apiId, e);
+        }
+        return references;
     }
 
     private class SubscriptionInfo {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -3391,6 +3391,9 @@ public class SQLConstants {
 
     public static final String GET_ALL_APIS_OF_ORG = "SELECT API_UUID, API_NAME, API_VERSION, API_PROVIDER, API_TYPE " +
             "FROM AM_API WHERE ORGANIZATION = ?";
+    public static final String GET_REFERENCE_ARTIFACTS_SQL = "SELECT GE.NAME,EMAPPING.REFERENCE_ARTIFACT FROM " +
+            "AM_API_EXTERNAL_API_MAPPING EMAPPING JOIN AM_GATEWAY_ENVIRONMENT GE ON " +
+            "EMAPPING.GATEWAY_ENV_ID=GE.UUID WHERE EMAPPING.API_ID = ?";
 
     /**
      * Throttle related constants

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8602,6 +8602,19 @@ public final class APIUtil {
         return ApiMgtDAO.getInstance().getApiExternalApiMappingReference(apiId, environmentId);
     }
 
+    /**
+     * Get all the external api mapping references of an API
+     *
+     * @param apiId UUID of the API
+     * @return Map of environmentId and referenceArtifact
+     * @throws APIManagementException if an error occurs while getting the mapping references
+     */
+    public static Map<String, String> getApiExternalApiMappingReferenceByApiId(String apiId)
+            throws APIManagementException {
+
+        return ApiMgtDAO.getInstance().getApiExternalApiMappingReferences(apiId);
+    }
+
     public static void deleteApiExternalApiMapping(String apiId, String environmentId)
             throws APIManagementException {
 


### PR DESCRIPTION
API Deletion aws not properly happen due to event failure
This pull request introduces improvements to how externally deployed APIs are undeployed when an API is deleted, as well as some minor code cleanups and refactoring. The main change is a more robust mechanism for retrieving and handling external API mapping references in multiple gateway environments during API deletion, which helps ensure all relevant deployments are properly cleaned up.

### Externally Deployed API Undeployment Improvements

* Refactored the undeployment logic in `ExternallyDeployedApiNotifier` to retrieve all external API mapping references for the API and iterate through them, undeploying from each relevant environment. This replaces the previous logic that only handled one environment at a time and improves reliability when an API is mapped to multiple gateways. Exception handling was also improved to log errors and continue processing. [[1]](diffhunk://#diff-2176e0245609ea6e67f74a6260aba8674ed3c0fcbc24ed7a5a15191819ab9c63L133-R155) [[2]](diffhunk://#diff-89936bdbe5e2d379a69fc65451651e30c344bede612fc302c4cedbcb0964416dR8605-R8610) [[3]](diffhunk://#diff-ac8fc1b7b2d10089084f9f842ad03ac096b64f8c555798aa18a926e0ec663a4cR23152-R23176) [[4]](diffhunk://#diff-cb287976d3a84e29d0703ac5c300f64b18213b2ebe84a04f8b504b754d5491d5R3394-R3396)

* Updated environment retrieval to use `APIUtil.getEnvironments(apiEvent.getTenantDomain())` instead of the read-only gateway environments, ensuring correct tenant-specific environments are used.

### Code Cleanups & Refactoring

* Removed duplicate event publishing logic in `APIProviderImpl.deleteAPI` and ensured event publishing occurs only once in the correct location. [[1]](diffhunk://#diff-19a032cb823fd4f31e79376db6427e305b79949a26979f42d5e7ea0c607cdff2R2902-R2913) [[2]](diffhunk://#diff-19a032cb823fd4f31e79376db6427e305b79949a26979f42d5e7ea0c607cdff2L2999-L3010)

* Standardized usage of SQL constants by referencing `ThrottleSQLConstants` directly instead of through `SQLConstants.ThrottleSQLConstants`. [[1]](diffhunk://#diff-ac8fc1b7b2d10089084f9f842ad03ac096b64f8c555798aa18a926e0ec663a4cL371-R371) [[2]](diffhunk://#diff-ac8fc1b7b2d10089084f9f842ad03ac096b64f8c555798aa18a926e0ec663a4cL14643-R14643)

* Minor JavaDoc and type improvements, such as correcting exception types and using `java.util.Date` consistently. [[1]](diffhunk://#diff-ac8fc1b7b2d10089084f9f842ad03ac096b64f8c555798aa18a926e0ec663a4cL657-R657) [[2]](diffhunk://#diff-ac8fc1b7b2d10089084f9f842ad03ac096b64f8c555798aa18a926e0ec663a4cL2828-R2828)