### PR TITLE
Add backend support for env ID path param to be base64 encoded

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -200,14 +200,17 @@ public class APIAdminImpl implements APIAdmin {
                     }
                 } catch (IllegalArgumentException e) {
                     //This catches errors if the string is not valid Base64
+                    String errorMessage = String.format("Provided env UUID: %s is not a valid Base64 encoded string. " +
+                            "Environment not found.", uuid);
                     if (log.isDebugEnabled()) {
-                        log.debug("Provided env UUID: " + uuid + " is not a valid Base64 encoded string. " +
-                                "Hence not decoding.", e);
+                        log.debug(errorMessage, e);
                     }
+                    throw new APIMgtResourceNotFoundException(errorMessage, ExceptionCodes.from(
+                            ExceptionCodes.GATEWAY_ENVIRONMENT_NOT_FOUND, String.format("UUID '%s'", uuid)));
                 }
             }
         }
-        if (env != null && env.getProvider().equalsIgnoreCase(APIConstants.EXTERNAL_GATEWAY_VENDOR)) {
+        if (env.getProvider().equalsIgnoreCase(APIConstants.EXTERNAL_GATEWAY_VENDOR)) {
             maskValues(env);
         }
         return env;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -106,6 +106,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -181,13 +182,17 @@ public class APIAdminImpl implements APIAdmin {
             if (env == null) {
                 //try decoding the UUID and search again
                 try {
-                    String decodedEnvId = new String(Base64.getDecoder().decode(uuid));
+                    String decodedEnvId = new String(Base64.getDecoder().decode(uuid), StandardCharsets.UTF_8);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Attempting to retrieve environment with decoded UUID: " + decodedEnvId);
+                    }
                     env = APIUtil.getReadOnlyEnvironments().get(decodedEnvId);
                     if (env == null) {
                         env = apiMgtDAO.getEnvironment(tenantDomain, decodedEnvId);
                         if (env == null) {
-                            String errorMessage = String.format("Failed to retrieve Environment with UUID %s." +
+                            String errorMessage = String.format("Failed to retrieve Environment with plain text UUID %s." +
                                     " Environment not found", uuid);
+                            log.error(errorMessage);
                             throw new APIMgtResourceNotFoundException(errorMessage, ExceptionCodes.from(
                                     ExceptionCodes.GATEWAY_ENVIRONMENT_NOT_FOUND, String.format("UUID '%s'", uuid))
                             );

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -7228,7 +7228,8 @@ components:
       name: environmentId
       in: path
       description: |
-        Environment UUID (or Environment name defined in config)
+        Environment UUID (or Environment name defined in config), in case the ID contains special characters it should 
+        be base64 encoded
       required: true
       schema:
         type: string


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/4368

- The plain text env ID is first searched in the readonly GW set, if a match is not found
- The plain text env ID is then searched in the DB, if a match is not found then also,
- The base64 decoded text env ID is first searched in the readonly GW set, if a match is not found then also,
- The base64 decoded text env ID is then searched in the DB, is no env is found after all these 4 checks, `APIMgtResourceNotFoundException` will be thrown.

Related admin UI improvement PR : https://github.com/wso2/apim-apps/pull/1135