### PR TITLE
[APIM] Fix NPE issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/common/APIMgtLatencyStatsHandler.java
@@ -183,7 +183,7 @@ public class APIMgtLatencyStatsHandler extends AbstractHandler {
     private List<Parameter> getLowercaseHeaderParameters(List<Parameter> parameters) {
 
         List<Parameter> headerParameters = parameters.stream()
-                .filter(param -> param.getIn().equalsIgnoreCase("header"))
+                .filter(param -> "header".equalsIgnoreCase(param.getIn()))
                 .filter(param -> !param.getName().equalsIgnoreCase(Headers.CONTENT_TYPE)) // Ignore content-type header
                 .filter(param -> !param.getName().equalsIgnoreCase(Headers.ACCEPT)) // Ignore accept header
                 .collect(Collectors.toList());


### PR DESCRIPTION
Related to https://github.com/wso2/api-manager/issues/4912

This pull request makes a minor improvement to the filtering logic for header parameters in the `APIMgtLatencyStatsHandler` class. The change refactors the filter to use a more conventional constant-first pattern in the `equalsIgnoreCase` check, which is a common best practice to prevent potential `NullPointerException`s.

