### PR TITLE
Port: Add config to preserve the hashmap ordering in resources (#8113) to public/master

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dao/ApiMgtDAO.java
@@ -207,6 +207,7 @@ public class ApiMgtDAO {
     private final Object scopeMutex = new Object();
     private boolean forceCaseInsensitiveComparisons = false;
     private boolean multiGroupAppSharingEnabled = false;
+    private boolean preserveSystemResourceOrdering = false;
     private String PublicAccessPermission = "PUBLIC";
     private static final String[] keyTypes =
             new String[]{APIConstants.API_KEY_TYPE_PRODUCTION, APIConstants.API_KEY_TYPE_SANDBOX};
@@ -223,6 +224,11 @@ public class ApiMgtDAO {
         }
 
         multiGroupAppSharingEnabled = APIUtil.isMultiGroupAppSharingEnabled();
+
+        String config = System.getProperty("preserveSystemResourceOrdering");
+        if (StringUtils.isNotEmpty(config)) {
+            preserveSystemResourceOrdering = Boolean.parseBoolean(config);
+        }
     }
 
     /**
@@ -17205,7 +17211,12 @@ public class ApiMgtDAO {
                     }
                 }
 
-                Map<String, URITemplate> uriTemplateMap = new HashMap<>();
+                Map<String, URITemplate> uriTemplateMap;
+                if (preserveSystemResourceOrdering) {
+                    uriTemplateMap = new HashMap<>(1024, 0.9F);
+                } else {
+                    uriTemplateMap = new LinkedHashMap<>();
+                }
                 for (URITemplate urlMapping : urlMappingList) {
                     if (urlMapping.getScope() != null) {
                         URITemplate urlMappingNew = urlMapping;
@@ -20278,7 +20289,12 @@ public class ApiMgtDAO {
                     }
                 }
 
-                Map<String, URITemplate> uriTemplateMap = new HashMap<>();
+                Map<String, URITemplate> uriTemplateMap;
+                if (preserveSystemResourceOrdering) {
+                    uriTemplateMap = new HashMap<>(1024, 0.9F);
+                } else {
+                    uriTemplateMap = new LinkedHashMap<>();
+                }
                 for (URITemplate urlMapping : urlMappingList) {
                     if (urlMapping.getScope() != null) {
                         URITemplate urlMappingNew = urlMapping;
@@ -21462,7 +21478,12 @@ public class ApiMgtDAO {
                     }
                 }
 
-                Map<String, URITemplate> uriTemplateMap = new HashMap<>();
+                Map<String, URITemplate> uriTemplateMap;
+                if (preserveSystemResourceOrdering) {
+                    uriTemplateMap = new HashMap<>(1024, 0.9F);
+                } else {
+                    uriTemplateMap = new LinkedHashMap<>();
+                }
                 for (URITemplate urlMapping : urlMappingList) {
                     if (urlMapping.getScope() != null) {
                         URITemplate urlMappingNew = urlMapping;
@@ -21881,7 +21902,12 @@ public class ApiMgtDAO {
                     }
                 }
 
-                Map<String, URITemplate> uriTemplateMap = new HashMap<>();
+                Map<String, URITemplate> uriTemplateMap;
+                if (preserveSystemResourceOrdering) {
+                    uriTemplateMap = new HashMap<>(1024, 0.9F);
+                } else {
+                    uriTemplateMap = new LinkedHashMap<>();
+                }
                 for (URITemplate urlMapping : urlMappingList) {
                     if (urlMapping.getScope() != null) {
                         URITemplate urlMappingNew = urlMapping;


### PR DESCRIPTION
This pull request adds support for controlling the ordering of system resources in the `ApiMgtDAO` class by introducing a new configuration option. The main change is the ability to toggle between using a `HashMap` or a `LinkedHashMap` for storing URI templates, based on a system property. This affects how resource ordering is preserved in various API and API Product revision operations.

Configuration and feature addition:

* Introduced a new boolean field `preserveSystemResourceOrdering` in `ApiMgtDAO`, set via the `preserveSystemResourceOrdering` system property. This allows administrators to control whether the original order of system resources is preserved. [[1]](diffhunk://#diff-ac8fc1b7b2d10089084f9f842ad03ac096b64f8c555798aa18a926e0ec663a4cR210) [[2]](diffhunk://#diff-ac8fc1b7b2d10089084f9f842ad03ac096b64f8c555798aa18a926e0ec663a4cR227-R231)

Resource mapping logic changes:

* Updated the logic in methods handling API and API Product resource mappings (`processAPIProductResourceMappings`, `addAPIRevision`, `restoreAPIRevision`, `addAPIProductRevision`) to use either a `HashMap` or a `LinkedHashMap` for `uriTemplateMap` depending on the `preserveSystemResourceOrdering` flag. This impacts the order in which URI templates are stored and processed. [[1]](diffhunk://#diff-ac8fc1b7b2d10089084f9f842ad03ac096b64f8c555798aa18a926e0ec663a4cL17208-R17219) [[2]](diffhunk://#diff-ac8fc1b7b2d10089084f9f842ad03ac096b64f8c555798aa18a926e0ec663a4cL20281-R20297) [[3]](diffhunk://#diff-ac8fc1b7b2d10089084f9f842ad03ac096b64f8c555798aa18a926e0ec663a4cL21465-R21486) [[4]](diffhunk://#diff-ac8fc1b7b2d10089084f9f842ad03ac096b64f8c555798aa18a926e0ec663a4cL21884-R21910)