### PR TITLE
Fix migration issue with governance

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -224,7 +224,7 @@ public class ExportUtils {
         String exportAPIBasePath = exportFolder.toString();
         String archivePath = exportAPIBasePath
                 .concat(File.separator + apiIdentifier.getApiName() + "-" + apiIdentifier.getVersion());
-        tenantId = APIUtil.getTenantId(userName);
+        tenantId = APIUtil.getTenantIdFromTenantDomain(organization);
         CommonUtil.createDirectory(archivePath);
 
         if (preserveDocs) {
@@ -507,7 +507,6 @@ public class ExportUtils {
         String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
         List<Documentation> docList = apiProvider.getAllDocumentation(identifier.getUUID(), tenantDomain);
         if (!docList.isEmpty()) {
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();
             String docDirectoryPath = archivePath + File.separator + ImportExportConstants.DOCUMENT_DIRECTORY;
             CommonUtil.createDirectory(docDirectoryPath);
             try {


### PR DESCRIPTION
This pull request updates tenant identification logic and removes unnecessary code in the API export utility. The main changes improve multi-tenancy support and clean up the codebase.

Multi-tenancy improvements:
* Changed tenant ID retrieval in `exportAPI` to use `APIUtil.getTenantIdFromTenantDomain(organization)` instead of `APIUtil.getTenantId(userName)`, making tenant identification more robust and organization-driven.

Code cleanup:
* Removed the unused instantiation of `Gson` in `addDocumentationToArchive`, reducing unnecessary object creation.