### PR TITLE
Add: File Size Limit

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/APIConstants.java
@@ -44,6 +44,18 @@ public class APIConstants {
     public static final String ENDPOINT_SECURITY_PRODUCTION = "production";
     public static final String ENDPOINT_SECURITY_SANDBOX = "sandbox";
     public static final String ENDPOINT_CONFIG_SESSION_TIMEOUT = "sessionTimeOut";
+    public static final String API_PUBLISHER = "APIPublisher.";
+    public static final String API_PUBLISHER_IMPORT_DEFINITION_FILE_SIZE_LIMIT = API_PUBLISHER + "ImportDefinitionFileSizeLimit.";
+    public static final String API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT = API_PUBLISHER_IMPORT_DEFINITION_FILE_SIZE_LIMIT + "OAS";
+    public static final String API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT_DEFAULT_MB = "10";
+    public static final String API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT = API_PUBLISHER_IMPORT_DEFINITION_FILE_SIZE_LIMIT + "ASYNC";
+    public static final String API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT_DEFAULT_MB = "10";
+    public static final String API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT = API_PUBLISHER_IMPORT_DEFINITION_FILE_SIZE_LIMIT + "WSDL";
+    public static final String API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB = "10";
+    public static final String API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT = API_PUBLISHER_IMPORT_DEFINITION_FILE_SIZE_LIMIT + "GRAPHQL";
+    public static final String API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT_DEFAULT_MB = "10";
+    public static final String API_PUBLISHER_IMPORT_MCP_FILE_SIZE_LIMIT = API_PUBLISHER_IMPORT_DEFINITION_FILE_SIZE_LIMIT + "MCP";
+    public static final String API_PUBLISHER_IMPORT_MCP_FILE_SIZE_LIMIT_DEFAULT_MB = "10";
     public static final String ENDPOINT_SECURITY_TYPE_AWS = "aws";
     public static final String LLM_PROVIDER_SERVICE_AWS_BEDROCK_SERVICE_NAME = "bedrock";
 

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -841,6 +841,8 @@ public enum ExceptionCodes implements ErrorHandler {
 
     ROLE_OF_SCOPE_DOES_NOT_EXIST(903250, "Role does not exist", 404,
             "Role %s does not exist"),
+    FILE_TOO_LARGE(902030, "Content retrieval from URL failed", 400,
+            "Maximum content size exceeded while retrieving content from URL"),
 
     OPERATION_OR_RESOURCE_TYPE_OR_METHOD_NOT_DEFINED(902031,
             "Operation type/http method is not specified for the operation/resource", 400,

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/FileSizeLimitExceededException.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/FileSizeLimitExceededException.java
@@ -1,0 +1,45 @@
+/*
+ *   Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ *   WSO2 LLC. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.wso2.carbon.apimgt.api;
+
+import java.io.IOException;
+
+/**
+ * Checked exception thrown when an input stream exceeds the configured file size limit.
+ */
+public class FileSizeLimitExceededException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public FileSizeLimitExceededException() {
+        super();
+    }
+
+    public FileSizeLimitExceededException(String message) {
+        super(message);
+    }
+
+    public FileSizeLimitExceededException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FileSizeLimitExceededException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/SizeLimitedInputStream.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/SizeLimitedInputStream.java
@@ -1,0 +1,44 @@
+/*
+ *   Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ *   WSO2 LLC. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.api;
+
+import org.apache.commons.fileupload.util.LimitedInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * {@code SizeLimitedInputStream} is a wrapper around an {@link InputStream} that enforces a maximum
+ * number of bytes that can be read. When the configured limit (in bytes) is exceeded, the overridden
+ * {@link #raiseError(long, long)} method throws a {@link FileSizeLimitExceededException}.
+ */
+public class SizeLimitedInputStream extends LimitedInputStream {
+    private final long maxSize;
+
+    public SizeLimitedInputStream(InputStream in, long maxSize) {
+        super(in, maxSize);
+        this.maxSize = maxSize;
+    }
+
+    @Override
+    protected void raiseError(long l, long l1) throws IOException {
+        throw new FileSizeLimitExceededException("File size exceeds maximum allowed limit of " + maxSize + " bytes");
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -679,7 +679,37 @@ public class APIManagerConfiguration {
             } else if (elementHasText(element)) {
                 String key = getKey(nameStack);
                 String value = MiscellaneousUtil.resolve(element, secretResolver);
-                addToConfiguration(key, APIUtil.replaceSystemProperty(value));
+                if (org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT.equals(key)) {
+                    String maxFileSize = StringUtils.isNumeric(value) ?
+                            value :
+                            org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT_DEFAULT_MB;
+                    addToConfiguration(key, APIUtil.replaceSystemProperty(maxFileSize));
+                } else if (org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT.equals(
+                        key)) {
+                    String maxFileSize = StringUtils.isNumeric(value) ?
+                            value :
+                            org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT_DEFAULT_MB;
+                    addToConfiguration(key, APIUtil.replaceSystemProperty(maxFileSize));
+                } else if (org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT.equals(
+                        key)) {
+                    String maxFileSize = StringUtils.isNumeric(value) ?
+                            value :
+                            org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB;
+                    addToConfiguration(key, APIUtil.replaceSystemProperty(maxFileSize));
+                } else if (org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT.equals(key)) {
+                    String maxFileSize = StringUtils.isNumeric(value) ?
+                            value :
+                            org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT_DEFAULT_MB;
+                    addToConfiguration(key, APIUtil.replaceSystemProperty(maxFileSize));
+                } else if (org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_MCP_FILE_SIZE_LIMIT.equals(
+                        key)) {
+                    String maxFileSize = StringUtils.isNumeric(value) ?
+                            value :
+                            org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_MCP_FILE_SIZE_LIMIT_DEFAULT_MB;
+                    addToConfiguration(key, APIUtil.replaceSystemProperty(maxFileSize));
+                } else {
+                    addToConfiguration(key, APIUtil.replaceSystemProperty(value));
+                }
             } else if ("Environments".equals(localName)) {
                 Iterator environmentIterator = element.getChildrenWithLocalName("Environment");
                 apiGatewayEnvironments = new LinkedHashMap<String, Environment>();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/MCPInitializerAndToolFetcher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/MCPInitializerAndToolFetcher.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.apimgt.impl;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -31,8 +32,13 @@ import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.api.FileSizeLimitExceededException;
+import org.wso2.carbon.apimgt.api.SizeLimitedInputStream;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -170,18 +176,46 @@ public class MCPInitializerAndToolFetcher {
 
         request.setEntity(new StringEntity(jsonBody.toString(), StandardCharsets.UTF_8));
 
+        String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                .getAPIManagerConfiguration()
+                .getFirstProperty(org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT);
+        final long maxBytes = Long.parseLong(maxFileSizeStr) * 1024L * 1024L;
+
         try (CloseableHttpResponse response = httpClient.execute(request)) {
             final int status = response.getStatusLine() != null ? response.getStatusLine().getStatusCode() : 0;
             if (status < 200 || status >= 300) {
                 String reason = response.getStatusLine() != null ?
                         response.getStatusLine().getReasonPhrase() : "Unknown";
-                String bodySnippet = response.getEntity() != null
-                        ? EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8) : StringUtils.EMPTY;
+                String bodySnippet = StringUtils.EMPTY;
+                if (response.getEntity() != null) {
+                    try (InputStream rawStream = response.getEntity().getContent();
+                            SizeLimitedInputStream limitedStream = new SizeLimitedInputStream(rawStream, maxBytes)) {
+                        bodySnippet = IOUtils.toString(limitedStream, StandardCharsets.UTF_8);
+                    } catch (FileSizeLimitExceededException e) {
+                        log.error(
+                                "MCP error response body exceeds the maximum allowed size of " + maxFileSizeStr + " MB. Truncating body snippet.",
+                                e);
+                        bodySnippet = "[Response body too large to display]";
+                    } catch (IOException e) {
+                        log.error("Failed to read MCP error response body.", e);
+                    }
+                }
                 throw new APIManagementException("MCP request failed: HTTP " + status + " " + reason + " Body: "
                         + bodySnippet);
             }
-            String body = response.getEntity() != null ?
-                    EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8) : StringUtils.EMPTY;
+            String body = StringUtils.EMPTY;
+            if (response.getEntity() != null) {
+                try (InputStream rawStream = response.getEntity().getContent();
+                        SizeLimitedInputStream limitedStream = new SizeLimitedInputStream(rawStream, maxBytes)) {
+                    body = IOUtils.toString(limitedStream, StandardCharsets.UTF_8);
+                } catch (FileSizeLimitExceededException e) {
+                    throw new APIManagementException(
+                            "MCP response body exceeds the maximum allowed size of " + maxFileSizeStr + " MB.",
+                            ExceptionCodes.FILE_TOO_LARGE);
+                } catch (IOException e) {
+                    throw new APIManagementException("Failed to read MCP response body.", e);
+                }
+            }
             Header sessionHeader = response.getFirstHeader(APIConstants.MCP.HEADER_MCP_SESSION_ID);
             String returnedSessionId = sessionHeader != null ? sessionHeader.getValue() : null;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/MCPInitializerAndToolFetcher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/MCPInitializerAndToolFetcher.java
@@ -179,6 +179,9 @@ public class MCPInitializerAndToolFetcher {
         String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                 .getAPIManagerConfiguration()
                 .getFirstProperty(org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_MCP_FILE_SIZE_LIMIT);
+        if (maxFileSizeStr == null || maxFileSizeStr.trim().isEmpty()) {
+            maxFileSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_MCP_FILE_SIZE_LIMIT_DEFAULT_MB;
+        }
         final long maxBytes = Long.parseLong(maxFileSizeStr) * 1024L * 1024L;
 
         try (CloseableHttpResponse response = httpClient.execute(request)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/MCPInitializerAndToolFetcher.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/MCPInitializerAndToolFetcher.java
@@ -178,7 +178,7 @@ public class MCPInitializerAndToolFetcher {
 
         String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                 .getAPIManagerConfiguration()
-                .getFirstProperty(org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT);
+                .getFirstProperty(org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_MCP_FILE_SIZE_LIMIT);
         final long maxBytes = Long.parseLong(maxFileSizeStr) * 1024L * 1024L;
 
         try (CloseableHttpResponse response = httpClient.execute(request)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
@@ -659,6 +659,10 @@ public class ApisApiServiceImplUtils {
                 String maxContentSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                         .getAPIManagerConfiguration().getFirstProperty(
                                 org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT);
+                if (maxContentSizeStr == null || maxContentSizeStr.trim().isEmpty()) {
+                    maxContentSizeStr = org.wso2.carbon.apimgt.api.
+                            APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT_DEFAULT_MB;
+                }
                 validationResponse = OASParserUtil.validateAPIDefinitionByURL(url, httpClient, returnContent,
                         parserOptions, maxContentSizeStr);
             } catch (MalformedURLException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
@@ -656,8 +656,11 @@ public class ApisApiServiceImplUtils {
             try {
                 URL urlObj = new URL(url);
                 HttpClient httpClient = APIUtil.getHttpClient(urlObj.getPort(), urlObj.getProtocol());
+                String maxContentSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                        .getAPIManagerConfiguration().getFirstProperty(
+                                org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT);
                 validationResponse = OASParserUtil.validateAPIDefinitionByURL(url, httpClient, returnContent,
-                        parserOptions);
+                        parserOptions, maxContentSizeStr);
             } catch (MalformedURLException e) {
                 throw new APIManagementException("Error while processing the API definition URL", e);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -87,11 +87,13 @@ import org.wso2.carbon.apimgt.api.ErrorHandler;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.FaultyGatewayDeploymentException;
 import org.wso2.carbon.apimgt.api.FederatedAPIDiscoveryService;
+import org.wso2.carbon.apimgt.api.FileSizeLimitExceededException;
 import org.wso2.carbon.apimgt.api.LoginPostExecutor;
 import org.wso2.carbon.apimgt.api.NewPostLoginExecutor;
 import org.wso2.carbon.apimgt.api.OrganizationResolver;
 import org.wso2.carbon.apimgt.api.PasswordResolver;
 import org.wso2.carbon.apimgt.api.PlatformGatewayService;
+import org.wso2.carbon.apimgt.api.SizeLimitedInputStream;
 import org.wso2.carbon.apimgt.api.doc.model.APIDefinition;
 import org.wso2.carbon.apimgt.api.doc.model.APIResource;
 import org.wso2.carbon.apimgt.api.doc.model.Operation;
@@ -262,6 +264,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -5321,9 +5324,14 @@ public final class APIUtil {
      * @return whether the provided URL content contains the string to match
      */
     public static boolean isURLContentContainsString(URL url, String match, int maxLines) {
-
-        try (BufferedReader in =
-                     new BufferedReader(new InputStreamReader(url.openStream(), Charset.defaultCharset()))) {
+        String maxWSDLSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                .getAPIManagerConfiguration()
+                .getFirstProperty(org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT);
+        long maxFileSize = Long.parseLong(maxWSDLSizeStr) * 1024L * 1024L;
+        try (BufferedInputStream bufferedStream = new BufferedInputStream(url.openStream(), 4096);
+                SizeLimitedInputStream limitedStream = new SizeLimitedInputStream(bufferedStream, maxFileSize);
+                BufferedReader in = new BufferedReader(
+                        new InputStreamReader(limitedStream, Charset.defaultCharset()))) {
             String inputLine;
             StringBuilder urlContent = new StringBuilder();
             while ((inputLine = in.readLine()) != null && maxLines > 0) {
@@ -5333,6 +5341,10 @@ public final class APIUtil {
                     return true;
                 }
             }
+        } catch (FileSizeLimitExceededException e) {
+            log.error(
+                    "Error Reading Input from Stream from " + url + ". The file size exceeds the maximum limit of " + maxFileSize + " bytes.",
+                    e);
         } catch (IOException e) {
             log.error("Error Reading Input from Stream from " + url, e);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -5327,6 +5327,9 @@ public final class APIUtil {
         String maxWSDLSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                 .getAPIManagerConfiguration()
                 .getFirstProperty(org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT);
+        if (maxWSDLSizeStr == null || maxWSDLSizeStr.trim().isEmpty()) {
+            maxWSDLSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB;
+        }
         long maxFileSize = Long.parseLong(maxWSDLSizeStr) * 1024L * 1024L;
         try (BufferedInputStream bufferedStream = new BufferedInputStream(url.openStream(), 4096);
                 SizeLimitedInputStream limitedStream = new SizeLimitedInputStream(bufferedStream, maxFileSize);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/AbstractWSDLProcessor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/AbstractWSDLProcessor.java
@@ -24,11 +24,13 @@ import org.apache.xerces.util.SecurityManager;
 import org.w3c.dom.Document;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.api.SizeLimitedInputStream;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.ZIPUtils;
 import org.wso2.carbon.apimgt.impl.wsdl.exceptions.APIMgtWSDLException;
 import org.xml.sax.SAXException;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -57,16 +59,29 @@ abstract class AbstractWSDLProcessor implements WSDLProcessor {
      * @throws APIMgtWSDLException When error occurred while reading from URL
      */
     Document getSecuredParsedDocumentFromURL(URL url) throws APIMgtWSDLException {
-        InputStream inputStream = null;
+        return getSecuredParsedDocumentFromURL(url ,getDefaultMaxFileSize());
+    }
+
+    /**
+     * Returns an "XXE safe" built DOM XML object by reading the content from the provided URL, enforcing a maximum file
+     * size limit.
+     *
+     * @param url         URL to fetch the content
+     * @param maxFileSize Maximum allowed file size in bytes for the content read from the URL.
+     * @return an "XXE safe" built DOM XML object by reading the content from the provided URL
+     * @throws APIMgtWSDLException When error occurred while reading from URL or if the content exceeds the specified
+     *                             maximum file size
+     */
+    Document getSecuredParsedDocumentFromURL(URL url, long maxFileSize) throws APIMgtWSDLException {
         try {
             DocumentBuilderFactory factory = getSecuredDocumentBuilder();
             DocumentBuilder builder = factory.newDocumentBuilder();
-            inputStream = url.openStream();
-            return builder.parse(inputStream);
+            try (BufferedInputStream bufferedStream = new BufferedInputStream(url.openStream(), 4096);
+                    SizeLimitedInputStream limitedStream = new SizeLimitedInputStream(bufferedStream, maxFileSize)) {
+                return builder.parse(limitedStream);
+            }
         } catch (ParserConfigurationException | IOException | SAXException e) {
             throw new APIMgtWSDLException("Error while reading WSDL document", e);
-        } finally {
-            IOUtils.closeQuietly(inputStream);
         }
     }
 
@@ -190,5 +205,10 @@ abstract class AbstractWSDLProcessor implements WSDLProcessor {
 
     public Mode getMode() {
         return this.mode;
+    }
+
+    protected long getDefaultMaxFileSize() {
+        return Long.parseLong(
+                org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB) * 1024 * 1024L;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11ProcessorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11ProcessorImpl.java
@@ -142,6 +142,9 @@ public class WSDL11ProcessorImpl extends AbstractWSDLProcessor {
             String maxWSDLSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                     .getAPIManagerConfiguration().getFirstProperty(
                             org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT);
+            if (maxWSDLSizeStr == null || maxWSDLSizeStr.trim().isEmpty()) {
+                maxWSDLSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB;
+            }
             long maxFileSize = Long.parseLong(maxWSDLSizeStr) * 1024L * 1024L;
             wsdlDefinition = wsdlReader.readWSDL(url.toString(), getSecuredParsedDocumentFromURL(url, maxFileSize));
             if (log.isDebugEnabled()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11ProcessorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL11ProcessorImpl.java
@@ -21,6 +21,7 @@ import com.google.common.primitives.Bytes;
 import com.ibm.wsdl.extensions.http.HTTPAddressImpl;
 import com.ibm.wsdl.extensions.soap.SOAPAddressImpl;
 import com.ibm.wsdl.extensions.soap12.SOAP12AddressImpl;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
@@ -29,8 +30,10 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ErrorHandler;
 import org.wso2.carbon.apimgt.api.ErrorItem;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.api.FileSizeLimitExceededException;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIFileUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIMWSDLReader;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
@@ -136,17 +139,30 @@ public class WSDL11ProcessorImpl extends AbstractWSDLProcessor {
         wsdlReader.setFeature(JAVAX_WSDL_VERBOSE_MODE, false);
         wsdlReader.setFeature(JAVAX_WSDL_IMPORT_DOCUMENTS, false);
         try {
-            wsdlDefinition = wsdlReader.readWSDL(url.toString(), getSecuredParsedDocumentFromURL(url));
+            String maxWSDLSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                    .getAPIManagerConfiguration().getFirstProperty(
+                            org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT);
+            long maxFileSize = Long.parseLong(maxWSDLSizeStr) * 1024L * 1024L;
+            wsdlDefinition = wsdlReader.readWSDL(url.toString(), getSecuredParsedDocumentFromURL(url, maxFileSize));
             if (log.isDebugEnabled()) {
                 log.debug("Successfully initialized an instance of " + this.getClass().getSimpleName()
                         + " with a single WSDL.");
             }
         } catch (WSDLException | APIManagementException e) {
-            //This implementation class cannot process the WSDL.
-            log.debug("Cannot process the WSDL by " + this.getClass().getName(), e);
-            setError(new ErrorItem(ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorMessage(), e.getMessage(),
-                    ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorCode(),
-                    ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getHttpStatusCode()));
+            if (log.isDebugEnabled()) {
+                //This implementation class cannot process the WSDL.
+                log.debug("Cannot process the WSDL by " + this.getClass().getName(), e);
+            }
+            if (ExceptionUtils.indexOfThrowable(e, FileSizeLimitExceededException.class) != -1) {
+                setError(new ErrorItem(ExceptionCodes.FILE_TOO_LARGE.getErrorMessage(),
+                        ExceptionCodes.FILE_TOO_LARGE.getErrorDescription(),
+                        ExceptionCodes.FILE_TOO_LARGE.getErrorCode(),
+                        ExceptionCodes.FILE_TOO_LARGE.getHttpStatusCode()));
+            } else {
+                setError(new ErrorItem(ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorMessage(), e.getMessage(),
+                        ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getErrorCode(),
+                        ExceptionCodes.CANNOT_PROCESS_WSDL_CONTENT.getHttpStatusCode()));
+            }
         }
         return !hasError;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20ProcessorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20ProcessorImpl.java
@@ -31,11 +31,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.wso2.carbon.apimgt.api.APIConstants;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ErrorHandler;
 import org.wso2.carbon.apimgt.api.ErrorItem;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIMWSDLReader;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.impl.wsdl.exceptions.APIMgtWSDLException;
@@ -103,9 +105,13 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
         }
 
         reader.setFeature(WSDLReader.FEATURE_VALIDATION, false);
-        Document document = getSecuredParsedDocumentFromURL(url);
-        WSDLSource wsdlSource = getWSDLSourceFromDocument(document, reader);
         try {
+            String maxWSDLSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                    .getAPIManagerConfiguration()
+                    .getFirstProperty(APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT);
+            long maxFileSize = Long.parseLong(maxWSDLSizeStr) * 1024L * 1024L;
+            Document document = getSecuredParsedDocumentFromURL(url, maxFileSize);
+            WSDLSource wsdlSource = getWSDLSourceFromDocument(document, reader);
             wsdlDescription = reader.readWSDL(wsdlSource);
         } catch (WSDLException e) {
             //This implementation class cannot process the WSDL.

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20ProcessorImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/wsdl/WSDL20ProcessorImpl.java
@@ -109,6 +109,9 @@ public class WSDL20ProcessorImpl extends AbstractWSDLProcessor {
             String maxWSDLSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                     .getAPIManagerConfiguration()
                     .getFirstProperty(APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT);
+            if (maxWSDLSizeStr == null || maxWSDLSizeStr.trim().isEmpty()) {
+                maxWSDLSizeStr = APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB;
+            }
             long maxFileSize = Long.parseLong(maxWSDLSizeStr) * 1024L * 1024L;
             Document document = getSecuredParsedDocumentFromURL(url, maxFileSize);
             WSDLSource wsdlSource = getWSDLSourceFromDocument(document, reader);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIMWSDLReaderTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/APIMWSDLReaderTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIConstants;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
@@ -222,6 +223,12 @@ public class APIMWSDLReaderTest {
                     .getAPIManagerConfigurationService()
                     .getAPIManagerConfiguration()
                     .getApiGatewayEnvironments()).thenReturn(gatewayEnvironments);
+
+            PowerMockito.when(ServiceReferenceHolder.getInstance()
+                            .getAPIManagerConfigurationService()
+                            .getAPIManagerConfiguration()
+                            .getFirstProperty(APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT))
+                    .thenReturn(APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB);
 
             ApiMgtDAO apiMgtDAO = Mockito.mock(ApiMgtDAO.class);
             PowerMockito.mockStatic(ApiMgtDAO.class);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/SOAPOperationBindingTestCase.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/wsdl/SOAPOperationBindingTestCase.java
@@ -23,8 +23,13 @@ import io.swagger.parser.SwaggerParser;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIConstants;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.APIManagerConfigurationService;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.wsdl.util.SOAPOperationBindingUtils;
 import org.wso2.carbon.apimgt.impl.utils.APIMWSDLReader;
@@ -34,9 +39,25 @@ import java.util.Map;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ServiceReferenceHolder.class})
 public class SOAPOperationBindingTestCase {
+    private static ServiceReferenceHolder serviceReferenceHolder = Mockito.mock(ServiceReferenceHolder.class);
+    private static APIManagerConfigurationService apimConfigService = Mockito.mock(
+            APIManagerConfigurationService.class);
+    private static APIManagerConfiguration apimConfig = Mockito.mock(APIManagerConfiguration.class);
+
+    public void mockConfigs() throws Exception {
+        PowerMockito.mockStatic(ServiceReferenceHolder.class);
+        Mockito.when(serviceReferenceHolder.getAPIManagerConfigurationService()).thenReturn(apimConfigService);
+        Mockito.when(apimConfigService.getAPIManagerConfiguration()).thenReturn(apimConfig);
+        PowerMockito.when(ServiceReferenceHolder.getInstance()).thenReturn(serviceReferenceHolder);
+        PowerMockito.when(
+                        ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService().getAPIManagerConfiguration()
+                                .getFirstProperty(APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT))
+                .thenReturn(APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB);
+    }
 
     @Test
     public void testGetSoapOperationMapping() throws Exception {
+        mockConfigs();
         String mapping = SOAPOperationBindingUtils.getSoapOperationMappingForUrl(Thread.currentThread().getContextClassLoader()
                 .getResource("wsdls/phoneverify.wsdl").toExternalForm());
         Assert.assertTrue("Failed getting soap operation mapping from the WSDL", !mapping.isEmpty());
@@ -54,6 +75,7 @@ public class SOAPOperationBindingTestCase {
 
     @Test
     public void testGetSwaggerFromWSDL() throws Exception {
+        mockConfigs();
         String swaggerStr = SOAPOperationBindingUtils.getSoapOperationMappingForUrl(Thread.currentThread().getContextClassLoader()
                 .getResource("wsdls/phoneverify.wsdl").toExternalForm());
 
@@ -66,7 +88,7 @@ public class SOAPOperationBindingTestCase {
     }
 
     @Test public void testGetSwaggerFromWSDLWithExternalXSDs() throws Exception {
-
+        mockConfigs();
         String externalXSDElementName = "InvokeClaimGeniousDataIntoCordysElement";
         String externalXSDElementInputOperation = "invokeClaimGeniousDataIntoCordysBindingOperationInput";
         String externalXSDElementOutputOperation = "invokeClaimGeniousDataIntoCordysBindingOperationOutput";
@@ -95,6 +117,7 @@ public class SOAPOperationBindingTestCase {
 
     @Test
     public void testCompareGeneratedSwagger() throws Exception {
+        mockConfigs();
         String swaggerString = "{\n" + "  \"swagger\": \"2.0\",\n" + "  \"paths\": {\n" + "    \"/getCustomer\": {\n"
                 + "      \"get\": {\n" + "        \"operationId\": \"getCustomer\",\n" + "        \"parameters\": [],\n"
                 + "        \"responses\": {\n" + "          \"default\": {\n" + "            \"description\": \"\",\n"
@@ -116,6 +139,7 @@ public class SOAPOperationBindingTestCase {
 
     @Test
     public void testVendorExtensions() throws Exception {
+        mockConfigs();
         String swaggerStr = SOAPOperationBindingUtils.getSoapOperationMappingForUrl(
                 Thread.currentThread().getContextClassLoader().getResource("wsdls/simpleCustomerService.wsdl")
                         .toExternalForm());

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -49,7 +49,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -3610,11 +3609,11 @@ public class PublisherCommonUtils {
                     schema = IOUtils.toString(sizeLimitedInputStream, StandardCharsets.UTF_8);
                 } catch (FileSizeLimitExceededException ex) {
                     log.error(
-                            "The GraphQL schema obtained from the URL exceeds the maximum allowed size of " + maxFileSizeStr + " MB. Error: ",
-                            ex);
+                            "The GraphQL schema obtained from the URL exceeds the maximum allowed size of "
+                                    + maxFileSizeStr + " MB. Error: ", ex);
                     throw new APIManagementException(
-                            "The GraphQL schema obtained from the URL exceeds the " + "maximum allowed size of " + maxFileSizeStr + " MB.",
-                            ExceptionCodes.FILE_TOO_LARGE);
+                            "The GraphQL schema obtained from the URL exceeds the " + "maximum allowed size of "
+                                    + maxFileSizeStr + " MB.", ExceptionCodes.FILE_TOO_LARGE);
                 }
             } else {
                 if (log.isDebugEnabled()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -3529,6 +3529,9 @@ public class PublisherCommonUtils {
             HttpResponse response = httpClient.execute(httpPost);
 
             if (HttpStatus.SC_OK == response.getStatusLine().getStatusCode()) {
+                if (response.getEntity() == null) {
+                    throw new IllegalArgumentException("Response entity is null for the provided URL: " + url);
+                }
                 String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfiguration()
                         .getFirstProperty(
                                 org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT);
@@ -3600,6 +3603,9 @@ public class PublisherCommonUtils {
             HttpGet httpGet = new HttpGet(url);
             HttpResponse response = httpClient.execute(httpGet);
             if (HttpStatus.SC_OK == response.getStatusLine().getStatusCode()) {
+                if (response.getEntity() == null) {
+                    throw new IllegalArgumentException("Response entity is null for the provided URL: " + url);
+                }
                 String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfiguration()
                         .getFirstProperty(
                                 org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -3536,7 +3536,8 @@ public class PublisherCommonUtils {
                         .getFirstProperty(
                                 org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT);
                 if (maxFileSizeStr == null || maxFileSizeStr.trim().isEmpty()) {
-                    maxFileSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT_DEFAULT_MB;
+                    maxFileSizeStr = org.wso2.carbon.apimgt.api.
+                            APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT_DEFAULT_MB;
                 }
                 long maxFileSize = Long.parseLong(maxFileSizeStr) * 1024L * 1024L;
                 try (InputStream responseStream = response.getEntity().getContent();
@@ -3613,7 +3614,8 @@ public class PublisherCommonUtils {
                         .getFirstProperty(
                                 org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT);
                 if (maxFileSizeStr == null || maxFileSizeStr.trim().isEmpty()) {
-                    maxFileSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT_DEFAULT_MB;
+                    maxFileSizeStr = org.wso2.carbon.apimgt.api.
+                            APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT_DEFAULT_MB;
                 }
                 long maxFileSize = Long.parseLong(maxFileSizeStr) * 1024L * 1024L;
                 try (SizeLimitedInputStream sizeLimitedInputStream = new SizeLimitedInputStream(

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -62,6 +62,8 @@ import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.ErrorHandler;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.FaultGatewaysException;
+import org.wso2.carbon.apimgt.api.FileSizeLimitExceededException;
+import org.wso2.carbon.apimgt.api.SizeLimitedInputStream;
 import org.wso2.carbon.apimgt.api.TokenBasedThrottlingCountHolder;
 import org.wso2.carbon.apimgt.api.UsedByMigrationClient;
 import org.wso2.carbon.apimgt.api.doc.model.APIResource;
@@ -149,6 +151,8 @@ import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.core.util.CryptoUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
@@ -3526,13 +3530,36 @@ public class PublisherCommonUtils {
             HttpResponse response = httpClient.execute(httpPost);
 
             if (HttpStatus.SC_OK == response.getStatusLine().getStatusCode()) {
-                String schemaResponse = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-                Type type = new TypeToken<Map<String, Object>>() {
-                }.getType();
-                Map<String, Object> schemaMap = gson.fromJson(schemaResponse, type);
-                Document schemaDocument = new IntrospectionResultToSchema().createSchemaDefinition(
-                        (Map<String, Object>) schemaMap.get("data"));
-                schema = AstPrinter.printAst(schemaDocument);
+                String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfiguration()
+                        .getFirstProperty(
+                                org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT);
+                long maxFileSize = Long.parseLong(maxFileSizeStr) * 1024L * 1024L;
+                try (InputStream responseStream = response.getEntity().getContent();
+                        BufferedInputStream bufferedStream = new BufferedInputStream(responseStream, 4096);
+                        SizeLimitedInputStream limitedStream = new SizeLimitedInputStream(bufferedStream, maxFileSize);
+                        ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+                    byte[] chunk = new byte[4096];
+                    int n;
+                    while ((n = limitedStream.read(chunk)) != -1) {
+                        buffer.write(chunk, 0, n);
+                    }
+                    String schemaResponse = buffer.toString(StandardCharsets.UTF_8.name());
+                    Type type = new TypeToken<Map<String, Object>>() {
+                    }.getType();
+                    Map<String, Object> schemaMap = gson.fromJson(schemaResponse, type);
+                    Document schemaDocument = new IntrospectionResultToSchema().createSchemaDefinition(
+                            (Map<String, Object>) schemaMap.get("data"));
+                    schema = AstPrinter.printAst(schemaDocument);
+                } catch (FileSizeLimitExceededException ex) {
+                    log.error(
+                            "The GraphQL schema obtained from introspection exceeds the maximum allowed size of "
+                                    + maxFileSizeStr + " MB. Error: ",
+                            ex);
+                    throw new APIManagementException(
+                            "The GraphQL schema obtained from introspection exceeds the " + "maximum allowed size of "
+                                    + maxFileSizeStr + " MB.",
+                            ExceptionCodes.FILE_TOO_LARGE);
+                }
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug(
@@ -3573,9 +3600,22 @@ public class PublisherCommonUtils {
             HttpClient httpClient = APIUtil.getHttpClient(urlObj.getPort(), urlObj.getProtocol());
             HttpGet httpGet = new HttpGet(url);
             HttpResponse response = httpClient.execute(httpGet);
-
             if (HttpStatus.SC_OK == response.getStatusLine().getStatusCode()) {
-                schema = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+                String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfiguration()
+                        .getFirstProperty(
+                                org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT);
+                long maxFileSize = Long.parseLong(maxFileSizeStr) * 1024L * 1024L;
+                try (SizeLimitedInputStream sizeLimitedInputStream = new SizeLimitedInputStream(
+                        response.getEntity().getContent(), maxFileSize)) {
+                    schema = IOUtils.toString(sizeLimitedInputStream, StandardCharsets.UTF_8);
+                } catch (FileSizeLimitExceededException ex) {
+                    log.error(
+                            "The GraphQL schema obtained from the URL exceeds the maximum allowed size of " + maxFileSizeStr + " MB. Error: ",
+                            ex);
+                    throw new APIManagementException(
+                            "The GraphQL schema obtained from the URL exceeds the " + "maximum allowed size of " + maxFileSizeStr + " MB.",
+                            ExceptionCodes.FILE_TOO_LARGE);
+                }
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug(

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -3535,6 +3535,9 @@ public class PublisherCommonUtils {
                 String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfiguration()
                         .getFirstProperty(
                                 org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT);
+                if (maxFileSizeStr == null || maxFileSizeStr.trim().isEmpty()) {
+                    maxFileSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT_DEFAULT_MB;
+                }
                 long maxFileSize = Long.parseLong(maxFileSizeStr) * 1024L * 1024L;
                 try (InputStream responseStream = response.getEntity().getContent();
                         BufferedInputStream bufferedStream = new BufferedInputStream(responseStream, 4096);
@@ -3609,6 +3612,9 @@ public class PublisherCommonUtils {
                 String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfiguration()
                         .getFirstProperty(
                                 org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT);
+                if (maxFileSizeStr == null || maxFileSizeStr.trim().isEmpty()) {
+                    maxFileSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT_DEFAULT_MB;
+                }
                 long maxFileSize = Long.parseLong(maxFileSizeStr) * 1024L * 1024L;
                 try (SizeLimitedInputStream sizeLimitedInputStream = new SizeLimitedInputStream(
                         response.getEntity().getContent(), maxFileSize)) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -4672,9 +4672,12 @@ public class ApisApiServiceImpl implements ApisApiService {
             try {
                 URL urlObj = new URL(url);
                 HttpClient httpClient = APIUtil.getHttpClient(urlObj.getPort(), urlObj.getProtocol());
+                String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                        .getAPIManagerConfiguration().getFirstProperty(
+                                org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT);
                 // Validate URL
                 validationResponse = AsyncApiParserUtil.validateAsyncAPISpecificationByURL(url, httpClient,
-                        returnContent, AsyncApiParserImplUtil.getParserOptionsFromConfig());
+                        returnContent, AsyncApiParserImplUtil.getParserOptionsFromConfig(), maxFileSizeStr);
             } catch (MalformedURLException e) {
                 throw new APIManagementException("Error while processing the API definition URL", e);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -4676,7 +4676,8 @@ public class ApisApiServiceImpl implements ApisApiService {
                         .getAPIManagerConfiguration().getFirstProperty(
                                 org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT);
                 if (maxFileSizeStr == null || maxFileSizeStr.trim().isEmpty()) {
-                    maxFileSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT_DEFAULT_MB;
+                    maxFileSizeStr = org.wso2.carbon.apimgt.api.
+                            APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT_DEFAULT_MB;
                 }
                 // Validate URL
                 validationResponse = AsyncApiParserUtil.validateAsyncAPISpecificationByURL(url, httpClient,

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -4675,6 +4675,9 @@ public class ApisApiServiceImpl implements ApisApiService {
                 String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                         .getAPIManagerConfiguration().getFirstProperty(
                                 org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT);
+                if (maxFileSizeStr == null || maxFileSizeStr.trim().isEmpty()) {
+                    maxFileSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT_DEFAULT_MB;
+                }
                 // Validate URL
                 validationResponse = AsyncApiParserUtil.validateAsyncAPISpecificationByURL(url, httpClient,
                         returnContent, AsyncApiParserImplUtil.getParserOptionsFromConfig(), maxFileSizeStr);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
@@ -480,6 +480,9 @@ public class ServicesApiServiceImpl implements ServicesApiService {
                 String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                         .getAPIManagerConfiguration().getFirstProperty(
                                 org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT);
+                if (maxFileSizeStr == null || maxFileSizeStr.trim().isEmpty()) {
+                    maxFileSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT_DEFAULT_MB;
+                }
                 // Validate URL
                 validationResponse = AsyncApiParserUtil.validateAsyncAPISpecificationByURL(url, httpClient, true,
                         AsyncApiParserImplUtil.getParserOptionsFromConfig(), maxFileSizeStr);
@@ -510,6 +513,9 @@ public class ServicesApiServiceImpl implements ServicesApiService {
                 String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
                         .getAPIManagerConfiguration().getFirstProperty(
                                 org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT);
+                if (maxFileSizeStr == null || maxFileSizeStr.trim().isEmpty()) {
+                    maxFileSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT_DEFAULT_MB;
+                }
                 validationResponse = OASParserUtil.validateAPIDefinitionByURL(url, httpClient, true, parserOptions,
                         maxFileSizeStr);
             } catch (MalformedURLException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
@@ -481,7 +481,8 @@ public class ServicesApiServiceImpl implements ServicesApiService {
                         .getAPIManagerConfiguration().getFirstProperty(
                                 org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT);
                 if (maxFileSizeStr == null || maxFileSizeStr.trim().isEmpty()) {
-                    maxFileSizeStr = org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT_DEFAULT_MB;
+                    maxFileSizeStr = org.wso2.carbon.apimgt.api.
+                            APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT_DEFAULT_MB;
                 }
                 // Validate URL
                 validationResponse = AsyncApiParserUtil.validateAsyncAPISpecificationByURL(url, httpClient, true,

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/java/org/wso2/carbon/apimgt/rest/api/service/catalog/impl/ServicesApiServiceImpl.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.apimgt.api.model.ServiceFilterParams;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.ServiceCatalogImpl;
 import org.wso2.carbon.apimgt.impl.importexport.utils.CommonUtil;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIMWSDLReader;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.impl.utils.AsyncApiParserImplUtil;
@@ -476,9 +477,12 @@ public class ServicesApiServiceImpl implements ServicesApiService {
             try {
                 URL urlObj = new URL(url);
                 HttpClient httpClient = APIUtil.getHttpClient(urlObj.getPort(), urlObj.getProtocol());
+                String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                        .getAPIManagerConfiguration().getFirstProperty(
+                                org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT);
                 // Validate URL
-                validationResponse = AsyncApiParserUtil.validateAsyncAPISpecificationByURL(url, httpClient,
-                        true, AsyncApiParserImplUtil.getParserOptionsFromConfig());
+                validationResponse = AsyncApiParserUtil.validateAsyncAPISpecificationByURL(url, httpClient, true,
+                        AsyncApiParserImplUtil.getParserOptionsFromConfig(), maxFileSizeStr);
             } catch (MalformedURLException e) {
                 throw new APIManagementException("Error while processing the API definition URL", e);
             }
@@ -503,7 +507,11 @@ public class ServicesApiServiceImpl implements ServicesApiService {
             try {
                 URL urlObj = new URL(url);
                 HttpClient httpClient = APIUtil.getHttpClient(urlObj.getPort(), urlObj.getProtocol());
-                validationResponse = OASParserUtil.validateAPIDefinitionByURL(url, httpClient, true, parserOptions);
+                String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
+                        .getAPIManagerConfiguration().getFirstProperty(
+                                org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT);
+                validationResponse = OASParserUtil.validateAPIDefinitionByURL(url, httpClient, true, parserOptions,
+                        maxFileSizeStr);
             } catch (MalformedURLException e) {
                 throw new APIManagementException("Error while processing the API definition URL", e);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/AsyncApiParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/AsyncApiParserUtil.java
@@ -245,6 +245,9 @@ public class AsyncApiParserUtil {
             HttpGet httpGet = new HttpGet(url);
             HttpResponse response = httpClient.execute(httpGet);
             if (HttpStatus.SC_OK == response.getStatusLine().getStatusCode()) {
+                if (response.getEntity() == null) {
+                    throw new IllegalArgumentException("Response entity is null for the provided URL: " + url);
+                }
                 long maxFileSize = Long.parseLong(maxFileSizeStr) * 1024L * 1024L;
                 try (InputStream responseStream = response.getEntity().getContent();
                         BufferedInputStream bufferedStream = new BufferedInputStream(responseStream, 4096);

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/AsyncApiParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/AsyncApiParserUtil.java
@@ -83,6 +83,7 @@ import io.apicurio.datamodels.validation.DefaultSeverityRegistry;
 import io.apicurio.datamodels.validation.IValidationSeverityRegistry;
 import io.apicurio.datamodels.validation.ValidationProblem;
 import io.apicurio.datamodels.validation.ValidationProblemSeverity;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
@@ -94,6 +95,8 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ErrorHandler;
 import org.wso2.carbon.apimgt.api.ErrorItem;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.api.FileSizeLimitExceededException;
+import org.wso2.carbon.apimgt.api.SizeLimitedInputStream;
 import org.wso2.carbon.apimgt.api.UsedByMigrationClient;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.Scope;
@@ -101,7 +104,9 @@ import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.spec.parser.definitions.asyncapi.AsyncApiParseOptions;
 import org.wso2.carbon.apimgt.spec.parser.definitions.asyncapi.AsyncApiParserFactory;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -232,7 +237,7 @@ public class AsyncApiParserUtil {
      * @throws APIManagementException
      */
     public static APIDefinitionValidationResponse validateAsyncAPISpecificationByURL(
-            String url, HttpClient httpClient, boolean returnJSONContent, AsyncApiParseOptions options)
+            String url, HttpClient httpClient, boolean returnJSONContent, AsyncApiParseOptions options, String maxFileSizeStr)
             throws APIManagementException {
 
         APIDefinitionValidationResponse validationResponse = new APIDefinitionValidationResponse();
@@ -240,11 +245,17 @@ public class AsyncApiParserUtil {
             HttpGet httpGet = new HttpGet(url);
             HttpResponse response = httpClient.execute(httpGet);
             if (HttpStatus.SC_OK == response.getStatusLine().getStatusCode()) {
-                ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
-                Object obj = yamlReader.readValue(new URL(url), Object.class);
-                ObjectMapper jsonWriter = new ObjectMapper();
-                String json = jsonWriter.writeValueAsString(obj);
-                validationResponse = validateAsyncAPISpecification(json, returnJSONContent, options);
+                long maxFileSize = Long.parseLong(maxFileSizeStr) * 1024L * 1024L;
+                try (InputStream responseStream = response.getEntity().getContent();
+                        BufferedInputStream bufferedStream = new BufferedInputStream(responseStream, 4096);
+                        SizeLimitedInputStream limitedStream = new SizeLimitedInputStream(bufferedStream,
+                                maxFileSize)) {
+                    ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+                    Object obj = yamlReader.readValue(limitedStream, Object.class);
+                    ObjectMapper jsonWriter = new ObjectMapper();
+                    String json = jsonWriter.writeValueAsString(obj);
+                    validationResponse = validateAsyncAPISpecification(json, returnJSONContent, options);
+                }
             } else {
                 validationResponse.setValid(false);
                 validationResponse.getErrorItems().add(ExceptionCodes.ASYNCAPI_URL_NO_200);
@@ -252,6 +263,12 @@ public class AsyncApiParserUtil {
         } catch (IOException e) {
             ErrorHandler errorHandler = ExceptionCodes.ASYNCAPI_URL_MALFORMED;
             log.error(errorHandler.getErrorDescription(), e); // log the error and continue
+
+            // Check FileSizeLimitExceed exception presents in the fasterxml exception
+            if (ExceptionUtils.indexOfThrowable(e, FileSizeLimitExceededException.class) != -1) {
+                errorHandler = ExceptionCodes.FILE_TOO_LARGE;
+            }
+
             // since this method is only intended to validate a definition
             validationResponse.setValid(false);
             validationResponse.getErrorItems().add(errorHandler);

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
@@ -73,12 +73,15 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.wso2.carbon.apimgt.api.APIConstants;
 import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ErrorHandler;
 import org.wso2.carbon.apimgt.api.ErrorItem;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.api.FileSizeLimitExceededException;
+import org.wso2.carbon.apimgt.api.SizeLimitedInputStream;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIProductResource;
 import org.wso2.carbon.apimgt.api.model.CORSConfiguration;
@@ -90,11 +93,14 @@ import org.wso2.carbon.apimgt.api.UsedByMigrationClient;
 import org.wso2.carbon.apimgt.spec.parser.definitions.mixin.License31Mixin;
 import org.yaml.snakeyaml.LoaderOptions;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -1265,7 +1271,8 @@ public class OASParserUtil {
     @Deprecated
     public static APIDefinitionValidationResponse validateAPIDefinitionByURL(String url, HttpClient httpClient,
             boolean returnJsonContent) throws APIManagementException {
-        return validateAPIDefinitionByURL(url, httpClient, returnJsonContent, null);
+        return validateAPIDefinitionByURL(url, httpClient, returnJsonContent, null,
+                APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT_DEFAULT_MB);
     }
 
     /**
@@ -1278,29 +1285,45 @@ public class OASParserUtil {
      * @return APIDefinitionValidationResponse object with validation information
      */
     public static APIDefinitionValidationResponse validateAPIDefinitionByURL(String url, HttpClient httpClient,
-            boolean returnJsonContent, OASParserOptions oasParserOptions) throws APIManagementException {
+            boolean returnJsonContent, OASParserOptions oasParserOptions, String maxFileSize) throws APIManagementException {
         APIDefinitionValidationResponse validationResponse = new APIDefinitionValidationResponse();
         try {
             HttpGet httpGet = new HttpGet(url);
             HttpResponse response = httpClient.execute(httpGet);
 
             if (HttpStatus.SC_OK == response.getStatusLine().getStatusCode()) {
-                String responseStr = EntityUtils.toString(response.getEntity(), "UTF-8");
-                String responseStrProcessed = responseStr;
-                if (!responseStr.trim().startsWith("{")) {
-                    try {
-                        JsonNode jsonNode = parseYamlWithLimit(responseStr, oasParserOptions);
-                        responseStrProcessed = jsonNode.toString();
-                    } catch (IOException e) {
-                        throw new APIManagementException("Error while reading API definition yaml", e);
+                long maxSize = Long.parseLong(maxFileSize) * 1024L * 1024L;
+                try (InputStream responseStream = response.getEntity().getContent();
+                        BufferedInputStream bufferedStream = new BufferedInputStream(responseStream, 4096);
+                        SizeLimitedInputStream limitedStream = new SizeLimitedInputStream(bufferedStream, maxSize);
+                        ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+                    byte[] chunk = new byte[4096];
+                    int n;
+                    while ((n = limitedStream.read(chunk)) != -1) {
+                        buffer.write(chunk, 0, n);
                     }
+                    String responseStr = buffer.toString(StandardCharsets.UTF_8.name());
+                    String responseStrProcessed = responseStr;
+                    if (!responseStr.trim().startsWith("{")) {
+                        try {
+                            JsonNode jsonNode = parseYamlWithLimit(responseStr, oasParserOptions);
+                            responseStrProcessed = jsonNode.toString();
+                        } catch (IOException e) {
+                            throw new APIManagementException("Error while reading API definition yaml", e);
+                        }
+                    }
+                    responseStrProcessed = removeUnsupportedBlocksFromResources(responseStrProcessed);
+                    if (responseStrProcessed != null) {
+                        responseStr = responseStrProcessed;
+                    }
+                    validationResponse = validateAPIDefinition(responseStr, new URL(url).getHost(), returnJsonContent,
+                            oasParserOptions);
+                } catch (FileSizeLimitExceededException ex) {
+                    ErrorHandler errorHandler = ExceptionCodes.FILE_TOO_LARGE;
+                    log.error(errorHandler.getErrorDescription());
+                    validationResponse.setValid(false);
+                    validationResponse.getErrorItems().add(errorHandler);
                 }
-                responseStrProcessed = removeUnsupportedBlocksFromResources(responseStrProcessed);
-                if (responseStrProcessed != null) {
-                    responseStr = responseStrProcessed;
-                }
-                validationResponse = validateAPIDefinition(responseStr, new URL(url).getHost(), returnJsonContent,
-                        oasParserOptions);
             } else {
                 validationResponse.setValid(false);
                 validationResponse.getErrorItems().add(ExceptionCodes.OPENAPI_URL_NO_200);

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/main/java/org/wso2/carbon/apimgt/spec/parser/definitions/OASParserUtil.java
@@ -1292,6 +1292,9 @@ public class OASParserUtil {
             HttpResponse response = httpClient.execute(httpGet);
 
             if (HttpStatus.SC_OK == response.getStatusLine().getStatusCode()) {
+                if (response.getEntity() == null) {
+                    throw new IllegalArgumentException("Response entity is null for the provided URL: " + url);
+                }
                 long maxSize = Long.parseLong(maxFileSize) * 1024L * 1024L;
                 try (InputStream responseStream = response.getEntity().getContent();
                         BufferedInputStream bufferedStream = new BufferedInputStream(responseStream, 4096);

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/AsyncApiParserUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/AsyncApiParserUtilTest.java
@@ -45,6 +45,7 @@ import org.wso2.carbon.apimgt.spec.parser.definitions.asyncapi.AsyncApiParseOpti
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -128,73 +129,13 @@ public class AsyncApiParserUtilTest {
 
         ObjectMapper yamlWriter = new ObjectMapper(new YAMLFactory());
         Object obj = yamlWriter.readValue(VALID_ASYNCAPI_JSON, Object.class);
+        String yamlBody = yamlWriter.writeValueAsString(obj);
 
         try (FileWriter fw = new FileWriter(tmp)) {
             yamlWriter.writeValue(fw, obj);
         }
 
-        // Use a simple HttpClient stub that returns 200 OK for execute(...) calls.
-        HttpClient okHttpClient = new HttpClient() {
-            @Override
-            public HttpResponse execute(org.apache.http.HttpHost host, org.apache.http.HttpRequest request) {
-                return buildResponse(200);
-            }
-
-            @Override
-            public HttpResponse execute(org.apache.http.HttpHost host, org.apache.http.HttpRequest request,
-                                        org.apache.http.protocol.HttpContext context) {
-                return buildResponse(200);
-            }
-
-            @Override
-            public <T> T execute(HttpUriRequest httpUriRequest, ResponseHandler<? extends T> responseHandler) throws
-                    IOException, ClientProtocolException {
-                return null;
-            }
-
-            @Override
-            public <T> T execute(HttpUriRequest httpUriRequest, ResponseHandler<?
-                    extends T> responseHandler, HttpContext httpContext) throws IOException, ClientProtocolException {
-                return null;
-            }
-
-            @Override
-            public <T> T execute(HttpHost httpHost, HttpRequest httpRequest, ResponseHandler<?
-                    extends T> responseHandler) throws IOException, ClientProtocolException {
-                return null;
-            }
-
-            @Override
-            public <T> T execute(HttpHost httpHost, HttpRequest httpRequest, ResponseHandler<?
-                    extends T> responseHandler, HttpContext httpContext) throws IOException, ClientProtocolException {
-                return null;
-            }
-
-            @Override
-            public HttpParams getParams() {
-                return null;
-            }
-
-            @Override
-            public ClientConnectionManager getConnectionManager() {
-                return null;
-            }
-
-            @Override
-            public HttpResponse execute(HttpUriRequest request) {
-                return buildResponse(200);
-            }
-
-            @Override
-            public HttpResponse execute(HttpUriRequest request, org.apache.http.protocol.HttpContext context) {
-                return buildResponse(200);
-            }
-
-            private HttpResponse buildResponse(int status) {
-                return new BasicHttpResponse(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1),
-                        status, ""));
-            }
-        };
+        HttpClient okHttpClient = createHttpClient(200, yamlBody);
 
         String fileUrl = tmp.toURI().toURL().toString();
         AsyncApiParseOptions options =  new AsyncApiParseOptions();
@@ -215,67 +156,7 @@ public class AsyncApiParserUtilTest {
         }
         String fileUrl = tmp.toURI().toURL().toString();
 
-        HttpClient nonOkHttpClient = new HttpClient() {
-            @Override
-            public HttpResponse execute(org.apache.http.HttpHost host, org.apache.http.HttpRequest request) {
-                return buildResponse(404);
-            }
-
-            @Override
-            public HttpResponse execute(org.apache.http.HttpHost host, org.apache.http.HttpRequest request,
-                                        org.apache.http.protocol.HttpContext context) {
-                return buildResponse(404);
-            }
-
-            @Override
-            public <T> T execute(HttpUriRequest httpUriRequest, ResponseHandler<? extends T> responseHandler)
-                    throws IOException, ClientProtocolException {
-                return null;
-            }
-
-            @Override
-            public <T> T execute(HttpUriRequest httpUriRequest, ResponseHandler<?
-                    extends T> responseHandler, HttpContext httpContext) throws IOException, ClientProtocolException {
-                return null;
-            }
-
-            @Override
-            public <T> T execute(HttpHost httpHost, HttpRequest httpRequest, ResponseHandler<?
-                    extends T> responseHandler) throws IOException, ClientProtocolException {
-                return null;
-            }
-
-            @Override
-            public <T> T execute(HttpHost httpHost, HttpRequest httpRequest, ResponseHandler<?
-                    extends T> responseHandler, HttpContext httpContext) throws IOException, ClientProtocolException {
-                return null;
-            }
-
-            @Override
-            public HttpParams getParams() {
-                return null;
-            }
-
-            @Override
-            public ClientConnectionManager getConnectionManager() {
-                return null;
-            }
-
-            @Override
-            public HttpResponse execute(HttpUriRequest request) {
-                return buildResponse(404);
-            }
-
-            @Override
-            public HttpResponse execute(HttpUriRequest request, org.apache.http.protocol.HttpContext context) {
-                return buildResponse(404);
-            }
-
-            private HttpResponse buildResponse(int status) {
-                return new BasicHttpResponse(new BasicStatusLine(
-                        new ProtocolVersion("HTTP", 1, 1), status, ""));
-            }
-        };
+        HttpClient nonOkHttpClient = createHttpClient(404, null);
 
         AsyncApiParseOptions options =  new AsyncApiParseOptions();
         options.setPreserveLegacyAsyncApiParser(true);
@@ -354,6 +235,73 @@ public class AsyncApiParserUtilTest {
         // Passing null security scheme should cause an exception (or UnsupportedOperationException)
         AsyncApiParserUtil.setAsyncApiOAuthFlowsScopes(
                 null, Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    private HttpClient createHttpClient(int statusCode, String body) {
+        return new HttpClient() {
+            @Override
+            public HttpResponse execute(HttpHost host, HttpRequest request) {
+                return buildResponse(statusCode, body);
+            }
+
+            @Override
+            public HttpResponse execute(HttpHost host, HttpRequest request, HttpContext context) {
+                return buildResponse(statusCode, body);
+            }
+
+            @Override
+            public <T> T execute(HttpUriRequest request, ResponseHandler<? extends T> responseHandler)
+                    throws IOException, ClientProtocolException {
+                throw new UnsupportedOperationException("Not used in this test");
+            }
+
+            @Override
+            public <T> T execute(HttpUriRequest request, ResponseHandler<? extends T> responseHandler,
+                    HttpContext context) throws IOException, ClientProtocolException {
+                throw new UnsupportedOperationException("Not used in this test");
+            }
+
+            @Override
+            public <T> T execute(HttpHost host, HttpRequest request, ResponseHandler<? extends T> responseHandler)
+                    throws IOException, ClientProtocolException {
+                throw new UnsupportedOperationException("Not used in this test");
+            }
+
+            @Override
+            public <T> T execute(HttpHost host, HttpRequest request, ResponseHandler<? extends T> responseHandler,
+                    HttpContext context) throws IOException, ClientProtocolException {
+                throw new UnsupportedOperationException("Not used in this test");
+            }
+
+            @Override
+            public HttpParams getParams() {
+                return null;
+            }
+
+            @Override
+            public ClientConnectionManager getConnectionManager() {
+                return null;
+            }
+
+            @Override
+            public HttpResponse execute(HttpUriRequest request) {
+                return buildResponse(statusCode, body);
+            }
+
+            @Override
+            public HttpResponse execute(HttpUriRequest request, HttpContext context) {
+                return buildResponse(statusCode, body);
+            }
+        };
+    }
+
+    private HttpResponse buildResponse(int statusCode, String body) {
+        BasicHttpResponse response = new BasicHttpResponse(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1),
+                statusCode, ""));
+        if (body != null) {
+            response.setEntity(new org.apache.http.entity.StringEntity(body, StandardCharsets.UTF_8));
+        }
+        return response;
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/AsyncApiParserUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.spec.parser/src/test/java/org/wso2/carbon/apimgt/spec/parser/definitions/AsyncApiParserUtilTest.java
@@ -36,6 +36,7 @@ import org.apache.http.message.BasicStatusLine;
 import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
 import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIConstants;
 import org.wso2.carbon.apimgt.api.APIDefinitionValidationResponse;
 import org.wso2.carbon.apimgt.api.ErrorItem;
 import org.wso2.carbon.apimgt.api.APIManagementException;
@@ -198,8 +199,8 @@ public class AsyncApiParserUtilTest {
         String fileUrl = tmp.toURI().toURL().toString();
         AsyncApiParseOptions options =  new AsyncApiParseOptions();
         options.setPreserveLegacyAsyncApiParser(true);
-        APIDefinitionValidationResponse resp = AsyncApiParserUtil.validateAsyncAPISpecificationByURL(
-                fileUrl, okHttpClient, true, options);
+        APIDefinitionValidationResponse resp = AsyncApiParserUtil.validateAsyncAPISpecificationByURL(fileUrl,
+                okHttpClient, true, options, APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT_DEFAULT_MB);
         assertNotNull(resp);
         assertTrue("Validation by URL with 200 status should succeed", resp.isValid());
     }
@@ -278,8 +279,8 @@ public class AsyncApiParserUtilTest {
 
         AsyncApiParseOptions options =  new AsyncApiParseOptions();
         options.setPreserveLegacyAsyncApiParser(true);
-        APIDefinitionValidationResponse resp = AsyncApiParserUtil.validateAsyncAPISpecificationByURL(
-                fileUrl, nonOkHttpClient, true, options);
+        APIDefinitionValidationResponse resp = AsyncApiParserUtil.validateAsyncAPISpecificationByURL(fileUrl,
+                nonOkHttpClient, true, options, APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT_DEFAULT_MB);
         assertNotNull(resp);
         assertFalse("Expected validation to fail when HTTP status != 200", resp.isValid());
         // Ensure the known error code for URL not 200 is present in the response error items

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -691,6 +691,25 @@
         {% endif %}
         <!-- This parameter is used to enable/disable using legacy async api parser.-->
         <PreserveLegacyAsyncParser>{{apim.publisher.use_legacy_async_parser}}</PreserveLegacyAsyncParser>
+        {% if apim.publisher.import_definition_file_size_limit is defined %}
+        <ImportDefinitionFileSizeLimit>
+            {% if apim.publisher.import_definition_file_size_limit.oas is defined %}
+            <OAS>{{apim.publisher.import_definition_file_size_limit.oas}}</OAS>
+            {% endif %}
+            {% if apim.publisher.import_definition_file_size_limit.async is defined %}
+            <ASYNC>{{apim.publisher.import_definition_file_size_limit.async}}</ASYNC>
+            {% endif %}
+            {% if apim.publisher.import_definition_file_size_limit.wsdl is defined %}
+            <WSDL>{{apim.publisher.import_definition_file_size_limit.wsdl}}</WSDL>
+            {% endif %}
+            {% if apim.publisher.import_definition_file_size_limit.graphql is defined %}
+            <GRAPHQL>{{apim.publisher.import_definition_file_size_limit.graphql}}</GRAPHQL>
+            {% endif %}
+            {% if apim.publisher.import_definition_file_size_limit.mcp is defined %}
+            <MCP>{{apim.publisher.import_definition_file_size_limit.mcp}}</MCP>
+            {% endif %}
+        </ImportDefinitionFileSizeLimit>
+        {% endif %}
     </APIPublisher>
 
     <!-- Status observers can be registered against the API Publisher to listen for


### PR DESCRIPTION
### Purpose
- Add file size limit to the APIs which can be created via API definition URL

### Approach
- Implemented SizeLimitedInputStream class to wrap the input stream of the response returned from the definition URL
- Existing `validateAsyncAPISpecificationByURL` and `validateAPIDefinitionByURL` methods are deprecated and introduced new parameter to accept maximum file size.