### PR TITLE
Improving Websocket logging by adding API URI into logs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/InboundWebSocketProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/inbound/websocket/InboundWebSocketProcessor.java
@@ -333,7 +333,8 @@ public class InboundWebSocketProcessor implements WebSocketProcessor {
             MessageContext synCtx = getMessageContext(inboundMessageContext);
             API api = InboundWebsocketProcessorUtil.getApi(synCtx, inboundMessageContext);
             if (api == null) {
-                throw new ResourceNotFoundException("No matching API found to dispatch the request");
+                throw new ResourceNotFoundException("No matching API was found to dispatch the request for path : "
+                        + inboundMessageContext.getRequestPath());
             }
             inboundMessageContext.setApi(api);
             reConstructFullUriWithVersion(req, synCtx, inboundMessageContext);
@@ -362,7 +363,8 @@ public class InboundWebSocketProcessor implements WebSocketProcessor {
             if (selectedResource == null) {
                 WebSocketUtils.setApiPropertyToChannel(ctx, SynapseConstants.ERROR_CODE,
                         org.wso2.carbon.apimgt.gateway.handlers.analytics.Constants.RESOURCE_NOT_FOUND_ERROR_CODE);
-                throw new ResourceNotFoundException("No matching resource found to dispatch the request");
+                throw new ResourceNotFoundException("No matching resource was found to dispatch the request for path : "
+                        + inboundMessageContext.getRequestPath());
             }
             if (APIConstants.GRAPHQL_API.equals(inboundMessageContext.getElectedAPI().getApiType())) {
                 inboundMessageContext.setGraphQLSchemaDTO(DataHolder.getInstance()


### PR DESCRIPTION
When APIM(4.6.0-alpha2) is not able to establish connection with websocket client, current error does not include the invalid url.
```
ERROR - InboundWebSocketProcessor No matching API found to dispatch the request.
ERROR - InboundWebSocketProcessor No matching resource found to dispatch the request 
```
This fix improve it by adding the url.
```
ERROR - InboundWebSocketProcessor No matching API was found to dispatch the request for path : /websocket2/1.0.9
ERROR - InboundWebSocketProcessor No matching resource was found to dispatch the request for path : /websocket/1.0.0/chat2
```

Fixes wso2-enterprise/wso2-apim-internal/issues/6382