### PR TITLE
Fix 3rd party MCP Server connection failure from vcode client

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/mcp/McpInitHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/mcp/McpInitHandler.java
@@ -237,19 +237,10 @@ public class McpInitHandler extends AbstractHandler implements ManagedLifecycle 
     private boolean isNoAuthMCPRequest(String method) throws McpException {
 
         switch (method) {
-            case APIConstants.MCP.METHOD_INITIALIZE:
-            case APIConstants.MCP.METHOD_PING:
-            case APIConstants.MCP.METHOD_NOTIFICATION_INITIALIZED:
-            case APIConstants.MCP.METHOD_RESOURCES_LIST:
-            case APIConstants.MCP.METHOD_RESOURCE_TEMPLATE_LIST:
-            case APIConstants.MCP.METHOD_PROMPTS_LIST:
-                return true;
-
-            case APIConstants.MCP.METHOD_TOOL_LIST:
             case APIConstants.MCP.METHOD_TOOL_CALL:
-
-            default:
                 return false;
+            default:
+                return true;
         }
     }
 }


### PR DESCRIPTION
- When connecting a MCP Server (Proxying an existing MCP Server) from vscode client, it fails. This PR fixes that issue.