### PR TITLE
Fix EndpointSecurity copy constructor missing API key fields

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/EndpointSecurity.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/EndpointSecurity.java
@@ -89,6 +89,9 @@ public class EndpointSecurity {
         this.proxyConfigs = endpointSecurity.proxyConfigs;
         this.connectionTimeoutConfigType = endpointSecurity.connectionTimeoutConfigType;
         this.proxyConfigType = endpointSecurity.proxyConfigType;
+        this.apiKeyIdentifier = endpointSecurity.apiKeyIdentifier;
+        this.apiKeyValue = endpointSecurity.apiKeyValue;
+        this.apiKeyIdentifierType = endpointSecurity.apiKeyIdentifierType;
     }
 
     public EndpointSecurity() {


### PR DESCRIPTION
## Summary
- Added missing `apiKeyIdentifier`, `apiKeyValue`, and `apiKeyIdentifierType` fields to the `EndpointSecurity` copy constructor
- Without this fix, API Products using APIs with API key endpoint security lose the key data during the copy, causing a NullPointerException in the Velocity template rendering

## Related
- Fixes https://github.com/wso2/api-manager/issues/4856
- Companion PR in product-apim for the template fix

## Test plan
- [x] Verified: API Product with AI API (Anthropic) endpoint security correctly forwards `x-api-key` header to backend
- [x] No Velocity template errors during deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)