### PR TITLE
Fix issue in saving and loading tenant-conf

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -2174,6 +2174,7 @@ public final class APIConstants {
     public static final String REST_API_SCOPE = "Scope";
     public static final String REST_API_SCOPE_NAME = "Name";
     public static final String REST_API_SCOPE_ROLE = "Roles";
+    public static final String REST_API_SCOPE_SUPPORTED_MODELS = "SupportedModels";
     public static final String REST_API_SCOPES_CONFIG = "RESTAPIScopes";
     public static final String REST_API_ROLE_MAPPINGS_CONFIG = "RoleMappings";
     public static final String APIM_SUBSCRIBE_SCOPE = "apim:subscribe";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -10469,16 +10469,21 @@ public final class APIUtil {
 
         // Iterating the existing (old) scope-role mappings
         for (JsonElement existingScopeRoleMapping : existingTenantConfScopesArray) {
-            String existingScopeName = existingScopeRoleMapping.getAsJsonObject().get(APIConstants.REST_API_SCOPE_NAME).
-                    getAsString();
+            JsonObject existingScopeObject = existingScopeRoleMapping.getAsJsonObject();
+            String existingScopeName = existingScopeObject.get(APIConstants.REST_API_SCOPE_NAME).getAsString();
             Boolean scopeRoleMappingExists = false;
-            // Iterating the modified (new) scope-role mappings and add the old scope mappings
-            // if those are not present in the list (merging)
-            for (JsonElement newScopeRoleMapping : newTenantConfScopesArray) {
-                String newScopeName = newScopeRoleMapping.getAsJsonObject().get(APIConstants.REST_API_SCOPE_NAME).
-                        getAsString();
+            // Iterating the merged (new) scope-role mappings to detect overlap
+            for (JsonElement newScopeRoleMapping : mergedTenantConfScopesArray) {
+                JsonObject newScopeObject = newScopeRoleMapping.getAsJsonObject();
+                String newScopeName = newScopeObject.get(APIConstants.REST_API_SCOPE_NAME).getAsString();
                 if (StringUtils.equals(existingScopeName, newScopeName)) {
-                    // If a particular mapping is already there, skip it
+                    // Preserve the SupportedModels field from the existing entry as it is not part
+                    // of the role-mapping update payload sent from the Scope Assignments page
+                    if (existingScopeObject.has(APIConstants.REST_API_SCOPE_SUPPORTED_MODELS)
+                            && !newScopeObject.has(APIConstants.REST_API_SCOPE_SUPPORTED_MODELS)) {
+                        newScopeObject.add(APIConstants.REST_API_SCOPE_SUPPORTED_MODELS,
+                                existingScopeObject.get(APIConstants.REST_API_SCOPE_SUPPORTED_MODELS));
+                    }
                     scopeRoleMappingExists = true;
                     break;
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SystemScopesMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/SystemScopesMappingUtil.java
@@ -92,7 +92,9 @@ public class SystemScopesMappingUtil {
                 roleScopeDTO.setTag(mapping.getValue().get(1));
                 scopeDTOs.add(roleScopeDTO);
             } else {
-                log.warn("The scope " + mapping.getKey() + " does not exist in tenant.conf");
+                if (log.isDebugEnabled()) {
+                    log.debug("The scope " + mapping.getKey() + " does not exist in tenant.conf");
+                }
             }
         }
         return scopeDTOs;


### PR DESCRIPTION
With the fix introduced in https://github.com/wso2/carbon-apimgt/pull/13837, there will be a new field added in tenant-conf.json by portal customized users. This PR will preserve the new field when overrding tenant-conf.json via updates to Scope Assignments in admin portal.