### PR TITLE
Add configurable retry policy for AWS Lambda invocations

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/pom.xml
@@ -512,6 +512,7 @@
                             software.amazon.awssdk.services.lambda.*; version="${org.wso2.orbit.com.amazonaws.version.range}"; resolution:=optional,
                             software.amazon.awssdk.core.*; version="${org.wso2.orbit.com.amazonaws.version.range}"; resolution:=optional,
                             software.amazon.awssdk.awscore.*; version="${org.wso2.orbit.com.amazonaws.version.range}"; resolution:=optional,
+                            software.amazon.awssdk.retries.*; version="${org.wso2.orbit.com.amazonaws.version.range}"; resolution:=optional,
                             org.apache.servicemix.bundles.jedis.*; version="${servicemix.bundles.jedis.version}",
                             com.nimbusds.jwt.*,
                             org.apache.commons.codec.*,

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/mediators/AWSLambdaMediator.java
@@ -58,6 +58,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.retries.StandardRetryStrategy;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvocationType;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
@@ -133,13 +134,7 @@ public class AWSLambdaMediator extends AbstractMediator implements ManagedLifecy
             log.debug("AWS Lambda proxy response mapping enabled: " + proxyResponseMappingEnabled);
         }
 
-        // Validate resource timeout and set client configuration
-        if (resourceTimeout.toMillis() < 1000 || resourceTimeout.toMillis() > 900000) {
-            setResourceTimeout(APIConstants.AWS_DEFAULT_CONNECTION_TIMEOUT);
-        }
-        ClientOverrideConfiguration clientConfig = ClientOverrideConfiguration.builder()
-                .apiCallTimeout(resourceTimeout)
-                .build();
+        ClientOverrideConfiguration clientConfig = buildClientOverrideConfiguration(config);
 
         if (StringUtils.isEmpty(accessKey) && StringUtils.isEmpty(secretKey)) {
             if (log.isDebugEnabled()) {
@@ -306,6 +301,53 @@ public class AWSLambdaMediator extends AbstractMediator implements ManagedLifecy
         }
 
         return true;
+    }
+
+    /**
+     * Validates timeout settings and builds the client override configuration with optional retry policy from deployment.toml.
+     * Falls back to AWS SDK defaults if not configured or invalid.
+     * Note: This method has a side effect - it corrects resourceTimeout if out of range.
+     *
+     * @param config API Manager configuration
+     * @return configured ClientOverrideConfiguration
+     */
+    private ClientOverrideConfiguration buildClientOverrideConfiguration(APIManagerConfiguration config) {
+        // Validate resource timeout and set client configuration
+        if (resourceTimeout.toMillis() < 1000 || resourceTimeout.toMillis() > 900000) {
+            log.warn("AWS Lambda resource timeout out of range (1s-900s): " + resourceTimeout.toMillis()
+                    + "ms. Using default: " + APIConstants.AWS_DEFAULT_CONNECTION_TIMEOUT + "ms.");
+            setResourceTimeout(APIConstants.AWS_DEFAULT_CONNECTION_TIMEOUT);
+        }
+        ClientOverrideConfiguration.Builder clientConfigBuilder = ClientOverrideConfiguration.builder()
+                .apiCallTimeout(resourceTimeout);
+
+        // Read retry configuration from config
+        String retryMaxAttemptsConfig = config.getFirstProperty(APIConstants.AWS_LAMBDA_RETRY_MAX_ATTEMPTS);
+
+        if (StringUtils.isNotEmpty(retryMaxAttemptsConfig)) {
+            try {
+                int maxAttempts = Integer.parseInt(retryMaxAttemptsConfig);
+                if (maxAttempts >= 1) {
+                    StandardRetryStrategy retryStrategy = StandardRetryStrategy.builder()
+                            .maxAttempts(maxAttempts)
+                            .build();
+                    clientConfigBuilder.retryStrategy(retryStrategy);
+                    if (log.isDebugEnabled()) {
+                        log.debug("AWS Lambda retry strategy configured with max attempts: " + maxAttempts);
+                    }
+                } else {
+                    log.warn("AWS Lambda RetryMaxAttempts must be >= 1, received: " + maxAttempts
+                            + ". Falling back to AWS SDK default.");
+                }
+            } catch (NumberFormatException nfe) {
+                log.warn("Invalid AWS Lambda RetryMaxAttempts: " + retryMaxAttemptsConfig
+                        + ". Falling back to AWS SDK default.");
+            }
+        } else {
+            log.debug("AWS Lambda RetryMaxAttempts not configured. Using AWS SDK default.");
+        }
+
+        return clientConfigBuilder.build();
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2983,6 +2983,8 @@ public final class APIConstants {
     // AWS Lambda: HTTP Client Configuration Constants
     public static final String AWS_LAMBDA_HTTP_CLIENT = "AWSLambdaConnector.HttpClient.";
     public static final String AWS_LAMBDA_PROXY_RESPONSE_ENABLED = "AWSLambdaConnector.EnableProxyResponseMapping";
+    // AWS Lambda: SDK Configuration Constants
+    public static final String AWS_LAMBDA_RETRY_MAX_ATTEMPTS = "AWSLambdaConnector.Sdk.RetryMaxAttempts";
     public static final String MAX_CONNECTIONS = "MaxConnections";
     public static final String CONNECTION_TIMEOUT = "ConnectionTimeout";
     public static final String SOCKET_TIMEOUT = "SocketTimeout";

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -2155,6 +2155,11 @@
 
       <AWSLambdaConnector>
           <EnableProxyResponseMapping>{{apim.aws_lambda.enable_proxy_response_mapping}}</EnableProxyResponseMapping>
+          <Sdk>
+              {% if apim.aws_lambda.sdk.retry_max_attempts is defined %}
+              <RetryMaxAttempts>{{apim.aws_lambda.sdk.retry_max_attempts}}</RetryMaxAttempts>
+              {% endif %}
+          </Sdk>
           <HttpClient>
               <MaxConnections>{{apim.aws_lambda.http_client.max_connections}}</MaxConnections>
               <ConnectionTimeout>{{apim.aws_lambda.http_client.connection_timeout}}</ConnectionTimeout>


### PR DESCRIPTION
## Purpose
Enhanced AWS Lambda mediator configuration to allow customizing AWS SDK retry attempts through `deployment.toml`.

## Goals
- Allow configuring AWS SDK retry attempts for Lambda invocations.
- Preserve AWS SDK defaults when configuration is not provided or invalid.

### Configuration Introduced
```toml
[apim.aws_lambda.sdk]
retry_max_attempts = 3
```

## Related Issue
- https://github.com/wso2/api-manager/issues/5029