### PR TITLE
Upgrade rule validator version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2217,7 +2217,7 @@
 
         <carbon.throttle.module.version>4.2.1</carbon.throttle.module.version>
 
-        <rule.validator.version>1.0.1</rule.validator.version>
+        <rule.validator.version>1.0.2</rule.validator.version>
 
         <!-- apache cxf version -->
         <cxf.version>3.6.8</cxf.version>


### PR DESCRIPTION
## Purpose

This pull request makes a minor update to the `pom.xml` file, specifically bumping the version of the `rule.validator` dependency from `1.0.1` to `1.0.2`.