### PR TITLE
Return 4xx when revoking the latest consumer secret (fixes #4965)

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -400,6 +400,10 @@ public enum ExceptionCodes implements ErrorHandler {
             "Client secret retrieval failed", 500,
             "Error occurred while retrieving the client secret for the application with " +
                     "consumer key %s."),
+    CANNOT_REMOVE_LATEST_CLIENT_SECRET(900921,
+            "Cannot remove the latest consumer secret", 400,
+            "Cannot remove the most recently added consumer secret for the application with " +
+                    "consumer key %s."),
 
     //Throttle related codes
     THROTTLE_TEMPLATE_EXCEPTION(900969, "Policy Generating Error", 500, " Error while generate policy configuration"),

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImpl.java
@@ -777,6 +777,11 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
         String encodedClientId = Base64.getUrlEncoder()
                 .encodeToString(clientId.getBytes(StandardCharsets.UTF_8));
         String encodedSecretId = Base64.getUrlEncoder().encodeToString(secretId.getBytes(StandardCharsets.UTF_8));
+        if (isMostRecentlyAddedSecret(encodedClientId, secretId)) {
+            throw new APIManagementException("Cannot remove the most recently added consumer secret of clientId : "
+                    + clientId,
+                    ExceptionCodes.from(ExceptionCodes.CANNOT_REMOVE_LATEST_CLIENT_SECRET, clientId));
+        }
         try {
             dcrClient.deleteApplicationSecret(encodedClientId, encodedSecretId);
             if (log.isDebugEnabled()) {
@@ -786,6 +791,26 @@ public class AMDefaultKeyManagerImpl extends AbstractKeyManager {
             String errMsg = "Error while deleting consumer secret of clientId : " + clientId;
             throw new APIManagementException(errMsg, e, ExceptionCodes
                     .from(ExceptionCodes.CLIENT_SECRET_DELETION_FAILED, clientId));
+        }
+    }
+
+    private boolean isMostRecentlyAddedSecret(String encodedClientId, String secretId) {
+
+        try {
+            ClientSecretList clientSecretList = dcrClient.getApplicationSecrets(encodedClientId);
+            if (clientSecretList == null || clientSecretList.getList() == null
+                    || clientSecretList.getList().isEmpty()) {
+                return false;
+            }
+            List<ClientSecret> secrets = clientSecretList.getList();
+            ClientSecret latest = secrets.get(secrets.size() - 1);
+            return latest != null && secretId.equals(latest.getSecretId());
+        } catch (KeyManagerClientException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Could not pre-check whether secretId " + secretId
+                        + " is the most recently added; deferring to delete call.", e);
+            }
+            return false;
         }
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/AMDefaultKeyManagerImplTest.java
@@ -33,12 +33,16 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
 import org.wso2.carbon.apimgt.api.model.ApplicationConstants;
+import org.wso2.carbon.apimgt.api.model.ConsumerSecretRequest;
 import org.wso2.carbon.apimgt.api.model.OAuthAppRequest;
 import org.wso2.carbon.apimgt.api.model.OAuthApplicationInfo;
 import org.wso2.carbon.apimgt.impl.kmclient.KeyManagerClientException;
 import org.wso2.carbon.apimgt.impl.kmclient.model.ClientInfo;
+import org.wso2.carbon.apimgt.impl.kmclient.model.ClientSecret;
+import org.wso2.carbon.apimgt.impl.kmclient.model.ClientSecretList;
 import org.wso2.carbon.apimgt.impl.kmclient.model.DCRClient;
 import org.wso2.carbon.apimgt.impl.kmclient.model.IntrospectInfo;
 import org.wso2.carbon.apimgt.impl.kmclient.model.IntrospectionClient;
@@ -47,9 +51,11 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RunWith(PowerMockRunner.class)
@@ -520,6 +526,181 @@ public class AMDefaultKeyManagerImplTest {
 //        Assert.assertFalse(tokenInfo.isTokenValid());
 //    }
 
+
+    @Test
+    public void testDeleteApplicationConsumerSecret_lastSecret_throwsClientError() throws Exception {
+        String clientId = "cvOZA28GfOftYnmV_bJwCYMuLJoa";
+        String latestSecretId = "e28683d7-3c48-4632-93ef-c0a6ee20930b";
+        String olderSecretId = "aac624d6-1111-2222-3333-444444444444";
+        String encodedClientId = java.util.Base64.getUrlEncoder()
+                .encodeToString(clientId.getBytes(StandardCharsets.UTF_8));
+
+        ClientSecret older = new ClientSecret();
+        older.setSecretId(olderSecretId);
+        ClientSecret latest = new ClientSecret();
+        latest.setSecretId(latestSecretId);
+        List<ClientSecret> secrets = new ArrayList<>();
+        secrets.add(older);
+        secrets.add(latest);
+        ClientSecretList list = new ClientSecretList();
+        list.setList(secrets);
+        list.setCount(secrets.size());
+
+        Mockito.when(dcrClient.getApplicationSecrets(encodedClientId)).thenReturn(list);
+
+        ConsumerSecretRequest request = new ConsumerSecretRequest();
+        request.setClientId(clientId);
+
+        try {
+            keyManager.deleteApplicationConsumerSecret(latestSecretId, request);
+            Assert.fail("Expected APIManagementException for last-secret deletion");
+        } catch (APIManagementException e) {
+            Assert.assertNotNull(e.getErrorHandler());
+            Assert.assertEquals(ExceptionCodes.CANNOT_REMOVE_LATEST_CLIENT_SECRET.getErrorCode(),
+                    e.getErrorHandler().getErrorCode());
+            Assert.assertEquals(400, e.getErrorHandler().getHttpStatusCode());
+        }
+        Mockito.verify(dcrClient, Mockito.never())
+                .deleteApplicationSecret(Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    public void testDeleteApplicationConsumerSecret_olderSecret_succeeds() throws Exception {
+        String clientId = "cvOZA28GfOftYnmV_bJwCYMuLJoa";
+        String olderSecretId = "aac624d6-1111-2222-3333-444444444444";
+        String latestSecretId = "e28683d7-3c48-4632-93ef-c0a6ee20930b";
+        String encodedClientId = java.util.Base64.getUrlEncoder()
+                .encodeToString(clientId.getBytes(StandardCharsets.UTF_8));
+        String encodedOlderSecretId = java.util.Base64.getUrlEncoder()
+                .encodeToString(olderSecretId.getBytes(StandardCharsets.UTF_8));
+
+        ClientSecret older = new ClientSecret();
+        older.setSecretId(olderSecretId);
+        ClientSecret latest = new ClientSecret();
+        latest.setSecretId(latestSecretId);
+        List<ClientSecret> secrets = new ArrayList<>();
+        secrets.add(older);
+        secrets.add(latest);
+        ClientSecretList list = new ClientSecretList();
+        list.setList(secrets);
+        list.setCount(secrets.size());
+
+        Mockito.when(dcrClient.getApplicationSecrets(encodedClientId)).thenReturn(list);
+
+        ConsumerSecretRequest request = new ConsumerSecretRequest();
+        request.setClientId(clientId);
+
+        keyManager.deleteApplicationConsumerSecret(olderSecretId, request);
+
+        Mockito.verify(dcrClient, Mockito.times(1))
+                .deleteApplicationSecret(encodedClientId, encodedOlderSecretId);
+    }
+
+    @Test
+    public void testDeleteApplicationConsumerSecret_genericFailure_stillMapsTo500() throws Exception {
+        String clientId = "cvOZA28GfOftYnmV_bJwCYMuLJoa";
+        String secretId = "aac624d6-1111-2222-3333-444444444444";
+        String encodedClientId = java.util.Base64.getUrlEncoder()
+                .encodeToString(clientId.getBytes(StandardCharsets.UTF_8));
+
+        // Pre-check returns a list where the requested secret is NOT the last one,
+        // so the pre-check will not short-circuit; we then simulate a generic failure
+        // from the DCR delete call.
+        ClientSecret target = new ClientSecret();
+        target.setSecretId(secretId);
+        ClientSecret latest = new ClientSecret();
+        latest.setSecretId("some-other-latest-id");
+        List<ClientSecret> secrets = new ArrayList<>();
+        secrets.add(target);
+        secrets.add(latest);
+        ClientSecretList list = new ClientSecretList();
+        list.setList(secrets);
+        list.setCount(secrets.size());
+
+        Mockito.when(dcrClient.getApplicationSecrets(encodedClientId)).thenReturn(list);
+        Mockito.doThrow(new KeyManagerClientException(500, "Internal server error"))
+                .when(dcrClient)
+                .deleteApplicationSecret(Mockito.eq(encodedClientId), Mockito.anyString());
+
+        ConsumerSecretRequest request = new ConsumerSecretRequest();
+        request.setClientId(clientId);
+
+        try {
+            keyManager.deleteApplicationConsumerSecret(secretId, request);
+            Assert.fail("Expected APIManagementException for generic delete failure");
+        } catch (APIManagementException e) {
+            Assert.assertNotNull(e.getErrorHandler());
+            Assert.assertEquals(ExceptionCodes.CLIENT_SECRET_DELETION_FAILED.getErrorCode(),
+                    e.getErrorHandler().getErrorCode());
+            Assert.assertEquals(500, e.getErrorHandler().getHttpStatusCode());
+        }
+    }
+
+    @Test
+    public void testDeleteApplicationConsumerSecret_emptySecretList_proceedsToDelete() throws Exception {
+        String clientId = "cvOZA28GfOftYnmV_bJwCYMuLJoa";
+        String secretId = "aac624d6-1111-2222-3333-444444444444";
+        String encodedClientId = java.util.Base64.getUrlEncoder()
+                .encodeToString(clientId.getBytes(StandardCharsets.UTF_8));
+        String encodedSecretId = java.util.Base64.getUrlEncoder()
+                .encodeToString(secretId.getBytes(StandardCharsets.UTF_8));
+
+        ClientSecretList emptyList = new ClientSecretList();
+        emptyList.setList(new ArrayList<>());
+        emptyList.setCount(0);
+
+        Mockito.when(dcrClient.getApplicationSecrets(encodedClientId)).thenReturn(emptyList);
+
+        ConsumerSecretRequest request = new ConsumerSecretRequest();
+        request.setClientId(clientId);
+
+        keyManager.deleteApplicationConsumerSecret(secretId, request);
+
+        Mockito.verify(dcrClient, Mockito.times(1))
+                .deleteApplicationSecret(encodedClientId, encodedSecretId);
+    }
+
+    @Test
+    public void testDeleteApplicationConsumerSecret_preCheckException_proceedsToDelete() throws Exception {
+        String clientId = "cvOZA28GfOftYnmV_bJwCYMuLJoa";
+        String secretId = "aac624d6-1111-2222-3333-444444444444";
+        String encodedClientId = java.util.Base64.getUrlEncoder()
+                .encodeToString(clientId.getBytes(StandardCharsets.UTF_8));
+        String encodedSecretId = java.util.Base64.getUrlEncoder()
+                .encodeToString(secretId.getBytes(StandardCharsets.UTF_8));
+
+        // Pre-check itself fails — should be swallowed and the delete call should still happen.
+        Mockito.when(dcrClient.getApplicationSecrets(encodedClientId))
+                .thenThrow(new KeyManagerClientException(500, "boom"));
+
+        ConsumerSecretRequest request = new ConsumerSecretRequest();
+        request.setClientId(clientId);
+
+        keyManager.deleteApplicationConsumerSecret(secretId, request);
+
+        Mockito.verify(dcrClient, Mockito.times(1))
+                .deleteApplicationSecret(encodedClientId, encodedSecretId);
+    }
+
+    @Test
+    public void testDeleteApplicationConsumerSecret_nullSecretList_proceedsToDelete() throws Exception {
+        String clientId = "cvOZA28GfOftYnmV_bJwCYMuLJoa";
+        String secretId = "aac624d6-1111-2222-3333-444444444444";
+        String encodedClientId = java.util.Base64.getUrlEncoder()
+                .encodeToString(clientId.getBytes(StandardCharsets.UTF_8));
+        String encodedSecretId = java.util.Base64.getUrlEncoder()
+                .encodeToString(secretId.getBytes(StandardCharsets.UTF_8));
+
+        Mockito.when(dcrClient.getApplicationSecrets(encodedClientId)).thenReturn(null);
+
+        ConsumerSecretRequest request = new ConsumerSecretRequest();
+        request.setClientId(clientId);
+
+        keyManager.deleteApplicationConsumerSecret(secretId, request);
+
+        Mockito.verify(dcrClient, Mockito.times(1))
+                .deleteApplicationSecret(encodedClientId, encodedSecretId);
+    }
 
     private String getJSONString() {
         Map<String, String> parameters = new HashMap<String, String>();


### PR DESCRIPTION
## Issue
Fixes wso2/api-manager#4965 — *Internal Server Error when Revoking the Latest Consumer Secret*.

## Root Cause
On the IS side, `OAuthAdminServiceImpl.removeOAuthConsumerSecret` raises `IdentityOAuthClientException` (\"Cannot remove the most recently added consumer secret...\"), which the IS Key Manager DCR layer wraps into a `DCRMServerException` and returns as HTTP 500 with an empty body. On the APIM side, `AMDefaultKeyManagerImpl.deleteApplicationConsumerSecret` unconditionally mapped every `KeyManagerClientException` to `CLIENT_SECRET_DELETION_FAILED` (900919, HTTP 500), so this client-side validation failure surfaced to Dev Portal users as a generic internal error with a full stack trace in `wso2carbon.log`.

Because IS returns an empty body for this case, substring matching on the exception message is not viable — there is no usable signal on the wire.

## What Changed
1. **`org.wso2.carbon.apimgt.api/ExceptionCodes.java`** — added `CANNOT_REMOVE_LATEST_CLIENT_SECRET(900921, \"Cannot remove the latest consumer secret\", 400, ...)` alongside the existing `CLIENT_SECRET_*` codes.
2. **`org.wso2.carbon.apimgt.impl/AMDefaultKeyManagerImpl.java`** — in `deleteApplicationConsumerSecret`, pre-check via a new private `isMostRecentlyAddedSecret(encodedClientId, secretId)` helper that calls `dcrClient.getApplicationSecrets(...)` and compares the requested `secretId` to the last entry in the returned list. If it matches, throw `APIManagementException` with the new 4xx code. Otherwise, the original delete + existing 500 mapping path is unchanged. The pre-check swallows its own `KeyManagerClientException` so genuine errors still surface as before.
3. **`AMDefaultKeyManagerImplTest.java`** — added 6 unit tests covering: last-secret rejection, older-secret success, generic-failure still maps to 500, empty-list edge case, null-list edge case, and pre-check-exception fallback.

The pre-check heuristic is positional (last entry of `getApplicationSecrets`) — called out in the fix plan as a known limitation; a more durable fix would be on the IS side (propagate `DCRMClientException` for `IdentityOAuthClientException` causes with the original message).

## Verification
Reproduced on a fresh `wso2am-4.7.0` pack, patched with the built `org.wso2.carbon.apimgt.api_9.33.119.jar` and `org.wso2.carbon.apimgt.impl_9.33.119.jar`.

| Case | Before | After |
|------|--------|-------|
| Revoke most-recently-added secret | HTTP 500, code 900919, `DCRMServerException` + `GlobalThrowableMapper` stack trace in log | HTTP 400, code 900921, meaningful description, clean log |
| Revoke older secret | HTTP 204 | HTTP 204 (unchanged) |

Full verification transcript in `.ai/verify-4965.md` (evidence: `revoke-latest-response.json`, `revoke-older-response.json`, `curl-output.txt`).

## Tests
```
mvn test -Dtest=AMDefaultKeyManagerImplTest -DfailIfNoTests=false
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0
```
The new bug-scenario test was confirmed to fail against the unfixed code (assertion not met) and pass with the fix — it does exercise the changed path.

## Test Plan
- [x] Unit tests pass (`AMDefaultKeyManagerImplTest`, 19/19)
- [x] End-to-end repro via Dev Portal REST APIs on a patched `wso2am-4.7.0` pack: last-secret revoke → HTTP 400; older-secret revoke → HTTP 204
- [x] `wso2carbon.log` shows no `DCRMServerException` / `GlobalThrowableMapper` entries for the fixed case
- [ ] Reviewer: confirm naming / numbering of `CANNOT_REMOVE_LATEST_CLIENT_SECRET` (900921) fits the existing `ExceptionCodes` conventions
- [ ] Reviewer: confirm the positional \"last entry of `getApplicationSecrets`\" heuristic is acceptable given the current IS contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)