### PR TITLE
Fix encoded certificate parsing failure in CBAT validation

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.gateway/src/main/java/org/wso2/carbon/apimgt/gateway/handlers/Utils.java
@@ -522,7 +522,7 @@ public class Utils {
                 bytes = certificate.getBytes();
             } else {
                 try {
-                    certificate = URLDecoder.decode(certificate, "UTF-8");
+                    certificate = URLDecoder.decode(certificate.replace("+", "%2B"), "UTF-8");
                 } catch (UnsupportedEncodingException e) {
                     String msg = "Error while URL decoding certificate";
                     throw new APIManagementException(msg, e);


### PR DESCRIPTION
### Purpose

When a load balancer like AWS ALB forwards the client certificate via a header using RFC 3986 encoding, literal + characters from the base64 certificate body are passed as + without any change. URLDecoder.decode() follows application/x-www-form-urlencoded semantics and incorrectly interprets + as a space, corrupting the base64 content and causing an Incomplete BER/DER data parse failure.

Fixed by escaping literal + as %2B before decoding, so URLDecoder preserves them correctly.

Fixes: https://github.com/wso2/api-manager/issues/5085