### PR TITLE
Derive apiKeyHeader from hub api-key-auth policy parameters

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -275,10 +275,11 @@ import static org.wso2.carbon.apimgt.impl.APIConstants.LC_RETIRE_LC_STATE;
 class APIProviderImpl extends AbstractAPIManager implements APIProvider {
 
     private static final Log log = LogFactory.getLog(APIProviderImpl.class);
-    private static final Pattern VALID_API_KEY_HEADER_PATTERN =
-            Pattern.compile("(^[^~!@#;:%^*()+={}|\\\\<>\"',&$\\s+]*$)");
-    /** Matches jwt-auth policy parameter {@code headerName} (Policy Hub JWT policy v1 YAML). */
-    private static final Pattern VALID_JWT_POLICY_HEADER_NAME_PATTERN =
+    /**
+     * HTTP header field-name token allowlist (RFC 9110 {@code token}); matches Policy Hub patterns for
+     * api-key-auth {@code key} (header mode) and jwt-auth {@code headerName}.
+     */
+    private static final Pattern VALID_HTTP_HEADER_NAME_PATTERN =
             Pattern.compile("^[!#$%&'*+.^_`|~0-9A-Za-z-]+$");
     private static final String ENDPOINT_CONFIG_SEARCH_TYPE_PREFIX = "endpointConfig:";
     private ServiceCatalogDAO serviceCatalogDAO = ServiceCatalogDAO.getInstance();
@@ -2410,19 +2411,15 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (!securitySchemes.isEmpty()) {
             api.setApiSecurity(String.join(",", securitySchemes));
 
-            if (hasHeaderApiKeyPolicy) {
-                if (apiKeyHeaderFromHubPolicy != null) {
-                    api.setApiKeyHeader(apiKeyHeaderFromHubPolicy);
-                } else if (api.getApiKeyHeader() == null) {
-                    api.setApiKeyHeader(APIConstants.API_KEY_HEADER_DEFAULT);
-                }
+            if (hasHeaderApiKeyPolicy && apiKeyHeaderFromHubPolicy != null) {
+                api.setApiKeyHeader(apiKeyHeaderFromHubPolicy);
+            } else {
+                api.setApiKeyHeader(APIConstants.API_KEY_HEADER_DEFAULT);
             }
-            if (hasJwtPolicy) {
-                if (authorizationHeaderFromJwtPolicy != null) {
-                    api.setAuthorizationHeader(authorizationHeaderFromJwtPolicy);
-                } else if (api.getAuthorizationHeader() == null) {
-                    api.setAuthorizationHeader(APIConstants.AUTHORIZATION_HEADER_DEFAULT);
-                }
+            if (hasJwtPolicy && authorizationHeaderFromJwtPolicy != null) {
+                api.setAuthorizationHeader(authorizationHeaderFromJwtPolicy);
+            } else {
+                api.setAuthorizationHeader(APIConstants.AUTHORIZATION_HEADER_DEFAULT);
             }
         } else {
             api.setApiSecurity(EmptyApiSecurity);
@@ -2466,7 +2463,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (StringUtils.isEmpty(key)) {
             return null;
         }
-        return VALID_API_KEY_HEADER_PATTERN.matcher(key).matches() ? key : null;
+        return VALID_HTTP_HEADER_NAME_PATTERN.matcher(key).matches() ? key : null;
     }
 
     /**
@@ -2504,7 +2501,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (StringUtils.isEmpty(headerName)) {
             return null;
         }
-        return VALID_JWT_POLICY_HEADER_NAME_PATTERN.matcher(headerName).matches() ? headerName : null;
+        return VALID_HTTP_HEADER_NAME_PATTERN.matcher(headerName).matches() ? headerName : null;
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -2319,7 +2319,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
      * For Platform Gateway APIs, derives apiSecurity from hub policies at both API-level and operation-level.
      * This ensures DevPortal functionalities work correctly by populating apiSecurity from the
      * attached authentication policies.
-     * Maps: api-key-auth → api_key, basic-auth → basic_auth, jwt-auth → oauth2
+     * Maps: api-key-auth → api_key, basic-auth → basic_auth, jwt-auth → oauth2.
+     * For api-key-auth, the policy parameter {@code key} (when {@code in} is header) is copied to
+     * {@link API#getApiKeyHeader()} so Dev Portal try-out matches the hub policy configuration.
      *
      * @param api The API object to process
      */
@@ -2332,6 +2334,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         Set<String> securitySchemes = new LinkedHashSet<>();
         boolean hasApiKeyPolicy = false;
         boolean hasJwtPolicy = false;
+        String apiKeyHeaderFromHubPolicy = null;
 
         // Collect from API-level hub policies
         List<OperationPolicy> apiLevelPolicies = api.getHubPolicies();
@@ -2344,6 +2347,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 collectSecuritySchemeFromPolicy(policyName, securitySchemes);
                 if ("api-key-auth".equalsIgnoreCase(policyName)) {
                     hasApiKeyPolicy = true;
+                    if (apiKeyHeaderFromHubPolicy == null) {
+                        apiKeyHeaderFromHubPolicy = extractApiKeyHeaderNameFromHubPolicy(policy);
+                    }
                 } else if ("jwt-auth".equalsIgnoreCase(policyName)) {
                     hasJwtPolicy = true;
                 }
@@ -2371,6 +2377,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                         collectSecuritySchemeFromPolicy(policyName, securitySchemes);
                         if ("api-key-auth".equalsIgnoreCase(policyName)) {
                             hasApiKeyPolicy = true;
+                            if (apiKeyHeaderFromHubPolicy == null) {
+                                apiKeyHeaderFromHubPolicy = extractApiKeyHeaderNameFromHubPolicy(policy);
+                            }
                         } else if ("jwt-auth".equalsIgnoreCase(policyName)) {
                             hasJwtPolicy = true;
                         }
@@ -2383,8 +2392,12 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (!securitySchemes.isEmpty()) {
             api.setApiSecurity(String.join(",", securitySchemes));
 
-            if (hasApiKeyPolicy && api.getApiKeyHeader() == null) {
-                api.setApiKeyHeader(APIConstants.API_KEY_HEADER_DEFAULT);
+            if (hasApiKeyPolicy) {
+                if (apiKeyHeaderFromHubPolicy != null) {
+                    api.setApiKeyHeader(apiKeyHeaderFromHubPolicy);
+                } else if (api.getApiKeyHeader() == null) {
+                    api.setApiKeyHeader(APIConstants.API_KEY_HEADER_DEFAULT);
+                }
             }
             if (hasJwtPolicy && api.getAuthorizationHeader() == null) {
                 api.setAuthorizationHeader(APIConstants.AUTHORIZATION_HEADER_DEFAULT);
@@ -2410,6 +2423,29 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         } else if ("jwt-auth".equalsIgnoreCase(policyName)) {
             securitySchemes.add(APIConstants.DEFAULT_API_SECURITY_OAUTH2);
         }
+    }
+
+    /**
+     * Returns the API key header name from an api-key-auth hub policy ({@code key} when {@code in} is header).
+     */
+    private String extractApiKeyHeaderNameFromHubPolicy(OperationPolicy policy) {
+        if (policy == null || !"api-key-auth".equalsIgnoreCase(policy.getPolicyName())) {
+            return null;
+        }
+        Map<String, Object> params = policy.getParameters();
+        if (MapUtils.isEmpty(params)) {
+            return null;
+        }
+        Object inVal = params.get("in");
+        if (inVal != null && "query".equalsIgnoreCase(inVal.toString().trim())) {
+            return null;
+        }
+        Object keyVal = params.get("key");
+        if (keyVal == null) {
+            return null;
+        }
+        String key = keyVal.toString().trim();
+        return StringUtils.isEmpty(key) ? null : key;
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -275,6 +275,8 @@ import static org.wso2.carbon.apimgt.impl.APIConstants.LC_RETIRE_LC_STATE;
 class APIProviderImpl extends AbstractAPIManager implements APIProvider {
 
     private static final Log log = LogFactory.getLog(APIProviderImpl.class);
+    private static final Pattern VALID_API_KEY_HEADER_PATTERN =
+            Pattern.compile("(^[^~!@#;:%^*()+={}|\\\\<>\"',&$\\s+]*$)");
     private static final String ENDPOINT_CONFIG_SEARCH_TYPE_PREFIX = "endpointConfig:";
     private ServiceCatalogDAO serviceCatalogDAO = ServiceCatalogDAO.getInstance();
 
@@ -2332,7 +2334,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         }
 
         Set<String> securitySchemes = new LinkedHashSet<>();
-        boolean hasApiKeyPolicy = false;
+        boolean hasHeaderApiKeyPolicy = false;
         boolean hasJwtPolicy = false;
         String apiKeyHeaderFromHubPolicy = null;
 
@@ -2346,8 +2348,10 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 String policyName = policy.getPolicyName();
                 collectSecuritySchemeFromPolicy(policyName, securitySchemes);
                 if ("api-key-auth".equalsIgnoreCase(policyName)) {
-                    hasApiKeyPolicy = true;
-                    if (apiKeyHeaderFromHubPolicy == null) {
+                    if (isApiKeyHeaderPolicy(policy)) {
+                        hasHeaderApiKeyPolicy = true;
+                    }
+                    if (hasHeaderApiKeyPolicy && apiKeyHeaderFromHubPolicy == null) {
                         apiKeyHeaderFromHubPolicy = extractApiKeyHeaderNameFromHubPolicy(policy);
                     }
                 } else if ("jwt-auth".equalsIgnoreCase(policyName)) {
@@ -2376,8 +2380,10 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                         String policyName = policy.getPolicyName();
                         collectSecuritySchemeFromPolicy(policyName, securitySchemes);
                         if ("api-key-auth".equalsIgnoreCase(policyName)) {
-                            hasApiKeyPolicy = true;
-                            if (apiKeyHeaderFromHubPolicy == null) {
+                            if (isApiKeyHeaderPolicy(policy)) {
+                                hasHeaderApiKeyPolicy = true;
+                            }
+                            if (hasHeaderApiKeyPolicy && apiKeyHeaderFromHubPolicy == null) {
                                 apiKeyHeaderFromHubPolicy = extractApiKeyHeaderNameFromHubPolicy(policy);
                             }
                         } else if ("jwt-auth".equalsIgnoreCase(policyName)) {
@@ -2392,7 +2398,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (!securitySchemes.isEmpty()) {
             api.setApiSecurity(String.join(",", securitySchemes));
 
-            if (hasApiKeyPolicy) {
+            if (hasHeaderApiKeyPolicy) {
                 if (apiKeyHeaderFromHubPolicy != null) {
                     api.setApiKeyHeader(apiKeyHeaderFromHubPolicy);
                 } else if (api.getApiKeyHeader() == null) {
@@ -2429,15 +2435,11 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
      * Returns the API key header name from an api-key-auth hub policy ({@code key} when {@code in} is header).
      */
     private String extractApiKeyHeaderNameFromHubPolicy(OperationPolicy policy) {
-        if (policy == null || !"api-key-auth".equalsIgnoreCase(policy.getPolicyName())) {
+        if (!isApiKeyHeaderPolicy(policy)) {
             return null;
         }
         Map<String, Object> params = policy.getParameters();
         if (MapUtils.isEmpty(params)) {
-            return null;
-        }
-        Object inVal = params.get("in");
-        if (inVal != null && "query".equalsIgnoreCase(inVal.toString().trim())) {
             return null;
         }
         Object keyVal = params.get("key");
@@ -2445,7 +2447,26 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             return null;
         }
         String key = keyVal.toString().trim();
-        return StringUtils.isEmpty(key) ? null : key;
+        if (StringUtils.isEmpty(key)) {
+            return null;
+        }
+        return VALID_API_KEY_HEADER_PATTERN.matcher(key).matches() ? key : null;
+    }
+
+    /**
+     * Returns true if the given policy is an api-key-auth policy that uses header transport.
+     * If {@code in} is not defined, this method defaults to header semantics for backward compatibility.
+     */
+    private boolean isApiKeyHeaderPolicy(OperationPolicy policy) {
+        if (policy == null || !"api-key-auth".equalsIgnoreCase(policy.getPolicyName())) {
+            return false;
+        }
+
+        Map<String, Object> params = policy.getParameters();
+        if (MapUtils.isEmpty(params) || params.get("in") == null) {
+            return true;
+        }
+        return "header".equalsIgnoreCase(params.get("in").toString().trim());
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -277,6 +277,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     private static final Log log = LogFactory.getLog(APIProviderImpl.class);
     private static final Pattern VALID_API_KEY_HEADER_PATTERN =
             Pattern.compile("(^[^~!@#;:%^*()+={}|\\\\<>\"',&$\\s+]*$)");
+    /** Matches jwt-auth policy parameter {@code headerName} (Policy Hub JWT policy v1 YAML). */
+    private static final Pattern VALID_JWT_POLICY_HEADER_NAME_PATTERN =
+            Pattern.compile("^[!#$%&'*+.^_`|~0-9A-Za-z-]+$");
     private static final String ENDPOINT_CONFIG_SEARCH_TYPE_PREFIX = "endpointConfig:";
     private ServiceCatalogDAO serviceCatalogDAO = ServiceCatalogDAO.getInstance();
 
@@ -2324,6 +2327,8 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
      * Maps: api-key-auth → api_key, basic-auth → basic_auth, jwt-auth → oauth2.
      * For api-key-auth, the policy parameter {@code key} (when {@code in} is header) is copied to
      * {@link API#getApiKeyHeader()} so Dev Portal try-out matches the hub policy configuration.
+     * For jwt-auth, the policy parameter {@code headerName} is copied to {@link API#getAuthorizationHeader()}
+     * (same semantics as Publisher Runtime “Authorization Header”).
      *
      * @param api The API object to process
      */
@@ -2337,6 +2342,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         boolean hasHeaderApiKeyPolicy = false;
         boolean hasJwtPolicy = false;
         String apiKeyHeaderFromHubPolicy = null;
+        String authorizationHeaderFromJwtPolicy = null;
 
         // Collect from API-level hub policies
         List<OperationPolicy> apiLevelPolicies = api.getHubPolicies();
@@ -2356,6 +2362,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     }
                 } else if ("jwt-auth".equalsIgnoreCase(policyName)) {
                     hasJwtPolicy = true;
+                    if (authorizationHeaderFromJwtPolicy == null) {
+                        authorizationHeaderFromJwtPolicy = extractJwtAuthorizationHeaderFromHubPolicy(policy);
+                    }
                 }
             }
         }
@@ -2388,6 +2397,9 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                             }
                         } else if ("jwt-auth".equalsIgnoreCase(policyName)) {
                             hasJwtPolicy = true;
+                            if (authorizationHeaderFromJwtPolicy == null) {
+                                authorizationHeaderFromJwtPolicy = extractJwtAuthorizationHeaderFromHubPolicy(policy);
+                            }
                         }
                     }
                 }
@@ -2405,8 +2417,12 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                     api.setApiKeyHeader(APIConstants.API_KEY_HEADER_DEFAULT);
                 }
             }
-            if (hasJwtPolicy && api.getAuthorizationHeader() == null) {
-                api.setAuthorizationHeader(APIConstants.AUTHORIZATION_HEADER_DEFAULT);
+            if (hasJwtPolicy) {
+                if (authorizationHeaderFromJwtPolicy != null) {
+                    api.setAuthorizationHeader(authorizationHeaderFromJwtPolicy);
+                } else if (api.getAuthorizationHeader() == null) {
+                    api.setAuthorizationHeader(APIConstants.AUTHORIZATION_HEADER_DEFAULT);
+                }
             }
         } else {
             api.setApiSecurity(EmptyApiSecurity);
@@ -2467,6 +2483,28 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             return true;
         }
         return "header".equalsIgnoreCase(params.get("in").toString().trim());
+    }
+
+    /**
+     * Returns the HTTP header name for JWT from a jwt-auth hub policy ({@code headerName}).
+     */
+    private String extractJwtAuthorizationHeaderFromHubPolicy(OperationPolicy policy) {
+        if (policy == null || !"jwt-auth".equalsIgnoreCase(policy.getPolicyName())) {
+            return null;
+        }
+        Map<String, Object> params = policy.getParameters();
+        if (MapUtils.isEmpty(params)) {
+            return null;
+        }
+        Object headerNameVal = params.get("headerName");
+        if (headerNameVal == null) {
+            return null;
+        }
+        String headerName = headerNameVal.toString().trim();
+        if (StringUtils.isEmpty(headerName)) {
+            return null;
+        }
+        return VALID_JWT_POLICY_HEADER_NAME_PATTERN.matcher(headerName).matches() ? headerName : null;
     }
 
     @Override

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -2340,6 +2340,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         }
 
         Set<String> securitySchemes = new LinkedHashSet<>();
+        boolean hasAnyApiKeyPolicy = false;
         boolean hasHeaderApiKeyPolicy = false;
         boolean hasJwtPolicy = false;
         String apiKeyHeaderFromHubPolicy = null;
@@ -2355,6 +2356,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                 String policyName = policy.getPolicyName();
                 collectSecuritySchemeFromPolicy(policyName, securitySchemes);
                 if ("api-key-auth".equalsIgnoreCase(policyName)) {
+                    hasAnyApiKeyPolicy = true;
                     if (isApiKeyHeaderPolicy(policy)) {
                         hasHeaderApiKeyPolicy = true;
                     }
@@ -2390,6 +2392,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
                         String policyName = policy.getPolicyName();
                         collectSecuritySchemeFromPolicy(policyName, securitySchemes);
                         if ("api-key-auth".equalsIgnoreCase(policyName)) {
+                            hasAnyApiKeyPolicy = true;
                             if (isApiKeyHeaderPolicy(policy)) {
                                 hasHeaderApiKeyPolicy = true;
                             }
@@ -2411,8 +2414,15 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
         if (!securitySchemes.isEmpty()) {
             api.setApiSecurity(String.join(",", securitySchemes));
 
-            if (hasHeaderApiKeyPolicy && apiKeyHeaderFromHubPolicy != null) {
-                api.setApiKeyHeader(apiKeyHeaderFromHubPolicy);
+            if (hasHeaderApiKeyPolicy) {
+                if (apiKeyHeaderFromHubPolicy != null) {
+                    api.setApiKeyHeader(apiKeyHeaderFromHubPolicy);
+                } else {
+                    api.setApiKeyHeader(APIConstants.API_KEY_HEADER_DEFAULT);
+                }
+            } else if (hasAnyApiKeyPolicy) {
+                // api-key-auth exists only in query mode; no API key header should be advertised.
+                api.setApiKeyHeader(null);
             } else {
                 api.setApiKeyHeader(APIConstants.API_KEY_HEADER_DEFAULT);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIProviderImplTest.java
@@ -125,6 +125,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -1757,6 +1758,70 @@ public class APIProviderImplTest {
                 "carbon.super", 1 , 6);
     }
 
+    @Test
+    public void testDeriveApiSecurityFromHubPoliciesForHeaderApiKeyPolicy() throws Exception {
+        APIProviderImplWrapper apiProvider = new APIProviderImplWrapper(apimgtDAO, scopesDAO);
+        API api = new API(new APIIdentifier("admin", "SampleAPI", "1.0.0"));
+        api.setGatewayType(APIConstants.WSO2_API_PLATFORM_GATEWAY);
+
+        List<OperationPolicy> hubPolicies = new ArrayList<>();
+        hubPolicies.add(createApiKeyAuthPolicy("header", "X-API-Key"));
+        api.setHubPolicies(hubPolicies);
+
+        invokeDeriveApiSecurityFromHubPolicies(apiProvider, api);
+
+        assertEquals(APIConstants.API_SECURITY_API_KEY, api.getApiSecurity());
+        assertEquals("X-API-Key", api.getApiKeyHeader());
+    }
+
+    @Test
+    public void testDeriveApiSecurityFromHubPoliciesForQueryApiKeyPolicy() throws Exception {
+        APIProviderImplWrapper apiProvider = new APIProviderImplWrapper(apimgtDAO, scopesDAO);
+        API api = new API(new APIIdentifier("admin", "SampleAPI", "1.0.0"));
+        api.setGatewayType(APIConstants.WSO2_API_PLATFORM_GATEWAY);
+
+        List<OperationPolicy> hubPolicies = new ArrayList<>();
+        hubPolicies.add(createApiKeyAuthPolicy("query", "api_key"));
+        api.setHubPolicies(hubPolicies);
+
+        invokeDeriveApiSecurityFromHubPolicies(apiProvider, api);
+
+        assertEquals(APIConstants.API_SECURITY_API_KEY, api.getApiSecurity());
+        assertNull(api.getApiKeyHeader());
+    }
+
+    @Test
+    public void testDeriveApiSecurityFromHubPoliciesDefaultsApiKeyHeaderForHeaderPolicyWithoutKey() throws Exception {
+        APIProviderImplWrapper apiProvider = new APIProviderImplWrapper(apimgtDAO, scopesDAO);
+        API api = new API(new APIIdentifier("admin", "SampleAPI", "1.0.0"));
+        api.setGatewayType(APIConstants.WSO2_API_PLATFORM_GATEWAY);
+
+        List<OperationPolicy> hubPolicies = new ArrayList<>();
+        hubPolicies.add(createApiKeyAuthPolicy("header", null));
+        api.setHubPolicies(hubPolicies);
+
+        invokeDeriveApiSecurityFromHubPolicies(apiProvider, api);
+
+        assertEquals(APIConstants.API_SECURITY_API_KEY, api.getApiSecurity());
+        assertEquals(APIConstants.API_KEY_HEADER_DEFAULT, api.getApiKeyHeader());
+    }
+
+    @Test
+    public void testDeriveApiSecurityFromHubPoliciesIgnoresInvalidApiKeyHeader() throws Exception {
+        APIProviderImplWrapper apiProvider = new APIProviderImplWrapper(apimgtDAO, scopesDAO);
+        API api = new API(new APIIdentifier("admin", "SampleAPI", "1.0.0"));
+        api.setGatewayType(APIConstants.WSO2_API_PLATFORM_GATEWAY);
+
+        List<OperationPolicy> hubPolicies = new ArrayList<>();
+        hubPolicies.add(createApiKeyAuthPolicy("header", "X API Key"));
+        api.setHubPolicies(hubPolicies);
+
+        invokeDeriveApiSecurityFromHubPolicies(apiProvider, api);
+
+        assertEquals(APIConstants.API_SECURITY_API_KEY, api.getApiSecurity());
+        assertEquals(APIConstants.API_KEY_HEADER_DEFAULT, api.getApiKeyHeader());
+    }
+
     private List<PublisherAPIInfo> createMockPublisherAPIInfoList(int num) {
         List<PublisherAPIInfo> list = new ArrayList<>();
         for(int i = 0; i < num; i++) {
@@ -1769,5 +1834,25 @@ public class APIProviderImplTest {
             list.add(publisherAPIInfo);
         }
         return list;
+    }
+
+    private void invokeDeriveApiSecurityFromHubPolicies(APIProviderImpl apiProvider, API api) throws Exception {
+        Method method = APIProviderImpl.class.getDeclaredMethod("deriveApiSecurityFromHubPolicies", API.class);
+        method.setAccessible(true);
+        method.invoke(apiProvider, api);
+    }
+
+    private OperationPolicy createApiKeyAuthPolicy(String in, String key) {
+        OperationPolicy policy = new OperationPolicy();
+        policy.setPolicyName("api-key-auth");
+        Map<String, Object> params = new HashMap<>();
+        if (in != null) {
+            params.put("in", in);
+        }
+        if (key != null) {
+            params.put("key", key);
+        }
+        policy.setParameters(params);
+        return policy;
     }
 }


### PR DESCRIPTION
### Goal
Fixes: https://github.com/wso2/api-manager/issues/4962

### Approach
This pull request enhances how API security is derived from hub policies, specifically improving the handling of `api-key-auth` policies. The main focus is to ensure that the correct API key header is set based on the policy configuration, which improves Dev Portal try-out compatibility and better reflects the actual security setup.

**Enhancements to API Security Derivation:**

* Added logic to extract the API key header name from `api-key-auth` hub policies (when the `in` parameter is `header`) and set it on the `API` object, so that the Dev Portal try-out uses the correct header. [[1]](diffhunk://#diff-19a032cb823fd4f31e79376db6427e305b79949a26979f42d5e7ea0c607cdff2R2350-R2352) [[2]](diffhunk://#diff-19a032cb823fd4f31e79376db6427e305b79949a26979f42d5e7ea0c607cdff2R2380-R2382) [[3]](diffhunk://#diff-19a032cb823fd4f31e79376db6427e305b79949a26979f42d5e7ea0c607cdff2L2386-R2401) [[4]](diffhunk://#diff-19a032cb823fd4f31e79376db6427e305b79949a26979f42d5e7ea0c607cdff2R2428-R2450)
* Updated the JavaDoc for `isPlatformGatewayApi` to clarify the mapping and document the new header extraction behavior.
* Ensured that the API key header is set from the hub policy if available, otherwise falls back to the default, only when `api-key-auth` is present.

These changes make the API security configuration in the portal more accurate and aligned with the actual gateway policy setup.

Related PR: https://github.com/wso2/apim-apps/pull/1329#issue-4294034844