### PR TITLE
Fix built-in AI provider auth config updates

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIAdminImpl.java
@@ -784,10 +784,8 @@ public class APIAdminImpl implements APIAdmin {
     public LLMProvider updateLLMProvider(String organization, LLMProvider provider) throws APIManagementException {
 
         LLMProvider result = apiMgtDAO.updateLLMProvider(organization, provider);
-        if (!result.isBuiltInSupport()) {
-            new LLMProviderNotificationSender().notify(result.getId(), result.getName(), result.getApiVersion(),
-                    provider.getConfigurations(), organization, APIConstants.EventType.LLM_PROVIDER_UPDATE.name());
-        }
+        new LLMProviderNotificationSender().notify(result.getId(), result.getName(), result.getApiVersion(),
+                provider.getConfigurations(), organization, APIConstants.EventType.LLM_PROVIDER_UPDATE.name());
         return result;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/AiServiceProvidersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/AiServiceProvidersApiServiceImpl.java
@@ -247,7 +247,7 @@ public class AiServiceProvidersApiServiceImpl implements AiServiceProvidersApiSe
         try (InputStream apiDefStream = apiDefinitionInputStream) {
             String organization = RestApiUtil.getValidatedOrganization(messageContext);
             ObjectMapper objectMapper = new ObjectMapper();
-            List<ModelProviderDTO> llmModel = new ArrayList<>();
+            List<ModelProviderDTO> llmModel = null;
             if (StringUtils.isNotEmpty(modelProviders)) {
                 llmModel = objectMapper.readValue(modelProviders, new TypeReference<List<ModelProviderDTO>>() {
                 });
@@ -317,24 +317,26 @@ public class AiServiceProvidersApiServiceImpl implements AiServiceProvidersApiSe
         String apiDefinition = getApiDefinitionFromStream(apiDefinitionInputStream);
         boolean isBuiltIn = retrievedProvider.isBuiltInSupport();
 
-        if (isBuiltIn && apiDefinition == null) {
+        if (isBuiltIn && apiDefinition == null && configurations == null) {
             return null;
         }
 
         provider.setApiDefinition(apiDefinition != null ? apiDefinition : retrievedProvider.getApiDefinition());
         provider.setDescription(isBuiltIn ? retrievedProvider.getDescription() :
                 (description != null ? description : retrievedProvider.getDescription()));
-        provider.setConfigurations(isBuiltIn ? retrievedProvider.getConfigurations() :
-                (configurations != null ? configurations : retrievedProvider.getConfigurations()));
-        List<LLMModel> llmModels = new ArrayList<>();
-        if (modelList != null) {
+        provider.setConfigurations(LLMProviderMappingUtil.resolveProviderConfigurations(retrievedProvider,
+                configurations));
+        if (modelList == null) {
+            provider.setModelList(retrievedProvider.getModelList());
+        } else {
+            List<LLMModel> llmModels = new ArrayList<>();
             for (ModelProviderDTO modelDTO : modelList) {
                 if (modelDTO != null && modelDTO.getName() != null && modelDTO.getModels() != null) {
                     llmModels.add(new LLMModel(modelDTO.getName(), modelDTO.getModels()));
                 }
             }
+            provider.setModelList(llmModels);
         }
-        provider.setModelList(llmModels);
         return provider;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/LlmProvidersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/LlmProvidersApiServiceImpl.java
@@ -299,17 +299,17 @@ public class LlmProvidersApiServiceImpl implements LlmProvidersApiService {
         String apiDefinition = getApiDefinitionFromStream(apiDefinitionInputStream);
         boolean isBuiltIn = retrievedProvider.isBuiltInSupport();
 
-        if (isBuiltIn && apiDefinition == null) {
+        if (isBuiltIn && apiDefinition == null && configurations == null) {
             return null;
         }
 
         provider.setApiDefinition(apiDefinition != null ? apiDefinition : retrievedProvider.getApiDefinition());
         provider.setDescription(isBuiltIn ? retrievedProvider.getDescription() :
                 (description != null ? description : retrievedProvider.getDescription()));
-        provider.setConfigurations(isBuiltIn ? retrievedProvider.getConfigurations() :
-                (configurations != null ? configurations : retrievedProvider.getConfigurations()));
-
-        provider.setModelList(Collections.singletonList(new LLMModel(provider.getName(), modelList)));
+        provider.setConfigurations(LLMProviderMappingUtil.resolveProviderConfigurations(retrievedProvider,
+                configurations));
+        provider.setModelList(modelList == null ? retrievedProvider.getModelList() :
+                Collections.singletonList(new LLMModel(provider.getName(), modelList)));
 
         return provider;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/LLMProviderMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/LLMProviderMappingUtil.java
@@ -17,6 +17,10 @@
 package org.wso2.carbon.apimgt.rest.api.admin.v1.utils.mappings;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
 import java.util.Collections;
 import org.wso2.carbon.apimgt.api.APIConstants;
 import org.wso2.carbon.apimgt.api.model.LLMProvider;
@@ -33,6 +37,9 @@ import java.util.stream.Collectors;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.ModelProviderDTO;
 
 public class LLMProviderMappingUtil {
+
+    private static final String AUTHENTICATION_CONFIGURATION = "authenticationConfiguration";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     /**
      * Converts a list of LLMProvider objects to an LLMProviderSummaryResponseListDTO.
@@ -187,6 +194,44 @@ public class LLMProviderMappingUtil {
                     configJson.optBoolean(APIConstants.AIAPIConstants.LLM_PROVIDER_DEPRECATED, false));
         }
         return aiServiceProviderSummaryResponseDTO;
+    }
+
+    /**
+     * Resolves provider configurations while allowing only authentication configuration changes for built-in providers.
+     *
+     * @param retrievedProvider Existing provider.
+     * @param configurations    Requested configuration payload.
+     * @return The resolved configuration payload.
+     * @throws IOException If configuration JSON cannot be parsed.
+     */
+    public static String resolveProviderConfigurations(LLMProvider retrievedProvider, String configurations)
+            throws IOException {
+
+        if (!retrievedProvider.isBuiltInSupport()) {
+            return configurations != null ? configurations : retrievedProvider.getConfigurations();
+        }
+        if (configurations == null) {
+            return retrievedProvider.getConfigurations();
+        }
+
+        JsonNode updatedConfigurations = OBJECT_MAPPER.readTree(configurations);
+        JsonNode updatedAuthenticationConfig = updatedConfigurations.get(AUTHENTICATION_CONFIGURATION);
+        if (updatedAuthenticationConfig == null) {
+            return retrievedProvider.getConfigurations();
+        }
+
+        String existingConfigurationString = retrievedProvider.getConfigurations();
+        if (existingConfigurationString == null) {
+            return configurations;
+        }
+
+        JsonNode existingConfigurations = OBJECT_MAPPER.readTree(existingConfigurationString);
+        if (!existingConfigurations.isObject()) {
+            return configurations;
+        }
+        ObjectNode resolvedConfigurations = (ObjectNode) existingConfigurations;
+        resolvedConfigurations.set(AUTHENTICATION_CONFIGURATION, updatedAuthenticationConfig);
+        return OBJECT_MAPPER.writeValueAsString(resolvedConfigurations);
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/test/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/LLMProviderMappingUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/test/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/LLMProviderMappingUtilTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.rest.api.admin.v1.utils.mappings;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.api.model.LLMProvider;
+
+public class LLMProviderMappingUtilTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    public void testResolveProviderConfigurationsUpdatesOnlyAuthConfigForBuiltInProvider() throws Exception {
+
+        String existingConfigurations = "{"
+                + "\"connectorType\":\"awsBedrock_1.0.0\","
+                + "\"metadata\":[{\"attributeName\":\"promptTokenCount\",\"attributeIdentifier\":\"$.usage.input\"}],"
+                + "\"authenticationConfiguration\":{\"enabled\":true,\"type\":\"aws\","
+                + "\"parameters\":{\"awsServiceName\":\"bedrock\"}}"
+                + "}";
+        String updatedConfigurations = "{"
+                + "\"connectorType\":\"updatedConnector\","
+                + "\"metadata\":[{\"attributeName\":\"totalTokenCount\",\"attributeIdentifier\":\"$.usage.total\"}],"
+                + "\"authenticationConfiguration\":{\"enabled\":true,\"type\":\"apikey\","
+                + "\"parameters\":{\"headerEnabled\":true,\"headerName\":\"x-api-key\"}}"
+                + "}";
+        LLMProvider retrievedProvider = new LLMProvider();
+        retrievedProvider.setBuiltInSupport(true);
+        retrievedProvider.setConfigurations(existingConfigurations);
+
+        String resolvedConfigurations = LLMProviderMappingUtil.resolveProviderConfigurations(retrievedProvider,
+                updatedConfigurations);
+
+        JsonNode resolvedConfig = OBJECT_MAPPER.readTree(resolvedConfigurations);
+        Assert.assertEquals("awsBedrock_1.0.0", resolvedConfig.get("connectorType").asText());
+        Assert.assertEquals("promptTokenCount", resolvedConfig.get("metadata").get(0).get("attributeName").asText());
+        Assert.assertEquals("apikey", resolvedConfig.get("authenticationConfiguration").get("type").asText());
+        Assert.assertEquals("x-api-key", resolvedConfig.get("authenticationConfiguration")
+                .get("parameters").get("headerName").asText());
+    }
+
+    @Test
+    public void testResolveProviderConfigurationsPreservesBuiltInConfigWhenAuthConfigIsAbsent() throws Exception {
+
+        String existingConfigurations = "{"
+                + "\"connectorType\":\"awsBedrock_1.0.0\","
+                + "\"authenticationConfiguration\":{\"enabled\":true,\"type\":\"aws\"}"
+                + "}";
+        String updatedConfigurations = "{\"connectorType\":\"updatedConnector\"}";
+        LLMProvider retrievedProvider = new LLMProvider();
+        retrievedProvider.setBuiltInSupport(true);
+        retrievedProvider.setConfigurations(existingConfigurations);
+
+        String resolvedConfigurations = LLMProviderMappingUtil.resolveProviderConfigurations(retrievedProvider,
+                updatedConfigurations);
+
+        Assert.assertEquals(OBJECT_MAPPER.readTree(existingConfigurations),
+                OBJECT_MAPPER.readTree(resolvedConfigurations));
+    }
+
+    @Test
+    public void testResolveProviderConfigurationsReplacesConfigForCustomProvider() throws Exception {
+
+        String existingConfigurations = "{\"connectorType\":\"oldConnector\"}";
+        String updatedConfigurations = "{\"connectorType\":\"newConnector\"}";
+        LLMProvider retrievedProvider = new LLMProvider();
+        retrievedProvider.setBuiltInSupport(false);
+        retrievedProvider.setConfigurations(existingConfigurations);
+
+        String resolvedConfigurations = LLMProviderMappingUtil.resolveProviderConfigurations(retrievedProvider,
+                updatedConfigurations);
+
+        Assert.assertEquals(OBJECT_MAPPER.readTree(updatedConfigurations),
+                OBJECT_MAPPER.readTree(resolvedConfigurations));
+    }
+}


### PR DESCRIPTION
## Purpose
Allow built-in AI service providers to update only their authentication configuration while preserving the rest of the provider configuration.

Fixes: https://github.com/wso2/api-manager/issues/5009

## Changes
- Merge only authenticationConfiguration from update requests for built-in providers.
- Preserve existing model lists when modelProviders/modelList is omitted in update requests.
- Send update notifications for built-in provider updates so runtime components receive the changed auth configuration.
- Add unit coverage for built-in auth-only updates and custom provider replacement behavior.

## Testing
- mvn test -Dtest=LLMProviderMappingUtilTest