### PR TITLE
Add missing project-level <name> tags and remove empty <description>

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.broker.lifecycle/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.broker.lifecycle/pom.xml
@@ -11,6 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.broker.lifecycle</artifactId>
     <packaging>bundle</packaging>
+    <name>WSO2 Carbon - API Management Broker Lifecycle</name>
 
     <dependencies>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.cache.invalidation/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.cache.invalidation/pom.xml
@@ -25,6 +25,7 @@
 
     <artifactId>org.wso2.carbon.apimgt.cache.invalidation</artifactId>
     <packaging>bundle</packaging>
+    <name>WSO2 Carbon - API Management Cache Invalidation</name>
     <dependencies>
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.analytics/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>org.wso2.carbon.apimgt.common.analytics</artifactId>
     <packaging>bundle</packaging>
+    <name>WSO2 Carbon - API Management Common Analytics</name>
 
     <dependencies>
         <dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.gateway/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>org.wso2.carbon.apimgt.common.gateway</artifactId>
     <packaging>bundle</packaging>
+    <name>WSO2 Carbon - API Management Common Gateway</name>
 
     <dependencies>
         <dependency>

--- a/components/apimgt/org.wso2.carbon.apimgt.common.jms/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.common.jms/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>
+    <name>WSO2 Carbon - API Management Common JMS</name>
     <artifactId>org.wso2.carbon.apimgt.common.jms</artifactId>
 
     <dependencies>

--- a/components/apimgt/org.wso2.carbon.apimgt.jms.listener/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.jms.listener/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>
+    <name>WSO2 Carbon - API Management JMS Listener</name>
     <artifactId>org.wso2.carbon.apimgt.jms.listener</artifactId>
 
     <dependencies>

--- a/components/apimgt/org.wso2.carbon.apimgt.notification/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.notification/pom.xml
@@ -24,6 +24,7 @@
     <artifactId>org.wso2.carbon.apimgt.notification</artifactId>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>
+    <name>WSO2 Carbon - API Management Notification</name>
     <build>
         <plugins>
             <plugin>

--- a/components/apimgt/org.wso2.carbon.apimgt.persistence/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.persistence/pom.xml
@@ -9,6 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.apimgt.persistence</artifactId>
     <packaging>bundle</packaging>
+    <name>WSO2 Carbon - API Management Persistence</name>
 
     <build>
         <plugins>

--- a/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.throttle.policy.deployer/pom.xml
@@ -23,6 +23,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>
+    <name>WSO2 Carbon - API Management Throttle Policy Deployer</name>
 
     <artifactId>org.wso2.carbon.apimgt.throttle.policy.deployer</artifactId>
 

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/pom.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/pom.xml
@@ -29,7 +29,6 @@
     <artifactId>org.wso2.carbon.apimgt.tracing</artifactId>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon - API Tracing</name>
-    <description />
     <url>http://wso2.org</url>
 
     <dependencies>


### PR DESCRIPTION
## Purpose
Migrating publishing from Nexus 2 to Nexus 3. The Nexus 3 build **fails** when a pom's project-level `<name>` tag is missing (Nexus 2 tolerated this). Empty `<description/>` tags are also cleaned up.

## Changes
- Added project-level `<name>` to 9 component poms that were missing it (placed after `<packaging>`, following the `WSO2 Carbon - <Component>` convention).
- Removed one empty `<description/>` (org.wso2.carbon.apimgt.tracing).

9 insertions, 1 deletion across 10 poms. All poms parse OK; no untouched lines reformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)