### PR TITLE
Add tests for app deletion with OAuth keys (#4866)

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/ApplicationDeletionWithKeysIntegrationTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/ApplicationDeletionWithKeysIntegrationTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.WorkflowResponse;
+import org.wso2.carbon.apimgt.api.model.Application;
+import org.wso2.carbon.apimgt.api.model.KeyManager;
+import org.wso2.carbon.apimgt.api.model.Subscriber;
+import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.dto.ApplicationWorkflowDTO;
+import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+import org.wso2.carbon.apimgt.impl.workflow.ApplicationDeletionSimpleWorkflowExecutor;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Integration-style test that exercises the full application deletion flow:
+ * WorkflowExecutor -> ApiMgtDAO.deleteApplication() -> KeyManager.deleteApplication()
+ *
+ * This test specifically reproduces the scenario from issue #4866:
+ * 1. An application is created with generated PRODUCTION keys
+ * 2. The application is deleted
+ * 3. During deletion, keyManager.deleteApplication(consumerKey) is called which
+ *    triggers the IS DCR endpoint to delete the OAuth app
+ * 4. The IS OAuthApplicationMgtListener then tries to look up the already-deleted
+ *    OAuth app and logs an ERROR
+ *
+ * The test verifies that:
+ * - The deletion flow completes successfully even when the key manager operation fails
+ * - All key manager cleanup operations are attempted
+ * - The database transaction is committed
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({KeyManagerHolder.class, APIMgtDBUtil.class, ApiMgtDAO.class,
+        ServiceReferenceHolder.class, APIUtil.class})
+public class ApplicationDeletionWithKeysIntegrationTest {
+
+    private ApiMgtDAO apiMgtDAO;
+    private KeyManager keyManager;
+    private Connection connection;
+    private PreparedStatement preparedStatement;
+    private ResultSet resultSet;
+
+    @Before
+    public void setUp() throws Exception {
+        keyManager = Mockito.mock(KeyManager.class);
+
+        // Mock ServiceReferenceHolder and APIManagerConfiguration (needed by ApiMgtDAO constructor)
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfigurationService configService = Mockito.mock(APIManagerConfigurationService.class);
+        APIManagerConfiguration config = Mockito.mock(APIManagerConfiguration.class);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService()).thenReturn(configService);
+        Mockito.when(configService.getAPIManagerConfiguration()).thenReturn(config);
+
+        // Mock APIUtil (needed by ApiMgtDAO constructor)
+        PowerMockito.mockStatic(APIUtil.class);
+        PowerMockito.when(APIUtil.isMultiGroupAppSharingEnabled()).thenReturn(false);
+
+        PowerMockito.mockStatic(KeyManagerHolder.class);
+        PowerMockito.mockStatic(APIMgtDBUtil.class);
+
+        connection = Mockito.mock(Connection.class);
+        preparedStatement = Mockito.mock(PreparedStatement.class);
+        resultSet = Mockito.mock(ResultSet.class);
+
+        PowerMockito.when(APIMgtDBUtil.getConnection()).thenReturn(connection);
+        Mockito.when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        // Reset the singleton and create a fresh instance with mocked dependencies
+        java.lang.reflect.Field instanceField = ApiMgtDAO.class.getDeclaredField("INSTANCE");
+        instanceField.setAccessible(true);
+        instanceField.set(null, null);
+
+        apiMgtDAO = ApiMgtDAO.getInstance();
+    }
+
+    /**
+     * Full flow test: Simulates creating an app with PRODUCTION keys, then deleting it.
+     * The keyManager.deleteApplication() call triggers the IS DCR delete which causes
+     * the OAuthApplicationMgtListener race condition from issue #4866.
+     *
+     * Expected: The deletion completes successfully. The error from the key manager is
+     * caught and logged (not propagated), and the DB cleanup proceeds normally.
+     */
+    @Test
+    public void testDeleteApplicationWithProductionKeysTriggersKeyManagerDelete() throws Exception {
+        String consumerKey = "bhihzmGIO6tkwwJfVfB4Ej2D4UUa";
+
+        Application application = new Application("TestDeleteApp", new Subscriber("admin"));
+        application.setId(42);
+        application.setUUID("app-uuid-prod-keys");
+
+        // Simulate: no subscriptions, one PRODUCTION consumer key
+        Mockito.when(resultSet.next())
+                .thenReturn(false)   // no subscriptions
+                .thenReturn(true)    // one consumer key (PRODUCTION)
+                .thenReturn(false);  // no more keys
+
+        Mockito.when(resultSet.getString(APIConstants.FIELD_CONSUMER_KEY)).thenReturn(consumerKey);
+        Mockito.when(resultSet.getString("NAME")).thenReturn("Resident Key Manager");
+        Mockito.when(resultSet.getString("ORGANIZATION")).thenReturn("carbon.super");
+        Mockito.when(resultSet.getString("CREATE_MODE")).thenReturn(APIConstants.OAuthAppMode.CREATED.name());
+
+        PowerMockito.when(KeyManagerHolder.getKeyManagerInstance("carbon.super", "Resident Key Manager"))
+                .thenReturn(keyManager);
+
+        // Execute the full deletion flow through the workflow executor
+        ApplicationWorkflowDTO workflowDTO = new ApplicationWorkflowDTO();
+        workflowDTO.setApplication(application);
+        workflowDTO.setWorkflowReference(String.valueOf(application.getId()));
+
+        // The ApiMgtDAO singleton was initialized in setUp() with mocked dependencies.
+        // The workflow executor calls ApiMgtDAO.getInstance() which returns our instance.
+        ApplicationDeletionSimpleWorkflowExecutor executor = new ApplicationDeletionSimpleWorkflowExecutor();
+        WorkflowResponse response = executor.execute(workflowDTO);
+
+        Assert.assertNotNull(response);
+
+        // Verify the key manager was called to delete the OAuth application
+        verify(keyManager, times(1)).deleteApplication(consumerKey);
+        // Verify mapped application cleanup was also called
+        verify(keyManager, times(1)).deleteMappedApplication(consumerKey);
+        // Verify the transaction committed
+        verify(connection, times(1)).commit();
+    }
+
+    /**
+     * Simulates the exact error from issue #4866: The key manager's deleteApplication
+     * succeeds on the DCR side, but the subsequent service provider deletion triggers
+     * OAuthApplicationMgtListener which fails because the OAuth app is already gone.
+     *
+     * In practice, this error manifests as an APIManagementException wrapping the
+     * IS-side error. The APIM code catches this at ApiMgtDAO line 4894-4896.
+     *
+     * This test verifies that even when deleteApplication() on the key manager fails,
+     * the overall application deletion still completes successfully.
+     */
+    @Test
+    public void testDeleteApplicationCompletesWhenKeyManagerThrowsRaceConditionError() throws Exception {
+        String consumerKey = "raceConditionConsumerKey";
+
+        Application application = new Application("AppWithRaceCondition", new Subscriber("admin"));
+        application.setId(99);
+        application.setUUID("race-condition-uuid");
+
+        Mockito.when(resultSet.next())
+                .thenReturn(false)
+                .thenReturn(true)
+                .thenReturn(false);
+
+        Mockito.when(resultSet.getString(APIConstants.FIELD_CONSUMER_KEY)).thenReturn(consumerKey);
+        Mockito.when(resultSet.getString("NAME")).thenReturn("Resident Key Manager");
+        Mockito.when(resultSet.getString("ORGANIZATION")).thenReturn("carbon.super");
+        Mockito.when(resultSet.getString("CREATE_MODE")).thenReturn(APIConstants.OAuthAppMode.CREATED.name());
+
+        PowerMockito.when(KeyManagerHolder.getKeyManagerInstance("carbon.super", "Resident Key Manager"))
+                .thenReturn(keyManager);
+
+        // Simulate the race condition: deleteApplication throws because the IS-side
+        // OAuthApplicationMgtListener can't find the already-deleted OAuth app
+        Mockito.doThrow(new APIManagementException(
+                "Error while Deleting Client Application - application.not.found"))
+                .when(keyManager).deleteApplication(consumerKey);
+
+        // The deletion should still complete without exception
+        apiMgtDAO.deleteApplication(application);
+
+        verify(keyManager, times(1)).deleteApplication(consumerKey);
+        verify(connection, times(1)).commit();
+    }
+
+    /**
+     * Test deletion of an app that has both PRODUCTION and SANDBOX keys.
+     * Both sets of keys should be cleaned up, and if one fails the other should still proceed.
+     */
+    @Test
+    public void testDeleteApplicationWithBothProductionAndSandboxKeys() throws Exception {
+        String prodConsumerKey = "prodKey123";
+        String sandboxConsumerKey = "sandboxKey456";
+
+        Application application = new Application("AppWithBothKeys", new Subscriber("admin"));
+        application.setId(55);
+        application.setUUID("both-keys-uuid");
+
+        Mockito.when(resultSet.next())
+                .thenReturn(false)   // no subscriptions
+                .thenReturn(true)    // PRODUCTION key
+                .thenReturn(true)    // SANDBOX key
+                .thenReturn(false);  // no more keys
+
+        Mockito.when(resultSet.getString(APIConstants.FIELD_CONSUMER_KEY))
+                .thenReturn(prodConsumerKey)
+                .thenReturn(sandboxConsumerKey);
+        Mockito.when(resultSet.getString("NAME"))
+                .thenReturn("Resident Key Manager")
+                .thenReturn("Resident Key Manager");
+        Mockito.when(resultSet.getString("ORGANIZATION"))
+                .thenReturn("carbon.super")
+                .thenReturn("carbon.super");
+        Mockito.when(resultSet.getString("CREATE_MODE"))
+                .thenReturn(APIConstants.OAuthAppMode.CREATED.name())
+                .thenReturn(APIConstants.OAuthAppMode.CREATED.name());
+
+        PowerMockito.when(KeyManagerHolder.getKeyManagerInstance("carbon.super", "Resident Key Manager"))
+                .thenReturn(keyManager);
+
+        // PRODUCTION key deletion fails (race condition), SANDBOX should still proceed
+        Mockito.doThrow(new APIManagementException("application.not.found"))
+                .when(keyManager).deleteApplication(prodConsumerKey);
+
+        apiMgtDAO.deleteApplication(application);
+
+        // Both keys should have been attempted
+        verify(keyManager, times(1)).deleteApplication(prodConsumerKey);
+        verify(keyManager, times(1)).deleteApplication(sandboxConsumerKey);
+        verify(keyManager, times(1)).deleteMappedApplication(prodConsumerKey);
+        verify(keyManager, times(1)).deleteMappedApplication(sandboxConsumerKey);
+        verify(connection, times(1)).commit();
+    }
+
+    /**
+     * Test deletion of an application that has keys that were already revoked/removed.
+     * The key manager should not be called for null consumer keys.
+     */
+    @Test
+    public void testDeleteApplicationWithRevokedKeys() throws Exception {
+        Application application = new Application("AppWithRevokedKeys", new Subscriber("admin"));
+        application.setId(77);
+        application.setUUID("revoked-keys-uuid");
+
+        Mockito.when(resultSet.next())
+                .thenReturn(false)   // no subscriptions
+                .thenReturn(true)    // one row with null consumer key
+                .thenReturn(false);
+
+        Mockito.when(resultSet.getString(APIConstants.FIELD_CONSUMER_KEY)).thenReturn(null);
+
+        apiMgtDAO.deleteApplication(application);
+
+        verify(keyManager, never()).deleteApplication(anyString());
+        verify(keyManager, never()).deleteMappedApplication(anyString());
+        verify(connection, times(1)).commit();
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/ApiMgtDAOApplicationDeletionTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dao/test/ApiMgtDAOApplicationDeletionTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.dao.test;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.Application;
+import org.wso2.carbon.apimgt.api.model.KeyManager;
+import org.wso2.carbon.apimgt.api.model.Subscriber;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
+import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for ApiMgtDAO.deleteApplication() focusing on key manager interaction
+ * during application deletion. These tests specifically target the scenario described
+ * in issue #4866 where deleting an application with generated keys causes an ERROR log
+ * due to a race condition between OAuth app deletion and service provider cleanup.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({KeyManagerHolder.class, APIMgtDBUtil.class, ApiMgtDAO.class,
+        ServiceReferenceHolder.class, APIUtil.class})
+public class ApiMgtDAOApplicationDeletionTest {
+
+    private ApiMgtDAO apiMgtDAO;
+    private KeyManager keyManager;
+    private Connection connection;
+    private PreparedStatement preparedStatement;
+    private ResultSet resultSet;
+
+    @Before
+    public void setUp() throws Exception {
+        keyManager = Mockito.mock(KeyManager.class);
+
+        // Mock ServiceReferenceHolder and APIManagerConfiguration (needed by ApiMgtDAO constructor)
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        APIManagerConfigurationService configService = Mockito.mock(APIManagerConfigurationService.class);
+        APIManagerConfiguration config = Mockito.mock(APIManagerConfiguration.class);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService()).thenReturn(configService);
+        Mockito.when(configService.getAPIManagerConfiguration()).thenReturn(config);
+
+        // Mock APIUtil (needed by ApiMgtDAO constructor)
+        PowerMockito.mockStatic(APIUtil.class);
+        PowerMockito.when(APIUtil.isMultiGroupAppSharingEnabled()).thenReturn(false);
+
+        // Mock static classes
+        PowerMockito.mockStatic(KeyManagerHolder.class);
+        PowerMockito.mockStatic(APIMgtDBUtil.class);
+
+        // Mock database connection and statements
+        connection = Mockito.mock(Connection.class);
+        preparedStatement = Mockito.mock(PreparedStatement.class);
+        resultSet = Mockito.mock(ResultSet.class);
+
+        PowerMockito.when(APIMgtDBUtil.getConnection()).thenReturn(connection);
+        Mockito.when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        Mockito.when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        // Reset the singleton and create a fresh instance with mocked dependencies
+        java.lang.reflect.Field instanceField = ApiMgtDAO.class.getDeclaredField("INSTANCE");
+        instanceField.setAccessible(true);
+        instanceField.set(null, null);
+
+        apiMgtDAO = ApiMgtDAO.getInstance();
+    }
+
+    /**
+     * Test that deleteApplication calls keyManager.deleteApplication() for non-MAPPED keys.
+     * This is the normal flow where the app has CREATED-mode OAuth keys.
+     */
+    @Test
+    public void testDeleteApplicationCallsKeyManagerDeleteForCreatedKeys() throws Exception {
+        Application application = createTestApplication();
+
+        // First resultSet call for subscriptions query - no subscriptions
+        Mockito.when(resultSet.next())
+                .thenReturn(false)  // no subscriptions
+                .thenReturn(true)   // one consumer key found
+                .thenReturn(false); // no more consumer keys
+
+        // Consumer key result set columns
+        Mockito.when(resultSet.getString(APIConstants.FIELD_CONSUMER_KEY)).thenReturn("testConsumerKey123");
+        Mockito.when(resultSet.getString("NAME")).thenReturn("Default");
+        Mockito.when(resultSet.getString("ORGANIZATION")).thenReturn("carbon.super");
+        Mockito.when(resultSet.getString("CREATE_MODE")).thenReturn(APIConstants.OAuthAppMode.CREATED.name());
+
+        PowerMockito.when(KeyManagerHolder.getKeyManagerInstance("carbon.super", "Default"))
+                .thenReturn(keyManager);
+
+        apiMgtDAO.deleteApplication(application);
+
+        // Verify keyManager.deleteApplication was called with the consumer key
+        verify(keyManager, times(1)).deleteApplication("testConsumerKey123");
+        // Verify keyManager.deleteMappedApplication was also called
+        verify(keyManager, times(1)).deleteMappedApplication("testConsumerKey123");
+    }
+
+    /**
+     * Test that deleteApplication does NOT call keyManager.deleteApplication() for MAPPED keys.
+     * MAPPED keys are created externally and should not be deleted by APIM.
+     */
+    @Test
+    public void testDeleteApplicationSkipsKeyManagerDeleteForMappedKeys() throws Exception {
+        Application application = createTestApplication();
+
+        Mockito.when(resultSet.next())
+                .thenReturn(false)  // no subscriptions
+                .thenReturn(true)   // one consumer key found
+                .thenReturn(false); // no more consumer keys
+
+        Mockito.when(resultSet.getString(APIConstants.FIELD_CONSUMER_KEY)).thenReturn("mappedConsumerKey");
+        Mockito.when(resultSet.getString("NAME")).thenReturn("Default");
+        Mockito.when(resultSet.getString("ORGANIZATION")).thenReturn("carbon.super");
+        Mockito.when(resultSet.getString("CREATE_MODE")).thenReturn(APIConstants.OAuthAppMode.MAPPED.name());
+
+        PowerMockito.when(KeyManagerHolder.getKeyManagerInstance("carbon.super", "Default"))
+                .thenReturn(keyManager);
+
+        apiMgtDAO.deleteApplication(application);
+
+        // deleteApplication should NOT be called for MAPPED mode
+        verify(keyManager, never()).deleteApplication(anyString());
+        // deleteMappedApplication should still be called
+        verify(keyManager, times(1)).deleteMappedApplication("mappedConsumerKey");
+    }
+
+    /**
+     * Test that deleteApplication handles APIManagementException from keyManager.deleteApplication()
+     * gracefully without propagating the exception. This simulates the scenario from issue #4866
+     * where the IS OAuthApplicationMgtListener throws an error because the OAuth app was already
+     * deleted before the service provider cleanup runs.
+     */
+    @Test
+    public void testDeleteApplicationHandlesKeyManagerDeleteError() throws Exception {
+        Application application = createTestApplication();
+
+        Mockito.when(resultSet.next())
+                .thenReturn(false)  // no subscriptions
+                .thenReturn(true)   // one consumer key found
+                .thenReturn(false); // no more consumer keys
+
+        Mockito.when(resultSet.getString(APIConstants.FIELD_CONSUMER_KEY)).thenReturn("errorConsumerKey");
+        Mockito.when(resultSet.getString("NAME")).thenReturn("Default");
+        Mockito.when(resultSet.getString("ORGANIZATION")).thenReturn("carbon.super");
+        Mockito.when(resultSet.getString("CREATE_MODE")).thenReturn(APIConstants.OAuthAppMode.CREATED.name());
+
+        PowerMockito.when(KeyManagerHolder.getKeyManagerInstance("carbon.super", "Default"))
+                .thenReturn(keyManager);
+
+        // Simulate the error that occurs when IS tries to look up the already-deleted OAuth app
+        Mockito.doThrow(new APIManagementException("Error while Deleting Client Application"))
+                .when(keyManager).deleteApplication("errorConsumerKey");
+
+        // The deletion should complete without throwing an exception
+        // because deleteApplication catches APIManagementException from keyManager
+        apiMgtDAO.deleteApplication(application);
+
+        // Verify that the key manager delete was attempted
+        verify(keyManager, times(1)).deleteApplication("errorConsumerKey");
+        // Verify the transaction was committed despite the key manager error
+        verify(connection, times(1)).commit();
+    }
+
+    /**
+     * Test that deleteApplication handles the case where keyManager.deleteMappedApplication()
+     * throws an error. Both deleteMappedApplication and deleteApplication errors should be
+     * handled gracefully.
+     */
+    @Test
+    public void testDeleteApplicationHandlesMappedApplicationDeleteError() throws Exception {
+        Application application = createTestApplication();
+
+        Mockito.when(resultSet.next())
+                .thenReturn(false)  // no subscriptions
+                .thenReturn(true)   // one consumer key found
+                .thenReturn(false); // no more consumer keys
+
+        Mockito.when(resultSet.getString(APIConstants.FIELD_CONSUMER_KEY)).thenReturn("errorMappedKey");
+        Mockito.when(resultSet.getString("NAME")).thenReturn("Default");
+        Mockito.when(resultSet.getString("ORGANIZATION")).thenReturn("carbon.super");
+        Mockito.when(resultSet.getString("CREATE_MODE")).thenReturn(APIConstants.OAuthAppMode.CREATED.name());
+
+        PowerMockito.when(KeyManagerHolder.getKeyManagerInstance("carbon.super", "Default"))
+                .thenReturn(keyManager);
+
+        Mockito.doThrow(new APIManagementException("Error deleting mapped application"))
+                .when(keyManager).deleteMappedApplication("errorMappedKey");
+
+        // Should not propagate the exception
+        apiMgtDAO.deleteApplication(application);
+
+        verify(keyManager, times(1)).deleteMappedApplication("errorMappedKey");
+        verify(connection, times(1)).commit();
+    }
+
+    /**
+     * Test deletion of application with multiple consumer keys across different key managers.
+     * Ensures all keys are processed even if one key manager fails.
+     */
+    @Test
+    public void testDeleteApplicationWithMultipleKeysAndPartialFailure() throws Exception {
+        Application application = createTestApplication();
+        KeyManager keyManager2 = Mockito.mock(KeyManager.class);
+
+        Mockito.when(resultSet.next())
+                .thenReturn(false)  // no subscriptions
+                .thenReturn(true)   // first consumer key
+                .thenReturn(true)   // second consumer key
+                .thenReturn(false); // no more consumer keys
+
+        Mockito.when(resultSet.getString(APIConstants.FIELD_CONSUMER_KEY))
+                .thenReturn("consumerKey1")
+                .thenReturn("consumerKey2");
+        Mockito.when(resultSet.getString("NAME"))
+                .thenReturn("DefaultKM")
+                .thenReturn("ExternalKM");
+        Mockito.when(resultSet.getString("ORGANIZATION"))
+                .thenReturn("carbon.super")
+                .thenReturn("carbon.super");
+        Mockito.when(resultSet.getString("CREATE_MODE"))
+                .thenReturn(APIConstants.OAuthAppMode.CREATED.name())
+                .thenReturn(APIConstants.OAuthAppMode.CREATED.name());
+
+        PowerMockito.when(KeyManagerHolder.getKeyManagerInstance("carbon.super", "DefaultKM"))
+                .thenReturn(keyManager);
+        PowerMockito.when(KeyManagerHolder.getKeyManagerInstance("carbon.super", "ExternalKM"))
+                .thenReturn(keyManager2);
+
+        // First key manager throws error (simulating the race condition from issue #4866)
+        Mockito.doThrow(new APIManagementException("application.not.found"))
+                .when(keyManager).deleteApplication("consumerKey1");
+
+        apiMgtDAO.deleteApplication(application);
+
+        // Both key managers should have been called despite the first one failing
+        verify(keyManager, times(1)).deleteApplication("consumerKey1");
+        verify(keyManager2, times(1)).deleteApplication("consumerKey2");
+        verify(connection, times(1)).commit();
+    }
+
+    /**
+     * Test deletion of application when key manager instance is null.
+     * This can happen when a key manager is removed but app keys still reference it.
+     */
+    @Test
+    public void testDeleteApplicationWithNullKeyManager() throws Exception {
+        Application application = createTestApplication();
+
+        Mockito.when(resultSet.next())
+                .thenReturn(false)  // no subscriptions
+                .thenReturn(true)   // one consumer key found
+                .thenReturn(false); // no more consumer keys
+
+        Mockito.when(resultSet.getString(APIConstants.FIELD_CONSUMER_KEY)).thenReturn("orphanedKey");
+        Mockito.when(resultSet.getString("NAME")).thenReturn("RemovedKM");
+        Mockito.when(resultSet.getString("ORGANIZATION")).thenReturn("carbon.super");
+        Mockito.when(resultSet.getString("CREATE_MODE")).thenReturn(APIConstants.OAuthAppMode.CREATED.name());
+
+        // Key manager not found - returns null
+        PowerMockito.when(KeyManagerHolder.getKeyManagerInstance("carbon.super", "RemovedKM"))
+                .thenReturn(null);
+
+        // Should complete without NullPointerException
+        apiMgtDAO.deleteApplication(application);
+
+        verify(connection, times(1)).commit();
+    }
+
+    /**
+     * Test deletion of application with no consumer keys (app without generated keys).
+     */
+    @Test
+    public void testDeleteApplicationWithNoConsumerKeys() throws Exception {
+        Application application = createTestApplication();
+
+        Mockito.when(resultSet.next())
+                .thenReturn(false)  // no subscriptions
+                .thenReturn(false); // no consumer keys
+
+        apiMgtDAO.deleteApplication(application);
+
+        // No key manager calls should be made
+        verify(keyManager, never()).deleteApplication(anyString());
+        verify(keyManager, never()).deleteMappedApplication(anyString());
+        verify(connection, times(1)).commit();
+    }
+
+    /**
+     * Test deletion of application where consumer key is null in the database.
+     */
+    @Test
+    public void testDeleteApplicationWithNullConsumerKey() throws Exception {
+        Application application = createTestApplication();
+
+        Mockito.when(resultSet.next())
+                .thenReturn(false)  // no subscriptions
+                .thenReturn(true)   // one row found
+                .thenReturn(false); // no more rows
+
+        Mockito.when(resultSet.getString(APIConstants.FIELD_CONSUMER_KEY)).thenReturn(null);
+
+        apiMgtDAO.deleteApplication(application);
+
+        // No key manager calls should be made for null consumer key
+        verify(keyManager, never()).deleteApplication(anyString());
+        verify(connection, times(1)).commit();
+    }
+
+    private Application createTestApplication() {
+        Subscriber subscriber = new Subscriber("testUser");
+        subscriber.setTenantId(-1234);
+        Application application = new Application("TestDeleteApp", subscriber);
+        application.setId(1);
+        application.setUUID("test-uuid-1234");
+        return application;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/workflow/ApplicationDeletionWorkflowWithKeysTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/workflow/ApplicationDeletionWorkflowWithKeysTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.workflow;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.WorkflowResponse;
+import org.wso2.carbon.apimgt.api.model.Application;
+import org.wso2.carbon.apimgt.api.model.Subscriber;
+import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.dto.ApplicationWorkflowDTO;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+/**
+ * Tests for application deletion workflow executor covering scenarios with
+ * generated OAuth keys. These tests specifically target the flow described in
+ * issue #4866 where the deletion of an application with generated keys causes
+ * errors in the IS OAuthApplicationMgtListener.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ApiMgtDAO.class})
+public class ApplicationDeletionWorkflowWithKeysTest {
+
+    private ApplicationDeletionSimpleWorkflowExecutor workflowExecutor;
+    private ApiMgtDAO apiMgtDAO;
+    private ApplicationWorkflowDTO workflowDTO;
+    private Application application;
+
+    @Before
+    public void init() {
+        workflowExecutor = new ApplicationDeletionSimpleWorkflowExecutor();
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        apiMgtDAO = Mockito.mock(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+
+        application = new Application("TestAppWithKeys", new Subscriber("testUser"));
+        application.setId(100);
+        application.setUUID("app-uuid-with-keys");
+
+        workflowDTO = new ApplicationWorkflowDTO();
+        workflowDTO.setWorkflowReference("100");
+        workflowDTO.setApplication(application);
+    }
+
+    /**
+     * Test that the workflow executor successfully deletes an application.
+     * The DAO's deleteApplication internally calls keyManager.deleteApplication,
+     * and when the DAO completes without error the workflow should succeed.
+     */
+    @Test
+    public void testSuccessfulDeletionOfApplicationWithKeys() throws Exception {
+        PowerMockito.doNothing().when(apiMgtDAO).deleteApplication(application);
+
+        WorkflowResponse response = workflowExecutor.execute(workflowDTO);
+
+        Assert.assertNotNull(response);
+        verify(apiMgtDAO, times(1)).deleteApplication(application);
+    }
+
+    /**
+     * Test that the workflow executor propagates errors from the DAO layer.
+     * If the DAO's deleteApplication throws (e.g., due to database errors),
+     * the workflow should throw WorkflowException.
+     */
+    @Test
+    public void testDeletionFailsWhenDAOThrowsException() throws Exception {
+        Mockito.doThrow(new APIManagementException("Database error during deletion"))
+                .when(apiMgtDAO).deleteApplication(application);
+
+        try {
+            workflowExecutor.execute(workflowDTO);
+            Assert.fail("Expected WorkflowException was not thrown");
+        } catch (WorkflowException e) {
+            Assert.assertTrue(e.getMessage().contains("Database error during deletion"));
+        }
+    }
+
+    /**
+     * Test the complete() method directly, which is what actually calls
+     * apiMgtDAO.deleteApplication(). The execute() method sets status to
+     * APPROVED and then calls complete().
+     */
+    @Test
+    public void testCompleteMethodCallsDAODelete() throws Exception {
+        PowerMockito.doNothing().when(apiMgtDAO).deleteApplication(application);
+
+        WorkflowResponse response = workflowExecutor.complete(workflowDTO);
+
+        Assert.assertNotNull(response);
+        verify(apiMgtDAO, times(1)).deleteApplication(application);
+    }
+
+    /**
+     * Test that after execute(), the workflow status is set to APPROVED.
+     * This ensures the deletion is immediately approved in the simple workflow.
+     */
+    @Test
+    public void testWorkflowStatusIsApprovedAfterExecution() throws Exception {
+        PowerMockito.doNothing().when(apiMgtDAO).deleteApplication(application);
+
+        workflowExecutor.execute(workflowDTO);
+
+        Assert.assertEquals(WorkflowStatus.APPROVED, workflowDTO.getStatus());
+    }
+
+    /**
+     * Test deletion when the APIManagementException has a null message.
+     * The workflow executor should generate a fallback error message.
+     */
+    @Test
+    public void testDeletionFailsWithNullErrorMessage() throws Exception {
+        Mockito.doThrow(new APIManagementException((String) null))
+                .when(apiMgtDAO).deleteApplication(application);
+
+        try {
+            workflowExecutor.execute(workflowDTO);
+            Assert.fail("Expected WorkflowException was not thrown");
+        } catch (WorkflowException e) {
+            Assert.assertTrue(e.getMessage().contains(
+                    "Couldn't complete simple application deletion workflow for application: TestAppWithKeys"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 17 unit and integration tests covering the application deletion flow when OAuth keys have been generated
- Tests specifically target the race condition from [issue #4866](https://github.com/wso2/api-manager/issues/4866) where the IS `OAuthApplicationMgtListener` fails to find an already-deleted OAuth app during service provider cleanup
- Verifies that `ApiMgtDAO.deleteApplication()` handles key manager errors gracefully without propagating exceptions

## Test Files
| File | Tests | Coverage |
|------|-------|----------|
| `ApiMgtDAOApplicationDeletionTest.java` | 8 | DAO-level key manager interaction (CREATED vs MAPPED keys, error handling, null key manager, multiple keys with partial failure) |
| `ApplicationDeletionWorkflowWithKeysTest.java` | 5 | Workflow executor deletion flow (success, error propagation, status verification) |
| `ApplicationDeletionWithKeysIntegrationTest.java` | 4 | Full WorkflowExecutor → DAO → KeyManager flow (race condition scenario, PRODUCTION+SANDBOX keys) |

## Test plan
- [x] All 17 new tests pass (`mvn clean test -Dtest=ApiMgtDAOApplicationDeletionTest,ApplicationDeletionWorkflowWithKeysTest,ApplicationDeletionWithKeysIntegrationTest`)
- [x] Existing `ApplicationDeletionSimpleWorkflowExecutorTest` still passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)