### PR TITLE
Add configurable OpenTelemetry sampler for OTLP tracing

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/OTLPTelemetry.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/OTLPTelemetry.java
@@ -27,6 +27,7 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -87,6 +88,7 @@ public class OTLPTelemetry implements APIMOpenTelemetry {
             sdkTracerProvider = SdkTracerProvider.builder()
                     .addSpanProcessor(BatchSpanProcessor.builder(otlpGrpcSpanExporterBuilder.build()).build())
                     .setResource(TelemetryUtil.getTracerProviderResource(serviceName))
+                    .setSampler(getConfiguredSampler())
                     .build();
 
             openTelemetry = OpenTelemetrySdk.builder()
@@ -143,6 +145,29 @@ public class OTLPTelemetry implements APIMOpenTelemetry {
             }
         }
         return null;
+    }
+
+    /**
+     * Resolves the trace sampler from the configured "OpenTelemetry.RemoteTracer.SamplerMode" value.
+     *
+     * @return the configured {@link Sampler}.
+     */
+    private Sampler getConfiguredSampler() {
+
+        String configuredSampler = configuration.getFirstProperty(TelemetryConstants.OTLP_CONFIG_SAMPLER);
+        if (StringUtils.isEmpty(configuredSampler)) {
+            return Sampler.parentBased(Sampler.alwaysOn());
+        }
+        if (StringUtils.equalsIgnoreCase(configuredSampler, TelemetryConstants.SAMPLER_ALWAYS_ON)) {
+            return Sampler.alwaysOn();
+        } else if (StringUtils.equalsIgnoreCase(configuredSampler, TelemetryConstants.SAMPLER_ALWAYS_OFF)) {
+            return Sampler.alwaysOff();
+        } else if (StringUtils.equalsIgnoreCase(configuredSampler, TelemetryConstants.SAMPLER_PARENT_BASED)) {
+            return Sampler.parentBased(Sampler.alwaysOn());
+        }
+        log.warn("Unknown OpenTelemetry sampler '" + configuredSampler + "' configured. Falling back to the "
+                + "default parent-based (always-on) sampler.");
+        return Sampler.parentBased(Sampler.alwaysOn());
     }
 
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/TelemetryConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.tracing/src/main/java/org/wso2/carbon/apimgt/tracing/telemetry/TelemetryConstants.java
@@ -64,6 +64,14 @@ public class TelemetryConstants {
      */
     static final String OTLP_CONFIG_URL = "OpenTelemetry.RemoteTracer.Url";
     static final String OPENTELEMETRY_PROPERTIES_PREFIX = "OpenTelemetry.RemoteTracer.Properties.";
+
+    /**
+     * Sampler Constants.
+     */
+    static final String OTLP_CONFIG_SAMPLER = "OpenTelemetry.RemoteTracer.SamplerMode";
+    static final String SAMPLER_ALWAYS_ON = "always_on";
+    static final String SAMPLER_ALWAYS_OFF = "always_off";
+    static final String SAMPLER_PARENT_BASED = "parent_based";
     static final String OTEL_RESOURCE_ATTRIBUTE_CONFIG_KEYS_PREFIX = "OpenTelemetry.ResourceAttributes.";
     static final String OTEL_RESOURCE_ATTRIBUTES_ENVIRONMENT_VARIABLE_NAME = "OTEL_RESOURCE_ATTRIBUTES";
 

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -1510,6 +1510,9 @@
             <Url>{{apim.open_telemetry.remote_tracer.url}}</Url>
             <HostName>{{apim.open_telemetry.remote_tracer.hostname}}</HostName>
             <Port>{{apim.open_telemetry.remote_tracer.port}}</Port>
+            {% if apim.open_telemetry.remote_tracer.sampler_mode is defined %}
+            <SamplerMode>{{apim.open_telemetry.remote_tracer.sampler_mode}}</SamplerMode>
+            {% endif %}
             <Properties>
                 {% for property in apim.open_telemetry.remote_tracer.properties %}
                 <{{property.name}}>{{property.value}}</{{property.name}}>


### PR DESCRIPTION
## Description 
This PR improves OpenTelemetry OTLP tracing by making the trace sampler configurable via `deployment.toml` (`remote_tracer.sampler_mode`).

## Issue 
https://github.com/wso2/api-manager/issues/5075
