### PR TITLE
Fix Azure discovery validation on federated discovery path

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -3384,8 +3384,10 @@ public class PublisherCommonUtils {
                 ServiceReferenceHolder.getInstance().getAPIMDependencyConfigurationService()
                         .getAPIMDependencyConfigurations().getOasParserOptions());
 
-        //Validate API with Federated Gateway before persisting to registry
-        APIUtil.validateApiWithFederatedGateway(existingAPI);
+        // Validate only CP-initiated APIs. Discovery-initiated APIs should not run deploy-path validation.
+        if (!existingAPI.isInitiatedFromGateway()) {
+            APIUtil.validateApiWithFederatedGateway(existingAPI);
+        }
 
         apiProvider.saveSwaggerDefinition(existingAPI, updatedApiDefinition, organization);
         existingAPI.setSwaggerDefinition(updatedApiDefinition);


### PR DESCRIPTION
## Related
- wso2/api-manager#4978

## Summary
- skip federated gateway deploy validation for discovery-initiated APIs in the swagger update path
- keep validation on CP-initiated create/update-definition flows
- prevent Azure discovery from failing for discovered APIs with hyphens in the API name