### PR TITLE
Fix tenant-qualified token/revoke endpoint URLs for key generation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -995,16 +995,16 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
         if (configuration.getParameter(APIConstants.KeyManager.TOKEN_ENDPOINT) != null) {
             tokenEndpoint = (String) configuration.getParameter(APIConstants.KeyManager.TOKEN_ENDPOINT);
         } else {
-            tokenEndpoint = keyManagerServiceUrl.split("/" + APIConstants.SERVICES_URL_RELATIVE_PATH)[0].concat(
-                    "/oauth2/token");
+            tokenEndpoint = keyManagerServiceUrl.split("/" + APIConstants.SERVICES_URL_RELATIVE_PATH)[0]
+                    .concat(getTenantAwareContext().trim()).concat("/oauth2/token");
         }
         addKeyManagerConfigsAsSystemProperties(tokenEndpoint);
         String revokeEndpoint;
         if (configuration.getParameter(APIConstants.KeyManager.REVOKE_ENDPOINT) != null) {
             revokeEndpoint = (String) configuration.getParameter(APIConstants.KeyManager.REVOKE_ENDPOINT);
         } else {
-            revokeEndpoint = keyManagerServiceUrl.split("/" + APIConstants.SERVICES_URL_RELATIVE_PATH)[0].concat(
-                    "/oauth2/revoke");
+            revokeEndpoint = keyManagerServiceUrl.split("/" + APIConstants.SERVICES_URL_RELATIVE_PATH)[0]
+                    .concat(getTenantAwareContext().trim()).concat("/oauth2/revoke");
         }
         String scopeEndpoint;
         if (configuration.getParameter(APIConstants.KeyManager.SCOPE_MANAGEMENT_ENDPOINT) != null) {
@@ -1075,14 +1075,17 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
         introspectionClient = introspectionFeignBuilder.target(IntrospectionClient.class, introspectionEndpoint);
         scopeClient = scopeFeignBuilder.target(ScopeClient.class, scopeEndpoint);
         userClient = userFeignBuilder.target(UserClient.class, userInfoEndpoint);
-        authClient = Feign.builder()
+        Feign.Builder authFeignBuilder = Feign.builder()
                 .client(new ApacheFeignHttpClient(APIUtil.getHttpClient(tokenEndpoint)))
                 .encoder(new GsonEncoder())
                 .decoder(new GsonDecoder())
                 .logger(new Slf4jLogger())
                 .errorDecoder(new KMClientErrorDecoder())
-                .encoder(new FormEncoder())
-                .target(AuthClient.class, tokenEndpoint);
+                .encoder(new FormEncoder());
+        if (configuration.getParameter(APIConstants.KEY_MANAGER_TENANT_DOMAIN) != null) {
+            authFeignBuilder.requestInterceptor(new TenantHeaderInterceptor(tenantDomain));
+        }
+        authClient = authFeignBuilder.target(AuthClient.class, tokenEndpoint);
 
         if (APIConstants.KeyManager.DEFAULT_KEY_MANAGER_TYPE.equals(configuration.getType())) {
             String revokeOneTimeTokenEndpoint;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10083,9 +10083,13 @@ public final class APIUtil {
                         Boolean.parseBoolean(enableTokenEncryption));
             }
             keyManagerConfigurationDTO.addProperty(APIConstants.REVOKE_URL, keyManagerUrl.split("/" +
-                    APIConstants.SERVICES_URL_RELATIVE_PATH)[0].concat(APIConstants.IDENTITY_REVOKE_ENDPOINT));
+                    APIConstants.SERVICES_URL_RELATIVE_PATH)[0]
+                    .concat(getTenantAwareContext(keyManagerConfigurationDTO.getOrganization()))
+                    .concat(APIConstants.IDENTITY_REVOKE_ENDPOINT));
             keyManagerConfigurationDTO.addProperty(APIConstants.TOKEN_URL, keyManagerUrl.split("/" +
-                    APIConstants.SERVICES_URL_RELATIVE_PATH)[0].concat(APIConstants.IDENTITY_TOKEN_ENDPOINT_CONTEXT));
+                    APIConstants.SERVICES_URL_RELATIVE_PATH)[0]
+                    .concat(getTenantAwareContext(keyManagerConfigurationDTO.getOrganization()))
+                    .concat(APIConstants.IDENTITY_TOKEN_ENDPOINT_CONTEXT));
             if (!keyManagerConfigurationDTO.getAdditionalProperties()
                     .containsKey(APIConstants.KeyManager.AVAILABLE_GRANT_TYPE)) {
                 keyManagerConfigurationDTO.addProperty(APIConstants.KeyManager.AVAILABLE_GRANT_TYPE,


### PR DESCRIPTION
## Summary
- Add tenant context (`/t/{tenantDomain}`) to token and revoke endpoint URL construction in `AMDefaultKeyManagerImpl.loadConfiguration()` and `APIUtil.getDefaultKeyManagerConfiguration()`
- Add `TenantHeaderInterceptor` to the `authClient` Feign builder so token requests include the tenant header
- Fixes key generation failing with 401 "Invalid Client" for tenant applications when `enable_tenant_qualified_urls = true`

## Related Issue
Fixes https://github.com/wso2/api-manager/issues/4867

## Test plan
- [ ] Start server with `enable_tenant_qualified_urls = true` in `deployment.toml`
- [ ] Create a tenant and a tenant application
- [ ] Generate keys for the tenant application — should succeed without 401 error
- [ ] Verify super tenant key generation still works (no `/t/` prefix added)
- [ ] Verify token revocation works for tenant applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)