### PR TITLE
Handle null values in getMetadata method of WorkflowDTO

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/dto/WorkflowDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/dto/WorkflowDTO.java
@@ -166,7 +166,8 @@ public class WorkflowDTO implements Serializable {
     }
 
     public String getMetadata(String key) {
-        return metadata.get(key).toString();
+        Object value = metadata.get(key);
+        return value != null ? value.toString() : null;
     }
 
     public void setMetadata(String key, String value) {


### PR DESCRIPTION
### Description
This pull request makes a small improvement to the `getMetadata` method in the `WorkflowDTO` class. The change ensures that if a metadata value is missing, the method will return `null` instead of throwing a `NullPointerException`.

- Resolves https://github.com/wso2/api-manager/issues/4951