### PR TITLE
Fix CORS error when invoking Anthropic AI APIs

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/api_definitions/anthropic_api.yaml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/api_definitions/anthropic_api.yaml
@@ -4446,3 +4446,25 @@ paths:
           $ref: '#/components/responses/Error500'
         '529':
           $ref: '#/components/responses/Error529'
+x-wso2-cors:
+  corsConfigurationEnabled: false
+  accessControlAllowOrigins:
+    - '*'
+  accessControlAllowCredentials: false
+  accessControlAllowHeaders:
+    - authorization
+    - Access-Control-Allow-Origin
+    - Content-Type
+    - SOAPAction
+    - apikey
+    - Internal-Key
+    - anthropic-version
+    - anthropic-beta
+    - anthropic-dangerous-direct-browser-access
+  accessControlAllowMethods:
+    - GET
+    - PUT
+    - POST
+    - DELETE
+    - PATCH
+    - OPTIONS


### PR DESCRIPTION
A CORS error occurs when trying out Anthropic AI APIs via the publisher and dev portal tryout consoles. This PR fixes the issue by adding the relevant cors headers by default.

Reference: https://github.com/wso2/api-manager/issues/4374