### PR TITLE
[APIM] Fix Rejected Subscription not being deleted

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -1508,6 +1508,29 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         WorkflowResponse workflowResponse = null;
         int subscriptionId;
         if (APIConstants.PUBLISHED.equals(state) || APIConstants.PROTOTYPED.equals(state)) {
+            SubscribedAPI existingSubscription = apiMgtDAO.getSubscriptionByUUID(inputSubscriptionId);
+            if (existingSubscription != null
+                    && APIConstants.SubscriptionStatus.DELETE_PENDING.equals(existingSubscription.getSubStatus())) {
+                // Clean up the pending delete workflow to allow transition from DELETE_PENDING to TIER_UPDATE_PENDING
+                String deleteWorkflowExtRef = apiMgtDAO.getExternalWorkflowReferenceForSubscriptionAndWFType(
+                        existingSubscription.getSubscriptionId(),
+                        WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_DELETION);
+                if (deleteWorkflowExtRef != null) {
+                    try {
+                        String deleteWfProviderDomain = MultitenantUtils.getTenantDomain(
+                                APIUtil.replaceEmailDomainBack(identifier.getProviderName()));
+                        String deleteWfDomain = APIUtil.isCrossTenantSubscriptionsEnabled()
+                                && deleteWfProviderDomain != null ? deleteWfProviderDomain : tenantDomain;
+                        WorkflowExecutor deleteSubscriptionWFExecutor = getWorkflowExecutor(
+                                WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_DELETION, deleteWfDomain);
+                        deleteSubscriptionWFExecutor.cleanUpPendingTask(deleteWorkflowExtRef);
+                    } catch (WorkflowException e) {
+                        throw new APIManagementException(
+                            "Failed to clean previously created pending subscription deletion workflow before update",
+                                e);
+                    }
+                }
+            }
             subscriptionId = apiMgtDAO.updateSubscription(apiTypeWrapper, inputSubscriptionId,
                     APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING, requestedThrottlingPolicy);
 
@@ -1771,41 +1794,54 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             }
 
             String subId = null;
-            if (APIConstants.SubscriptionStatus.ON_HOLD.equals(status)) {
-                try {
-                    createSubscriptionWFExecutor.cleanUpPendingTask(workflowExtRef);
-                } catch (WorkflowException ex) {
-
-                    // failed cleanup processes are ignored to prevent failing the deletion process
-                    log.warn("Failed to clean pending subscription approval task");
-                }
-            } else if (APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING.equals(status)) {
-                try {
-                    if (apiIdentifier != null) {
-                        subId = apiMgtDAO.getSubscriptionId(apiIdentifier.getUUID(), applicationId);
-                    } else if (apiProdIdentifier != null) {
-                        subId = apiMgtDAO.getSubscriptionId(apiProdIdentifier.getUUID(), applicationId);
+            if (APIConstants.SubscriptionStatus.ON_HOLD.equals(status)
+                    || APIConstants.SubscriptionStatus.REJECTED.equals(status)) {
+                if (APIConstants.SubscriptionStatus.ON_HOLD.equals(status)) {
+                    try {
+                        createSubscriptionWFExecutor.cleanUpPendingTask(workflowExtRef);
+                    } catch (WorkflowException ex) {
+                        // failed cleanup processes are ignored to prevent failing the deletion process
+                        log.warn("Failed to clean pending subscription approval task");
                     }
+                }
+                subId = workflowDTO.getWorkflowReference();
+                if (subId == null) {
+                    subId = getSubscriptionId(apiIdentifier, apiProdIdentifier, applicationId);
+                    if (subId == null) {
+                        throw new APIManagementException("Failed to resolve subscription id for status: " + status);
+                    }
+                }
+                apiMgtDAO.removeSubscriptionById(Integer.parseInt(subId));
+                JsonObject subsLogObject = new JsonObject();
+                subsLogObject.addProperty(APIConstants.AuditLogConstants.API_NAME, identifier.getName());
+                subsLogObject.addProperty(APIConstants.AuditLogConstants.PROVIDER, identifier.getProviderName());
+                subsLogObject.addProperty(APIConstants.AuditLogConstants.APPLICATION_ID, applicationId);
+                subsLogObject.addProperty(APIConstants.AuditLogConstants.APPLICATION_NAME, applicationName);
+                APIUtil.logAuditMessage(APIConstants.AuditLogConstants.SUBSCRIPTION, subsLogObject.toString(),
+                        APIConstants.AuditLogConstants.DELETED, this.username);
+                return;
+            } else if (APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING.equals(status)) {
+                subId = getSubscriptionId(apiIdentifier, apiProdIdentifier, applicationId);
+                try {
                     if (subId != null) {
                         WorkflowDTO wf = apiMgtDAO.retrieveWorkflowFromInternalReference(subId,
                                 WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_UPDATE);
-                        WorkflowExecutor updateSubscriptionWFExecutor =
-                                getWorkflowExecutor(WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_UPDATE);
-                        updateSubscriptionWFExecutor.cleanUpPendingTask(wf.getExternalWorkflowReference());
+                        if (wf != null) {
+                            WorkflowExecutor updateSubscriptionWFExecutor = getWorkflowExecutor(
+                                    WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_UPDATE, workflowDomain);
+                            updateSubscriptionWFExecutor.cleanUpPendingTask(wf.getExternalWorkflowReference());
+                        } else if (log.isDebugEnabled()) {
+                            log.debug(CLEAN_PENDING_SUB_APPROVAL_TASK_FAILED
+                                    + "No pending update workflow found for subscription: " + subId);
+                        }
                     }
-
                 } catch (WorkflowException ex) {
-                    // failed cleanup processes are ignored to prevent failing the deletion process
-                    log.warn("Failed to clean pending subscription update approval task");
+                    throw new APIManagementException(
+                            "Failed to clean previously created pending subscription update workflow before deletion", ex);
                 }
             } else if (APIConstants.SubscriptionStatus.UNBLOCKED.equals(status)) {
                 try {
-                    if (apiIdentifier != null) {
-                        subId = apiMgtDAO.getSubscriptionId(apiIdentifier.getUUID(), applicationId);
-                    } else if (apiProdIdentifier != null) {
-                        subId = apiMgtDAO.getSubscriptionId(apiProdIdentifier.getUUID(), applicationId);
-                    }
-
+                    subId = getSubscriptionId(apiIdentifier, apiProdIdentifier, applicationId);
                 } catch (APIManagementException ex) {
                     // failed cleanup processes are ignored to prevent failing the deletion process
                     log.warn("Failed to retrive subscription id");
@@ -1888,6 +1924,16 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
         }
     }
 
+    private String getSubscriptionId(APIIdentifier apiIdentifier, APIProductIdentifier apiProdIdentifier,
+            int applicationId) throws APIManagementException {
+        if (apiIdentifier != null) {
+            return apiMgtDAO.getSubscriptionId(apiIdentifier.getUUID(), applicationId);
+        } else if (apiProdIdentifier != null) {
+            return apiMgtDAO.getSubscriptionId(apiProdIdentifier.getUUID(), applicationId);
+        }
+        return null;
+    }
+
     @Override
     public void removeSubscription(APIIdentifier identifier, String userId, int applicationId, String groupId,
                                    String organization) throws APIManagementException {
@@ -1912,20 +1958,55 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
 
         if (subscription != null) {
             String uuid = subscription.getUUID();
-            String deleteWorkflowExtRef =
-                    apiMgtDAO.getExternalWorkflowReferenceForSubscriptionAndWFType(subscription.getSubscriptionId(),
+            Application application = subscription.getApplication();
+            Identifier identifier = subscription.getAPIIdentifier() != null ? subscription.getAPIIdentifier()
+                    : subscription.getProductId();
+            String deleteWorkflowExtRef = apiMgtDAO
+                    .getExternalWorkflowReferenceForSubscriptionAndWFType(subscription.getSubscriptionId(),
                             WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_DELETION);
             if (deleteWorkflowExtRef != null) {
                 WorkflowDTO deleteWorkflow = apiMgtDAO.retrieveWorkflow(deleteWorkflowExtRef);
                 if (deleteWorkflow != null && WorkflowStatus.CREATED.equals(deleteWorkflow.getStatus())) {
+                    // Check if this is a pre-fix stuck state: a REJECTED subscription that erroneously
+                    // went through the delete workflow path before the REJECTED bypass was introduced.
+                    boolean isStuckRejectedSubscription = false;
+                    String creationWorkflowExtRef = apiMgtDAO.getExternalWorkflowReferenceForSubscription(
+                            identifier, application.getId(), organization);
+                    if (creationWorkflowExtRef != null) {
+                        WorkflowDTO creationWorkflow = apiMgtDAO.retrieveWorkflow(creationWorkflowExtRef);
+                        isStuckRejectedSubscription = creationWorkflow != null
+                                && WorkflowStatus.REJECTED.equals(creationWorkflow.getStatus());
+                    }
+                    if (isStuckRejectedSubscription) {
+                        // Clean up the stuck delete workflow and delete the subscription directly,
+                        // consistent with how REJECTED subscriptions are now handled.
+                        try {
+                            String deleteWfProviderDomain = MultitenantUtils.getTenantDomain(
+                                    APIUtil.replaceEmailDomainBack(identifier.getProviderName()));
+                            String deleteWfDomain = APIUtil.isCrossTenantSubscriptionsEnabled()
+                                    && deleteWfProviderDomain != null ? deleteWfProviderDomain : tenantDomain;
+                            WorkflowExecutor deleteSubscriptionWFExecutor = getWorkflowExecutor(
+                                    WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_DELETION, deleteWfDomain);
+                            deleteSubscriptionWFExecutor.cleanUpPendingTask(deleteWorkflowExtRef);
+                        } catch (WorkflowException e) {
+                            log.warn(CLEAN_PENDING_SUB_APPROVAL_TASK_FAILED + e.getMessage());
+                        }
+                        apiMgtDAO.removeSubscriptionById(subscription.getSubscriptionId());
+                        JsonObject subsLogObject = new JsonObject();
+                        subsLogObject.addProperty(APIConstants.AuditLogConstants.API_NAME, identifier.getName());
+                        subsLogObject.addProperty(APIConstants.AuditLogConstants.PROVIDER, identifier.getProviderName());
+                        subsLogObject.addProperty(APIConstants.AuditLogConstants.APPLICATION_ID, application.getId());
+                        subsLogObject.addProperty(APIConstants.AuditLogConstants.APPLICATION_NAME, application.getName());
+                        APIUtil.logAuditMessage(APIConstants.AuditLogConstants.SUBSCRIPTION, subsLogObject.toString(),
+                                APIConstants.AuditLogConstants.DELETED, this.username);
+                        return;
+                    }
+                    // A legitimate pending delete approval workflow exists — preserve governance guard.
                     subscription.setSubscriptionId(-1);
                     subscription.setSubStatus(APIConstants.SubscriptionStatus.DELETE_PENDING);
                     return;
                 }
             }
-            Application application = subscription.getApplication();
-            Identifier identifier = subscription.getAPIIdentifier() != null ? subscription.getAPIIdentifier() :
-                    subscription.getProductId();
             String userId = application.getSubscriber().getName();
             removeSubscription(identifier, userId, application.getId(), organization);
             SubscribedAPI subscriptionAfterDeletion = apiMgtDAO.getSubscriptionById(subscription.getSubscriptionId());

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionApprovalWorkflowExecutor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionApprovalWorkflowExecutor.java
@@ -95,12 +95,7 @@ public class SubscriptionDeletionApprovalWorkflowExecutor extends WorkflowExecut
                 apiMgtDAO.updateSubscriptionStatus(Integer.parseInt(subWorkflowDTO.getWorkflowReference()),
                         APIConstants.SubscriptionStatus.UNBLOCKED);
             } catch (APIManagementException e) {
-                if (e.getMessage() == null) {
-                    errorMsg = "Couldn't complete simple application deletion workflow for application: ";
-                } else {
-                    errorMsg = e.getMessage();
-                }
-                throw new WorkflowException(errorMsg, e);
+                throw new WorkflowException("Could not complete subscription deletion workflow", e);
             }
         }
         return new GeneralWorkflowResponse();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIConsumerImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIConsumerImplTest.java
@@ -812,23 +812,45 @@ public class APIConsumerImplTest {
 
     }
 
+    /**
+     * Tests that a subscription stuck in DELETE_PENDING because it was REJECTED and went through the
+     * delete workflow path before the REJECTED bypass was introduced gets cleaned up and deleted directly.
+     * The distinguishing signal is that its creation workflow is in REJECTED state.
+     */
     @Test
-    public void testRemoveSubscriptionWhenDeletePending() throws APIManagementException, WorkflowException, APIPersistenceException {
+    public void testRemoveSubscriptionWhenDeletePendingWithRejectedCreationWorkflowDeletesDirectly()
+            throws APIManagementException, WorkflowException, APIPersistenceException {
         String uuid = UUID.randomUUID().toString();
         String apiUUID = UUID.randomUUID().toString();
         final String deletionWorkflowRef = "SUB_DELETION_WORKFLOW_REF";
+        final String creationWorkflowRef = "SUB_CREATION_WORKFLOW_REF";
+        final int subscriptionId = 42;
+
         WorkflowDTO deletionWorkflow = new SubscriptionWorkflowDTO();
         deletionWorkflow.setStatus(org.wso2.carbon.apimgt.impl.workflow.WorkflowStatus.CREATED);
+
+        WorkflowDTO creationWorkflow = new SubscriptionWorkflowDTO();
+        creationWorkflow.setStatus(org.wso2.carbon.apimgt.impl.workflow.WorkflowStatus.REJECTED);
+
         Subscriber subscriber = new Subscriber("sub1");
         Application application = new Application("app1", subscriber);
         application.setId(1);
         APIIdentifier identifier = new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION);
         identifier.setUuid(apiUUID);
-        SubscribedAPI subscribedAPIOld = new SubscribedAPI(subscriber, identifier);
-        subscribedAPIOld.setApplication(application);
-        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscriptionAndWFType(Mockito.anyInt(), Mockito.anyString()))
+
+        SubscribedAPI subscribedAPINew = new SubscribedAPI(subscriber, identifier);
+        subscribedAPINew.setUUID(uuid);
+        subscribedAPINew.setApplication(application);
+        subscribedAPINew.setSubscriptionId(subscriptionId);
+
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscriptionAndWFType(
+                Mockito.eq(subscriptionId), Mockito.anyString()))
                 .thenReturn(deletionWorkflowRef);
         Mockito.when(apiMgtDAO.retrieveWorkflow(deletionWorkflowRef)).thenReturn(deletionWorkflow);
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscription(
+                (APIIdentifier) Mockito.any(), Mockito.eq(1), Mockito.anyString()))
+                .thenReturn(creationWorkflowRef);
+        Mockito.when(apiMgtDAO.retrieveWorkflow(creationWorkflowRef)).thenReturn(creationWorkflow);
 
         PowerMockito.mockStatic(ApiMgtDAO.class);
         PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
@@ -836,15 +858,163 @@ public class APIConsumerImplTest {
         DevPortalAPI devPortalAPI = Mockito.mock(DevPortalAPI.class);
         Mockito.when(apiPersistenceInstance.getDevPortalAPI(any(Organization.class), any(String.class)))
                 .thenReturn(devPortalAPI);
+
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, apiPersistenceInstance);
+        apiConsumer.removeSubscription(subscribedAPINew, "org1");
+
+        // Stuck delete workflow should be cleaned up and subscription deleted directly
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).removeSubscriptionById(subscriptionId);
+        Mockito.verify(apiMgtDAO, Mockito.never()).updateSubscriptionStatus(
+                Mockito.anyInt(), Mockito.eq(APIConstants.SubscriptionStatus.DELETE_PENDING));
+    }
+
+    /**
+     * Tests that when a subscription is legitimately in DELETE_PENDING (an active subscription going
+     * through admin delete approval), the governance guard is preserved — the subscription is not
+     * deleted and the subscriptionId is set to -1 to signal DELETE_PENDING to the caller.
+     */
+    @Test
+    public void testRemoveSubscriptionWhenDeletePendingWithActiveCreationWorkflowPreservesGuard()
+            throws APIManagementException, WorkflowException, APIPersistenceException {
+        String uuid = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+        final String deletionWorkflowRef = "SUB_DELETION_WORKFLOW_REF";
+        final String creationWorkflowRef = "SUB_CREATION_WORKFLOW_REF";
+        final int subscriptionId = 42;
+
+        WorkflowDTO deletionWorkflow = new SubscriptionWorkflowDTO();
+        deletionWorkflow.setStatus(org.wso2.carbon.apimgt.impl.workflow.WorkflowStatus.CREATED);
+
+        // Creation workflow was APPROVED (normal active subscription going through delete approval)
+        WorkflowDTO creationWorkflow = new SubscriptionWorkflowDTO();
+        creationWorkflow.setStatus(org.wso2.carbon.apimgt.impl.workflow.WorkflowStatus.APPROVED);
+
+        Subscriber subscriber = new Subscriber("sub1");
+        Application application = new Application("app1", subscriber);
+        application.setId(1);
+        APIIdentifier identifier = new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION);
+        identifier.setUuid(apiUUID);
+
         SubscribedAPI subscribedAPINew = new SubscribedAPI(subscriber, identifier);
         subscribedAPINew.setUUID(uuid);
         subscribedAPINew.setApplication(application);
