### PR TITLE
Add AWS Lambda proxy response mapping

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
@@ -17,11 +17,21 @@
  */
 package org.wso2.carbon.apimgt.gateway.mediators;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
+import org.apache.axiom.attachments.ByteArrayDataSource;
+import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.axiom.soap.SOAPBody;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axis2.AxisFault;
+import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -56,11 +66,18 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
+import javax.activation.DataHandler;
+import javax.xml.XMLConstants;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -88,6 +105,9 @@ public class AWSLambdaMediator extends AbstractMediator implements ManagedLifecy
     private LambdaClient awsLambdaClient;
     private StsClient stsClient;
     private StsAssumeRoleCredentialsProvider assumeRoleCredentialsProvider;
+    private static final String STATUS_CODE = "statusCode";
+    private static final String MULTI_VALUE_HEADERS = "multiValueHeaders";
+    private boolean proxyResponseMappingEnabled = false;
 
     public AWSLambdaMediator() {
 
@@ -103,6 +123,14 @@ public class AWSLambdaMediator extends AbstractMediator implements ManagedLifecy
 
         if (log.isDebugEnabled()) {
             log.debug("AWSLambdaMediator initialized.");
+        }
+
+        APIManagerConfiguration config = ServiceReferenceHolder.getInstance()
+                .getApiManagerConfigurationService().getAPIManagerConfiguration();
+        String proxyMappingConfig = config.getFirstProperty(APIConstants.AWS_LAMBDA_PROXY_RESPONSE_ENABLED);
+        proxyResponseMappingEnabled = Boolean.parseBoolean(proxyMappingConfig);
+        if (log.isDebugEnabled()) {
+            log.debug("AWS Lambda proxy response mapping enabled: " + proxyResponseMappingEnabled);
         }
 
         // Validate resource timeout and set client configuration
@@ -264,12 +292,7 @@ public class AWSLambdaMediator extends AbstractMediator implements ManagedLifecy
                 if (log.isDebugEnabled()) {
                     log.debug("AWS Lambda function: " + resourceName + " is invoked successfully.");
                 }
-                JsonUtil.getNewJsonPayload(axis2MessageContext, new String(invokeResult.payload().asByteArray(), StandardCharsets.UTF_8),
-                        true, true);
-                axis2MessageContext.setProperty(APIMgtGatewayConstants.HTTP_SC, invokeResult.statusCode());
-                axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_MESSAGE_TYPE, APIConstants.APPLICATION_JSON_MEDIA_TYPE);
-                axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_CONTENT_TYPE, APIConstants.APPLICATION_JSON_MEDIA_TYPE);
-                axis2MessageContext.removeProperty(APIConstants.NO_ENTITY_BODY);
+                handleLambdaResponse(axis2MessageContext, invokeResult);
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("Failed to invoke AWS Lambda function: " + resourceName);
@@ -444,6 +467,423 @@ public class AWSLambdaMediator extends AbstractMediator implements ManagedLifecy
                 log.error("Error closing " + resource.getClass().getSimpleName(), e);
             }
         }
