### PR TITLE
Improving cross tenant subscription approval work flow

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/WorkflowUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/WorkflowUtils.java
@@ -114,7 +114,7 @@ public class WorkflowUtils {
             if (sub.getAPIIdentifier() != null) {
                 subscriptionEvent = new SubscriptionEvent(UUID.randomUUID().toString(),
                         System.currentTimeMillis(), APIConstants.EventType.SUBSCRIPTIONS_CREATE.name(),
-                        subWFDto.getTenantId(), orgId,
+                        subWFDto.getTenantId(), subWFDto.getTenantDomain(),
                         Integer.parseInt(subWFDto.getWorkflowReference()), sub.getUUID(), sub.getIdentifier().getId(),
                         sub.getIdentifier().getUUID(), sub.getApplication().getId(), sub.getApplication().getUUID(),
                         sub.getTier().getName(), sub.getSubCreatedStatus(), sub.getIdentifier().getName(),
@@ -122,7 +122,7 @@ public class WorkflowUtils {
             } else {
                 subscriptionEvent = new SubscriptionEvent(UUID.randomUUID().toString(),
                         System.currentTimeMillis(), APIConstants.EventType.SUBSCRIPTIONS_CREATE.name(),
-                        subWFDto.getTenantId(), orgId,
+                        subWFDto.getTenantId(), subWFDto.getTenantDomain(),
                         Integer.parseInt(subWFDto.getWorkflowReference()), sub.getUUID(), sub.getProductId().getId(),
                         sub.getProductId().getUUID(), sub.getApplication().getId(), sub.getApplication().getUUID(),
                         sub.getTier().getName(), sub.getSubCreatedStatus(), sub.getIdentifier().getName(),


### PR DESCRIPTION
### Purpose
Further improvements for wso2/carbon-apimgt/pull/13430 to prevent subscription inactive error even after approving the subscription.

### Approach 
Replacing orgId(which populate as null) with tenant domain in subscription create event.