### PR TITLE
Improving lambda backend invocation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
@@ -228,26 +228,30 @@ public class AWSLambdaMediator extends AbstractMediator implements ManagedLifecy
             }
             payload.add(PATH_PARAMETERS, pathParameters);
             payload.add(QUERY_STRING_PARAMETERS, queryStringParameters);
-            payload.addProperty(HTTP_METHOD, (String) messageContext.getProperty(APIConstants.REST_METHOD));
+            String httpMethod = (String) messageContext.getProperty(APIConstants.REST_METHOD);
+            payload.addProperty(HTTP_METHOD, httpMethod);
             payload.addProperty(PATH, (String) messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE));
 
             // Set lambda backend invocation start time for analytics
             messageContext.setProperty(Constants.BACKEND_START_TIME_PROPERTY, System.currentTimeMillis());
 
-            String body = "{}";
-            if (JsonUtil.hasAJsonPayload(axis2MessageContext)) {
-                body = JsonUtil.jsonPayloadToString(axis2MessageContext);
-                if (isContentEncodingEnabled) {
-                    body = Base64.encodeBase64String(body.getBytes());
+            if (!APIConstants.HTTP_GET.equalsIgnoreCase(httpMethod) && !APIConstants.HTTP_HEAD.equalsIgnoreCase(httpMethod)) {
+                String body = "{}";
+                if (JsonUtil.hasAJsonPayload(axis2MessageContext)) {
+                    body = JsonUtil.jsonPayloadToString(axis2MessageContext);
+                    if (isContentEncodingEnabled) {
+                        body = Base64.encodeBase64String(body.getBytes());
+                    }
+                } else {
+                    String multipartContent = extractFormDataContent(axis2MessageContext);
+                    if (StringUtils.isNotEmpty(multipartContent)) {
+                        body = isContentEncodingEnabled ? Base64.encodeBase64String(multipartContent.getBytes()) :
+                                multipartContent;
+                    }
                 }
-            } else {
-                String multipartContent = extractFormDataContent(axis2MessageContext);
-                if (StringUtils.isNotEmpty(multipartContent)) {
-                    body = isContentEncodingEnabled ? Base64.encodeBase64String(multipartContent.getBytes()) :
-                            multipartContent;
-                }
+                payload.addProperty(BODY_PARAMETER, body);
             }
-            payload.addProperty(BODY_PARAMETER, body);
+
             payload.addProperty(IS_BASE64_ENCODED_PARAMETER, isContentEncodingEnabled);
 
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
## Purpose

Currently, when Lambda backends are integrated with WSO2 API Manager, a request body is sent for all Lambda API invocations by default. For GET/HEAD requests, an empty body is sent. However, according to HTTP standards, methods such as GET and HEAD should not include a request body.

This PR fixes the issue by ensuring that request body parameters are only sent for methods other than GET/HEAD.

## Approach

- Introduced a condition to check the HTTP method of the request
- Ensured that the request body is processed and attached to the payload only for methods other than GET/HEAD
- For GET/HEAD requests, the body is  omitted from the invocation payload

## Related issues

- Fixes https://github.com/wso2/api-manager/issues/4813