### PR TITLE
Fix gateway hang on schema validation with enum fields

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/security/SchemaValidator.java
@@ -70,23 +70,29 @@ public class SchemaValidator extends AbstractHandler {
         logger.debug("Validating the API request Body content..");
         OpenAPI openAPI = (OpenAPI) messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_OBJECT);
         if (openAPI != null) {
-            OpenApiInteractionValidator validator = getOpenAPIValidator(openAPI);
-            OpenAPIRequest request = new OpenAPIRequest(messageContext);
+            try {
+                OpenApiInteractionValidator validator = getOpenAPIValidator(openAPI);
+                OpenAPIRequest request = new OpenAPIRequest(messageContext);
 
-            ValidationReport validationReport = validator.validateRequest(request);
-            messageContext.setProperty(APIMgtGatewayConstants.SCHEMA_VALIDATION_REPORT, validationReport);
-            if (validationReport.hasErrors()) {
-                StringBuilder finalMessage = new StringBuilder();
-                for (ValidationReport.Message message : validationReport.getMessages()) {
-                    finalMessage.append(getErrorMessage(message)).append(", ");
+                ValidationReport validationReport = validator.validateRequest(request);
+                messageContext.setProperty(APIMgtGatewayConstants.SCHEMA_VALIDATION_REPORT, validationReport);
+                if (validationReport.hasErrors()) {
+                    StringBuilder finalMessage = new StringBuilder();
+                    for (ValidationReport.Message message : validationReport.getMessages()) {
+                        finalMessage.append(getErrorMessage(message)).append(", ");
+                    }
+                    // Remove the last comma and space, if present
+                    if (finalMessage.length() > 0) {
+                        finalMessage.setLength(finalMessage.length() - 2);
+                    }
+                    String errMessage = "Schema validation failed in the Request: ";
+                    logger.error(errMessage);
+                    GatewayUtils.handleThreat(messageContext, HTTP_SC_CODE, errMessage + finalMessage);
                 }
-                // Remove the last comma and space, if present
-                if (finalMessage.length() > 0) {
-                    finalMessage.setLength(finalMessage.length() - 2);
-                }
-                String errMessage = "Schema validation failed in the Request: ";
-                logger.error(errMessage);
-                GatewayUtils.handleThreat(messageContext, HTTP_SC_CODE, errMessage + finalMessage);
+            } catch (Throwable t) {
+                String errMessage = "Internal error while validating request schema: " + t.getMessage();
+                logger.error(errMessage, t);
+                GatewayUtils.handleThreat(messageContext, INTERNAL_ERROR_CODE, errMessage);
             }
         }
         return true;
@@ -97,23 +103,29 @@ public class SchemaValidator extends AbstractHandler {
 
         OpenAPI openAPI = (OpenAPI) messageContext.getProperty(APIMgtGatewayConstants.OPEN_API_OBJECT);
         if (openAPI != null) {
-            OpenApiInteractionValidator validator = getOpenAPIValidator(openAPI);
-            OpenAPIResponse response = new OpenAPIResponse(messageContext);
+            try {
+                OpenApiInteractionValidator validator = getOpenAPIValidator(openAPI);
+                OpenAPIResponse response = new OpenAPIResponse(messageContext);
 
-            ValidationReport validationReport = validator.validateResponse(response.getPath(), response.getMethod(),
-                    response);
-            if (validationReport.hasErrors()) {
-                StringBuilder finalMessage = new StringBuilder();
-                for (ValidationReport.Message message : validationReport.getMessages()) {
-                    finalMessage.append(getErrorMessage(message)).append(", ");
+                ValidationReport validationReport = validator.validateResponse(response.getPath(), response.getMethod(),
+                        response);
+                if (validationReport.hasErrors()) {
+                    StringBuilder finalMessage = new StringBuilder();
+                    for (ValidationReport.Message message : validationReport.getMessages()) {
+                        finalMessage.append(getErrorMessage(message)).append(", ");
+                    }
+                    // Remove the last comma and space, if present
+                    if (finalMessage.length() > 0) {
+                        finalMessage.setLength(finalMessage.length() - 2);
+                    }
+                    String errMessage = "Schema validation failed in the Response: ";
+                    logger.error(errMessage);
+                    GatewayUtils.handleThreat(messageContext, INTERNAL_ERROR_CODE, errMessage + finalMessage);
                 }
-                // Remove the last comma and space, if present
-                if (finalMessage.length() > 0) {
-                    finalMessage.setLength(finalMessage.length() - 2);
-                }
-                String errMessage = "Schema validation failed in the Response: ";
-                logger.error(errMessage);
-                GatewayUtils.handleThreat(messageContext, INTERNAL_ERROR_CODE, errMessage + finalMessage);
+            } catch (Throwable t) {
+                String errMessage = "Internal error while validating response schema: " + t.getMessage();
+                logger.error(errMessage, t);
+                GatewayUtils.handleThreat(messageContext, INTERNAL_ERROR_CODE, errMessage);
             }
         }
         return true;


### PR DESCRIPTION
## Summary
- Fixes gateway hanging indefinitely when `enableSchemaValidation: true` and the request/response contains `enum` fields
- Wraps `validateRequest()` and `validateResponse()` in `try-catch(Throwable)` blocks in `SchemaValidator` to catch `ExecutionError`/`NoSuchMethodError`/`NoClassDefFoundError` from the FGE json-schema-validator library
- Returns a proper HTTP 500 response with descriptive error message instead of hanging

## Root Cause
The bundled `json-schema-validator-all_2.2.14.wso2v1.jar` (FGE library) is incompatible with Guava 33.x. When validating `enum` keywords, `EnumValidator`'s static initializer calls `JsonNumEquals.getInstance()` which expects an older Guava `Equivalence` class signature, causing `NoSuchMethodError`. The uncaught error crashes the gateway worker thread without sending a response, causing the client to hang.

## What This Fix Does
Catches `Throwable` (including `Error` subclasses like `ExecutionError`) during schema validation and converts it to a proper HTTP 500 response. This is a defensive fix — the full resolution requires updating the orbit bundle for `json-schema-validator-all`.

## Test Plan
- [x] Deployed patched jar to product pack
- [x] Created API with `enableSchemaValidation: true` and enum fields in schema
- [x] Verified gateway returns HTTP 500 with descriptive error instead of hanging
- [x] Verified error is properly logged in server logs

Fixes https://github.com/wso2/api-manager/issues/4899

🤖 Generated with [Claude Code](https://claude.com/claude-code)