### PR TITLE
Reject duplicate certificate content on endpoint certificate upload

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/certificatemgt/CertificateManagerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/certificatemgt/CertificateManagerImpl.java
@@ -92,6 +92,11 @@ public class CertificateManagerImpl implements CertificateManager {
                         .getResponseCode()) {
                     log.error("Could not add Certificate to Trust Store. Certificate Exists. Rolling back...");
                     certificateMgtDAO.deleteCertificate(alias, endpoint, tenantId);
+                } else if (responseCode.getResponseCode() == ResponseCode.CERTIFICATE_EXISTS_IN_TRUST_STORE
+                        .getResponseCode()) {
+                    log.error("Could not add Certificate to Trust Store. Certificate content already exists. " +
+                            "Rolling back...");
+                    certificateMgtDAO.deleteCertificate(alias, endpoint, tenantId);
                 } else if (responseCode.getResponseCode() == ResponseCode.CERTIFICATE_EXPIRED.getResponseCode()) {
                     log.error("Could not add Certificate. Certificate has already expired.");
                     certificateMgtDAO.deleteCertificate(alias, endpoint, tenantId);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/certificatemgt/PeerNodeCertificateManager.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/certificatemgt/PeerNodeCertificateManager.java
@@ -76,8 +76,14 @@ public class PeerNodeCertificateManager {
                     break;
                 case ALIAS_EXISTS_IN_TRUST_STORE:
                     if (log.isDebugEnabled()) {
-                        log.debug("Certificate already exists in trust store. alias='" + alias + "', endpoint='" + 
+                        log.debug("Certificate already exists in trust store. alias='" + alias + "', endpoint='" +
                                 endpoint + "', tenantId=" + tenantId);
+                    }
+                    break;
+                case CERTIFICATE_EXISTS_IN_TRUST_STORE:
+                    if (log.isDebugEnabled()) {
+                        log.debug("Certificate content already exists in trust store. alias='" + alias +
+                                "', endpoint='" + endpoint + "', tenantId=" + tenantId);
                     }
                     break;
                 case CERTIFICATE_EXPIRED:

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/certificatemgt/ResponseCode.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/certificatemgt/ResponseCode.java
@@ -28,7 +28,7 @@ package org.wso2.carbon.apimgt.impl.certificatemgt;
  * 4. CERTIFICATE_NOT_FOUND : Failed to remove the certificate from trust store. Certificate not found.
  * 5. FAILED_TO_REMOVE_FROM_DB : Failed to remove the certificate from Database.
  * 6. CERTIFICATE_EXPIRED : Failed to add certificate to key store. Certificate expired.
- * 7. CERTIFICATE_FOR_ENDPOINT_EXISTS : Failed to add Certificate to database. Certificate for endpoint exists.
+ * 7. CERTIFICATE_EXISTS_IN_TRUST_STORE : Failed to add certificate. Certificate content already exists in trust store.
  */
 public enum ResponseCode {
 
@@ -37,7 +37,8 @@ public enum ResponseCode {
     ALIAS_EXISTS_IN_TRUST_STORE(3),
     CERTIFICATE_NOT_FOUND(4),
     FAILED_TO_REMOVE_FROM_DB(5),
-    CERTIFICATE_EXPIRED(6);
+    CERTIFICATE_EXPIRED(6),
+    CERTIFICATE_EXISTS_IN_TRUST_STORE(7);
 
     private final int responseCode;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/CertificateMgtUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/CertificateMgtUtils.java
@@ -152,6 +152,7 @@ public class CertificateMgtUtils {
      * SUCCESS : If certificate added successfully.
      * INTERNAL_SERVER_ERROR : If any internal error occurred
      * ALIAS_EXISTS_IN_TRUST_STORE : If the alias exists in trust store.
+     * CERTIFICATE_EXISTS_IN_TRUST_STORE : If the certificate content already exists in trust store under another alias.
      * CERTIFICATE_EXPIRED : If the given certificate is expired.
      */
     public ResponseCode addCertificateToTrustStore(String base64Cert, String alias) {
@@ -171,6 +172,7 @@ public class CertificateMgtUtils {
      * SUCCESS : If certificate added successfully.
      * INTERNAL_SERVER_ERROR : If any internal error occurred
      * ALIAS_EXISTS_IN_TRUST_STORE : If the alias exists in trust store.
+     * CERTIFICATE_EXISTS_IN_TRUST_STORE : If the certificate content already exists in trust store under another alias.
      * CERTIFICATE_EXPIRED : If the given certificate is expired.
      */
     private ResponseCode addCertificateToTrustStore(TrustStoreDTO trustStoreDTO, String base64Cert, String alias) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/CertificateMgtUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/CertificateMgtUtils.java
@@ -176,6 +176,7 @@ public class CertificateMgtUtils {
     private ResponseCode addCertificateToTrustStore(TrustStoreDTO trustStoreDTO, String base64Cert, String alias) {
 
         boolean isCertExists = false;
+        boolean isCertificateContentExists = false;
         boolean expired = false;
 
         try {
@@ -198,6 +199,8 @@ public class CertificateMgtUtils {
                             //Check whether the Alias exists in the trust store.
                             if (trustStore.containsAlias(alias)) {
                                 isCertExists = true;
+                            } else if (trustStore.getCertificateAlias(certificate) != null) {
+                                isCertificateContentExists = true;
                             } else {
                                 /*
                                  * If alias is not exists, check whether the certificate is expired or not. If expired
@@ -219,8 +222,10 @@ public class CertificateMgtUtils {
                         try (OutputStream fileOutputStream = new FileOutputStream(trustStoreFile)) {
                             trustStore.store(fileOutputStream, trustStoreDTO.getPassword());
                         }
-                        return expired ? ResponseCode.CERTIFICATE_EXPIRED :
-                                                        isCertExists ? ResponseCode.ALIAS_EXISTS_IN_TRUST_STORE : ResponseCode.SUCCESS;
+                        return isCertExists ? ResponseCode.ALIAS_EXISTS_IN_TRUST_STORE
+                                : isCertificateContentExists ? ResponseCode.CERTIFICATE_EXISTS_IN_TRUST_STORE
+                                : expired ? ResponseCode.CERTIFICATE_EXPIRED
+                                : ResponseCode.SUCCESS;
                     }
                 }
             }
@@ -429,6 +434,12 @@ public class CertificateMgtUtils {
             if (x509Certificate.getNotAfter().getTime() <= System.currentTimeMillis()) {
                 log.error("Could not update the certificate. The certificate expired.");
                 return ResponseCode.CERTIFICATE_EXPIRED;
+            }
+            String existingAlias = trustStore.getCertificateAlias(newCertificate);
+            if (StringUtils.isNotEmpty(existingAlias) && !alias.equalsIgnoreCase(existingAlias)) {
+                log.error("Could not update the certificate. Certificate content already exists in the trust store " +
+                        "with alias '" + existingAlias + "'.");
+                return ResponseCode.CERTIFICATE_EXISTS_IN_TRUST_STORE;
             }
             // If the certificate is not expired, delete the existing certificate and add the new cert.
             trustStore.deleteEntry(alias);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/certificatemgt/CertificateManagerImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/certificatemgt/CertificateManagerImplTest.java
@@ -158,6 +158,20 @@ public class CertificateManagerImplTest {
         Assert.assertEquals(ResponseCode.ALIAS_EXISTS_IN_TRUST_STORE, responseCode);
     }
 
+    @Test
+    public void testAddToPublisherWithExistingCertificateContent()
+            throws CertificateAliasExistsException, CertificateManagementException {
+        Mockito.when(certificateMgtDAO.addCertificate(BASE64_ENCODED_CERT, ALIAS, END_POINT, TENANT_ID))
+                .thenReturn(true);
+        Mockito.when(certificateMgtDAO.deleteCertificate(ALIAS, END_POINT, TENANT_ID)).thenReturn(true);
+        PowerMockito.stub(PowerMockito
+                .method(CertificateMgtUtils.class, "addCertificateToTrustStore", String.class, String.class))
+                .toReturn(ResponseCode.CERTIFICATE_EXISTS_IN_TRUST_STORE);
+        ResponseCode responseCode = certificateManager.addCertificateToParentNode(BASE64_ENCODED_CERT, ALIAS,
+                END_POINT, TENANT_ID);
+        Assert.assertEquals(ResponseCode.CERTIFICATE_EXISTS_IN_TRUST_STORE, responseCode);
+    }
+
     //@Test
     public void testAddToPublisherWhenDBError() {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/certificatemgt/CertificateManagerImplTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/certificatemgt/CertificateManagerImplTest.java
@@ -167,9 +167,14 @@ public class CertificateManagerImplTest {
         PowerMockito.stub(PowerMockito
                 .method(CertificateMgtUtils.class, "addCertificateToTrustStore", String.class, String.class))
                 .toReturn(ResponseCode.CERTIFICATE_EXISTS_IN_TRUST_STORE);
+        // certificateMgtDAO is a shared static mock; clear prior invocations so the rollback assertion
+        // below only counts the deleteCertificate call triggered by this test.
+        Mockito.clearInvocations(certificateMgtDAO);
         ResponseCode responseCode = certificateManager.addCertificateToParentNode(BASE64_ENCODED_CERT, ALIAS,
                 END_POINT, TENANT_ID);
         Assert.assertEquals(ResponseCode.CERTIFICATE_EXISTS_IN_TRUST_STORE, responseCode);
+        // Verify the DB entry is rolled back when the trust store reports duplicate certificate content.
+        Mockito.verify(certificateMgtDAO).deleteCertificate(ALIAS, END_POINT, TENANT_ID);
     }
 
     //@Test

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/CertificateMgtUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/CertificateMgtUtilTest.java
@@ -39,6 +39,7 @@ public class CertificateMgtUtilTest {
 
     private static CertificateMgtUtils certificateMgtUtils;
     private static final String ALIAS = "TEST_ALIAS";
+    private static final String ALIAS_WITH_DUPLICATE_CONTENT = "TEST_ALIAS_DUPLICATE_CONTENT";
     private static final URL CERT_PATH = CertificateMgtUtilTest.class.getClassLoader().getResource
             ("security/client-truststore.jks");
     private static final String ALIAS_NOT_EXIST = "TEST_ALIAS_NOT";
@@ -100,6 +101,7 @@ public class CertificateMgtUtilTest {
     @Test
     public void testAddCertificateToTrustStore() {
 
+        certificateMgtUtils.removeCertificateFromTrustStore(ALIAS);
         ResponseCode result = certificateMgtUtils.addCertificateToTrustStore(BASE64_ENCODED_CERT_STRING, ALIAS);
         Assert.assertEquals(result, ResponseCode.SUCCESS);
     }
@@ -109,6 +111,14 @@ public class CertificateMgtUtilTest {
 
         ResponseCode result = certificateMgtUtils.addCertificateToTrustStore(BASE64_ENCODED_CERT_STRING, ALIAS);
         Assert.assertEquals(result, ResponseCode.ALIAS_EXISTS_IN_TRUST_STORE);
+    }
+
+    @Test
+    public void testAddExistingCertificateContentWithDifferentAlias() {
+
+        ResponseCode result = certificateMgtUtils
+                .addCertificateToTrustStore(BASE64_ENCODED_CERT_STRING, ALIAS_WITH_DUPLICATE_CONTENT);
+        Assert.assertEquals(result, ResponseCode.CERTIFICATE_EXISTS_IN_TRUST_STORE);
     }
 
     @Test
@@ -213,6 +223,7 @@ public class CertificateMgtUtilTest {
      */
     @Test
     public void testValidateCertificate() {
+        certificateMgtUtils.removeCertificateFromTrustStore(ALIAS);
         certificateMgtUtils.addCertificateToTrustStore(BASE64_ENCODED_CERT_STRING,
                 ALIAS + "_" + MultitenantConstants.SUPER_TENANT_ID);
         ResponseCode responseCode = certificateMgtUtils

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/EndpointCertificatesApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/publisher/v1/impl/EndpointCertificatesApiServiceImpl.java
@@ -204,6 +204,8 @@ public class EndpointCertificatesApiServiceImpl implements EndpointCertificatesA
                         "server error", log);
             } else if (ResponseCode.CERTIFICATE_NOT_FOUND.getResponseCode() == responseCode) {
                 RestApiUtil.handleResourceNotFoundError("", log);
+            } else if (ResponseCode.CERTIFICATE_EXISTS_IN_TRUST_STORE.getResponseCode() == responseCode) {
+                RestApiUtil.handleResourceAlreadyExistsError("Certificate already exists in the trust store.", log);
             } else if (ResponseCode.CERTIFICATE_EXPIRED.getResponseCode() == responseCode) {
                 RestApiUtil.handleBadRequest("Error while updating the certificate. Certificate Expired.", log);
             }
@@ -319,6 +321,8 @@ public class EndpointCertificatesApiServiceImpl implements EndpointCertificatesA
             } else if (ResponseCode.ALIAS_EXISTS_IN_TRUST_STORE.getResponseCode() == responseCode) {
                 RestApiUtil.handleResourceAlreadyExistsError("The alias '" + alias +
                         "' already exists in the trust store.", log);
+            } else if (ResponseCode.CERTIFICATE_EXISTS_IN_TRUST_STORE.getResponseCode() == responseCode) {
+                RestApiUtil.handleResourceAlreadyExistsError("Certificate already exists in the trust store.", log);
             } else if (ResponseCode.CERTIFICATE_EXPIRED.getResponseCode() == responseCode) {
                 RestApiUtil.handleBadRequest("Error while adding the certificate. Certificate Expired.", log);
             }


### PR DESCRIPTION
## Summary

- APIM allowed the same certificate content to be uploaded multiple times under different aliases via `POST /api/am/publisher/v4/endpoint-certificates`, causing truststore bloat with duplicate entries.
- The only validation performed was alias uniqueness (`trustStore.containsAlias(alias)`); there was no check for duplicate certificate content.
- This fix adds a content-uniqueness check using `KeyStore.getCertificateAlias(cert)` on both the add and update paths, returning HTTP 409 when duplicate content is detected.

## Root Cause

`CertificateMgtUtils.addCertificateToTrustStore()` only called `trustStore.containsAlias(alias)`. No fingerprint or content comparison was done against existing truststore entries.

## Changes

| File | Change |
|------|--------|
| `ResponseCode.java` | Added `CERTIFICATE_EXISTS_IN_TRUST_STORE(7)` |
| `CertificateMgtUtils.java` | Added `getCertificateAlias()` duplicate content check in add path and update path (with same-alias guard) |
| `CertificateManagerImpl.java` | Added DB rollback for `CERTIFICATE_EXISTS_IN_TRUST_STORE` in `addCertificateToParentNode` |
| `PeerNodeCertificateManager.java` | Added `CERTIFICATE_EXISTS_IN_TRUST_STORE` case to switch statement |
| `EndpointCertificatesApiServiceImpl.java` | Return HTTP 409 for new response code in both POST and PUT handlers |

## Verification

Tested on APIM 4.7.0-SNAPSHOT pack:

| Scenario | Expected | Result |
|----------|----------|--------|
| POST new cert, new alias | 201 | ✅ 201 |
| POST same cert content, different alias | 409 | ✅ 409 |
| POST different cert content, new alias | 201 | ✅ 201 |
| PUT cert with content already stored under another alias | 409 | ✅ 409 |

## Related

- Port of: https://github.com/wso2-support/carbon-apimgt/pull/8298 (fixed in 4.6.0)
- Public issue: https://github.com/wso2/api-manager/issues/5057

🤖 Generated with [Claude Code](https://claude.com/claude-code)