### PR TITLE
Validate scope name for restricted prefixes

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -427,7 +427,7 @@ public enum ExceptionCodes implements ErrorHandler {
     SCOPE_VALIDATION_FAILED(900986, "Scope validation failed", 412, "Scope validation failed"),
     SHARED_SCOPE_DISPLAY_NAME_NOT_SPECIFIED(900987, "Shared Scope display name not specified", 400,
             "Shared Scope display name not specified"),
-    INVALID_SCOPE_NAME(901001, "Invalid Scope name", 400, "Scope name contains invalid characters"),
+    INVALID_SCOPE_NAME(901004, "Invalid Scope name", 400, "Invalid Scope name"),
     BLOCK_CONDITION_RETRIEVE_PARAMS_EXCEPTION(900254, "Block conditions retrieval error", 400,
             "Provided query parameters are not valid"),
     BLOCK_CONDITION_RETRIEVE_FAILED(900255, "Failed to get Block conditions", 500,

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -427,6 +427,7 @@ public enum ExceptionCodes implements ErrorHandler {
     SCOPE_VALIDATION_FAILED(900986, "Scope validation failed", 412, "Scope validation failed"),
     SHARED_SCOPE_DISPLAY_NAME_NOT_SPECIFIED(900987, "Shared Scope display name not specified", 400,
             "Shared Scope display name not specified"),
+    INVALID_SCOPE_NAME(901001, "Invalid Scope name", 400, "Scope name contains invalid characters"),
     BLOCK_CONDITION_RETRIEVE_PARAMS_EXCEPTION(900254, "Block conditions retrieval error", 400,
             "Provided query parameters are not valid"),
     BLOCK_CONDITION_RETRIEVE_FAILED(900255, "Failed to get Block conditions", 500,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/CommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/CommonUtils.java
@@ -141,7 +141,7 @@ public class CommonUtils {
 
             // Validate scope name for restricted prefixes
             if (APIUtil.hasRestrictedScopePrefix(scopeName)) {
-                log.error("Invalid scope name with restricted prefix: " + scopeName);
+                log.error("Invalid scope name with restricted prefix: " + scopeName + " for API: " + api.getId().getApiName());
                 throw new APIManagementException(ExceptionCodes.INVALID_SCOPE_NAME);
             }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/CommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/CommonUtils.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.apimgt.impl.restapi;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
@@ -37,6 +39,8 @@ import java.util.Set;
  * This class is used to have the functionalities common to all REST API utils
  */
 public class CommonUtils {
+
+    private static final Log log = LogFactory.getLog(CommonUtils.class);
 
     private CommonUtils() {
     }
@@ -131,8 +135,13 @@ public class CommonUtils {
                 }
             }
 
+            if (log.isDebugEnabled()) {
+                log.debug("Validating scope: " + scopeName + " for API: " + api.getId().getApiName());
+            }
+
             // Validate scope name for restricted prefixes
             if (APIUtil.hasRestrictedScopePrefix(scopeName)) {
+                log.error("Invalid scope name with restricted prefix: " + scopeName);
                 throw new APIManagementException(ExceptionCodes.INVALID_SCOPE_NAME);
             }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/CommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/CommonUtils.java
@@ -131,6 +131,11 @@ public class CommonUtils {
                 }
             }
 
+            // Validate scope name for restricted prefixes
+            if (APIUtil.hasRestrictedScopePrefix(scopeName)) {
+                throw new APIManagementException(ExceptionCodes.INVALID_SCOPE_NAME);
+            }
+
             //set display name as empty if it is not provided
             if (StringUtils.isBlank(scope.getName())) {
                 scope.setName(scopeName);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -12338,9 +12338,12 @@ public final class APIUtil {
         if (log.isDebugEnabled()) {
             log.debug("Checking if scope has restricted prefix: " + scopeName);
         }
-
-        return scopeName.startsWith(RESTRICTED_SCOPE_PREFIX_APIM)
+        boolean hasRestrictedPrefix = scopeName.startsWith(RESTRICTED_SCOPE_PREFIX_APIM)
                 || scopeName.startsWith(RESTRICTED_SCOPE_PREFIX_APIM_ANALYTICS)
                 || scopeName.startsWith(RESTRICTED_SCOPE_PREFIX_SERVICE_CATALOG);
+        if (hasRestrictedPrefix && log.isDebugEnabled()) {
+            log.debug("Scope has restricted prefix: " + scopeName);
+        }
+        return hasRestrictedPrefix;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -12335,6 +12335,9 @@ public final class APIUtil {
      * @return true if the scope name starts with a restricted prefix
      */
     public static boolean hasRestrictedScopePrefix(String scopeName) {
+        if (log.isDebugEnabled()) {
+            log.debug("Checking if scope has restricted prefix: " + scopeName);
+        }
 
         return scopeName.startsWith(RESTRICTED_SCOPE_PREFIX_APIM)
                 || scopeName.startsWith(RESTRICTED_SCOPE_PREFIX_APIM_ANALYTICS)

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -402,6 +402,10 @@ public final class APIUtil {
 
     private static final ThreadLocal<Boolean> skipSecretMasking = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
+    private static final String RESTRICTED_SCOPE_PREFIX_APIM = "apim:";
+    private static final String RESTRICTED_SCOPE_PREFIX_APIM_ANALYTICS = "apim_analytics:";
+    private static final String RESTRICTED_SCOPE_PREFIX_SERVICE_CATALOG = "service_catalog:";
+
     private APIUtil() {
 
     }
@@ -12321,5 +12325,19 @@ public final class APIUtil {
         } else {
             log.error("Swagger definition is null for API: " + api.getId().getApiName());
         }
+    }
+
+    /**
+     * Checks whether a scope name starts with a restricted/reserved prefix.
+     * This method performs an exact, case-sensitive prefix match to preserve existing behaviour.
+     *
+     * @param scopeName Scope name to check
+     * @return true if the scope name starts with a restricted prefix
+     */
+    public static boolean hasRestrictedScopePrefix(String scopeName) {
+
+        return scopeName.startsWith(RESTRICTED_SCOPE_PREFIX_APIM)
+                || scopeName.startsWith(RESTRICTED_SCOPE_PREFIX_APIM_ANALYTICS)
+                || scopeName.startsWith(RESTRICTED_SCOPE_PREFIX_SERVICE_CATALOG);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -2216,7 +2216,7 @@ public class PublisherCommonUtils {
 
             // Validate scope name for restricted prefixes
             if (APIUtil.hasRestrictedScopePrefix(scopeName)) {
-                log.warn("Scope validation failed: scope name '{}' contains restricted prefix "+ scopeName);
+                log.error("Invalid scope name with restricted prefix: " + scopeName);
                 throw new APIManagementException(ExceptionCodes.INVALID_SCOPE_NAME);
             }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -2214,6 +2214,11 @@ public class PublisherCommonUtils {
                 }
             }
 
+            // Validate scope name for restricted prefixes
+            if (APIUtil.hasRestrictedScopePrefix(scopeName)) {
+                throw new APIManagementException(ExceptionCodes.INVALID_SCOPE_NAME);
+            }
+
             //set display name as empty if it is not provided
             if (StringUtils.isBlank(scope.getName())) {
                 scope.setName(scopeName);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -2216,6 +2216,7 @@ public class PublisherCommonUtils {
 
             // Validate scope name for restricted prefixes
             if (APIUtil.hasRestrictedScopePrefix(scopeName)) {
+                log.warn("Scope validation failed: scope name '{}' contains restricted prefix "+ scopeName);
                 throw new APIManagementException(ExceptionCodes.INVALID_SCOPE_NAME);
             }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ScopesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ScopesApiServiceImpl.java
@@ -116,6 +116,7 @@ public class ScopesApiServiceImpl implements ScopesApiService {
             }
             // Validate scope name for restricted prefixes
             if (APIUtil.hasRestrictedScopePrefix(scopeName)) {
+                log.warn("Attempt to create scope with restricted prefix: " + scopeName);
                 throw new APIManagementException(ExceptionCodes.INVALID_SCOPE_NAME);
             }
             if (apiProvider.isScopeKeyExist(scopeName, APIUtil.getTenantIdFromTenantDomain(tenantDomain)) ||

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ScopesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ScopesApiServiceImpl.java
@@ -114,6 +114,10 @@ public class ScopesApiServiceImpl implements ScopesApiService {
                 throw new APIManagementException("Shared scope Display Name cannot be null or empty",
                         ExceptionCodes.SHARED_SCOPE_DISPLAY_NAME_NOT_SPECIFIED);
             }
+            // Validate scope name for restricted prefixes
+            if (APIUtil.hasRestrictedScopePrefix(scopeName)) {
+                throw new APIManagementException(ExceptionCodes.INVALID_SCOPE_NAME);
+            }
             if (apiProvider.isScopeKeyExist(scopeName, APIUtil.getTenantIdFromTenantDomain(tenantDomain)) ||
                     apiProvider.isScopeKeyExistInKeyManager(scopeName, tenantDomain)) {
                 throw new APIManagementException(ExceptionCodes.from(ExceptionCodes.SCOPE_ALREADY_REGISTERED,


### PR DESCRIPTION
### Approach
**Local scopes:**

- When creating/updating scopes:
    - Block if the scope name contains apim:, apim_analytics, or service_catalog.

**Global scopes:**

- When creating scopes:
    - Block if the scope name contains apim:, apim_analytics, or service_catalog.

- When updating scopes:
    - Keep the existing behavior. (Because scope name cannot be edited)

**validateScopes endpoint (HEAD scopes/{scopeId}):**

- No changes. This method is used to return 200 or 404 depending on whether the scope exists or not. We are not validating the scope name here, as there is no suitable output defined for an invalid scope name. Introducing one would require API changes.

Manual Testing

- [x] Local scopes
- [x] Global scopes

Fixes https://github.com/wso2/api-manager/issues/4955