### PR TITLE
Fixing JWT claim cache enable configuration

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -3300,7 +3300,7 @@ public class APIManagerConfiguration {
 
     public boolean isJWTClaimCacheEnabled() {
 
-        String jwtClaimCacheExpiryEnabledString = getFirstProperty(APIConstants.JWT_CLAIM_CACHE_EXPIRY);
+        String jwtClaimCacheExpiryEnabledString = getFirstProperty(APIConstants.ENABLED_JWT_CLAIM_CACHE);
         if (StringUtils.isNotEmpty(jwtClaimCacheExpiryEnabledString)){
             return Boolean.parseBoolean(jwtClaimCacheExpiryEnabledString);
         }


### PR DESCRIPTION
## Purpose

This PR fixes an issue where  configuration `[apim.cache.jwt_claim] `does not work as expected even when it is set to true.
JWT claim caching is intended to be enabled by default and allow user claims to be retrieved from the cache instead of repeatedly calling the Key Manager

`APIManagerConfiguration.isJWTClaimCacheEnabled()` incorrectly reads the property `JWT_CLAIM_CACHE_EXPIRY` (e.g., "15m") and attempts to interpret it as a boolean. Since non-boolean values cannot be parsed correctly, this evaluation always resulted in false. As a result, JWT user-claim caching in the Key Manager JWT generation path remained disabled

## Approach

This fix updates the logic to correctly read the `ENABLED_JWT_CLAIM_CACHE`  property instead of the expiry value.

## Tests

Lowered the JWT token cache (Upper caching layer before claim cache) and verified the behaviour for  in JWTGenerator.getClaims() method

- Set expiry_time to 4 minutes and test the cache hit/miss behaviour for that time
- Set apim.cache.jwt_claim to false and verified claims are always retrieved from KM.

## Related issues

- Fixes https://github.com/wso2/api-manager/issues/5017