### PR TITLE
Add configurable thread pool parameters for SynapseArtifactGenerator

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3819,4 +3819,15 @@ public final class APIConstants {
             REGISTERED
         }
     }
+
+    // Constants related to Synapse Artifact Generator
+    public static class SynapseArtifactGenerator {
+        public static final String SYNAPSE_ARTIFACT_GENERATOR_CONFIG = "SynapseArtifactGenerator.";
+        public static final String THREAD_POOL_CONFIG = SYNAPSE_ARTIFACT_GENERATOR_CONFIG + "ThreadPool.";
+        public static final String CORE_POOL_SIZE = THREAD_POOL_CONFIG + "CorePoolSize";
+        public static final String MAX_POOL_SIZE = THREAD_POOL_CONFIG + "MaxPoolSize";
+        public static final String KEEP_ALIVE_TIME_MS = THREAD_POOL_CONFIG + "KeepAliveTimeMs";
+        public static final String QUEUE_CAPACITY = THREAD_POOL_CONFIG + "QueueCapacity";
+    }
+
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -257,5 +257,9 @@
       "uri_path": "/api/am/gateway/*",
       "http_method": "GET,DELETE,PUT,POST"
     }
-  ]
+  ],
+  "apim.synapse_artifact_generator.thread_pool.core_pool_size": "10",
+  "apim.synapse_artifact_generator.thread_pool.max_pool_size": "50",
+  "apim.synapse_artifact_generator.thread_pool.keep_alive_time_ms": "60000",
+  "apim.synapse_artifact_generator.thread_pool.queue_capacity": "1000"
 }

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -2048,5 +2048,15 @@
           </GatewayCleanup>
       </GatewayNotificationConfiguration>
 
+      <!-- SynapseArtifactGenerator thread pool configuration -->
+      <SynapseArtifactGenerator>
+          <ThreadPool>
+              <CorePoolSize>{{apim.synapse_artifact_generator.thread_pool.core_pool_size}}</CorePoolSize>
+              <MaxPoolSize>{{apim.synapse_artifact_generator.thread_pool.max_pool_size}}</MaxPoolSize>
+              <KeepAliveTimeMs>{{apim.synapse_artifact_generator.thread_pool.keep_alive_time_ms}}</KeepAliveTimeMs>
+              <QueueCapacity>{{apim.synapse_artifact_generator.thread_pool.queue_capacity}}</QueueCapacity>
+          </ThreadPool>
+      </SynapseArtifactGenerator>
+
       <EnableFailoverInLoadbalancedEndpoints>{{apim.endpoint_config.loadbalanced.enable_failover}}</EnableFailoverInLoadbalancedEndpoints>
 </APIManager>


### PR DESCRIPTION
### Purpose

This PR introduces configurability for the thread pool parameters used by the **SynapseArtifactGenerator**.

Previously, the thread pool executor was initialized with hard-coded constants for core pool size, max pool size, keep-alive time, and queue capacity. This limited flexibility when tuning performance in different deployment environments.

With this change, these parameters can now be configured using the `default.json`, allowing operators to optimize resource usage for different workloads and scale based on API artifact generation demand.

The following values are the configurable parameters in the `default.json` file, and by default they use the tested & verified values shown below:

```
  "apim.synapse_artifact_generator.thread_pool.core_pool_size": "10",
  "apim.synapse_artifact_generator.thread_pool.max_pool_size": "50",
  "apim.synapse_artifact_generator.thread_pool.keep_alive_time_ms": "60000",
  "apim.synapse_artifact_generator.thread_pool.queue_capacity": "1000",
```