-        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, apiPersistenceInstance);
+        subscribedAPINew.setSubscriptionId(subscriptionId);
+
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscriptionAndWFType(
+                Mockito.eq(subscriptionId), Mockito.anyString()))
+                .thenReturn(deletionWorkflowRef);
+        Mockito.when(apiMgtDAO.retrieveWorkflow(deletionWorkflowRef)).thenReturn(deletionWorkflow);
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscription(
+                (APIIdentifier) Mockito.any(), Mockito.eq(1), Mockito.anyString()))
+                .thenReturn(creationWorkflowRef);
+        Mockito.when(apiMgtDAO.retrieveWorkflow(creationWorkflowRef)).thenReturn(creationWorkflow);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, SAMPLE_TENANT_DOMAIN_1);
         apiConsumer.removeSubscription(subscribedAPINew, "org1");
+
+        // Governance guard: subscription must NOT be deleted directly
+        Mockito.verify(apiMgtDAO, Mockito.never()).removeSubscriptionById(Mockito.anyInt());
+        // Signal to the REST layer that the delete is still pending approval
         Assert.assertEquals(-1, subscribedAPINew.getSubscriptionId());
         Assert.assertEquals(APIConstants.SubscriptionStatus.DELETE_PENDING, subscribedAPINew.getSubStatus());
     }
 
