### PR TITLE
Analytics: handle masking and error paths properly

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/CommonRequestDataCollector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/CommonRequestDataCollector.java
@@ -22,10 +22,14 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.common.analytics.Constants;
 import org.wso2.carbon.apimgt.common.analytics.collectors.AnalyticsDataProvider;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Application;
+import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Event;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import static org.wso2.carbon.apimgt.common.analytics.Constants.EMAIL_PROP_TYPE;
 import static org.wso2.carbon.apimgt.common.analytics.Constants.IPV4_MASK_VALUE;
@@ -116,5 +120,75 @@ public abstract class CommonRequestDataCollector extends AbstractRequestDataColl
             }
         }
         return null;
+    }
+
+    protected Event maskAnalyticsEvent(Event event, Map<String, String> maskData) {
+
+        for (Map.Entry<String, String> entry : maskData.entrySet()) {
+            Map<String, Object> props = event.getProperties();
+            if (props != null) {
+                Object value = props.get(entry.getKey());
+                if (value != null) {
+                    String maskStr = maskAnalyticsData(entry.getValue(), value);
+                    props.replace(entry.getKey(), maskStr);
+                }
+            }
+        }
+
+        // Mask UserName if configured
+        String userName = event.getUserName();
+        if (userName != null) {
+            String maskType = Stream.of("api.ut.userName", "api.ut.userId", "userName", "userId")
+                    .map(maskData::get)
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
+
+            if (maskType != null) {
+                userName = maskAnalyticsData(maskType, userName);
+            }
+            event.setUserName(userName);
+        }
+
+        // Mask Application Owner if configured
+        Application application = event.getApplication();
+        if (application != null && application.getApplicationOwner() != null
+                && maskData.containsKey("applicationOwner")) {
+            String appOwner = application.getApplicationOwner();
+            appOwner = maskAnalyticsData(maskData.get("applicationOwner"), appOwner);
+            application.setApplicationOwner(appOwner);
+        }
+
+        // Mask User IP if configured
+        String userIp = event.getUserIp();
+        if (userIp != null && !userIp.equals(Constants.UNKNOWN_VALUE)) {
+            String maskType = Stream.of("api.analytics.user.ip", "userIp")
+                    .map(maskData::get)
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
+
+            if (maskType != null) {
+                userIp = maskAnalyticsData(maskType, userIp);
+            }
+            event.setUserIp(userIp);
+        }
+
+        // Mask User Agent if configured
+        String userAgent = event.getUserAgentHeader();
+        if (userAgent != null && !userAgent.equals(Constants.UNKNOWN_VALUE)) {
+            String maskType = Stream.of("api.analytics.user.agent", "userAgent")
+                    .map(maskData::get)
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
+
+            if (maskType != null) {
+                userAgent = maskAnalyticsData(maskType, userAgent);
+            }
+            event.setUserAgentHeader(userAgent);
+        }
+
+        return event;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/CommonRequestDataCollector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/CommonRequestDataCollector.java
@@ -134,7 +134,9 @@ public abstract class CommonRequestDataCollector extends AbstractRequestDataColl
                 Object value = props.get(entry.getKey());
                 if (value != null) {
                     String maskStr = maskAnalyticsData(entry.getValue(), value);
-                    props.replace(entry.getKey(), maskStr);
+                    if (maskStr != null) {
+                        props.replace(entry.getKey(), maskStr);
+                    }
                 }
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/CommonRequestDataCollector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/CommonRequestDataCollector.java
@@ -124,6 +124,10 @@ public abstract class CommonRequestDataCollector extends AbstractRequestDataColl
 
     protected Event maskAnalyticsEvent(Event event, Map<String, String> maskData) {
 
+        if (maskData == null || maskData.isEmpty()) {
+            return event;
+        }
+
         for (Map.Entry<String, String> entry : maskData.entrySet()) {
             Map<String, Object> props = event.getProperties();
             if (props != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/FaultyRequestDataCollector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/FaultyRequestDataCollector.java
@@ -36,6 +36,8 @@ import org.wso2.carbon.apimgt.common.analytics.publishers.dto.MetaInfo;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Operation;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Target;
 
+import java.util.Map;
+
 /**
  * Faulty request data collector.
  */
@@ -84,6 +86,7 @@ public class FaultyRequestDataCollector extends CommonRequestDataCollector imple
     private Event getFaultyEvent() throws DataNotFoundException {
         long requestInTime = provider.getRequestTime();
         String offsetDateTime = getTimeInISO(requestInTime);
+        Map<String, String> maskData = provider.getMaskProperties();
 
         Event event = new Event();
         event.setProperties(provider.getProperties());
@@ -105,6 +108,6 @@ public class FaultyRequestDataCollector extends CommonRequestDataCollector imple
         event.setMetaInfo(metaInfo);
         event.setUserIp(userIp);
 
-        return event;
+        return maskAnalyticsEvent(event, maskData);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/SuccessRequestDataCollector.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/src/main/java/org/wso2/carbon/apimgt/common/analytics/collectors/impl/SuccessRequestDataCollector.java
@@ -32,10 +32,7 @@ import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Operation;
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.Target;
 import org.wso2.carbon.apimgt.common.analytics.publishers.impl.SuccessRequestDataPublisher;
 
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Stream;
 
 /**
  * Success request data collector.
@@ -60,24 +57,10 @@ public class SuccessRequestDataCollector extends CommonRequestDataCollector impl
 
         long requestInTime = provider.getRequestTime();
         String offsetDateTime = getTimeInISO(requestInTime);
+        Map<String, String> maskData = provider.getMaskProperties();
 
         Event event = new Event();
         event.setProperties(provider.getProperties());
-
-        // Masking the configured data
-        Map<String, String> maskData = provider.getMaskProperties();
-        Iterator<Map.Entry<String, String>> iterator = maskData.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<String, String> entry = iterator.next();
-            Map<String, Object> props = event.getProperties();
-            if (props != null) {
-                Object value = props.get(entry.getKey());
-                if (value != null) {
-                    String maskStr = maskAnalyticsData(entry.getValue(), value);
-                    props.replace(entry.getKey(), maskStr);
-                }
-            }
-        }
 
         API api = provider.getApi();
         Operation operation = provider.getOperation();
@@ -95,62 +78,16 @@ public class SuccessRequestDataCollector extends CommonRequestDataCollector impl
         String userAgent = provider.getUserAgentHeader();
         String userName = provider.getUserName();
 
-        // Mask UserName if configured
-        if (userName != null) {
-            String maskType = Stream.of(
-                            "api.ut.userName",
-                            "userName",
-                            "api.ut.userId",
-                            "userId"
-                    )
-                    .map(maskData::get)
-                    .filter(Objects::nonNull)
-                    .findFirst()
-                    .orElse(null);
-
-            if (maskType != null) {
-                userName = maskAnalyticsData(maskType, userName);
-            }
-        } else {
+        String userIp = provider.getEndUserIP();
+        if (userName == null) {
             userName = Constants.UNKNOWN_VALUE;
         }
-
-        // Mask Application Owner if configured
-        if (application.getApplicationOwner() != null && maskData.containsKey("applicationOwner")) {
-            String appOwner = application.getApplicationOwner();
-            appOwner = maskAnalyticsData(maskData.get("applicationOwner"), appOwner);
-            application.setApplicationOwner(appOwner);
-        }
-
-        String userIp = provider.getEndUserIP();
-
         if (userIp == null) {
             userIp = Constants.UNKNOWN_VALUE;
-        } else {
-            // Mask User IP if configured
-            String maskType = Stream.of("api.analytics.user.ip", "userIp")
-                    .map(maskData::get)
-                    .filter(Objects::nonNull)
-                    .findFirst()
-                    .orElse(null);
-
-            if (maskType != null) {
-                userIp = maskAnalyticsData(maskType, userIp);
-            }
         }
+
         if (userAgent == null) {
             userAgent = Constants.UNKNOWN_VALUE;
-        } else {
-            String maskType = Stream.of("api.analytics.user.agent", "userAgent")
-                    .map(maskData::get)
-                    .filter(Objects::nonNull)
-                    .findFirst()
-                    .orElse(null);
-
-            if (maskType != null) {
-                userAgent = maskAnalyticsData(maskType, userAgent);
-            }
-
         }
 
         event.setApi(api);
@@ -165,7 +102,7 @@ public class SuccessRequestDataCollector extends CommonRequestDataCollector impl
         event.setUserName(userName);
         event.setUserIp(userIp);
 
-        this.processor.publish(event);
+        this.processor.publish(maskAnalyticsEvent(event, maskData));
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -81,6 +81,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS;
+import static org.apache.synapse.rest.RESTConstants.REST_SUB_REQUEST_PATH;
 import static org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants.API_OBJECT;
 import static org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants.API_ELECTED_RESOURCE;
 import static org.wso2.carbon.apimgt.gateway.handlers.analytics.Constants.MASK_VALUE;
@@ -286,7 +287,7 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
         String apiResourceTemplate = (String) messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE);
         // If path is invalid, the elected resource is not set in the message context.
         if (apiResourceTemplate == null) {
-            apiResourceTemplate = (String) messageContext.getProperty(APIConstants.REST_SUB_REQUEST_PATH);
+            apiResourceTemplate = (String) messageContext.getProperty(REST_SUB_REQUEST_PATH);
         }
         Operation operation = new Operation();
         operation.setApiMethod(httpMethod);

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/analytics/SynapseAnalyticsDataProvider.java
@@ -284,6 +284,10 @@ public class SynapseAnalyticsDataProvider implements AnalyticsDataProvider {
 
         String httpMethod = (String) messageContext.getProperty(APIMgtGatewayConstants.HTTP_METHOD);
         String apiResourceTemplate = (String) messageContext.getProperty(APIConstants.API_ELECTED_RESOURCE);
+        // If path is invalid, the elected resource is not set in the message context.
+        if (apiResourceTemplate == null) {
+            apiResourceTemplate = (String) messageContext.getProperty(APIConstants.REST_SUB_REQUEST_PATH);
+        }
         Operation operation = new Operation();
         operation.setApiMethod(httpMethod);
         if (APIConstants.GRAPHQL_API.equalsIgnoreCase(getApi().getApiType())) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1634,6 +1634,7 @@ public final class APIConstants {
 
     public static final String API_RESOURCE_CACHE_KEY = "API_RESOURCE_CACHE_KEY";
     public static final String API_ELECTED_RESOURCE = "API_ELECTED_RESOURCE";
+    public static final String REST_SUB_REQUEST_PATH = "REST_SUB_REQUEST_PATH";
     public static final String REST_METHOD = "REST_METHOD";
 
     // GraphQL related constants

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1634,7 +1634,6 @@ public final class APIConstants {
 
     public static final String API_RESOURCE_CACHE_KEY = "API_RESOURCE_CACHE_KEY";
     public static final String API_ELECTED_RESOURCE = "API_ELECTED_RESOURCE";
-    public static final String REST_SUB_REQUEST_PATH = "REST_SUB_REQUEST_PATH";
     public static final String REST_METHOD = "REST_METHOD";
 
     // GraphQL related constants


### PR DESCRIPTION
Related to: https://github.com/wso2/api-manager/issues/3968
This pull request introduces a significant refactoring and enhancement to the analytics data masking logic in the API Manager. The main improvement is the centralization of all masking logic into a new `maskAnalyticsEvent` method in `CommonRequestDataCollector`, which is now reused by both the success and faulty request data collectors. This change ensures consistent and maintainable masking of sensitive analytics data. Additionally, a minor fix was made to improve the retrieval of the API resource path in the gateway data provider.

**Centralized and Enhanced Analytics Data Masking**

* [`CommonRequestDataCollector.java`](diffhunk://#diff-f57d7f65301364f1fffc520c55797075a8bbaa577f1b1a70c3a6aae332678a49R124-R193): Introduced the `maskAnalyticsEvent` method to handle masking of properties, user name, application owner, user IP, and user agent in a single, reusable place. This method uses the provided masking configuration and is now the standard way to mask analytics data.
* `SuccessRequestDataCollector.java` and `FaultyRequestDataCollector.java`: Refactored to delegate all masking responsibilities to `maskAnalyticsEvent`, removing duplicated masking logic and streamlining the data collection process. [[1]](diffhunk://#diff-3daa1f119228e6efdbdbb2c354227832ae6cb3609e8a262de964a701f6163f40R60-L81) [[2]](diffhunk://#diff-3daa1f119228e6efdbdbb2c354227832ae6cb3609e8a262de964a701f6163f40L98-L153) [[3]](diffhunk://#diff-3daa1f119228e6efdbdbb2c354227832ae6cb3609e8a262de964a701f6163f40L168-R105) [[4]](diffhunk://#diff-c3b3b1646fc318a345bf8564513fd8f2ffc9d4c2243537ed0fc0d81ecf74191dR89) [[5]](diffhunk://#diff-c3b3b1646fc318a345bf8564513fd8f2ffc9d4c2243537ed0fc0d81ecf74191dL108-R111)

**Gateway Analytics Resource Path Handling**

* [`SynapseAnalyticsDataProvider.java`](diffhunk://#diff-9aa5ba13d787ed6cb131be88887fc3c7da66f86cf235cfa4abcbe06ba389a9c4R287-R290): Improved logic for determining the API resource template by falling back to `REST_SUB_REQUEST_PATH` if `API_ELECTED_RESOURCE` is not available, ensuring resource path is always set for analytics.
* [`APIConstants.java`](diffhunk://#diff-53180db9d61eccf226f337dec15f32bb7e951677a1e8b930daef9c9c30828d17R1637): Added the `REST_SUB_REQUEST_PATH` constant to support the above change.

**Imports and Cleanup**

* Cleaned up unused imports and added necessary ones to support the refactored masking logic. [[1]](diffhunk://#diff-f57d7f65301364f1fffc520c55797075a8bbaa577f1b1a70c3a6aae332678a49R25-R32) [[2]](diffhunk://#diff-c3b3b1646fc318a345bf8564513fd8f2ffc9d4c2243537ed0fc0d81ecf74191dR39-R40) [[3]](diffhunk://#diff-3daa1f119228e6efdbdbb2c354227832ae6cb3609e8a262de964a701f6163f40L35-L38)

These changes improve maintainability, consistency, and security of analytics data handling across the codebase.