### PR TITLE
Fix initial consumer secret not viewable after approval workflow

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3106,6 +3106,8 @@ public final class APIConstants {
         public static final String WSO2_IS7_KEY_MANAGER_TYPE = "WSO2-IS-7";
         public static final String SP_NAME_APPLICATION = "sp.name.application";
 
+        public static final String INITIAL_CONSUMER_SECRET = "INITIAL_CONSUMER_SECRET";
+
         public static final String ISSUER = "issuer";
         public static final String JWKS_ENDPOINT = "jwks_endpoint";
         public static final String USERINFO_ENDPOINT = "userinfo_endpoint";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AbstractAPIManager.java
@@ -1143,6 +1143,7 @@ public abstract class AbstractAPIManager implements APIManager {
         Set<APIKey> resultantApiKeyList = new HashSet<>();
         for (APIKey apiKey : apiKeyList) {
             String keyManagerName = apiKey.getKeyManager();
+            String dbKeyManagerId = keyManagerName;
             String consumerKey = apiKey.getConsumerKey();
             String tenantDomain = this.tenantDomain;
             if (StringUtils.isNotEmpty(xWso2Tenant)) {
@@ -1214,6 +1215,27 @@ public abstract class AbstractAPIManager implements APIManager {
                                 if (StringUtils.isEmpty(oAuthApplicationInfo.getClientSecret()) &&
                                         StringUtils.isNotEmpty(storedOAuthApplicationInfo.getClientSecret())) {
                                     oAuthApplicationInfo.setClientSecret(storedOAuthApplicationInfo.getClientSecret());
+                                }
+                            }
+                            // Check for pending initial consumer secret from approval workflow.
+                            // When keys are generated via an approval workflow, the user never sees the
+                            // full secret. Return the stored full secret on the first retrieval and clear
+                            // the flag so subsequent retrievals return the masked secret from the KM.
+                            if (storedOAuthApplicationInfo != null) {
+                                Object initialSecret = storedOAuthApplicationInfo
+                                        .getParameter(APIConstants.KeyManager.INITIAL_CONSUMER_SECRET);
+                                if (initialSecret instanceof String) {
+                                    oAuthApplicationInfo.setClientSecret((String) initialSecret);
+                                    storedOAuthApplicationInfo
+                                            .removeParameter(APIConstants.KeyManager.INITIAL_CONSUMER_SECRET);
+                                    try {
+                                        apiMgtDAO.updateApplicationKeyTypeMetaData(applicationId,
+                                                apiKey.getType(),
+                                                dbKeyManagerId,
+                                                storedOAuthApplicationInfo);
+                                    } catch (APIManagementException e) {
+                                        log.error("Error clearing initial consumer secret flag", e);
+                                    }
                                 }
                             }
                         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/AbstractApplicationRegistrationWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/AbstractApplicationRegistrationWorkflowExecutor.java
@@ -152,6 +152,15 @@ public abstract class AbstractApplicationRegistrationWorkflowExecutor extends Wo
             //createApplication on oAuthorization server.
             OAuthApplicationInfo oAuthApplication = keyManager.createApplication(workflowDTO.getAppInfoDTO());
 
+            // Store the initial consumer secret for one-time retrieval after approval workflow completion.
+            // When using approval workflows, the generate-keys response returns null (pending approval),
+            // so the user never sees the full secret. This parameter allows getApplicationKeys() to
+            // return the full secret on the first retrieval after approval.
+            if (oAuthApplication.getClientSecret() != null) {
+                oAuthApplication.addParameter(APIConstants.KeyManager.INITIAL_CONSUMER_SECRET,
+                        oAuthApplication.getClientSecret());
+            }
+
             //update associateApplication
             ApplicationUtils
                     .updateOAuthAppAssociation(application, workflowDTO.getKeyType(), oAuthApplication, keyManagerId);


### PR DESCRIPTION
## Summary

- When the `ApplicationRegistrationApprovalWorkflowExecutor` is engaged, the consumer secret created during background workflow approval was never visible to the user — the `generate-keys` call returns null (pending), and after approval, only a masked secret was returned.
- This fix stores the initial plaintext consumer secret as `INITIAL_CONSUMER_SECRET` metadata during workflow completion, returns it unmasked on the first retrieval via `getApplicationKeys()`, then clears it from the database for subsequent masked retrievals (one-time view).

## Changes

| File | Change |
|------|--------|
| `APIConstants.java` | Added `INITIAL_CONSUMER_SECRET` constant in `KeyManager` inner class |
| `AbstractApplicationRegistrationWorkflowExecutor.java` | Store plaintext consumer secret as metadata after OAuth app creation during workflow completion |
| `AbstractAPIManager.java` | In `getApplicationKeys()`, check for stored initial secret, return it unmasked on first retrieval, then clear the flag from DB |

## Test plan

- [x] Configured `ApplicationRegistrationApprovalWorkflowExecutor` for production/sandbox registration
- [x] Created API, published, deployed revision
- [x] Created application, subscribed to API, called generate-keys (returned `CREATED` with null secret)
- [x] Approved workflow via Admin API
- [x] First `GET /oauth-keys` returned full unmasked consumer secret
- [x] Second `GET /oauth-keys` returned masked secret (one-time view confirmed)
- [x] Verified DevPortal UI shows consumer key and secret entry on Production Keys page

Fixes: https://github.com/wso2/api-manager/issues/4902

🤖 Generated with [Claude Code](https://claude.com/claude-code)