### PR TITLE
fix: prevent JSONException when creating SSE API without endpoint config

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/AsyncApiParser.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/AsyncApiParser.java
@@ -1948,19 +1948,22 @@ public class AsyncApiParser extends APIDefinition {
         aaiDocument.info.title = api.getId().getName();
         aaiDocument.info.version = api.getId().getVersion();
         if (!APISpecParserConstants.API_TYPE_WEBSUB.equals(api.getType()) && !APISpecParserConstants.API_TYPE_WS.equals(api.getType())) {
-            JSONObject endpointConfig = new JSONObject(api.getEndpointConfig());
+            String endpointConfigString = api.getEndpointConfig();
+            if (StringUtils.isNotEmpty(endpointConfigString)) {
+                JSONObject endpointConfig = new JSONObject(endpointConfigString);
 
-            if (endpointConfig.has(APISpecParserConstants.ENDPOINT_PRODUCTION_ENDPOINTS)) {
-                AaiServer prodServer = getAaiServer(api, aaiDocument, endpointConfig,
-                                                    APISpecParserConstants.GATEWAY_ENV_TYPE_PRODUCTION,
-                                                    APISpecParserConstants.ENDPOINT_PRODUCTION_ENDPOINTS);
-                aaiDocument.addServer(APISpecParserConstants.GATEWAY_ENV_TYPE_PRODUCTION, prodServer);
-            }
-            if (endpointConfig.has(APISpecParserConstants.ENDPOINT_SANDBOX_ENDPOINTS)) {
-                AaiServer sandboxServer = getAaiServer(api, aaiDocument, endpointConfig,
-                                                    APISpecParserConstants.GATEWAY_ENV_TYPE_SANDBOX,
-                                                    APISpecParserConstants.ENDPOINT_SANDBOX_ENDPOINTS);
-                aaiDocument.addServer(APISpecParserConstants.GATEWAY_ENV_TYPE_SANDBOX, sandboxServer);
+                if (endpointConfig.has(APISpecParserConstants.ENDPOINT_PRODUCTION_ENDPOINTS)) {
+                    AaiServer prodServer = getAaiServer(api, aaiDocument, endpointConfig,
+                                                        APISpecParserConstants.GATEWAY_ENV_TYPE_PRODUCTION,
+                                                        APISpecParserConstants.ENDPOINT_PRODUCTION_ENDPOINTS);
+                    aaiDocument.addServer(APISpecParserConstants.GATEWAY_ENV_TYPE_PRODUCTION, prodServer);
+                }
+                if (endpointConfig.has(APISpecParserConstants.ENDPOINT_SANDBOX_ENDPOINTS)) {
+                    AaiServer sandboxServer = getAaiServer(api, aaiDocument, endpointConfig,
+                                                        APISpecParserConstants.GATEWAY_ENV_TYPE_SANDBOX,
+                                                        APISpecParserConstants.ENDPOINT_SANDBOX_ENDPOINTS);
+                    aaiDocument.addServer(APISpecParserConstants.GATEWAY_ENV_TYPE_SANDBOX, sandboxServer);
+                }
             }
         }
 


### PR DESCRIPTION

## Problem  
When creating a **Server-Sent Events (SSE) API** without specifying an endpoint configuration, the system fails with the following error:  

```
JSONException: A JSONObject text must begin with '{' at 0 [character 1 line 1]
```

This occurs during the execution of `generateAsyncAPIDefinition()` in the **AsyncApiParser** class.

## Root Cause  
The `generateAsyncAPIDefinition()` method directly attempts to parse the endpoint configuration returned by `api.getEndpointConfig()` as JSON.  
- When the endpoint configuration is **null** or an **empty string**, the `JSONObject` constructor fails because it expects a valid JSON object string starting with `{`.  
- A similar safeguard exists in the `updateAsyncAPIDefinition()` method but was missing here.

## Solution  
Added a **null/empty check** for the endpoint configuration string in the `generateAsyncAPIDefinition()` method before attempting JSON parsing.  
- This ensures the method gracefully handles cases where no endpoint configuration is provided.  
- The fix aligns the behavior with the existing pattern used in `updateAsyncAPIDefinition()`.

## Related Issue
- https://github.com/wso2/api-manager/issues/4139