### PR TITLE
Fix 405 error log by adding /mcp GET dummy resource

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/mcp/McpInitHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/mcp/McpInitHandler.java
@@ -87,6 +87,11 @@ public class McpInitHandler extends AbstractHandler implements ManagedLifecycle 
             if (StringUtils.startsWith(path, APIMgtGatewayConstants.MCP_WELL_KNOWN_RESOURCE) &&
                     StringUtils.equals(APIConstants.HTTP_GET, httpMethod)) {
                 messageContext.setProperty(APIMgtGatewayConstants.MCP_NO_AUTH_REQUEST, true);
+            } else if (StringUtils.startsWith(path,  APIMgtGatewayConstants.MCP_RESOURCE) &&
+                    StringUtils.equals(APIConstants.HTTP_GET, httpMethod)) {
+                McpResponseDto errorResponse = new McpResponseDto("Server-Sent Events (SSE) not supported",
+                        405, null);
+                MCPUtils.handleMCPFailure(messageContext, errorResponse);
             } else { //currently the only other mcp resource available is /mcp POST, it must have a jsonrpc payload
                 boolean isNoAuthMCPRequest = isNoAuthMCPRequest(buildMCPRequest(messageContext));
                 messageContext.setProperty(APIMgtGatewayConstants.MCP_NO_AUTH_REQUEST, isNoAuthMCPRequest);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3733,11 +3733,13 @@ public final class APIConstants {
             public static final int METHOD_NOT_FOUND_CODE = -32601;
             public static final int INVALID_PARAMS_CODE = -32602;
             public static final int INTERNAL_ERROR_CODE = -32603;
+            public static final int CONNECTION_CLOSED = -32000;
             public static final String PARSE_ERROR_MESSAGE = "Parse error";
             public static final String INVALID_REQUEST_MESSAGE = "Invalid Request";
             public static final String METHOD_NOT_FOUND_MESSAGE = "Method not found";
             public static final String INVALID_PARAMS_MESSAGE = "Invalid params";
             public static final String INTERNAL_ERROR_MESSAGE = "Internal error";
+            public static final String CONNECTION_CLOSED_MESSAGE = "Connection closed";
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OAS3Parser.java
@@ -662,6 +662,7 @@ public class OAS3Parser extends APIDefinition {
             modifyGraphQLSwagger(openAPI);
         } else if (APISpecParserConstants.MCP_API.equals(swaggerData.getTransportType())) {
             addDefaultPostPathToSwagger(openAPI, APISpecParserConstants.MCP_RESOURCES_MCP);
+            addDefaultGetPathToSwagger(openAPI, APISpecParserConstants.MCP_RESOURCES_MCP);
             addAuthServerMetaEndpointPathToSwagger(openAPI, APISpecParserConstants.MCP_RESOURCES_WELL_KNOWN);
         } else {
             for (SwaggerData.Resource resource : swaggerData.getResources()) {
@@ -3109,7 +3110,12 @@ public class OAS3Parser extends APIDefinition {
             operation.addExtension(APISpecParserConstants.X_WSO2_DISABLE_SECURITY, true);
         }
 
-        PathItem pathItem = new PathItem();
+        Paths paths = openAPI.getPaths();
+        PathItem pathItem = (paths != null) ? paths.get(resource.getPath()) : null;
+        if (pathItem == null) {
+            pathItem = new PathItem();
+        }
+
         switch (resource.getVerb()) {
             case APISpecParserConstants.HTTP_POST:
                 pathItem.setPost(operation);
@@ -3139,6 +3145,24 @@ public class OAS3Parser extends APIDefinition {
         resource.setPolicy(APISpecParserConstants.DEFAULT_SUB_POLICY_UNLIMITED);
         resource.setPath(path);
         resource.setVerb(APISpecParserConstants.HTTP_POST);
+        addResourceToSwagger(openAPI, resource, true);
+    }
+
+    /**
+     * Adds a default HTTP GET resource to the given {@link OpenAPI} definition.
+     * This resource is configured with application or user-level token authentication and unlimited subscription
+     * policy.
+     *
+     * @param openAPI the {@link OpenAPI} object to which the resource will be added
+     * @param path    the resource path to add
+     */
+    private void addDefaultGetPathToSwagger(OpenAPI openAPI, String path) {
+
+        SwaggerData.Resource resource = new SwaggerData.Resource();
+        resource.setAuthType(APISpecParserConstants.AUTH_APPLICATION_OR_USER_LEVEL_TOKEN);
+        resource.setPolicy(APISpecParserConstants.DEFAULT_SUB_POLICY_UNLIMITED);
+        resource.setPath(path);
+        resource.setVerb(APISpecParserConstants.HTTP_GET);
         addResourceToSwagger(openAPI, resource, true);
     }
 


### PR DESCRIPTION
This PR fixes,
- 405 error log by adding /mcp GET dummy resource (point 4 of https://github.com/wso2/api-manager/issues/4124)