+    @Test
+    public void testRemoveSubscriptionWhenOnHoldDeletesDirectly()
+            throws APIManagementException, WorkflowException, APIPersistenceException {
+        String subscriptionUUID = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+        String creationWorkflowExtRef = "creation_wf_ref";
+
+        Subscriber subscriber = new Subscriber("sub1");
+        Application application = new Application("app1", subscriber);
+        application.setId(1);
+        APIIdentifier identifier = new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION);
+        identifier.setUuid(apiUUID);
+
+        SubscribedAPI subscribedAPINew = new SubscribedAPI(subscriber, identifier);
+        subscribedAPINew.setUUID(subscriptionUUID);
+        subscribedAPINew.setApplication(application);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+        Mockito.when(apiMgtDAO.checkAPIUUIDIsARevisionUUID(Mockito.anyString())).thenReturn(null);
+
+        DevPortalAPI devPortalAPI = Mockito.mock(DevPortalAPI.class);
+        Mockito.when(apiPersistenceInstance.getDevPortalAPI(any(Organization.class), any(String.class)))
+                .thenReturn(devPortalAPI);
+
+        // Subscription creation workflow reference exists (ON_HOLD state has a pending creation workflow)
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscription(
+                (APIIdentifier) Mockito.any(), Mockito.anyInt(), Mockito.anyString()))
+                .thenReturn(creationWorkflowExtRef);
+        SubscriptionWorkflowDTO subscriptionWorkflowDTO = new SubscriptionWorkflowDTO();
+        subscriptionWorkflowDTO.setWorkflowReference("1");
+        Mockito.when(apiMgtDAO.retrieveWorkflow(creationWorkflowExtRef)).thenReturn(subscriptionWorkflowDTO);
+
+        SubscribedAPI existingSubscription = new SubscribedAPI(subscriptionUUID);
+        existingSubscription.setTier(new Tier("Gold"));
+        Mockito.when(apiMgtDAO.getSubscriptionById(1)).thenReturn(existingSubscription);
+
+        Mockito.when(apiMgtDAO.getSubscriptionStatus(apiUUID, 1))
+                .thenReturn(APIConstants.SubscriptionStatus.ON_HOLD);
+        Mockito.when(apiMgtDAO.getSubscriptionId(apiUUID, 1)).thenReturn("1");
+
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, apiPersistenceInstance);
+        apiConsumer.removeSubscription(subscribedAPINew, "org1");
+
+        // Verify the subscription was deleted directly, bypassing the approval workflow
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).removeSubscriptionById(1);
+        // Verify no DELETE_PENDING status update was written (no approval workflow started)
+        Mockito.verify(apiMgtDAO, Mockito.never()).updateSubscriptionStatus(
+                Mockito.anyInt(), Mockito.eq(APIConstants.SubscriptionStatus.DELETE_PENDING));
+    }
+
+    @Test
+    public void testRemoveSubscriptionWhenRejectedDeletesDirectly()
+            throws APIManagementException, WorkflowException, APIPersistenceException {
+        String subscriptionUUID = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+
+        Subscriber subscriber = new Subscriber("sub1");
+        Application application = new Application("app1", subscriber);
+        application.setId(1);
+        APIIdentifier identifier = new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION);
+        identifier.setUuid(apiUUID);
+
+        SubscribedAPI subscribedAPINew = new SubscribedAPI(subscriber, identifier);
+        subscribedAPINew.setUUID(subscriptionUUID);
+        subscribedAPINew.setApplication(application);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+        Mockito.when(apiMgtDAO.checkAPIUUIDIsARevisionUUID(Mockito.anyString())).thenReturn(null);
+
+        DevPortalAPI devPortalAPI = Mockito.mock(DevPortalAPI.class);
+        Mockito.when(apiPersistenceInstance.getDevPortalAPI(any(Organization.class), any(String.class)))
+                .thenReturn(devPortalAPI);
+
+        // No pending creation workflow for a REJECTED subscription
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscription(
+                (APIIdentifier) Mockito.any(), Mockito.anyInt(), Mockito.anyString()))
+                .thenReturn(null);
+
+        Mockito.when(apiMgtDAO.getSubscriptionStatus(apiUUID, 1))
+                .thenReturn(APIConstants.SubscriptionStatus.REJECTED);
+        Mockito.when(apiMgtDAO.getSubscriptionId(apiUUID, 1)).thenReturn("1");
+
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, apiPersistenceInstance);
+        apiConsumer.removeSubscription(subscribedAPINew, "org1");
+
+        // Verify the subscription was deleted directly, bypassing the approval workflow
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).removeSubscriptionById(1);
+        // Verify no DELETE_PENDING status update was written (no approval workflow started)
+        Mockito.verify(apiMgtDAO, Mockito.never()).updateSubscriptionStatus(
+                Mockito.anyInt(), Mockito.eq(APIConstants.SubscriptionStatus.DELETE_PENDING));
+    }
 
     @Test
     public void testAddSubscription() throws APIManagementException {
@@ -1008,5 +1178,848 @@ public class APIConsumerImplTest {
         assertNotNull(apiKeySet);
         assertEquals(apiKeySet.size(), 2);
         assertNotNull(apiKeySet.iterator().next().getAccessToken());
+    }
+
+    /**
+     * Tests that when a subscription is in TIER_UPDATE_PENDING state and the user requests deletion,
+     * the pending tier-update workflow is cleaned up before transitioning the subscription to DELETE_PENDING.
+     */
+    @Test
+    public void testRemoveSubscriptionWhenTierUpdatePendingCleansUpUpdateWorkflow()
+            throws APIManagementException, WorkflowException, APIPersistenceException {
+        String subscriptionUUID = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+        String updateWorkflowExtRef = "update_wf_ref";
+
+        Subscriber subscriber = new Subscriber("sub1");
+        Application application = new Application("app1", subscriber);
+        application.setId(1);
+        APIIdentifier identifier = new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION);
+        identifier.setUuid(apiUUID);
+
+        SubscribedAPI subscribedAPINew = new SubscribedAPI(subscriber, identifier);
+        subscribedAPINew.setUUID(subscriptionUUID);
+        subscribedAPINew.setApplication(application);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+        Mockito.when(apiMgtDAO.checkAPIUUIDIsARevisionUUID(Mockito.anyString())).thenReturn(null);
+
+        DevPortalAPI devPortalAPI = Mockito.mock(DevPortalAPI.class);
+        Mockito.when(apiPersistenceInstance.getDevPortalAPI(any(Organization.class), any(String.class)))
+                .thenReturn(devPortalAPI);
+
+        // No pending creation workflow for TIER_UPDATE_PENDING state
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscription(
+                (APIIdentifier) Mockito.any(), Mockito.anyInt(), Mockito.anyString()))
+                .thenReturn(null);
+
+        Mockito.when(apiMgtDAO.getSubscriptionStatus(apiUUID, 1))
+                .thenReturn(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING);
+
+        String subId = "42";
+        Mockito.when(apiMgtDAO.getSubscriptionId(apiUUID, 1)).thenReturn(subId);
+
+        // The subscription carries the current tier name (needed for monetization checks later)
+        SubscribedAPI existingSubscription = new SubscribedAPI(subscriptionUUID);
+        existingSubscription.setTier(new Tier("Gold"));
+        Mockito.when(apiMgtDAO.getSubscriptionById(Integer.parseInt(subId))).thenReturn(existingSubscription);
+
+        // The pending tier-update workflow
+        SubscriptionWorkflowDTO updateWfDTO = new SubscriptionWorkflowDTO();
+        updateWfDTO.setExternalWorkflowReference(updateWorkflowExtRef);
+        updateWfDTO.setWorkflowReference(subId);
+        Mockito.when(apiMgtDAO.retrieveWorkflowFromInternalReference(subId,
+                org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_UPDATE))
+                .thenReturn(updateWfDTO);
+
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, apiPersistenceInstance);
+        apiConsumer.removeSubscription(subscribedAPINew, "org1");
+
+        // The pending update workflow entry should have been cleaned up before deletion proceeds
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .retrieveWorkflowFromInternalReference(subId,
+                        org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_UPDATE);
+        // Subscription should be transitioned to DELETE_PENDING (not deleted directly)
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .updateSubscriptionStatus(Integer.parseInt(subId), APIConstants.SubscriptionStatus.DELETE_PENDING);
+        Mockito.verify(apiMgtDAO, Mockito.never()).removeSubscriptionById(Mockito.anyInt());
+    }
+
+    /**
+     * Tests that when a subscription is in TIER_UPDATE_PENDING state and the pending update
+     * workflow record does not exist in the DB, removal still proceeds gracefully to DELETE_PENDING.
+     */
+    @Test
+    public void testRemoveSubscriptionWhenTierUpdatePendingWithNoWorkflowRecord()
+            throws APIManagementException, WorkflowException, APIPersistenceException {
+        String subscriptionUUID = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+
+        Subscriber subscriber = new Subscriber("sub1");
+        Application application = new Application("app1", subscriber);
+        application.setId(1);
+        APIIdentifier identifier = new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION);
+        identifier.setUuid(apiUUID);
+
+        SubscribedAPI subscribedAPINew = new SubscribedAPI(subscriber, identifier);
+        subscribedAPINew.setUUID(subscriptionUUID);
+        subscribedAPINew.setApplication(application);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+        Mockito.when(apiMgtDAO.checkAPIUUIDIsARevisionUUID(Mockito.anyString())).thenReturn(null);
+
+        DevPortalAPI devPortalAPI = Mockito.mock(DevPortalAPI.class);
+        Mockito.when(apiPersistenceInstance.getDevPortalAPI(any(Organization.class), any(String.class)))
+                .thenReturn(devPortalAPI);
+
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscription(
+                (APIIdentifier) Mockito.any(), Mockito.anyInt(), Mockito.anyString()))
+                .thenReturn(null);
+
+        Mockito.when(apiMgtDAO.getSubscriptionStatus(apiUUID, 1))
+                .thenReturn(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING);
+
+        String subId = "42";
+        Mockito.when(apiMgtDAO.getSubscriptionId(apiUUID, 1)).thenReturn(subId);
+
+        SubscribedAPI existingSubscription = new SubscribedAPI(subscriptionUUID);
+        existingSubscription.setTier(new Tier("Gold"));
+        Mockito.when(apiMgtDAO.getSubscriptionById(Integer.parseInt(subId))).thenReturn(existingSubscription);
+
+        // Return null to simulate no workflow record found (e.g., simple workflow executor path)
+        Mockito.when(apiMgtDAO.retrieveWorkflowFromInternalReference(subId,
+                org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_UPDATE))
+                .thenReturn(null);
+
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, apiPersistenceInstance);
+        // Should complete without throwing an exception
+        apiConsumer.removeSubscription(subscribedAPINew, "org1");
+
+        // Subscription should still be transitioned to DELETE_PENDING
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .updateSubscriptionStatus(Integer.parseInt(subId), APIConstants.SubscriptionStatus.DELETE_PENDING);
+    }
+
+    /**
+     * Tests that when a subscription is in DELETE_PENDING state and the user requests a tier update,
+     * the pending delete workflow is cleaned up and the subscription transitions to TIER_UPDATE_PENDING.
+     */
+    @Test
+    public void testUpdateSubscriptionWhenDeletePendingCleansUpDeleteWorkflow() throws APIManagementException {
+        String subscriptionUUID = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+        String deleteWorkflowExtRef = "delete_wf_ext_ref";
+
+        API api = new API(new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION));
+        api.setSubscriptionAvailability(APIConstants.SUBSCRIPTION_TO_ALL_TENANTS);
+        api.setStatus(APIConstants.PUBLISHED);
+        Set<Tier> tiers = new HashSet<>();
+        tiers.add(new Tier("Gold"));
+        tiers.add(new Tier("Silver"));
+        api.setAvailableTiers(tiers);
+        api.setUuid(apiUUID);
+
+        ApiTypeWrapper apiTypeWrapper = new ApiTypeWrapper(api);
+        apiTypeWrapper.setTier("Silver");
+
+        Application application = new Application(1);
+
+        // Existing subscription is currently in DELETE_PENDING
+        SubscribedAPI existingSubscription = new SubscribedAPI(subscriptionUUID);
+        existingSubscription.setSubscriptionId(10);
+        existingSubscription.setSubStatus(APIConstants.SubscriptionStatus.DELETE_PENDING);
+        Mockito.when(apiMgtDAO.getSubscriptionByUUID(subscriptionUUID)).thenReturn(existingSubscription);
+
+        // A pending deletion workflow exists for this subscription
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscriptionAndWFType(
+                existingSubscription.getSubscriptionId(),
+                org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_DELETION))
+                .thenReturn(deleteWorkflowExtRef);
+
+        // updateSubscription writes TIER_UPDATE_PENDING and returns a subscription id
+        int newSubId = 10;
+        Mockito.when(apiMgtDAO.updateSubscription(
+                Mockito.eq(apiTypeWrapper), Mockito.eq(subscriptionUUID),
+                Mockito.eq(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING), Mockito.eq("Silver")))
+                .thenReturn(newSubId);
+
+        SubscribedAPI updatedSubscription = new SubscribedAPI(subscriptionUUID);
+        updatedSubscription.setSubStatus(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING);
+        Mockito.when(apiMgtDAO.getSubscriptionById(newSubId)).thenReturn(updatedSubscription);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, SAMPLE_TENANT_DOMAIN_1);
+        SubscriptionResponse response = apiConsumer.updateSubscription(
+                apiTypeWrapper, "user1", application, subscriptionUUID, "Gold", "Silver");
+
+        // The delete workflow cleanup should have been attempted
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).getExternalWorkflowReferenceForSubscriptionAndWFType(
+                existingSubscription.getSubscriptionId(),
+                org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_DELETION);
+
+        // The subscription should now be set to TIER_UPDATE_PENDING, not blocked
+        Assert.assertEquals(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING, response.getSubscriptionStatus());
+    }
+
+    /**
+     * Tests that when a subscription is in UNBLOCKED (active/approved) state and the user requests deletion,
+     * the deletion workflow is triggered and the subscription is first transitioned to DELETE_PENDING.
+     * This covers the scenario where only the deletion workflow is enabled (or all workflows enabled
+     * and the subscription has already been approved by the creation workflow).
+     */
+    @Test
+    public void testRemoveSubscriptionWhenUnblockedTransitionsToDeletePending()
+            throws APIManagementException, WorkflowException, APIPersistenceException {
+        String subscriptionUUID = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+        String subId = "10";
+
+        Subscriber subscriber = new Subscriber("sub1");
+        Application application = new Application("app1", subscriber);
+        application.setId(1);
+        APIIdentifier identifier = new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION);
+        identifier.setUuid(apiUUID);
+
+        SubscribedAPI subscribedAPINew = new SubscribedAPI(subscriber, identifier);
+        subscribedAPINew.setUUID(subscriptionUUID);
+        subscribedAPINew.setApplication(application);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+        Mockito.when(apiMgtDAO.checkAPIUUIDIsARevisionUUID(Mockito.anyString())).thenReturn(null);
+
+        DevPortalAPI devPortalAPI = Mockito.mock(DevPortalAPI.class);
+        Mockito.when(apiPersistenceInstance.getDevPortalAPI(any(Organization.class), any(String.class)))
+                .thenReturn(devPortalAPI);
+
+        // No pending creation workflow — subscription was already approved
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscription(
+                (APIIdentifier) Mockito.any(), Mockito.anyInt(), Mockito.anyString()))
+                .thenReturn(null);
+
+        Mockito.when(apiMgtDAO.getSubscriptionStatus(apiUUID, 1))
+                .thenReturn(APIConstants.SubscriptionStatus.UNBLOCKED);
+        Mockito.when(apiMgtDAO.getSubscriptionId(apiUUID, 1)).thenReturn(subId);
+
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, apiPersistenceInstance);
+        apiConsumer.removeSubscription(subscribedAPINew, "org1");
+
+        // Subscription should be transitioned to DELETE_PENDING before the deletion workflow runs
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .updateSubscriptionStatus(Integer.parseInt(subId), APIConstants.SubscriptionStatus.DELETE_PENDING);
+        // Subscription should NOT be deleted directly (deletion workflow handles the actual removal)
+        Mockito.verify(apiMgtDAO, Mockito.never()).removeSubscriptionById(Mockito.anyInt());
+    }
+
+
+    /**
+     * Tests that when a subscription is in a normal UNBLOCKED state (no pending deletion workflow),
+     * calling updateSubscription transitions it to TIER_UPDATE_PENDING without attempting any cleanup.
+     * This covers the scenario where only the update workflow is enabled, or the update + creation
+     * workflows are both enabled.
+     */
+    @Test
+    public void testUpdateSubscriptionNormalFlowTransitionsToTierUpdatePending() throws APIManagementException {
+        String subscriptionUUID = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+
+        API api = new API(new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION));
+        api.setSubscriptionAvailability(APIConstants.SUBSCRIPTION_TO_ALL_TENANTS);
+        api.setStatus(APIConstants.PUBLISHED);
+        Set<Tier> tiers = new HashSet<>();
+        tiers.add(new Tier("Gold"));
+        tiers.add(new Tier("Silver"));
+        api.setAvailableTiers(tiers);
+        api.setUuid(apiUUID);
+
+        ApiTypeWrapper apiTypeWrapper = new ApiTypeWrapper(api);
+        apiTypeWrapper.setTier("Gold");
+
+        Application application = new Application(1);
+
+        // Subscription is currently UNBLOCKED (active, approved) — not in DELETE_PENDING
+        SubscribedAPI existingSubscription = new SubscribedAPI(subscriptionUUID);
+        existingSubscription.setSubscriptionId(5);
+        existingSubscription.setSubStatus(APIConstants.SubscriptionStatus.UNBLOCKED);
+        Mockito.when(apiMgtDAO.getSubscriptionByUUID(subscriptionUUID)).thenReturn(existingSubscription);
+
+        int updatedSubId = 5;
+        Mockito.when(apiMgtDAO.updateSubscription(
+                Mockito.eq(apiTypeWrapper), Mockito.eq(subscriptionUUID),
+                Mockito.eq(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING), Mockito.eq("Silver")))
+                .thenReturn(updatedSubId);
+
+        SubscribedAPI updatedSubscription = new SubscribedAPI(subscriptionUUID);
+        updatedSubscription.setSubStatus(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING);
+        Mockito.when(apiMgtDAO.getSubscriptionById(updatedSubId)).thenReturn(updatedSubscription);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, SAMPLE_TENANT_DOMAIN_1);
+        SubscriptionResponse response = apiConsumer.updateSubscription(
+                apiTypeWrapper, "user1", application, subscriptionUUID, "Gold", "Silver");
+
+        // No deletion workflow cleanup should have been attempted since status is not DELETE_PENDING
+        Mockito.verify(apiMgtDAO, Mockito.never()).getExternalWorkflowReferenceForSubscriptionAndWFType(
+                Mockito.anyInt(),
+                Mockito.eq(org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_DELETION));
+        Assert.assertEquals(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING, response.getSubscriptionStatus());
+    }
+
+    /**
+     * Tests that when a subscription is in DELETE_PENDING state but no corresponding deletion
+     * workflow reference is found in the DB (e.g., already cleaned up or simple workflow executor path),
+     * updateSubscription proceeds normally and transitions the subscription to TIER_UPDATE_PENDING.
+     * This covers the update + deletion workflow combination where the deletion workflow record is absent.
+     */
+    @Test
+    public void testUpdateSubscriptionWhenDeletePendingWithNoWorkflowRef() throws APIManagementException {
+        String subscriptionUUID = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+
+        API api = new API(new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION));
+        api.setSubscriptionAvailability(APIConstants.SUBSCRIPTION_TO_ALL_TENANTS);
+        api.setStatus(APIConstants.PUBLISHED);
+        Set<Tier> tiers = new HashSet<>();
+        tiers.add(new Tier("Gold"));
+        tiers.add(new Tier("Silver"));
+        api.setAvailableTiers(tiers);
+        api.setUuid(apiUUID);
+
+        ApiTypeWrapper apiTypeWrapper = new ApiTypeWrapper(api);
+        apiTypeWrapper.setTier("Gold");
+
+        Application application = new Application(1);
+
+        // Subscription is currently in DELETE_PENDING
+        SubscribedAPI existingSubscription = new SubscribedAPI(subscriptionUUID);
+        existingSubscription.setSubscriptionId(8);
+        existingSubscription.setSubStatus(APIConstants.SubscriptionStatus.DELETE_PENDING);
+        Mockito.when(apiMgtDAO.getSubscriptionByUUID(subscriptionUUID)).thenReturn(existingSubscription);
+
+        // No deletion workflow reference exists (e.g., simple executor path or already cleaned up)
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscriptionAndWFType(
+                existingSubscription.getSubscriptionId(),
+                org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_DELETION))
+                .thenReturn(null);
+
+        int updatedSubId = 8;
+        Mockito.when(apiMgtDAO.updateSubscription(
+                Mockito.eq(apiTypeWrapper), Mockito.eq(subscriptionUUID),
+                Mockito.eq(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING), Mockito.eq("Silver")))
+                .thenReturn(updatedSubId);
+
+        SubscribedAPI updatedSubscription = new SubscribedAPI(subscriptionUUID);
+        updatedSubscription.setSubStatus(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING);
+        Mockito.when(apiMgtDAO.getSubscriptionById(updatedSubId)).thenReturn(updatedSubscription);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, SAMPLE_TENANT_DOMAIN_1);
+        SubscriptionResponse response = apiConsumer.updateSubscription(
+                apiTypeWrapper, "user1", application, subscriptionUUID, "Gold", "Silver");
+
+        // The lookup was made but no cleanup was triggered (no ref returned)
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).getExternalWorkflowReferenceForSubscriptionAndWFType(
+                existingSubscription.getSubscriptionId(),
+                org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_DELETION);
+        Assert.assertEquals(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING, response.getSubscriptionStatus());
+    }
+
+    /**
+     * Tests that when a subscription is in ON_HOLD state (pending creation workflow approval)
+     * but its workflow reference is not found (e.g., already expired or cleaned up),
+     * the subscription is still deleted directly without going through the deletion workflow.
+     * This covers the creation-only workflow scenario where the pending task cleanup is a no-op.
+     */
+    @Test
+    public void testRemoveSubscriptionWhenOnHoldWithNoWorkflowRefDeletesDirectly()
+            throws APIManagementException, WorkflowException, APIPersistenceException {
+        String subscriptionUUID = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+        String subId = "3";
+
+        Subscriber subscriber = new Subscriber("sub1");
+        Application application = new Application("app1", subscriber);
+        application.setId(1);
+        APIIdentifier identifier = new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION);
+        identifier.setUuid(apiUUID);
+
+        SubscribedAPI subscribedAPINew = new SubscribedAPI(subscriber, identifier);
+        subscribedAPINew.setUUID(subscriptionUUID);
+        subscribedAPINew.setApplication(application);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+        Mockito.when(apiMgtDAO.checkAPIUUIDIsARevisionUUID(Mockito.anyString())).thenReturn(null);
+
+        DevPortalAPI devPortalAPI = Mockito.mock(DevPortalAPI.class);
+        Mockito.when(apiPersistenceInstance.getDevPortalAPI(any(Organization.class), any(String.class)))
+                .thenReturn(devPortalAPI);
+
+        // No workflow reference found for this subscription (e.g., creation WF already cleaned up)
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscription(
+                (APIIdentifier) Mockito.any(), Mockito.anyInt(), Mockito.anyString()))
+                .thenReturn(null);
+
+        Mockito.when(apiMgtDAO.getSubscriptionStatus(apiUUID, 1))
+                .thenReturn(APIConstants.SubscriptionStatus.ON_HOLD);
+        Mockito.when(apiMgtDAO.getSubscriptionId(apiUUID, 1)).thenReturn(subId);
+
+        SubscribedAPI existingSubscription = new SubscribedAPI(subscriptionUUID);
+        existingSubscription.setTier(new Tier("Gold"));
+        Mockito.when(apiMgtDAO.getSubscriptionById(Integer.parseInt(subId))).thenReturn(existingSubscription);
+
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, apiPersistenceInstance);
+        apiConsumer.removeSubscription(subscribedAPINew, "org1");
+
+        // Subscription should be deleted directly regardless of missing workflow reference
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).removeSubscriptionById(Integer.parseInt(subId));
+        // No DELETE_PENDING transition should occur
+        Mockito.verify(apiMgtDAO, Mockito.never()).updateSubscriptionStatus(
+                Mockito.anyInt(), Mockito.eq(APIConstants.SubscriptionStatus.DELETE_PENDING));
+    }
+
+    /**
+     * Tests the addSubscription creation workflow path: when the workflow executor throws a
+     * WorkflowException, the subscription entry added to the DB is rolled back via removeSubscriptionById.
+     * This covers the creation-workflow-only scenario where the executor fails.
+     */
+    @Test
+    public void testAddSubscriptionWorkflowExceptionRollsBackSubscription() throws APIManagementException {
+        final int newSubscriptionId = 99;
+
+        API api = new API(new APIIdentifier(API_PROVIDER, "published_api", SAMPLE_API_VERSION));
+        api.setSubscriptionAvailability(APIConstants.SUBSCRIPTION_TO_ALL_TENANTS);
+        api.setStatus(APIConstants.PUBLISHED);
+        Set<Tier> tiers = new HashSet<>();
+        tiers.add(new Tier("tier1"));
+        api.setAvailableTiers(tiers);
+        ApiTypeWrapper apiTypeWrapper = new ApiTypeWrapper(api);
+        apiTypeWrapper.setTier("tier1");
+
+        Application application = new Application(1);
+
+        String tenantAwareUsername = "user1@" + SAMPLE_TENANT_DOMAIN_1;
+        Mockito.when(MultitenantUtils.getTenantAwareUsername(Mockito.eq("user1"))).thenReturn(tenantAwareUsername);
+        Mockito.when(apiMgtDAO.addSubscription(apiTypeWrapper, application,
+                APIConstants.SubscriptionStatus.ON_HOLD, tenantAwareUsername)).thenReturn(newSubscriptionId);
+
+        // Use a wrapper whose workflow executor throws WorkflowException
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, SAMPLE_TENANT_DOMAIN_1) {
+            @Override
+            protected org.wso2.carbon.apimgt.impl.workflow.WorkflowExecutor getWorkflowExecutor(
+                    String workflowType, String tenant)
+                    throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                return new org.wso2.carbon.apimgt.impl.workflow.SampleWorkFlowExecutor() {
+                    @Override
+                    public org.wso2.carbon.apimgt.api.WorkflowResponse execute(
+                            org.wso2.carbon.apimgt.impl.dto.WorkflowDTO workflowDTO)
+                            throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                        throw new org.wso2.carbon.apimgt.impl.workflow.WorkflowException(
+                                "Simulated workflow failure");
+                    }
+                };
+            }
+
+            @Override
+            protected org.wso2.carbon.apimgt.impl.workflow.WorkflowExecutor getWorkflowExecutor(
+                    String workflowType)
+                    throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                return getWorkflowExecutor(workflowType, SAMPLE_TENANT_DOMAIN_1);
+            }
+        };
+
+        try {
+            apiConsumer.addSubscription(apiTypeWrapper, "user1", application);
+            Assert.fail("Expected APIManagementException due to workflow failure");
+        } catch (APIManagementException e) {
+            Assert.assertTrue(e.getMessage().contains("Could not execute Workflow"));
+        }
+
+        // The subscription entry must be rolled back on workflow failure
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).removeSubscriptionById(newSubscriptionId);
+    }
+
+    // =========================================================================
+    // Workflow combination tests (8 permutations of creation/deletion/update WF)
+    // =========================================================================
+
+    /**
+     * Creation approval WF active.
+     * addSubscription: the approval executor does not immediately update the subscription
+     * status, so the subscription stays ON_HOLD until an admin completes the workflow.
+     */
+    @Test
+    public void testAddSubscriptionCreationWorkflowActive_subscriptionStaysOnHold()
+            throws APIManagementException {
+        API api = new API(new APIIdentifier(API_PROVIDER, "published_api", SAMPLE_API_VERSION));
+        api.setSubscriptionAvailability(APIConstants.SUBSCRIPTION_TO_ALL_TENANTS);
+        api.setStatus(APIConstants.PUBLISHED);
+        Set<Tier> tiers = new HashSet<>();
+        tiers.add(new Tier("tier1"));
+        api.setAvailableTiers(tiers);
+        ApiTypeWrapper apiTypeWrapper = new ApiTypeWrapper(api);
+        apiTypeWrapper.setTier("tier1");
+        Application application = new Application(1);
+
+        String tenantAwareUsername = "user1@" + SAMPLE_TENANT_DOMAIN_1;
+        Mockito.when(MultitenantUtils.getTenantAwareUsername(Mockito.eq("user1"))).thenReturn(tenantAwareUsername);
+        Mockito.when(apiMgtDAO.addSubscription(apiTypeWrapper, application,
+                APIConstants.SubscriptionStatus.ON_HOLD, tenantAwareUsername)).thenReturn(1);
+
+        SubscribedAPI subscribedAPI = new SubscribedAPI(UUID.randomUUID().toString());
+        subscribedAPI.setSubStatus(APIConstants.SubscriptionStatus.ON_HOLD);
+        Mockito.when(apiMgtDAO.getSubscriptionById(1)).thenReturn(subscribedAPI);
+
+        // SampleWorkFlowExecutor simulates the approval executor: execute() does not
+        // immediately update the subscription status — admin approval is required.
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, SAMPLE_TENANT_DOMAIN_1);
+        SubscriptionResponse response = apiConsumer.addSubscription(apiTypeWrapper, "user1", application);
+
+        Assert.assertEquals(APIConstants.SubscriptionStatus.ON_HOLD, response.getSubscriptionStatus());
+        Mockito.verify(apiMgtDAO, Mockito.never())
+                .updateSubscriptionStatus(Mockito.anyInt(),
+                        Mockito.eq(APIConstants.SubscriptionStatus.UNBLOCKED));
+    }
+
+    /**
+     * No creation approval WF (simple/default executor).
+     * addSubscription: the executor immediately approves and transitions the subscription
+     * to UNBLOCKED without waiting for admin action.
+     */
+    @Test
+    public void testAddSubscriptionNoCreationWorkflow_subscriptionImmediatelyUnblocked()
+            throws APIManagementException {
+        API api = new API(new APIIdentifier(API_PROVIDER, "published_api", SAMPLE_API_VERSION));
+        api.setSubscriptionAvailability(APIConstants.SUBSCRIPTION_TO_ALL_TENANTS);
+        api.setStatus(APIConstants.PUBLISHED);
+        Set<Tier> tiers = new HashSet<>();
+        tiers.add(new Tier("tier1"));
+        api.setAvailableTiers(tiers);
+        ApiTypeWrapper apiTypeWrapper = new ApiTypeWrapper(api);
+        apiTypeWrapper.setTier("tier1");
+        Application application = new Application(1);
+
+        String tenantAwareUsername = "user1@" + SAMPLE_TENANT_DOMAIN_1;
+        Mockito.when(MultitenantUtils.getTenantAwareUsername(Mockito.eq("user1"))).thenReturn(tenantAwareUsername);
+        Mockito.when(apiMgtDAO.addSubscription(apiTypeWrapper, application,
+                APIConstants.SubscriptionStatus.ON_HOLD, tenantAwareUsername)).thenReturn(1);
+
+        SubscribedAPI subscribedAPI = new SubscribedAPI(UUID.randomUUID().toString());
+        subscribedAPI.setSubStatus(APIConstants.SubscriptionStatus.UNBLOCKED);
+        Mockito.when(apiMgtDAO.getSubscriptionById(1)).thenReturn(subscribedAPI);
+
+        // Custom executor simulates a simple/default WF that immediately approves:
+        // it calls updateSubscriptionStatus(UNBLOCKED) inline, just as the real simple executor would.
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, SAMPLE_TENANT_DOMAIN_1) {
+            @Override
+            protected org.wso2.carbon.apimgt.impl.workflow.WorkflowExecutor getWorkflowExecutor(
+                    String workflowType, String tenant)
+                    throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                return new org.wso2.carbon.apimgt.impl.workflow.SampleWorkFlowExecutor() {
+                    @Override
+                    public org.wso2.carbon.apimgt.api.WorkflowResponse execute(
+                            org.wso2.carbon.apimgt.impl.dto.WorkflowDTO workflowDTO)
+                            throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                        try {
+                            apiMgtDAO.updateSubscriptionStatus(
+                                    Integer.parseInt(workflowDTO.getWorkflowReference()),
+                                    APIConstants.SubscriptionStatus.UNBLOCKED);
+                        } catch (APIManagementException e) {
+                            throw new org.wso2.carbon.apimgt.impl.workflow.WorkflowException(
+                                    "Immediate approval failed", e);
+                        }
+                        return super.execute(workflowDTO);
+                    }
+                };
+            }
+
+            @Override
+            protected org.wso2.carbon.apimgt.impl.workflow.WorkflowExecutor getWorkflowExecutor(
+                    String workflowType)
+                    throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                return getWorkflowExecutor(workflowType, SAMPLE_TENANT_DOMAIN_1);
+            }
+        };
+
+        SubscriptionResponse response = apiConsumer.addSubscription(apiTypeWrapper, "user1", application);
+
+        Assert.assertEquals(APIConstants.SubscriptionStatus.UNBLOCKED, response.getSubscriptionStatus());
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .updateSubscriptionStatus(1, APIConstants.SubscriptionStatus.UNBLOCKED);
+    }
+
+    /**
+     * No deletion approval WF (simple/default executor).
+     * removeSubscription from UNBLOCKED: the executor immediately removes the subscription
+     * from the DB instead of waiting for admin approval.
+     */
+    @Test
+    public void testRemoveSubscriptionWhenUnblockedNoDeletionWorkflow_subscriptionRemovedImmediately()
+            throws APIManagementException, WorkflowException, APIPersistenceException {
+        String subscriptionUUID = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+        String subId = "10";
+
+        Subscriber subscriber = new Subscriber("sub1");
+        Application application = new Application("app1", subscriber);
+        application.setId(1);
+        APIIdentifier identifier = new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION);
+        identifier.setUuid(apiUUID);
+
+        SubscribedAPI subscribedAPINew = new SubscribedAPI(subscriber, identifier);
+        subscribedAPINew.setUUID(subscriptionUUID);
+        subscribedAPINew.setApplication(application);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+        Mockito.when(apiMgtDAO.checkAPIUUIDIsARevisionUUID(Mockito.anyString())).thenReturn(null);
+
+        DevPortalAPI devPortalAPI = Mockito.mock(DevPortalAPI.class);
+        Mockito.when(apiPersistenceInstance.getDevPortalAPI(any(Organization.class), any(String.class)))
+                .thenReturn(devPortalAPI);
+
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscription(
+                (APIIdentifier) Mockito.any(), Mockito.anyInt(), Mockito.anyString()))
+                .thenReturn(null);
+        Mockito.when(apiMgtDAO.getSubscriptionStatus(apiUUID, 1))
+                .thenReturn(APIConstants.SubscriptionStatus.UNBLOCKED);
+        Mockito.when(apiMgtDAO.getSubscriptionId(apiUUID, 1)).thenReturn(subId);
+
+        // Custom executor simulates a simple/default deletion WF that immediately removes
+        // the subscription from the DB upon execution.
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, apiPersistenceInstance) {
+            @Override
+            protected org.wso2.carbon.apimgt.impl.workflow.WorkflowExecutor getWorkflowExecutor(
+                    String workflowType, String tenant)
+                    throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                if (org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants
+                        .WF_TYPE_AM_SUBSCRIPTION_DELETION.equals(workflowType)) {
+                    return new org.wso2.carbon.apimgt.impl.workflow.SampleWorkFlowExecutor() {
+                        @Override
+                        public org.wso2.carbon.apimgt.api.WorkflowResponse execute(
+                                org.wso2.carbon.apimgt.impl.dto.WorkflowDTO workflowDTO)
+                                throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                            try {
+                                apiMgtDAO.removeSubscriptionById(
+                                        Integer.parseInt(workflowDTO.getWorkflowReference()));
+                            } catch (APIManagementException e) {
+                                throw new org.wso2.carbon.apimgt.impl.workflow.WorkflowException(
+                                        "Immediate removal failed", e);
+                            }
+                            return super.execute(workflowDTO);
+                        }
+                    };
+                }
+                return new org.wso2.carbon.apimgt.impl.workflow.SampleWorkFlowExecutor();
+            }
+
+            @Override
+            protected org.wso2.carbon.apimgt.impl.workflow.WorkflowExecutor getWorkflowExecutor(
+                    String workflowType)
+                    throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                return getWorkflowExecutor(workflowType, "");
+            }
+        };
+
+        apiConsumer.removeSubscription(subscribedAPINew, "org1");
+
+        // Subscription transitions to DELETE_PENDING first, then is removed immediately by the simple executor
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .updateSubscriptionStatus(Integer.parseInt(subId),
+                        APIConstants.SubscriptionStatus.DELETE_PENDING);
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).removeSubscriptionById(Integer.parseInt(subId));
+    }
+
+    /**
+     * No update approval WF (simple/default executor).
+     * updateSubscription: the executor immediately applies the new tier and transitions
+     * the subscription back to UNBLOCKED without admin approval.
+     */
+    @Test
+    public void testUpdateSubscriptionNoUpdateWorkflow_tierAppliedImmediately()
+            throws APIManagementException {
+        String subscriptionUUID = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+        int updatedSubId = 5;
+
+        API api = new API(new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION));
+        api.setSubscriptionAvailability(APIConstants.SUBSCRIPTION_TO_ALL_TENANTS);
+        api.setStatus(APIConstants.PUBLISHED);
+        Set<Tier> tiers = new HashSet<>();
+        tiers.add(new Tier("Gold"));
+        tiers.add(new Tier("Silver"));
+        api.setAvailableTiers(tiers);
+        api.setUuid(apiUUID);
+
+        ApiTypeWrapper apiTypeWrapper = new ApiTypeWrapper(api);
+        apiTypeWrapper.setTier("Gold");
+
+        Application application = new Application(1);
+
+        // Subscription is currently UNBLOCKED — no pending deletion workflow
+        SubscribedAPI existingSubscription = new SubscribedAPI(subscriptionUUID);
+        existingSubscription.setSubscriptionId(updatedSubId);
+        existingSubscription.setSubStatus(APIConstants.SubscriptionStatus.UNBLOCKED);
+        Mockito.when(apiMgtDAO.getSubscriptionByUUID(subscriptionUUID)).thenReturn(existingSubscription);
+
+        Mockito.when(apiMgtDAO.updateSubscription(
+                Mockito.eq(apiTypeWrapper), Mockito.eq(subscriptionUUID),
+                Mockito.eq(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING), Mockito.eq("Silver")))
+                .thenReturn(updatedSubId);
+
+        SubscribedAPI updatedSubscription = new SubscribedAPI(subscriptionUUID);
+        updatedSubscription.setSubStatus(APIConstants.SubscriptionStatus.UNBLOCKED);
+        Mockito.when(apiMgtDAO.getSubscriptionById(updatedSubId)).thenReturn(updatedSubscription);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+
+        // Custom executor simulates a simple/default update WF that immediately applies
+        // the tier change by calling updateSubscriptionStatusAndTier(UNBLOCKED).
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, SAMPLE_TENANT_DOMAIN_1) {
+            @Override
+            protected org.wso2.carbon.apimgt.impl.workflow.WorkflowExecutor getWorkflowExecutor(
+                    String workflowType, String tenant)
+                    throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                return new org.wso2.carbon.apimgt.impl.workflow.SampleWorkFlowExecutor() {
+                    @Override
+                    public org.wso2.carbon.apimgt.api.WorkflowResponse execute(
+                            org.wso2.carbon.apimgt.impl.dto.WorkflowDTO workflowDTO)
+                            throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                        try {
+                            apiMgtDAO.updateSubscriptionStatusAndTier(
+                                    Integer.parseInt(workflowDTO.getWorkflowReference()),
+                                    APIConstants.SubscriptionStatus.UNBLOCKED);
+                        } catch (APIManagementException e) {
+                            throw new org.wso2.carbon.apimgt.impl.workflow.WorkflowException(
+                                    "Immediate tier update failed", e);
+                        }
+                        return super.execute(workflowDTO);
+                    }
+                };
+            }
+
+            @Override
+            protected org.wso2.carbon.apimgt.impl.workflow.WorkflowExecutor getWorkflowExecutor(
+                    String workflowType)
+                    throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                return getWorkflowExecutor(workflowType, SAMPLE_TENANT_DOMAIN_1);
+            }
+        };
+
+        SubscriptionResponse response = apiConsumer.updateSubscription(
+                apiTypeWrapper, "user1", application, subscriptionUUID, "Gold", "Silver");
+
+        // Tier is applied immediately — no admin approval step
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .updateSubscriptionStatusAndTier(updatedSubId, APIConstants.SubscriptionStatus.UNBLOCKED);
+        Assert.assertEquals(APIConstants.SubscriptionStatus.UNBLOCKED, response.getSubscriptionStatus());
+    }
+
+    /**
+     * Update approval WF was active (TIER_UPDATE_PENDING), no deletion approval WF.
+     * removeSubscription: the pending update workflow is cleaned up, then the simple deletion
+     * executor immediately removes the subscription from the DB.
+     */
+    @Test
+    public void testRemoveSubscriptionWhenTierUpdatePendingNoDeletionWorkflow_cleanupThenImmediateRemoval()
+            throws APIManagementException, WorkflowException, APIPersistenceException {
+        String subscriptionUUID = UUID.randomUUID().toString();
+        String apiUUID = UUID.randomUUID().toString();
+        String subId = "42";
+        String updateWorkflowExtRef = "update_wf_ext_ref_combo46";
+
+        Subscriber subscriber = new Subscriber("sub1");
+        Application application = new Application("app1", subscriber);
+        application.setId(1);
+        APIIdentifier identifier = new APIIdentifier(API_PROVIDER, SAMPLE_API_NAME, SAMPLE_API_VERSION);
+        identifier.setUuid(apiUUID);
+
+        SubscribedAPI subscribedAPINew = new SubscribedAPI(subscriber, identifier);
+        subscribedAPINew.setUUID(subscriptionUUID);
+        subscribedAPINew.setApplication(application);
+
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+        Mockito.when(apiMgtDAO.checkAPIUUIDIsARevisionUUID(Mockito.anyString())).thenReturn(null);
+
+        DevPortalAPI devPortalAPI = Mockito.mock(DevPortalAPI.class);
+        Mockito.when(apiPersistenceInstance.getDevPortalAPI(any(Organization.class), any(String.class)))
+                .thenReturn(devPortalAPI);
+
+        // No pending creation workflow
+        Mockito.when(apiMgtDAO.getExternalWorkflowReferenceForSubscription(
+                (APIIdentifier) Mockito.any(), Mockito.anyInt(), Mockito.anyString()))
+                .thenReturn(null);
+
+        Mockito.when(apiMgtDAO.getSubscriptionStatus(apiUUID, 1))
+                .thenReturn(APIConstants.SubscriptionStatus.TIER_UPDATE_PENDING);
+        Mockito.when(apiMgtDAO.getSubscriptionId(apiUUID, 1)).thenReturn(subId);
+
+        SubscribedAPI existingSubscription = new SubscribedAPI(subscriptionUUID);
+        existingSubscription.setTier(new Tier("Gold"));
+        Mockito.when(apiMgtDAO.getSubscriptionById(Integer.parseInt(subId))).thenReturn(existingSubscription);
+
+        // Pending update workflow that can be cleaned up
+        SubscriptionWorkflowDTO updateWfDTO = new SubscriptionWorkflowDTO();
+        updateWfDTO.setExternalWorkflowReference(updateWorkflowExtRef);
+        updateWfDTO.setWorkflowReference(subId);
+        Mockito.when(apiMgtDAO.retrieveWorkflowFromInternalReference(subId,
+                org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_UPDATE))
+                .thenReturn(updateWfDTO);
+
+        // Custom executor simulates simple deletion WF: immediately removes the subscription
+        APIConsumerImpl apiConsumer = new APIConsumerImplWrapper(apiMgtDAO, apiPersistenceInstance) {
+            @Override
+            protected org.wso2.carbon.apimgt.impl.workflow.WorkflowExecutor getWorkflowExecutor(
+                    String workflowType, String tenant)
+                    throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                if (org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants
+                        .WF_TYPE_AM_SUBSCRIPTION_DELETION.equals(workflowType)) {
+                    return new org.wso2.carbon.apimgt.impl.workflow.SampleWorkFlowExecutor() {
+                        @Override
+                        public org.wso2.carbon.apimgt.api.WorkflowResponse execute(
+                                org.wso2.carbon.apimgt.impl.dto.WorkflowDTO workflowDTO)
+                                throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                            try {
+                                apiMgtDAO.removeSubscriptionById(
+                                        Integer.parseInt(workflowDTO.getWorkflowReference()));
+                            } catch (APIManagementException e) {
+                                throw new org.wso2.carbon.apimgt.impl.workflow.WorkflowException(
+                                        "Immediate removal failed", e);
+                            }
+                            return super.execute(workflowDTO);
+                        }
+                    };
+                }
+                return new org.wso2.carbon.apimgt.impl.workflow.SampleWorkFlowExecutor();
+            }
+
+            @Override
+            protected org.wso2.carbon.apimgt.impl.workflow.WorkflowExecutor getWorkflowExecutor(
+                    String workflowType)
+                    throws org.wso2.carbon.apimgt.impl.workflow.WorkflowException {
+                return getWorkflowExecutor(workflowType, "");
+            }
+        };
+
+        apiConsumer.removeSubscription(subscribedAPINew, "org1");
+
+        // The pending update workflow was cleaned up first
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).retrieveWorkflowFromInternalReference(
+                subId, org.wso2.carbon.apimgt.impl.workflow.WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_UPDATE);
+        // Subscription transitioned to DELETE_PENDING, then immediately removed by the simple executor
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .updateSubscriptionStatus(Integer.parseInt(subId),
+                        APIConstants.SubscriptionStatus.DELETE_PENDING);
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).removeSubscriptionById(Integer.parseInt(subId));
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionCreationApprovalWorkflowExecutorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionCreationApprovalWorkflowExecutorTest.java
@@ -1,0 +1,179 @@
+/*
+ *   Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ *   WSO2 LLC. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.impl.workflow;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
+
+/**
+ * SubscriptionCreationApprovalWorkflowExecutor test cases.
+ *
+ * Covers the following transitions:
+ *   Creation Flow — admin approves:  ON HOLD → UNBLOCKED
+ *   Admin Rejection:                 ON HOLD → REJECTED
+ *   Illegal Approval Path (negative): ON HOLD admin-reject must NOT go to UNBLOCKED
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ApiMgtDAO.class})
+public class SubscriptionCreationApprovalWorkflowExecutorTest {
+
+    private SubscriptionCreationApprovalWorkflowExecutor executor;
+    private ApiMgtDAO apiMgtDAO;
+
+    @Before
+    public void init() {
+        executor = new SubscriptionCreationApprovalWorkflowExecutor();
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        apiMgtDAO = Mockito.mock(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+    }
+
+    @Test
+    public void testGetWorkflowType() {
+        Assert.assertEquals(WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_CREATION, executor.getWorkflowType());
+    }
+
+    /**
+     * Creation Flow: ON HOLD → admin approves → UNBLOCKED.
+     * Verifies that completing the creation workflow with APPROVED status
+     * calls updateSubscriptionStatus with UNBLOCKED.
+     */
+    @Test
+    public void testCompleteSubscriptionCreationApprovedUpdatesStatusToUnblocked()
+            throws APIManagementException, WorkflowException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("5");
+        workflowDTO.setStatus(WorkflowStatus.APPROVED);
+
+        executor.complete(workflowDTO);
+
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .updateSubscriptionStatus(5, APIConstants.SubscriptionStatus.UNBLOCKED);
+    }
+
+    @Test
+    public void testCompleteSubscriptionCreationApprovedDAOExceptionThrowsWorkflowException()
+            throws APIManagementException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("5");
+        workflowDTO.setStatus(WorkflowStatus.APPROVED);
+
+        Mockito.doThrow(new APIManagementException("DB error"))
+                .when(apiMgtDAO).updateSubscriptionStatus(5, APIConstants.SubscriptionStatus.UNBLOCKED);
+
+        try {
+            executor.complete(workflowDTO);
+            Assert.fail("Expected WorkflowException was not thrown");
+        } catch (WorkflowException e) {
+            Assert.assertTrue(e.getMessage().contains("Could not complete subscription creation workflow"));
+        }
+    }
+
+    /**
+     * Admin Rejection: ON HOLD → admin rejects → REJECTED.
+     * Also validates Illegal Approval Path (negative): an admin rejection must NOT set the subscription to UNBLOCKED.
+     */
+    @Test
+    public void testCompleteSubscriptionCreationRejectedUpdatesStatusToRejected()
+            throws APIManagementException, WorkflowException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("5");
+        workflowDTO.setStatus(WorkflowStatus.REJECTED);
+
+        executor.complete(workflowDTO);
+
+        // Must go to REJECTED — proves the illegal approval path is blocked
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .updateSubscriptionStatus(5, APIConstants.SubscriptionStatus.REJECTED);
+        Mockito.verify(apiMgtDAO, Mockito.never())
+                .updateSubscriptionStatus(5, APIConstants.SubscriptionStatus.UNBLOCKED);
+    }
+
+    @Test
+    public void testCompleteSubscriptionCreationRejectedDAOExceptionThrowsWorkflowException()
+            throws APIManagementException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("5");
+        workflowDTO.setStatus(WorkflowStatus.REJECTED);
+
+        Mockito.doThrow(new APIManagementException("DB error"))
+                .when(apiMgtDAO).updateSubscriptionStatus(5, APIConstants.SubscriptionStatus.REJECTED);
+
+        try {
+            executor.complete(workflowDTO);
+            Assert.fail("Expected WorkflowException was not thrown");
+        } catch (WorkflowException e) {
+            Assert.assertTrue(e.getMessage().contains("Could not complete subscription creation workflow"));
+        }
+    }
+
+    @Test
+    public void testCleanUpPendingTaskDeletesWorkflowRequest() throws APIManagementException {
+        String workflowExtRef = "creation-ext-ref-123";
+        try {
+            executor.cleanUpPendingTask(workflowExtRef);
+        } catch (WorkflowException e) {
+            Assert.fail("Unexpected WorkflowException during cleanUpPendingTask: " + e.getMessage());
+        }
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).deleteWorkflowRequest(workflowExtRef);
+    }
+
+    @Test
+    public void testCleanUpPendingTaskDAOExceptionThrowsWorkflowException() throws APIManagementException {
+        String workflowExtRef = "creation-ext-ref-123";
+        Mockito.doThrow(new APIManagementException("DB error"))
+                .when(apiMgtDAO).deleteWorkflowRequest(workflowExtRef);
+
+        try {
+            executor.cleanUpPendingTask(workflowExtRef);
+            Assert.fail("Expected WorkflowException was not thrown");
+        } catch (WorkflowException e) {
+            Assert.assertTrue("Expected error message to mention cancellation of pending approval",
+                    e.getMessage().contains("cancel pending subscription approval"));
+        }
+    }
+
+    /**
+     * Verifies that complete() with a status other than APPROVED or REJECTED (e.g. CREATED)
+     * is a no-op — no subscription status update is written to the database.
+     */
+    @Test
+    public void testCompleteSubscriptionCreationWithNeutralStatus_isNoOp()
+            throws APIManagementException, WorkflowException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("5");
+        workflowDTO.setStatus(WorkflowStatus.CREATED);
+
+        executor.complete(workflowDTO);
+
+        Mockito.verify(apiMgtDAO, Mockito.never())
+                .updateSubscriptionStatus(Mockito.anyInt(), Mockito.anyString());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionApprovalWorkflowExecutorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionDeletionApprovalWorkflowExecutorTest.java
@@ -1,0 +1,177 @@
+/*
+ *   Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ *   WSO2 LLC. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.apimgt.impl.workflow;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
+
+/**
+ * SubscriptionDeletionApprovalWorkflowExecutor test cases.
+ *
+ * Covers the following transitions:
+ *   Deletion Flow — admin approves:  DELETE PENDING → No Subscription (removed)
+ *   Rollback Deletion — admin rejects: DELETE PENDING → UNBLOCKED
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ApiMgtDAO.class})
+public class SubscriptionDeletionApprovalWorkflowExecutorTest {
+
+    private SubscriptionDeletionApprovalWorkflowExecutor executor;
+    private ApiMgtDAO apiMgtDAO;
+
+    @Before
+    public void init() {
+        executor = new SubscriptionDeletionApprovalWorkflowExecutor();
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        apiMgtDAO = Mockito.mock(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+    }
+
+    @Test
+    public void testGetWorkflowType() {
+        Assert.assertEquals(WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_DELETION, executor.getWorkflowType());
+    }
+
+    /**
+     * Deletion Flow: DELETE PENDING → admin approves → subscription removed (No Subscription).
+     * Verifies that completing the deletion workflow with APPROVED status calls removeSubscriptionById.
+     */
+    @Test
+    public void testCompleteSubscriptionDeletionApprovedRemovesSubscription()
+            throws APIManagementException, WorkflowException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("7");
+        workflowDTO.setStatus(WorkflowStatus.APPROVED);
+
+        executor.complete(workflowDTO);
+
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).removeSubscriptionById(7);
+        Mockito.verify(apiMgtDAO, Mockito.never())
+                .updateSubscriptionStatus(Mockito.anyInt(), Mockito.anyString());
+    }
+
+    @Test
+    public void testCompleteSubscriptionDeletionApprovedDAOExceptionThrowsWorkflowException()
+            throws APIManagementException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("7");
+        workflowDTO.setStatus(WorkflowStatus.APPROVED);
+
+        Mockito.doThrow(new APIManagementException("DB error")).when(apiMgtDAO).removeSubscriptionById(7);
+
+        try {
+            executor.complete(workflowDTO);
+            Assert.fail("Expected WorkflowException was not thrown");
+        } catch (WorkflowException e) {
+            Assert.assertTrue("Expected error message to mention subscription deletion workflow",
+                    e.getMessage().contains("subscription deletion workflow"));
+        }
+    }
+
+    /**
+     * Rollback Deletion: DELETE PENDING → admin rejects → UNBLOCKED.
+     * Verifies that completing the deletion workflow with REJECTED status restores the subscription
+     * to UNBLOCKED without removing it.
+     */
+    @Test
+    public void testCompleteSubscriptionDeletionRejectedRestoresStatusToUnblocked()
+            throws APIManagementException, WorkflowException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("7");
+        workflowDTO.setStatus(WorkflowStatus.REJECTED);
+
+        executor.complete(workflowDTO);
+
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .updateSubscriptionStatus(7, APIConstants.SubscriptionStatus.UNBLOCKED);
+        Mockito.verify(apiMgtDAO, Mockito.never()).removeSubscriptionById(Mockito.anyInt());
+    }
+
+    @Test
+    public void testCompleteSubscriptionDeletionRejectedDAOExceptionThrowsWorkflowException()
+            throws APIManagementException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("7");
+        workflowDTO.setStatus(WorkflowStatus.REJECTED);
+
+        Mockito.doThrow(new APIManagementException("DB error"))
+                .when(apiMgtDAO).updateSubscriptionStatus(7, APIConstants.SubscriptionStatus.UNBLOCKED);
+
+        try {
+            executor.complete(workflowDTO);
+            Assert.fail("Expected WorkflowException was not thrown");
+        } catch (WorkflowException e) {
+            Assert.assertTrue(e.getMessage().contains("Could not complete subscription deletion workflow"));
+        }
+    }
+
+    /**
+     * Verifies that complete() with a neutral status (e.g. CREATED) is a no-op —
+     * neither removeSubscriptionById nor updateSubscriptionStatus is called.
+     */
+    @Test
+    public void testCompleteSubscriptionDeletionWithNeutralStatus_isNoOp()
+            throws APIManagementException, WorkflowException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("7");
+        workflowDTO.setStatus(WorkflowStatus.CREATED);
+
+        executor.complete(workflowDTO);
+
+        Mockito.verify(apiMgtDAO, Mockito.never()).removeSubscriptionById(Mockito.anyInt());
+        Mockito.verify(apiMgtDAO, Mockito.never()).updateSubscriptionStatus(Mockito.anyInt(), Mockito.anyString());
+    }
+
+    @Test
+    public void testCleanUpPendingTaskDeletesWorkflowRequest() throws APIManagementException {
+        String workflowExtRef = "deletion-ext-ref-456";
+        try {
+            executor.cleanUpPendingTask(workflowExtRef);
+        } catch (WorkflowException e) {
+            Assert.fail("Unexpected WorkflowException during cleanUpPendingTask: " + e.getMessage());
+        }
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).deleteWorkflowRequest(workflowExtRef);
+    }
+
+    @Test
+    public void testCleanUpPendingTaskDAOExceptionThrowsWorkflowException() throws APIManagementException {
+        String workflowExtRef = "deletion-ext-ref-456";
+        Mockito.doThrow(new APIManagementException("DB error"))
+                .when(apiMgtDAO).deleteWorkflowRequest(workflowExtRef);
+
+        try {
+            executor.cleanUpPendingTask(workflowExtRef);
+            Assert.fail("Expected WorkflowException was not thrown");
+        } catch (WorkflowException e) {
+            Assert.assertTrue("Expected error message to mention cancellation of pending deletion approval",
+                    e.getMessage().contains("cancel pending subscription deletion"));
+        }
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionUpdateApprovalWorkflowExecutorTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/workflow/SubscriptionUpdateApprovalWorkflowExecutorTest.java
@@ -1,0 +1,182 @@
+/*
+ *   Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ *   WSO2 LLC. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.wso2.carbon.apimgt.impl.workflow;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+import org.wso2.carbon.apimgt.impl.dto.SubscriptionWorkflowDTO;
+
+/**
+ * SubscriptionUpdateApprovalWorkflowExecutor test cases.
+ *
+ * Covers the following transitions:
+ *   Update Flow — admin approves:  TIER UPDATE PENDING → UNBLOCKED (tier applied)
+ *   Update Flow — admin rejects/deletes: TIER UPDATE PENDING → UNBLOCKED (tier rolled back)
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ApiMgtDAO.class})
+public class SubscriptionUpdateApprovalWorkflowExecutorTest {
+
+    private SubscriptionUpdateApprovalWorkflowExecutor executor;
+    private ApiMgtDAO apiMgtDAO;
+
+    @Before
+    public void init() {
+        executor = new SubscriptionUpdateApprovalWorkflowExecutor();
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        apiMgtDAO = Mockito.mock(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+    }
+
+    @Test
+    public void testGetWorkflowType() {
+        Assert.assertEquals(WorkflowConstants.WF_TYPE_AM_SUBSCRIPTION_UPDATE, executor.getWorkflowType());
+    }
+
+    /**
+     * Update Flow: TIER UPDATE PENDING → admin approves → UNBLOCKED (requested tier applied).
+     * Verifies that completing the update workflow with APPROVED status calls
+     * updateSubscriptionStatusAndTier, which both activates the subscription and commits the new tier.
+     */
+    @Test
+    public void testCompleteSubscriptionUpdateApprovedUpdatesStatusAndTierToUnblocked()
+            throws APIManagementException, WorkflowException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("3");
+        workflowDTO.setStatus(WorkflowStatus.APPROVED);
+
+        executor.complete(workflowDTO);
+
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .updateSubscriptionStatusAndTier(3, APIConstants.SubscriptionStatus.UNBLOCKED);
+        Mockito.verify(apiMgtDAO, Mockito.never())
+                .updateSubscriptionStatus(Mockito.anyInt(), Mockito.anyString());
+    }
+
+    @Test
+    public void testCompleteSubscriptionUpdateApprovedDAOExceptionThrowsWorkflowException()
+            throws APIManagementException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("3");
+        workflowDTO.setStatus(WorkflowStatus.APPROVED);
+
+        Mockito.doThrow(new APIManagementException("DB error"))
+                .when(apiMgtDAO).updateSubscriptionStatusAndTier(3, APIConstants.SubscriptionStatus.UNBLOCKED);
+
+        try {
+            executor.complete(workflowDTO);
+            Assert.fail("Expected WorkflowException was not thrown");
+        } catch (WorkflowException e) {
+            Assert.assertTrue(e.getMessage().contains("Could not complete subscription update workflow"));
+        }
+    }
+
+    /**
+     * Update Flow: TIER UPDATE PENDING → admin rejects/deletes → UNBLOCKED (tier rolled back).
+     * Verifies that completing the update workflow with REJECTED status restores the subscription to
+     * UNBLOCKED without applying the tier change (uses updateSubscriptionStatus, not
+     * updateSubscriptionStatusAndTier).
+     */
+    @Test
+    public void testCompleteSubscriptionUpdateRejectedRestoresStatusToUnblocked()
+            throws APIManagementException, WorkflowException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("3");
+        workflowDTO.setStatus(WorkflowStatus.REJECTED);
+
+        executor.complete(workflowDTO);
+
+        Mockito.verify(apiMgtDAO, Mockito.times(1))
+                .updateSubscriptionStatus(3, APIConstants.SubscriptionStatus.UNBLOCKED);
+        Mockito.verify(apiMgtDAO, Mockito.never())
+                .updateSubscriptionStatusAndTier(Mockito.anyInt(), Mockito.anyString());
+    }
+
+    @Test
+    public void testCompleteSubscriptionUpdateRejectedDAOExceptionThrowsWorkflowException()
+            throws APIManagementException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("3");
+        workflowDTO.setStatus(WorkflowStatus.REJECTED);
+
+        Mockito.doThrow(new APIManagementException("DB error"))
+                .when(apiMgtDAO).updateSubscriptionStatus(3, APIConstants.SubscriptionStatus.UNBLOCKED);
+
+        try {
+            executor.complete(workflowDTO);
+            Assert.fail("Expected WorkflowException was not thrown");
+        } catch (WorkflowException e) {
+            Assert.assertTrue(e.getMessage().contains("Could not complete subscription update workflow"));
+        }
+    }
+
+    @Test
+    public void testCleanUpPendingTaskDeletesWorkflowRequest() throws APIManagementException {
+        String workflowExtRef = "update-ext-ref-789";
+        try {
+            executor.cleanUpPendingTask(workflowExtRef);
+        } catch (WorkflowException e) {
+            Assert.fail("Unexpected WorkflowException during cleanUpPendingTask: " + e.getMessage());
+        }
+        Mockito.verify(apiMgtDAO, Mockito.times(1)).deleteWorkflowRequest(workflowExtRef);
+    }
+
+    @Test
+    public void testCleanUpPendingTaskDAOExceptionThrowsWorkflowException() throws APIManagementException {
+        String workflowExtRef = "update-ext-ref-789";
+        Mockito.doThrow(new APIManagementException("DB error"))
+                .when(apiMgtDAO).deleteWorkflowRequest(workflowExtRef);
+
+        try {
+            executor.cleanUpPendingTask(workflowExtRef);
+            Assert.fail("Expected WorkflowException was not thrown");
+        } catch (WorkflowException e) {
+            Assert.assertTrue("Expected error message to mention cancellation of pending update approval",
+                    e.getMessage().contains("cancel pending subscription update"));
+        }
+    }
+
+    /**
+     * Verifies that complete() with a neutral status (e.g. CREATED) is a no-op —
+     * neither updateSubscriptionStatusAndTier nor updateSubscriptionStatus is called.
+     */
+    @Test
+    public void testCompleteSubscriptionUpdateWithNeutralStatus_isNoOp()
+            throws APIManagementException, WorkflowException {
+        SubscriptionWorkflowDTO workflowDTO = new SubscriptionWorkflowDTO();
+        workflowDTO.setWorkflowReference("3");
+        workflowDTO.setStatus(WorkflowStatus.CREATED);
+
+        executor.complete(workflowDTO);
+
+        Mockito.verify(apiMgtDAO, Mockito.never())
+                .updateSubscriptionStatusAndTier(Mockito.anyInt(), Mockito.anyString());
+        Mockito.verify(apiMgtDAO, Mockito.never())
+                .updateSubscriptionStatus(Mockito.anyInt(), Mockito.anyString());
+    }
+}


