### PR TITLE
Handle Mediation Policies Flow in Api Products

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -5358,6 +5358,14 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             }
             if (api != null) {
                 validateApiLifeCycleForApiProducts(api);
+                if (APIUtil.isSequenceDefined(api.getInSequence()) || APIUtil.isSequenceDefined(api.getOutSequence())
+                        || APIUtil.isSequenceDefined(api.getFaultSequence())) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Migrating mediation policies for reference API: " + api.getId() +
+                                " in tenant domain: " + tenantDomain);
+                    }
+                    migrateMediationPoliciesOfAPI(api, tenantDomain, false);
+                }
                 if (api.getSwaggerDefinition() != null) {
                     api.setSwaggerDefinition(getOpenAPIDefinition(apiUUID, product.getOrganization()));
                 }
@@ -5572,10 +5580,20 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 apiUUID = apiProductResource.getApiId();
                 api = getAPIbyUUID(apiUUID, tenantDomain);
             }
-            if (APIConstants.API_SUBTYPE_AI_API.equals(api.getSubtype())) {
-                log.warn("Cannot create API Products using AI APIs.");
-                throw new APIManagementException(
-                        ExceptionCodes.from(ExceptionCodes.INVALID_API_FOR_API_PRODUCT, APIConstants.AI.AI));
+            if (api != null) {
+                if (APIConstants.API_SUBTYPE_AI_API.equals(api.getSubtype())) {
+                    log.warn("Cannot create API Products using AI APIs.");
+                    throw new APIManagementException(
+                            ExceptionCodes.from(ExceptionCodes.INVALID_API_FOR_API_PRODUCT, APIConstants.AI.AI));
+                }
+                if (APIUtil.isSequenceDefined(api.getInSequence()) || APIUtil.isSequenceDefined(api.getOutSequence())
+                        || APIUtil.isSequenceDefined(api.getFaultSequence())) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Migrating mediation policies for reference API: " + api.getId() +
+                                " in tenant domain: " + tenantDomain);
+                    }
+                    migrateMediationPoliciesOfAPI(api, tenantDomain, false);
+                }
             }
             if (api.getSwaggerDefinition() != null) {
                 api.setSwaggerDefinition(getOpenAPIDefinition(apiUUID, tenantDomain));


### PR DESCRIPTION
### Description

Mediation policy attached APIs were not working after attaching to API Products after migrating to APIM 4.7.0. This PR addresses this issue by running on-the-fly migration of the reference API while trying to update the API Product if it is not yet run on the reference APIs

Tested below flows with this fix on a migrated MySQL DB
Default mediation policy
- [x] Invoke API product and verify policy behavior of respective resource.
- [x] Save API Product and invoke API Product.
- [x] Save API Product and invoke reference APIs.
- [x] Save one of the reference APIs and invoke a resource of that API from API Product.
- [x] Save API product after saving a reference API and invoke both APIs and API Product.
- [x] Test API revisioning feature together with above combinations for both reference API and API Product. 
- [x] API Product versioning

Custom mediation policy
- [x] Invoke API product and verify policy behavior of respective resource.
- [x] Save API Product and invoke API Product.
- [x] Save API Product and invoke reference APIs.
- [x] Save one of the reference APIs and invoke a resource of that API from API Product.
- [x] Save API product after saving a reference API and invoke both APIs and API Product.
- [x] Test API revisioning feature together with above combinations for both reference API and API Product. 
- [x] API Product versioning

- Resolves https://github.com/wso2/api-manager/issues/4918