### PR TITLE
Fix documentation file overwrite issue by using docId for path while maintaining original name.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/src/main/java/org/wso2/carbon/apimgt/persistence/RegistryPersistenceImpl.java
@@ -2769,8 +2769,9 @@ public class RegistryPersistenceImpl implements APIPersistence {
             String visibleOrgs = getOrganizationVisibilityForApiArtifact(registry, apiId);
             if (DocumentContent.ContentSourceType.FILE.equals(content.getSourceType())) {
                 ResourceFile resource = content.getResourceFile();
-                String filePath = RegistryPersistenceDocUtil.getDocumentFilePath(apiProviderName, apiName, apiVersion,
-                        resource.getName());
+                String filePath = RegistryPersistenceDocUtil.getDocumentPath(apiProviderName, apiName, apiVersion)
+                        + APIConstants.DOCUMENT_FILE_DIR + RegistryConstants.PATH_SEPARATOR
+                        + docId + RegistryConstants.PATH_SEPARATOR + resource.getName();
                 String visibility = apiArtifact.getAttribute(APIConstants.API_OVERVIEW_VISIBILITY);
                 String visibleRolesList = apiArtifact.getAttribute(APIConstants.API_OVERVIEW_VISIBLE_ROLES);
                 String[] visibleRoles = new String[0];


### PR DESCRIPTION
Resolves wso2/api-manager#3891

What was the problem?
When multiple API documentation files with the same filename were uploaded, they would overwrite each other in the registry storage. This occurred because the file storage path only used the filename without any unique identifier, causing files like `guide.pdf` from different documents to collide.

How was this fixed?
This pull request implements a docID-based approach to ensure each document file gets a unique storage location while preserving the original filename for user facing purposes.

How to test this
1. Log in to the Publisher portal and create an API
2. Navigate to the API's Documents section
3. Add two different documents (e.g., "User Guide" and "API Reference")
4. Select Type File and Upload files with the same name (e.g., `documentation.pdf`) to both documents
5. Verify that both files are stored successfully without overwriting each other
6. Download both files and verify they have the correct original filename
7. Verify the files contain different content (the correct content for each document)