### PR TITLE
Fix publishing discovered apis

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/LifeCycleUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/LifeCycleUtils.java
@@ -171,15 +171,18 @@ public class LifeCycleUtils {
                         || endPoint != null && endPoint.trim().length() > 0
                         || api.isAdvertiseOnly() && (api.getApiExternalProductionEndpoint() != null
                         || api.getApiExternalSandboxEndpoint() != null)) {
-                    if ((isOauthProtected && (tiers == null || tiers.size() == 0)) && !api.isAdvertiseOnly()) {
+                    if ((isOauthProtected && (tiers == null || tiers.size() == 0)) && !api.isAdvertiseOnly()
+                            && !api.isInitiatedFromGateway()) {
                         throw new APIManagementException("Failed to publish service to API store. No Tiers selected",
                                 ExceptionCodes.from(ExceptionCodes.FAILED_PUBLISHING_API_NO_TIERS_SELECTED,
                                         api.getUuid()));
                     }
                 } else {
-                    throw new APIManagementException("Failed to publish service to API store. No endpoint selected",
-                            ExceptionCodes.from(ExceptionCodes.FAILED_PUBLISHING_API_NO_ENDPOINT_SELECTED,
-                                    api.getUuid()));
+                    if (!api.isInitiatedFromGateway()) {
+                        throw new APIManagementException("Failed to publish service to API store. No endpoint selected",
+                                ExceptionCodes.from(ExceptionCodes.FAILED_PUBLISHING_API_NO_ENDPOINT_SELECTED,
+                                        api.getUuid()));
+                    }
                 }
             }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/LifeCycleUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/LifeCycleUtils.java
@@ -173,13 +173,17 @@ public class LifeCycleUtils {
                         || api.getApiExternalSandboxEndpoint() != null)) {
                     if ((isOauthProtected && (tiers == null || tiers.size() == 0)) && !api.isAdvertiseOnly()
                             && !api.isInitiatedFromGateway()) {
-                        throw new APIManagementException("Failed to publish service to API store. No Tiers selected",
+                        String errorMessage = "Failed to publish service to API store. No Tiers selected";
+                        log.error(errorMessage + " for API: " + api.getUuid());
+                        throw new APIManagementException(errorMessage,
                                 ExceptionCodes.from(ExceptionCodes.FAILED_PUBLISHING_API_NO_TIERS_SELECTED,
                                         api.getUuid()));
                     }
                 } else {
                     if (!api.isInitiatedFromGateway()) {
-                        throw new APIManagementException("Failed to publish service to API store. No endpoint selected",
+                        String errorMessage = "Failed to publish service to API store. No endpoint selected";
+                        log.error(errorMessage + " for API: " + api.getUuid());
+                        throw new APIManagementException(errorMessage,
                                 ExceptionCodes.from(ExceptionCodes.FAILED_PUBLISHING_API_NO_ENDPOINT_SELECTED,
                                         api.getUuid()));
                     }


### PR DESCRIPTION
This PR fixes the issue where discovered apis cannot be published when they do not have tiers attached or no backend endpoints are present. It should not be prevented from publishing if this information is not available.