### PR TITLE
Add configurable outbound host validation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -142,6 +142,11 @@ public enum ExceptionCodes implements ErrorHandler {
     RESOURCE_RETRIEVAL_FAILED(900402, "Resource retrieval failed", 400, "Resource retrieval failed"),
     USER_MAPPING_RETRIEVAL_FAILED(900404, "User mapping retrieval failed", 404, "User mapping retrieval failed"),
     MALFORMED_URL(900403, "Malformed URL", 400, "Malformed URL"),
+    UNTRUSTED_URL(900405, "URL is not trusted", 400,
+            "The provided URL is not trusted. Please contact the system administrator."),
+    NETWORK_SECURITY_ACCESS_CONTROL_MISCONFIGURED(900406,
+            "Internal server error. Please contact the system administrator.", 500,
+            "Internal server error. Please contact the system administrator."),
 
     // Endpoint related codes
     ENDPOINT_NOT_FOUND(900450, "Endpoint Not Found", 404, "Endpoint Not Found"),

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3997,4 +3997,21 @@ public final class APIConstants {
         public static final String QUEUE_CAPACITY = THREAD_POOL_CONFIG + "QueueCapacity";
     }
 
+    // Constants related to network security access control
+    public static class NetworkSecurityAccessControl {
+
+        private static final String CONFIG_PREFIX = "NetworkSecurityAccessControl.";
+        public static final String ENABLED = CONFIG_PREFIX + "Enabled";
+        public static final String MODE = CONFIG_PREFIX + "Mode";
+        public static final String HOSTS = CONFIG_PREFIX + "Host";
+        public static final String BLOCK_PRIVATE_NETWORK_ACCESS = CONFIG_PREFIX + "BlockPrivateNetworkAccess";
+        public static final String MODE_ALLOW = "allow";
+        public static final String MODE_DENY = "deny";
+
+        // Tenant config JSON keys (under "NetworkSecurityAccessControl" in tenant-conf.json)
+        public static final String TENANT_CONFIG_KEY = "NetworkSecurityAccessControl";
+        public static final String TENANT_MODE = "Mode";
+        public static final String TENANT_HOSTS = "Hosts";
+        public static final String TENANT_BLOCK_PRIVATE_NETWORK_ACCESS = "BlockPrivateNetworkAccess";
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -283,6 +283,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.NetworkInterface;
@@ -459,6 +460,10 @@ public final class APIUtil {
     private static double retryProgressionFactor;
     private static String gatewayTypes;
     private static int maxRetryCount;
+    private static boolean networkSecurityEnabled;
+    private static String networkSecurityMode;
+    private static List<String> networkSecurityHosts;
+    private static boolean networkSecurityBlockPrivateAccess;
 
     //constants for getting masked token
     private static final int MAX_LEN = 36;
@@ -486,6 +491,14 @@ public final class APIUtil {
         retryProgressionFactor = apiManagerConfiguration.getGatewayArtifactSynchronizerProperties()
                 .getRetryProgressionFactor();
         gatewayTypes = apiManagerConfiguration.getFirstProperty(APIConstants.API_GATEWAY_TYPE);
+        networkSecurityEnabled = Boolean.parseBoolean(apiManagerConfiguration
+                .getFirstProperty(APIConstants.NetworkSecurityAccessControl.ENABLED));
+        networkSecurityMode = apiManagerConfiguration
+                .getFirstProperty(APIConstants.NetworkSecurityAccessControl.MODE);
+        networkSecurityHosts = apiManagerConfiguration
+                .getProperty(APIConstants.NetworkSecurityAccessControl.HOSTS);
+        networkSecurityBlockPrivateAccess = Boolean.parseBoolean(apiManagerConfiguration
+                .getFirstProperty(APIConstants.NetworkSecurityAccessControl.BLOCK_PRIVATE_NETWORK_ACCESS));
         try {
             eventPublisherFactory = ServiceReferenceHolder.getInstance().getEventPublisherFactory();
             eventPublishers.putIfAbsent(EventPublisherType.ASYNC_WEBHOOKS,
@@ -12456,4 +12469,270 @@ public final class APIUtil {
         }
         return hasRestrictedPrefix;
     }
+
+    /**
+     * Validates an outbound URL against platform and tenant network security access control policies.
+     * Blank URLs are silently skipped. Malformed URLs throw with {@code ExceptionCodes.MALFORMED_URL}.
+     *
+     * @param url          URL to validate; null or blank values are silently skipped
+     * @param tenantDomain tenant domain used to load tenant-level config
+     * @throws APIManagementException if the URL is malformed or blocked by an access control policy
+     */
+    public static void validateRemoteURL(String url, String tenantDomain) throws APIManagementException {
+        if (StringUtils.isBlank(url)) {
+            if (log.isDebugEnabled()) {
+                log.debug("URL validation skipped - blank URL provided");
+            }
+            return;
+        }
+
+        JSONObject tenantConfig = getTenantConfig(tenantDomain);
+        JSONObject tenantAccessControl = null;
+        if (tenantConfig != null) {
+            tenantAccessControl = (JSONObject) tenantConfig.get(
+                    APIConstants.NetworkSecurityAccessControl.TENANT_CONFIG_KEY);
+        }
+        boolean tenantEnabled = tenantAccessControl != null;
+
+        if (!networkSecurityEnabled && !tenantEnabled) {
+            return;
+        }
+
+        String host;
+        try {
+            host = new URL(url).getHost();
+            if (StringUtils.isBlank(host)) {
+                throw new APIManagementException("Could not extract a valid host from the provided URL: " + url,
+                        ExceptionCodes.MALFORMED_URL);
+            }
+        } catch (MalformedURLException e) {
+            throw new APIManagementException("The provided URL is malformed: " + url,
+                    ExceptionCodes.MALFORMED_URL);
+        }
+
+        if (networkSecurityEnabled) {
+            applyAccessControlPolicy(host, networkSecurityMode, networkSecurityHosts,
+                    networkSecurityBlockPrivateAccess);
+        }
+
+        if (tenantEnabled) {
+            String tenantMode = (String) tenantAccessControl.get(
+                    APIConstants.NetworkSecurityAccessControl.TENANT_MODE);
+            boolean tenantBlockPrivate = Boolean.TRUE.equals(
+                    tenantAccessControl.get(
+                            APIConstants.NetworkSecurityAccessControl.TENANT_BLOCK_PRIVATE_NETWORK_ACCESS));
+            JSONArray tenantHostsArray = (JSONArray) tenantAccessControl.get(
+                    APIConstants.NetworkSecurityAccessControl.TENANT_HOSTS);
+            List<String> tenantHosts = null;
+            if (tenantHostsArray != null) {
+                tenantHosts = new ArrayList<>();
+                for (Object tenantHost : tenantHostsArray) {
+                    tenantHosts.add(tenantHost.toString());
+                }
+            }
+            applyAccessControlPolicy(host, tenantMode, tenantHosts, tenantBlockPrivate);
+        }
+    }
+
+    /**
+     * Extract endpoint URLs from endpoint config object.
+     *
+     * @param endpointConfigObj Endpoint config JSON object
+     * @param endpointType      Indicating which endpoint to be extracted
+     * @param endpoints         List of URLs. Extracted URL(s), if any, are added to this list.
+     */
+    public static void extractURLsFromEndpointConfig(org.json.JSONObject endpointConfigObj, String endpointType,
+                                                     ArrayList<String> endpoints) throws APIManagementException {
+        if (!endpointConfigObj.isNull(endpointType)) {
+            org.json.JSONObject endpointObj = endpointConfigObj.optJSONObject(endpointType);
+            if (endpointObj != null) {
+                String url = endpointObj.optString(APIConstants.API_DATA_URL, null);
+                if (StringUtils.isNotBlank(url)) {
+                    endpoints.add(url);
+                }
+            } else {
+                org.json.JSONArray endpointArray = endpointConfigObj.optJSONArray(endpointType);
+                if (endpointArray != null) {
+                    for (int i = 0; i < endpointArray.length(); i++) {
+                        String url = endpointArray.getJSONObject(i)
+                                .optString(APIConstants.API_DATA_URL, null);
+                        if (StringUtils.isNotBlank(url)) {
+                            endpoints.add(url);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void applyAccessControlPolicy(String host, String mode, List<String> hosts,
+                                                 boolean blockPrivateNetworkAccess) throws APIManagementException {
+
+        if (StringUtils.isBlank(mode)) {
+            if (hosts != null && !hosts.isEmpty()) {
+                log.warn("Network security access control has hosts configured but no mode is set. "
+                        + "The hosts list will be ignored. Set mode to 'allow' or 'deny'.");
+            }
+            // fall through to blank-mode private network check below
+        } else if (APIConstants.NetworkSecurityAccessControl.MODE_ALLOW.equalsIgnoreCase(mode)) {
+            if (hosts == null || hosts.isEmpty()) {
+                log.warn("Network security access control is configured with mode 'allow' but no hosts are defined. "
+                        + "All outbound requests will be blocked.");
+                throw buildURLBlockedException(host);
+            }
+            // hostname match → ALLOW immediately, DNS resolution skipped
+            if (isHostInList(host, hosts)) {
+                return;
+            }
+            // hostname did not match — resolve and check resolved IPs against allow list.
+            // hosts list is authoritative: blockPrivateNetworkAccess does not apply in allow mode.
+            InetAddress[] addresses;
+            try {
+                addresses = InetAddress.getAllByName(host);
+            } catch (UnknownHostException e) {
+                log.warn("Blocking outbound request to host: '" + host + "' — hostname could not be resolved.");
+                throw buildURLBlockedException(host);
+            }
+            if (isAnyResolvedIpInList(addresses, hosts)) {
+                return;
+            }
+            throw buildURLBlockedException(host);
+
+        } else if (APIConstants.NetworkSecurityAccessControl.MODE_DENY.equalsIgnoreCase(mode)) {
+            if (isHostInList(host, hosts)) {
+                throw buildURLBlockedException(host);
+            }
+            // hostname did not match — resolve once, reused for IP deny list check and private network check
+            InetAddress[] addresses;
+            try {
+                addresses = InetAddress.getAllByName(host);
+            } catch (UnknownHostException e) {
+                log.warn("Blocking outbound request to host: '" + host + "' — hostname could not be resolved.");
+                throw buildURLBlockedException(host);
+            }
+            if (isAnyResolvedIpInList(addresses, hosts)) {
+                log.warn("Blocking outbound request to host: '" + host + "' — a resolved IP is in the deny list.");
+                throw buildURLBlockedException(host);
+            }
+            if (blockPrivateNetworkAccess) {
+                for (InetAddress address : addresses) {
+                    if (isPrivateNetworkAddress(address)) {
+                        log.warn("Blocking private network access attempt to host: '" + host
+                                + "' (" + address.getHostAddress() + ")");
+                        throw buildURLBlockedException(host);
+                    }
+                }
+            }
+            return; // deny mode fully handled — do not fall through
+
+        } else {
+            APIManagementException ex = new APIManagementException(
+                    ExceptionCodes.NETWORK_SECURITY_ACCESS_CONTROL_MISCONFIGURED.getErrorMessage(),
+                    ExceptionCodes.NETWORK_SECURITY_ACCESS_CONTROL_MISCONFIGURED);
+            log.error("Network security access control misconfiguration: mode='" + mode + "' is not a valid value "
+                    + "(expected 'allow' or 'deny').", ex);
+            throw ex;
+        }
+
+        // Blank mode: hosts ignored, only blockPrivateNetworkAccess applies
+        if (blockPrivateNetworkAccess) {
+            try {
+                InetAddress[] addresses = InetAddress.getAllByName(host);
+                for (InetAddress address : addresses) {
+                    if (isPrivateNetworkAddress(address)) {
+                        log.warn("Blocking private network access attempt to host: '" + host
+                                + "' (" + address.getHostAddress() + ")");
+                        throw buildURLBlockedException(host);
+                    }
+                }
+            } catch (UnknownHostException e) {
+                log.warn("Blocking outbound request to host: '" + host + "' — hostname could not be resolved.");
+                throw buildURLBlockedException(host);
+            }
+        }
+    }
+
+    private static boolean isAnyResolvedIpInList(InetAddress[] addresses, List<String> hosts) {
+        if (hosts == null || addresses == null) {
+            return false;
+        }
+        for (InetAddress address : addresses) {
+            if (isHostInList(address.getHostAddress(), hosts)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isHostInList(String host, List<String> hosts) {
+        if (hosts == null) {
+            return false;
+        }
+        String normalizedHost = host.toLowerCase(Locale.ROOT);
+        for (String pattern : hosts) {
+            if (StringUtils.isBlank(pattern)) {
+                continue;
+            }
+            if (normalizedHost.matches(toWildcardRegex(pattern.toLowerCase(Locale.ROOT)))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether the given IP address belongs to a private, local, or otherwise
+     * non-public network range that should be blocked for outbound requests.
+     *
+     * This includes:
+     * <ul>
+     *     <li>Loopback addresses (e.g., 127.0.0.1, ::1)</li>
+     *     <li>Link-local addresses</li>
+     *     <li>Site-local/private addresses</li>
+     *     <li>Wildcard/any-local addresses</li>
+     *     <li>Multicast addresses</li>
+     *     <li>IPv6 Unique Local Addresses (fc00::/7)</li>
+     * </ul>
+     *
+     * @param address The resolved IP address to validate
+     * @return {@code true} if the address belongs to a blocked private or local
+     *         network range, {@code false} otherwise
+     */
+    private static boolean isPrivateNetworkAddress(InetAddress address) {
+        if (address instanceof Inet6Address) {
+            byte[] bytes = address.getAddress();
+            if ((bytes[0] & 0xFE) == 0xFC) {
+                return true; // IPv6 Unique Local Address (fc00::/7)
+            }
+        }
+        return address.isLoopbackAddress()
+                || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress()
+                || address.isAnyLocalAddress()
+                || address.isMulticastAddress();
+    }
+
+    private static APIManagementException buildURLBlockedException(String host) {
+        APIManagementException ex = new APIManagementException(
+                "Outbound request blocked by network security access control policy.",
+                ExceptionCodes.UNTRUSTED_URL);
+        log.error("Outbound request to host '" + host + "' blocked by network security access control policy.", ex);
+        return ex;
+    }
+
+    /**
+     * Converts a simple wildcard host pattern into a safe Java regex.
+     * Uses Pattern.quote() to safely escape all literal parts so that users can
+     * write plain host patterns such as *.wso2.com or 169.254.* without needing
+     * to know regex syntax. Only '*' is treated as a wildcard.
+     *
+     * @param pattern wildcard host pattern (e.g. *.wso2.com, 169.254.*, *)
+     * @return equivalent anchored regex string
+     */
+    private static String toWildcardRegex(String pattern) {
+        return "^" + Arrays.stream(pattern.trim().split("\\*", -1))
+                .map(Pattern::quote)
+                .collect(Collectors.joining(".*")) + "$";
+    }
+
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -12500,12 +12500,12 @@ public final class APIUtil {
 
         String host;
         try {
-            host = new URL(url).getHost();
+            host = new URI(url).getHost();
             if (StringUtils.isBlank(host)) {
                 throw new APIManagementException("Could not extract a valid host from the provided URL: " + url,
                         ExceptionCodes.MALFORMED_URL);
             }
-        } catch (MalformedURLException e) {
+        } catch (URISyntaxException e) {
             throw new APIManagementException("The provided URL is malformed: " + url,
                     ExceptionCodes.MALFORMED_URL);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-config-schema.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-config-schema.json
@@ -1368,6 +1368,7 @@
           "type": "string",
           "title": "Mode schema",
           "description": "'allow' — only hosts matching the Hosts list are permitted; others are blocked. 'deny' — hosts matching the Hosts list are blocked; others are permitted.",
+          "enum": ["allow", "deny"],
           "examples": ["allow", "deny"]
         },
         "Hosts": {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-config-schema.json
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/resources/tenant/tenant-config-schema.json
@@ -1355,6 +1355,44 @@
       "examples": [
         true, false
       ]
+    },
+    "NetworkSecurityAccessControl": {
+      "$id": "#/properties/NetworkSecurityAccessControl",
+      "type": "object",
+      "title": "NetworkSecurityAccessControl schema",
+      "description": "Tenant-level network security access control. Activated when this key is present.",
+      "default": {},
+      "properties": {
+        "Mode": {
+          "$id": "#/properties/NetworkSecurityAccessControl/properties/Mode",
+          "type": "string",
+          "title": "Mode schema",
+          "description": "'allow' — only hosts matching the Hosts list are permitted; others are blocked. 'deny' — hosts matching the Hosts list are blocked; others are permitted.",
+          "examples": ["allow", "deny"]
+        },
+        "Hosts": {
+          "$id": "#/properties/NetworkSecurityAccessControl/properties/Hosts",
+          "type": "array",
+          "title": "Hosts schema",
+          "description": "Wildcard host patterns. In 'allow' mode these are permitted and bypass BlockPrivateNetworkAccess. In 'deny' mode these are blocked.",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            ["*.mycompany.com", "trustedpartner.io"]
+          ]
+        },
+        "BlockPrivateNetworkAccess": {
+          "$id": "#/properties/NetworkSecurityAccessControl/properties/BlockPrivateNetworkAccess",
+          "type": "boolean",
+          "title": "BlockPrivateNetworkAccess schema",
+          "description": "When true, blocks outbound requests resolving to private/reserved IP ranges. Hosts matched by the Hosts list are exempt.",
+          "default": false,
+          "examples": [true, false]
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": true

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
@@ -26,7 +26,9 @@ import org.wso2.carbon.apimgt.impl.kmclient.model.OpenIdConnectConfiguration;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.persistence.dto.AdminContentSearchResult;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.KeyManagersApiService;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.KeyManagerCertificatesDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.KeyManagerDTO;
+import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.KeyManagerEndpointDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.KeyManagerListDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.KeyManagerWellKnownResponseDTO;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.utils.RestApiAdminUtils;
@@ -35,10 +37,13 @@ import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.util.utils.RestApiUtil;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.core.Response;
@@ -51,6 +56,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
     public Response keyManagersDiscoverPost(String url, String type, MessageContext messageContext)
             throws APIManagementException {
         if (StringUtils.isNotEmpty(url)) {
+            APIUtil.validateRemoteURL(url, RestApiCommonUtil.getLoggedInUserTenantDomain());
             Gson gson = new GsonBuilder().serializeNulls().create();
             OpenIDConnectDiscoveryClient openIDConnectDiscoveryClient =
                     Feign.builder().client(new ApacheFeignHttpClient(APIUtil.getHttpClient(url)))
@@ -140,6 +146,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
                 body.setAllowedOrganizations(allowedOrgs);
             }
         }
+        validateKeyManagerURLs(body);
         try {
             KeyManagerConfigurationDTO keyManagerConfigurationDTO =
                     KeyManagerMappingUtil.toKeyManagerConfigurationDTO(organization, body);
@@ -223,6 +230,7 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
         String organization = RestApiUtil.getOrganization(messageContext);
         APIAdmin apiAdmin = new APIAdminImpl();
         try {
+            validateKeyManagerURLs(body);
             KeyManagerConfigurationDTO keyManagerConfigurationDTO =
                     KeyManagerMappingUtil.toKeyManagerConfigurationDTO(organization, body);
             KeyManagerPermissionConfigurationDTO keyManagerPermissionConfigurationDTO =
@@ -265,4 +273,100 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
         }
     }
 
+    /**
+     * Validates all outbound URLs defined in the given Key Manager configuration against
+     * network security access control policies. Blank and non-URL values are silently skipped.
+     * If a URL fails validation with a client error (HTTP 400), a field-specific bad request
+     * is returned. Internal errors are propagated unchanged.
+     *
+     * @param body Key Manager configuration containing URLs to validate
+     * @throws APIManagementException if URL validation fails
+     */
+    private void validateKeyManagerURLs(KeyManagerDTO body) throws APIManagementException {
+        Map<String, String> urlFields = new LinkedHashMap<>();
+        urlFields.put("well-known endpoint", body.getWellKnownEndpoint());
+        urlFields.put("token endpoint", body.getTokenEndpoint());
+        urlFields.put("introspection endpoint", body.getIntrospectionEndpoint());
+        urlFields.put("client registration endpoint", body.getClientRegistrationEndpoint());
+        urlFields.put("revoke endpoint", body.getRevokeEndpoint());
+        urlFields.put("user info endpoint", body.getUserInfoEndpoint());
+        urlFields.put("authorize endpoint", body.getAuthorizeEndpoint());
+        urlFields.put("scope management endpoint", body.getScopeManagementEndpoint());
+
+        for (Map.Entry<String, String> entry : urlFields.entrySet()) {
+            try {
+                validateKeyManagerURL(entry.getValue(), entry.getKey());
+            } catch (APIManagementException e) {
+                if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                    log.warn(e.getMessage(), e);
+                    RestApiUtil.handleBadRequest(e.getMessage());
+                } else {
+                    throw e;
+                }
+            }
+        }
+        if (body.getEndpoints() != null) {
+            for (KeyManagerEndpointDTO endpoint : body.getEndpoints()) {
+                if (endpoint != null) {
+                    try {
+                        validateKeyManagerURL(endpoint.getValue(),
+                                "custom endpoint '" + endpoint.getName() + "'");
+                    } catch (APIManagementException e) {
+                        if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                            log.warn(e.getMessage(), e);
+                            RestApiUtil.handleBadRequest(e.getMessage());
+                        } else {
+                            throw e;
+                        }
+                    }
+                }
+            }
+        }
+        if (body.getCertificates() != null
+                && KeyManagerCertificatesDTO.TypeEnum.JWKS.equals(body.getCertificates().getType())) {
+            try {
+                validateKeyManagerURL(body.getCertificates().getValue(), "JWKS endpoint");
+            } catch (APIManagementException e) {
+                if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                    log.warn(e.getMessage(), e);
+                    RestApiUtil.handleBadRequest(e.getMessage());
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates a single Key Manager endpoint URL against network security access control policies.
+     * Blank and non-URL values (e.g. "none") are silently skipped for backward compatibility.
+     * If validation fails with a client error (HTTP 400), the exception is re-thrown with a
+     * field-specific message. Other failures are propagated unchanged.
+     *
+     * @param url       URL to validate; blank and non-URL values are silently skipped
+     * @param fieldName descriptive name of the Key Manager URL field being validated
+     * @throws APIManagementException if the URL is blocked by a host validation policy
+     */
+    private void validateKeyManagerURL(String url, String fieldName)
+            throws APIManagementException {
+        if (StringUtils.isBlank(url)) {
+            return;
+        }
+        try {
+            new URL(url).getHost();
+        } catch (MalformedURLException e) {
+            return; // not a URL (e.g. "none"), skip validation
+        }
+        try {
+            APIUtil.validateRemoteURL(url, RestApiCommonUtil.getLoggedInUserTenantDomain());
+        } catch (APIManagementException e) {
+            if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                throw new APIManagementException(
+                        "Invalid Key Manager URL configuration. The " + fieldName
+                                + " URL is not trusted. Please contact the system administrator.",
+                        e.getErrorHandler());
+            }
+            throw e;
+        }
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/KeyManagersApiServiceImpl.java
@@ -353,8 +353,8 @@ public class KeyManagersApiServiceImpl implements KeyManagersApiService {
             return;
         }
         try {
-            new URL(url).getHost();
-        } catch (MalformedURLException e) {
+            new URI(url).getHost();
+        } catch (URISyntaxException e) {
             return; // not a URL (e.g. "none"), skip validation
         }
         try {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/ImportUtils.java
@@ -336,6 +336,25 @@ public class ImportUtils {
             // Get the endpoint config object updated
             APIUtil.validateAPIEndpointConfig(importedApiDTO.getEndpointConfig(), importedApiDTO.getType().toString(),
                     importedApiDTO.getName());
+            if (importedApiDTO.getEndpointConfig() instanceof Map) {
+                org.json.JSONObject endpointConfigObj =
+                        new org.json.JSONObject((Map) importedApiDTO.getEndpointConfig());
+                if (!APIConstants.ENDPOINT_TYPE_DEFAULT.equalsIgnoreCase(
+                        endpointConfigObj.optString(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE))) {
+                    ArrayList<String> endpointURLs = new ArrayList<>();
+                    APIUtil.extractURLsFromEndpointConfig(endpointConfigObj,
+                            APIConstants.API_DATA_PRODUCTION_ENDPOINTS, endpointURLs);
+                    APIUtil.extractURLsFromEndpointConfig(endpointConfigObj,
+                            APIConstants.API_DATA_SANDBOX_ENDPOINTS, endpointURLs);
+                    APIUtil.extractURLsFromEndpointConfig(endpointConfigObj,
+                            APIConstants.ENDPOINT_PRODUCTION_FAILOVERS, endpointURLs);
+                    APIUtil.extractURLsFromEndpointConfig(endpointConfigObj,
+                            APIConstants.ENDPOINT_SANDBOX_FAILOVERS, endpointURLs);
+                    for (String endpointURL : endpointURLs) {
+                        APIUtil.validateRemoteURL(endpointURL, tenantDomain);
+                    }
+                }
+            }
 
             API targetApi = retrieveApiToOverwrite(importedApiDTO.getName(), importedApiDTO.getVersion(),
                     currentTenantDomain, apiProvider, Boolean.TRUE, organization);
@@ -818,6 +837,23 @@ public class ImportUtils {
                     }
                     Backend oldBackend = existingBackends.get(0);
                     Backend importedBackend = importedBackends.get(0);
+                    org.json.JSONObject importedConfig =
+                            new org.json.JSONObject(importedBackend.getEndpointConfig());
+                    if (!APIConstants.ENDPOINT_TYPE_DEFAULT.equalsIgnoreCase(
+                            importedConfig.optString(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE))) {
+                        ArrayList<String> endpointURLs = new ArrayList<>();
+                        APIUtil.extractURLsFromEndpointConfig(importedConfig,
+                                APIConstants.API_DATA_PRODUCTION_ENDPOINTS, endpointURLs);
+                        APIUtil.extractURLsFromEndpointConfig(importedConfig,
+                                APIConstants.API_DATA_SANDBOX_ENDPOINTS, endpointURLs);
+                        APIUtil.extractURLsFromEndpointConfig(importedConfig,
+                                APIConstants.ENDPOINT_PRODUCTION_FAILOVERS, endpointURLs);
+                        APIUtil.extractURLsFromEndpointConfig(importedConfig,
+                                APIConstants.ENDPOINT_SANDBOX_FAILOVERS, endpointURLs);
+                        for (String endpointURL : endpointURLs) {
+                            APIUtil.validateRemoteURL(endpointURL, tenantDomain);
+                        }
+                    }
                     Backend backend = new Backend(oldBackend);
                     backend.setEndpointConfig(importedBackend.getEndpointConfig());
                     String importedDefinition = importedBackend.getDefinition();
@@ -875,6 +911,22 @@ public class ImportUtils {
 
                     final JSONObject endpointObject =
                             (JSONObject) new JSONParser().parse(backend.getEndpointConfig());
+                    org.json.JSONObject endpointConfigObj = new org.json.JSONObject((Map) endpointObject);
+                    if (!APIConstants.ENDPOINT_TYPE_DEFAULT.equalsIgnoreCase(
+                            endpointConfigObj.optString(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE))) {
+                        ArrayList<String> endpointURLs = new ArrayList<>();
+                        APIUtil.extractURLsFromEndpointConfig(endpointConfigObj,
+                                APIConstants.API_DATA_PRODUCTION_ENDPOINTS, endpointURLs);
+                        APIUtil.extractURLsFromEndpointConfig(endpointConfigObj,
+                                APIConstants.API_DATA_SANDBOX_ENDPOINTS, endpointURLs);
+                        APIUtil.extractURLsFromEndpointConfig(endpointConfigObj,
+                                APIConstants.ENDPOINT_PRODUCTION_FAILOVERS, endpointURLs);
+                        APIUtil.extractURLsFromEndpointConfig(endpointConfigObj,
+                                APIConstants.ENDPOINT_SANDBOX_FAILOVERS, endpointURLs);
+                        for (String endpointURL : endpointURLs) {
+                            APIUtil.validateRemoteURL(endpointURL, tenantDomain);
+                        }
+                    }
                     final Map<String, Object> endpointConfigMap =
                             (Map<String, Object>) endpointObject;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -2698,6 +2698,12 @@ public class PublisherCommonUtils {
         if (externalExtractor != null) {
             externalExtractor.accept(endpoints);
         }
+        extractURLsFromEndpointConfig(endpointConfigObj, APIConstants.ENDPOINT_PRODUCTION_FAILOVERS, endpoints);
+        extractURLsFromEndpointConfig(endpointConfigObj, APIConstants.ENDPOINT_SANDBOX_FAILOVERS, endpoints);
+        String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
+        for (String endpoint : endpoints) {
+            APIUtil.validateRemoteURL(endpoint, tenantDomain);
+        }
         return APIUtil.validateEndpointURLs(endpoints);
     }
 
@@ -4517,6 +4523,7 @@ public class PublisherCommonUtils {
             throw new APIManagementException("Invalid/Malformed endpoint URL detected",
                     ExceptionCodes.API_ENDPOINT_URL_INVALID);
         }
+        APIUtil.validateRemoteURL(endpointURL, RestApiCommonUtil.getLoggedInUserTenantDomain());
 
         APIEndpointInfo apiEndpointUpdated = apiProvider.updateAPIEndpoint(apiId, apiEndpoint, organization);
         if (apiEndpointUpdated == null) {
@@ -4566,6 +4573,7 @@ public class PublisherCommonUtils {
             throw new APIManagementException("Invalid/Malformed endpoint URL detected",
                     ExceptionCodes.API_ENDPOINT_URL_INVALID);
         }
+        APIUtil.validateRemoteURL(endpointURL, RestApiCommonUtil.getLoggedInUserTenantDomain());
 
         // validate endpoint name
         if (StringUtils.isBlank(apiEndpoint.getName())) {
@@ -5097,6 +5105,7 @@ public class PublisherCommonUtils {
             final String authHeader = securityInfo != null ? securityInfo.getHeader() : null;
             final String authValue = securityInfo != null ? securityInfo.getValue() : null;
 
+            APIUtil.validateRemoteURL(serverUrl, RestApiCommonUtil.getLoggedInUserTenantDomain());
             MCPInitializerAndToolFetcher fetcher =
                     new MCPInitializerAndToolFetcher(serverUrl, authHeader, authValue, secureRequested);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtils.java
@@ -2702,7 +2702,10 @@ public class PublisherCommonUtils {
         extractURLsFromEndpointConfig(endpointConfigObj, APIConstants.ENDPOINT_SANDBOX_FAILOVERS, endpoints);
         String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
         for (String endpoint : endpoints) {
-            APIUtil.validateRemoteURL(endpoint, tenantDomain);
+            if (!endpoint.startsWith("jms:") && !endpoint.startsWith("consul(")
+                    && !endpoint.contains("{") && !endpoint.contains("}")) {
+                APIUtil.validateRemoteURL(endpoint, tenantDomain);
+            }
         }
         return APIUtil.validateEndpointURLs(endpoints);
     }
@@ -4523,7 +4526,10 @@ public class PublisherCommonUtils {
             throw new APIManagementException("Invalid/Malformed endpoint URL detected",
                     ExceptionCodes.API_ENDPOINT_URL_INVALID);
         }
-        APIUtil.validateRemoteURL(endpointURL, RestApiCommonUtil.getLoggedInUserTenantDomain());
+        if (!endpointURL.startsWith("jms:") && !endpointURL.startsWith("consul(")
+                && !endpointURL.contains("{") && !endpointURL.contains("}")) {
+            APIUtil.validateRemoteURL(endpointURL, RestApiCommonUtil.getLoggedInUserTenantDomain());
+        }
 
         APIEndpointInfo apiEndpointUpdated = apiProvider.updateAPIEndpoint(apiId, apiEndpoint, organization);
         if (apiEndpointUpdated == null) {
@@ -4573,7 +4579,10 @@ public class PublisherCommonUtils {
             throw new APIManagementException("Invalid/Malformed endpoint URL detected",
                     ExceptionCodes.API_ENDPOINT_URL_INVALID);
         }
-        APIUtil.validateRemoteURL(endpointURL, RestApiCommonUtil.getLoggedInUserTenantDomain());
+        if (!endpointURL.startsWith("jms:") && !endpointURL.startsWith("consul(")
+                && !endpointURL.contains("{") && !endpointURL.contains("}")) {
+            APIUtil.validateRemoteURL(endpointURL, RestApiCommonUtil.getLoggedInUserTenantDomain());
+        }
 
         // validate endpoint name
         if (StringUtils.isBlank(apiEndpoint.getName())) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtilsTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtilsTest.java
@@ -288,6 +288,8 @@ public class PublisherCommonUtilsTest {
         Mockito.when(advertiseInfoDto.getApiExternalProductionEndpoint()).thenReturn(externalProductionEndpointString);
         Mockito.when(advertiseInfoDto.getApiExternalSandboxEndpoint()).thenReturn(externalSandboxEndpointString);
         Mockito.when(advertiseInfoDto.getOriginalDevPortalUrl()).thenReturn(originalDevPortalUrl);
+        PowerMockito.mockStatic(RestApiCommonUtil.class);
+        PowerMockito.when(RestApiCommonUtil.getLoggedInUserTenantDomain()).thenReturn(ORGANIZATION);
         PowerMockito.mockStatic(APIUtil.class);
         PowerMockito.when(APIUtil.validateEndpointURLs(endpoints)).thenReturn(true);
         Assert.assertTrue(PublisherCommonUtils.validateEndpoints(new APIDTOTypeWrapper(apiDto)));

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtilsTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1.common/src/test/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/common/mappings/PublisherCommonUtilsTest.java
@@ -179,6 +179,8 @@ public class PublisherCommonUtilsTest {
 
         Mockito.when(apiDto.getEndpointConfig()).thenReturn(endpointConfig);
         Mockito.when(advertiseInfoDto.isAdvertised()).thenReturn(false);
+        PowerMockito.mockStatic(RestApiCommonUtil.class);
+        PowerMockito.when(RestApiCommonUtil.getLoggedInUserTenantDomain()).thenReturn(ORGANIZATION);
         PowerMockito.mockStatic(APIUtil.class);
         PowerMockito.when(APIUtil.validateEndpointURLs(endpoints)).thenReturn(true);
         Assert.assertTrue(PublisherCommonUtils.validateEndpoints(new APIDTOTypeWrapper(apiDto)));
@@ -210,6 +212,8 @@ public class PublisherCommonUtilsTest {
 
         Mockito.when(apiDto.getEndpointConfig()).thenReturn(endpointConfig);
         Mockito.when(advertiseInfoDto.isAdvertised()).thenReturn(false);
+        PowerMockito.mockStatic(RestApiCommonUtil.class);
+        PowerMockito.when(RestApiCommonUtil.getLoggedInUserTenantDomain()).thenReturn(ORGANIZATION);
         PowerMockito.mockStatic(APIUtil.class);
         PowerMockito.when(APIUtil.validateEndpointURLs(endpoints)).thenReturn(false);
         Assert.assertFalse(PublisherCommonUtils.validateEndpoints(new APIDTOTypeWrapper(apiDto)));
@@ -241,6 +245,8 @@ public class PublisherCommonUtilsTest {
 
         Mockito.when(apiDto.getEndpointConfig()).thenReturn(endpointConfig);
         Mockito.when(advertiseInfoDto.isAdvertised()).thenReturn(false);
+        PowerMockito.mockStatic(RestApiCommonUtil.class);
+        PowerMockito.when(RestApiCommonUtil.getLoggedInUserTenantDomain()).thenReturn(ORGANIZATION);
         PowerMockito.mockStatic(APIUtil.class);
         PowerMockito.when(APIUtil.validateEndpointURLs(endpoints)).thenReturn(false);
         Assert.assertFalse(PublisherCommonUtils.validateEndpoints(new APIDTOTypeWrapper(apiDto)));
@@ -323,6 +329,8 @@ public class PublisherCommonUtilsTest {
         Mockito.when(advertiseInfoDto.getApiExternalProductionEndpoint()).thenReturn(externalProductionEndpointString);
         Mockito.when(advertiseInfoDto.getApiExternalSandboxEndpoint()).thenReturn(externalSandboxEndpointString);
         Mockito.when(advertiseInfoDto.getOriginalDevPortalUrl()).thenReturn(originalDevPortalUrl);
+        PowerMockito.mockStatic(RestApiCommonUtil.class);
+        PowerMockito.when(RestApiCommonUtil.getLoggedInUserTenantDomain()).thenReturn(ORGANIZATION);
         PowerMockito.mockStatic(APIUtil.class);
         PowerMockito.when(APIUtil.validateEndpointURLs(endpoints)).thenReturn(false);
         Assert.assertFalse(PublisherCommonUtils.validateEndpoints(new APIDTOTypeWrapper(apiDto)));
@@ -373,6 +381,8 @@ public class PublisherCommonUtilsTest {
 
         Mockito.when(apiDto.getEndpointConfig()).thenReturn(endpointConfig);
         Mockito.when(apiDto.getAdvertiseInfo()).thenReturn(null);
+        PowerMockito.mockStatic(RestApiCommonUtil.class);
+        PowerMockito.when(RestApiCommonUtil.getLoggedInUserTenantDomain()).thenReturn(ORGANIZATION);
         PowerMockito.mockStatic(APIUtil.class);
         PowerMockito.when(APIUtil.validateEndpointURLs(endpoints)).thenReturn(true);
         Assert.assertTrue(PublisherCommonUtils.validateEndpoints(new APIDTOTypeWrapper(apiDto)));
@@ -412,6 +422,8 @@ public class PublisherCommonUtilsTest {
         Mockito.when(advertiseInfoDto.getApiExternalProductionEndpoint()).thenReturn(null);
         Mockito.when(advertiseInfoDto.getApiExternalSandboxEndpoint()).thenReturn(externalSandboxEndpointString);
         Mockito.when(advertiseInfoDto.getOriginalDevPortalUrl()).thenReturn(originalDevPortalUrl);
+        PowerMockito.mockStatic(RestApiCommonUtil.class);
+        PowerMockito.when(RestApiCommonUtil.getLoggedInUserTenantDomain()).thenReturn(ORGANIZATION);
         PowerMockito.mockStatic(APIUtil.class);
         PowerMockito.when(APIUtil.validateEndpointURLs(endpoints)).thenReturn(true);
         Assert.assertTrue(PublisherCommonUtils.validateEndpoints(new APIDTOTypeWrapper(apiDto)));

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/ApisApiServiceImpl.java
@@ -3205,9 +3205,15 @@ public class ApisApiServiceImpl implements ApisApiService {
         ApiEndpointValidationResponseDTO apiEndpointValidationResponseDTO = new ApiEndpointValidationResponseDTO();
         apiEndpointValidationResponseDTO.setError("");
         try {
+            APIUtil.validateRemoteURL(endpointUrl, RestApiCommonUtil.getLoggedInUserTenantDomain());
             APIEndpointValidationDTO apiEndpointValidationDTO = ApisApiServiceImplUtils.sendHttpHEADRequest(endpointUrl);
             apiEndpointValidationResponseDTO = APIMappingUtil.fromEndpointValidationToDTO(apiEndpointValidationDTO);
             return Response.status(Response.Status.OK).entity(apiEndpointValidationResponseDTO).build();
+        } catch (APIManagementException e) {
+            if (e.getErrorHandler() == null || e.getErrorHandler().getHttpStatusCode() != 400) {
+                throw RestApiUtil.buildInternalServerErrorException(e.getMessage());
+            }
+            apiEndpointValidationResponseDTO.setError(e.getErrorHandler().getErrorDescription());
         } catch (MalformedURLException e) {
             log.error("Malformed Url error occurred while sending the HEAD request to the given endpoint url:", e);
             apiEndpointValidationResponseDTO.setError(e.getMessage());
@@ -3411,6 +3417,7 @@ public class ApisApiServiceImpl implements ApisApiService {
         WSDLValidationResponse validationResponse = new WSDLValidationResponse();
 
         if (url != null) {
+            APIUtil.validateRemoteURL(url, RestApiCommonUtil.getLoggedInUserTenantDomain());
             try {
                 URL wsdlUrl = new URL(url);
                 validationResponse = APIMWSDLReader.validateWSDLUrl(wsdlUrl);
@@ -3494,6 +3501,22 @@ public class ApisApiServiceImpl implements ApisApiService {
             additionalPropertiesAPI.setProvider(username);
             additionalPropertiesAPI.setType(APIDTO.TypeEnum.fromValue(implementationType));
             String organization = RestApiUtil.getValidatedOrganization(messageContext);
+            Object wsdlEndpointConfig = additionalPropertiesAPI.getEndpointConfig();
+            if (wsdlEndpointConfig instanceof Map) {
+                String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
+                org.json.JSONObject endpointConfigObj = new org.json.JSONObject((Map) wsdlEndpointConfig);
+                if (!APIConstants.ENDPOINT_TYPE_DEFAULT.equalsIgnoreCase(
+                        endpointConfigObj.optString(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE))) {
+                    ArrayList<String> endpoints = new ArrayList<>();
+                    APIUtil.extractURLsFromEndpointConfig(endpointConfigObj, APIConstants.API_DATA_PRODUCTION_ENDPOINTS, endpoints);
+                    APIUtil.extractURLsFromEndpointConfig(endpointConfigObj, APIConstants.API_DATA_SANDBOX_ENDPOINTS, endpoints);
+                    APIUtil.extractURLsFromEndpointConfig(endpointConfigObj, APIConstants.ENDPOINT_PRODUCTION_FAILOVERS, endpoints);
+                    APIUtil.extractURLsFromEndpointConfig(endpointConfigObj, APIConstants.ENDPOINT_SANDBOX_FAILOVERS, endpoints);
+                    for (String endpoint : endpoints) {
+                        APIUtil.validateRemoteURL(endpoint, tenantDomain);
+                    }
+                }
+            }
             API apiToAdd = PublisherCommonUtils
                     .prepareToCreateAPIByDTO(new APIDTOTypeWrapper(additionalPropertiesAPI), RestApiCommonUtil.getLoggedInUserProvider(),
                             username, organization);
@@ -3959,6 +3982,25 @@ public class ApisApiServiceImpl implements ApisApiService {
                 RestApiUtil.handleBadRequest(errorMessage, log);
             } else {
                 additionalPropertiesAPI = new ObjectMapper().readValue(additionalProperties, APIDTO.class);
+                Object rawEndpointConfig = additionalPropertiesAPI.getEndpointConfig();
+                if (rawEndpointConfig instanceof Map) {
+                    org.json.JSONObject endpointConfigObj = new org.json.JSONObject((Map) rawEndpointConfig);
+                    if (!APIConstants.ENDPOINT_TYPE_DEFAULT.equalsIgnoreCase(
+                            endpointConfigObj.optString(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE))) {
+                        ArrayList<String> endpointURLs = new ArrayList<>();
+                        APIUtil.extractURLsFromEndpointConfig(endpointConfigObj,
+                                APIConstants.API_DATA_PRODUCTION_ENDPOINTS, endpointURLs);
+                        APIUtil.extractURLsFromEndpointConfig(endpointConfigObj,
+                                APIConstants.API_DATA_SANDBOX_ENDPOINTS, endpointURLs);
+                        APIUtil.extractURLsFromEndpointConfig(endpointConfigObj,
+                                APIConstants.ENDPOINT_PRODUCTION_FAILOVERS, endpointURLs);
+                        APIUtil.extractURLsFromEndpointConfig(endpointConfigObj,
+                                APIConstants.ENDPOINT_SANDBOX_FAILOVERS, endpointURLs);
+                        for (String endpointURL : endpointURLs) {
+                            APIUtil.validateRemoteURL(endpointURL, RestApiCommonUtil.getLoggedInUserTenantDomain());
+                        }
+                    }
+                }
             }
 
             if (schema != null && StringUtils.isNotEmpty(schema)) {
@@ -3966,6 +4008,14 @@ public class ApisApiServiceImpl implements ApisApiService {
             } else if (fileInputStream != null && !StringUtils.isBlank(additionalProperties)) {
                 graphQLSchema = IOUtils.toString(fileInputStream, RestApiConstants.CHARSET);
             } else if (url != null) {
+                try {
+                    APIUtil.validateRemoteURL(url, RestApiCommonUtil.getLoggedInUserTenantDomain());
+                } catch (APIManagementException e) {
+                    if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                        throw RestApiUtil.buildBadRequestException(e.getErrorHandler().getErrorDescription());
+                    }
+                    throw RestApiUtil.buildInternalServerErrorException(e.getMessage());
+                }
                 graphQLSchema = PublisherCommonUtils.retrieveGraphQLSchemaFromURL(url);
             } else {
                 Map<String, Object> endpointConfigurationMap =
@@ -3975,6 +4025,14 @@ public class ApisApiServiceImpl implements ApisApiService {
                     Map<String, String> productionEndpoints = (Map<String, String>) endpointConfigurationMap.get(
                         "production_endpoints");
                     endpointURL = productionEndpoints.get("url");
+                }
+                try {
+                    APIUtil.validateRemoteURL(endpointURL, RestApiCommonUtil.getLoggedInUserTenantDomain());
+                } catch (APIManagementException e) {
+                    if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                        throw RestApiUtil.buildBadRequestException(e.getErrorHandler().getErrorDescription());
+                    }
+                    throw RestApiUtil.buildInternalServerErrorException(e.getMessage());
                 }
                 graphQLSchema = PublisherCommonUtils.generateGraphQLSchemaFromIntrospection(endpointURL);
             }
@@ -4019,6 +4077,9 @@ public class ApisApiServiceImpl implements ApisApiService {
         } catch (APIManagementException e) {
             if (e.getMessage().contains(ExceptionCodes.API_CONTEXT_MALFORMED_EXCEPTION.getErrorMessage())) {
                 RestApiUtil.handleBadRequest(e.getMessage(), e, log);
+            }
+            if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                RestApiUtil.handleBadRequest(e.getErrorHandler().getErrorDescription(), e, log);
             }
             String errorMessage = "Error while adding new API : " + additionalPropertiesAPI.getProvider() + "-" +
                     additionalPropertiesAPI.getName() + "-" + additionalPropertiesAPI.getVersion() + " - "
@@ -4102,6 +4163,18 @@ public class ApisApiServiceImpl implements ApisApiService {
             if (fileDetail != null) {
                 filename = fileDetail.getDataHandler().getName();
                 schema = IOUtils.toString(fileInputStream, RestApiConstants.CHARSET);
+            }
+            if (url != null) {
+                try {
+                    APIUtil.validateRemoteURL(url, RestApiCommonUtil.getLoggedInUserTenantDomain());
+                } catch (APIManagementException e) {
+                    if (e.getErrorHandler() == null || e.getErrorHandler().getHttpStatusCode() != 400) {
+                        throw RestApiUtil.buildInternalServerErrorException(e.getMessage());
+                    }
+                    validationResponse.setIsValid(false);
+                    validationResponse.setErrorMessage(e.getErrorHandler().getErrorDescription());
+                    return Response.ok().entity(validationResponse).build();
+                }
             }
             validationResponse = PublisherCommonUtils.validateGraphQLSchema(filename, schema, url, useIntrospection);
         } catch (IOException | APIManagementException e) {
@@ -4666,6 +4739,14 @@ public class ApisApiServiceImpl implements ApisApiService {
 
         if (url != null) {
             try {
+                APIUtil.validateRemoteURL(url, RestApiCommonUtil.getLoggedInUserTenantDomain());
+            } catch (APIManagementException e) {
+                if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                    throw RestApiUtil.buildBadRequestException(e.getErrorHandler().getErrorDescription());
+                }
+                throw e;
+            }
+            try {
                 URL urlObj = new URL(url);
                 HttpClient httpClient = APIUtil.getHttpClient(urlObj.getPort(), urlObj.getProtocol());
                 String maxFileSizeStr = ServiceReferenceHolder.getInstance().getAPIManagerConfigurationService()
@@ -4750,6 +4831,23 @@ public class ApisApiServiceImpl implements ApisApiService {
             websocketTransports.add(APIConstants.WS_PROTOCOL);
             websocketTransports.add(APIConstants.WSS_PROTOCOL);
             apiDTOFromProperties.setTransport(websocketTransports);
+        }
+
+        Object asyncEndpointConfig = apiDTOFromProperties.getEndpointConfig();
+        if (asyncEndpointConfig instanceof Map) {
+            String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
+            org.json.JSONObject endpointConfigObj = new org.json.JSONObject((Map) asyncEndpointConfig);
+            if (!APIConstants.ENDPOINT_TYPE_DEFAULT.equalsIgnoreCase(
+                    endpointConfigObj.optString(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE))) {
+                ArrayList<String> endpoints = new ArrayList<>();
+                APIUtil.extractURLsFromEndpointConfig(endpointConfigObj, APIConstants.API_DATA_PRODUCTION_ENDPOINTS, endpoints);
+                APIUtil.extractURLsFromEndpointConfig(endpointConfigObj, APIConstants.API_DATA_SANDBOX_ENDPOINTS, endpoints);
+                APIUtil.extractURLsFromEndpointConfig(endpointConfigObj, APIConstants.ENDPOINT_PRODUCTION_FAILOVERS, endpoints);
+                APIUtil.extractURLsFromEndpointConfig(endpointConfigObj, APIConstants.ENDPOINT_SANDBOX_FAILOVERS, endpoints);
+                for (String endpoint : endpoints) {
+                    APIUtil.validateRemoteURL(endpoint, tenantDomain);
+                }
+            }
         }
 
         try {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/McpServersApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/McpServersApiServiceImpl.java
@@ -1005,6 +1005,7 @@ public class McpServersApiServiceImpl implements McpServersApiService {
                     ExceptionCodes.MCP_REQUEST_BODY_CANNOT_BE_NULL);
         }
         String url = StringUtils.trimToEmpty(mcPServerProxyRequest.getUrl());
+        APIUtil.validateRemoteURL(url, RestApiCommonUtil.getLoggedInUserTenantDomain());
         MCPServerDTO mcpServerDTO = mcPServerProxyRequest.getAdditionalProperties();
         SecurityInfoDTO securityInfoDTO = mcPServerProxyRequest.getSecurityInfo();
 
@@ -2423,6 +2424,32 @@ public class McpServersApiServiceImpl implements McpServersApiService {
             } else {
                 RestApiUtil.handleBadRequest("Endpoint config is not in correct format", log);
             }
+
+            org.json.JSONObject endpointConfig = null;
+            if (endpointConfigObj instanceof Map) {
+                endpointConfig = new org.json.JSONObject((Map<?, ?>) endpointConfigObj);
+            } else if (endpointConfigObj instanceof String) {
+                endpointConfig = new org.json.JSONObject(endpointConfigObj.toString());
+            }
+            if (endpointConfig != null) {
+                String tenantDomain = RestApiCommonUtil.getLoggedInUserTenantDomain();
+                if (!APIConstants.ENDPOINT_TYPE_DEFAULT.equalsIgnoreCase(
+                        endpointConfig.optString(APIConstants.API_ENDPOINT_CONFIG_PROTOCOL_TYPE))) {
+                    ArrayList<String> endpoints = new ArrayList<>();
+                    APIUtil.extractURLsFromEndpointConfig(endpointConfig,
+                            APIConstants.API_DATA_PRODUCTION_ENDPOINTS, endpoints);
+                    APIUtil.extractURLsFromEndpointConfig(endpointConfig,
+                            APIConstants.API_DATA_SANDBOX_ENDPOINTS, endpoints);
+                    APIUtil.extractURLsFromEndpointConfig(endpointConfig,
+                            APIConstants.ENDPOINT_PRODUCTION_FAILOVERS, endpoints);
+                    APIUtil.extractURLsFromEndpointConfig(endpointConfig,
+                            APIConstants.ENDPOINT_SANDBOX_FAILOVERS, endpoints);
+                    for (String endpoint : endpoints) {
+                        APIUtil.validateRemoteURL(endpoint, tenantDomain);
+                    }
+                }
+            }
+
             String definition = backendAPIDTO.getDefinition();
             if (StringUtils.isNotBlank(definition)) {
                 APIDefinitionValidationResponse validationResponse =
@@ -2580,10 +2607,16 @@ public class McpServersApiServiceImpl implements McpServersApiService {
         ApiEndpointValidationResponseDTO apiEndpointValidationResponseDTO = new ApiEndpointValidationResponseDTO();
         apiEndpointValidationResponseDTO.setError("");
         try {
+            APIUtil.validateRemoteURL(endpointUrl, RestApiCommonUtil.getLoggedInUserTenantDomain());
             APIEndpointValidationDTO apiEndpointValidationDTO =
                     ApisApiServiceImplUtils.sendHttpHEADRequest(endpointUrl);
             apiEndpointValidationResponseDTO = APIMappingUtil.fromEndpointValidationToDTO(apiEndpointValidationDTO);
             return Response.status(Response.Status.OK).entity(apiEndpointValidationResponseDTO).build();
+        } catch (APIManagementException e) {
+            if (e.getErrorHandler() == null || e.getErrorHandler().getHttpStatusCode() != 400) {
+                throw e;
+            }
+            apiEndpointValidationResponseDTO.setError(e.getErrorHandler().getErrorDescription());
         } catch (MalformedURLException e) {
             log.error("Malformed Url error occurred while sending the HEAD request to the given endpoint url:", e);
             apiEndpointValidationResponseDTO.setError(e.getMessage());
@@ -2655,6 +2688,7 @@ public class McpServersApiServiceImpl implements McpServersApiService {
         }
 
         final String organization = RestApiUtil.getValidatedOrganization(messageContext);
+        APIUtil.validateRemoteURL(serverUrl, RestApiCommonUtil.getLoggedInUserTenantDomain());
         SecurityInfoDTO securityInfo = dto.getSecurityInfo();
         final boolean isSecure = securityInfo != null && Boolean.TRUE.equals(securityInfo.isIsSecure());
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/utils/RestApiPublisherUtils.java
@@ -745,6 +745,16 @@ public class RestApiPublisherUtils {
             throws APIManagementException {
         //validate inputs
         handleInvalidParams(fileInputStream, fileDetail, url, apiDefinition, isServiceAPI);
+        if (url != null) {
+            try {
+                APIUtil.validateRemoteURL(url, RestApiCommonUtil.getLoggedInUserTenantDomain());
+            } catch (APIManagementException e) {
+                if (e.getErrorHandler() != null && e.getErrorHandler().getHttpStatusCode() == 400) {
+                    throw RestApiUtil.buildBadRequestException(e.getErrorHandler().getErrorDescription());
+                }
+                throw e;
+            }
+        }
         String fileName = null;
 
         OpenAPIDefinitionValidationResponseDTO responseDTO;

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -2177,4 +2177,18 @@
       <Mediation>
         <EnableSecureXMLProcessing>{{apim.mediation.enable_secure_xml_processing}}</EnableSecureXMLProcessing>
       </Mediation>
+      {% if apim.network_security.access_control is defined %}
+            <NetworkSecurityAccessControl>
+              <Enabled>true</Enabled>
+              {% if apim.network_security.access_control.mode is defined %}
+              <Mode>{{apim.network_security.access_control.mode}}</Mode>
+              {% endif %}
+              <BlockPrivateNetworkAccess>{{apim.network_security.access_control.block_private_network_access | default("false")}}</BlockPrivateNetworkAccess>
+              {% if apim.network_security.access_control.hosts is defined %}
+              {% for host in apim.network_security.access_control.hosts %}
+              <Host>{{host}}</Host>
+              {% endfor %}
+              {% endif %}
+            </NetworkSecurityAccessControl>
+            {% endif %}
 </APIManager>


### PR DESCRIPTION
### Description

API Manager performs outbound network requests using user-provided URLs across several features, including:

* OpenAPI URL imports
* AsyncAPI URL imports
* WSDL URL imports
* GraphQL schema URL imports
* API endpoint validation
* API endpoint creation and updates
* Key Manager discovery and endpoint configuration
* MCP server creation and updates
* Backend endpoint configuration

These outbound requests may access destinations outside the control of the API Manager runtime. This improvement introduces centralized outbound network access control and destination validation for user-provided URLs.

### Goals

* Provide centralized validation for user-provided URLs
* Support platform-level network access control policies
* Support tenant-level network access control policies
* Support optional private network access restrictions
* Maintain backward compatibility when no configuration is present
* Provide consistent validation behavior across supported URL validation flows

### Approach

#### Platform-Level Configuration

Network access control can be configured using:

```toml
[apim.network_security.access_control]
mode = "allow"
hosts = ["api.github.com", "*.wso2.com"]
block_private_network_access = true
```

Platform administrators can:

* Restrict outbound access using allow mode
* Block destinations using deny mode
* Restrict access to private network ranges
* Define platform-wide destination restrictions

Platform-level validation is always evaluated before tenant-level validation.

#### Tenant-Level Configuration

Introduced optional tenant-level network access control through tenant configuration.

```json
{
  "NetworkSecurityAccessControl": {
    "Mode": "allow",
    "Hosts": [
      "*.allowed.example.com"
    ],
    "BlockPrivateNetworkAccess": true
  }
}
```

Behavior:

* Tenant-level validation is applied only when configured
* Platform-level restrictions always take precedence
* Tenant configuration cannot override platform restrictions

### Validation Behavior

* Allow mode uses the configured hosts list as an allowlist
* Deny mode uses the configured hosts list as a denylist
* Optional private network restrictions can be enabled
* Host matching is performed against the request host and resolved destination addresses
* Invalid or unresolved destinations are rejected when validation cannot be completed

### Covered Validation Entry Points

The following endpoints are protected by this implementation:

- POST /api/am/publisher/v4/mcp-servers/validate-endpoint
- POST /api/am/publisher/v4/mcp-servers/validate-mcp-server
- POST /api/am/publisher/v4/mcp-servers/validate-endpoint
- POST /api/am/admin/v4/key-managers/discover
- POST /api/am/admin/v4/key-managers
- PUT /api/am/admin/v4/key-managers/{keyManagerId}
- POST /api/am/publisher/v4/mcp-servers/generate-from-mcp-server
- POST /api/am/publisher/v4/apis/import-graphql-schema
- PUT /api/am/publisher/v4/apis/{apiId}/swagger
- POST /api/am/publisher/v4/apis/validate-wsdl
- POST /api/am/publisher/v4/apis/import-wsdl
- POST /api/am/publisher/v4/apis/validate-openapi
- POST /api/am/publisher/v4/mcp-servers/validate-openapi
- POST /api/am/publisher/v4/apis/import-openapi
- POST /api/am/publisher/v4/apis/validate-graphql-schema
- POST /api/am/publisher/v4/apis/validate-asyncapi
- POST /api/am/publisher/v4/mcp-servers/import
- POST /api/am/publisher/v4/apis/import-asyncapi
- POST /api/am/publisher/v4/mcp-servers/generate-from-openapi
- POST /api/am/publisher/v4/apis/{apiId}/endpoints
- PUT /api/am/publisher/v4/apis/{apiId}/endpoints/{endpointId}
- PUT /api/am/publisher/v4/mcp-servers/{mcpServerId}/backends/{backendId}
- POST /api/am/publisher/v4/apis
- PUT /api/am/publisher/v4/apis/{apiId}
- PUT /api/am/publisher/v4/apis/{apiId}/asyncapi
- PUT /api/am/publisher/v4/apis/{apiId}/wsdl
- POST /api/am/publisher/v4/mcp-servers/generate-from-api
- PUT /api/am/publisher/v4/mcp-servers/{mcpServerId}
- POST /api/am/publisher/v4/apis/import

### Error Handling

Client validation failures:

```text
HTTP 400: The provided URL is not trusted. Please contact the system administrator.
```

Configuration issues:

```text
HTTP 500: Internal server error. Please contact the system administrator.
```

Detailed diagnostics remain available in server logs.

### Testing

Added and updated coverage for:

* Platform allow mode validation
* Platform deny mode validation
* Tenant access control validation
* Private network access restrictions
* Configuration precedence validation

### Backward Compatibility

When network access control configuration is not present, existing behavior remains unchanged.
