### PR TITLE
Fix select queries related to primary endpoint mappings to handle the presence of multiple Endpoint UUIDs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/constants/SQLConstants.java
@@ -5012,11 +5012,11 @@ public class SQLConstants {
                 "INSERT INTO AM_API_PRIMARY_EP_MAPPING (API_UUID, ENDPOINT_UUID, REVISION_UUID) VALUES(?,?,?)";
 
         public static final String GET_PRIMARY_ENDPOINT_MAPPINGS =
-                "SELECT ENDPOINT_UUID " +
+                "SELECT DISTINCT ENDPOINT_UUID " +
                         "FROM AM_API_PRIMARY_EP_MAPPING WHERE API_UUID = ? AND REVISION_UUID = ?";
 
         public static final String GET_API_PRIMARY_ENDPOINT_UUIDS_BY_API_UUID =
-                "SELECT AME.ENDPOINT_UUID " +
+                "SELECT DISTINCT AME.ENDPOINT_UUID " +
                         "FROM AM_API_ENDPOINTS AME INNER JOIN AM_API_PRIMARY_EP_MAPPING AMPM " +
                         "ON (AMPM.ENDPOINT_UUID = AME.ENDPOINT_UUID AND AMPM.API_UUID = AME.API_UUID " +
                         "AND AMPM.REVISION_UUID = AME.REVISION_UUID) " +
@@ -5034,7 +5034,8 @@ public class SQLConstants {
                         "AME.API_UUID = ? " +
                         "AND AME.ORGANIZATION = ? " +
                         "AND AME.REVISION_UUID = 'Current API' " +
-                        "AND AME.KEY_TYPE = ?";
+                        "AND AME.KEY_TYPE = ? " +
+                        "LIMIT 1";
 
         public static final String GET_API_PRIMARY_ENDPOINT_UUID_BY_API_UUID_AND_KEY_TYPE_REVISION =
                 "SELECT AME.ENDPOINT_UUID " +
@@ -5045,7 +5046,8 @@ public class SQLConstants {
                         "AME.API_UUID = ? " +
                         "AND AME.ORGANIZATION = ? " +
                         "AND AME.REVISION_UUID = ? " +
-                        "AND AME.KEY_TYPE = ?";
+                        "AND AME.KEY_TYPE = ? " +
+                        "LIMIT 1";
 
         public static final String DELETE_API_ENDPOINTS_BY_API_UUID_AND_REVISION_UUID =
                 "DELETE FROM AM_API_ENDPOINTS WHERE API_UUID = ? AND REVISION_UUID = ? ";


### PR DESCRIPTION
### Purpose

This pull request updates several SQL query constants in `SQLConstants.java` to improve data accuracy and query performance for API endpoint mappings. The main changes involve ensuring unique results are returned and limiting results to a single entry where appropriate.

**Query accuracy and performance improvements:**

* Added `DISTINCT` to the `SELECT ENDPOINT_UUID` queries in `GET_PRIMARY_ENDPOINT_MAPPINGS` and `GET_API_PRIMARY_ENDPOINT_UUIDS_BY_API_UUID` to prevent duplicate endpoint UUIDs from being returned.
* Added `LIMIT 1` to the queries in `GET_API_PRIMARY_ENDPOINT_UUID_BY_API_UUID_AND_KEY_TYPE_CURRENT` and `GET_API_PRIMARY_ENDPOINT_UUID_BY_API_UUID_AND_KEY_TYPE_REVISION` to ensure only one endpoint UUID is returned for the given criteria, improving efficiency and preventing multiple results. [[1]](diffhunk://#diff-cb287976d3a84e29d0703ac5c300f64b18213b2ebe84a04f8b504b754d5491d5L5037-R5038) [[2]](diffhunk://#diff-cb287976d3a84e29d0703ac5c300f64b18213b2ebe84a04f8b504b754d5491d5L5048-R5050)

- Related PR: https://github.com/wso2/carbon-apimgt/pull/13400