### PR TITLE
Enable cors for anthropic API

### DIFF
--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/api_definitions/anthropic_api.yaml
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/api_definitions/anthropic_api.yaml
@@ -4447,7 +4447,7 @@ paths:
         '529':
           $ref: '#/components/responses/Error529'
 x-wso2-cors:
-  corsConfigurationEnabled: false
+  corsConfigurationEnabled: true
   accessControlAllowOrigins:
     - '*'
   accessControlAllowCredentials: false


### PR DESCRIPTION
A CORS error occurs when trying out Anthropic AI APIs via the publisher and dev portal tryout consoles. This enables the cors configuration by default for anthropic AI API.