### PR TITLE
Treat PARAMETERS as a String in the AM_GATEWAY_POLICY_MAPPING table.

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -27090,8 +27090,16 @@ public class ApiMgtDAO {
             statement.setString(1, policyMappingUUID);
             try (ResultSet rs = statement.executeQuery()) {
                 while (rs.next()) {
-                    OperationPolicy policy = populateOperationPolicyWithRS(rs);
-                    gatewayPolicies.add(policy);
+                    OperationPolicy operationPolicy = new OperationPolicy();
+                    operationPolicy.setPolicyName(rs.getString("POLICY_NAME"));
+                    operationPolicy.setPolicyVersion(rs.getString("POLICY_VERSION"));
+                    operationPolicy.setPolicyId(rs.getString("POLICY_UUID"));
+                    operationPolicy.setOrder(rs.getInt("POLICY_ORDER"));
+                    operationPolicy.setDirection(rs.getString("DIRECTION"));
+                    Map<String, Object> parameters =
+                    APIMgtDBUtil.convertJSONStringToMap(rs.getString("PARAMETERS"));
+                    operationPolicy.setParameters(parameters != null ? parameters : new HashMap<>());
+                    gatewayPolicies.add(operationPolicy);
                 }
             }
         } catch (SQLException e) {


### PR DESCRIPTION
### Description
This pull request refactors how `OperationPolicy` objects are created and populated in the `getGatewayPoliciesOfPolicyMapping` method to treat the PARAMETERS value as a String since it is stored in the DB as a String.

Resolves https://github.com/wso2/api-manager/issues/4482