### PR DESCRIPTION
Related to https://github.com/wso2/api-manager/issues/4980

This pull request improves the handling of subscription workflow transitions and error cases in the API Manager, particularly around subscription deletion, tier update, and rejected subscriptions. It also introduces comprehensive unit tests for the subscription creation approval workflow logic.

**Subscription workflow and deletion improvements:**

* Enhanced the `updateSubscription` and `removeSubscription` logic to properly clean up pending deletion workflows and handle transitions from `DELETE_PENDING` to `TIER_UPDATE_PENDING`, ensuring that stuck or previously rejected subscriptions are correctly processed and removed when appropriate. [[1]](diffhunk://#diff-eea96b2f615001930c3a7cf2ec3802f9dc86ac99cabcd2ae10716b934c76c3a2R1511-R1533) [[2]](diffhunk://#diff-eea96b2f615001930c3a7cf2ec3802f9dc86ac99cabcd2ae10716b934c76c3a2R1797-R1844) [[3]](diffhunk://#diff-eea96b2f615001930c3a7cf2ec3802f9dc86ac99cabcd2ae10716b934c76c3a2L1915-L1928)
* Refactored workflow cleanup logic by introducing a helper method `getSubscriptionId` to avoid code duplication and improve clarity in resolving subscription IDs.
* Improved error handling in workflow executors to throw more descriptive exceptions when subscription deletion or creation workflows fail.

**Testing and validation:**

* Added a new test class `SubscriptionCreationApprovalWorkflowExecutorTest` with comprehensive unit tests covering approval, rejection, error, and no-op scenarios for the subscription creation approval workflow executor.