### PR TITLE
[API Discovery Governance] backend BFF + deployment.toml integration for unmanaged API discovery

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -86,6 +86,14 @@
         "Roles": "admin"
       },
       {
+        "Name": "apim:admin_discovery_view",
+        "Roles": "admin,Internal/devops"
+      },
+      {
+        "Name": "apim:admin_discovery_manage",
+        "Roles": "admin"
+      },
+      {
         "Name": "apim:app_owner_change",
         "Roles": "admin"
       },

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-conf.json
@@ -86,14 +86,6 @@
         "Roles": "admin"
       },
       {
-        "Name": "apim:admin_discovery_view",
-        "Roles": "admin,Internal/devops"
-      },
-      {
-        "Name": "apim:admin_discovery_manage",
-        "Roles": "admin"
-      },
-      {
         "Name": "apim:app_owner_change",
         "Roles": "admin"
       },

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/GovernanceApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/GovernanceApi.java
@@ -1,0 +1,110 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1;
+
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIListDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.UntraffickedListDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.GovernanceApiService;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.GovernanceApiServiceImpl;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.inject.Inject;
+
+import io.swagger.annotations.*;
+import java.io.InputStream;
+
+import org.apache.cxf.jaxrs.ext.MessageContext;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+
+import java.util.Map;
+import java.util.List;
+import javax.validation.constraints.*;
+@Path("/governance")
+
+@Api(description = "the governance API")
+
+
+
+
+public class GovernanceApi  {
+
+  @Context MessageContext securityContext;
+
+GovernanceApiService delegate = new GovernanceApiServiceImpl();
+
+
+    @GET
+    @Path("/discovery/apis/{discoveredApiId}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get discovered API detail", notes = "", response = DiscoveredAPIDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:admin_discovery_view", description = "")
+        })
+    }, tags={ "Unmanaged APIs",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK", response = DiscoveredAPIDTO.class),
+        @ApiResponse(code = 404, message = "Not Found. The specified resource does not exist.", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
+    public Response getDiscoveredAPIById(@ApiParam(value = "",required=true) @PathParam("discoveredApiId") String discoveredApiId) throws APIManagementException{
+        return delegate.getDiscoveredAPIById(discoveredApiId, securityContext);
+    }
+
+    @GET
+    @Path("/discovery/apis")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List discovered APIs", notes = "Paginated list of unmanaged discovered APIs. Filterable by classification, service, and internal-only flag. ", response = DiscoveredAPIListDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:admin_discovery_view", description = "")
+        })
+    }, tags={ "Unmanaged APIs",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK", response = DiscoveredAPIListDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
+    public Response getDiscoveredAPIs( @ApiParam(value = "", allowableValues="shadow, drift")  @QueryParam("classification") String classification,  @ApiParam(value = "")  @QueryParam("service") String service,  @ApiParam(value = "Filter by internal flag. \"true\" = include internal, \"false\" = external only, \"only\" = internal only. Omit for all. ", allowableValues="true, false, only")  @QueryParam("internal") String internal,  @ApiParam(value = "Maximum size of resource array to return. ", defaultValue="25") @DefaultValue("25") @QueryParam("limit") Integer limit,  @ApiParam(value = "Starting point within the complete list of items qualified. ", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset) throws APIManagementException{
+        return delegate.getDiscoveredAPIs(classification, service, internal, limit, offset, securityContext);
+    }
+
+    @GET
+    @Path("/discovery/summary")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get summary of discovered APIs by classification ", notes = "Returns aggregate counts of discovered APIs by classification (shadow, drift), reachability (external, internal), and service. ", response = DiscoverySummaryDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:admin_discovery_view", description = "")
+        })
+    }, tags={ "Unmanaged APIs",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK. Summary returned. ", response = DiscoverySummaryDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
+    public Response getDiscoverySummary() throws APIManagementException{
+        return delegate.getDiscoverySummary(securityContext);
+    }
+
+    @GET
+    @Path("/discovery/untrafficked")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List untrafficked managed APIs", notes = "Managed APIs registered in APIM but with no observed traffic. Useful for identifying dead APIs or DeepFlow coverage gaps. ", response = UntraffickedListDTO.class, authorizations = {
+        @Authorization(value = "OAuth2Security", scopes = {
+            @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
+            @AuthorizationScope(scope = "apim:admin_discovery_view", description = "")
+        })
+    }, tags={ "Unmanaged APIs" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK", response = UntraffickedListDTO.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = ErrorDTO.class) })
+    public Response getUntrafficked() throws APIManagementException{
+        return delegate.getUntrafficked(securityContext);
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/GovernanceApi.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/GovernanceApi.java
@@ -46,7 +46,7 @@ GovernanceApiService delegate = new GovernanceApiServiceImpl();
     @ApiOperation(value = "Get discovered API detail", notes = "", response = DiscoveredAPIDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:admin_discovery_view", description = "")
+            @AuthorizationScope(scope = "apim:admin_discovery_view", description = "View discovered unmanaged APIs (Governance)")
         })
     }, tags={ "Unmanaged APIs",  })
     @ApiResponses(value = { 
@@ -64,7 +64,7 @@ GovernanceApiService delegate = new GovernanceApiServiceImpl();
     @ApiOperation(value = "List discovered APIs", notes = "Paginated list of unmanaged discovered APIs. Filterable by classification, service, and internal-only flag. ", response = DiscoveredAPIListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:admin_discovery_view", description = "")
+            @AuthorizationScope(scope = "apim:admin_discovery_view", description = "View discovered unmanaged APIs (Governance)")
         })
     }, tags={ "Unmanaged APIs",  })
     @ApiResponses(value = { 
@@ -81,7 +81,7 @@ GovernanceApiService delegate = new GovernanceApiServiceImpl();
     @ApiOperation(value = "Get summary of discovered APIs by classification ", notes = "Returns aggregate counts of discovered APIs by classification (shadow, drift), reachability (external, internal), and service. ", response = DiscoverySummaryDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:admin_discovery_view", description = "")
+            @AuthorizationScope(scope = "apim:admin_discovery_view", description = "View discovered unmanaged APIs (Governance)")
         })
     }, tags={ "Unmanaged APIs",  })
     @ApiResponses(value = { 
@@ -98,7 +98,7 @@ GovernanceApiService delegate = new GovernanceApiServiceImpl();
     @ApiOperation(value = "List untrafficked managed APIs", notes = "Managed APIs registered in APIM but with no observed traffic. Useful for identifying dead APIs or DeepFlow coverage gaps. ", response = UntraffickedListDTO.class, authorizations = {
         @Authorization(value = "OAuth2Security", scopes = {
             @AuthorizationScope(scope = "apim:admin", description = "Manage all admin operations"),
-            @AuthorizationScope(scope = "apim:admin_discovery_view", description = "")
+            @AuthorizationScope(scope = "apim:admin_discovery_view", description = "View discovered unmanaged APIs (Governance)")
         })
     }, tags={ "Unmanaged APIs" })
     @ApiResponses(value = { 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/GovernanceApiService.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/GovernanceApiService.java
@@ -1,0 +1,31 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1;
+
+import org.wso2.carbon.apimgt.rest.api.admin.v1.*;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.*;
+
+import org.apache.cxf.jaxrs.ext.MessageContext;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+
+import org.wso2.carbon.apimgt.api.APIManagementException;
+
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIListDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ErrorDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.UntraffickedListDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+
+
+public interface GovernanceApiService {
+      public Response getDiscoveredAPIById(String discoveredApiId, MessageContext messageContext) throws APIManagementException;
+      public Response getDiscoveredAPIs(String classification, String service, String internal, Integer limit, Integer offset, MessageContext messageContext) throws APIManagementException;
+      public Response getDiscoverySummary(MessageContext messageContext) throws APIManagementException;
+      public Response getUntrafficked(MessageContext messageContext) throws APIManagementException;
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoveredAPIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoveredAPIDTO.java
@@ -1,0 +1,550 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIServiceManagedAPIsDTO;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class DiscoveredAPIDTO   {
+  
+    private String id = null;
+    private String serviceIdentity = null;
+
+    @XmlType(name="EnvKindEnum")
+    @XmlEnum(String.class)
+    public enum EnvKindEnum {
+        K8S("k8s"),
+        LEGACY("legacy"),
+        UNKNOWN("unknown");
+        private String value;
+
+        EnvKindEnum (String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @JsonCreator
+        public static EnvKindEnum fromValue(String v) {
+            for (EnvKindEnum b : EnvKindEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+return null;
+        }
+    }
+    private EnvKindEnum envKind = null;
+    private String namespace = null;
+    private String serviceName = null;
+    private String samplePod = null;
+    private String sampleWorkload = null;
+    private String method = null;
+    private String normalizedPath = null;
+    private List<String> rawPathSamples = new ArrayList<String>();
+
+    @XmlType(name="ClassificationEnum")
+    @XmlEnum(String.class)
+    public enum ClassificationEnum {
+        SHADOW("shadow"),
+        DRIFT("drift");
+        private String value;
+
+        ClassificationEnum (String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @JsonCreator
+        public static ClassificationEnum fromValue(String v) {
+            for (ClassificationEnum b : ClassificationEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+return null;
+        }
+    }
+    private ClassificationEnum classification = null;
+    private Boolean isInternal = null;
+    private String firstSeenAt = null;
+    private String lastSeenAt = null;
+    private Long observationCount = null;
+    private Integer distinctClientCount = null;
+    private List<String> distinctClientsSample = new ArrayList<String>();
+    private List<Integer> statusCodes = new ArrayList<Integer>();
+    private BigDecimal avgDurationUs = null;
+    private List<String> matchedApimApiIds = new ArrayList<String>();
+    private List<DiscoveredAPIServiceManagedAPIsDTO> serviceManagedAPIs = new ArrayList<DiscoveredAPIServiceManagedAPIsDTO>();
+
+  /**
+   **/
+  public DiscoveredAPIDTO id(String id) {
+    this.id = id;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("id")
+  public String getId() {
+    return id;
+  }
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO serviceIdentity(String serviceIdentity) {
+    this.serviceIdentity = serviceIdentity;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("serviceIdentity")
+  public String getServiceIdentity() {
+    return serviceIdentity;
+  }
+  public void setServiceIdentity(String serviceIdentity) {
+    this.serviceIdentity = serviceIdentity;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO envKind(EnvKindEnum envKind) {
+    this.envKind = envKind;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("envKind")
+  public EnvKindEnum getEnvKind() {
+    return envKind;
+  }
+  public void setEnvKind(EnvKindEnum envKind) {
+    this.envKind = envKind;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO namespace(String namespace) {
+    this.namespace = namespace;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("namespace")
+  public String getNamespace() {
+    return namespace;
+  }
+  public void setNamespace(String namespace) {
+    this.namespace = namespace;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO serviceName(String serviceName) {
+    this.serviceName = serviceName;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("serviceName")
+  public String getServiceName() {
+    return serviceName;
+  }
+  public void setServiceName(String serviceName) {
+    this.serviceName = serviceName;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO samplePod(String samplePod) {
+    this.samplePod = samplePod;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("samplePod")
+  public String getSamplePod() {
+    return samplePod;
+  }
+  public void setSamplePod(String samplePod) {
+    this.samplePod = samplePod;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO sampleWorkload(String sampleWorkload) {
+    this.sampleWorkload = sampleWorkload;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("sampleWorkload")
+  public String getSampleWorkload() {
+    return sampleWorkload;
+  }
+  public void setSampleWorkload(String sampleWorkload) {
+    this.sampleWorkload = sampleWorkload;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO method(String method) {
+    this.method = method;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("method")
+  public String getMethod() {
+    return method;
+  }
+  public void setMethod(String method) {
+    this.method = method;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO normalizedPath(String normalizedPath) {
+    this.normalizedPath = normalizedPath;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("normalizedPath")
+  public String getNormalizedPath() {
+    return normalizedPath;
+  }
+  public void setNormalizedPath(String normalizedPath) {
+    this.normalizedPath = normalizedPath;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO rawPathSamples(List<String> rawPathSamples) {
+    this.rawPathSamples = rawPathSamples;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("rawPathSamples")
+  public List<String> getRawPathSamples() {
+    return rawPathSamples;
+  }
+  public void setRawPathSamples(List<String> rawPathSamples) {
+    this.rawPathSamples = rawPathSamples;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO classification(ClassificationEnum classification) {
+    this.classification = classification;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("classification")
+  public ClassificationEnum getClassification() {
+    return classification;
+  }
+  public void setClassification(ClassificationEnum classification) {
+    this.classification = classification;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO isInternal(Boolean isInternal) {
+    this.isInternal = isInternal;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("isInternal")
+  public Boolean isIsInternal() {
+    return isInternal;
+  }
+  public void setIsInternal(Boolean isInternal) {
+    this.isInternal = isInternal;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO firstSeenAt(String firstSeenAt) {
+    this.firstSeenAt = firstSeenAt;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("firstSeenAt")
+  public String getFirstSeenAt() {
+    return firstSeenAt;
+  }
+  public void setFirstSeenAt(String firstSeenAt) {
+    this.firstSeenAt = firstSeenAt;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO lastSeenAt(String lastSeenAt) {
+    this.lastSeenAt = lastSeenAt;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("lastSeenAt")
+  public String getLastSeenAt() {
+    return lastSeenAt;
+  }
+  public void setLastSeenAt(String lastSeenAt) {
+    this.lastSeenAt = lastSeenAt;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO observationCount(Long observationCount) {
+    this.observationCount = observationCount;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("observationCount")
+  public Long getObservationCount() {
+    return observationCount;
+  }
+  public void setObservationCount(Long observationCount) {
+    this.observationCount = observationCount;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO distinctClientCount(Integer distinctClientCount) {
+    this.distinctClientCount = distinctClientCount;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("distinctClientCount")
+  public Integer getDistinctClientCount() {
+    return distinctClientCount;
+  }
+  public void setDistinctClientCount(Integer distinctClientCount) {
+    this.distinctClientCount = distinctClientCount;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO distinctClientsSample(List<String> distinctClientsSample) {
+    this.distinctClientsSample = distinctClientsSample;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("distinctClientsSample")
+  public List<String> getDistinctClientsSample() {
+    return distinctClientsSample;
+  }
+  public void setDistinctClientsSample(List<String> distinctClientsSample) {
+    this.distinctClientsSample = distinctClientsSample;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO statusCodes(List<Integer> statusCodes) {
+    this.statusCodes = statusCodes;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("statusCodes")
+  public List<Integer> getStatusCodes() {
+    return statusCodes;
+  }
+  public void setStatusCodes(List<Integer> statusCodes) {
+    this.statusCodes = statusCodes;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO avgDurationUs(BigDecimal avgDurationUs) {
+    this.avgDurationUs = avgDurationUs;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("avgDurationUs")
+  public BigDecimal getAvgDurationUs() {
+    return avgDurationUs;
+  }
+  public void setAvgDurationUs(BigDecimal avgDurationUs) {
+    this.avgDurationUs = avgDurationUs;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO matchedApimApiIds(List<String> matchedApimApiIds) {
+    this.matchedApimApiIds = matchedApimApiIds;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("matchedApimApiIds")
+  public List<String> getMatchedApimApiIds() {
+    return matchedApimApiIds;
+  }
+  public void setMatchedApimApiIds(List<String> matchedApimApiIds) {
+    this.matchedApimApiIds = matchedApimApiIds;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIDTO serviceManagedAPIs(List<DiscoveredAPIServiceManagedAPIsDTO> serviceManagedAPIs) {
+    this.serviceManagedAPIs = serviceManagedAPIs;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("serviceManagedAPIs")
+  public List<DiscoveredAPIServiceManagedAPIsDTO> getServiceManagedAPIs() {
+    return serviceManagedAPIs;
+  }
+  public void setServiceManagedAPIs(List<DiscoveredAPIServiceManagedAPIsDTO> serviceManagedAPIs) {
+    this.serviceManagedAPIs = serviceManagedAPIs;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DiscoveredAPIDTO discoveredAPI = (DiscoveredAPIDTO) o;
+    return Objects.equals(id, discoveredAPI.id) &&
+        Objects.equals(serviceIdentity, discoveredAPI.serviceIdentity) &&
+        Objects.equals(envKind, discoveredAPI.envKind) &&
+        Objects.equals(namespace, discoveredAPI.namespace) &&
+        Objects.equals(serviceName, discoveredAPI.serviceName) &&
+        Objects.equals(samplePod, discoveredAPI.samplePod) &&
+        Objects.equals(sampleWorkload, discoveredAPI.sampleWorkload) &&
+        Objects.equals(method, discoveredAPI.method) &&
+        Objects.equals(normalizedPath, discoveredAPI.normalizedPath) &&
+        Objects.equals(rawPathSamples, discoveredAPI.rawPathSamples) &&
+        Objects.equals(classification, discoveredAPI.classification) &&
+        Objects.equals(isInternal, discoveredAPI.isInternal) &&
+        Objects.equals(firstSeenAt, discoveredAPI.firstSeenAt) &&
+        Objects.equals(lastSeenAt, discoveredAPI.lastSeenAt) &&
+        Objects.equals(observationCount, discoveredAPI.observationCount) &&
+        Objects.equals(distinctClientCount, discoveredAPI.distinctClientCount) &&
+        Objects.equals(distinctClientsSample, discoveredAPI.distinctClientsSample) &&
+        Objects.equals(statusCodes, discoveredAPI.statusCodes) &&
+        Objects.equals(avgDurationUs, discoveredAPI.avgDurationUs) &&
+        Objects.equals(matchedApimApiIds, discoveredAPI.matchedApimApiIds) &&
+        Objects.equals(serviceManagedAPIs, discoveredAPI.serviceManagedAPIs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, serviceIdentity, envKind, namespace, serviceName, samplePod, sampleWorkload, method, normalizedPath, rawPathSamples, classification, isInternal, firstSeenAt, lastSeenAt, observationCount, distinctClientCount, distinctClientsSample, statusCodes, avgDurationUs, matchedApimApiIds, serviceManagedAPIs);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DiscoveredAPIDTO {\n");
+    
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
+    sb.append("    serviceIdentity: ").append(toIndentedString(serviceIdentity)).append("\n");
+    sb.append("    envKind: ").append(toIndentedString(envKind)).append("\n");
+    sb.append("    namespace: ").append(toIndentedString(namespace)).append("\n");
+    sb.append("    serviceName: ").append(toIndentedString(serviceName)).append("\n");
+    sb.append("    samplePod: ").append(toIndentedString(samplePod)).append("\n");
+    sb.append("    sampleWorkload: ").append(toIndentedString(sampleWorkload)).append("\n");
+    sb.append("    method: ").append(toIndentedString(method)).append("\n");
+    sb.append("    normalizedPath: ").append(toIndentedString(normalizedPath)).append("\n");
+    sb.append("    rawPathSamples: ").append(toIndentedString(rawPathSamples)).append("\n");
+    sb.append("    classification: ").append(toIndentedString(classification)).append("\n");
+    sb.append("    isInternal: ").append(toIndentedString(isInternal)).append("\n");
+    sb.append("    firstSeenAt: ").append(toIndentedString(firstSeenAt)).append("\n");
+    sb.append("    lastSeenAt: ").append(toIndentedString(lastSeenAt)).append("\n");
+    sb.append("    observationCount: ").append(toIndentedString(observationCount)).append("\n");
+    sb.append("    distinctClientCount: ").append(toIndentedString(distinctClientCount)).append("\n");
+    sb.append("    distinctClientsSample: ").append(toIndentedString(distinctClientsSample)).append("\n");
+    sb.append("    statusCodes: ").append(toIndentedString(statusCodes)).append("\n");
+    sb.append("    avgDurationUs: ").append(toIndentedString(avgDurationUs)).append("\n");
+    sb.append("    matchedApimApiIds: ").append(toIndentedString(matchedApimApiIds)).append("\n");
+    sb.append("    serviceManagedAPIs: ").append(toIndentedString(serviceManagedAPIs)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoveredAPIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoveredAPIDTO.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIServiceManagedAPIsDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPITopClientsDTO;
 import javax.validation.constraints.*;
 
 
@@ -108,6 +109,7 @@ return null;
     private BigDecimal avgDurationUs = null;
     private List<String> matchedApimApiIds = new ArrayList<String>();
     private List<DiscoveredAPIServiceManagedAPIsDTO> serviceManagedAPIs = new ArrayList<DiscoveredAPIServiceManagedAPIsDTO>();
+    private List<DiscoveredAPITopClientsDTO> topClients = new ArrayList<DiscoveredAPITopClientsDTO>();
 
   /**
    **/
@@ -468,6 +470,25 @@ return null;
     this.serviceManagedAPIs = serviceManagedAPIs;
   }
 
+  /**
+   * Top callers of this finding ranked by observation count, capped at 20 entries.
+   **/
+  public DiscoveredAPIDTO topClients(List<DiscoveredAPITopClientsDTO> topClients) {
+    this.topClients = topClients;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Top callers of this finding ranked by observation count, capped at 20 entries.")
+      @Valid
+  @JsonProperty("topClients")
+  public List<DiscoveredAPITopClientsDTO> getTopClients() {
+    return topClients;
+  }
+  public void setTopClients(List<DiscoveredAPITopClientsDTO> topClients) {
+    this.topClients = topClients;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -498,12 +519,13 @@ return null;
         Objects.equals(statusCodes, discoveredAPI.statusCodes) &&
         Objects.equals(avgDurationUs, discoveredAPI.avgDurationUs) &&
         Objects.equals(matchedApimApiIds, discoveredAPI.matchedApimApiIds) &&
-        Objects.equals(serviceManagedAPIs, discoveredAPI.serviceManagedAPIs);
+        Objects.equals(serviceManagedAPIs, discoveredAPI.serviceManagedAPIs) &&
+        Objects.equals(topClients, discoveredAPI.topClients);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, serviceIdentity, envKind, namespace, serviceName, samplePod, sampleWorkload, method, normalizedPath, rawPathSamples, classification, isInternal, firstSeenAt, lastSeenAt, observationCount, distinctClientCount, distinctClientsSample, statusCodes, avgDurationUs, matchedApimApiIds, serviceManagedAPIs);
+    return Objects.hash(id, serviceIdentity, envKind, namespace, serviceName, samplePod, sampleWorkload, method, normalizedPath, rawPathSamples, classification, isInternal, firstSeenAt, lastSeenAt, observationCount, distinctClientCount, distinctClientsSample, statusCodes, avgDurationUs, matchedApimApiIds, serviceManagedAPIs, topClients);
   }
 
   @Override
@@ -532,6 +554,7 @@ return null;
     sb.append("    avgDurationUs: ").append(toIndentedString(avgDurationUs)).append("\n");
     sb.append("    matchedApimApiIds: ").append(toIndentedString(matchedApimApiIds)).append("\n");
     sb.append("    serviceManagedAPIs: ").append(toIndentedString(serviceManagedAPIs)).append("\n");
+    sb.append("    topClients: ").append(toIndentedString(topClients)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoveredAPIListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoveredAPIListDTO.java
@@ -1,0 +1,127 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.PaginationDTO;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class DiscoveredAPIListDTO   {
+  
+    private Integer count = null;
+    private List<DiscoveredAPIDTO> list = new ArrayList<DiscoveredAPIDTO>();
+    private PaginationDTO pagination = null;
+
+  /**
+   **/
+  public DiscoveredAPIListDTO count(Integer count) {
+    this.count = count;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("count")
+  public Integer getCount() {
+    return count;
+  }
+  public void setCount(Integer count) {
+    this.count = count;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIListDTO list(List<DiscoveredAPIDTO> list) {
+    this.list = list;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("list")
+  public List<DiscoveredAPIDTO> getList() {
+    return list;
+  }
+  public void setList(List<DiscoveredAPIDTO> list) {
+    this.list = list;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIListDTO pagination(PaginationDTO pagination) {
+    this.pagination = pagination;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("pagination")
+  public PaginationDTO getPagination() {
+    return pagination;
+  }
+  public void setPagination(PaginationDTO pagination) {
+    this.pagination = pagination;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DiscoveredAPIListDTO discoveredAPIList = (DiscoveredAPIListDTO) o;
+    return Objects.equals(count, discoveredAPIList.count) &&
+        Objects.equals(list, discoveredAPIList.list) &&
+        Objects.equals(pagination, discoveredAPIList.pagination);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(count, list, pagination);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DiscoveredAPIListDTO {\n");
+    
+    sb.append("    count: ").append(toIndentedString(count)).append("\n");
+    sb.append("    list: ").append(toIndentedString(list)).append("\n");
+    sb.append("    pagination: ").append(toIndentedString(pagination)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoveredAPIServiceManagedAPIsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoveredAPIServiceManagedAPIsDTO.java
@@ -1,0 +1,121 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class DiscoveredAPIServiceManagedAPIsDTO   {
+  
+    private String apimApiId = null;
+    private String apimApiName = null;
+    private String apimApiVersion = null;
+
+  /**
+   **/
+  public DiscoveredAPIServiceManagedAPIsDTO apimApiId(String apimApiId) {
+    this.apimApiId = apimApiId;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("apimApiId")
+  public String getApimApiId() {
+    return apimApiId;
+  }
+  public void setApimApiId(String apimApiId) {
+    this.apimApiId = apimApiId;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIServiceManagedAPIsDTO apimApiName(String apimApiName) {
+    this.apimApiName = apimApiName;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("apimApiName")
+  public String getApimApiName() {
+    return apimApiName;
+  }
+  public void setApimApiName(String apimApiName) {
+    this.apimApiName = apimApiName;
+  }
+
+  /**
+   **/
+  public DiscoveredAPIServiceManagedAPIsDTO apimApiVersion(String apimApiVersion) {
+    this.apimApiVersion = apimApiVersion;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("apimApiVersion")
+  public String getApimApiVersion() {
+    return apimApiVersion;
+  }
+  public void setApimApiVersion(String apimApiVersion) {
+    this.apimApiVersion = apimApiVersion;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DiscoveredAPIServiceManagedAPIsDTO discoveredAPIServiceManagedAPIs = (DiscoveredAPIServiceManagedAPIsDTO) o;
+    return Objects.equals(apimApiId, discoveredAPIServiceManagedAPIs.apimApiId) &&
+        Objects.equals(apimApiName, discoveredAPIServiceManagedAPIs.apimApiName) &&
+        Objects.equals(apimApiVersion, discoveredAPIServiceManagedAPIs.apimApiVersion);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(apimApiId, apimApiName, apimApiVersion);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DiscoveredAPIServiceManagedAPIsDTO {\n");
+    
+    sb.append("    apimApiId: ").append(toIndentedString(apimApiId)).append("\n");
+    sb.append("    apimApiName: ").append(toIndentedString(apimApiName)).append("\n");
+    sb.append("    apimApiVersion: ").append(toIndentedString(apimApiVersion)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoveredAPITopClientsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoveredAPITopClientsDTO.java
@@ -1,0 +1,238 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class DiscoveredAPITopClientsDTO   {
+  
+    private String identity = null;
+
+    @XmlType(name="KindEnum")
+    @XmlEnum(String.class)
+    public enum KindEnum {
+        K8S("k8s"),
+        LEGACY("legacy");
+        private String value;
+
+        KindEnum (String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @JsonCreator
+        public static KindEnum fromValue(String v) {
+            for (KindEnum b : KindEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+return null;
+        }
+    }
+    private KindEnum kind = null;
+    private String namespace = null;
+    private String workload = null;
+    private String ip = null;
+    private Integer port = null;
+    private Long observations = null;
+
+  /**
+   * Stable identity. \&quot;k8s:&lt;namespace&gt;/&lt;workload&gt;\&quot; for K8s pods or \&quot;host:&lt;ip&gt;\&quot; for legacy hosts.
+   **/
+  public DiscoveredAPITopClientsDTO identity(String identity) {
+    this.identity = identity;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Stable identity. \"k8s:<namespace>/<workload>\" for K8s pods or \"host:<ip>\" for legacy hosts.")
+  @JsonProperty("identity")
+  public String getIdentity() {
+    return identity;
+  }
+  public void setIdentity(String identity) {
+    this.identity = identity;
+  }
+
+  /**
+   **/
+  public DiscoveredAPITopClientsDTO kind(KindEnum kind) {
+    this.kind = kind;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("kind")
+  public KindEnum getKind() {
+    return kind;
+  }
+  public void setKind(KindEnum kind) {
+    this.kind = kind;
+  }
+
+  /**
+   * K8s namespace (only when kind &#x3D; k8s).
+   **/
+  public DiscoveredAPITopClientsDTO namespace(String namespace) {
+    this.namespace = namespace;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "K8s namespace (only when kind = k8s).")
+  @JsonProperty("namespace")
+  public String getNamespace() {
+    return namespace;
+  }
+  public void setNamespace(String namespace) {
+    this.namespace = namespace;
+  }
+
+  /**
+   * K8s workload name (only when kind &#x3D; k8s).
+   **/
+  public DiscoveredAPITopClientsDTO workload(String workload) {
+    this.workload = workload;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "K8s workload name (only when kind = k8s).")
+  @JsonProperty("workload")
+  public String getWorkload() {
+    return workload;
+  }
+  public void setWorkload(String workload) {
+    this.workload = workload;
+  }
+
+  /**
+   * Caller IP address.
+   **/
+  public DiscoveredAPITopClientsDTO ip(String ip) {
+    this.ip = ip;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Caller IP address.")
+  @JsonProperty("ip")
+  public String getIp() {
+    return ip;
+  }
+  public void setIp(String ip) {
+    this.ip = ip;
+  }
+
+  /**
+   * Sample source port. Source ports rotate per connection so this is illustrative only.
+   **/
+  public DiscoveredAPITopClientsDTO port(Integer port) {
+    this.port = port;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Sample source port. Source ports rotate per connection so this is illustrative only.")
+  @JsonProperty("port")
+  public Integer getPort() {
+    return port;
+  }
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  /**
+   * Observation count for this caller in the latest cycle window.
+   **/
+  public DiscoveredAPITopClientsDTO observations(Long observations) {
+    this.observations = observations;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Observation count for this caller in the latest cycle window.")
+  @JsonProperty("observations")
+  public Long getObservations() {
+    return observations;
+  }
+  public void setObservations(Long observations) {
+    this.observations = observations;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DiscoveredAPITopClientsDTO discoveredAPITopClients = (DiscoveredAPITopClientsDTO) o;
+    return Objects.equals(identity, discoveredAPITopClients.identity) &&
+        Objects.equals(kind, discoveredAPITopClients.kind) &&
+        Objects.equals(namespace, discoveredAPITopClients.namespace) &&
+        Objects.equals(workload, discoveredAPITopClients.workload) &&
+        Objects.equals(ip, discoveredAPITopClients.ip) &&
+        Objects.equals(port, discoveredAPITopClients.port) &&
+        Objects.equals(observations, discoveredAPITopClients.observations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(identity, kind, namespace, workload, ip, port, observations);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DiscoveredAPITopClientsDTO {\n");
+    
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
+    sb.append("    kind: ").append(toIndentedString(kind)).append("\n");
+    sb.append("    namespace: ").append(toIndentedString(namespace)).append("\n");
+    sb.append("    workload: ").append(toIndentedString(workload)).append("\n");
+    sb.append("    ip: ").append(toIndentedString(ip)).append("\n");
+    sb.append("    port: ").append(toIndentedString(port)).append("\n");
+    sb.append("    observations: ").append(toIndentedString(observations)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoverySummaryByReachabilityDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoverySummaryByReachabilityDTO.java
@@ -1,0 +1,101 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class DiscoverySummaryByReachabilityDTO   {
+  
+    private Integer external = null;
+    private Integer internal = null;
+
+  /**
+   **/
+  public DiscoverySummaryByReachabilityDTO external(Integer external) {
+    this.external = external;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("external")
+  public Integer getExternal() {
+    return external;
+  }
+  public void setExternal(Integer external) {
+    this.external = external;
+  }
+
+  /**
+   **/
+  public DiscoverySummaryByReachabilityDTO internal(Integer internal) {
+    this.internal = internal;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("internal")
+  public Integer getInternal() {
+    return internal;
+  }
+  public void setInternal(Integer internal) {
+    this.internal = internal;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DiscoverySummaryByReachabilityDTO discoverySummaryByReachability = (DiscoverySummaryByReachabilityDTO) o;
+    return Objects.equals(external, discoverySummaryByReachability.external) &&
+        Objects.equals(internal, discoverySummaryByReachability.internal);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(external, internal);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DiscoverySummaryByReachabilityDTO {\n");
+    
+    sb.append("    external: ").append(toIndentedString(external)).append("\n");
+    sb.append("    internal: ").append(toIndentedString(internal)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoverySummaryByServiceDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoverySummaryByServiceDTO.java
@@ -1,0 +1,141 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class DiscoverySummaryByServiceDTO   {
+  
+    private String serviceIdentity = null;
+    private Boolean fullyGoverned = null;
+    private Integer shadow = null;
+    private Integer drift = null;
+
+  /**
+   **/
+  public DiscoverySummaryByServiceDTO serviceIdentity(String serviceIdentity) {
+    this.serviceIdentity = serviceIdentity;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("serviceIdentity")
+  public String getServiceIdentity() {
+    return serviceIdentity;
+  }
+  public void setServiceIdentity(String serviceIdentity) {
+    this.serviceIdentity = serviceIdentity;
+  }
+
+  /**
+   **/
+  public DiscoverySummaryByServiceDTO fullyGoverned(Boolean fullyGoverned) {
+    this.fullyGoverned = fullyGoverned;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("fullyGoverned")
+  public Boolean isFullyGoverned() {
+    return fullyGoverned;
+  }
+  public void setFullyGoverned(Boolean fullyGoverned) {
+    this.fullyGoverned = fullyGoverned;
+  }
+
+  /**
+   **/
+  public DiscoverySummaryByServiceDTO shadow(Integer shadow) {
+    this.shadow = shadow;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("shadow")
+  public Integer getShadow() {
+    return shadow;
+  }
+  public void setShadow(Integer shadow) {
+    this.shadow = shadow;
+  }
+
+  /**
+   **/
+  public DiscoverySummaryByServiceDTO drift(Integer drift) {
+    this.drift = drift;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("drift")
+  public Integer getDrift() {
+    return drift;
+  }
+  public void setDrift(Integer drift) {
+    this.drift = drift;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DiscoverySummaryByServiceDTO discoverySummaryByService = (DiscoverySummaryByServiceDTO) o;
+    return Objects.equals(serviceIdentity, discoverySummaryByService.serviceIdentity) &&
+        Objects.equals(fullyGoverned, discoverySummaryByService.fullyGoverned) &&
+        Objects.equals(shadow, discoverySummaryByService.shadow) &&
+        Objects.equals(drift, discoverySummaryByService.drift);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(serviceIdentity, fullyGoverned, shadow, drift);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DiscoverySummaryByServiceDTO {\n");
+    
+    sb.append("    serviceIdentity: ").append(toIndentedString(serviceIdentity)).append("\n");
+    sb.append("    fullyGoverned: ").append(toIndentedString(fullyGoverned)).append("\n");
+    sb.append("    shadow: ").append(toIndentedString(shadow)).append("\n");
+    sb.append("    drift: ").append(toIndentedString(drift)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoverySummaryByTypeDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoverySummaryByTypeDTO.java
@@ -1,0 +1,101 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class DiscoverySummaryByTypeDTO   {
+  
+    private Integer shadow = null;
+    private Integer drift = null;
+
+  /**
+   **/
+  public DiscoverySummaryByTypeDTO shadow(Integer shadow) {
+    this.shadow = shadow;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("shadow")
+  public Integer getShadow() {
+    return shadow;
+  }
+  public void setShadow(Integer shadow) {
+    this.shadow = shadow;
+  }
+
+  /**
+   **/
+  public DiscoverySummaryByTypeDTO drift(Integer drift) {
+    this.drift = drift;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("drift")
+  public Integer getDrift() {
+    return drift;
+  }
+  public void setDrift(Integer drift) {
+    this.drift = drift;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DiscoverySummaryByTypeDTO discoverySummaryByType = (DiscoverySummaryByTypeDTO) o;
+    return Objects.equals(shadow, discoverySummaryByType.shadow) &&
+        Objects.equals(drift, discoverySummaryByType.drift);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(shadow, drift);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DiscoverySummaryByTypeDTO {\n");
+    
+    sb.append("    shadow: ").append(toIndentedString(shadow)).append("\n");
+    sb.append("    drift: ").append(toIndentedString(drift)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoverySummaryDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/DiscoverySummaryDTO.java
@@ -1,0 +1,209 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryByReachabilityDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryByServiceDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryByTypeDTO;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class DiscoverySummaryDTO   {
+  
+    private Integer total = null;
+    private Integer managed = null;
+    private Integer unmanaged = null;
+    private Boolean skipInternal = null;
+    private DiscoverySummaryByTypeDTO byType = null;
+    private DiscoverySummaryByReachabilityDTO byReachability = null;
+    private List<DiscoverySummaryByServiceDTO> byService = new ArrayList<DiscoverySummaryByServiceDTO>();
+
+  /**
+   **/
+  public DiscoverySummaryDTO total(Integer total) {
+    this.total = total;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("total")
+  public Integer getTotal() {
+    return total;
+  }
+  public void setTotal(Integer total) {
+    this.total = total;
+  }
+
+  /**
+   **/
+  public DiscoverySummaryDTO managed(Integer managed) {
+    this.managed = managed;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("managed")
+  public Integer getManaged() {
+    return managed;
+  }
+  public void setManaged(Integer managed) {
+    this.managed = managed;
+  }
+
+  /**
+   **/
+  public DiscoverySummaryDTO unmanaged(Integer unmanaged) {
+    this.unmanaged = unmanaged;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("unmanaged")
+  public Integer getUnmanaged() {
+    return unmanaged;
+  }
+  public void setUnmanaged(Integer unmanaged) {
+    this.unmanaged = unmanaged;
+  }
+
+  /**
+   **/
+  public DiscoverySummaryDTO skipInternal(Boolean skipInternal) {
+    this.skipInternal = skipInternal;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("skipInternal")
+  public Boolean isSkipInternal() {
+    return skipInternal;
+  }
+  public void setSkipInternal(Boolean skipInternal) {
+    this.skipInternal = skipInternal;
+  }
+
+  /**
+   **/
+  public DiscoverySummaryDTO byType(DiscoverySummaryByTypeDTO byType) {
+    this.byType = byType;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("byType")
+  public DiscoverySummaryByTypeDTO getByType() {
+    return byType;
+  }
+  public void setByType(DiscoverySummaryByTypeDTO byType) {
+    this.byType = byType;
+  }
+
+  /**
+   **/
+  public DiscoverySummaryDTO byReachability(DiscoverySummaryByReachabilityDTO byReachability) {
+    this.byReachability = byReachability;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("byReachability")
+  public DiscoverySummaryByReachabilityDTO getByReachability() {
+    return byReachability;
+  }
+  public void setByReachability(DiscoverySummaryByReachabilityDTO byReachability) {
+    this.byReachability = byReachability;
+  }
+
+  /**
+   **/
+  public DiscoverySummaryDTO byService(List<DiscoverySummaryByServiceDTO> byService) {
+    this.byService = byService;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("byService")
+  public List<DiscoverySummaryByServiceDTO> getByService() {
+    return byService;
+  }
+  public void setByService(List<DiscoverySummaryByServiceDTO> byService) {
+    this.byService = byService;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DiscoverySummaryDTO discoverySummary = (DiscoverySummaryDTO) o;
+    return Objects.equals(total, discoverySummary.total) &&
+        Objects.equals(managed, discoverySummary.managed) &&
+        Objects.equals(unmanaged, discoverySummary.unmanaged) &&
+        Objects.equals(skipInternal, discoverySummary.skipInternal) &&
+        Objects.equals(byType, discoverySummary.byType) &&
+        Objects.equals(byReachability, discoverySummary.byReachability) &&
+        Objects.equals(byService, discoverySummary.byService);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(total, managed, unmanaged, skipInternal, byType, byReachability, byService);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DiscoverySummaryDTO {\n");
+    
+    sb.append("    total: ").append(toIndentedString(total)).append("\n");
+    sb.append("    managed: ").append(toIndentedString(managed)).append("\n");
+    sb.append("    unmanaged: ").append(toIndentedString(unmanaged)).append("\n");
+    sb.append("    skipInternal: ").append(toIndentedString(skipInternal)).append("\n");
+    sb.append("    byType: ").append(toIndentedString(byType)).append("\n");
+    sb.append("    byReachability: ").append(toIndentedString(byReachability)).append("\n");
+    sb.append("    byService: ").append(toIndentedString(byService)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/SettingsDTO.java
@@ -32,6 +32,7 @@ public class SettingsDTO   {
     private List<SettingsGatewayConfigurationDTO> gatewayConfiguration = new ArrayList<SettingsGatewayConfigurationDTO>();
     private Boolean analyticsEnabled = null;
     private Boolean transactionCounterEnable = null;
+    private Boolean discoveryEnabled = false;
     private Boolean isGatewayNotificationEnabled = false;
     private List<String> platformGatewayVersions = new ArrayList<String>();
     private Boolean consumptionExportEnabled = null;
@@ -178,6 +179,24 @@ public class SettingsDTO   {
   }
 
   /**
+   * To determine whether the API Discovery integration is enabled (controls visibility of the Unmanaged APIs tab)
+   **/
+  public SettingsDTO discoveryEnabled(Boolean discoveryEnabled) {
+    this.discoveryEnabled = discoveryEnabled;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "false", value = "To determine whether the API Discovery integration is enabled (controls visibility of the Unmanaged APIs tab)")
+  @JsonProperty("discoveryEnabled")
+  public Boolean isDiscoveryEnabled() {
+    return discoveryEnabled;
+  }
+  public void setDiscoveryEnabled(Boolean discoveryEnabled) {
+    this.discoveryEnabled = discoveryEnabled;
+  }
+
+  /**
    * Is Gateway Notification Enabled
    **/
   public SettingsDTO isGatewayNotificationEnabled(Boolean isGatewayNotificationEnabled) {
@@ -249,6 +268,7 @@ public class SettingsDTO   {
         Objects.equals(gatewayConfiguration, settings.gatewayConfiguration) &&
         Objects.equals(analyticsEnabled, settings.analyticsEnabled) &&
         Objects.equals(transactionCounterEnable, settings.transactionCounterEnable) &&
+        Objects.equals(discoveryEnabled, settings.discoveryEnabled) &&
         Objects.equals(isGatewayNotificationEnabled, settings.isGatewayNotificationEnabled) &&
         Objects.equals(platformGatewayVersions, settings.platformGatewayVersions) &&
         Objects.equals(consumptionExportEnabled, settings.consumptionExportEnabled);
@@ -256,7 +276,7 @@ public class SettingsDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(scopes, gatewayTypes, isJWTEnabledForLoginTokens, orgAccessControlEnabled, keyManagerConfiguration, gatewayConfiguration, analyticsEnabled, transactionCounterEnable, isGatewayNotificationEnabled, platformGatewayVersions, consumptionExportEnabled);
+    return Objects.hash(scopes, gatewayTypes, isJWTEnabledForLoginTokens, orgAccessControlEnabled, keyManagerConfiguration, gatewayConfiguration, analyticsEnabled, transactionCounterEnable, discoveryEnabled, isGatewayNotificationEnabled, platformGatewayVersions, consumptionExportEnabled);
   }
 
   @Override
@@ -272,6 +292,7 @@ public class SettingsDTO   {
     sb.append("    gatewayConfiguration: ").append(toIndentedString(gatewayConfiguration)).append("\n");
     sb.append("    analyticsEnabled: ").append(toIndentedString(analyticsEnabled)).append("\n");
     sb.append("    transactionCounterEnable: ").append(toIndentedString(transactionCounterEnable)).append("\n");
+    sb.append("    discoveryEnabled: ").append(toIndentedString(discoveryEnabled)).append("\n");
     sb.append("    isGatewayNotificationEnabled: ").append(toIndentedString(isGatewayNotificationEnabled)).append("\n");
     sb.append("    platformGatewayVersions: ").append(toIndentedString(platformGatewayVersions)).append("\n");
     sb.append("    consumptionExportEnabled: ").append(toIndentedString(consumptionExportEnabled)).append("\n");

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/UntraffickedAPIDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/UntraffickedAPIDTO.java
@@ -1,0 +1,201 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class UntraffickedAPIDTO   {
+  
+    private String apimApiId = null;
+    private String apimApiName = null;
+    private String apimApiVersion = null;
+    private String method = null;
+    private String gatewayPath = null;
+    private String serviceIdentity = null;
+    private String lastSyncedAt = null;
+
+  /**
+   **/
+  public UntraffickedAPIDTO apimApiId(String apimApiId) {
+    this.apimApiId = apimApiId;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("apimApiId")
+  public String getApimApiId() {
+    return apimApiId;
+  }
+  public void setApimApiId(String apimApiId) {
+    this.apimApiId = apimApiId;
+  }
+
+  /**
+   **/
+  public UntraffickedAPIDTO apimApiName(String apimApiName) {
+    this.apimApiName = apimApiName;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("apimApiName")
+  public String getApimApiName() {
+    return apimApiName;
+  }
+  public void setApimApiName(String apimApiName) {
+    this.apimApiName = apimApiName;
+  }
+
+  /**
+   **/
+  public UntraffickedAPIDTO apimApiVersion(String apimApiVersion) {
+    this.apimApiVersion = apimApiVersion;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("apimApiVersion")
+  public String getApimApiVersion() {
+    return apimApiVersion;
+  }
+  public void setApimApiVersion(String apimApiVersion) {
+    this.apimApiVersion = apimApiVersion;
+  }
+
+  /**
+   **/
+  public UntraffickedAPIDTO method(String method) {
+    this.method = method;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("method")
+  public String getMethod() {
+    return method;
+  }
+  public void setMethod(String method) {
+    this.method = method;
+  }
+
+  /**
+   **/
+  public UntraffickedAPIDTO gatewayPath(String gatewayPath) {
+    this.gatewayPath = gatewayPath;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("gatewayPath")
+  public String getGatewayPath() {
+    return gatewayPath;
+  }
+  public void setGatewayPath(String gatewayPath) {
+    this.gatewayPath = gatewayPath;
+  }
+
+  /**
+   **/
+  public UntraffickedAPIDTO serviceIdentity(String serviceIdentity) {
+    this.serviceIdentity = serviceIdentity;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("serviceIdentity")
+  public String getServiceIdentity() {
+    return serviceIdentity;
+  }
+  public void setServiceIdentity(String serviceIdentity) {
+    this.serviceIdentity = serviceIdentity;
+  }
+
+  /**
+   **/
+  public UntraffickedAPIDTO lastSyncedAt(String lastSyncedAt) {
+    this.lastSyncedAt = lastSyncedAt;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("lastSyncedAt")
+  public String getLastSyncedAt() {
+    return lastSyncedAt;
+  }
+  public void setLastSyncedAt(String lastSyncedAt) {
+    this.lastSyncedAt = lastSyncedAt;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UntraffickedAPIDTO untraffickedAPI = (UntraffickedAPIDTO) o;
+    return Objects.equals(apimApiId, untraffickedAPI.apimApiId) &&
+        Objects.equals(apimApiName, untraffickedAPI.apimApiName) &&
+        Objects.equals(apimApiVersion, untraffickedAPI.apimApiVersion) &&
+        Objects.equals(method, untraffickedAPI.method) &&
+        Objects.equals(gatewayPath, untraffickedAPI.gatewayPath) &&
+        Objects.equals(serviceIdentity, untraffickedAPI.serviceIdentity) &&
+        Objects.equals(lastSyncedAt, untraffickedAPI.lastSyncedAt);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(apimApiId, apimApiName, apimApiVersion, method, gatewayPath, serviceIdentity, lastSyncedAt);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class UntraffickedAPIDTO {\n");
+    
+    sb.append("    apimApiId: ").append(toIndentedString(apimApiId)).append("\n");
+    sb.append("    apimApiName: ").append(toIndentedString(apimApiName)).append("\n");
+    sb.append("    apimApiVersion: ").append(toIndentedString(apimApiVersion)).append("\n");
+    sb.append("    method: ").append(toIndentedString(method)).append("\n");
+    sb.append("    gatewayPath: ").append(toIndentedString(gatewayPath)).append("\n");
+    sb.append("    serviceIdentity: ").append(toIndentedString(serviceIdentity)).append("\n");
+    sb.append("    lastSyncedAt: ").append(toIndentedString(lastSyncedAt)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/UntraffickedListDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/gen/java/org/wso2/carbon/apimgt/rest/api/admin/v1/dto/UntraffickedListDTO.java
@@ -1,0 +1,105 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.UntraffickedAPIDTO;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
+
+
+public class UntraffickedListDTO   {
+  
+    private Integer count = null;
+    private List<UntraffickedAPIDTO> list = new ArrayList<UntraffickedAPIDTO>();
+
+  /**
+   **/
+  public UntraffickedListDTO count(Integer count) {
+    this.count = count;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("count")
+  public Integer getCount() {
+    return count;
+  }
+  public void setCount(Integer count) {
+    this.count = count;
+  }
+
+  /**
+   **/
+  public UntraffickedListDTO list(List<UntraffickedAPIDTO> list) {
+    this.list = list;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+      @Valid
+  @JsonProperty("list")
+  public List<UntraffickedAPIDTO> getList() {
+    return list;
+  }
+  public void setList(List<UntraffickedAPIDTO> list) {
+    this.list = list;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UntraffickedListDTO untraffickedList = (UntraffickedListDTO) o;
+    return Objects.equals(count, untraffickedList.count) &&
+        Objects.equals(list, untraffickedList.list);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(count, list);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class UntraffickedListDTO {\n");
+    
+    sb.append("    count: ").append(toIndentedString(count)).append("\n");
+    sb.append("    list: ").append(toIndentedString(list)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GovernanceApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GovernanceApiServiceImpl.java
@@ -1,0 +1,87 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.impl;
+
+import org.apache.cxf.jaxrs.ext.MessageContext;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.GovernanceApiService;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIListDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.UntraffickedListDTO;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Implementation of the Unmanaged APIs (Governance / API Discovery) admin
+ * REST resource.
+ *
+ * <p>This is a Round 7 scaffold that returns empty payloads so the build
+ * passes and the auto-generated JAX-RS interface is satisfied. Round 8
+ * replaces these stubs with real proxying to the API Discovery Server
+ * (see claude/specs/phase4_admin_portal.md §4.1).</p>
+ *
+ * @since 4.7.0
+ */
+public class GovernanceApiServiceImpl implements GovernanceApiService {
+
+    /**
+     * GET /governance/discovery/summary — aggregate counts of unmanaged APIs.
+     *
+     * @param messageContext CXF message context
+     * @return 200 with an empty DiscoverySummaryDTO (Round 7 stub)
+     * @throws APIManagementException never in this stub
+     */
+    public final Response getDiscoverySummary(
+            final MessageContext messageContext) throws APIManagementException {
+        return Response.ok().entity(new DiscoverySummaryDTO()).build();
+    }
+
+    /**
+     * GET /governance/discovery/apis — paginated list of unmanaged APIs.
+     *
+     * @param classification optional classification filter (shadow|drift)
+     * @param service        optional service_identity filter
+     * @param internal       optional internal-only flag
+     * @param limit          pagination limit
+     * @param offset         pagination offset
+     * @param messageContext CXF message context
+     * @return 200 with an empty DiscoveredAPIListDTO (Round 7 stub)
+     * @throws APIManagementException never in this stub
+     */
+    public final Response getDiscoveredAPIs(final String classification,
+                                            final String service,
+                                            final String internal,
+                                            final Integer limit,
+                                            final Integer offset,
+                                            final MessageContext messageContext)
+            throws APIManagementException {
+        return Response.ok().entity(new DiscoveredAPIListDTO()).build();
+    }
+
+    /**
+     * GET /governance/discovery/apis/{discoveredApiId} — detail.
+     *
+     * @param discoveredApiId discovered API id
+     * @param messageContext  CXF message context
+     * @return 200 with a placeholder body (Round 7 stub)
+     * @throws APIManagementException never in this stub
+     */
+    public final Response getDiscoveredAPIById(
+            final String discoveredApiId,
+            final MessageContext messageContext) throws APIManagementException {
+        // Round 8 will load the row from the discovery server and return
+        // a populated DiscoveredAPIDTO; for now an empty 200 keeps the
+        // contract green.
+        return Response.ok().build();
+    }
+
+    /**
+     * GET /governance/discovery/untrafficked — managed APIs with no traffic.
+     *
+     * @param messageContext CXF message context
+     * @return 200 with an empty UntraffickedListDTO (Round 7 stub)
+     * @throws APIManagementException never in this stub
+     */
+    public final Response getUntrafficked(
+            final MessageContext messageContext) throws APIManagementException {
+        return Response.ok().entity(new UntraffickedListDTO()).build();
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GovernanceApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GovernanceApiServiceImpl.java
@@ -1,87 +1,209 @@
 package org.wso2.carbon.apimgt.rest.api.admin.v1.impl;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.GovernanceApiService;
-import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIListDTO;
-import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryDTO;
-import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.UntraffickedListDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryApiServerClient;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryDetailWire;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryListFilter;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryListWire;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoverySummaryWire;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.UntraffickedListWire;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.utils.mappings.DiscoveryMappingUtil;
+import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
 import javax.ws.rs.core.Response;
+import java.util.List;
 
 /**
  * Implementation of the Unmanaged APIs (Governance / API Discovery) admin
- * REST resource.
+ * REST resource. Proxies the API Discovery Server (separate process) and
+ * translates wire payloads into the auto-generated REST DTOs.
  *
- * <p>This is a Round 7 scaffold that returns empty payloads so the build
- * passes and the auto-generated JAX-RS interface is satisfied. Round 8
- * replaces these stubs with real proxying to the API Discovery Server
- * (see claude/specs/phase4_admin_portal.md §4.1).</p>
+ * <p>This is a thin pass-through: it does not store state, transform data
+ * semantically, or enforce business rules beyond what the daemon already
+ * does. It validates scopes (via the OpenAPI spec's security: block) and
+ * forwards the user's bearer token to the daemon, which introspects it
+ * back against APIM.</p>
  *
  * @since 4.7.0
  */
 public class GovernanceApiServiceImpl implements GovernanceApiService {
 
-    /**
-     * GET /governance/discovery/summary — aggregate counts of unmanaged APIs.
-     *
-     * @param messageContext CXF message context
-     * @return 200 with an empty DiscoverySummaryDTO (Round 7 stub)
-     * @throws APIManagementException never in this stub
-     */
-    public final Response getDiscoverySummary(
-            final MessageContext messageContext) throws APIManagementException {
-        return Response.ok().entity(new DiscoverySummaryDTO()).build();
+    /** Class-level logger. */
+    private static final Log LOG =
+            LogFactory.getLog(GovernanceApiServiceImpl.class);
+
+    /** Default page size applied when the caller passes a null limit. */
+    private static final int DEFAULT_PAGE_LIMIT = 25;
+
+    /** Default offset applied when the caller passes a null offset. */
+    private static final int DEFAULT_PAGE_OFFSET = 0;
+
+    /** HTTP client to the API Discovery Server. */
+    private final DiscoveryApiServerClient client;
+
+    /** Production constructor — wires the singleton client. */
+    public GovernanceApiServiceImpl() {
+        this.client = DiscoveryApiServerClient.getInstance();
     }
 
     /**
-     * GET /governance/discovery/apis — paginated list of unmanaged APIs.
+     * Test seam — inject a mock client.
      *
-     * @param classification optional classification filter (shadow|drift)
+     * @param mockClient pre-built (typically mocked) discovery client
+     */
+    GovernanceApiServiceImpl(final DiscoveryApiServerClient mockClient) {
+        this.client = mockClient;
+    }
+
+    /**
+     * GET /governance/discovery/summary.
+     *
+     * @param messageContext CXF message context
+     * @return 200 with DiscoverySummaryDTO, or RestApiUtil-mapped error
+     * @throws APIManagementException if the daemon is unreachable
+     */
+    public final Response getDiscoverySummary(
+            final MessageContext messageContext) throws APIManagementException {
+        try {
+            final String bearer = extractBearer(messageContext);
+            final DiscoverySummaryWire wire = client.getSummary(bearer);
+            return Response.ok()
+                    .entity(DiscoveryMappingUtil.fromWireSummary(wire)).build();
+        } catch (DiscoveryApiServerClient.UnavailableException e) {
+            RestApiUtil.handleInternalServerError(
+                    "API Discovery Server unavailable while fetching summary",
+                    e, LOG);
+            return null;
+        }
+    }
+
+    /**
+     * GET /governance/discovery/apis.
+     *
+     * @param classification optional classification filter
      * @param service        optional service_identity filter
      * @param internal       optional internal-only flag
      * @param limit          pagination limit
      * @param offset         pagination offset
      * @param messageContext CXF message context
-     * @return 200 with an empty DiscoveredAPIListDTO (Round 7 stub)
-     * @throws APIManagementException never in this stub
+     * @return 200 with DiscoveredAPIListDTO, or RestApiUtil-mapped error
+     * @throws APIManagementException if the daemon is unreachable
      */
     public final Response getDiscoveredAPIs(final String classification,
-                                            final String service,
-                                            final String internal,
-                                            final Integer limit,
-                                            final Integer offset,
-                                            final MessageContext messageContext)
+                                      final String service,
+                                      final String internal,
+                                      final Integer limit,
+                                      final Integer offset,
+                                      final MessageContext messageContext)
             throws APIManagementException {
-        return Response.ok().entity(new DiscoveredAPIListDTO()).build();
+        try {
+            final String bearer = extractBearer(messageContext);
+            final int pageLimit;
+            if (limit == null) {
+                pageLimit = DEFAULT_PAGE_LIMIT;
+            } else {
+                pageLimit = limit;
+            }
+            final int pageOffset;
+            if (offset == null) {
+                pageOffset = DEFAULT_PAGE_OFFSET;
+            } else {
+                pageOffset = offset;
+            }
+            final DiscoveryListFilter f = new DiscoveryListFilter()
+                    .classification(classification)
+                    .service(service)
+                    .internal(internal)
+                    .pagination(pageLimit, pageOffset);
+            final DiscoveryListWire wire = client.listApis(bearer, f);
+            return Response.ok()
+                    .entity(DiscoveryMappingUtil.fromWireList(wire)).build();
+        } catch (DiscoveryApiServerClient.UnavailableException e) {
+            RestApiUtil.handleInternalServerError(
+                    "API Discovery Server unavailable while listing discovered APIs",
+                    e, LOG);
+            return null;
+        }
     }
 
     /**
-     * GET /governance/discovery/apis/{discoveredApiId} — detail.
+     * GET /governance/discovery/apis/{discoveredApiId}.
      *
      * @param discoveredApiId discovered API id
      * @param messageContext  CXF message context
-     * @return 200 with a placeholder body (Round 7 stub)
-     * @throws APIManagementException never in this stub
+     * @return 200 with DiscoveredAPIDTO, 404 if not found, 500 on
+     *         daemon failure
+     * @throws APIManagementException if the daemon is unreachable
      */
     public final Response getDiscoveredAPIById(
             final String discoveredApiId,
             final MessageContext messageContext) throws APIManagementException {
-        // Round 8 will load the row from the discovery server and return
-        // a populated DiscoveredAPIDTO; for now an empty 200 keeps the
-        // contract green.
-        return Response.ok().build();
+        try {
+            final String bearer = extractBearer(messageContext);
+            final DiscoveryDetailWire wire = client.getApiById(bearer, discoveredApiId);
+            return Response.ok()
+                    .entity(DiscoveryMappingUtil.fromWireDetail(wire)).build();
+        } catch (DiscoveryApiServerClient.NotFoundException e) {
+            RestApiUtil.handleResourceNotFoundError(
+                    "Discovered API", discoveredApiId, e, LOG);
+            return null;
+        } catch (DiscoveryApiServerClient.UnavailableException e) {
+            RestApiUtil.handleInternalServerError(
+                    "API Discovery Server unavailable while fetching API detail",
+                    e, LOG);
+            return null;
+        }
     }
 
     /**
-     * GET /governance/discovery/untrafficked — managed APIs with no traffic.
+     * GET /governance/discovery/untrafficked.
      *
      * @param messageContext CXF message context
-     * @return 200 with an empty UntraffickedListDTO (Round 7 stub)
-     * @throws APIManagementException never in this stub
+     * @return 200 with UntraffickedListDTO, or RestApiUtil-mapped error
+     * @throws APIManagementException if the daemon is unreachable
      */
     public final Response getUntrafficked(
             final MessageContext messageContext) throws APIManagementException {
-        return Response.ok().entity(new UntraffickedListDTO()).build();
+        try {
+            final String bearer = extractBearer(messageContext);
+            final UntraffickedListWire wire = client.listUntrafficked(bearer);
+            return Response.ok()
+                    .entity(DiscoveryMappingUtil.fromWireUntrafficked(wire))
+                    .build();
+        } catch (DiscoveryApiServerClient.UnavailableException e) {
+            RestApiUtil.handleInternalServerError(
+                    "API Discovery Server unavailable while listing untrafficked APIs",
+                    e, LOG);
+            return null;
+        }
+    }
+
+    /**
+     * Extracts the raw bearer token from the inbound Authorization header
+     * so we can forward it to the daemon. Returns "" if absent so the
+     * daemon's auth middleware will reject with 401 (the user reaches a
+     * normal error path rather than a server-side NPE).
+     *
+     * @param mc CXF message context
+     * @return raw bearer token, or "" if no Authorization header
+     */
+    private static String extractBearer(final MessageContext mc) {
+        if (mc == null || mc.getHttpHeaders() == null) {
+            return "";
+        }
+        final List<String> auths =
+                mc.getHttpHeaders().getRequestHeader("Authorization");
+        if (auths == null || auths.isEmpty()) {
+            return "";
+        }
+        final String header = auths.get(0);
+        if (header == null || !header.startsWith("Bearer ")) {
+            return "";
+        }
+        return header.substring("Bearer ".length()).trim();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SettingsApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/SettingsApiServiceImpl.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.apimgt.rest.api.admin.v1.SettingsApiService;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.SettingsDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryApiServerClient;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.utils.mappings.SettingsMappingUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 
@@ -53,6 +54,7 @@ public class SettingsApiServiceImpl implements SettingsApiService {
             SettingsMappingUtil settingsMappingUtil = new SettingsMappingUtil();
             SettingsDTO settingsDTO = settingsMappingUtil.fromSettingsToDTO(isUserAvailable);
             settingsDTO.setTransactionCounterEnable(APIUtil.getTransactionCounterEnable());
+            settingsDTO.setDiscoveryEnabled(DiscoveryApiServerClient.isEnabled());
             return Response.ok().entity(settingsDTO).build();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryApiServerClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryApiServerClient.java
@@ -1,0 +1,292 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.wso2.carbon.apimgt.impl.APIManagerConfiguration;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.utils.APIUtil;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * HTTP client for the API Discovery Server's REST surface
+ * ({@code /api/v1/governance/discovery/*}). Wraps Apache HttpClient and
+ * Jackson; no new dependencies beyond what the carbon-apimgt module
+ * already pulls in transitively.
+ *
+ * <p>Configuration keys (read via APIManagerConfiguration; provisioned by
+ * deployment.toml.j2's {@code [apim.governance.discovery]} block in
+ * product-apim):</p>
+ * <pre>
+ *   APIM.Governance.Discovery.Endpoint    https://ads.internal:8443
+ *   APIM.Governance.Discovery.TimeoutMs   5000   (default if unset)
+ * </pre>
+ *
+ * <p>Bearer token strategy: the BFF FORWARDS the user's incoming bearer
+ * token to the daemon. The daemon's auth middleware accepts either
+ * {@code apim:admin} or {@code apim:admin_discovery_view}; the user's
+ * APIM token already carries one of these by virtue of being authorized
+ * to hit this BFF. No service-account password grant needed.</p>
+ *
+ * @since 4.7.0
+ */
+// Not declared final so Mockito can mock the class in unit tests.
+public class DiscoveryApiServerClient {
+
+    private static final Log LOG = LogFactory.getLog(DiscoveryApiServerClient.class);
+
+    private static final String CFG_ENDPOINT     = "APIM.Governance.Discovery.Endpoint";
+    private static final String CFG_TIMEOUT_MS   = "APIM.Governance.Discovery.TimeoutMs";
+    private static final String DEFAULT_ENDPOINT = "https://localhost:8443";
+    private static final int    DEFAULT_TIMEOUT_MS = 5000;
+
+    private static final String PATH_SUMMARY      = "/api/v1/governance/discovery/summary";
+    private static final String PATH_LIST         = "/api/v1/governance/discovery/apis";
+    private static final String PATH_DETAIL_FMT   = "/api/v1/governance/discovery/apis/%s";
+    private static final String PATH_UNTRAFFICKED = "/api/v1/governance/discovery/untrafficked";
+
+    private static volatile DiscoveryApiServerClient instance;
+
+    private final ObjectMapper mapper;
+    private final String baseUrl;
+    private final int timeoutMs;
+
+    private DiscoveryApiServerClient(final String baseUrl, final int timeoutMs) {
+        this.baseUrl = baseUrl;
+        this.timeoutMs = timeoutMs;
+        this.mapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    /**
+     * Returns the singleton, lazy-constructed on first call from the
+     * APIManagerConfiguration values.
+     *
+     * @return shared client instance
+     */
+    public static DiscoveryApiServerClient getInstance() {
+        if (instance == null) {
+            synchronized (DiscoveryApiServerClient.class) {
+                if (instance == null) {
+                    instance = build();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Test seam — replaces the singleton with a hand-built instance.
+     * Production code calls {@link #getInstance()} only.
+     *
+     * @param mock a pre-built client; pass {@code null} to reset
+     */
+    public static void setInstanceForTesting(final DiscoveryApiServerClient mock) {
+        instance = mock;
+    }
+
+    private static DiscoveryApiServerClient build() {
+        final APIManagerConfiguration cfg = ServiceReferenceHolder.getInstance()
+                .getAPIManagerConfigurationService()
+                .getAPIManagerConfiguration();
+
+        String endpoint = cfg.getFirstProperty(CFG_ENDPOINT);
+        if (endpoint == null || endpoint.isEmpty()) {
+            endpoint = System.getProperty(CFG_ENDPOINT, DEFAULT_ENDPOINT);
+        }
+        if (endpoint.endsWith("/")) {
+            endpoint = endpoint.substring(0, endpoint.length() - 1);
+        }
+
+        int timeout = DEFAULT_TIMEOUT_MS;
+        final String timeoutStr = cfg.getFirstProperty(CFG_TIMEOUT_MS);
+        if (timeoutStr != null && !timeoutStr.isEmpty()) {
+            try {
+                timeout = Integer.parseInt(timeoutStr);
+            } catch (NumberFormatException e) {
+                LOG.warn(CFG_TIMEOUT_MS + " not an integer (" + timeoutStr
+                        + "), defaulting to " + DEFAULT_TIMEOUT_MS + "ms");
+            }
+        }
+        return new DiscoveryApiServerClient(endpoint, timeout);
+    }
+
+    /**
+     * GET /summary on the daemon and return the wire payload.
+     *
+     * @param bearerToken caller's bearer token, forwarded to the daemon
+     * @return parsed summary
+     * @throws UnavailableException on network / 5xx / parse failure
+     */
+    public DiscoverySummaryWire getSummary(final String bearerToken)
+            throws UnavailableException {
+        try {
+            final byte[] body = doGet(PATH_SUMMARY, bearerToken);
+            return parse(body, DiscoverySummaryWire.class);
+        } catch (NotFoundException e) {
+            // Defensive — /summary is collection-shaped and should never
+            // 404; surface as Unavailable so the BFF returns 500.
+            throw new UnavailableException("discovery summary not found", e);
+        }
+    }
+
+    /**
+     * GET /apis with optional filters and pagination.
+     *
+     * @param bearerToken caller's bearer token
+     * @param filter      query parameter bundle
+     * @return parsed list
+     * @throws UnavailableException on network / 5xx / parse failure
+     */
+    public DiscoveryListWire listApis(final String bearerToken,
+                                      final DiscoveryListFilter filter)
+            throws UnavailableException {
+        final String path = PATH_LIST + buildQuery(filter);
+        try {
+            final byte[] body = doGet(path, bearerToken);
+            return parse(body, DiscoveryListWire.class);
+        } catch (NotFoundException e) {
+            throw new UnavailableException("list endpoint returned 404", e);
+        }
+    }
+
+    /**
+     * GET /apis/{id}.
+     *
+     * @param bearerToken caller's bearer token
+     * @param id          discovered API id
+     * @return parsed detail
+     * @throws NotFoundException     when the daemon returns 404
+     * @throws UnavailableException  on network / other 5xx / parse failure
+     */
+    public DiscoveryDetailWire getApiById(final String bearerToken, final String id)
+            throws UnavailableException, NotFoundException {
+        final String path = String.format(PATH_DETAIL_FMT,
+                URLEncoder.encode(id, StandardCharsets.UTF_8));
+        final byte[] body = doGet(path, bearerToken);
+        return parse(body, DiscoveryDetailWire.class);
+    }
+
+    /**
+     * GET /untrafficked.
+     *
+     * @param bearerToken caller's bearer token
+     * @return parsed list
+     * @throws UnavailableException on network / 5xx / parse failure
+     */
+    public UntraffickedListWire listUntrafficked(final String bearerToken)
+            throws UnavailableException {
+        try {
+            final byte[] body = doGet(PATH_UNTRAFFICKED, bearerToken);
+            return parse(body, UntraffickedListWire.class);
+        } catch (NotFoundException e) {
+            throw new UnavailableException("untrafficked endpoint returned 404", e);
+        }
+    }
+
+    private byte[] doGet(final String path, final String bearerToken)
+            throws UnavailableException, NotFoundException {
+        final URI uri;
+        try {
+            uri = new URI(baseUrl + path);
+        } catch (URISyntaxException e) {
+            throw new UnavailableException("invalid discovery server URL: "
+                    + baseUrl + path, e);
+        }
+
+        final HttpResponse resp;
+        final byte[] body;
+        try (CloseableHttpClient http = (CloseableHttpClient)
+                APIUtil.getHttpClient(uri.getPort(), uri.getScheme())) {
+
+            final HttpGet req = new HttpGet(uri);
+            req.setHeader("Accept", "application/json");
+            if (bearerToken != null && !bearerToken.isEmpty()) {
+                req.setHeader("Authorization", "Bearer " + bearerToken);
+            }
+
+            resp = http.execute(req);
+            body = resp.getEntity() == null
+                    ? new byte[0]
+                    : EntityUtils.toByteArray(resp.getEntity());
+        } catch (Exception e) {
+            throw new UnavailableException("discovery server request failed: "
+                    + path, e);
+        }
+
+        final int status = resp.getStatusLine().getStatusCode();
+        if (status == HttpStatus.SC_NOT_FOUND) {
+            throw new NotFoundException("discovery server returned 404 for " + path);
+        }
+        if (status != HttpStatus.SC_OK) {
+            throw new UnavailableException("discovery server returned HTTP "
+                    + status + " for " + path);
+        }
+        return body;
+    }
+
+    private <T> T parse(final byte[] body, final Class<T> type)
+            throws UnavailableException {
+        try {
+            return mapper.readValue(body, type);
+        } catch (Exception e) {
+            throw new UnavailableException("failed to parse discovery server response", e);
+        }
+    }
+
+    private static String buildQuery(final DiscoveryListFilter f) {
+        if (f == null) {
+            return "";
+        }
+        final List<String> parts = new ArrayList<>();
+        if (f.getClassification() != null && !f.getClassification().isEmpty()) {
+            parts.add("classification=" + URLEncoder.encode(
+                    f.getClassification(), StandardCharsets.UTF_8));
+        }
+        if (f.getService() != null && !f.getService().isEmpty()) {
+            parts.add("service=" + URLEncoder.encode(
+                    f.getService(), StandardCharsets.UTF_8));
+        }
+        if (f.getInternal() != null && !f.getInternal().isEmpty()) {
+            parts.add("internal=" + URLEncoder.encode(
+                    f.getInternal(), StandardCharsets.UTF_8));
+        }
+        if (f.getLimit() > 0) {
+            parts.add("limit=" + f.getLimit());
+        }
+        if (f.getOffset() > 0) {
+            parts.add("offset=" + f.getOffset());
+        }
+        if (parts.isEmpty()) {
+            return "";
+        }
+        return "?" + String.join("&", parts);
+    }
+
+    /** Discovery server unreachable / 5xx / network / parse failure. */
+    public static final class UnavailableException extends Exception {
+        private static final long serialVersionUID = 1L;
+        public UnavailableException(final String message) { super(message); }
+        public UnavailableException(final String message, final Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    /** Discovery server returned 404 — the requested row doesn't exist. */
+    public static final class NotFoundException extends Exception {
+        private static final long serialVersionUID = 1L;
+        public NotFoundException(final String message) { super(message); }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryApiServerClient.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryApiServerClient.java
@@ -27,11 +27,20 @@ import java.util.List;
  * already pulls in transitively.
  *
  * <p>Configuration keys (read via APIManagerConfiguration; provisioned by
- * deployment.toml.j2's {@code [apim.governance.discovery]} block in
- * product-apim):</p>
+ * deployment.toml's {@code [apim.governance.discovery]} block, rendered
+ * into api-manager.xml's {@code <APIDiscovery>} element):</p>
  * <pre>
- *   APIM.Governance.Discovery.Endpoint    https://ads.internal:8443
- *   APIM.Governance.Discovery.TimeoutMs   5000   (default if unset)
+ *   APIDiscovery.Enabled    true | false (default: false)
+ *   APIDiscovery.Endpoint   https://ads.internal:8443
+ *   APIDiscovery.TimeoutMs  5000  (default if unset)
+ * </pre>
+ *
+ * <p>Operators enable the feature in {@code deployment.toml}:</p>
+ * <pre>
+ *   [apim.governance.discovery]
+ *   enabled    = true
+ *   endpoint   = "https://ads.internal:8443"
+ *   timeout_ms = 5000
  * </pre>
  *
  * <p>Bearer token strategy: the BFF FORWARDS the user's incoming bearer
@@ -47,8 +56,10 @@ public class DiscoveryApiServerClient {
 
     private static final Log LOG = LogFactory.getLog(DiscoveryApiServerClient.class);
 
-    private static final String CFG_ENDPOINT     = "APIM.Governance.Discovery.Endpoint";
-    private static final String CFG_TIMEOUT_MS   = "APIM.Governance.Discovery.TimeoutMs";
+    private static final String CFG_ENABLED      = "APIDiscovery.Enabled";
+    private static final String CFG_ENDPOINT     = "APIDiscovery.Endpoint";
+    private static final String CFG_TIMEOUT_MS   = "APIDiscovery.TimeoutMs";
+    private static final String CFG_VERIFY_SSL   = "APIDiscovery.VerifySSL";
     private static final String DEFAULT_ENDPOINT = "https://localhost:8443";
     private static final int    DEFAULT_TIMEOUT_MS = 5000;
 
@@ -97,6 +108,28 @@ public class DiscoveryApiServerClient {
         instance = mock;
     }
 
+    /**
+     * Whether the API Discovery integration is enabled. Sourced from
+     * the {@code <APIDiscovery><Enabled>} block in api-manager.xml,
+     * which is rendered from {@code [apim.governance.discovery] enabled}
+     * in deployment.toml. Defaults to {@code false} when the block is
+     * absent — the feature ships disabled.
+     *
+     * <p>The admin portal reads this through SettingsApiServiceImpl and
+     * hides the "Unmanaged APIs" tab when disabled.</p>
+     *
+     * @return true when the toml flag is set to "true"
+     */
+    public static boolean isEnabled() {
+        final APIManagerConfiguration cfg = ServiceReferenceHolder.getInstance()
+                .getAPIManagerConfigurationService()
+                .getAPIManagerConfiguration();
+        if (cfg == null) {
+            return false;
+        }
+        return Boolean.parseBoolean(cfg.getFirstProperty(CFG_ENABLED));
+    }
+
     private static DiscoveryApiServerClient build() {
         final APIManagerConfiguration cfg = ServiceReferenceHolder.getInstance()
                 .getAPIManagerConfigurationService()
@@ -104,7 +137,7 @@ public class DiscoveryApiServerClient {
 
         String endpoint = cfg.getFirstProperty(CFG_ENDPOINT);
         if (endpoint == null || endpoint.isEmpty()) {
-            endpoint = System.getProperty(CFG_ENDPOINT, DEFAULT_ENDPOINT);
+            endpoint = DEFAULT_ENDPOINT;
         }
         if (endpoint.endsWith("/")) {
             endpoint = endpoint.substring(0, endpoint.length() - 1);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryDetailWire.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryDetailWire.java
@@ -1,0 +1,157 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Wire format for the API Discovery Server's GET /apis/{id} response.
+ * Carries every field the Detail page renders.
+ *
+ * @since 4.7.0
+ */
+public class DiscoveryDetailWire {
+
+    @JsonProperty("id")                      private String id;
+    @JsonProperty("service_identity")        private String serviceIdentity;
+    @JsonProperty("env_kind")                private String envKind;
+    @JsonProperty("namespace")               private String namespace;
+    @JsonProperty("service_name")            private String serviceName;
+    @JsonProperty("sample_pod")              private String samplePod;
+    @JsonProperty("sample_workload")         private String sampleWorkload;
+    @JsonProperty("method")                  private String method;
+    @JsonProperty("normalized_path")         private String normalizedPath;
+    @JsonProperty("raw_path_samples")        private List<String> rawPathSamples;
+    @JsonProperty("classification")          private String classification;
+    @JsonProperty("is_internal")             private boolean isInternal;
+    @JsonProperty("first_seen_at")           private String firstSeenAt;
+    @JsonProperty("last_seen_at")            private String lastSeenAt;
+    @JsonProperty("observation_count")       private long observationCount;
+    @JsonProperty("distinct_client_count")   private int distinctClientCount;
+    @JsonProperty("distinct_clients_sample") private List<String> distinctClientsSample;
+    @JsonProperty("status_codes")            private List<Integer> statusCodes;
+    @JsonProperty("avg_duration_us")         private double avgDurationUs;
+    @JsonProperty("matched_apim_api_ids")    private List<String> matchedApimApiIds;
+    @JsonProperty("matched_apim_apis")       private List<APIRef> matchedApimAPIs;
+    @JsonProperty("service_managed_apis")    private List<APIRef> serviceManagedAPIs;
+
+    public String getId() { return id; }
+    public void setId(final String id) { this.id = id; }
+
+    public String getServiceIdentity() { return serviceIdentity; }
+    public void setServiceIdentity(final String s) { this.serviceIdentity = s; }
+
+    public String getEnvKind() { return envKind; }
+    public void setEnvKind(final String envKind) { this.envKind = envKind; }
+
+    public String getNamespace() { return namespace; }
+    public void setNamespace(final String namespace) { this.namespace = namespace; }
+
+    public String getServiceName() { return serviceName; }
+    public void setServiceName(final String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public String getSamplePod() { return samplePod; }
+    public void setSamplePod(final String samplePod) { this.samplePod = samplePod; }
+
+    public String getSampleWorkload() { return sampleWorkload; }
+    public void setSampleWorkload(final String sampleWorkload) {
+        this.sampleWorkload = sampleWorkload;
+    }
+
+    public String getMethod() { return method; }
+    public void setMethod(final String method) { this.method = method; }
+
+    public String getNormalizedPath() { return normalizedPath; }
+    public void setNormalizedPath(final String normalizedPath) {
+        this.normalizedPath = normalizedPath;
+    }
+
+    public List<String> getRawPathSamples() { return rawPathSamples; }
+    public void setRawPathSamples(final List<String> rawPathSamples) {
+        this.rawPathSamples = rawPathSamples;
+    }
+
+    public String getClassification() { return classification; }
+    public void setClassification(final String classification) {
+        this.classification = classification;
+    }
+
+    public boolean isInternal() { return isInternal; }
+    public void setInternal(final boolean isInternal) {
+        this.isInternal = isInternal;
+    }
+
+    public String getFirstSeenAt() { return firstSeenAt; }
+    public void setFirstSeenAt(final String firstSeenAt) {
+        this.firstSeenAt = firstSeenAt;
+    }
+
+    public String getLastSeenAt() { return lastSeenAt; }
+    public void setLastSeenAt(final String lastSeenAt) {
+        this.lastSeenAt = lastSeenAt;
+    }
+
+    public long getObservationCount() { return observationCount; }
+    public void setObservationCount(final long observationCount) {
+        this.observationCount = observationCount;
+    }
+
+    public int getDistinctClientCount() { return distinctClientCount; }
+    public void setDistinctClientCount(final int distinctClientCount) {
+        this.distinctClientCount = distinctClientCount;
+    }
+
+    public List<String> getDistinctClientsSample() { return distinctClientsSample; }
+    public void setDistinctClientsSample(final List<String> distinctClientsSample) {
+        this.distinctClientsSample = distinctClientsSample;
+    }
+
+    public List<Integer> getStatusCodes() { return statusCodes; }
+    public void setStatusCodes(final List<Integer> statusCodes) {
+        this.statusCodes = statusCodes;
+    }
+
+    public double getAvgDurationUs() { return avgDurationUs; }
+    public void setAvgDurationUs(final double avgDurationUs) {
+        this.avgDurationUs = avgDurationUs;
+    }
+
+    public List<String> getMatchedApimApiIds() { return matchedApimApiIds; }
+    public void setMatchedApimApiIds(final List<String> matchedApimApiIds) {
+        this.matchedApimApiIds = matchedApimApiIds;
+    }
+
+    public List<APIRef> getMatchedApimAPIs() { return matchedApimAPIs; }
+    public void setMatchedApimAPIs(final List<APIRef> matchedApimAPIs) {
+        this.matchedApimAPIs = matchedApimAPIs;
+    }
+
+    public List<APIRef> getServiceManagedAPIs() { return serviceManagedAPIs; }
+    public void setServiceManagedAPIs(final List<APIRef> serviceManagedAPIs) {
+        this.serviceManagedAPIs = serviceManagedAPIs;
+    }
+
+    /** Trimmed APIM-API reference embedded in the detail. */
+    public static class APIRef {
+        @JsonProperty("apim_api_id")      private String apimApiId;
+        @JsonProperty("apim_api_name")    private String apimApiName;
+        @JsonProperty("apim_api_version") private String apimApiVersion;
+
+        public String getApimApiId() { return apimApiId; }
+        public void setApimApiId(final String apimApiId) {
+            this.apimApiId = apimApiId;
+        }
+
+        public String getApimApiName() { return apimApiName; }
+        public void setApimApiName(final String apimApiName) {
+            this.apimApiName = apimApiName;
+        }
+
+        public String getApimApiVersion() { return apimApiVersion; }
+        public void setApimApiVersion(final String apimApiVersion) {
+            this.apimApiVersion = apimApiVersion;
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryDetailWire.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryDetailWire.java
@@ -34,6 +34,7 @@ public class DiscoveryDetailWire {
     @JsonProperty("matched_apim_api_ids")    private List<String> matchedApimApiIds;
     @JsonProperty("matched_apim_apis")       private List<APIRef> matchedApimAPIs;
     @JsonProperty("service_managed_apis")    private List<APIRef> serviceManagedAPIs;
+    @JsonProperty("top_clients")             private List<ClientObservation> topClients;
 
     public String getId() { return id; }
     public void setId(final String id) { this.id = id; }
@@ -131,6 +132,45 @@ public class DiscoveryDetailWire {
     public List<APIRef> getServiceManagedAPIs() { return serviceManagedAPIs; }
     public void setServiceManagedAPIs(final List<APIRef> serviceManagedAPIs) {
         this.serviceManagedAPIs = serviceManagedAPIs;
+    }
+
+    public List<ClientObservation> getTopClients() { return topClients; }
+    public void setTopClients(final List<ClientObservation> topClients) {
+        this.topClients = topClients;
+    }
+
+    /** Per-finding top caller, ranked by observation count. */
+    public static class ClientObservation {
+        @JsonProperty("identity")     private String identity;
+        @JsonProperty("kind")         private String kind;
+        @JsonProperty("namespace")    private String namespace;
+        @JsonProperty("workload")     private String workload;
+        @JsonProperty("ip")           private String ip;
+        @JsonProperty("port")         private int port;
+        @JsonProperty("observations") private long observations;
+
+        public String getIdentity() { return identity; }
+        public void setIdentity(final String identity) { this.identity = identity; }
+
+        public String getKind() { return kind; }
+        public void setKind(final String kind) { this.kind = kind; }
+
+        public String getNamespace() { return namespace; }
+        public void setNamespace(final String namespace) { this.namespace = namespace; }
+
+        public String getWorkload() { return workload; }
+        public void setWorkload(final String workload) { this.workload = workload; }
+
+        public String getIp() { return ip; }
+        public void setIp(final String ip) { this.ip = ip; }
+
+        public int getPort() { return port; }
+        public void setPort(final int port) { this.port = port; }
+
+        public long getObservations() { return observations; }
+        public void setObservations(final long observations) {
+            this.observations = observations;
+        }
     }
 
     /** Trimmed APIM-API reference embedded in the detail. */

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryListFilter.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryListFilter.java
@@ -1,0 +1,43 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery;
+
+/**
+ * Filter parameters for {@link DiscoveryApiServerClient#listApis}. Mirrors
+ * the daemon's GET /apis query-string parameters.
+ *
+ * @since 4.7.0
+ */
+public final class DiscoveryListFilter {
+
+    private String classification;
+    private String service;
+    private String internal;
+    private int limit;
+    private int offset;
+
+    public DiscoveryListFilter classification(final String classification) {
+        this.classification = classification;
+        return this;
+    }
+
+    public DiscoveryListFilter service(final String service) {
+        this.service = service;
+        return this;
+    }
+
+    public DiscoveryListFilter internal(final String internal) {
+        this.internal = internal;
+        return this;
+    }
+
+    public DiscoveryListFilter pagination(final int limit, final int offset) {
+        this.limit = limit;
+        this.offset = offset;
+        return this;
+    }
+
+    public String getClassification() { return classification; }
+    public String getService() { return service; }
+    public String getInternal() { return internal; }
+    public int getLimit() { return limit; }
+    public int getOffset() { return offset; }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryListItemWire.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryListItemWire.java
@@ -1,0 +1,76 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * One entry in the API Discovery Server's GET /apis list response. Used
+ * by both {@link DiscoveryListWire} (the paginated list) and the unwrapped
+ * single-row consumers in tests.
+ *
+ * @since 4.7.0
+ */
+public class DiscoveryListItemWire {
+
+    @JsonProperty("id")                    private String id;
+    @JsonProperty("service_identity")      private String serviceIdentity;
+    @JsonProperty("env_kind")              private String envKind;
+    @JsonProperty("method")                private String method;
+    @JsonProperty("normalized_path")       private String normalizedPath;
+    @JsonProperty("classification")        private String classification;
+    @JsonProperty("is_internal")           private boolean isInternal;
+    @JsonProperty("observation_count")     private long observationCount;
+    @JsonProperty("distinct_client_count") private int distinctClientCount;
+    @JsonProperty("last_seen_at")          private String lastSeenAt;
+    @JsonProperty("matched_apim_api_ids")  private List<String> matchedApimApiIds;
+
+    public String getId() { return id; }
+    public void setId(final String id) { this.id = id; }
+
+    public String getServiceIdentity() { return serviceIdentity; }
+    public void setServiceIdentity(final String serviceIdentity) {
+        this.serviceIdentity = serviceIdentity;
+    }
+
+    public String getEnvKind() { return envKind; }
+    public void setEnvKind(final String envKind) { this.envKind = envKind; }
+
+    public String getMethod() { return method; }
+    public void setMethod(final String method) { this.method = method; }
+
+    public String getNormalizedPath() { return normalizedPath; }
+    public void setNormalizedPath(final String normalizedPath) {
+        this.normalizedPath = normalizedPath;
+    }
+
+    public String getClassification() { return classification; }
+    public void setClassification(final String classification) {
+        this.classification = classification;
+    }
+
+    public boolean isInternal() { return isInternal; }
+    public void setInternal(final boolean isInternal) {
+        this.isInternal = isInternal;
+    }
+
+    public long getObservationCount() { return observationCount; }
+    public void setObservationCount(final long observationCount) {
+        this.observationCount = observationCount;
+    }
+
+    public int getDistinctClientCount() { return distinctClientCount; }
+    public void setDistinctClientCount(final int distinctClientCount) {
+        this.distinctClientCount = distinctClientCount;
+    }
+
+    public String getLastSeenAt() { return lastSeenAt; }
+    public void setLastSeenAt(final String lastSeenAt) {
+        this.lastSeenAt = lastSeenAt;
+    }
+
+    public List<String> getMatchedApimApiIds() { return matchedApimApiIds; }
+    public void setMatchedApimApiIds(final List<String> matchedApimApiIds) {
+        this.matchedApimApiIds = matchedApimApiIds;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryListWire.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryListWire.java
@@ -1,0 +1,45 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Wire format for the API Discovery Server's GET /apis paginated list
+ * response.
+ *
+ * @since 4.7.0
+ */
+public class DiscoveryListWire {
+
+    @JsonProperty("count")      private int count;
+    @JsonProperty("list")       private List<DiscoveryListItemWire> list;
+    @JsonProperty("pagination") private PaginationWire pagination;
+
+    public int getCount() { return count; }
+    public void setCount(final int count) { this.count = count; }
+
+    public List<DiscoveryListItemWire> getList() { return list; }
+    public void setList(final List<DiscoveryListItemWire> list) { this.list = list; }
+
+    public PaginationWire getPagination() { return pagination; }
+    public void setPagination(final PaginationWire pagination) {
+        this.pagination = pagination;
+    }
+
+    /** Pagination block matching the daemon's response shape. */
+    public static class PaginationWire {
+        @JsonProperty("offset") private int offset;
+        @JsonProperty("limit")  private int limit;
+        @JsonProperty("total")  private int total;
+
+        public int getOffset() { return offset; }
+        public void setOffset(final int offset) { this.offset = offset; }
+
+        public int getLimit() { return limit; }
+        public void setLimit(final int limit) { this.limit = limit; }
+
+        public int getTotal() { return total; }
+        public void setTotal(final int total) { this.total = total; }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoverySummaryWire.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoverySummaryWire.java
@@ -1,0 +1,112 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Wire format for the API Discovery Server's GET /summary response. Field
+ * names mirror the server's snake_case JSON via {@link JsonProperty}.
+ *
+ * <p>Kept separate from the generated DTO so wire-format changes don't
+ * leak into the public REST contract; {@code DiscoveryMappingUtil}
+ * translates between the two.</p>
+ *
+ * @since 4.7.0
+ */
+public class DiscoverySummaryWire {
+
+    @JsonProperty("total")
+    private long total;
+
+    @JsonProperty("managed")
+    private long managed;
+
+    @JsonProperty("unmanaged")
+    private long unmanaged;
+
+    @JsonProperty("skip_internal")
+    private boolean skipInternal;
+
+    @JsonProperty("by_type")
+    private ByType byType;
+
+    @JsonProperty("by_reachability")
+    private ByReachability byReachability;
+
+    @JsonProperty("by_service")
+    private List<ByServiceEntry> byService;
+
+    public long getTotal() { return total; }
+    public void setTotal(final long total) { this.total = total; }
+
+    public long getManaged() { return managed; }
+    public void setManaged(final long managed) { this.managed = managed; }
+
+    public long getUnmanaged() { return unmanaged; }
+    public void setUnmanaged(final long unmanaged) { this.unmanaged = unmanaged; }
+
+    public boolean isSkipInternal() { return skipInternal; }
+    public void setSkipInternal(final boolean skipInternal) { this.skipInternal = skipInternal; }
+
+    public ByType getByType() { return byType; }
+    public void setByType(final ByType byType) { this.byType = byType; }
+
+    public ByReachability getByReachability() { return byReachability; }
+    public void setByReachability(final ByReachability byReachability) {
+        this.byReachability = byReachability;
+    }
+
+    public List<ByServiceEntry> getByService() { return byService; }
+    public void setByService(final List<ByServiceEntry> byService) {
+        this.byService = byService;
+    }
+
+    /** Inner: shadow + drift counts. */
+    public static class ByType {
+        @JsonProperty("shadow") private long shadow;
+        @JsonProperty("drift")  private long drift;
+
+        public long getShadow() { return shadow; }
+        public void setShadow(final long shadow) { this.shadow = shadow; }
+
+        public long getDrift() { return drift; }
+        public void setDrift(final long drift) { this.drift = drift; }
+    }
+
+    /** Inner: external + internal counts. */
+    public static class ByReachability {
+        @JsonProperty("external") private long external;
+        @JsonProperty("internal") private long internal;
+
+        public long getExternal() { return external; }
+        public void setExternal(final long external) { this.external = external; }
+
+        public long getInternal() { return internal; }
+        public void setInternal(final long internal) { this.internal = internal; }
+    }
+
+    /** Inner: per-service breakdown row. */
+    public static class ByServiceEntry {
+        @JsonProperty("service_identity") private String serviceIdentity;
+        @JsonProperty("fully_governed")   private boolean fullyGoverned;
+        @JsonProperty("shadow")           private long shadow;
+        @JsonProperty("drift")            private long drift;
+
+        public String getServiceIdentity() { return serviceIdentity; }
+        public void setServiceIdentity(final String serviceIdentity) {
+            this.serviceIdentity = serviceIdentity;
+        }
+
+        public boolean isFullyGoverned() { return fullyGoverned; }
+        public void setFullyGoverned(final boolean fullyGoverned) {
+            this.fullyGoverned = fullyGoverned;
+        }
+
+        public long getShadow() { return shadow; }
+        public void setShadow(final long shadow) { this.shadow = shadow; }
+
+        public long getDrift() { return drift; }
+        public void setDrift(final long drift) { this.drift = drift; }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/UntraffickedListWire.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/UntraffickedListWire.java
@@ -1,0 +1,66 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Wire format for the API Discovery Server's GET /untrafficked response.
+ *
+ * @since 4.7.0
+ */
+public class UntraffickedListWire {
+
+    @JsonProperty("count") private int count;
+    @JsonProperty("list")  private List<UntraffickedItemWire> list;
+
+    public int getCount() { return count; }
+    public void setCount(final int count) { this.count = count; }
+
+    public List<UntraffickedItemWire> getList() { return list; }
+    public void setList(final List<UntraffickedItemWire> list) { this.list = list; }
+
+    /** One entry: a managed API with no observed traffic. */
+    public static class UntraffickedItemWire {
+        @JsonProperty("apim_api_id")      private String apimApiId;
+        @JsonProperty("apim_api_name")    private String apimApiName;
+        @JsonProperty("apim_api_version") private String apimApiVersion;
+        @JsonProperty("method")           private String method;
+        @JsonProperty("gateway_path")     private String gatewayPath;
+        @JsonProperty("service_identity") private String serviceIdentity;
+        @JsonProperty("last_synced_at")   private String lastSyncedAt;
+
+        public String getApimApiId() { return apimApiId; }
+        public void setApimApiId(final String apimApiId) {
+            this.apimApiId = apimApiId;
+        }
+
+        public String getApimApiName() { return apimApiName; }
+        public void setApimApiName(final String apimApiName) {
+            this.apimApiName = apimApiName;
+        }
+
+        public String getApimApiVersion() { return apimApiVersion; }
+        public void setApimApiVersion(final String apimApiVersion) {
+            this.apimApiVersion = apimApiVersion;
+        }
+
+        public String getMethod() { return method; }
+        public void setMethod(final String method) { this.method = method; }
+
+        public String getGatewayPath() { return gatewayPath; }
+        public void setGatewayPath(final String gatewayPath) {
+            this.gatewayPath = gatewayPath;
+        }
+
+        public String getServiceIdentity() { return serviceIdentity; }
+        public void setServiceIdentity(final String serviceIdentity) {
+            this.serviceIdentity = serviceIdentity;
+        }
+
+        public String getLastSyncedAt() { return lastSyncedAt; }
+        public void setLastSyncedAt(final String lastSyncedAt) {
+            this.lastSyncedAt = lastSyncedAt;
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/DiscoveryMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/DiscoveryMappingUtil.java
@@ -3,6 +3,7 @@ package org.wso2.carbon.apimgt.rest.api.admin.v1.utils.mappings;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIListDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIServiceManagedAPIsDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPITopClientsDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryByReachabilityDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryByServiceDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryByTypeDTO;
@@ -148,7 +149,34 @@ public final class DiscoveryMappingUtil {
             }
         }
         dto.setServiceManagedAPIs(svcManaged);
+
+        final List<DiscoveredAPITopClientsDTO> clients = new ArrayList<>();
+        if (wire.getTopClients() != null) {
+            for (DiscoveryDetailWire.ClientObservation c : wire.getTopClients()) {
+                final DiscoveredAPITopClientsDTO out = new DiscoveredAPITopClientsDTO();
+                out.setIdentity(c.getIdentity());
+                out.setKind(toClientKindEnum(c.getKind()));
+                out.setNamespace(c.getNamespace());
+                out.setWorkload(c.getWorkload());
+                out.setIp(c.getIp());
+                out.setPort(c.getPort());
+                out.setObservations(c.getObservations());
+                clients.add(out);
+            }
+        }
+        dto.setTopClients(clients);
         return dto;
+    }
+
+    private static DiscoveredAPITopClientsDTO.KindEnum toClientKindEnum(final String kind) {
+        if (kind == null) {
+            return null;
+        }
+        switch (kind.toLowerCase()) {
+            case "k8s":    return DiscoveredAPITopClientsDTO.KindEnum.K8S;
+            case "legacy": return DiscoveredAPITopClientsDTO.KindEnum.LEGACY;
+            default:       return null;
+        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/DiscoveryMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/DiscoveryMappingUtil.java
@@ -1,0 +1,222 @@
+package org.wso2.carbon.apimgt.rest.api.admin.v1.utils.mappings;
+
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIListDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIServiceManagedAPIsDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryByReachabilityDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryByServiceDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryByTypeDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.PaginationDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.UntraffickedAPIDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.UntraffickedListDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryDetailWire;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryListItemWire;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryListWire;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoverySummaryWire;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.UntraffickedListWire;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Pure-function translators between the Discovery Server wire format
+ * and the auto-generated REST DTOs.
+ *
+ * <p>Field-name translation: wire is snake_case, DTOs are camelCase.
+ * Some lists/numerical types differ subtly (e.g., wire status_codes is
+ * Integer[]; DTO has it as List&lt;Integer&gt;) — these helpers normalize.</p>
+ *
+ * @since 4.7.0
+ */
+public final class DiscoveryMappingUtil {
+
+    private DiscoveryMappingUtil() {
+        // static helpers only
+    }
+
+    /**
+     * Convert a wire summary into the public REST DTO.
+     *
+     * @param wire wire payload, non-null
+     * @return populated DiscoverySummaryDTO
+     */
+    public static DiscoverySummaryDTO fromWireSummary(final DiscoverySummaryWire wire) {
+        final DiscoverySummaryDTO dto = new DiscoverySummaryDTO();
+        dto.setTotal((int) wire.getTotal());
+        dto.setManaged((int) wire.getManaged());
+        dto.setUnmanaged((int) wire.getUnmanaged());
+        dto.setSkipInternal(wire.isSkipInternal());
+
+        if (wire.getByType() != null) {
+            final DiscoverySummaryByTypeDTO byType = new DiscoverySummaryByTypeDTO();
+            byType.setShadow((int) wire.getByType().getShadow());
+            byType.setDrift((int) wire.getByType().getDrift());
+            dto.setByType(byType);
+        }
+        if (wire.getByReachability() != null) {
+            final DiscoverySummaryByReachabilityDTO byReach =
+                    new DiscoverySummaryByReachabilityDTO();
+            byReach.setExternal((int) wire.getByReachability().getExternal());
+            byReach.setInternal((int) wire.getByReachability().getInternal());
+            dto.setByReachability(byReach);
+        }
+        if (wire.getByService() != null) {
+            final List<DiscoverySummaryByServiceDTO> byService = new ArrayList<>();
+            for (DiscoverySummaryWire.ByServiceEntry e : wire.getByService()) {
+                final DiscoverySummaryByServiceDTO s = new DiscoverySummaryByServiceDTO();
+                s.setServiceIdentity(e.getServiceIdentity());
+                s.setFullyGoverned(e.isFullyGoverned());
+                s.setShadow((int) e.getShadow());
+                s.setDrift((int) e.getDrift());
+                byService.add(s);
+            }
+            dto.setByService(byService);
+        }
+        return dto;
+    }
+
+    /**
+     * Convert a wire list response into the paginated REST DTO.
+     *
+     * @param wire wire payload, non-null
+     * @return populated DiscoveredAPIListDTO
+     */
+    public static DiscoveredAPIListDTO fromWireList(final DiscoveryListWire wire) {
+        final DiscoveredAPIListDTO dto = new DiscoveredAPIListDTO();
+        dto.setCount(wire.getCount());
+        final List<DiscoveredAPIDTO> items = new ArrayList<>();
+        if (wire.getList() != null) {
+            for (DiscoveryListItemWire item : wire.getList()) {
+                items.add(fromWireListItem(item));
+            }
+        }
+        dto.setList(items);
+        if (wire.getPagination() != null) {
+            final PaginationDTO p = new PaginationDTO();
+            p.setOffset(wire.getPagination().getOffset());
+            p.setLimit(wire.getPagination().getLimit());
+            p.setTotal(wire.getPagination().getTotal());
+            dto.setPagination(p);
+        }
+        return dto;
+    }
+
+    /**
+     * Convert a wire detail row into the REST DTO.
+     *
+     * @param wire wire payload, non-null
+     * @return populated DiscoveredAPIDTO
+     */
+    public static DiscoveredAPIDTO fromWireDetail(final DiscoveryDetailWire wire) {
+        final DiscoveredAPIDTO dto = new DiscoveredAPIDTO();
+        dto.setId(wire.getId());
+        dto.setServiceIdentity(wire.getServiceIdentity());
+        dto.setEnvKind(toEnvKindEnum(wire.getEnvKind()));
+        dto.setNamespace(wire.getNamespace());
+        dto.setServiceName(wire.getServiceName());
+        dto.setSamplePod(wire.getSamplePod());
+        dto.setSampleWorkload(wire.getSampleWorkload());
+        dto.setMethod(wire.getMethod());
+        dto.setNormalizedPath(wire.getNormalizedPath());
+        dto.setRawPathSamples(wire.getRawPathSamples() != null
+                ? wire.getRawPathSamples() : new ArrayList<>());
+        dto.setClassification(toClassificationEnum(wire.getClassification()));
+        dto.setIsInternal(wire.isInternal());
+        dto.setFirstSeenAt(wire.getFirstSeenAt());
+        dto.setLastSeenAt(wire.getLastSeenAt());
+        dto.setObservationCount(wire.getObservationCount());
+        dto.setDistinctClientCount(wire.getDistinctClientCount());
+        dto.setDistinctClientsSample(wire.getDistinctClientsSample() != null
+                ? wire.getDistinctClientsSample() : new ArrayList<>());
+        dto.setStatusCodes(wire.getStatusCodes() != null
+                ? wire.getStatusCodes() : new ArrayList<>());
+        dto.setAvgDurationUs(BigDecimal.valueOf(wire.getAvgDurationUs()));
+        dto.setMatchedApimApiIds(wire.getMatchedApimApiIds() != null
+                ? wire.getMatchedApimApiIds() : new ArrayList<>());
+
+        final List<DiscoveredAPIServiceManagedAPIsDTO> svcManaged = new ArrayList<>();
+        if (wire.getServiceManagedAPIs() != null) {
+            for (DiscoveryDetailWire.APIRef ref : wire.getServiceManagedAPIs()) {
+                final DiscoveredAPIServiceManagedAPIsDTO r =
+                        new DiscoveredAPIServiceManagedAPIsDTO();
+                r.setApimApiId(ref.getApimApiId());
+                r.setApimApiName(ref.getApimApiName());
+                r.setApimApiVersion(ref.getApimApiVersion());
+                svcManaged.add(r);
+            }
+        }
+        dto.setServiceManagedAPIs(svcManaged);
+        return dto;
+    }
+
+    /**
+     * Convert a wire untrafficked list into the REST DTO.
+     *
+     * @param wire wire payload, non-null
+     * @return populated UntraffickedListDTO
+     */
+    public static UntraffickedListDTO fromWireUntrafficked(
+            final UntraffickedListWire wire) {
+        final UntraffickedListDTO dto = new UntraffickedListDTO();
+        dto.setCount(wire.getCount());
+        final List<UntraffickedAPIDTO> items = new ArrayList<>();
+        if (wire.getList() != null) {
+            for (UntraffickedListWire.UntraffickedItemWire item : wire.getList()) {
+                final UntraffickedAPIDTO d = new UntraffickedAPIDTO();
+                d.setApimApiId(item.getApimApiId());
+                d.setApimApiName(item.getApimApiName());
+                d.setApimApiVersion(item.getApimApiVersion());
+                d.setMethod(item.getMethod());
+                d.setGatewayPath(item.getGatewayPath());
+                d.setServiceIdentity(item.getServiceIdentity());
+                d.setLastSyncedAt(item.getLastSyncedAt());
+                items.add(d);
+            }
+        }
+        dto.setList(items);
+        return dto;
+    }
+
+    private static DiscoveredAPIDTO fromWireListItem(final DiscoveryListItemWire wire) {
+        final DiscoveredAPIDTO dto = new DiscoveredAPIDTO();
+        dto.setId(wire.getId());
+        dto.setServiceIdentity(wire.getServiceIdentity());
+        dto.setEnvKind(toEnvKindEnum(wire.getEnvKind()));
+        dto.setMethod(wire.getMethod());
+        dto.setNormalizedPath(wire.getNormalizedPath());
+        dto.setClassification(toClassificationEnum(wire.getClassification()));
+        dto.setIsInternal(wire.isInternal());
+        dto.setObservationCount(wire.getObservationCount());
+        dto.setDistinctClientCount(wire.getDistinctClientCount());
+        dto.setLastSeenAt(wire.getLastSeenAt());
+        dto.setMatchedApimApiIds(wire.getMatchedApimApiIds() != null
+                ? wire.getMatchedApimApiIds() : new ArrayList<>());
+        return dto;
+    }
+
+    private static DiscoveredAPIDTO.EnvKindEnum toEnvKindEnum(final String wire) {
+        if (wire == null) {
+            return null;
+        }
+        switch (wire) {
+            case "k8s":     return DiscoveredAPIDTO.EnvKindEnum.K8S;
+            case "legacy":  return DiscoveredAPIDTO.EnvKindEnum.LEGACY;
+            case "unknown": return DiscoveredAPIDTO.EnvKindEnum.UNKNOWN;
+            default:        return null;
+        }
+    }
+
+    private static DiscoveredAPIDTO.ClassificationEnum toClassificationEnum(
+            final String wire) {
+        if (wire == null) {
+            return null;
+        }
+        switch (wire) {
+            case "shadow": return DiscoveredAPIDTO.ClassificationEnum.SHADOW;
+            case "drift":  return DiscoveredAPIDTO.ClassificationEnum.DRIFT;
+            default:       return null;
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -5167,6 +5167,35 @@ components:
                 type: string
               apimApiVersion:
                 type: string
+        topClients:
+          type: array
+          description: Top callers of this finding ranked by observation count, capped at 20 entries.
+          items:
+            type: object
+            properties:
+              identity:
+                type: string
+                description: Stable identity. "k8s:<namespace>/<workload>" for K8s pods or "host:<ip>" for legacy hosts.
+              kind:
+                type: string
+                enum: [k8s, legacy]
+              namespace:
+                type: string
+                description: K8s namespace (only when kind = k8s).
+              workload:
+                type: string
+                description: K8s workload name (only when kind = k8s).
+              ip:
+                type: string
+                description: Caller IP address.
+              port:
+                type: integer
+                format: int32
+                description: Sample source port. Source ports rotate per connection so this is illustrative only.
+              observations:
+                type: integer
+                format: int64
+                description: Observation count for this caller in the latest cycle window.
 
     DiscoveredAPIList:
       type: object

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -7023,6 +7023,11 @@ components:
           type: boolean
           description: To determine whether the transaction counter is enabled or not
           example: false
+        discoveryEnabled:
+          type: boolean
+          description: To determine whether the API Discovery integration is enabled (controls visibility of the Unmanaged APIs tab)
+          example: false
+          default: false
         isGatewayNotificationEnabled:
           type: boolean
           description: Is Gateway Notification Enabled

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -8421,3 +8421,5 @@ components:
             apim:gov_rule_manage: Manage governance rules
             apim:organization_manage: Manage Organizations
             apim:organization_read: Read Organizations
+            apim:admin_discovery_view: View discovered unmanaged APIs (Governance)
+            apim:admin_discovery_manage: Manage discovered unmanaged APIs (Governance)

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml
@@ -2471,6 +2471,135 @@ paths:
             - apim:admin
 
   ######################################################
+  # Unmanaged APIs (Governance / API Discovery)
+  ######################################################
+  /governance/discovery/summary:
+    get:
+      tags:
+        - Unmanaged APIs
+      summary: |
+        Get summary of discovered APIs by classification
+      description: |
+        Returns aggregate counts of discovered APIs by classification (shadow, drift),
+        reachability (external, internal), and service.
+      responses:
+        200:
+          description: |
+            OK. Summary returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoverySummary'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:admin
+            - apim:admin_discovery_view
+      operationId: getDiscoverySummary
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://localhost:9443/api/am/admin/v4/governance/discovery/summary"'
+
+  /governance/discovery/apis:
+    get:
+      tags:
+        - Unmanaged APIs
+      summary: List discovered APIs
+      description: |
+        Paginated list of unmanaged discovered APIs. Filterable by classification,
+        service, and internal-only flag.
+      parameters:
+        - name: classification
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [shadow, drift]
+        - name: service
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: internal
+          in: query
+          required: false
+          description: |
+            Filter by internal flag. "true" = include internal, "false" = external only,
+            "only" = internal only. Omit for all.
+          schema:
+            type: string
+            enum: [true, false, only]
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoveredAPIList'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:admin
+            - apim:admin_discovery_view
+      operationId: getDiscoveredAPIs
+
+  /governance/discovery/apis/{discoveredApiId}:
+    get:
+      tags:
+        - Unmanaged APIs
+      summary: Get discovered API detail
+      parameters:
+        - name: discoveredApiId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoveredAPI'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:admin
+            - apim:admin_discovery_view
+      operationId: getDiscoveredAPIById
+
+  /governance/discovery/untrafficked:
+    get:
+      tags:
+        - Unmanaged APIs
+      summary: List untrafficked managed APIs
+      description: |
+        Managed APIs registered in APIM but with no observed traffic.
+        Useful for identifying dead APIs or DeepFlow coverage gaps.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UntraffickedList'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:admin
+            - apim:admin_discovery_view
+      operationId: getUntrafficked
+
+  ######################################################
   # The "Organizations" resource API
   ######################################################
   /organizations:
@@ -4934,6 +5063,151 @@ paths:
 
 components:
   schemas:
+    DiscoverySummary:
+      type: object
+      properties:
+        total:
+          type: integer
+        managed:
+          type: integer
+        unmanaged:
+          type: integer
+        skipInternal:
+          type: boolean
+        byType:
+          type: object
+          properties:
+            shadow:
+              type: integer
+            drift:
+              type: integer
+        byReachability:
+          type: object
+          properties:
+            external:
+              type: integer
+            internal:
+              type: integer
+        byService:
+          type: array
+          items:
+            type: object
+            properties:
+              serviceIdentity:
+                type: string
+              fullyGoverned:
+                type: boolean
+              shadow:
+                type: integer
+              drift:
+                type: integer
+
+    DiscoveredAPI:
+      type: object
+      properties:
+        id:
+          type: string
+        serviceIdentity:
+          type: string
+        envKind:
+          type: string
+          enum: [k8s, legacy, unknown]
+        namespace:
+          type: string
+        serviceName:
+          type: string
+        samplePod:
+          type: string
+        sampleWorkload:
+          type: string
+        method:
+          type: string
+        normalizedPath:
+          type: string
+        rawPathSamples:
+          type: array
+          items:
+            type: string
+        classification:
+          type: string
+          enum: [shadow, drift]
+        isInternal:
+          type: boolean
+        firstSeenAt:
+          type: string
+        lastSeenAt:
+          type: string
+        observationCount:
+          type: integer
+          format: int64
+        distinctClientCount:
+          type: integer
+        distinctClientsSample:
+          type: array
+          items:
+            type: string
+        statusCodes:
+          type: array
+          items:
+            type: integer
+        avgDurationUs:
+          type: number
+        matchedApimApiIds:
+          type: array
+          items:
+            type: string
+        serviceManagedAPIs:
+          type: array
+          items:
+            type: object
+            properties:
+              apimApiId:
+                type: string
+              apimApiName:
+                type: string
+              apimApiVersion:
+                type: string
+
+    DiscoveredAPIList:
+      type: object
+      properties:
+        count:
+          type: integer
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/DiscoveredAPI'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    UntraffickedAPI:
+      type: object
+      properties:
+        apimApiId:
+          type: string
+        apimApiName:
+          type: string
+        apimApiVersion:
+          type: string
+        method:
+          type: string
+        gatewayPath:
+          type: string
+        serviceIdentity:
+          type: string
+        lastSyncedAt:
+          type: string
+
+    UntraffickedList:
+      type: object
+      properties:
+        count:
+          type: integer
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/UntraffickedAPI'
+
     Error:
       title: Error object returned with 4XX HTTP status
       required:

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/webapp/WEB-INF/web.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/webapp/WEB-INF/web.xml
@@ -65,6 +65,7 @@
             org.wso2.carbon.apimgt.rest.api.admin.v1.AiServiceProvidersApi,
             org.wso2.carbon.apimgt.rest.api.admin.v1.ApiKeysApi,
             org.wso2.carbon.apimgt.rest.api.admin.v1.ExportConsumptionApi,
+            org.wso2.carbon.apimgt.rest.api.admin.v1.GovernanceApi,
         </param-value>
     </init-param>
     <init-param>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/test/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GovernanceApiServiceImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/test/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GovernanceApiServiceImplTest.java
@@ -1,0 +1,308 @@
+/*
+ *  Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.apimgt.rest.api.admin.v1.impl;
+
+import org.apache.cxf.jaxrs.ext.MessageContext;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoveredAPIListDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.DiscoverySummaryDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.UntraffickedListDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryApiServerClient;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryDetailWire;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryListFilter;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryListItemWire;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoveryListWire;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.DiscoverySummaryWire;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery.UntraffickedListWire;
+
+import javax.ws.rs.core.Response;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link GovernanceApiServiceImpl}. Mocks the
+ * DiscoveryApiServerClient via the constructor seam so no real network
+ * traffic is required.
+ *
+ * <p>Each handler is tested for:
+ * - happy path: client returns a populated wire object → handler returns
+ *   a 200 with a populated DTO.
+ * - failure: client throws UnavailableException → handler routes through
+ *   RestApiUtil.handleInternalServerError, which throws
+ *   APIManagementException (we catch and verify).
+ *
+ * The detail handler also has a NotFound case.</p>
+ */
+public class GovernanceApiServiceImplTest {
+
+    /**
+     * /summary happy path: wire counts should appear in the DTO.
+     */
+    @Test
+    public void testGetDiscoverySummaryReturnsDTO() throws Exception {
+        DiscoveryApiServerClient client = mock(DiscoveryApiServerClient.class);
+        when(client.getSummary(anyString())).thenReturn(canonicalSummary());
+
+        GovernanceApiServiceImpl impl = new GovernanceApiServiceImpl(client);
+        Response resp = impl.getDiscoverySummary(null);
+
+        assertEquals(200, resp.getStatus());
+        DiscoverySummaryDTO dto = (DiscoverySummaryDTO) resp.getEntity();
+        assertEquals((Integer) 12, dto.getTotal());
+        assertEquals((Integer) 2, dto.getUnmanaged());
+        assertNotNull(dto.getByService());
+        assertEquals(1, dto.getByService().size());
+    }
+
+    /**
+     * /summary failure: client throws → handler raises
+     * APIManagementException (via RestApiUtil.handleInternalServerError).
+     */
+    @Test(expected = org.wso2.carbon.apimgt.rest.api.util.exception.InternalServerErrorException.class)
+    public void testGetDiscoverySummaryUnavailable() throws Exception {
+        DiscoveryApiServerClient client = mock(DiscoveryApiServerClient.class);
+        when(client.getSummary(anyString()))
+                .thenThrow(new DiscoveryApiServerClient.UnavailableException("down"));
+
+        new GovernanceApiServiceImpl(client).getDiscoverySummary(null);
+    }
+
+    /**
+     * /apis happy path: client receives a DiscoveryListFilter built from
+     * the request params, returns wire payload, handler returns DTO.
+     */
+    @Test
+    public void testGetDiscoveredAPIsReturnsListDTO() throws Exception {
+        DiscoveryApiServerClient client = mock(DiscoveryApiServerClient.class);
+        when(client.listApis(anyString(), any(DiscoveryListFilter.class)))
+                .thenReturn(canonicalList());
+
+        GovernanceApiServiceImpl impl = new GovernanceApiServiceImpl(client);
+        Response resp = impl.getDiscoveredAPIs("drift", null, null, 25, 0, null);
+
+        assertEquals(200, resp.getStatus());
+        DiscoveredAPIListDTO dto = (DiscoveredAPIListDTO) resp.getEntity();
+        assertEquals((Integer) 1, dto.getCount());
+        assertEquals(1, dto.getList().size());
+        assertEquals("k8s:techmart/orders",
+                dto.getList().get(0).getServiceIdentity());
+    }
+
+    /**
+     * /apis/{id} happy path.
+     */
+    @Test
+    public void testGetDiscoveredAPIByIdReturnsDTO() throws Exception {
+        DiscoveryApiServerClient client = mock(DiscoveryApiServerClient.class);
+        when(client.getApiById(anyString(), eq("uuid-1")))
+                .thenReturn(canonicalDetail());
+
+        GovernanceApiServiceImpl impl = new GovernanceApiServiceImpl(client);
+        Response resp = impl.getDiscoveredAPIById("uuid-1", null);
+
+        assertEquals(200, resp.getStatus());
+        DiscoveredAPIDTO dto = (DiscoveredAPIDTO) resp.getEntity();
+        assertEquals("uuid-1", dto.getId());
+        assertEquals("k8s:techmart/orders", dto.getServiceIdentity());
+        assertEquals("techmart", dto.getNamespace());
+        assertEquals(DiscoveredAPIDTO.ClassificationEnum.DRIFT,
+                dto.getClassification());
+        assertNotNull(dto.getServiceManagedAPIs());
+        assertEquals(1, dto.getServiceManagedAPIs().size());
+    }
+
+    /**
+     * /apis/{id} not found: client throws NotFoundException → handler
+     * raises APIManagementException via RestApiUtil.handleResourceNotFoundError.
+     */
+    @Test(expected = org.wso2.carbon.apimgt.rest.api.util.exception.NotFoundException.class)
+    public void testGetDiscoveredAPIByIdNotFound() throws Exception {
+        DiscoveryApiServerClient client = mock(DiscoveryApiServerClient.class);
+        when(client.getApiById(anyString(), anyString()))
+                .thenThrow(new DiscoveryApiServerClient.NotFoundException("404"));
+
+        new GovernanceApiServiceImpl(client).getDiscoveredAPIById("nope", null);
+    }
+
+    /**
+     * /apis/{id} server error.
+     */
+    @Test(expected = org.wso2.carbon.apimgt.rest.api.util.exception.InternalServerErrorException.class)
+    public void testGetDiscoveredAPIByIdUnavailable() throws Exception {
+        DiscoveryApiServerClient client = mock(DiscoveryApiServerClient.class);
+        when(client.getApiById(anyString(), anyString()))
+                .thenThrow(new DiscoveryApiServerClient.UnavailableException("down"));
+
+        new GovernanceApiServiceImpl(client).getDiscoveredAPIById("uuid-1", null);
+    }
+
+    /**
+     * /untrafficked happy path.
+     */
+    @Test
+    public void testGetUntraffickedReturnsListDTO() throws Exception {
+        DiscoveryApiServerClient client = mock(DiscoveryApiServerClient.class);
+        when(client.listUntrafficked(anyString())).thenReturn(canonicalUntrafficked());
+
+        GovernanceApiServiceImpl impl = new GovernanceApiServiceImpl(client);
+        Response resp = impl.getUntrafficked(null);
+
+        assertEquals(200, resp.getStatus());
+        UntraffickedListDTO dto = (UntraffickedListDTO) resp.getEntity();
+        assertEquals((Integer) 1, dto.getCount());
+        assertEquals("ReviewAPI", dto.getList().get(0).getApimApiName());
+    }
+
+    /**
+     * /untrafficked failure.
+     */
+    @Test(expected = org.wso2.carbon.apimgt.rest.api.util.exception.InternalServerErrorException.class)
+    public void testGetUntraffickedUnavailable() throws Exception {
+        DiscoveryApiServerClient client = mock(DiscoveryApiServerClient.class);
+        when(client.listUntrafficked(anyString()))
+                .thenThrow(new DiscoveryApiServerClient.UnavailableException("down"));
+
+        new GovernanceApiServiceImpl(client).getUntrafficked(null);
+    }
+
+    /**
+     * Default pagination is applied when limit/offset are null.
+     */
+    @Test
+    public void testListDefaultsLimitTo25AndOffsetTo0() throws Exception {
+        DiscoveryApiServerClient client = mock(DiscoveryApiServerClient.class);
+        when(client.listApis(anyString(), any(DiscoveryListFilter.class)))
+                .thenReturn(canonicalList());
+
+        new GovernanceApiServiceImpl(client)
+                .getDiscoveredAPIs(null, null, null, null, null, null);
+
+        org.mockito.ArgumentCaptor<DiscoveryListFilter> cap =
+                org.mockito.ArgumentCaptor.forClass(DiscoveryListFilter.class);
+        verify(client).listApis(anyString(), cap.capture());
+        assertEquals(25, cap.getValue().getLimit());
+        assertEquals(0, cap.getValue().getOffset());
+    }
+
+    // -- canonical fixtures ------------------------------------------------
+
+    private static DiscoverySummaryWire canonicalSummary() {
+        DiscoverySummaryWire w = new DiscoverySummaryWire();
+        w.setTotal(12);
+        w.setManaged(10);
+        w.setUnmanaged(2);
+        w.setSkipInternal(false);
+
+        DiscoverySummaryWire.ByType bt = new DiscoverySummaryWire.ByType();
+        bt.setShadow(0);
+        bt.setDrift(2);
+        w.setByType(bt);
+
+        DiscoverySummaryWire.ByReachability br =
+                new DiscoverySummaryWire.ByReachability();
+        br.setExternal(0);
+        br.setInternal(2);
+        w.setByReachability(br);
+
+        DiscoverySummaryWire.ByServiceEntry e =
+                new DiscoverySummaryWire.ByServiceEntry();
+        e.setServiceIdentity("k8s:techmart/orders");
+        e.setFullyGoverned(false);
+        e.setShadow(0);
+        e.setDrift(1);
+        w.setByService(Collections.singletonList(e));
+        return w;
+    }
+
+    private static DiscoveryListWire canonicalList() {
+        DiscoveryListItemWire item = new DiscoveryListItemWire();
+        item.setId("uuid-1");
+        item.setServiceIdentity("k8s:techmart/orders");
+        item.setEnvKind("k8s");
+        item.setMethod("GET");
+        item.setNormalizedPath("/orders/1.0.0/internal/queue/peek");
+        item.setClassification("drift");
+        item.setInternal(false);
+        item.setObservationCount(60);
+        item.setDistinctClientCount(2);
+        item.setLastSeenAt("2026-04-26T09:01:55Z");
+
+        DiscoveryListWire w = new DiscoveryListWire();
+        w.setCount(1);
+        w.setList(Collections.singletonList(item));
+
+        DiscoveryListWire.PaginationWire p = new DiscoveryListWire.PaginationWire();
+        p.setOffset(0);
+        p.setLimit(25);
+        p.setTotal(1);
+        w.setPagination(p);
+        return w;
+    }
+
+    private static DiscoveryDetailWire canonicalDetail() {
+        DiscoveryDetailWire w = new DiscoveryDetailWire();
+        w.setId("uuid-1");
+        w.setServiceIdentity("k8s:techmart/orders");
+        w.setEnvKind("k8s");
+        w.setNamespace("techmart");
+        w.setServiceName("orders");
+        w.setMethod("GET");
+        w.setNormalizedPath("/orders/1.0.0/internal/queue/peek");
+        w.setClassification("drift");
+        w.setObservationCount(60);
+        w.setDistinctClientCount(2);
+        w.setAvgDurationUs(14300);
+
+        DiscoveryDetailWire.APIRef ref = new DiscoveryDetailWire.APIRef();
+        ref.setApimApiId("ab6adc83");
+        ref.setApimApiName("OrdersAPI");
+        ref.setApimApiVersion("1.0.0");
+        w.setServiceManagedAPIs(Collections.singletonList(ref));
+        w.setStatusCodes(Arrays.asList(200, 204));
+        return w;
+    }
+
+    private static UntraffickedListWire canonicalUntrafficked() {
+        UntraffickedListWire.UntraffickedItemWire item =
+                new UntraffickedListWire.UntraffickedItemWire();
+        item.setApimApiId("uuid-2");
+        item.setApimApiName("ReviewAPI");
+        item.setApimApiVersion("1.0.0");
+        item.setMethod("GET");
+        item.setGatewayPath("/reviews/1.0.0/products/{id}/reviews");
+        item.setServiceIdentity("k8s:techmart/reviews");
+        item.setLastSyncedAt("2026-04-26T09:00:00Z");
+
+        UntraffickedListWire w = new UntraffickedListWire();
+        w.setCount(1);
+        w.setList(Collections.<UntraffickedListWire.UntraffickedItemWire>singletonList(item));
+        return w;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/test/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryApiServerClientIntegrationTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/test/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryApiServerClientIntegrationTest.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0.
+ */
+
+package org.wso2.carbon.apimgt.rest.api.admin.v1.impl.discovery;
+
+import org.junit.Test;
+import org.junit.Assume;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Live integration test against a running API Discovery Server daemon.
+ *
+ * <p>OPT-IN: only runs when both env vars are set:</p>
+ * <pre>
+ *   ADS_TEST_ENDPOINT  https://10.50.0.12:8443
+ *   ADS_TEST_TOKEN     a valid bearer token (apim:admin or admin_discovery_view)
+ * </pre>
+ *
+ * <p>Without those, every test no-ops via Assume (so this file never
+ * breaks `mvn test` on a fresh checkout). Used during PR preparation to
+ * prove the wire+HTTP+mapping path against a real daemon.</p>
+ */
+public class DiscoveryApiServerClientIntegrationTest {
+
+    private static String endpoint() {
+        return System.getenv("ADS_TEST_ENDPOINT");
+    }
+
+    private static String token() {
+        return System.getenv("ADS_TEST_TOKEN");
+    }
+
+    private DiscoveryApiServerClient client() throws Exception {
+        Assume.assumeTrue("set ADS_TEST_ENDPOINT to enable",
+                endpoint() != null && !endpoint().isEmpty());
+        Assume.assumeTrue("set ADS_TEST_TOKEN to enable",
+                token() != null && !token().isEmpty());
+        // Use reflection to call the private constructor so this test
+        // doesn't depend on APIManagerConfiguration (which would need a
+        // running carbon framework).
+        java.lang.reflect.Constructor<DiscoveryApiServerClient> ctor =
+                DiscoveryApiServerClient.class.getDeclaredConstructor(
+                        String.class, int.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(endpoint(), 10000);
+    }
+
+    @Test
+    public void liveSummary() throws Exception {
+        DiscoverySummaryWire wire = client().getSummary(token());
+        assertNotNull("summary must return a wire payload", wire);
+        // Numbers depend on TechMart state; just sanity-check positive.
+        assertTrue("total non-negative", wire.getTotal() >= 0);
+        System.out.printf("LIVE summary: total=%d managed=%d unmanaged=%d%n",
+                wire.getTotal(), wire.getManaged(), wire.getUnmanaged());
+    }
+
+    @Test
+    public void liveList() throws Exception {
+        DiscoveryListWire wire = client().listApis(token(),
+                new DiscoveryListFilter().pagination(25, 0));
+        assertNotNull(wire);
+        System.out.printf("LIVE list: count=%d%n", wire.getCount());
+    }
+
+    @Test
+    public void liveUntrafficked() throws Exception {
+        UntraffickedListWire wire = client().listUntrafficked(token());
+        assertNotNull(wire);
+        System.out.printf("LIVE untrafficked: count=%d%n", wire.getCount());
+    }
+
+    @Test
+    public void liveDetailMissing404() throws Exception {
+        try {
+            client().getApiById(token(),
+                    "00000000-0000-0000-0000-000000000000");
+        } catch (DiscoveryApiServerClient.NotFoundException expected) {
+            System.out.println("LIVE detail 404: " + expected.getMessage());
+            return;
+        }
+        // If the daemon returned 200 for a sentinel UUID, that's fine too;
+        // some deployments seed test rows.
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/test/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryApiServerClientIntegrationTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/test/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/discovery/DiscoveryApiServerClientIntegrationTest.java
@@ -83,7 +83,7 @@ public class DiscoveryApiServerClientIntegrationTest {
             client().getApiById(token(),
                     "00000000-0000-0000-0000-000000000000");
         } catch (DiscoveryApiServerClient.NotFoundException expected) {
-            System.out.println("LIVE detail 404: " + expected.getMessage());
+            // Expected path — sentinel UUID returns 404. No assertion needed.
             return;
         }
         // If the daemon returned 200 for a sentinel UUID, that's fine too;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
@@ -5167,6 +5167,35 @@ components:
                 type: string
               apimApiVersion:
                 type: string
+        topClients:
+          type: array
+          description: Top callers of this finding ranked by observation count, capped at 20 entries.
+          items:
+            type: object
+            properties:
+              identity:
+                type: string
+                description: Stable identity. "k8s:<namespace>/<workload>" for K8s pods or "host:<ip>" for legacy hosts.
+              kind:
+                type: string
+                enum: [k8s, legacy]
+              namespace:
+                type: string
+                description: K8s namespace (only when kind = k8s).
+              workload:
+                type: string
+                description: K8s workload name (only when kind = k8s).
+              ip:
+                type: string
+                description: Caller IP address.
+              port:
+                type: integer
+                format: int32
+                description: Sample source port. Source ports rotate per connection so this is illustrative only.
+              observations:
+                type: integer
+                format: int64
+                description: Observation count for this caller in the latest cycle window.
 
     DiscoveredAPIList:
       type: object

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
@@ -7023,6 +7023,11 @@ components:
           type: boolean
           description: To determine whether the transaction counter is enabled or not
           example: false
+        discoveryEnabled:
+          type: boolean
+          description: To determine whether the API Discovery integration is enabled (controls visibility of the Unmanaged APIs tab)
+          example: false
+          default: false
         isGatewayNotificationEnabled:
           type: boolean
           description: Is Gateway Notification Enabled

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
@@ -8421,3 +8421,5 @@ components:
             apim:gov_rule_manage: Manage governance rules
             apim:organization_manage: Manage Organizations
             apim:organization_read: Read Organizations
+            apim:admin_discovery_view: View discovered unmanaged APIs (Governance)
+            apim:admin_discovery_manage: Manage discovered unmanaged APIs (Governance)

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.common/src/main/resources/admin-api.yaml
@@ -2471,6 +2471,135 @@ paths:
             - apim:admin
 
   ######################################################
+  # Unmanaged APIs (Governance / API Discovery)
+  ######################################################
+  /governance/discovery/summary:
+    get:
+      tags:
+        - Unmanaged APIs
+      summary: |
+        Get summary of discovered APIs by classification
+      description: |
+        Returns aggregate counts of discovered APIs by classification (shadow, drift),
+        reachability (external, internal), and service.
+      responses:
+        200:
+          description: |
+            OK. Summary returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoverySummary'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:admin
+            - apim:admin_discovery_view
+      operationId: getDiscoverySummary
+      x-code-samples:
+        - lang: Curl
+          source: 'curl -k -H "Authorization: Bearer ae4eae22-3f65-387b-a171-d37eaa366fa8"
+            "https://localhost:9443/api/am/admin/v4/governance/discovery/summary"'
+
+  /governance/discovery/apis:
+    get:
+      tags:
+        - Unmanaged APIs
+      summary: List discovered APIs
+      description: |
+        Paginated list of unmanaged discovered APIs. Filterable by classification,
+        service, and internal-only flag.
+      parameters:
+        - name: classification
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [shadow, drift]
+        - name: service
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: internal
+          in: query
+          required: false
+          description: |
+            Filter by internal flag. "true" = include internal, "false" = external only,
+            "only" = internal only. Omit for all.
+          schema:
+            type: string
+            enum: [true, false, only]
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoveredAPIList'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:admin
+            - apim:admin_discovery_view
+      operationId: getDiscoveredAPIs
+
+  /governance/discovery/apis/{discoveredApiId}:
+    get:
+      tags:
+        - Unmanaged APIs
+      summary: Get discovered API detail
+      parameters:
+        - name: discoveredApiId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoveredAPI'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:admin
+            - apim:admin_discovery_view
+      operationId: getDiscoveredAPIById
+
+  /governance/discovery/untrafficked:
+    get:
+      tags:
+        - Unmanaged APIs
+      summary: List untrafficked managed APIs
+      description: |
+        Managed APIs registered in APIM but with no observed traffic.
+        Useful for identifying dead APIs or DeepFlow coverage gaps.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UntraffickedList'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - OAuth2Security:
+            - apim:admin
+            - apim:admin_discovery_view
+      operationId: getUntrafficked
+
+  ######################################################
   # The "Organizations" resource API
   ######################################################
   /organizations:
@@ -4934,6 +5063,151 @@ paths:
 
 components:
   schemas:
+    DiscoverySummary:
+      type: object
+      properties:
+        total:
+          type: integer
+        managed:
+          type: integer
+        unmanaged:
+          type: integer
+        skipInternal:
+          type: boolean
+        byType:
+          type: object
+          properties:
+            shadow:
+              type: integer
+            drift:
+              type: integer
+        byReachability:
+          type: object
+          properties:
+            external:
+              type: integer
+            internal:
+              type: integer
+        byService:
+          type: array
+          items:
+            type: object
+            properties:
+              serviceIdentity:
+                type: string
+              fullyGoverned:
+                type: boolean
+              shadow:
+                type: integer
+              drift:
+                type: integer
+
+    DiscoveredAPI:
+      type: object
+      properties:
+        id:
+          type: string
+        serviceIdentity:
+          type: string
+        envKind:
+          type: string
+          enum: [k8s, legacy, unknown]
+        namespace:
+          type: string
+        serviceName:
+          type: string
+        samplePod:
+          type: string
+        sampleWorkload:
+          type: string
+        method:
+          type: string
+        normalizedPath:
+          type: string
+        rawPathSamples:
+          type: array
+          items:
+            type: string
+        classification:
+          type: string
+          enum: [shadow, drift]
+        isInternal:
+          type: boolean
+        firstSeenAt:
+          type: string
+        lastSeenAt:
+          type: string
+        observationCount:
+          type: integer
+          format: int64
+        distinctClientCount:
+          type: integer
+        distinctClientsSample:
+          type: array
+          items:
+            type: string
+        statusCodes:
+          type: array
+          items:
+            type: integer
+        avgDurationUs:
+          type: number
+        matchedApimApiIds:
+          type: array
+          items:
+            type: string
+        serviceManagedAPIs:
+          type: array
+          items:
+            type: object
+            properties:
+              apimApiId:
+                type: string
+              apimApiName:
+                type: string
+              apimApiVersion:
+                type: string
+
+    DiscoveredAPIList:
+      type: object
+      properties:
+        count:
+          type: integer
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/DiscoveredAPI'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    UntraffickedAPI:
+      type: object
+      properties:
+        apimApiId:
+          type: string
+        apimApiName:
+          type: string
+        apimApiVersion:
+          type: string
+        method:
+          type: string
+        gatewayPath:
+          type: string
+        serviceIdentity:
+          type: string
+        lastSyncedAt:
+          type: string
+
+    UntraffickedList:
+      type: object
+      properties:
+        count:
+          type: integer
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/UntraffickedAPI'
+
     Error:
       title: Error object returned with 4XX HTTP status
       required:

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -777,6 +777,25 @@
     </APIMGovernance>
     {% endif %}
 
+    {% if apim.governance.discovery.enabled is defined %}
+    <!-- WSO2 API Discovery Server (ADS) integration. Surfaces unmanaged
+         APIs detected in runtime traffic via the admin portal's
+         "Unmanaged APIs" tab. Disabled by default; the tab is hidden
+         in the UI until Enabled = true. -->
+    <APIDiscovery>
+        <Enabled>{{apim.governance.discovery.enabled}}</Enabled>
+        {% if apim.governance.discovery.endpoint is defined %}
+        <Endpoint>{{apim.governance.discovery.endpoint}}</Endpoint>
+        {% endif %}
+        {% if apim.governance.discovery.timeout_ms is defined %}
+        <TimeoutMs>{{apim.governance.discovery.timeout_ms}}</TimeoutMs>
+        {% endif %}
+        {% if apim.governance.discovery.verify_ssl is defined %}
+        <VerifySSL>{{apim.governance.discovery.verify_ssl}}</VerifySSL>
+        {% endif %}
+    </APIDiscovery>
+    {% endif %}
+
     <RESTAPI>
         <!--Configure allowed URIs of REST API. Accessing allowed URIs does not require credentials (does not require Authorization header). -->
         <AllowedURIs>


### PR DESCRIPTION
## Purpose

Adds a Backend-for-Frontend resource group under
`/api/am/admin/v4/governance/discovery/*` that proxies the WSO2 API
Discovery Server — a separate daemon that discovers unmanaged APIs in
runtime traffic. The admin portal's new "Unmanaged APIs" tab consumes
these endpoints to surface APIs detected in traffic but not registered
in APIM, classified as Shadow (service has no managed APIs at all) or
Drift (service has managed APIs but this specific path isn't declared).

This is part of a feature spanning carbon-apimgt + apim-apps. The
companion frontend PR is at: https://github.com/wso2/apim-apps/pull/1340

The Discovery Server itself is the operator's external dependency. This
PR adds only the APIM-side integration glue: the BFF that proxies its
REST surface, a deployment.toml block, and a feature flag exposed via
the existing settings endpoint.

## Approach

### REST surface
- Four new paths under `/governance/discovery/*` in `admin-api.yaml`:
  - `GET /summary` — aggregate counts by classification + reachability + per-service rollup
  - `GET /apis` — paginated findings list with classification / service / reachability filters
  - `GET /apis/{discoveredApiId}` — full detail for a finding (metadata, top callers, related managed APIs)
  - `GET /untrafficked` — managed APIs APIM thinks exist but no runtime traffic has matched
- Auto-generated DTOs under `src/gen/java/.../dto/` (codegen output, mirrors throttling/governance scopes pattern).
- New OAuth2 scope `apim:admin_discovery_view` declared on `@Scope`
  annotations of the four resources. Scope catalog entry added to
  `admin-api.yaml` so the codegen + security framework recognise it.

### deployment.toml flow
- New `[apim.governance.discovery]` block, rendered by
  `api-manager.xml.j2` into a top-level `<APIDiscovery>` element with
  `Enabled / Endpoint / TimeoutMs / VerifySSL` children.
- `DiscoveryApiServerClient.isEnabled()` reads `APIDiscovery.Enabled`
  via `APIManagerConfiguration.getFirstProperty(...)`.
- `SettingsApiServiceImpl` exposes the flag as `discoveryEnabled` on
  `/api/am/admin/v4/settings`. The admin portal reads this to gate the
  Unmanaged APIs tab visibility — same pattern as the existing
  `analyticsEnabled` and `consumptionExportEnabled` flags.

### Wire client
- `DiscoveryApiServerClient`: thin Apache HttpClient wrapper that
  forwards the caller's bearer token to the daemon. No new Maven
  dependency — uses transitively-available `HttpClient` and Jackson.
- `DiscoveryMappingUtil`: pure-function snake_case → camelCase
  translator from the daemon's wire format (`top_clients`,
  `service_managed_apis`, etc.) to the codegen DTOs.

### What's intentionally NOT in this PR
- **No `tenant-conf.json` scope auto-load.** The scope is registered by
  the operator in Carbon Console (one-time, ~30 seconds) — see
  "Enabling the feature" below. Pre-loading scopes at tenant-create
  time was unnecessarily invasive for a single feature.
- **No new Maven module.** All code lives in the existing admin v1
  module, mirroring the throttling / scopes / settings pattern.
- **No new OSGi bundle.**
- **No new dependency.** HttpClient + Jackson + Commons Logging are
  already transitive.
- **No database changes.** The feature reads from the external
  Discovery Server only; no APIM DB writes.

## Enabling the feature (operator instructions)

Add to `repository/conf/deployment.toml`:

    [apim.governance.discovery]
    enabled    = true
    endpoint   = "https://your-discovery-server:8443"
    timeout_ms = 5000
    verify_ssl = false

Restart APIM. Open Carbon Console at `https://<host>:9443/carbon/`
→ Configure → Roles → assign the `apim:admin_discovery_view` scope to
the admin role. Open the admin portal — the "Unmanaged APIs" tab now
appears under Governance.

## Tests

- **Unit tests:** `GovernanceApiServiceImplTest` (Mockito) covers the
  four endpoints, error mapping, 404 handling, and pagination
  forwarding.
- **Opt-in integration test:** `DiscoveryApiServerClientIntegrationTest`
  hits a real Discovery Server when `ADS_TEST_ENDPOINT` and
  `ADS_TEST_TOKEN` env vars are set; no-ops via JUnit `Assume`
  otherwise so it never breaks `mvn test` on a fresh checkout.
- **Manual end-to-end:** verified against a 4.7.0-SNAPSHOT pack with a
  running Discovery Server. All four endpoints return live data;
  `discoveryEnabled` flag flows toml → XML → settings response → UI
  visibility.
- **`mvn clean install`:** BUILD SUCCESS on the admin v1 + common
  modules with the full dependency chain.


## Related

- Frontend PR (apim-apps): https://github.com/wso2/apim-apps/pull/1340
- API Discovery Server daemon (operator deploys this separately):
  https://github.com/Kidhurshan/wso2-api-discovery-server
