### PR TITLE
Improve distributed throttle counter synchronization

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/RedisBaseDistributedCountManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/RedisBaseDistributedCountManager.java
@@ -21,12 +21,13 @@ package org.wso2.carbon.apimgt.gateway;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.commons.throttle.core.DistributedCounterManager;
+import org.wso2.carbon.apimgt.impl.dto.RedisConfig;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.Response;
 import redis.clients.jedis.Transaction;
-import org.wso2.carbon.apimgt.gateway.throttling.util.ThrottleUtils;
-import org.wso2.carbon.apimgt.impl.dto.RedisConfig;
+import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.params.SetParams;
 
 /**
  * Redis Base Distributed Counter Manager for Throttler.
@@ -460,33 +461,27 @@ public class RedisBaseDistributedCountManager implements DistributedCounterManag
         long startTime = 0;
         try {
             startTime = System.currentTimeMillis();
+            long ttlMillis = expiryTimeStamp - System.currentTimeMillis();
+            if (ttlMillis <= 0) {
+                // Lock lease already expired — refuse to borrow a pool connection for a useless lock.
+                return false;
+            }
             try (Jedis jedis = redisPool.getResource()) {
-                Transaction transaction = jedis.multi();
-                transaction.setnx(key, value);
-                Response<Long> pexpireAtResponse = transaction.pexpireAt(key, expiryTimeStamp);
-                transaction.exec();
-                long pexpireAtResponseCode = pexpireAtResponse.get();
-                if (pexpireAtResponseCode == 1) {
-                    if (log.isTraceEnabled()) {
-                        log.trace("expiry time of key:" + key + " was set successfully.");
+                // Atomic NX + expiry: only the client that creates the key gets "OK".
+                String result = jedis.set(key, value, SetParams.setParams().nx().px(ttlMillis));
+                boolean acquired = "OK".equals(result);
+                if (log.isTraceEnabled()) {
+                    if (acquired) {
+                        log.trace("Lock acquired for key:" + key);
+                    } else {
+                        log.trace("Lock not acquired for key:" + key + " (already held by another node)");
                     }
-                    return true;
-                } else if (pexpireAtResponseCode == 0) {
-                    if (log.isTraceEnabled()) {
-                        log.trace("expiry time was not set of key:" + key
-                                + " e.g. key doesn't exist, or operation skipped due to the provided arguments.");
-                    }
-                    return false;
-                } else {
-                    if (log.isTraceEnabled()) {
-                        log.trace("expiry time was not set of key:" + key);
-                    }
-                    return false;
                 }
+                return acquired;
             }
         } finally {
             if (log.isTraceEnabled()) {
-                log.trace("Time Taken to setLock :" + (System.currentTimeMillis() - startTime));
+                log.trace("Time Taken to setLockWithExpiry :" + (System.currentTimeMillis() - startTime));
             }
         }
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/internal/APIHandlerServiceComponent.java
@@ -96,6 +96,7 @@ import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.ConfigurationContextService;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
 
 @Component(
         name = "org.wso2.carbon.apimgt.handlers",
@@ -655,27 +656,42 @@ public class APIHandlerServiceComponent {
 
     private JedisPool getJedisPool(RedisConfig redisConfig) {
 
+        int connectionTimeout = redisConfig.getConnectionTimeout() != 0
+                ? redisConfig.getConnectionTimeout() : Protocol.DEFAULT_TIMEOUT;
+        int socketTimeout = redisConfig.getSocketTimeout() != 0
+                ? redisConfig.getSocketTimeout() : Protocol.DEFAULT_TIMEOUT;
         JedisPoolConfig jedisPoolConfig = new JedisPoolConfig();
         jedisPoolConfig.setMaxTotal(redisConfig.getMaxTotal());
         jedisPoolConfig.setMaxIdle(redisConfig.getMaxIdle());
         jedisPoolConfig.setMinIdle(redisConfig.getMinIdle());
         jedisPoolConfig.setTestOnBorrow(redisConfig.isTestOnBorrow());
         jedisPoolConfig.setBlockWhenExhausted(redisConfig.isBlockWhenExhausted());
+        jedisPoolConfig.setMaxWaitMillis(redisConfig.getMaxWaitMillis());
         jedisPoolConfig.setMinEvictableIdleTimeMillis(redisConfig.getMinEvictableIdleTimeMillis());
         jedisPoolConfig.setTimeBetweenEvictionRunsMillis(redisConfig.getTimeBetweenEvictionRunsMillis());
         jedisPoolConfig.setNumTestsPerEvictionRun(redisConfig.getNumTestsPerEvictionRun());
         JedisPool jedisPool;
         if (StringUtils.isNotEmpty(redisConfig.getUser()) && redisConfig.getPassword() != null) {
             jedisPool = new JedisPool(jedisPoolConfig, redisConfig.getHost(), redisConfig.getPort(),
-                    redisConfig.getConnectionTimeout(), redisConfig.getUser(),
-                    String.valueOf(redisConfig.getPassword()), redisConfig.getDatabaseId(), redisConfig.isSslEnabled());
+                    connectionTimeout, socketTimeout,
+                    redisConfig.getUser(), String.valueOf(redisConfig.getPassword()),
+                    redisConfig.getDatabaseId(), null, redisConfig.isSslEnabled());
         } else if (redisConfig.getPassword() != null) {
             jedisPool = new JedisPool(jedisPoolConfig, redisConfig.getHost(), redisConfig.getPort(),
-                    redisConfig.getConnectionTimeout(), String.valueOf(redisConfig.getPassword()),
-                    redisConfig.getDatabaseId(), redisConfig.isSslEnabled());
+                    connectionTimeout, socketTimeout,
+                    String.valueOf(redisConfig.getPassword()), redisConfig.getDatabaseId(), null,
+                    redisConfig.isSslEnabled());
         } else {
             jedisPool = new JedisPool(jedisPoolConfig, redisConfig.getHost(), redisConfig.getPort(),
-                    redisConfig.getConnectionTimeout(), null, redisConfig.getDatabaseId(), redisConfig.isSslEnabled());
+                    connectionTimeout, socketTimeout,
+                    null, redisConfig.getDatabaseId(), null, redisConfig.isSslEnabled());
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Redis connection pool initialized with connection timeout: "
+                    + connectionTimeout + "ms, socket timeout: "
+                    + socketTimeout + "ms, max wait: "
+                    + jedisPoolConfig.getMaxWaitMillis() + "ms, block when exhausted: "
+                    + redisConfig.isBlockWhenExhausted());
         }
         return jedisPool;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -1786,11 +1786,13 @@ public final class APIConstants {
     public static final String CONFIG_REDIS_PASSWORD =  "RedisPassword";
     public static final String CONFIG_REDIS_DATABASE_ID =  "RedisDatabaseId";
     public static final String CONFIG_REDIS_CONNECTION_TIMEOUT =  "RedisConnectionTimeout";
+    public static final String CONFIG_REDIS_SOCKET_TIMEOUT =  "RedisSocketTimeout";
     public static final String CONFIG_REDIS_IS_SSL_ENABLED =  "RedisIsSslEnabled";
     public static final String CONFIG_REDIS_PROPERTIES = "Properties";
     public static final String CONFIG_REDIS_MAX_TOTAL = "MaxTotal";
     public static final String CONFIG_REDIS_MAX_IDLE = "MaxIdle";
     public static final String CONFIG_REDIS_MIN_IDLE = "MinIdle";
+    public static final String CONFIG_REDIS_MAX_WAIT_MILLIS = "MaxWaitMillis";
     public static final String CONFIG_REDIS_TEST_ON_BORROW = "TestOnBorrow";
     public static final String CONFIG_REDIS_TEST_ON_RETURN = "TestOnReturn";
     public static final String CONFIG_REDIS_TEST_WHILE_IDLE = "TestWhileIdle";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -493,6 +493,7 @@ public class APIManagerConfiguration {
                 OMElement redisPassword = element.getFirstChildWithName(new QName(APIConstants.CONFIG_REDIS_PASSWORD));
                 OMElement redisDatabaseId = element.getFirstChildWithName(new QName(APIConstants.CONFIG_REDIS_DATABASE_ID));
                 OMElement redisConnectionTimeout = element.getFirstChildWithName(new QName(APIConstants.CONFIG_REDIS_CONNECTION_TIMEOUT));
+                OMElement redisSocketTimeout = element.getFirstChildWithName(new QName(APIConstants.CONFIG_REDIS_SOCKET_TIMEOUT));
                 OMElement redisIsSslEnabled = element.getFirstChildWithName(new QName(APIConstants.CONFIG_REDIS_IS_SSL_ENABLED));
                 OMElement propertiesElement = element.getFirstChildWithName(new QName(APIConstants.CONFIG_REDIS_PROPERTIES));
                 OMElement gatewayId = element.getFirstChildWithName(new QName(APIConstants.CONFIG_REDIS_GATEWAY_ID));
@@ -527,6 +528,9 @@ public class APIManagerConfiguration {
                 if (redisConnectionTimeout != null) {
                     redisConfig.setConnectionTimeout(Integer.parseInt(redisConnectionTimeout.getText()));
                 }
+                if (redisSocketTimeout != null) {
+                    redisConfig.setSocketTimeout(Integer.parseInt(redisSocketTimeout.getText()));
+                }
                 if (redisIsSslEnabled != null) {
                     redisConfig.setSslEnabled(Boolean.parseBoolean(redisIsSslEnabled.getText()));
                 }
@@ -541,6 +545,8 @@ public class APIManagerConfiguration {
                                 redisConfig.setMaxIdle(Integer.parseInt(propertyNode.getText()));
                             } else if (APIConstants.CONFIG_REDIS_MIN_IDLE.equals(propertyNode.getLocalName())) {
                                 redisConfig.setMinIdle(Integer.parseInt(propertyNode.getText()));
+                            } else if (APIConstants.CONFIG_REDIS_MAX_WAIT_MILLIS.equals(propertyNode.getLocalName())) {
+                                redisConfig.setMaxWaitMillis(Long.parseLong(propertyNode.getText()));
                             } else if (APIConstants.CONFIG_REDIS_TEST_ON_BORROW.equals(propertyNode.getLocalName())) {
                                 redisConfig.setTestOnBorrow(Boolean.parseBoolean(propertyNode.getText()));
                             } else if (APIConstants.CONFIG_REDIS_TEST_ON_RETURN.equals(propertyNode.getLocalName())) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/RedisConfig.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/RedisConfig.java
@@ -30,7 +30,9 @@ public class RedisConfig {
     private char[] password;
     private int databaseId = 0;
     private int connectionTimeout;
+    private int socketTimeout;
     private boolean isSslEnabled;
+    private long maxWaitMillis = -1;
     private int maxTotal = 8;
     private int maxIdle = 8;
     private int minIdle = 0;
@@ -220,6 +222,22 @@ public class RedisConfig {
     public void setConnectionTimeout(int connectionTimeout) {
 
         this.connectionTimeout = connectionTimeout;
+    }
+
+    public int getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    public void setSocketTimeout(int socketTimeout) {
+        this.socketTimeout = socketTimeout;
+    }
+
+    public long getMaxWaitMillis() {
+        return maxWaitMillis;
+    }
+
+    public void setMaxWaitMillis(long maxWaitMillis) {
+        this.maxWaitMillis = maxWaitMillis;
     }
 
     public boolean isSslEnabled() {

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1581,6 +1581,9 @@
         {% if apim.redis_config.connection_timeout is defined %}
         <RedisConnectionTimeout>{{apim.redis_config.connection_timeout}}</RedisConnectionTimeout>
         {% endif %}
+        {% if apim.redis_config.socket_timeout is defined %}
+        <RedisSocketTimeout>{{apim.redis_config.socket_timeout}}</RedisSocketTimeout>
+        {% endif %}
         {% if apim.redis_config.ssl is defined %}
         <RedisIsSslEnabled>{{apim.redis_config.ssl}}</RedisIsSslEnabled>
         {% endif %}
@@ -1605,6 +1608,9 @@
                 {% endif %}
                 {% if apim.redis_config.pool_options.min_idle is defined %}
                 <MinIdle>{{apim.redis_config.pool_options.min_idle}}</MinIdle>
+                {% endif %}
+                {% if apim.redis_config.pool_options.max_wait_millis is defined %}
+                <MaxWaitMillis>{{apim.redis_config.pool_options.max_wait_millis}}</MaxWaitMillis>
                 {% endif %}
                 {% if apim.redis_config.pool_options.block_when_exhausted is defined %}
                 <BlockWhenExhausted>{{apim.redis_config.pool_options.block_when_exhausted}}</BlockWhenExhausted>


### PR DESCRIPTION
This pull request enhances the robustness and configurability of Redis integration in the API Manager Gateway. The main improvements include better error handling for Redis operations, expanded Redis connection and pool configuration options, and updates to configuration templates to support these new options.

**Redis error handling and robustness:**

- Added catch blocks for `JedisException` in all Redis access methods in `RedisBaseDistributedCountManager`, ensuring that Redis failures are logged as warnings and safe fallback values are returned or operations are skipped gracefully. This prevents Redis outages from causing application failures. [[1]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816R76-R79) [[2]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816R93-R95) [[3]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816R109-R111) [[4]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816R316-R319) [[5]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816R339-R341) [[6]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816R371-R373) [[7]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816R423-R425) [[8]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816L464-R508)

**Redis connection and pool configuration:**

- Introduced support for `socketTimeout` and `maxWaitMillis` parameters in the `RedisConfig` class, their parsing from XML config, and their use in the Jedis connection pool setup. This allows finer control over Redis connection and pool behavior. [[1]](diffhunk://#diff-204e6166c08c8b3afe759ef6ccf0689d18c9457d54599c9ea9a8c9215be3a539R33-R35) [[2]](diffhunk://#diff-204e6166c08c8b3afe759ef6ccf0689d18c9457d54599c9ea9a8c9215be3a539R227-R242) [[3]](diffhunk://#diff-53180db9d61eccf226f337dec15f32bb7e951677a1e8b930daef9c9c30828d17R1789-R1795) [[4]](diffhunk://#diff-6ad5a30e0da551268318842e70c7a6e235b4e71a5985b57b662723142c8d9ff9R496) [[5]](diffhunk://#diff-6ad5a30e0da551268318842e70c7a6e235b4e71a5985b57b662723142c8d9ff9R531-R533) [[6]](diffhunk://#diff-6ad5a30e0da551268318842e70c7a6e235b4e71a5985b57b662723142c8d9ff9R548-R549) [[7]](diffhunk://#diff-649006684e3e8849fc79c523c743e3f860052acf9df6f12d072e11b1727c3109R659-R696)
- Updated the `getJedisPool` method to use these new parameters, including debug logging to report the applied pool settings.

**Configuration templates and defaults:**

- Updated configuration templates (`api-manager.xml.j2` and default JSON) to support the new `socket_timeout` and `max_wait_millis` options, allowing users to easily specify these in their deployments. [[1]](diffhunk://#diff-85fc7dbc8f3e4e90f11c8648fc0285bb211c08fc5c57448f41e8ab92e02667b6R1584-R1586) [[2]](diffhunk://#diff-85fc7dbc8f3e4e90f11c8648fc0285bb211c08fc5c57448f41e8ab92e02667b6R1612-R1614) [[3]](diffhunk://#diff-088555df3dd2624705c4194a56fb6b0cba1f52ba32ec535c8ecfd8deb9065e24L288-R289)

**Redis lock acquisition improvement:**

- Refactored the locking logic in `setLockWithExpiry` to use an atomic `SET NX PX` operation, ensuring correct lock semantics and simplifying the code.

**Dependency and import cleanup:**

- Adjusted imports to include necessary Jedis classes and parameters for the new timeout and error handling logic. [[1]](diffhunk://#diff-7bc14acf7420fc908a6db1393bc7c04509c998f188a45223a1b3622defee5816R24-R31) [[2]](diffhunk://#diff-649006684e3e8849fc79c523c743e3f860052acf9df6f12d072e11b1727c3109R99)

These changes make the Redis integration more resilient to failures and provide greater flexibility in tuning connection and pooling behavior.

### Related Issue : https://github.com/wso2/api-manager/issues/5048