+    }
+
+    /**
+     * Populates the Axis2 message context with HTTP status, headers, and body from AWS Lambda response.
+     * Handles proxy response format {statusCode, headers, body, isBase64Encoded}.
+     * Routes body by Content-Type: JSON via JsonUtil, XML via StAX, text via PlainTextFormatter,
+     * binary via ExpandingMessageFormatter. Decodes base64 first if isBase64Encoded=true.
+     * Falls back to JSON string primitive for unknown types.
+     *
+     * @param axis2MessageContext message context to populate
+     * @param invokeResult        result of the AWS Lambda Invoke API call
+     * @throws AxisFault if setting the JSON payload fails
+     */
+    private void handleLambdaResponse(org.apache.axis2.context.MessageContext axis2MessageContext,
+            InvokeResponse invokeResult) throws AxisFault {
+
+        // --- proxy response mapping disabled ---
+        if (!proxyResponseMappingEnabled) {
+            JsonUtil.getNewJsonPayload(axis2MessageContext,
+                    new String(invokeResult.payload().asByteArray(), StandardCharsets.UTF_8), true, true);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.HTTP_SC, invokeResult.statusCode());
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_MESSAGE_TYPE,
+                    APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_CONTENT_TYPE,
+                    APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+            axis2MessageContext.removeProperty(APIConstants.NO_ENTITY_BODY);
+            return;
+        }
+
+        // --- Proxy response mapping mode ---
+        Map<String, String> transportHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        if (invokeResult.payload() == null) {
+            log.warn("Lambda invocation returned a null payload; treating as empty response.");
+            axis2MessageContext.setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS, transportHeaders);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.HTTP_SC, 502);
+            axis2MessageContext.setProperty(APIConstants.NO_ENTITY_BODY, true);
+            return;
+        }
+        String lambdaPayload = new String(invokeResult.payload().asByteArray(), StandardCharsets.UTF_8);
+        if (log.isDebugEnabled()) {
+            log.debug("Received Lambda response payload (length=" + lambdaPayload.length() + ").");
+        }
+
+        // If x-amz-function-error is set, Lambda itself crashed (not a user-thrown error).
+        // The payload {errorMessage, errorType, stackTrace} is logged server-side only.
+        // A generic 502 body is returned to avoid leaking backend internals to the client.
+        if (StringUtils.isNotEmpty(invokeResult.functionError())) {
+            log.error("Lambda function error [" + invokeResult.functionError() + "]");
+            axis2MessageContext.setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS, transportHeaders);
+            JsonUtil.getNewJsonPayload(axis2MessageContext, "{\"message\":\"Internal Server Error\"}", true, true);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.HTTP_SC, 502);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_MESSAGE_TYPE,
+                    APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_CONTENT_TYPE,
+                    APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+            axis2MessageContext.removeProperty(APIConstants.NO_ENTITY_BODY);
+            return;
+        }
+
+        // Parse the Lambda proxy response envelope: {statusCode, headers, body, isBase64Encoded}
+        LambdaResponse lambdaResponse = getLambdaResponse(lambdaPayload, invokeResult.statusCode());
+        String responseBody = lambdaResponse.getBody();
+
+        axis2MessageContext.setProperty(APIMgtGatewayConstants.HTTP_SC, lambdaResponse.getStatusCode());
+
+        if (log.isDebugEnabled()) {
+            log.debug("Parsed Lambda proxy response: statusCode=" + lambdaResponse.getStatusCode()
+                    + ", contentType=" + lambdaResponse.getContentType()
+                    + ", isBase64Encoded=" + lambdaResponse.isBase64Encoded()
+                    + ", bodyLength=" + (responseBody != null ? responseBody.length() : 0));
+        }
+
+        // Forward Lambda response headers — always, even for empty-body responses (e.g. 204, 301).
+        // Always create a fresh response header map to avoid leaking inbound request headers to the client.
+        // Content-Type is excluded here; it is applied via the Axis2 message context properties below.
+        axis2MessageContext.setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS, transportHeaders);
+        for (Map.Entry<String, String> entry : lambdaResponse.getHeaders().entrySet()) {
+            if (!APIConstants.HEADER_CONTENT_TYPE.equalsIgnoreCase(entry.getKey())) {
+                transportHeaders.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        // No body field in the proxy response (e.g. 204 No Content) — suppress the HTTP body entirely.
+        if (StringUtils.isEmpty(responseBody)) {
+            axis2MessageContext.setProperty(APIConstants.NO_ENTITY_BODY, true);
+            return;
+        }
+
+        // Extract charset from Content-Type before stripping params; used for text/XML byte decoding.
+        Charset responseCharset = StandardCharsets.UTF_8;
+        String rawContentType = lambdaResponse.getContentType();
+        if (rawContentType != null) {
+            for (String param : rawContentType.split(";")) {
+                String trimmed = param.trim();
+                if (trimmed.toLowerCase(java.util.Locale.ROOT).startsWith("charset=")) {
+                    String charsetName = trimmed.substring("charset=".length()).trim().replace("\"", "");
+                    try {
+                        responseCharset = Charset.forName(charsetName);
+                    } catch (IllegalArgumentException e) {
+                        log.warn("Unsupported charset '" + charsetName + "' in Content-Type; falling back to UTF-8.");
+                    }
+                    break;
+                }
+            }
+        }
+
+        // Strip content-type parameters (e.g. "; charset=UTF-8") so formatter lookup is unambiguous.
+        String responseContentType = lambdaResponse.getContentType();
+        if (responseContentType != null && responseContentType.contains(";")) {
+            responseContentType = responseContentType.split(";")[0].trim();
+        }
+        // Normalise to lower-case once for all comparisons below.
+        String contentTypeLower = responseContentType != null ? responseContentType.toLowerCase(java.util.Locale.ROOT) : "";
+
+        // Pre-decode base64 once; null means the body is a plain string (not base64).
+        // Use the strict JDK decoder (RFC 4648) so invalid base64 throws immediately rather than
+        // silently producing garbage bytes, which Commons Codec's lenient decoder would not catch.
+        byte[] decodedBytes = null;
+        if (lambdaResponse.isBase64Encoded()) {
+            try {
+                decodedBytes = java.util.Base64.getDecoder().decode(responseBody);
+            } catch (IllegalArgumentException e) {
+                log.warn("Lambda response has isBase64Encoded=true but the body is not valid base64; returning 502.", e);
+                transportHeaders.clear();
+                axis2MessageContext.setProperty(APIMgtGatewayConstants.HTTP_SC, 502);
+                axis2MessageContext.setProperty(APIConstants.NO_ENTITY_BODY, true);
+                return;
+            }
+        }
+
+        // Configure XMLInputFactory once — reused if the body turns out to be XML.
+        XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+        xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+        try {
+            xmlInputFactory.setProperty(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (IllegalArgumentException ignored) {
+            // Parser does not support FEATURE_SECURE_PROCESSING; XXE is still blocked above.
+        }
+
+        OMFactory omFactory = OMAbstractFactory.getOMFactory();
+
+        if (contentTypeLower.contains("json")) {
+            String src = decodedBytes != null ? new String(decodedBytes, responseCharset) : responseBody;
+            String jsonBody;
+            try {
+                JsonParser.parseString(src);
+                jsonBody = src;
+            } catch (JsonSyntaxException e) {
+                log.warn("Lambda response body is not valid JSON despite Content-Type claiming application/json;"
+                        + " wrapping as JSON string primitive.", e);
+                jsonBody = new JsonPrimitive(src).toString();
+            }
+            JsonUtil.getNewJsonPayload(axis2MessageContext, jsonBody, true, true);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_MESSAGE_TYPE,
+                    APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_CONTENT_TYPE,
+                    APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+
+        } else if (contentTypeLower.endsWith("/xml") || contentTypeLower.contains("+xml")) {
+            String src = decodedBytes != null ? new String(decodedBytes, responseCharset) : responseBody;
+            OMElement existingBodyChild = axis2MessageContext.getEnvelope().getBody().getFirstElement();
+            if (existingBodyChild != null) {
+                existingBodyChild.detach();
+            }
+            boolean xmlParsed = false;
+            try {
+                XMLStreamReader xmlReader = xmlInputFactory.createXMLStreamReader(new StringReader(src));
+                OMElement xmlElement = new StAXOMBuilder(xmlReader).getDocumentElement();
+                axis2MessageContext.getEnvelope().getBody().addChild(xmlElement);
+                xmlParsed = true;
+            } catch (Exception e) {
+                log.error("Failed to parse XML body; falling back to JSON string primitive.", e);
+                JsonUtil.getNewJsonPayload(axis2MessageContext, new JsonPrimitive(src).toString(), true, true);
+            }
+            if (xmlParsed) {
+                axis2MessageContext.setProperty(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE,
+                        responseContentType);
+                axis2MessageContext.setProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE,
+                        responseContentType);
+                axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_MESSAGE_TYPE, responseContentType);
+                axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_CONTENT_TYPE, responseContentType);
+            } else {
+                axis2MessageContext.setProperty(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE,
+                        APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+                axis2MessageContext.setProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE,
+                        APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+                axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_MESSAGE_TYPE,
+                        APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+                axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_CONTENT_TYPE,
+                        APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+            }
+
+        } else if (contentTypeLower.startsWith("text/")) {
+            String src = decodedBytes != null ? new String(decodedBytes, responseCharset) : responseBody;
+            OMElement existingBodyChild = axis2MessageContext.getEnvelope().getBody().getFirstElement();
+            if (existingBodyChild != null) {
+                existingBodyChild.detach();
+            }
+            OMElement textWrapper = omFactory.createOMElement(BaseConstants.DEFAULT_TEXT_WRAPPER);
+            textWrapper.setText(src);
+            axis2MessageContext.getEnvelope().getBody().addChild(textWrapper);
+            axis2MessageContext.setProperty(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE, responseContentType);
+            axis2MessageContext.setProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE, responseContentType);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_MESSAGE_TYPE, responseContentType);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_CONTENT_TYPE, responseContentType);
+
+        } else if (decodedBytes != null) {
+            // Base64-encoded binary: wrap with DEFAULT_BINARY_WRAPPER for ExpandingMessageFormatter.
+            OMElement existingBodyChild = axis2MessageContext.getEnvelope().getBody().getFirstElement();
+            if (existingBodyChild != null) {
+                existingBodyChild.detach();
+            }
+            String mimeType = StringUtils.isNotEmpty(responseContentType)
+                    ? responseContentType
+                    : APIConstants.APPLICATION_OCTET_STREAM_MEDIA_TYPE;
+            DataHandler dataHandler = new DataHandler(new ByteArrayDataSource(decodedBytes, mimeType));
+            OMElement binaryWrapper = omFactory.createOMElement(BaseConstants.DEFAULT_BINARY_WRAPPER);
+            binaryWrapper.addChild(omFactory.createOMText(dataHandler, true));
+            axis2MessageContext.getEnvelope().getBody().addChild(binaryWrapper);
+            axis2MessageContext.setProperty(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE, mimeType);
+            axis2MessageContext.setProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE, mimeType);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_MESSAGE_TYPE, mimeType);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_CONTENT_TYPE, mimeType);
+
+        } else {
+            if (isBinaryContentType(responseContentType)) {
+                log.warn("Lambda response has binary Content-Type '" + responseContentType
+                        + "' but isBase64Encoded is not true; returning 502.");
+                transportHeaders.clear();
+                axis2MessageContext.setProperty(APIMgtGatewayConstants.HTTP_SC, 502);
+                axis2MessageContext.setProperty(APIConstants.NO_ENTITY_BODY, true);
+                return;
+            }
+            // Unknown non-binary type without base64: treat as JSON string primitive.
+            JsonUtil.getNewJsonPayload(axis2MessageContext,
+                    new JsonPrimitive(responseBody).toString(), true, true);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_MESSAGE_TYPE,
+                    APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+            axis2MessageContext.setProperty(APIMgtGatewayConstants.REST_CONTENT_TYPE,
+                    APIConstants.APPLICATION_JSON_MEDIA_TYPE);
+        }
+
+        // Body has been set — ensure NO_ENTITY_BODY is cleared so the transport layer sends it.
+        axis2MessageContext.removeProperty(APIConstants.NO_ENTITY_BODY);
+    }
+
+    /**
+     * Parses an AWS Lambda proxy integration response payload into a {@link LambdaResponse}
+     *
+     * @param lambdaPayload raw UTF-8 payload from the Lambda Invoke response
+     * @param defaultStatusCode HTTP status code to use if the payload does not contain a valid one
+     * @return LambdaResponse populated from the payload
+     */
+    private LambdaResponse getLambdaResponse(String lambdaPayload, int defaultStatusCode) {
+        // Body is initialized as null. It is only set if the proxy response contains a 'body' field.
+        // If JSON parsing fails entirely, we fall back to the raw lambdaPayload in the catch block.
+        LambdaResponse lambdaResponse = new LambdaResponse(defaultStatusCode, null);
+
+        if (StringUtils.isEmpty(lambdaPayload)) {
+            log.warn("Lambda proxy response payload is empty; treating as malformed proxy envelope and returning 502.");
+            lambdaResponse.setStatusCode(502);
+            return lambdaResponse;
+        }
+
+        try {
+            JsonObject responseObject = JsonParser.parseString(lambdaPayload).getAsJsonObject();
+            if (responseObject.has(STATUS_CODE) && !responseObject.get(STATUS_CODE).isJsonNull()) {
+                int parsedStatusCode = responseObject.get(STATUS_CODE).getAsInt();
+                if (parsedStatusCode >= 100 && parsedStatusCode <= 599) {
+                    lambdaResponse.setStatusCode(parsedStatusCode);
+                } else {
+                    log.warn("Lambda proxy response contains an out-of-range statusCode (" + parsedStatusCode
+                            + "); treating as malformed proxy envelope and returning 502.");
+                    lambdaResponse.setStatusCode(502);
+                    return lambdaResponse;
+                }
+            } else {
+                log.warn("Lambda proxy response is missing the required statusCode field;"
+                        + " treating as malformed proxy envelope and returning 502.");
+                lambdaResponse.setStatusCode(502);
+                return lambdaResponse;
+            }
+            if (responseObject.has(BODY_PARAMETER) && !responseObject.get(BODY_PARAMETER).isJsonNull()) {
+                String responseBody = responseObject.get(BODY_PARAMETER).getAsString();
+                if (responseObject.has(IS_BASE64_ENCODED_PARAMETER)
+                        && !responseObject.get(IS_BASE64_ENCODED_PARAMETER).isJsonNull()
+                        && responseObject.get(IS_BASE64_ENCODED_PARAMETER).getAsBoolean()) {
+                    lambdaResponse.setBase64Encoded(true);
+                    // Do not decode here; keep as base64 string for payload setting
+                } else {
+                    lambdaResponse.setBase64Encoded(false);
+                }
+                lambdaResponse.setBody(responseBody);
+            }
+            // Per AWS proxy integration spec: headers and multiValueHeaders are merged.
+            // If the same key appears in both, only the values from multiValueHeaders are used.
+            // Keys present only in headers are included normally.
+            if (responseObject.has(MULTI_VALUE_HEADERS)
+                    && responseObject.get(MULTI_VALUE_HEADERS).isJsonObject()) {
+                JsonObject multiHeaders = responseObject.getAsJsonObject(MULTI_VALUE_HEADERS);
+                for (String headerKey : multiHeaders.keySet()) {
+                    if (multiHeaders.get(headerKey).isJsonArray()) {
+                        JsonArray values = multiHeaders.getAsJsonArray(headerKey);
+                        StringBuilder headerValue = new StringBuilder();
+                        for (JsonElement element : values) {
+                            if (element.isJsonNull()) {
+                                continue;
+                            }
+                            if (headerValue.length() > 0) {
+                                headerValue.append(", ");
+                            }
+                            headerValue.append(element.getAsString());
+                        }
+                        if (headerValue.length() > 0) {
+                            lambdaResponse.addHeader(headerKey, headerValue.toString());
+                        }
+                    } else if (!multiHeaders.get(headerKey).isJsonNull()) {
+                        lambdaResponse.addHeader(headerKey, multiHeaders.get(headerKey).getAsString());
+                    }
+                }
+            }
+            if (responseObject.has(APIConstants.PROPERTY_HEADERS_KEY)
+                    && responseObject.get(APIConstants.PROPERTY_HEADERS_KEY).isJsonObject()) {
+                JsonObject responseHeaders = responseObject.getAsJsonObject(APIConstants.PROPERTY_HEADERS_KEY);
+                for (String headerKey : responseHeaders.keySet()) {
+                    // Skip keys already populated from multiValueHeaders.
+                    if (!lambdaResponse.getHeaders().containsKey(headerKey)) {
+                        JsonElement headerValue = responseHeaders.get(headerKey);
+                        if (!headerValue.isJsonNull()) {
+                            lambdaResponse.addHeader(headerKey, headerValue.getAsString());
+                        }
+                    } else {
+                        log.debug("Lambda response header '" + headerKey + "' from 'headers' map is being"
+                                + " dropped because it is already present in 'multiValueHeaders'."
+                                + " Per AWS proxy integration spec, multiValueHeaders takes precedence.");
+                    }
+                }
+            }
+        } catch (IllegalStateException | JsonSyntaxException | NumberFormatException
+                | UnsupportedOperationException e) {
+            log.warn("Failed to parse AWS Lambda proxy response payload as proxy integration envelope; returning 502.", e);
+            lambdaResponse.setStatusCode(502);
+            lambdaResponse.setBody(null);
+            lambdaResponse.getHeaders().clear();
+        }
+
+        return lambdaResponse;
+    }
+
+    /**
+     * Holds the parsed fields of an AWS Lambda proxy integration response
+     */
+    private static class LambdaResponse {
+        private int statusCode;
+        private String body;
+        private String contentType;
+        private boolean isBase64Encoded;
+        private Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+        LambdaResponse(int statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+
+        int getStatusCode() {
+            return statusCode;
+        }
+
+        void setStatusCode(int statusCode) {
+            this.statusCode = statusCode;
+        }
+
+        String getBody() {
+            return body;
+        }
+
+        void setBody(String body) {
+            this.body = body;
+        }
+
+        Map<String, String> getHeaders() {
+            return headers;
+        }
+
+        void addHeader(String name, String value) {
+            this.headers.put(name, value);
+            if (APIConstants.HEADER_CONTENT_TYPE.equalsIgnoreCase(name)) {
+                this.contentType = value;
+            }
+        }
+
+        String getContentType() {
+            return contentType;
+        }
+
+        boolean isBase64Encoded() {
+            return isBase64Encoded;
+        }
+
+        void setBase64Encoded(boolean base64Encoded) {
+            isBase64Encoded = base64Encoded;
+        }
+    }
+
+    private boolean isBinaryContentType(String contentType) {
+        if (contentType == null) return false;
+        String lower = contentType.toLowerCase();
+        return lower.startsWith("image/")
+                || lower.startsWith("audio/")
+                || lower.startsWith("video/")
+                || lower.equals("application/octet-stream")
+                || lower.equals("application/pdf")
+                || lower.equals("application/zip")
+                || lower.equals("application/x-zip-compressed")
+                || lower.equals("application/gzip")
+                || lower.equals("application/x-gzip");
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -92,6 +92,8 @@ public final class APIConstants {
 
     public static final String APPLICATION_XML_MEDIA_TYPE = "application/xml";
 
+    public static final String APPLICATION_OCTET_STREAM_MEDIA_TYPE = "application/octet-stream";
+
     public static final String APPLICATION_WSDL_MEDIA_TYPE = "application/wsdl";
 
     public static final String APPLICATION_XML_SOAP_MEDIA_TYPE = "application/soap+xml";
@@ -2980,6 +2982,7 @@ public final class APIConstants {
     public static final String APPLICATION_TOKEN_TYPE_JWT = "JWT";
     // AWS Lambda: HTTP Client Configuration Constants
     public static final String AWS_LAMBDA_HTTP_CLIENT = "AWSLambdaConnector.HttpClient.";
+    public static final String AWS_LAMBDA_PROXY_RESPONSE_ENABLED = "AWSLambdaConnector.EnableProxyResponseMapping";
     public static final String MAX_CONNECTIONS = "MaxConnections";
     public static final String CONNECTION_TIMEOUT = "ConnectionTimeout";
     public static final String SOCKET_TIMEOUT = "SocketTimeout";

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/org.wso2.carbon.apimgt.core.default.json
@@ -21,6 +21,7 @@
   "apim.aws_lambda.http_client.connection_timeout": "2",
   "apim.aws_lambda.http_client.socket_timeout": "30",
   "apim.aws_lambda.http_client.connection_acquisition_timeout": "30",
+  "apim.aws_lambda.enable_proxy_response_mapping": "false",
   "apim.basic_authenticator.max_idle": "200",
   "apim.basic_authenticator.init_idle_capacity": "100",
   "apim.basic_authenticator.max_active": "110",

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -2154,6 +2154,7 @@
       <EnableCertificateManagementEventListening>{{apim.certificate_manager.events_enabled}}</EnableCertificateManagementEventListening>
 
       <AWSLambdaConnector>
+          <EnableProxyResponseMapping>{{apim.aws_lambda.enable_proxy_response_mapping}}</EnableProxyResponseMapping>
           <HttpClient>
               <MaxConnections>{{apim.aws_lambda.http_client.max_connections}}</MaxConnections>
               <ConnectionTimeout>{{apim.aws_lambda.http_client.connection_timeout}}</ConnectionTimeout>


### PR DESCRIPTION
## Purpose
Introduce support for AWS Lambda proxy integration response format to correctly map Lambda responses (status, headers, body, encoding) into the API Gateway response model.

## Goals
- Enable optional parsing of Lambda proxy responses `{statusCode, headers, multiValueHeaders, body, isBase64Encoded}`
- Ensure accurate propagation of HTTP status codes and headers
- Support content-type aware response handling (JSON, XML, text, binary)

## Approach
- Introduced `handleLambdaResponse(...)` to centralize response processing logic
- Added configuration flag `AWSLambdaConnector.EnableProxyResponseMapping` to toggle behavior
- Implemented `LambdaResponse` model to represent parsed proxy response
- Added `getLambdaResponse(...)` to parse and validate proxy response payload
- Implemented content-type driven handling:
  - JSON → validated and set via `JsonUtil`
  - XML → parsed via StAX with secure parser configuration
  - Text → wrapped using Axis2 text formatter
  - Binary → decoded (base64) and wrapped using DataHandler
- Added strict base64 decoding using JDK decoder
- Implemented header merging logic respecting `multiValueHeaders` precedence
- Ensured charset extraction from `Content-Type`
- Added safeguards for malformed payloads and invalid status codes
- Default behavior preserved when feature is disabled

## Backward Compatibility
- Feature is disabled by default
- Existing behavior remains unchanged unless explicitly enabled

## Related Issue
- https://github.com/wso2/api-manager/issues/4926