### PR TITLE
Add Netty dependency to federated gateway feature

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.federated.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.federated.gateway.feature/pom.xml
@@ -74,6 +74,30 @@
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.federated.gateway:${carbon.apimgt.version}
                                 </bundleDef>
                                 <bundleDef>
+                                    io.netty:netty-common:${netty.version}
+                                </bundleDef>
+                                <bundleDef>
+                                    io.netty:netty-buffer:${netty.version}
+                                </bundleDef>
+                                <bundleDef>
+                                    io.netty:netty-transport:${netty.version}
+                                </bundleDef>
+                                <bundleDef>
+                                    io.netty:netty-codec:${netty.version}
+                                </bundleDef>
+                                <bundleDef>
+                                    io.netty:netty-handler:${netty.version}
+                                </bundleDef>
+                                <bundleDef>
+                                    io.netty:netty-resolver:${netty.version}
+                                </bundleDef>
+                                <bundleDef>
+                                    io.netty:netty-resolver-dns:${netty.version}
+                                </bundleDef>
+                                <bundleDef>
+                                    io.netty:netty-codec-dns:${netty.version}
+                                </bundleDef>
+                                <bundleDef>
                                     io.netty:netty-codec-http:${netty.version}
                                 </bundleDef>
                                 <bundleDef>

--- a/features/apimgt/org.wso2.carbon.apimgt.federated.gateway.feature/pom.xml
+++ b/features/apimgt/org.wso2.carbon.apimgt.federated.gateway.feature/pom.xml
@@ -73,6 +73,18 @@
                                 <bundleDef>
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.federated.gateway:${carbon.apimgt.version}
                                 </bundleDef>
+                                <bundleDef>
+                                    io.netty:netty-codec-http:${netty.version}
+                                </bundleDef>
+                                <bundleDef>
+                                    io.netty:netty-codec-http2:${netty.version}
+                                </bundleDef>
+                                <bundleDef>
+                                    io.netty:netty-codec-socks:${netty.version}
+                                </bundleDef>
+                                <bundleDef>
+                                    io.netty:netty-handler-proxy:${netty.version}
+                                </bundleDef>
                             </bundles>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -2328,5 +2328,6 @@
         <tika.version>2.7.0</tika.version>
         <batik.version>1.17</batik.version>
         <mcp.transformer.version>0.9.0</mcp.transformer.version>
+        <netty.version>4.1.126.Final</netty.version>
     </properties>
 </project>


### PR DESCRIPTION
### Purpose

- Resolves https://github.com/wso2/api-manager/issues/4313
- Updates the project dependencies to include several Netty modules in the federated gateway feature, and introduces a new property for the Netty version in the root `pom.xml`. 

**Federated gateway dependency enhancements:**

* Added the following Netty modules as bundle dependencies in `features/apimgt/org.wso2.carbon.apimgt.federated.gateway.feature/pom.xml`:
  * `netty-codec-http`
  * `netty-codec-http2`
  * `netty-codec-socks`
  * `netty-handler-proxy`