### PR TITLE
Rename Universal Gateway to Platform Gateway

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -187,9 +187,9 @@ public enum ExceptionCodes implements ErrorHandler {
             "Cannot delete the environment with UUID %s as active gateway policy deployment exist"),
     GATEWAY_ENVIRONMENT_API_REVISIONS_EXIST(900515, "API Revisions Deployed to Gateway Environment Exist", 409,
             "Cannot delete the environment with UUID %s as API revisions are deployed to it"),
-    UNIVERSAL_GATEWAY_NAME_ALREADY_EXISTS(900518, "API Platform gateway name already exists", 409,
+    PLATFORM_GATEWAY_NAME_ALREADY_EXISTS(900518, "API Platform gateway name already exists", 409,
             "An API Platform gateway with name '%s' already exists in the organization"),
-    UNIVERSAL_GATEWAY_NOT_FOUND(900519, "API Platform gateway not found", 404,
+    PLATFORM_GATEWAY_NOT_FOUND(900519, "API Platform gateway not found", 404,
             "API Platform gateway not found"),
 
     // Workflow related codes

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/PlatformGatewayService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/PlatformGatewayService.java
@@ -39,7 +39,7 @@ public interface PlatformGatewayService {
      * @param vhost           vhost
      * @param propertiesJson  optional JSON string for custom properties
      * @return created gateway and registration token (returned only once)
-     * @throws APIManagementException if validation fails or name already exists (use ExceptionCodes.UNIVERSAL_GATEWAY_NAME_ALREADY_EXISTS for 409)
+     * @throws APIManagementException if validation fails or name already exists (use ExceptionCodes.PLATFORM_GATEWAY_NAME_ALREADY_EXISTS for 409)
      */
     PlatformGatewayRegistrationResult createGateway(String organizationId, String name, String displayName,
                                               String description, String vhost, String propertiesJson)
@@ -118,7 +118,8 @@ public interface PlatformGatewayService {
      * @param description    new description, or null to keep existing
      * @param propertiesJson new properties JSON string, or null to keep existing
      * @return the updated platform gateway
-     * @throws APIManagementException if gateway not found or not in organization (use ExceptionCodes.UNIVERSAL_GATEWAY_NOT_FOUND for 404)
+     * @throws APIManagementException if gateway not found or not in organization
+     * (use ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND for 404)
      */
     PlatformGateway updateGateway(String organizationId, String gatewayId, String displayName,
                                   String description, String propertiesJson)

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3967,7 +3967,7 @@ public final class APIConstants {
         public static final int DEFAULT_CLEANUP_STARTUP_DELAY = 60;
 
         public static final String PLATFORM_GATEWAY_CONNECT_CONFIGURATION = "PlatformGatewayConnectConfiguration";
-        public static final String UNIVERSAL_GATEWAY_VERSIONS = "UniversalGatewayVersions";
+        public static final String PLATFORM_GATEWAY_VERSIONS = "PlatformGatewayVersions";
         public static final String VERSION = "Version";
         public static final String API_KEY_NOTIFICATION = "APIKeyNotification";
         public static final String QUEUE_SIZE = "QueueSize";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -3621,22 +3621,22 @@ public class APIManagerConfiguration {
         OMElement pgConnectElem = omElement.getFirstChildWithName(
                 new QName(APIConstants.GatewayNotification.PLATFORM_GATEWAY_CONNECT_CONFIGURATION));
         if (pgConnectElem != null) {
-            List<String> universalGatewayVersions = new ArrayList<>();
-            OMElement universalGatewayVersionsEl = pgConnectElem.getFirstChildWithName(
-                    new QName(APIConstants.GatewayNotification.UNIVERSAL_GATEWAY_VERSIONS));
-            if (universalGatewayVersionsEl != null) {
-                Iterator<?> versionIterator = universalGatewayVersionsEl.getChildrenWithName(
+            List<String> platformGatewayVersions = new ArrayList<>();
+            OMElement platformGatewayVersionsEl = pgConnectElem.getFirstChildWithName(
+                    new QName(APIConstants.GatewayNotification.PLATFORM_GATEWAY_VERSIONS));
+            if (platformGatewayVersionsEl != null) {
+                Iterator<?> versionIterator = platformGatewayVersionsEl.getChildrenWithName(
                         new QName(APIConstants.GatewayNotification.VERSION));
                 while (versionIterator != null && versionIterator.hasNext()) {
                     OMElement versionElement = (OMElement) versionIterator.next();
                     if (versionElement != null && versionElement.getText() != null
                             && !versionElement.getText().trim().isEmpty()) {
-                        universalGatewayVersions.add(versionElement.getText().trim());
+                        platformGatewayVersions.add(versionElement.getText().trim());
                     }
                 }
             }
-            if (!universalGatewayVersions.isEmpty()) {
-                platformGatewayConnectConfig.setUniversalGatewayVersions(universalGatewayVersions);
+            if (!platformGatewayVersions.isEmpty()) {
+                platformGatewayConnectConfig.setPlatformGatewayVersions(platformGatewayVersions);
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -3617,7 +3617,7 @@ public class APIManagerConfiguration {
             }
         }
 
-        // Universal Gateway version metadata for UI quick-start (separate element under gateway notification).
+        // Platform Gateway version metadata for UI quick-start (separate element under gateway notification).
         OMElement pgConnectElem = omElement.getFirstChildWithName(
                 new QName(APIConstants.GatewayNotification.PLATFORM_GATEWAY_CONNECT_CONFIGURATION));
         if (pgConnectElem != null) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -2324,6 +2324,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
      * @param api The API object to process
      */
     private void deriveApiSecurityFromHubPolicies(API api) {
+        String EmptyApiSecurity = "";
         if (!isPlatformGatewayApi(api)) {
             return;
         }
@@ -2389,7 +2390,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 api.setAuthorizationHeader(APIConstants.AUTHORIZATION_HEADER_DEFAULT);
             }
         } else {
-            api.setApiSecurity(null);
+            api.setApiSecurity(EmptyApiSecurity);
             api.setApiKeyHeader(null);
             api.setAuthorizationHeader(null);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/PlatformGatewayConnectConfig.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/PlatformGatewayConnectConfig.java
@@ -27,21 +27,21 @@ import java.util.List;
  * Separate from {@link GatewayNotificationConfiguration} for notification/heartbeat settings.
  */
 public class PlatformGatewayConnectConfig {
-    private List<String> universalGatewayVersions = new ArrayList<>();
+    private List<String> platformGatewayVersions = new ArrayList<>();
 
     /**
      * Global API Platform Gateway versions (e.g. ["0.11.0","1.0.0"]).
      */
-    public List<String> getUniversalGatewayVersions() {
-        if (universalGatewayVersions == null) {
-            universalGatewayVersions = new ArrayList<>();
+    public List<String> getPlatformGatewayVersions() {
+        if (platformGatewayVersions == null) {
+            platformGatewayVersions = new ArrayList<>();
         }
-        return Collections.unmodifiableList(universalGatewayVersions);
+        return Collections.unmodifiableList(platformGatewayVersions);
     }
 
-    public void setUniversalGatewayVersions(List<String> universalGatewayVersions) {
-        this.universalGatewayVersions = universalGatewayVersions != null
-                ? new ArrayList<>(universalGatewayVersions)
+    public void setPlatformGatewayVersions(List<String> platformGatewayVersions) {
+        this.platformGatewayVersions = platformGatewayVersions != null
+                ? new ArrayList<>(platformGatewayVersions)
                 : new ArrayList<>();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
@@ -96,7 +96,7 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         if (nameExists) {
             throw new APIManagementException(
                     String.format("A platform gateway with name '%s' already exists in the organization", name),
-                    ExceptionCodes.UNIVERSAL_GATEWAY_NAME_ALREADY_EXISTS);
+                    ExceptionCodes.PLATFORM_GATEWAY_NAME_ALREADY_EXISTS);
         }
 
         String gatewayId = UUID.randomUUID().toString();
@@ -236,11 +236,11 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         PlatformGateway existing = getGatewayById(gatewayId);
         if (existing == null) {
             throw new APIManagementException("Platform gateway not found: " + gatewayId,
-                    ExceptionCodes.UNIVERSAL_GATEWAY_NOT_FOUND);
+                    ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
         }
         if (!organizationId.equals(existing.getOrganizationId())) {
             throw new APIManagementException("Platform gateway not found in organization: " + gatewayId,
-                    ExceptionCodes.UNIVERSAL_GATEWAY_NOT_FOUND);
+                    ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
         }
 
         String tokenId = PlatformGatewayTokenUtil.generateTokenId();
@@ -264,7 +264,7 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         Environment env = ApiMgtDAO.getInstance().getEnvironment(organizationId, gatewayId);
         if (env == null || !APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
             throw new APIManagementException("Platform gateway not found: " + gatewayId,
-                    ExceptionCodes.UNIVERSAL_GATEWAY_NOT_FOUND);
+                    ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
         }
         if (ApiMgtDAO.getInstance().hasExistingAPIRevisions(gatewayId, organizationId)) {
             throw new APIManagementException(
@@ -288,7 +288,7 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         Environment env = ApiMgtDAO.getInstance().getEnvironment(organizationId, gatewayId);
         if (env == null || !APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
             throw new APIManagementException("Platform gateway not found: " + gatewayId,
-                    ExceptionCodes.UNIVERSAL_GATEWAY_NOT_FOUND);
+                    ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
         }
         if (displayName != null) {
             env.setDisplayName(displayName);

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/GatewayWellKnownApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/GatewayWellKnownApi.java
@@ -38,7 +38,7 @@ import javax.ws.rs.core.Response;
  * Discovery endpoint for platform gateway connection details.
  * <p>
  * {@code gatewayPath} is the internal REST API base path (no {@code /ws} suffix), e.g. {@code internal/data/v1}.
- * The Universal Gateway client appends {@code /ws} when opening WebSocket connections. Control plane metadata
+ * The Platform Gateway client appends {@code /ws} when opening WebSocket connections. Control plane metadata
  * is included for client diagnostics.
  */
 @Path("/.well-known")
@@ -101,7 +101,7 @@ public class GatewayWellKnownApi {
 
     /**
      * Builds {@code gatewayPath}: internal web app base path without a leading slash and without a {@code /ws}
-     * suffix (Universal Gateway adds {@code /ws} when dialing WebSockets).
+     * suffix (Platform Gateway adds {@code /ws} when dialing WebSockets).
      *
      * @return base path (e.g. {@code internal/data/v1})
      */

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/ApisApiServiceImpl.java
@@ -182,7 +182,7 @@ public class ApisApiServiceImpl implements ApisApiService {
     /**
      * Records platform gateway deployment outcome in AM_GW_REVISION_DEPLOYMENT (same data path as
      * {@link org.wso2.carbon.apimgt.internal.service.impl.NotifyApiDeploymentStatusApiServiceImpl}) so Publisher
-     * deployment stats (liveGatewayCount / deployedGatewayCount) update for Universal gateways.
+     * deployment stats (liveGatewayCount / deployedGatewayCount) update for Platform gateways.
      */
     private Response persistPlatformGatewayDeploymentNotification(String apiId, PlatformGatewayDAO.PlatformGateway gateway,
             String deploymentIdQueryParam, Map<String, Object> requestBody) throws APIManagementException {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/EnvironmentDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/EnvironmentDTO.java
@@ -106,7 +106,7 @@ return null;
     }
     private StatusEnum status = StatusEnum.ACTIVE;
     private URI vhost = null;
-    private List<String> universalGatewayVersions = new ArrayList<String>();
+    private List<String> platformGatewayVersions = new ArrayList<String>();
 
   /**
    **/
@@ -391,21 +391,21 @@ return null;
   }
 
   /**
-   * Universal Gateway versions from config. Set for deploy targets so UI can show version choices in the quick-start guide.
+   * API Platform Gateway versions from config. Set for deploy targets so UI can show version choices in the quick-start guide.
    **/
-  public EnvironmentDTO universalGatewayVersions(List<String> universalGatewayVersions) {
-    this.universalGatewayVersions = universalGatewayVersions;
+  public EnvironmentDTO platformGatewayVersions(List<String> platformGatewayVersions) {
+    this.platformGatewayVersions = platformGatewayVersions;
     return this;
   }
 
   
-  @ApiModelProperty(value = "Universal Gateway versions from config. Set for deploy targets so UI can show version choices in the quick-start guide.")
-  @JsonProperty("universalGatewayVersions")
-  public List<String> getUniversalGatewayVersions() {
-    return universalGatewayVersions;
+  @ApiModelProperty(value = "API Platform Gateway versions from config. Set for deploy targets so UI can show version choices in the quick-start guide.")
+  @JsonProperty("platformGatewayVersions")
+  public List<String> getPlatformGatewayVersions() {
+    return platformGatewayVersions;
   }
-  public void setUniversalGatewayVersions(List<String> universalGatewayVersions) {
-    this.universalGatewayVersions = universalGatewayVersions;
+  public void setPlatformGatewayVersions(List<String> platformGatewayVersions) {
+    this.platformGatewayVersions = platformGatewayVersions;
   }
 
 
@@ -434,12 +434,12 @@ return null;
         Objects.equals(permissions, environment.permissions) &&
         Objects.equals(status, environment.status) &&
         Objects.equals(vhost, environment.vhost) &&
-        Objects.equals(universalGatewayVersions, environment.universalGatewayVersions);
+        Objects.equals(platformGatewayVersions, environment.platformGatewayVersions);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, displayName, provider, type, gatewayType, description, isReadOnly, mode, apiDiscoveryScheduledWindow, vhosts, endpointURIs, additionalProperties, permissions, status, vhost, universalGatewayVersions);
+    return Objects.hash(id, name, displayName, provider, type, gatewayType, description, isReadOnly, mode, apiDiscoveryScheduledWindow, vhosts, endpointURIs, additionalProperties, permissions, status, vhost, platformGatewayVersions);
   }
 
   @Override
@@ -463,7 +463,7 @@ return null;
     sb.append("    permissions: ").append(toIndentedString(permissions)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    vhost: ").append(toIndentedString(vhost)).append("\n");
-    sb.append("    universalGatewayVersions: ").append(toIndentedString(universalGatewayVersions)).append("\n");
+    sb.append("    platformGatewayVersions: ").append(toIndentedString(platformGatewayVersions)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsDTO.java
@@ -33,7 +33,7 @@ public class SettingsDTO   {
     private Boolean analyticsEnabled = null;
     private Boolean transactionCounterEnable = null;
     private Boolean isGatewayNotificationEnabled = false;
-    private List<String> universalGatewayVersions = new ArrayList<String>();
+    private List<String> platformGatewayVersions = new ArrayList<String>();
     private Boolean consumptionExportEnabled = null;
 
   /**
@@ -196,21 +196,21 @@ public class SettingsDTO   {
   }
 
   /**
-   * Universal Gateway versions for the quick-start guide.
+   * API Platform Gateway versions for the quick-start guide.
    **/
-  public SettingsDTO universalGatewayVersions(List<String> universalGatewayVersions) {
-    this.universalGatewayVersions = universalGatewayVersions;
+  public SettingsDTO platformGatewayVersions(List<String> platformGatewayVersions) {
+    this.platformGatewayVersions = platformGatewayVersions;
     return this;
   }
 
   
-  @ApiModelProperty(value = "Universal Gateway versions for the quick-start guide.")
-  @JsonProperty("universalGatewayVersions")
-  public List<String> getUniversalGatewayVersions() {
-    return universalGatewayVersions;
+  @ApiModelProperty(value = "API Platform Gateway versions for the quick-start guide.")
+  @JsonProperty("platformGatewayVersions")
+  public List<String> getPlatformGatewayVersions() {
+    return platformGatewayVersions;
   }
-  public void setUniversalGatewayVersions(List<String> universalGatewayVersions) {
-    this.universalGatewayVersions = universalGatewayVersions;
+  public void setPlatformGatewayVersions(List<String> platformGatewayVersions) {
+    this.platformGatewayVersions = platformGatewayVersions;
   }
 
   /**
@@ -250,13 +250,13 @@ public class SettingsDTO   {
         Objects.equals(analyticsEnabled, settings.analyticsEnabled) &&
         Objects.equals(transactionCounterEnable, settings.transactionCounterEnable) &&
         Objects.equals(isGatewayNotificationEnabled, settings.isGatewayNotificationEnabled) &&
-        Objects.equals(universalGatewayVersions, settings.universalGatewayVersions) &&
+        Objects.equals(platformGatewayVersions, settings.platformGatewayVersions) &&
         Objects.equals(consumptionExportEnabled, settings.consumptionExportEnabled);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(scopes, gatewayTypes, isJWTEnabledForLoginTokens, orgAccessControlEnabled, keyManagerConfiguration, gatewayConfiguration, analyticsEnabled, transactionCounterEnable, isGatewayNotificationEnabled, universalGatewayVersions, consumptionExportEnabled);
+    return Objects.hash(scopes, gatewayTypes, isJWTEnabledForLoginTokens, orgAccessControlEnabled, keyManagerConfiguration, gatewayConfiguration, analyticsEnabled, transactionCounterEnable, isGatewayNotificationEnabled, platformGatewayVersions, consumptionExportEnabled);
   }
 
   @Override
@@ -273,7 +273,7 @@ public class SettingsDTO   {
     sb.append("    analyticsEnabled: ").append(toIndentedString(analyticsEnabled)).append("\n");
     sb.append("    transactionCounterEnable: ").append(toIndentedString(transactionCounterEnable)).append("\n");
     sb.append("    isGatewayNotificationEnabled: ").append(toIndentedString(isGatewayNotificationEnabled)).append("\n");
-    sb.append("    universalGatewayVersions: ").append(toIndentedString(universalGatewayVersions)).append("\n");
+    sb.append("    platformGatewayVersions: ").append(toIndentedString(platformGatewayVersions)).append("\n");
     sb.append("    consumptionExportEnabled: ").append(toIndentedString(consumptionExportEnabled)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
@@ -53,7 +53,6 @@ import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
 import javax.ws.rs.core.Response;
 
-import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -199,8 +198,8 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
                 .anyMatch(gw -> StringUtils.equals(gw.getName(), gatewayName));
         if (gatewayExists) {
             throw new APIManagementException(
-                    String.format(ExceptionCodes.UNIVERSAL_GATEWAY_NAME_ALREADY_EXISTS.getErrorDescription(), gatewayName),
-                    ExceptionCodes.UNIVERSAL_GATEWAY_NAME_ALREADY_EXISTS);
+                    String.format(ExceptionCodes.PLATFORM_GATEWAY_NAME_ALREADY_EXISTS.getErrorDescription(), gatewayName),
+                    ExceptionCodes.PLATFORM_GATEWAY_NAME_ALREADY_EXISTS);
         }
 
         // Also check if a non-platform environment with this name exists
@@ -210,8 +209,8 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
                 .anyMatch(env -> StringUtils.equals(env.getName(), gatewayName));
         if (envExists) {
             throw new APIManagementException(
-                    String.format(ExceptionCodes.UNIVERSAL_GATEWAY_NAME_ALREADY_EXISTS.getErrorDescription(), gatewayName),
-                    ExceptionCodes.UNIVERSAL_GATEWAY_NAME_ALREADY_EXISTS);
+                    String.format(ExceptionCodes.PLATFORM_GATEWAY_NAME_ALREADY_EXISTS.getErrorDescription(), gatewayName),
+                    ExceptionCodes.PLATFORM_GATEWAY_NAME_ALREADY_EXISTS);
         }
     }
 
@@ -420,7 +419,7 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
         PlatformGateway existing = service.getGatewayById(gatewayId);
         if (existing == null) {
             throw new APIManagementException("Platform gateway not found: " + gatewayId,
-                    ExceptionCodes.UNIVERSAL_GATEWAY_NOT_FOUND);
+                    ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
         }
         if (!Objects.equals(body.getName(), existing.getName())) {
             throw RestApiUtil.buildBadRequestException("name in body must match existing gateway (immutable)");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
@@ -86,7 +86,7 @@ public class EnvironmentMappingUtil {
      * traditional gateway environments.
      *
      * @param gateway       PlatformGateway from AM_PLATFORM_GATEWAY
-     * @param gatewayType   gateway type constant (e.g. Universal)
+     * @param gatewayType   gateway type constant (e.g. APIPlatform)
      * @return EnvironmentDTO suitable for deploy-target list
      */
     public static EnvironmentDTO fromPlatformGatewayToEnvDTO(PlatformGateway gateway, String gatewayType,

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
@@ -76,7 +76,7 @@ public class EnvironmentMappingUtil {
         envDTO.setAdditionalProperties(fromAdditionalPropertiesToAdditionalPropertiesDTO
                 (env.getAdditionalProperties()));
         envDTO.setPermissions(mapPermissionsToDTO(env.getPermissions()));
-        envDTO.setUniversalGatewayVersions(resolveUniversalGatewayVersions());
+        envDTO.setPlatformGatewayVersions(resolvePlatformGatewayVersions());
         return envDTO;
     }
 
@@ -137,20 +137,20 @@ public class EnvironmentMappingUtil {
         envDTO.setStatus(Boolean.TRUE.equals(gateway.isActive())
                 ? EnvironmentDTO.StatusEnum.ACTIVE
                 : EnvironmentDTO.StatusEnum.INACTIVE);
-        envDTO.setUniversalGatewayVersions(resolveUniversalGatewayVersions());
+        envDTO.setPlatformGatewayVersions(resolvePlatformGatewayVersions());
         return envDTO;
     }
 
     /**
      * Resolve Universal Gateway versions from config.
      */
-    private static List<String> resolveUniversalGatewayVersions() {
+    private static List<String> resolvePlatformGatewayVersions() {
         PlatformGatewayConnectConfig config = ServiceReferenceHolder.getInstance()
                 .getAPIManagerConfigurationService().getAPIManagerConfiguration().getPlatformGatewayConnectConfig();
         if (config == null) {
             return new ArrayList<>();
         }
-        List<String> versions = config.getUniversalGatewayVersions();
+        List<String> versions = config.getPlatformGatewayVersions();
         return versions.isEmpty() ? new ArrayList<>() : versions;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
@@ -142,7 +142,7 @@ public class EnvironmentMappingUtil {
     }
 
     /**
-     * Resolve Universal Gateway versions from config.
+     * Resolve Platform Gateway versions from config.
      */
     private static List<String> resolvePlatformGatewayVersions() {
         PlatformGatewayConnectConfig config = ServiceReferenceHolder.getInstance()

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SettingsMappingUtil.java
@@ -63,19 +63,19 @@ public class SettingsMappingUtil {
         settingsDTO.setIsJWTEnabledForLoginTokens(APIUtil.isJWTEnabledForPortals());
         settingsDTO.setOrgAccessControlEnabled(APIUtil.isOrganizationAccessControlEnabled());
         settingsDTO.setIsGatewayNotificationEnabled(APIUtil.isGatewayNotificationEnabled());
-        settingsDTO.setUniversalGatewayVersions(resolveUniversalGatewayVersions());
+        settingsDTO.setPlatformGatewayVersions(resolvePlatformGatewayVersions());
         settingsDTO.setConsumptionExportEnabled(
                 ServiceReferenceHolder.getInstance().getConsumptionDataExportService() != null);
         return settingsDTO;
     }
 
-    private static List<String> resolveUniversalGatewayVersions() {
+    private static List<String> resolvePlatformGatewayVersions() {
         PlatformGatewayConnectConfig config = ServiceReferenceHolder.getInstance()
                 .getAPIManagerConfigurationService().getAPIManagerConfiguration().getPlatformGatewayConnectConfig();
         if (config == null) {
             return null;
         }
-        List<String> versions = config.getUniversalGatewayVersions();
+        List<String> versions = config.getPlatformGatewayVersions();
         return versions.isEmpty() ? null : versions;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -5926,7 +5926,7 @@ components:
           readOnly: true
           description: For platform gateway environments, the gateway URL (e.g. https://host:9443). Same as Platform Gateways API; only set when this environment represents a platform gateway.
           example: https://mg.wso2.com
-        universalGatewayVersions:
+        platformGatewayVersions:
           type: array
           readOnly: true
           description: API Platform Gateway versions from config. Set for deploy targets so UI can show version choices in the quick-start guide.
@@ -6753,7 +6753,7 @@ components:
           type: boolean
           description: Is Gateway Notification Enabled
           default: false
-        universalGatewayVersions:
+        platformGatewayVersions:
           type: array
           description: API Platform Gateway versions for the quick-start guide.
           items:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
@@ -5926,7 +5926,7 @@ components:
           readOnly: true
           description: For platform gateway environments, the gateway URL (e.g. https://host:9443). Same as Platform Gateways API; only set when this environment represents a platform gateway.
           example: https://mg.wso2.com
-        universalGatewayVersions:
+        platformGatewayVersions:
           type: array
           readOnly: true
           description: API Platform Gateway versions from config. Set for deploy targets so UI can show version choices in the quick-start guide.
@@ -6753,7 +6753,7 @@ components:
           type: boolean
           description: Is Gateway Notification Enabled
           default: false
-        universalGatewayVersions:
+        platformGatewayVersions:
           type: array
           description: API Platform Gateway versions for the quick-start guide.
           items:

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -2119,11 +2119,11 @@
           </GatewayCleanup>
           {% if apim.platform_gateway.versions is defined and apim.platform_gateway.versions | length > 0 %}
           <PlatformGatewayConnectConfiguration>
-              <UniversalGatewayVersions>
+              <PlatformGatewayVersions>
               {% for version in apim.platform_gateway.versions %}
                   <Version>{{ version }}</Version>
               {% endfor %}
-              </UniversalGatewayVersions>
+              </PlatformGatewayVersions>
           </PlatformGatewayConnectConfiguration>
           {% endif %}
           <APIKeyNotification>


### PR DESCRIPTION
This pull request standardizes terminology across the codebase by replacing all references to "Universal Gateway" with "Platform Gateway". This affects error codes, DTOs, configuration classes, and related documentation, ensuring consistency throughout the API management platform.

**Terminology Standardization:**

* All error codes and exception messages now use `PLATFORM_GATEWAY_NAME_ALREADY_EXISTS` and `PLATFORM_GATEWAY_NOT_FOUND` instead of their previous "UNIVERSAL_GATEWAY" equivalents in `ExceptionCodes`, service interfaces, and service implementations. [[1]](diffhunk://#diff-be2960044fad86c5477b0e45758aa0aa98d693a31efeb66e92b6abaad72470e9L190-R192) [[2]](diffhunk://#diff-8009b0150dec4e915d33c2911a3cfcdb5454176f872b4a09d8b1358353e76210L42-R42) [[3]](diffhunk://#diff-8009b0150dec4e915d33c2911a3cfcdb5454176f872b4a09d8b1358353e76210L121-R122) [[4]](diffhunk://#diff-bb6128497bbcaa51282dc6600ef8be58ddd15a5a8e506885ba89a89f2f04b9b8L99-R99) [[5]](diffhunk://#diff-bb6128497bbcaa51282dc6600ef8be58ddd15a5a8e506885ba89a89f2f04b9b8L239-R243) [[6]](diffhunk://#diff-bb6128497bbcaa51282dc6600ef8be58ddd15a5a8e506885ba89a89f2f04b9b8L267-R267) [[7]](diffhunk://#diff-bb6128497bbcaa51282dc6600ef8be58ddd15a5a8e506885ba89a89f2f04b9b8L291-R291) [[8]](diffhunk://#diff-388b1ae4b5a4b0975fc019439abdc8a42a4433e56694fdbb18243e96ee286c85L202-R202)

* All configuration and DTO fields, methods, and documentation comments now use `platformGatewayVersions` instead of `universalGatewayVersions` in `PlatformGatewayConnectConfig`, `EnvironmentDTO`, and `SettingsDTO`. [[1]](diffhunk://#diff-53180db9d61eccf226f337dec15f32bb7e951677a1e8b930daef9c9c30828d17L3970-R3970) [[2]](diffhunk://#diff-6ad5a30e0da551268318842e70c7a6e235b4e71a5985b57b662723142c8d9ff9L3624-R3639) [[3]](diffhunk://#diff-050a6dd4e247f89efdd3b2450c3f7ccbd297e6dd615ebea06e2818fe17579ba6L30-R44) [[4]](diffhunk://#diff-1562aecf5c65af4d126862f3ab0c04de7c72fb6bfdf65a5373cee84ac87dd13fL109-R109) [[5]](diffhunk://#diff-1562aecf5c65af4d126862f3ab0c04de7c72fb6bfdf65a5373cee84ac87dd13fL394-R408) [[6]](diffhunk://#diff-1562aecf5c65af4d126862f3ab0c04de7c72fb6bfdf65a5373cee84ac87dd13fL437-R442) [[7]](diffhunk://#diff-1562aecf5c65af4d126862f3ab0c04de7c72fb6bfdf65a5373cee84ac87dd13fL466-R466) [[8]](diffhunk://#diff-245bd2d555bffd4a0bb10d6643670c9f8e603112ddbf8919d7d6c60a64dd44f2L36-R36) [[9]](diffhunk://#diff-245bd2d555bffd4a0bb10d6643670c9f8e603112ddbf8919d7d6c60a64dd44f2L199-R213) [[10]](diffhunk://#diff-245bd2d555bffd4a0bb10d6643670c9f8e603112ddbf8919d7d6c60a64dd44f2L253-R259) [[11]](diffhunk://#diff-245bd2d555bffd4a0bb10d6643670c9f8e603112ddbf8919d7d6c60a64dd44f2L276-R276)

**Documentation and Comments:**

* All related JavaDoc and property descriptions have been updated to reference "API Platform Gateway" instead of "Universal Gateway", improving clarity for developers and users. [[1]](diffhunk://#diff-1562aecf5c65af4d126862f3ab0c04de7c72fb6bfdf65a5373cee84ac87dd13fL394-R408) [[2]](diffhunk://#diff-245bd2d555bffd4a0bb10d6643670c9f8e603112ddbf8919d7d6c60a64dd44f2L199-R213)

**Minor Cleanups:**

* Removed an unused import (`java.io.IOException`) from `GatewaysApiServiceImpl.java`.