### PR TITLE
[Don't merge] Remove underutilized dependencies

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.rest.api/pom.xml
@@ -58,20 +58,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.validation</groupId>
-                    <artifactId>validation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.osgi.foundation</artifactId>
             <scope>compile</scope>

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/pom.xml
@@ -32,25 +32,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.analytics-common</groupId>
-            <artifactId>org.wso2.carbon.event.output.adapter.email</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>wsdl4j</groupId>
-                    <artifactId>wsdl4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>wsdl4j.wso2</groupId>
-                    <artifactId>wsdl4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wso2.carbon.analytics-common</groupId>
-            <artifactId>org.wso2.carbon.event.output.adapter.sms</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.woden.wso2</groupId>
             <artifactId>woden</artifactId>
         </dependency>
@@ -99,26 +80,12 @@
             <artifactId>org.wso2.carbon.apimgt.api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.apimgt</groupId>
-            <artifactId>org.wso2.carbon.apimgt.keymgt.client</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>wsdl4j.wso2</groupId>
-                    <artifactId>wsdl4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
             <artifactId>org.wso2.carbon.identity.oauth</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.captcha.mgt</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.governance</groupId>
@@ -148,12 +115,6 @@
             <artifactId>h2-engine</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.ibm.icu</groupId>
-            <artifactId>icu4j</artifactId>
-            <version>58.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
@@ -170,10 +131,6 @@
             <artifactId>httpmime</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.commons</groupId>
-            <artifactId>org.wso2.carbon.event.core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.registry</groupId>
             <artifactId>org.wso2.carbon.registry.indexing</artifactId>
         </dependency>
@@ -188,30 +145,6 @@
         <dependency>
             <groupId>org.wso2.orbit.com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.apimgt</groupId>
-            <artifactId>org.wso2.carbon.apimgt.keymgt.stub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
-            <artifactId>org.wso2.carbon.identity.oauth.stub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.application.mgt.stub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.mgt.stub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.user.ws</groupId>
-            <artifactId>org.wso2.carbon.um.ws.api.stub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.user.mgt.stub</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.analytics-common</groupId>
@@ -274,14 +207,6 @@
             <artifactId>xercesImpl</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.user.profile.stub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.user.registration.stub</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <scope>test</scope>
@@ -311,11 +236,6 @@
             <artifactId>aspectjrt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.orbit.graphQL</groupId>
             <artifactId>graphQL</artifactId>
             <version>${graphql.java.version}</version>
@@ -337,10 +257,6 @@
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-gson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.github.openfeign</groupId>
-            <artifactId>feign-okhttp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/pom.xml
@@ -73,11 +73,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.util</artifactId>
             <scope>provided</scope>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/pom.xml
@@ -75,20 +75,6 @@
             <artifactId>org.wso2.carbon.apimgt.rest.api.common</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.validation</groupId>
-                    <artifactId>jakarta.validation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <dependency>
             <groupId>org.powermock</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.dcr/pom.xml
@@ -89,20 +89,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.validation</groupId>
-                    <artifactId>jakarta.validation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
             <scope>provided</scope>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.devops/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.devops/pom.xml
@@ -84,20 +84,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.validation</groupId>
-                    <artifactId>jakarta.validation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
             <scope>provided</scope>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.gateway/pom.xml
@@ -89,20 +89,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.validation</groupId>
-                    <artifactId>jakarta.validation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
             <scope>provided</scope>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/pom.xml
@@ -98,20 +98,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.validation</groupId>
-                    <artifactId>jakarta.validation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
             <scope>provided</scope>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/pom.xml
@@ -88,20 +88,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.validation</groupId>
-                    <artifactId>jakarta.validation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
             <scope>provided</scope>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/pom.xml
@@ -89,20 +89,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.validation</groupId>
-                    <artifactId>jakarta.validation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
             <scope>provided</scope>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.util/pom.xml
@@ -98,11 +98,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.rest.api.common</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -484,12 +484,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.core.services</artifactId>
-                <version>${carbon.kernel.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.application.mgt.stub</artifactId>
                 <version>${carbon.identity.version}</version>
@@ -498,12 +492,6 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.mgt.stub</artifactId>
-                <version>${carbon.identity.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.claim.metadata.mgt.stub</artifactId>
                 <version>${carbon.identity.version}</version>
             </dependency>
 
@@ -851,30 +839,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.owasp.encoder</groupId>
-                <artifactId>encoder</artifactId>
-                <version>${owasp.encoder.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jaggeryjs</groupId>
-                <artifactId>org.jaggeryjs.hostobjects.web</artifactId>
-                <version>${jaggery.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jaggeryjs</groupId>
-                <artifactId>org.jaggeryjs.hostobjects.file</artifactId>
-                <version>${jaggery.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wso2.carbon.multitenancy</groupId>
-                <artifactId>org.wso2.carbon.tenant.usage.agent</artifactId>
-                <version>${carbon.multitenancy.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.wso2.carbon.multitenancy</groupId>
                 <artifactId>org.wso2.carbon.tenant.mgt.stub</artifactId>
                 <version>${carbon.multitenancy.version}</version>
@@ -920,13 +884,6 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.registry.core</artifactId>
                 <version>${carbon.kernel.version}</version>
-            </dependency>
-
-
-            <dependency>
-                <groupId>org.jaggeryjs</groupId>
-                <artifactId>org.jaggeryjs.scriptengine</artifactId>
-                <version>${jaggery.version}</version>
             </dependency>
 
             <dependency>
@@ -981,12 +938,6 @@
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.tomcat</artifactId>
-                <version>${carbon.kernel.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.tomcat.ext</artifactId>
                 <version>${carbon.kernel.version}</version>
             </dependency>
 
@@ -1252,12 +1203,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wso2.carbon.commons</groupId>
-                <artifactId>org.wso2.carbon.application.mgt.stub</artifactId>
-                <version>${carbon.commons.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${google.code.gson.version}</version>
@@ -1273,12 +1218,6 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
                 <version>${httpcomponents.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.ndatasource.core</artifactId>
-                <version>${carbon.kernel.version}</version>
             </dependency>
 
             <dependency>
@@ -1364,11 +1303,6 @@
                 <groupId>org.reflections</groupId>
                 <artifactId>reflections</artifactId>
                 <version>${reflection.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.validator</groupId>
-                <artifactId>hibernate-validator</artifactId>
-                <version>${hibernate-validator.version}</version>
             </dependency>
 
             <dependency>
@@ -1660,11 +1594,6 @@
                 <version>${slf4j.api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.commons</groupId>
-                <artifactId>org.wso2.carbon.tenant.common</artifactId>
-                <version>${carbon.commons.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.carbon.apimgt</groupId>
                 <artifactId>org.wso2.carbon.apimgt.tracing</artifactId>
                 <version>${carbon.apimgt.version}</version>
@@ -1693,12 +1622,6 @@
                 <groupId>org.wso2.orbit.com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
                 <version>${okio.wso2.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.opentracing</groupId>
-                <artifactId>opentracing-mock</artifactId>
-                <version>${opentracing.mock.version}</version>
-                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>io.opentracing</groupId>
@@ -1783,16 +1706,6 @@
                 <version>${graphql.java.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.saml.common</groupId>
-                <artifactId>org.wso2.carbon.identity.saml.common.util</artifactId>
-                <version>${saml.common.util.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.saml.common</groupId>
-                <artifactId>org.wso2.carbon.identity.saml.common.util.feature</artifactId>
-                <version>${saml.common.util.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${apache.felix.scr.ds.annotations.version}</version>
@@ -1826,11 +1739,6 @@
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-models</artifactId>
-                <version>${swagger3.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.swagger.core.v3</groupId>
-                <artifactId>swagger-jaxrs2</artifactId>
                 <version>${swagger3.core.version}</version>
             </dependency>
             <dependency>
@@ -1990,11 +1898,6 @@
                 <groupId>org.apache.xmlgraphics</groupId>
                 <artifactId>batik-all</artifactId>
                 <version>${batik.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.integration.transaction.counter</groupId>
-                <artifactId>transaction-count-handler</artifactId>
-                <version>${integration.transaction.counter.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
Removed 17 root pom dependencyManagement entries:
- org.wso2.carbon.core.services
- org.wso2.carbon.ndatasource.core
- org.wso2.carbon.tomcat.ext
- org.wso2.carbon.application.mgt.stub
- org.wso2.carbon.tenant.common
- org.wso2.carbon.tenant.usage.agent
- org.wso2.carbon.identity.claim.metadata.mgt.stub
- org.wso2.carbon.identity.saml.common.util
- org.wso2.carbon.identity.saml.common.util.feature
- transaction-count-handler
- hibernate-validator
- encoder
- org.jaggeryjs.hostobjects.web
- org.jaggeryjs.hostobjects.file
- org.jaggeryjs.scriptengine
- opentracing-mock
- swagger-jaxrs2

Removed 16 dependencies from impl module:
- feign-okhttp
- org.wso2.carbon.event.output.adapter.sms
- org.apache.felix.scr.ds-annotations
- org.wso2.carbon.apimgt.keymgt.client
- org.wso2.carbon.captcha.mgt
- org.wso2.carbon.event.output.adapter.email
- org.wso2.carbon.apimgt.keymgt.stub
- org.wso2.carbon.event.core
- org.wso2.carbon.identity.user.registration.stub
- org.wso2.carbon.identity.user.profile.stub
- org.wso2.carbon.identity.application.mgt.stub
- org.wso2.carbon.user.mgt.stub
- org.wso2.carbon.identity.mgt.stub
- org.wso2.carbon.identity.oauth.stub
- org.wso2.carbon.um.ws.api.stub
- icu4j (test scope)

Removed hibernate-validator from 10 REST API modules:
- rest.api.util, rest.api.store.v1, rest.api.publisher.v1
- rest.api.admin.v1, rest.api.gateway, rest.api.dcr
- rest.api.devops, rest.api.service.catalog
- internal.service, governance.rest.api

Total: 43 dependency declarations removed
Net lines removed: 303

Validation: mvn clean install - BUILD SUCCESS (23:22 min, all tests pass)