### PR TITLE
Fix PEM certificate dropped on federated IdP for external Key Managers

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -1259,7 +1259,7 @@ public class APIAdminImpl implements APIAdmin {
                     idpProperties.add(jwksProperty);
                 }
             } else if (APIConstants.KeyManager.CERTIFICATE_TYPE_PEM_FILE.equals(certificateType)) {
-                identityProvider.setCertificate(String.join(certificate, ""));
+                identityProvider.setCertificate(certificate);
             }
         }
 
@@ -2282,7 +2282,7 @@ public class APIAdminImpl implements APIAdmin {
                     idpProperties.add(jwksProperty);
                 }
             } else if (APIConstants.KeyManager.CERTIFICATE_TYPE_PEM_FILE.equals(certificateType)) {
-                identityProvider.setCertificate(String.join(certificate, ""));
+                identityProvider.setCertificate(certificate);
             }
         }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIAdminImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIAdminImplTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 import org.wso2.carbon.apimgt.api.APIAdmin;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
@@ -48,6 +49,8 @@ import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.impl.workflow.DefaultWorkflowTaskService;
 import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -451,5 +454,191 @@ public class APIAdminImplTest {
     private void assertUpdateDisabledKeyManagerConfigurationModification(APIManagementException exception) {
         Assert.assertTrue(exception.getMessage().contains("Modification of the Key Manager configuration"));
         Assert.assertEquals(ExceptionCodes.KEY_MANAGER_UPDATE_VIOLATION, exception.getErrorHandler());
+    }
+
+    // ---------- Issue #16480: PEM cert was dropped on the IdP record (private createIdp / updatedIDP) ----------
+
+    private static final String SAMPLE_PEM =
+            "-----BEGIN CERTIFICATE-----\n" +
+                    "MIIDazCCAlOgAwIBAgIUJ+abcDEFghIJklMNopQRsTUVwxYwDQYJKoZIhvcNAQEL\n" +
+                    "BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM\n" +
+                    "GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNjA1MDUwMDAwMDBaFw0yNzA1\n" +
+                    "MDUwMDAwMDBaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw\n" +
+                    "HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB\n" +
+                    "AQUAA4IBDwAwggEKAoIBAQDtESTcert==\n" +
+                    "-----END CERTIFICATE-----";
+
+    private static final String SAMPLE_JWKS_URL = "https://idp.example.com/oauth2/jwks";
+
+    private KeyManagerConfigurationDTO buildExchangedKM(String certType, String certValue) {
+        KeyManagerConfigurationDTO config = new KeyManagerConfigurationDTO();
+        config.setName("TestKM");
+        config.setDisplayName("Test KM");
+        config.setDescription("");
+        config.setOrganization("carbon.super");
+        config.setType("WSO2-IS");
+        config.setEnabled(true);
+        config.setTokenType("EXCHANGED");
+        config.setAlias("https://localhost:9443/oauth2/token");
+        config.setUuid("11111111-2222-3333-4444-555555555555");
+
+        Map<String, Object> additionalProps = new HashMap<>();
+        if (certType != null) {
+            additionalProps.put("certificate_type", certType);
+        }
+        if (certValue != null) {
+            additionalProps.put("certificate_value", certValue);
+        }
+        config.setAdditionalProperties(additionalProps);
+        return config;
+    }
+
+    /**
+     * #16480 (create path): a KM with PEM cert must populate the IdP's {@code certificate}
+     * field verbatim — pre-fix the inverted {@code String.join(certificate, "")} dropped it
+     * to an empty string.
+     */
+    @Test
+    public void testCreateIdpSetsCertificateForPemType() throws Exception {
+
+        APIAdminImpl apiAdmin = new APIAdminImpl();
+        KeyManagerConfigurationDTO km = buildExchangedKM("PEM", SAMPLE_PEM);
+
+        IdentityProvider idp = Whitebox.invokeMethod(apiAdmin, "createIdp", km);
+
+        Assert.assertNotNull("IdP should be created", idp);
+        Assert.assertEquals("PEM cert must be set verbatim on the IdP (issue #16480)",
+                SAMPLE_PEM, idp.getCertificate());
+        // PEM branch must NOT add a JWKS_URI property
+        IdentityProviderProperty[] props = idp.getIdpProperties();
+        if (props != null) {
+            for (IdentityProviderProperty p : props) {
+                Assert.assertNotEquals("PEM branch must not set JWKS_URI", "jwksUri", p.getName());
+            }
+        }
+    }
+
+    /**
+     * #16480 (update path): same expectation as create — the PEM cert must round-trip
+     * onto the IdP record.
+     */
+    @Test
+    public void testUpdatedIDPSetsCertificateForPemType() throws Exception {
+
+        APIAdminImpl apiAdmin = new APIAdminImpl();
+        IdentityProvider retrieved = new IdentityProvider();
+        retrieved.setIdentityProviderName("existing");
+        retrieved.setCertificate(""); // simulate the prior empty placeholder
+        KeyManagerConfigurationDTO km = buildExchangedKM("PEM", SAMPLE_PEM);
+
+        IdentityProvider idp = Whitebox.invokeMethod(apiAdmin, "updatedIDP", retrieved, km);
+
+        Assert.assertNotNull("IdP should be returned from update", idp);
+        Assert.assertEquals("PEM cert must be set verbatim on update (issue #16480)",
+                SAMPLE_PEM, idp.getCertificate());
+    }
+
+    /**
+     * #16480 regression guard: a PEM containing newlines, leading/trailing whitespace,
+     * and embedded blank lines must round-trip without truncation or modification.
+     * This is what the inverted {@code String.join} would silently mangle.
+     */
+    @Test
+    public void testCreateIdpPreservesPemWithNewlinesAndWhitespace() throws Exception {
+
+        APIAdminImpl apiAdmin = new APIAdminImpl();
+        String multilinePem = "  \n-----BEGIN CERTIFICATE-----\nLINE1\n\nLINE2\n   \n-----END CERTIFICATE-----\n";
+        KeyManagerConfigurationDTO km = buildExchangedKM("PEM", multilinePem);
+
+        IdentityProvider idp = Whitebox.invokeMethod(apiAdmin, "createIdp", km);
+
+        Assert.assertEquals("Multi-line PEM must round-trip verbatim",
+                multilinePem, idp.getCertificate());
+    }
+
+    /**
+     * JWKS branch: with {@code certificate_type=JWKS}, the cert value goes into the
+     * {@code jwksUri} IdP property and {@code IdentityProvider.certificate} must remain unset.
+     * Sanity check that the fix is scoped to the PEM arm only.
+     */
+    @Test
+    public void testCreateIdpJwksTypeDoesNotSetCertificate() throws Exception {
+
+        APIAdminImpl apiAdmin = new APIAdminImpl();
+        KeyManagerConfigurationDTO km = buildExchangedKM("JWKS", SAMPLE_JWKS_URL);
+
+        IdentityProvider idp = Whitebox.invokeMethod(apiAdmin, "createIdp", km);
+
+        Assert.assertNull("JWKS branch must not populate IdP.certificate", idp.getCertificate());
+        IdentityProviderProperty[] props = idp.getIdpProperties();
+        Assert.assertNotNull("JWKS branch should add a jwksUri property", props);
+        boolean jwksFound = false;
+        for (IdentityProviderProperty p : props) {
+            if ("jwksUri".equals(p.getName())) {
+                Assert.assertEquals(SAMPLE_JWKS_URL, p.getValue());
+                jwksFound = true;
+            }
+        }
+        Assert.assertTrue("Expected jwksUri property on JWKS branch", jwksFound);
+    }
+
+    /**
+     * Edge case: an empty {@code certificate_value} must NOT cause
+     * {@code setCertificate} to be invoked — the existing {@code StringUtils.isNotEmpty}
+     * guard should short-circuit. The IdP's certificate field remains at its
+     * default (null).
+     */
+    @Test
+    public void testCreateIdpEmptyCertificateValueIsSkipped() throws Exception {
+
+        APIAdminImpl apiAdmin = new APIAdminImpl();
+        KeyManagerConfigurationDTO km = buildExchangedKM("PEM", "");
+
+        IdentityProvider idp = Whitebox.invokeMethod(apiAdmin, "createIdp", km);
+
+        Assert.assertNull("Empty PEM must not be set on the IdP", idp.getCertificate());
+    }
+
+    /**
+     * Edge case: a missing {@code certificate_type} (with a non-empty value) must also
+     * skip {@code setCertificate} — the outer guard checks both type and value.
+     */
+    @Test
+    public void testCreateIdpMissingCertificateTypeIsSkipped() throws Exception {
+
+        APIAdminImpl apiAdmin = new APIAdminImpl();
+        KeyManagerConfigurationDTO km = buildExchangedKM(null, SAMPLE_PEM);
+
+        IdentityProvider idp = Whitebox.invokeMethod(apiAdmin, "createIdp", km);
+
+        Assert.assertNull("PEM without certificate_type must not be set", idp.getCertificate());
+    }
+
+    /**
+     * Update path JWKS sanity: confirm the update path also preserves the PEM-only
+     * scope of the fix — JWKS path stays unchanged.
+     */
+    @Test
+    public void testUpdatedIDPJwksTypeDoesNotSetCertificate() throws Exception {
+
+        APIAdminImpl apiAdmin = new APIAdminImpl();
+        IdentityProvider retrieved = new IdentityProvider();
+        retrieved.setIdentityProviderName("existing");
+        KeyManagerConfigurationDTO km = buildExchangedKM("JWKS", SAMPLE_JWKS_URL);
+
+        IdentityProvider idp = Whitebox.invokeMethod(apiAdmin, "updatedIDP", retrieved, km);
+
+        Assert.assertNull("JWKS update branch must not populate IdP.certificate",
+                idp.getCertificate());
+        IdentityProviderProperty[] props = idp.getIdpProperties();
+        Assert.assertNotNull(props);
+        boolean jwksFound = false;
+        for (IdentityProviderProperty p : props) {
+            if ("jwksUri".equals(p.getName())) {
+                Assert.assertEquals(SAMPLE_JWKS_URL, p.getValue());
+                jwksFound = true;
+            }
+        }
+        Assert.assertTrue("Expected jwksUri property on JWKS update", jwksFound);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIAdminImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIAdminImplTest.java
@@ -456,7 +456,7 @@ public class APIAdminImplTest {
         Assert.assertEquals(ExceptionCodes.KEY_MANAGER_UPDATE_VIOLATION, exception.getErrorHandler());
     }
 
-    // ---------- Issue #16480: PEM cert was dropped on the IdP record (private createIdp / updatedIDP) ----------
+    // ---------- Issue #4990: PEM cert was dropped on the IdP record (private createIdp / updatedIDP) ----------
 
     private static final String SAMPLE_PEM =
             "-----BEGIN CERTIFICATE-----\n" +
@@ -484,17 +484,17 @@ public class APIAdminImplTest {
 
         Map<String, Object> additionalProps = new HashMap<>();
         if (certType != null) {
-            additionalProps.put("certificate_type", certType);
+            additionalProps.put(APIConstants.KeyManager.CERTIFICATE_TYPE, certType);
         }
         if (certValue != null) {
-            additionalProps.put("certificate_value", certValue);
+            additionalProps.put(APIConstants.KeyManager.CERTIFICATE_VALUE, certValue);
         }
         config.setAdditionalProperties(additionalProps);
         return config;
     }
 
     /**
-     * #16480 (create path): a KM with PEM cert must populate the IdP's {@code certificate}
+     * #4990 (create path): a KM with PEM cert must populate the IdP's {@code certificate}
      * field verbatim — pre-fix the inverted {@code String.join(certificate, "")} dropped it
      * to an empty string.
      */
@@ -507,7 +507,7 @@ public class APIAdminImplTest {
         IdentityProvider idp = Whitebox.invokeMethod(apiAdmin, "createIdp", km);
 
         Assert.assertNotNull("IdP should be created", idp);
-        Assert.assertEquals("PEM cert must be set verbatim on the IdP (issue #16480)",
+        Assert.assertEquals("PEM cert must be set verbatim on the IdP (issue #4990)",
                 SAMPLE_PEM, idp.getCertificate());
         // PEM branch must NOT add a JWKS_URI property
         IdentityProviderProperty[] props = idp.getIdpProperties();
@@ -519,7 +519,7 @@ public class APIAdminImplTest {
     }
 
     /**
-     * #16480 (update path): same expectation as create — the PEM cert must round-trip
+     * #4990 (update path): same expectation as create — the PEM cert must round-trip
      * onto the IdP record.
      */
     @Test
@@ -534,12 +534,12 @@ public class APIAdminImplTest {
         IdentityProvider idp = Whitebox.invokeMethod(apiAdmin, "updatedIDP", retrieved, km);
 
         Assert.assertNotNull("IdP should be returned from update", idp);
-        Assert.assertEquals("PEM cert must be set verbatim on update (issue #16480)",
+        Assert.assertEquals("PEM cert must be set verbatim on update (issue #4990)",
                 SAMPLE_PEM, idp.getCertificate());
     }
 
     /**
-     * #16480 regression guard: a PEM containing newlines, leading/trailing whitespace,
+     * #4990 regression guard: a PEM containing newlines, leading/trailing whitespace,
      * and embedded blank lines must round-trip without truncation or modification.
      * This is what the inverted {@code String.join} would silently mangle.
      */
@@ -571,15 +571,15 @@ public class APIAdminImplTest {
 
         Assert.assertNull("JWKS branch must not populate IdP.certificate", idp.getCertificate());
         IdentityProviderProperty[] props = idp.getIdpProperties();
-        Assert.assertNotNull("JWKS branch should add a jwksUri property", props);
+        Assert.assertNotNull("JWKS branch should add a " + APIConstants.JWKS_URI + " property", props);
         boolean jwksFound = false;
         for (IdentityProviderProperty p : props) {
-            if ("jwksUri".equals(p.getName())) {
+            if (APIConstants.JWKS_URI.equals(p.getName())) {
                 Assert.assertEquals(SAMPLE_JWKS_URL, p.getValue());
                 jwksFound = true;
             }
         }
-        Assert.assertTrue("Expected jwksUri property on JWKS branch", jwksFound);
+        Assert.assertTrue("Expected " + APIConstants.JWKS_URI + " property on JWKS branch", jwksFound);
     }
 
     /**
@@ -611,7 +611,8 @@ public class APIAdminImplTest {
 
         IdentityProvider idp = Whitebox.invokeMethod(apiAdmin, "createIdp", km);
 
-        Assert.assertNull("PEM without certificate_type must not be set", idp.getCertificate());
+        Assert.assertNull("PEM without " + APIConstants.KeyManager.CERTIFICATE_TYPE + " must not be set",
+                idp.getCertificate());
     }
 
     /**
@@ -634,11 +635,11 @@ public class APIAdminImplTest {
         Assert.assertNotNull(props);
         boolean jwksFound = false;
         for (IdentityProviderProperty p : props) {
-            if ("jwksUri".equals(p.getName())) {
+            if (APIConstants.JWKS_URI.equals(p.getName())) {
                 Assert.assertEquals(SAMPLE_JWKS_URL, p.getValue());
                 jwksFound = true;
             }
         }
-        Assert.assertTrue("Expected jwksUri property on JWKS update", jwksFound);
+        Assert.assertTrue("Expected " + APIConstants.JWKS_URI + " property on JWKS update", jwksFound);
     }
 }


### PR DESCRIPTION
## Summary

The PEM branch in `APIAdminImpl#createIdp` and `APIAdminImpl#updatedIDP` set the IdP certificate via `String.join(certificate, "")`, which inverts the `String.join(CharSequence delimiter, CharSequence... elements)` arguments. The PEM payload is treated as the delimiter and `""` as the only element, so joining a single empty element always yields `""`. The IdP record's `CERTIFICATE` column was persisted as the empty placeholder `[]` instead of the uploaded PEM. Downstream Token Exchange JWT signature validation against the federated IdP failed with:

```
CertificateException: Could not parse certificate: java.io.IOException: Empty input
```

The Admin Portal hid the regression because the Admin REST API GET reads the certificate back from the `AM_KEY_MANAGER` additional-properties (which is populated correctly), not from the IdP record.

Fix: replace `setCertificate(String.join(certificate, ""))` with `setCertificate(certificate)` at both call sites — `APIAdminImpl.java:1262` (`createIdp`) and `APIAdminImpl.java:2285` (`updatedIDP`). A repo-wide grep confirms exactly these two occurrences.

## Changes

- `components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java` — corrected the two `setCertificate` calls (2 lines).
- `components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIAdminImplTest.java` — added 7 unit tests reaching the private `createIdp` / `updatedIDP` methods via PowerMock `Whitebox`:
  - `testCreateIdpSetsCertificateForPemType` — PEM cert set verbatim on create path.
  - `testUpdatedIDPSetsCertificateForPemType` — PEM cert overwrites prior value on update path.
  - `testCreateIdpPreservesPemWithNewlinesAndWhitespace` — multi-line PEM round-trips byte-identical (regression guard for the inverted `String.join`).
  - `testCreateIdpJwksTypeDoesNotSetCertificate`, `testUpdatedIDPJwksTypeDoesNotSetCertificate` — JWKS scope guards: `IdentityProvider.certificate` stays null and a `jwksUri` IdP property is added.
  - `testCreateIdpEmptyCertificateValueIsSkipped`, `testCreateIdpMissingCertificateTypeIsSkipped` — confirm the existing `StringUtils.isNotEmpty` guards still short-circuit.

## Verification

- **Unit tests:** `mvn -Dtest=APIAdminImplTest test` in `components/apimgt/org.wso2.carbon.apimgt.impl` — `Tests run: 18, Failures: 0, Errors: 0, Skipped: 0`. Without the source change, the three PEM-arm tests fail with `expected SAMPLE_PEM, got \"\"`, anchoring the regression coverage.
- **Runtime:** built `org.wso2.carbon.apimgt.impl-9.33.122.jar`, dropped it into `repository/components/patches/patch9999/`, started the server, and exercised the Admin REST API:
  - `POST /api/am/admin/v4/key-managers` with `tokenType=EXCHANGED`, `certificate_type=PEM`, `certificate_value=<self-signed PEM>` → HTTP 201; `IDP.CERTIFICATE` row contains the full 1178-byte PEM blob (was `[]` / 2 bytes pre-fix).
  - `PUT /api/am/admin/v4/key-managers/{id}` with a different self-signed PEM → HTTP 200; `IDP.CERTIFICATE` rotates to the new 1198-byte PEM.

## Risks / Notes for reviewers and release

- **Security / token-validation surface.** This patch governs the bytes persisted into `IDP.CERTIFICATE`, which IS consumes for JWT signature validation in the Token Exchange flow. End-to-end JWT validation against an external IS instance is recommended pre-merge — the unit contract validates the in-memory write, not downstream cryptographic consumption.
- **No DB migration ships.** Existing customer KM records that were saved on a pre-fix build hold `IDP.CERTIFICATE = '[]'`. They will continue to fail JWT validation until manually re-saved (Admin Portal → Key Managers → Update). **Please call this out in the release note.**
- **Behavioural change for invalid/expired PEMs.** Pre-fix, the cert never reached IS so any PEM string yielded HTTP 201; post-fix, an invalid PEM now produces HTTP 400 / code `900611` ("Unable to add the identity provider"). Intended consequence — flag to QA.

Fixes wso2/api-manager#4990

🤖 Generated with [Claude Code](https://claude.com/claude-code)