### PR TITLE
Fix internal server error when adding deny policy with invalid condition

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ThrottlingApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/ThrottlingApiServiceImpl.java
@@ -1480,7 +1480,7 @@ public class ThrottlingApiServiceImpl implements ThrottlingApiService {
             } else {
                 String errorMessage = "Error while adding Blocking Condition. Condition type: "
                         + body.getConditionType() + ", " + "value: " + body.getConditionValue() + ". " + e.getMessage();
-                RestApiUtil.handleInternalServerError(errorMessage, e, log);
+                RestApiUtil.handleBadRequest(errorMessage, e, log);
             }
         } catch (URISyntaxException e) {
             String errorMessage = "Error while retrieving Blocking Condition resource location: Condition type: "


### PR DESCRIPTION
$subject

Fix: [Adding an deny policy with invalid condition result in internal server error #4253](https://github.com/wso2/api-manager/issues/4253)

changed from handleInternalServerError to handleBadRequest to return 400 bad request when POST on deny-policies is called

https://github.com/user-attachments/assets/e9280084-f7ec-4b78-90b0-579cefd9cc7b


