### PR TITLE
[APIM] Remove WS endpoints in UI

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.apimgt.api.UsedByMigrationClient;
 import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Objects;
 
 /**
  * This class represent an Virtual Host
@@ -158,10 +159,12 @@ public class VHost implements Serializable {
     }
 
     public String getWsUrl() {
+        if (wsHost == null) return null;
         return getUrl("ws", wsHost, wsPort == DEFAULT_HTTP_PORT ? ""  : ":" + wsPort, "");
     }
 
     public String getWssUrl() {
+        if (wssHost == null) return null;
         return getUrl("wss", wssHost, wssPort == DEFAULT_HTTPS_PORT ? "" : ":" + wssPort, "");
     }
 
@@ -293,10 +296,10 @@ public class VHost implements Serializable {
                 && StringUtils.equals(vHost.httpContext, this.httpContext)
                 && vHost.httpPort.equals(this.httpPort)
                 && vHost.httpsPort.equals(this.httpsPort)
-                && StringUtils.equals(vHost.wsHost, this.wsHost)
-                && StringUtils.equals(vHost.wssHost, this.wssHost)
-                && vHost.wsPort.equals(this.wsPort)
-                && vHost.wssPort.equals(this.wssPort);
+                && Objects.equals(vHost.wsHost, this.wsHost)
+                && Objects.equals(vHost.wssHost, this.wssHost)
+                && Objects.equals(vHost.wsPort, this.wsPort)
+                && Objects.equals(vHost.wssPort, this.wssPort);
     }
 
     @Override
@@ -313,8 +316,8 @@ public class VHost implements Serializable {
                 + ((wsHost == null) ? 0 : wsHost.hashCode());
         result = prime * result
                 + ((wssHost == null) ? 0 : wssHost.hashCode());
-        result = prime * result + wsPort;
-        result = prime * result + wssPort;
+        result = prime * result + ((wsPort == null) ? 0 : wsPort);
+        result = prime * result + ((wssPort == null) ? 0 : wssPort);
         return result;
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/model/VHost.java
@@ -173,9 +173,38 @@ public class VHost implements Serializable {
         return String.format("%s://%s%s%s", protocol, hostName, port, context);
     }
 
+    private void findAndDisableMissingProtocols(String[] endpoints) {
+        boolean wsFound = false;
+        boolean wssFound = false;
+        for (String endpoint : endpoints) {
+            if (StringUtils.isEmpty(endpoint)) {
+                continue;
+            }
+            String[] elem = endpoint.split(PROTOCOL_SEPARATOR);
+            if (elem.length != 2) {
+                continue;
+            }
+            switch (elem[0]) {
+            case WS_PROTOCOL:
+                wsFound = true;
+                break;
+            case WSS_PROTOCOL:
+                wssFound = true;
+                break;
+            }
+        }
+        if (!wsFound) {
+            this.disableWs();
+        }
+        if (!wssFound) {
+            this.disableWss();
+        }
+    }
+
     @UsedByMigrationClient
     public static VHost fromEndpointUrls(String[] endpoints) throws APIManagementException {
         VHost vhost = new VHost();
+        vhost.findAndDisableMissingProtocols(endpoints);
 
         for (String endpoint : endpoints) {
             if (StringUtils.isEmpty(endpoint)) {
@@ -235,16 +264,18 @@ public class VHost implements Serializable {
         if (StringUtils.isEmpty(vhost.getHost())) {
             throw new APIManagementException("Error while building VHost, missing required HTTP or HTTPS endpoint");
         }
-
-        // If WebSocket host name of Vhost is empty, use HTTP/HTTPS endpoint hostname
-        if ((vhost.getWsHost() == null) || (StringUtils.isEmpty(vhost.getWsHost()))) {
-            vhost.setWsHost(vhost.getHost());
-        }
-        if ((vhost.getWssHost() == null) || (StringUtils.isEmpty(vhost.getWssHost()))) {
-            vhost.setWssHost(vhost.getHost());
-        }
-
+        
         return vhost;
+    }
+
+    public void disableWs() {
+        this.wsPort = null;
+        this.wsHost = null;
+    }
+
+    public void disableWss() {
+        this.wssPort = null;
+        this.wssHost = null;
     }
 
     @Override
@@ -262,6 +293,8 @@ public class VHost implements Serializable {
                 && StringUtils.equals(vHost.httpContext, this.httpContext)
                 && vHost.httpPort.equals(this.httpPort)
                 && vHost.httpsPort.equals(this.httpsPort)
+                && StringUtils.equals(vHost.wsHost, this.wsHost)
+                && StringUtils.equals(vHost.wssHost, this.wssHost)
                 && vHost.wsPort.equals(this.wsPort)
                 && vHost.wssPort.equals(this.wssPort);
     }
@@ -276,6 +309,10 @@ public class VHost implements Serializable {
                 + ((httpContext == null) ? 0 : httpContext.hashCode());
         result = prime * result + httpPort;
         result = prime * result + httpsPort;
+        result = prime * result
+                + ((wsHost == null) ? 0 : wsHost.hashCode());
+        result = prime * result
+                + ((wssHost == null) ? 0 : wssHost.hashCode());
         result = prime * result + wsPort;
         result = prime * result + wssPort;
         return result;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/restapi/publisher/ApisApiServiceImplUtils.java
@@ -119,6 +119,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Objects;
 
 import static org.wso2.carbon.apimgt.impl.restapi.CommonUtils.constructEndpointConfigForService;
 import static org.wso2.carbon.apimgt.impl.restapi.CommonUtils.validateScopes;
@@ -1157,7 +1158,8 @@ public class ApisApiServiceImplUtils {
             //Checking the vhost is included in the available vhost list
             if (vhostItem.getHost().equals(vhost)) {
                 isVhostValidated = true;
-            } else if (vhostItem.getWsHost().equals(vhost)) {
+            } else if (Objects.equals(vhostItem.getWsHost(), vhost) 
+                    || Objects.equals(vhostItem.getWssHost(), vhost)) {
                 // This was added to preserve the functionality in case of Deploying a WebSocket API revision.
                 // For WebSocket APIs apiRevisionDeploymentDTO.getVhost() returns the wsHost
                 isVhostValidated = true;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
@@ -202,6 +202,8 @@ public class EnvironmentMappingUtil {
         vHostDTO.setHttpsPort(vHost.getHttpsPort());
         vHostDTO.setWsPort(vHost.getWsPort());
         vHostDTO.setWssPort(vHost.getWssPort());
+        vHostDTO.setWsHost(vHost.getWsHost());
+        vHostDTO.setWssHost(vHost.getWssHost());
         return vHostDTO;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
@@ -273,16 +273,8 @@ public class EnvironmentMappingUtil {
         vhost.setHttpsPort(vhostDTO.getHttpsPort());
         vhost.setWsPort(vhostDTO.getWsPort());
         vhost.setWssPort(vhostDTO.getWssPort());
-        if (vhostDTO.getWsHost() == null) {
-            vhost.setWsHost(vhostDTO.getHost());
-        } else {
-            vhost.setWsHost(vhostDTO.getWsHost());
-        }
-        if (vhostDTO.getWssHost() == null) {
-            vhost.setWssHost(vhostDTO.getHost());
-        } else {
-            vhost.setWssHost(vhostDTO.getWssHost());
-        }
+        vhost.setWsHost(vhostDTO.getWsHost());
+        vhost.setWssHost(vhostDTO.getWssHost());
         return vhost;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -709,9 +709,17 @@ public class APIMappingUtil {
                 }
             }
         }
-        if (isWs || isGQLSubscription) {
+        if (isGQLSubscription) {
             apiurLsDTO.setWs(vHost.getWsUrl() + context);
             apiurLsDTO.setWss(vHost.getWssUrl() + context);
+        }
+        if (isWs) {
+            if (vHost.getWsHost() != null) {
+                apiurLsDTO.setWs(vHost.getWsUrl() + context);
+            }
+            if (vHost.getWssHost() != null) {
+                apiurLsDTO.setWss(vHost.getWssUrl() + context);
+            }
         }
         apiEndpointURLsDTO.setUrLs(apiurLsDTO);
 
@@ -726,9 +734,17 @@ public class APIMappingUtil {
                     apiDefaultVersionURLsDTO.setHttps(vHost.getHttpsUrl() + defaultContext);
                 }
             }
-            if (isWs || isGQLSubscription) {
+            if (isGQLSubscription) {
                 apiDefaultVersionURLsDTO.setWs(vHost.getWsUrl() + defaultContext);
                 apiDefaultVersionURLsDTO.setWss(vHost.getWssUrl() + defaultContext);
+            }
+            if (isWs) {
+                if (vHost.getWsHost() != null) {
+                    apiDefaultVersionURLsDTO.setWs(vHost.getWsUrl() + defaultContext);
+                }
+                if (vHost.getWssHost() != null) {
+                    apiDefaultVersionURLsDTO.setWss(vHost.getWssUrl() + defaultContext);
+                }
             }
         }
         apiEndpointURLsDTO.setDefaultVersionURLs(apiDefaultVersionURLsDTO);


### PR DESCRIPTION
Related to https://github.com/wso2/api-manager/issues/4234
This pull request introduces improvements and fixes to the handling of WebSocket (WS/WSS) hosts and ports in the `VHost` model and related mapping utilities. The changes ensure more robust management of optional WS/WSS endpoints, improve equality/hash handling, and update DTO mappings to accurately reflect host and port values.

Key changes include:

### VHost Model Enhancements

* Added logic in `VHost` to disable WS/WSS endpoints if they are missing from the endpoint URLs, ensuring that unused protocols are not erroneously enabled. (`findAndDisableMissingProtocols`, `disableWs`, `disableWss`) [[1]](diffhunk://#diff-823ec17be75788871a923c935870ad5e27a4021ef5f73e32530d07c1e8b2c425R179-R210) [[2]](diffhunk://#diff-823ec17be75788871a923c935870ad5e27a4021ef5f73e32530d07c1e8b2c425L239-R281)
* Updated `equals` and `hashCode` methods in `VHost` to use `Objects.equals` for WS/WSS host and port fields, improving correctness when these fields are `null`.
* Modified `getWsUrl` and `getWssUrl` to return `null` if the corresponding host is not set, preventing malformed URLs.

### DTO and Mapping Adjustments

* Updated `VHostDTO` mapping utilities to always set WS/WSS hosts directly from the model, removing fallback to the main host and ensuring accurate representation of the endpoints. [[1]](diffhunk://#diff-525eb5c59ff2fca3b143bb2182048a6c7768b2c6d5c8703b6cdb3a21ebcac39dR205-R206) [[2]](diffhunk://#diff-525eb5c59ff2fca3b143bb2182048a6c7768b2c6d5c8703b6cdb3a21ebcac39dL276-L285)

### API Endpoint URL Generation

* Improved logic in API endpoint URL generation to only set WS/WSS URLs if the corresponding hosts are present, preventing null pointer exceptions and avoiding the publication of invalid endpoints. [[1]](diffhunk://#diff-e03c4259d4902b9d1c4b4407ec084b901e17d309c501b4eab01b71ec6312ef00L712-R723) [[2]](diffhunk://#diff-e03c4259d4902b9d1c4b4407ec084b901e17d309c501b4eab01b71ec6312ef00L729-R748)

### Validation Logic

* Enhanced vhost validation to check both WS and WSS hosts using `Objects.equals`, ensuring correct validation for WebSocket APIs.

### Miscellaneous

* Added missing imports for `Objects` in affected files. [[1]](diffhunk://#diff-823ec17be75788871a923c935870ad5e27a4021ef5f73e32530d07c1e8b2c425R27) [[2]](diffhunk://#diff-831bd793a420f8934f6675a1dac59dd2b8afd291568c2c5af87f01c05c10a7afR122)

These changes collectively improve the reliability and correctness of virtual host handling, especially in scenarios where WebSocket endpoints may be optional or absent.