### PR TITLE
Fix false debug log for URL type documents during API export

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ExportUtils.java
@@ -545,9 +545,9 @@ public class ExportUtils {
                                 individualDocDirectoryPath + File.separator + localFileName);) {
                             IOUtils.copy(inputStream, outputStream);
                         }
-                    } else {
-                        // Log error and avoid throwing as we give the capability to export document artifact without
-                        // the content if does not exist
+                    } else if (!Documentation.DocumentSourceType.URL.toString().equalsIgnoreCase(sourceType)) {
+                        // Log only for non-URL type documents. URL type documents don't have file content
+                        // to export — they only have a source URL stored in the document metadata.
                         if (log.isDebugEnabled()) {
                             log.debug("Documentation resource for API/API Product: " + identifier.getName()
                                     + " document name: " + individualDocument.getName()


### PR DESCRIPTION
## Summary
- Fixes false debug log emitted for URL type documents during API export. URL documents don't have file content to export — they only have a source URL in metadata — so the "Documentation resource not found" debug log is misleading.
- Added an explicit check to skip the debug log when the document source type is URL.

Fixes https://github.com/wso2/api-manager/issues/4863

## Test plan
- [ ] Export an API with a URL type document and verify no debug log is emitted for it
- [ ] Export an API with a FILE type document without content and verify the debug log is still emitted
- [ ] Export an API with INLINE/MARKDOWN documents and verify content is exported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)