### PR TITLE
[APIM] Fix file path issue

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -2004,10 +2004,8 @@ public class ImportUtils {
         try {
             OperationPolicyDefinition synapseGatewayDefinition = null;
             OperationPolicyDefinition ccGatewayDefinition = null;
-            String[] fileLocations = pathToArchive.split("/");
 
-            // File names of all types should be the same
-            String fileName = fileLocations[fileLocations.length - 1];
+            String fileName = Paths.get(pathToArchive).getFileName().toString();
             policySpecification = getOperationPolicySpecificationFromFile(pathToArchive, fileName);
             if (policySpecification == null) {
                 throw new APIManagementException("Policy Specification Cannot be null",

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -2005,7 +2005,7 @@ public class ImportUtils {
             OperationPolicyDefinition synapseGatewayDefinition = null;
             OperationPolicyDefinition ccGatewayDefinition = null;
 
-            String fileName = Paths.get(pathToArchive).getFileName().toString();
+            String fileName = new File(pathToArchive).getName();
             policySpecification = getOperationPolicySpecificationFromFile(pathToArchive, fileName);
             if (policySpecification == null) {
                 throw new APIManagementException("Policy Specification Cannot be null",

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/OperationPoliciesApiServiceImpl.java
@@ -445,8 +445,8 @@ public class OperationPoliciesApiServiceImpl implements OperationPoliciesApiServ
         try {
             extractedFolderPath = ImportUtils.getArchivePathOfPolicyExtractedDirectory(fileInputStream);
             createdPolicy = ImportUtils.importPolicy(extractedFolderPath, organization, apiProvider);
-            createdPolicyUri = new URI(RestApiConstants.REST_API_PUBLISHER_VERSION + File.separator
-                    + RestApiConstants.RESOURCE_PATH_OPERATION_POLICIES + File.separator + createdPolicy.getId());
+            createdPolicyUri = new URI(RestApiConstants.REST_API_PUBLISHER_VERSION + "/"
+                    + RestApiConstants.RESOURCE_PATH_OPERATION_POLICIES + "/" + createdPolicy.getId());
             return Response.created(createdPolicyUri).entity(createdPolicy).build();
         } catch (URISyntaxException e) {
             String errorMessage = "An Error has occurred while adding common operation policy. " + e.getMessage();


### PR DESCRIPTION
Related to https://github.com/wso2/api-manager/issues/4963
This pull request includes minor improvements to file path handling and URI construction in the operation policy import functionality. The changes enhance code robustness and consistency by using platform-independent methods for file name extraction and URI creation.

Path handling improvements:

* Replaced manual string splitting with `Paths.get(...).getFileName().toString()` to extract file names in `ImportUtils.java`, ensuring correct behavior across different operating systems.

URI construction consistency:

* Updated URI construction in `OperationPoliciesApiServiceImpl.java` to use forward slashes (`/`) instead of `File.separator`, ensuring URIs are correctly formatted regardless of the underlying OS.