### PR TITLE
Fix tracing startup: Jaeger via OTLP/gRPC + update tracing orbit deps

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/JaegerTelemetry.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/JaegerTelemetry.java
@@ -21,7 +21,7 @@ package org.wso2.carbon.apimgt.tracing.telemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -56,17 +56,17 @@ public class JaegerTelemetry implements APIMOpenTelemetry {
                 Integer.parseInt(configuration.getFirstProperty(TelemetryConstants.JAEGER_CONFIG_PORT))
                 : TelemetryConstants.JAEGER_DEFAULT_PORT;
 
-        JaegerGrpcSpanExporter jaegerExporter = JaegerGrpcSpanExporter.builder()
-                .setEndpoint("http://" + hostname + ":" + port)
-                .setTimeout(30, TimeUnit.SECONDS)
-                .build();
+        OtlpGrpcSpanExporter spanExporter = OtlpGrpcSpanExporter.builder()
+            .setEndpoint("http://" + hostname + ":" + port)
+            .setTimeout(30, TimeUnit.SECONDS)
+            .build();
 
         if (log.isDebugEnabled()) {
-            log.debug("Jaeger exporter: " + jaegerExporter + " is configured at http://" + hostname + ":" + port);
+            log.debug("Jaeger OTLP gRPC exporter: " + spanExporter + " is configured at http://" + hostname + ":" + port);
         }
 
         sdkTracerProvider = SdkTracerProvider.builder()
-                .addSpanProcessor(BatchSpanProcessor.builder(jaegerExporter).build())
+            .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
                 .setResource(TelemetryUtil.getTracerProviderResource(serviceName))
                 .build();
 

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/TelemetryConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/TelemetryConstants.java
@@ -41,7 +41,7 @@ public class TelemetryConstants {
      */
     static final String JAEGER_CONFIG_PORT = "OpenTelemetry.RemoteTracer.Port";
     static final String JAEGER_CONFIG_HOST = "OpenTelemetry.RemoteTracer.HostName";
-    static final int JAEGER_DEFAULT_PORT = 14250;
+    static final int JAEGER_DEFAULT_PORT = 4317;     // OTLP/gRPC default port of Jaeger
     static final String JAEGER_DEFAULT_HOST = "localhost";
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -2278,10 +2278,10 @@
         <swagger3-codegen-maven-plugin.version>3.0.19</swagger3-codegen-maven-plugin.version>
         <swagger3.core.version>2.2.20</swagger3.core.version>
         <javax.enterprise.version>2.0</javax.enterprise.version>
-        <jaeger.client.version>1.8.0.wso2v1</jaeger.client.version>
-        <zipkin.sender.okhttp3.version>2.17.2.wso2v2</zipkin.sender.okhttp3.version>
-        <zipkin.reporter.version>2.17.2</zipkin.reporter.version>
-        <zipkin.reporter.version.range>[2.17,4)</zipkin.reporter.version.range>
+        <jaeger.client.version>1.8.0.wso2v2</jaeger.client.version>
+        <zipkin.sender.okhttp3.version>3.5.1.wso2v2</zipkin.sender.okhttp3.version>
+        <zipkin.reporter.version>3.5.1</zipkin.reporter.version>
+        <zipkin.reporter.version.range>[3.5,4)</zipkin.reporter.version.range>
         <brave.opentracing.version>0.32.0</brave.opentracing.version>
         <opentracing.api.version>0.31.0</opentracing.api.version>
         <opentracing.mock.version>0.31.0</opentracing.mock.version>


### PR DESCRIPTION
## Purpose

Resolves : 
-  https://github.com/wso2/api-manager/issues/4775


## Changes
- Switch “jaeger” telemetry implementation to OTLP/gRPC exporter.
- Update default port for Jaeger telemetry to OTLP/gRPC 4317.
- Bump orbit dependencies for Jaeger client + Zipkin reporter sender versions.

## Orbit PR

- https://github.com/wso2/orbit/pull/1346

## Testing

Tested the setup mentioned in [1] , traces were visible in both jaeger and zipkin dashboards

[1] - https://apim.docs.wso2.com/en/latest/monitoring/observability/traces/monitoring-with-opentelemetry/