### PR TITLE
Fixing unnecessary nullpointer logs in tenant startup flow

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/DataHolder.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/DataHolder.java
@@ -324,6 +324,11 @@ public class DataHolder {
     }
 
     public void markAPIAsDeployed(GatewayAPIDTO gatewayAPIDTO) {
+        if (gatewayAPIDTO.getApiContext() == null) {
+            // Internal/special-purpose APIs (e.g. JWKS endpoint) may not have an API context set;
+            // they are not tracked in tenantAPIMap, so nothing to mark.
+            return;
+        }
         Map<String, API> apiMap = tenantAPIMap.get(gatewayAPIDTO.getTenantDomain());
         if (apiMap != null) {
             API api = apiMap.get(gatewayAPIDTO.getApiContext());
@@ -349,6 +354,10 @@ public class DataHolder {
      *         {@code true}; {@code false} otherwise
      */
     public boolean isDeployed(GatewayAPIDTO gatewayAPIDTO) {
+        if (gatewayAPIDTO.getApiContext() == null) {
+            // Internal/special-purpose APIs (e.g. JWKS endpoint) are not tracked in tenantAPIMap.
+            return false;
+        }
         Map<String, API> apiMap = tenantAPIMap.get(gatewayAPIDTO.getTenantDomain());
         if (apiMap != null) {
             API api = apiMap.get(gatewayAPIDTO.getApiContext());


### PR DESCRIPTION
Fixing unnecessary nullpointer logs in tenant startup flow,

[2026-05-18 11:00:04,004]  INFO - TenantAxisUtils Loaded tenant test.com in 1188 ms
[2026-05-18 11:00:04,018]  INFO - InMemoryAPIDeployer Deploying synapse artifacts of _JwksEndpoint_
[2026-05-18 11:00:04,025]  INFO - API {api:_JwksEndpoint_} Initializing API: _JwksEndpoint_
[2026-05-18 11:00:04,029]  INFO - DependencyTracker API : _JwksEndpoint_ was added to the Synapse configuration successfully
Exception in thread "Thread-159" java.lang.NullPointerException
	at java.base/java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
	at org.wso2.carbon.apimgt.gateway.internal.DataHolder.markAPIAsDeployed_aroundBody48(DataHolder.java:228)
	at org.wso2.carbon.apimgt.gateway.internal.DataHolder.markAPIAsDeployed(DataHolder.java:1)
	at org.wso2.carbon.apimgt.gateway.InMemoryAPIDeployer.deployJWKSSynapseAPI_aroundBody32(InMemoryAPIDeployer.java:646)
	at org.wso2.carbon.apimgt.gateway.InMemoryAPIDeployer.deployJWKSSynapseAPI(InMemoryAPIDeployer.java:1)
	at org.wso2.carbon.apimgt.gateway.InMemoryAPIDeployer.deployAllAPIs_aroundBody8(InMemoryAPIDeployer.java:232)
	at org.wso2.carbon.apimgt.gateway.InMemoryAPIDeployer.deployAllAPIs(InMemoryAPIDeployer.java:1)
	at org.wso2.carbon.apimgt.gateway.InMemoryAPIDeployer.deployAllAPIsAtGatewayStartup_aroundBody6(InMemoryAPIDeployer.java:210)
	at org.wso2.carbon.apimgt.gateway.InMemoryAPIDeployer.deployAllAPIsAtGatewayStartup(InMemoryAPIDeployer.java:1)
	at org.wso2.carbon.apimgt.gateway.listeners.GatewayStartupListener.deployArtifactsAtStartup_aroundBody2(GatewayStartupListener.java:151)
	at org.wso2.carbon.apimgt.gateway.listeners.GatewayStartupListener.deployArtifactsAtStartup(GatewayStartupListener.java:1)
	at org.wso2.carbon.apimgt.gateway.listeners.GatewayStartupListener.deployArtifactsInGateway_aroundBody26(GatewayStartupListener.java:407)
	at org.wso2.carbon.apimgt.gateway.listeners.GatewayStartupListener.deployArtifactsInGateway(GatewayStartupListener.java:1)
	at org.wso2.carbon.apimgt.gateway.listeners.GatewayStartupListener.access$0_aroundBody40(GatewayStartupListener.java:393)
	at org.wso2.carbon.apimgt.gateway.listeners.GatewayStartupListener.access$0(GatewayStartupListener.java:1)
	at org.wso2.carbon.apimgt.gateway.listeners.GatewayStartupListener$AsyncAPIDeployment.run_aroundBody0(GatewayStartupListener.java:584)
	at org.wso2.carbon.apimgt.gateway.listeners.GatewayStartupListener$AsyncAPIDeployment.run(GatewayStartupListener.java:1)
	at java.base/java.lang.Thread.run(Thread.java:829)
[2026-05-18 11:00:04,035]  INFO - DependencyTracker Local entry : ga-config-key was added to the Synapse configuration successfully
[2026-05-18 11:00:09,058]  INFO - CommonUtil Creation of folder is successful. Directory Name : PizzaShackAPI-1.0.0
[2026-05-18 11:00:09,060]  INFO - CommonUtil Creation of folder is successful. Directory Name : Definitions
[2026-05-18 11:00:09,350]  INFO - DependencyTracker Local entry : 4877b088-73f9-4433-afd3-f60d111a1dec was added to the Synapse configuration successfully
[2026-05-18 11:00:09,352]  INFO - DependencyTracker Endpoint : PizzaShackAPI--v1.0.0_APIsandboxEndpoint was added to the Synapse configuration successfully
[2026-05-18 11:00:09,353]  INFO - DependencyTracker Endpoint : PizzaShackAPI--v1.0.0_APIproductionEndpoint was added to the Synapse configuration successfully
[2026-05-18 11:00:09,366]  INFO - API {api:PizzaShackAPI:v1.0.0} Initializing API: PizzaShackAPI:v1.0.0
[2026-05-18 11:00:09,367]  INFO - DependencyTracker API : PizzaShackAPI:v1.0.0 was added to the Synapse configuration successfully

Impact Analysis,

JWKS endpoint: deployed and functional
tenantAPIMap: not marked as deployed for JWKS (irrelevant — JWKS is not a tenant API tracked there)
The stack trace is noisy/alarming but not functionally harmful


Root cause: The switch from HashMap to ConcurrentHashMap (made as part of the race condition fix) introduced a behavioural change — ConcurrentHashMap does not permit null keys and throws NullPointerException when one is passed to get(). _JwksEndpoint_ has apiContext == null, so both markAPIAsDeployed() and isDeployed() crashed.
Fix applied:
markAPIAsDeployed(): Early-return if getApiContext() == null — JWKS/internal APIs have no entry in tenantAPIMap, nothing to mark.
isDeployed(): Early-return false if getApiContext() == null — same reasoning; such APIs are never tracked as tenant APIs.
Impact: JWKS endpoint continues to deploy and function correctly (the NPE was non-fatal but noisy). The tenantAPIMap tracking for real tenant APIs is completely unaffected.