### PR TITLE
Add support for Connect Universal Gateway via TOML configs

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3987,6 +3987,8 @@ public final class APIConstants {
         public static final String CONNECT_DESCRIPTION = "Description";
         public static final String CONNECT_URL = "Url";
         public static final String CONNECT_ORGANIZATION = "Organization";
+        /** Original gateway base URL (scheme/host/port/path) for platform gateway environments. */
+        public static final String GATEWAY_BASE_URL = "gatewayBaseUrl";
         public static final String VERSION = "Version";
         public static final String API_KEY_NOTIFICATION = "APIKeyNotification";
         public static final String QUEUE_SIZE = "QueueSize";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3979,6 +3979,13 @@ public final class APIConstants {
 
         public static final String PLATFORM_GATEWAY_CONNECT_CONFIGURATION = "PlatformGatewayConnectConfiguration";
         public static final String PLATFORM_GATEWAY_VERSIONS = "PlatformGatewayVersions";
+        public static final String CONNECT_GATEWAYS = "ConnectGateways";
+        public static final String CONNECT = "Connect";
+        public static final String REGISTRATION_TOKEN = "RegistrationToken";
+        public static final String CONNECT_NAME = "Name";
+        public static final String CONNECT_DISPLAY_NAME = "DisplayName";
+        public static final String CONNECT_DESCRIPTION = "Description";
+        public static final String CONNECT_URL = "Url";
         public static final String VERSION = "Version";
         public static final String API_KEY_NOTIFICATION = "APIKeyNotification";
         public static final String QUEUE_SIZE = "QueueSize";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java
@@ -3986,6 +3986,7 @@ public final class APIConstants {
         public static final String CONNECT_DISPLAY_NAME = "DisplayName";
         public static final String CONNECT_DESCRIPTION = "Description";
         public static final String CONNECT_URL = "Url";
+        public static final String CONNECT_ORGANIZATION = "Organization";
         public static final String VERSION = "Version";
         public static final String API_KEY_NOTIFICATION = "APIKeyNotification";
         public static final String QUEUE_SIZE = "QueueSize";

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -115,6 +115,7 @@ import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
 import org.wso2.carbon.apimgt.impl.gateway.PlatformGatewayAPIKeyEvents;
 import org.wso2.carbon.apimgt.impl.gateway.PlatformGatewayAPIKeyEventService;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.service.PlatformGatewayServiceImpl;
 import org.wso2.carbon.apimgt.impl.monetization.DefaultMonetizationImpl;
 import org.wso2.carbon.apimgt.impl.notifier.events.APIKeyAssociationEvent;
 import org.wso2.carbon.apimgt.impl.notifier.events.APIKeyEvent;
@@ -5095,7 +5096,12 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 return hostsWithSchemes;
             }
 
-            VHost vhost = VHostUtils.getVhostFromEnvironment(environment, host);
+            VHost vhost = VHostUtils.getInvocationVhostFromEnvironment(environment, host);
+            Map<String, String> platformInvocationUrls =
+                    PlatformGatewayServiceImpl.resolveInvocationUrlsForTransports(environment, api.getTransports());
+            if (!platformInvocationUrls.isEmpty()) {
+                return platformInvocationUrls;
+            }
             GatewayAgentConfiguration gatewayConfiguration = ServiceReferenceHolder.getInstance()
                     .getExternalGatewayConnectorConfiguration(environment.getGatewayType());
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConsumerImpl.java
@@ -5090,6 +5090,11 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                     host = deployment.getVhost();
                 }
             }
+            Map<String, String> platformInvocationUrls =
+                    PlatformGatewayServiceImpl.resolveInvocationUrlsForTransports(environment, api.getTransports());
+            if (!platformInvocationUrls.isEmpty()) {
+                return platformInvocationUrls;
+            }
             if (StringUtils.isEmpty(host)) {
                 // returns empty server urls
                 hostsWithSchemes.put(APIConstants.HTTP_PROTOCOL, "");
@@ -5097,11 +5102,6 @@ public class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
             }
 
             VHost vhost = VHostUtils.getInvocationVhostFromEnvironment(environment, host);
-            Map<String, String> platformInvocationUrls =
-                    PlatformGatewayServiceImpl.resolveInvocationUrlsForTransports(environment, api.getTransports());
-            if (!platformInvocationUrls.isEmpty()) {
-                return platformInvocationUrls;
-            }
             GatewayAgentConfiguration gatewayConfiguration = ServiceReferenceHolder.getInstance()
                     .getExternalGatewayConnectorConfiguration(environment.getGatewayType());
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -51,6 +51,7 @@ import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.VHost;
 import org.wso2.carbon.apimgt.common.gateway.configdto.HttpClientConfigurationDTO;
 import org.wso2.carbon.apimgt.impl.dto.APIMGovernanceConfigDTO;
+import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
 import org.wso2.carbon.apimgt.impl.dto.DistributedThrottleConfig;
 import org.wso2.carbon.apimgt.impl.dto.EventHubConfigurationDto;
 import org.wso2.carbon.apimgt.impl.dto.ExtendedJWTConfigurationDto;
@@ -3671,19 +3672,20 @@ public class APIManagerConfiguration {
             if (!platformGatewayVersions.isEmpty()) {
                 platformGatewayConnectConfig.setPlatformGatewayVersions(platformGatewayVersions);
             }
-            List<org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig> connectGateways = new ArrayList<>();
+            List<ConnectGatewayConfig> connectGateways = new ArrayList<>();
+            int declaredConnectEntryCount = 0;
             OMElement connectGatewaysElem = pgConnectElem.getFirstChildWithName(
                     new QName(APIConstants.GatewayNotification.CONNECT_GATEWAYS));
             if (connectGatewaysElem != null) {
                 Iterator<?> connectIt = connectGatewaysElem.getChildrenWithName(
                         new QName(APIConstants.GatewayNotification.CONNECT));
                 while (connectIt != null && connectIt.hasNext()) {
+                    declaredConnectEntryCount++;
                     OMElement connectElem = (OMElement) connectIt.next();
                     if (connectElem == null) {
                         continue;
                     }
-                    org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig entry =
-                            new org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig();
+                    ConnectGatewayConfig entry = new ConnectGatewayConfig();
                     OMElement rt = connectElem.getFirstChildWithName(
                             new QName(APIConstants.GatewayNotification.REGISTRATION_TOKEN));
                     if (rt != null && rt.getText() != null && !rt.getText().trim().isEmpty()) {
@@ -3714,11 +3716,10 @@ public class APIManagerConfiguration {
                     if (orgEl != null && orgEl.getText() != null && !orgEl.getText().trim().isEmpty()) {
                         entry.setOrganization(orgEl.getText().trim());
                     }
-                    if (!entry.getRegistrationToken().isEmpty()) {
-                        connectGateways.add(entry);
-                    }
+                    connectGateways.add(entry);
                 }
             }
+            platformGatewayConnectConfig.setDeclaredConnectEntryCount(declaredConnectEntryCount);
             if (!connectGateways.isEmpty()) {
                 platformGatewayConnectConfig.setConnectGateways(connectGateways);
             }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -3709,6 +3709,11 @@ public class APIManagerConfiguration {
                     if (urlEl != null && urlEl.getText() != null && !urlEl.getText().trim().isEmpty()) {
                         entry.setUrl(urlEl.getText().trim());
                     }
+                    OMElement orgEl = connectElem.getFirstChildWithName(
+                            new QName(APIConstants.GatewayNotification.CONNECT_ORGANIZATION));
+                    if (orgEl != null && orgEl.getText() != null && !orgEl.getText().trim().isEmpty()) {
+                        entry.setOrganization(orgEl.getText().trim());
+                    }
                     if (!entry.getRegistrationToken().isEmpty()) {
                         connectGateways.add(entry);
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -3671,6 +3671,52 @@ public class APIManagerConfiguration {
             if (!platformGatewayVersions.isEmpty()) {
                 platformGatewayConnectConfig.setPlatformGatewayVersions(platformGatewayVersions);
             }
+            List<org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig> connectGateways = new ArrayList<>();
+            OMElement connectGatewaysElem = pgConnectElem.getFirstChildWithName(
+                    new QName(APIConstants.GatewayNotification.CONNECT_GATEWAYS));
+            if (connectGatewaysElem != null) {
+                Iterator<?> connectIt = connectGatewaysElem.getChildrenWithName(
+                        new QName(APIConstants.GatewayNotification.CONNECT));
+                while (connectIt != null && connectIt.hasNext()) {
+                    OMElement connectElem = (OMElement) connectIt.next();
+                    if (connectElem == null) {
+                        continue;
+                    }
+                    org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig entry =
+                            new org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig();
+                    OMElement rt = connectElem.getFirstChildWithName(
+                            new QName(APIConstants.GatewayNotification.REGISTRATION_TOKEN));
+                    if (rt != null && rt.getText() != null && !rt.getText().trim().isEmpty()) {
+                        entry.setRegistrationToken(rt.getText().trim());
+                    }
+                    OMElement nameEl = connectElem.getFirstChildWithName(
+                            new QName(APIConstants.GatewayNotification.CONNECT_NAME));
+                    if (nameEl != null && nameEl.getText() != null) {
+                        entry.setName(nameEl.getText().trim());
+                    }
+                    OMElement displayEl = connectElem.getFirstChildWithName(
+                            new QName(APIConstants.GatewayNotification.CONNECT_DISPLAY_NAME));
+                    if (displayEl != null && displayEl.getText() != null) {
+                        entry.setDisplayName(displayEl.getText().trim());
+                    }
+                    OMElement descEl = connectElem.getFirstChildWithName(
+                            new QName(APIConstants.GatewayNotification.CONNECT_DESCRIPTION));
+                    if (descEl != null && descEl.getText() != null) {
+                        entry.setDescription(descEl.getText().trim());
+                    }
+                    OMElement urlEl = connectElem.getFirstChildWithName(
+                            new QName(APIConstants.GatewayNotification.CONNECT_URL));
+                    if (urlEl != null && urlEl.getText() != null && !urlEl.getText().trim().isEmpty()) {
+                        entry.setUrl(urlEl.getText().trim());
+                    }
+                    if (!entry.getRegistrationToken().isEmpty()) {
+                        connectGateways.add(entry);
+                    }
+                }
+            }
+            if (!connectGateways.isEmpty()) {
+                platformGatewayConnectConfig.setConnectGateways(connectGateways);
+            }
         }
     }
 
@@ -3679,7 +3725,8 @@ public class APIManagerConfiguration {
     }
 
     /**
-     * API Platform Gateway metadata config (e.g. supported versions for UI).
+     * Platform Gateway connect-with-token config ({@code [[apim.platform_gateway.connect]]}) and
+     * version metadata ({@code apim.platform_gateway.versions}).
      */
     public PlatformGatewayConnectConfig getPlatformGatewayConnectConfig() {
         return platformGatewayConnectConfig;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -3705,7 +3705,13 @@ public class APIManagerConfiguration {
                     OMElement urlEl = connectElem.getFirstChildWithName(
                             new QName(APIConstants.GatewayNotification.CONNECT_URL));
                     if (urlEl != null && urlEl.getText() != null && !urlEl.getText().trim().isEmpty()) {
-                        entry.setUrl(urlEl.getText().trim());
+                        try {
+                            entry.setUrl(urlEl.getText().trim());
+                        } catch (IllegalArgumentException e) {
+                            log.error("Skipping [[apim.platform_gateway.connect]] entry " + declaredConnectEntryCount
+                                    + " (name=" + entry.getName() + "): invalid url - " + e.getMessage());
+                            continue;
+                        }
                     }
                     OMElement orgEl = connectElem.getFirstChildWithName(
                             new QName(APIConstants.GatewayNotification.CONNECT_ORGANIZATION));

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -268,6 +268,23 @@ public class APIManagerConfiguration {
     private GatewayNotificationConfiguration gatewayNotificationConfiguration = new GatewayNotificationConfiguration();
     private PlatformGatewayConnectConfig platformGatewayConnectConfig = new PlatformGatewayConnectConfig();
 
+    private static final Map<String, String> PUBLISHER_IMPORT_FILE_SIZE_LIMIT_DEFAULTS;
+
+    static {
+        Map<String, String> defaults = new HashMap<>();
+        defaults.put(org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT,
+                org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT_DEFAULT_MB);
+        defaults.put(org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT,
+                org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT_DEFAULT_MB);
+        defaults.put(org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT,
+                org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB);
+        defaults.put(org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT,
+                org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT_DEFAULT_MB);
+        defaults.put(org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_MCP_FILE_SIZE_LIMIT,
+                org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_MCP_FILE_SIZE_LIMIT_DEFAULT_MB);
+        PUBLISHER_IMPORT_FILE_SIZE_LIMIT_DEFAULTS = Collections.unmodifiableMap(defaults);
+    }
+
     /**
      * Returns the configuration of the Identity Provider.
      *
@@ -687,33 +704,9 @@ public class APIManagerConfiguration {
             } else if (elementHasText(element)) {
                 String key = getKey(nameStack);
                 String value = MiscellaneousUtil.resolve(element, secretResolver);
-                if (org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT.equals(key)) {
-                    String maxFileSize = StringUtils.isNumeric(value) ?
-                            value :
-                            org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_OAS_FILE_SIZE_LIMIT_DEFAULT_MB;
-                    addToConfiguration(key, APIUtil.replaceSystemProperty(maxFileSize));
-                } else if (org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT.equals(
-                        key)) {
-                    String maxFileSize = StringUtils.isNumeric(value) ?
-                            value :
-                            org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_ASYNC_FILE_SIZE_LIMIT_DEFAULT_MB;
-                    addToConfiguration(key, APIUtil.replaceSystemProperty(maxFileSize));
-                } else if (org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT.equals(
-                        key)) {
-                    String maxFileSize = StringUtils.isNumeric(value) ?
-                            value :
-                            org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_WSDL_FILE_SIZE_LIMIT_DEFAULT_MB;
-                    addToConfiguration(key, APIUtil.replaceSystemProperty(maxFileSize));
-                } else if (org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT.equals(key)) {
-                    String maxFileSize = StringUtils.isNumeric(value) ?
-                            value :
-                            org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_GRAPHQL_FILE_SIZE_LIMIT_DEFAULT_MB;
-                    addToConfiguration(key, APIUtil.replaceSystemProperty(maxFileSize));
-                } else if (org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_MCP_FILE_SIZE_LIMIT.equals(
-                        key)) {
-                    String maxFileSize = StringUtils.isNumeric(value) ?
-                            value :
-                            org.wso2.carbon.apimgt.api.APIConstants.API_PUBLISHER_IMPORT_MCP_FILE_SIZE_LIMIT_DEFAULT_MB;
+                String defaultFileSizeLimit = PUBLISHER_IMPORT_FILE_SIZE_LIMIT_DEFAULTS.get(key);
+                if (defaultFileSizeLimit != null) {
+                    String maxFileSize = StringUtils.isNumeric(value) ? value : defaultFileSizeLimit;
                     addToConfiguration(key, APIUtil.replaceSystemProperty(maxFileSize));
                 } else {
                     addToConfiguration(key, APIUtil.replaceSystemProperty(value));

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java
@@ -3688,8 +3688,11 @@ public class APIManagerConfiguration {
                     ConnectGatewayConfig entry = new ConnectGatewayConfig();
                     OMElement rt = connectElem.getFirstChildWithName(
                             new QName(APIConstants.GatewayNotification.REGISTRATION_TOKEN));
-                    if (rt != null && rt.getText() != null && !rt.getText().trim().isEmpty()) {
-                        entry.setRegistrationToken(rt.getText().trim());
+                    if (rt != null) {
+                        String resolvedToken = MiscellaneousUtil.resolve(rt, secretResolver);
+                        if (resolvedToken != null && !resolvedToken.trim().isEmpty()) {
+                            entry.setRegistrationToken(resolvedToken.trim());
+                        }
                     }
                     OMElement nameEl = connectElem.getFirstChildWithName(
                             new QName(APIConstants.GatewayNotification.CONNECT_NAME));

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfig.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfig.java
@@ -26,9 +26,9 @@ import java.net.URI;
  * One connect-with-token config entry for a self-hosted Platform Gateway.
  * Used when multiple gateways are configured via {@code [[apim.platform_gateway.connect]]}.
  * {@code url} is required: the base URL where the gateway will be accessible (e.g. https://gw.example.com:8243).
- * {@code organization} is optional: tenant/org domain for gateway ownership (same as Admin Portal create).
- * When omitted, defaults to {@link MultitenantConstants#SUPER_TENANT_DOMAIN_NAME}. Set to
- * {@code WSO2-ALL-TENANTS} explicitly for a shared gateway visible to all tenants.
+ * {@code organization} is optional: single-tenant org domain for gateway ownership (same as Admin Portal create).
+ * When omitted, defaults to {@link MultitenantConstants#SUPER_TENANT_DOMAIN_NAME}. Platform gateways are not
+ * shared across tenants.
  */
 public class ConnectGatewayConfig {
     private String registrationToken = "";
@@ -71,7 +71,7 @@ public class ConnectGatewayConfig {
     }
 
     /**
-     * Tenant organization for this gateway (e.g. {@code carbon.super}, {@code t.com}, or {@code WSO2-ALL-TENANTS}).
+     * Single-tenant organization for this gateway (e.g. {@code carbon.super} or {@code t.com}).
      */
     public String getOrganization() {
         return organization;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfig.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfig.java
@@ -114,6 +114,15 @@ public class ConnectGatewayConfig {
             if (u.getHost() == null || u.getHost().isEmpty()) {
                 throw new IllegalArgumentException("missing host");
             }
+            if (u.getUserInfo() != null && !u.getUserInfo().isEmpty()) {
+                throw new IllegalArgumentException("user-info not allowed in base URL");
+            }
+            if (u.getQuery() != null && !u.getQuery().isEmpty()) {
+                throw new IllegalArgumentException("query not allowed in base URL");
+            }
+            if (u.getFragment() != null && !u.getFragment().isEmpty()) {
+                throw new IllegalArgumentException("fragment not allowed in base URL");
+            }
             String scheme = u.getScheme();
             if (scheme == null || (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme))) {
                 throw new IllegalArgumentException("scheme must be http or https");

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfig.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfig.java
@@ -18,12 +18,17 @@
 
 package org.wso2.carbon.apimgt.impl.dto;
 
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
 import java.net.URI;
 
 /**
  * One connect-with-token config entry for a self-hosted Platform Gateway.
  * Used when multiple gateways are configured via {@code [[apim.platform_gateway.connect]]}.
  * {@code url} is required: the base URL where the gateway will be accessible (e.g. https://gw.example.com:8243).
+ * {@code organization} is optional: tenant/org domain for gateway ownership (same as Admin Portal create).
+ * When omitted, defaults to {@link MultitenantConstants#SUPER_TENANT_DOMAIN_NAME}. Set to
+ * {@code WSO2-ALL-TENANTS} explicitly for a shared gateway visible to all tenants.
  */
 public class ConnectGatewayConfig {
     private String registrationToken = "";
@@ -31,6 +36,7 @@ public class ConnectGatewayConfig {
     private String displayName = "";
     private String description = "";
     private String url;
+    private String organization = "";
 
     public String getRegistrationToken() {
         return registrationToken;
@@ -62,6 +68,27 @@ public class ConnectGatewayConfig {
 
     public void setDescription(String description) {
         this.description = description != null ? description : "";
+    }
+
+    /**
+     * Tenant organization for this gateway (e.g. {@code carbon.super}, {@code t.com}, or {@code WSO2-ALL-TENANTS}).
+     */
+    public String getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(String organization) {
+        this.organization = organization != null ? organization : "";
+    }
+
+    /**
+     * Resolved organization for persistence: configured value or super-tenant default.
+     */
+    public String resolveOrganization() {
+        if (organization != null && !organization.isBlank()) {
+            return organization.trim();
+        }
+        return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfig.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfig.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.dto;
+
+import java.net.URI;
+
+/**
+ * One connect-with-token config entry for a self-hosted Platform Gateway.
+ * Used when multiple gateways are configured via {@code [[apim.platform_gateway.connect]]}.
+ * {@code url} is required: the base URL where the gateway will be accessible (e.g. https://gw.example.com:8243).
+ */
+public class ConnectGatewayConfig {
+    private String registrationToken = "";
+    private String name = "";
+    private String displayName = "";
+    private String description = "";
+    private String url;
+
+    public String getRegistrationToken() {
+        return registrationToken;
+    }
+
+    public void setRegistrationToken(String registrationToken) {
+        this.registrationToken = registrationToken != null ? registrationToken : "";
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name != null ? name : "";
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName != null ? displayName : "";
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description != null ? description : "";
+    }
+
+    /**
+     * Base URL where the gateway will be accessible (e.g. https://gw.example.com:8243). Required for connect config.
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * Sets the base URL; validates format (http/https, non-empty host). Null or blank clears the field.
+     *
+     * @throws IllegalArgumentException if url is non-blank and malformed
+     */
+    public void setUrl(String url) {
+        if (url == null || url.isBlank()) {
+            this.url = null;
+            return;
+        }
+        String trimmed = url.trim();
+        try {
+            URI u = URI.create(trimmed);
+            if (u.getHost() == null || u.getHost().isEmpty()) {
+                throw new IllegalArgumentException("missing host");
+            }
+            String scheme = u.getScheme();
+            if (scheme == null || (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme))) {
+                throw new IllegalArgumentException("scheme must be http or https");
+            }
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Invalid URL in apim.platform_gateway.connect: \"" + url + "\" - " + e.getMessage(), e);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Invalid URL in apim.platform_gateway.connect: \"" + url + "\" - " + e.getMessage(), e);
+        }
+        this.url = trimmed;
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfig.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfig.java
@@ -130,9 +130,6 @@ public class ConnectGatewayConfig {
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(
                     "Invalid URL in apim.platform_gateway.connect: \"" + url + "\" - " + e.getMessage(), e);
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
-                    "Invalid URL in apim.platform_gateway.connect: \"" + url + "\" - " + e.getMessage(), e);
         }
         this.url = trimmed;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/PlatformGatewayConnectConfig.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/PlatformGatewayConnectConfig.java
@@ -23,14 +23,16 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Config for API Platform Gateway metadata (e.g. versions advertised to the UI).
+ * Config for Platform Gateway connect-with-token ({@code [[apim.platform_gateway.connect]]})
+ * and version metadata ({@code apim.platform_gateway.versions}).
  * Separate from {@link GatewayNotificationConfiguration} for notification/heartbeat settings.
  */
 public class PlatformGatewayConnectConfig {
     private List<String> platformGatewayVersions = new ArrayList<>();
+    private List<ConnectGatewayConfig> connectGateways = new ArrayList<>();
 
     /**
-     * Global API Platform Gateway versions (e.g. ["0.11.0","1.0.0"]).
+     * Global API Platform Gateway versions (e.g. ["1.0.0"]).
      */
     public List<String> getPlatformGatewayVersions() {
         if (platformGatewayVersions == null) {
@@ -43,5 +45,19 @@ public class PlatformGatewayConnectConfig {
         this.platformGatewayVersions = platformGatewayVersions != null
                 ? new ArrayList<>(platformGatewayVersions)
                 : new ArrayList<>();
+    }
+
+    /**
+     * Connect configs (one per gateway) for connect-with-token. If empty, platform connect is disabled.
+     */
+    public List<ConnectGatewayConfig> getConnectGateways() {
+        if (connectGateways == null) {
+            connectGateways = new ArrayList<>();
+        }
+        return connectGateways;
+    }
+
+    public void setConnectGateways(List<ConnectGatewayConfig> connectGateways) {
+        this.connectGateways = connectGateways != null ? new ArrayList<>(connectGateways) : new ArrayList<>();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/PlatformGatewayConnectConfig.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/PlatformGatewayConnectConfig.java
@@ -30,6 +30,8 @@ import java.util.List;
 public class PlatformGatewayConnectConfig {
     private List<String> platformGatewayVersions = new ArrayList<>();
     private List<ConnectGatewayConfig> connectGateways = new ArrayList<>();
+    /** Number of {@code <Connect>} elements under {@code ConnectGateways} in api-manager.xml. */
+    private int declaredConnectEntryCount;
 
     /**
      * Global API Platform Gateway versions (e.g. ["1.0.0"]).
@@ -59,5 +61,17 @@ public class PlatformGatewayConnectConfig {
 
     public void setConnectGateways(List<ConnectGatewayConfig> connectGateways) {
         this.connectGateways = connectGateways != null ? new ArrayList<>(connectGateways) : new ArrayList<>();
+    }
+
+    /**
+     * How many connect entries were declared in api-manager.xml (from deployment.toml).
+     * Used to fail startup when XML declares entries but none are loaded into memory.
+     */
+    public int getDeclaredConnectEntryCount() {
+        return declaredConnectEntryCount;
+    }
+
+    public void setDeclaredConnectEntryCount(int declaredConnectEntryCount) {
+        this.declaredConnectEntryCount = Math.max(0, declaredConnectEntryCount);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/PlatformGatewayConnectConfig.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/PlatformGatewayConnectConfig.java
@@ -54,7 +54,7 @@ public class PlatformGatewayConnectConfig {
         if (connectGateways == null) {
             connectGateways = new ArrayList<>();
         }
-        return connectGateways;
+        return Collections.unmodifiableList(connectGateways);
     }
 
     public void setConnectGateways(List<ConnectGatewayConfig> connectGateways) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java
@@ -94,6 +94,7 @@ import org.wso2.carbon.apimgt.impl.recommendationmgt.RecommendationEnvironment;
 import org.wso2.carbon.apimgt.impl.utils.APIMgtDBUtil;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.impl.utils.GatewayArtifactsMgtDBUtil;
+import org.wso2.carbon.apimgt.impl.utils.GatewayManagementUtils;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.CarbonContext;
@@ -235,6 +236,7 @@ public class APIManagerComponent {
                     null);
             APIMgtDBUtil.initialize();
             APIUtil.init();
+            GatewayManagementUtils.performPlatformGatewayConnectFromConfigIfConfigured();
             String migrationEnabled = System.getProperty(APIConstants.MIGRATE);
             if (migrationEnabled == null) {
                 new RevokedJWTMapCleaner().startJWTRevokedMapCleaner();

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
@@ -35,9 +35,12 @@ import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dao.PlatformGatewayDAO;
 import org.wso2.carbon.apimgt.impl.gateway.PlatformGatewayDeploymentDispatcher;
+import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
+import org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.PlatformGatewayTokenUtil;
 
+import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -182,6 +185,49 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         GatewayVisibilityPermissionConfigurationDTO perms = new GatewayVisibilityPermissionConfigurationDTO();
         perms.setPermissionType(APIConstants.PERMISSION_NOT_RESTRICTED);
         env.setPermissions(perms);
+    }
+
+    /**
+     * Build an Environment from a base URL (http or https). URL must already be validated via
+     * {@link ConnectGatewayConfig#setUrl(String)}.
+     */
+    private static Environment toEnvironmentFromUrl(String gatewayId, String name, String displayName,
+                                                    String description, String url) {
+        URI u = URI.create(url);
+        String host = u.getHost();
+        int port = u.getPort() != -1 ? u.getPort()
+                : ("https".equalsIgnoreCase(u.getScheme()) ? VHost.DEFAULT_HTTPS_PORT : VHost.DEFAULT_HTTP_PORT);
+        boolean isHttps = "https".equalsIgnoreCase(u.getScheme());
+        String httpContext = u.getPath() != null && !u.getPath().isEmpty() && !"/".equals(u.getPath())
+                ? u.getPath() : "";
+
+        VHost vhostObj = new VHost();
+        vhostObj.setHost(host);
+        vhostObj.setWsHost(host);
+        vhostObj.setWssHost(host);
+        vhostObj.setHttpContext(httpContext);
+        if (isHttps) {
+            vhostObj.setHttpsPort(port);
+            vhostObj.setHttpPort(VHost.DEFAULT_HTTP_PORT);
+        } else {
+            vhostObj.setHttpPort(port);
+            vhostObj.setHttpsPort(VHost.DEFAULT_HTTPS_PORT);
+        }
+        vhostObj.setWsPort(VHost.DEFAULT_WS_PORT);
+        vhostObj.setWssPort(VHost.DEFAULT_WSS_PORT);
+
+        Environment env = new Environment();
+        env.setUuid(gatewayId);
+        env.setName(name);
+        env.setDisplayName(StringUtils.isNotBlank(displayName) ? displayName : name);
+        env.setDescription(description);
+        env.setType(APIConstants.GATEWAY_ENV_TYPE_HYBRID);
+        env.setProvider(APIConstants.WSO2_GATEWAY_ENVIRONMENT);
+        env.setGatewayType(APIConstants.WSO2_API_PLATFORM_GATEWAY);
+        env.setMode(GatewayMode.WRITE_ONLY.getMode());
+        env.setVhosts(Collections.singletonList(vhostObj));
+        setDefaultVisibilityPublic(env);
+        return env;
     }
 
     @Override
@@ -401,5 +447,99 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         api.setCreatedAt(g.createdAt != null ? new Date(g.createdAt.getTime()) : null);
         api.setUpdatedAt(g.updatedAt != null ? new Date(g.updatedAt.getTime()) : null);
         return api;
+    }
+
+    public static boolean ensurePlatformGatewayFromConnectToken(PlatformGatewayConnectConfig config,
+                                                                String gatewayId, ConnectGatewayConfig entry) {
+        if (config == null || entry == null || StringUtils.isBlank(entry.getRegistrationToken())) {
+            return false;
+        }
+        String orgId = APIConstants.GatewayNotification.WSO2_ALL_TENANTS;
+        String registrationToken = entry.getRegistrationToken();
+        String name = StringUtils.isNotBlank(entry.getName()) ? entry.getName() : gatewayId;
+        String displayNameOverride = entry.getDisplayName();
+        String descriptionOverride = entry.getDescription();
+        String urlOverride = entry.getUrl();
+        if (StringUtils.isBlank(gatewayId) || StringUtils.isBlank(registrationToken)) {
+            return false;
+        }
+        if (StringUtils.isNotBlank(entry.getName())) {
+            try {
+                Environment existingByName = new APIAdminImpl().getAllEnvironments(orgId).stream()
+                        .filter(e -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(e.getGatewayType())
+                                && entry.getName().equals(e.getName()))
+                        .findFirst()
+                        .orElse(null);
+                if (existingByName != null && !gatewayId.equals(existingByName.getUuid())) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Connect with token: name '" + entry.getName()
+                                + "' already exists; using gateway_id as name");
+                    }
+                    name = gatewayId;
+                }
+            } catch (APIManagementException e) {
+                // ignore, proceed with requested name
+            }
+        }
+        if (!registrationToken.contains(PlatformGatewayTokenUtil.COMBINED_TOKEN_SEPARATOR)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Connect with token skipped: registration_token must be in format tokenId.plainToken");
+            }
+            return false;
+        }
+        int sep = registrationToken.indexOf(PlatformGatewayTokenUtil.COMBINED_TOKEN_SEPARATOR);
+        String tokenId = registrationToken.substring(0, sep);
+        String plainToken = registrationToken.substring(sep + 1);
+        if (StringUtils.isBlank(tokenId) || StringUtils.isBlank(plainToken)) {
+            return false;
+        }
+        try {
+            PlatformGatewayDAO dao = PlatformGatewayDAO.getInstance();
+            if (dao.getActiveTokenById(tokenId) != null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Connect with token: gateway already exists for token_id=" + tokenId);
+                }
+                return false;
+            }
+            String tokenHash = PlatformGatewayTokenUtil.hashToken(plainToken);
+            APIAdminImpl apiAdmin = new APIAdminImpl();
+            Environment existing = null;
+            try {
+                existing = ApiMgtDAO.getInstance().getEnvironmentByUuid(gatewayId);
+            } catch (APIManagementException e) {
+                // ignore
+            }
+            String displayName = StringUtils.isNotBlank(displayNameOverride) ? displayNameOverride : name;
+            String description = StringUtils.isNotBlank(descriptionOverride) ? descriptionOverride : "";
+            String vhostForDao = StringUtils.isNotBlank(urlOverride) ? urlOverride : "default";
+            if (existing == null) {
+                Environment env = StringUtils.isNotBlank(urlOverride)
+                        ? toEnvironmentFromUrl(gatewayId, name, displayName, description, urlOverride)
+                        : toEnvironment(gatewayId, name, displayName, description, "default");
+                apiAdmin.addEnvironment(orgId, env);
+            }
+            Timestamp now = Timestamp.from(Instant.now());
+            PlatformGatewayDAO.PlatformGateway gateway = new PlatformGatewayDAO.PlatformGateway(
+                    gatewayId, orgId, name, displayName, description, vhostForDao,
+                    null, false, now, now);
+            dao.createGatewayWithTokenAndGatewayInstance(gateway, tokenId, tokenHash,
+                    Collections.singletonList(name));
+            if (log.isInfoEnabled()) {
+                log.info("Platform gateway connected with token: gateway_id=" + gatewayId + ", name=" + name);
+            }
+            return true;
+        } catch (NoSuchAlgorithmException | APIManagementException e) {
+            if (log.isWarnEnabled()) {
+                log.warn("Connect with token failed for gateway_id=" + gatewayId + ": " + e.getMessage(), e);
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Startup hook for connect config. Gateway records are created on first connect, not at startup.
+     */
+    public static void ensurePlatformGatewayFromConfigOnStartup(PlatformGatewayConnectConfig config) {
+        // No startup creation; gateway is registered on first connect with registration_token.
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
@@ -700,8 +700,10 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
                         try {
                             apiAdmin.deleteEnvironment(orgId, persistedGatewayId);
                         } catch (Exception rollbackEx) {
-                            log.warn("Rollback failed for connect-with-token environment cleanup: "
-                                    + persistedGatewayId, rollbackEx);
+                            log.error("Rollback failed for connect-with-token environment cleanup: gateway_id="
+                                    + persistedGatewayId + ". Environment row is now orphaned (no matching "
+                                    + "gateway/token) and will block future connect attempts for this gateway "
+                                    + "until manually removed.", rollbackEx);
                         }
                     }
                     activeToken = dao.getActiveTokenById(tokenId);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
@@ -351,10 +351,12 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         if (description != null) {
             env.setDescription(description);
         }
-        if (propertiesJson != null) {
+        if (displayName != null || description != null || propertiesJson != null) {
             Map<String, String> additional = env.getAdditionalProperties() != null
                     ? new HashMap<>(env.getAdditionalProperties()) : new HashMap<>();
-            additional.put("properties", propertiesJson);
+            if (propertiesJson != null) {
+                additional.put("properties", propertiesJson);
+            }
             additional.put("updatedAt", String.valueOf(System.currentTimeMillis()));
             env.setAdditionalProperties(additional);
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
@@ -572,7 +572,14 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         synchronized (bootstrapLock) {
             try {
                 PlatformGatewayDAO dao = PlatformGatewayDAO.getInstance();
-                if (dao.getActiveTokenById(tokenId) != null) {
+                PlatformGatewayDAO.TokenWithGateway activeToken = dao.getActiveTokenById(tokenId);
+                if (activeToken != null) {
+                    if (!PlatformGatewayTokenUtil.matchesActiveTokenHash(activeToken, plainToken)) {
+                        if (log.isWarnEnabled()) {
+                            log.warn("Connect with token: configured token hash mismatch for token_id=" + tokenId);
+                        }
+                        return false;
+                    }
                     if (log.isDebugEnabled()) {
                         log.debug("Connect with token: gateway already exists for token_id=" + tokenId);
                     }
@@ -641,7 +648,9 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
                                     + persistedGatewayId, rollbackEx);
                         }
                     }
-                    if (dao.getActiveTokenById(tokenId) != null) {
+                    activeToken = dao.getActiveTokenById(tokenId);
+                    if (activeToken != null
+                            && PlatformGatewayTokenUtil.matchesActiveTokenHash(activeToken, plainToken)) {
                         return true;
                     }
                     throw e;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
@@ -292,13 +292,14 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
 
     @Override
     public void deleteGateway(String organizationId, String gatewayId) throws APIManagementException {
-        String storageOrgId = resolveStorageOrganizationId(organizationId, gatewayId);
-        Environment env = storageOrgId != null
-                ? ApiMgtDAO.getInstance().getEnvironment(storageOrgId, gatewayId) : null;
-        if (env == null || !APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
+        ResolvedPlatformGatewayEnvironment resolved =
+                resolvePlatformGatewayEnvironment(organizationId, gatewayId);
+        if (resolved == null) {
             throw new APIManagementException("Platform gateway not found: " + gatewayId,
                     ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
         }
+        Environment env = resolved.environment;
+        String storageOrgId = resolved.storageOrganizationId;
         if (ApiMgtDAO.getInstance().hasExistingAPIRevisions(gatewayId, storageOrgId)) {
             throw new APIManagementException(
                     "Cannot delete platform gateway: API revisions are currently deployed to it. "
@@ -318,13 +319,14 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
     public PlatformGateway updateGateway(String organizationId, String gatewayId, String displayName,
                                          String description, String propertiesJson)
             throws APIManagementException {
-        String storageOrgId = resolveStorageOrganizationId(organizationId, gatewayId);
-        Environment env = storageOrgId != null
-                ? ApiMgtDAO.getInstance().getEnvironment(storageOrgId, gatewayId) : null;
-        if (env == null || !APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
+        ResolvedPlatformGatewayEnvironment resolved =
+                resolvePlatformGatewayEnvironment(organizationId, gatewayId);
+        if (resolved == null) {
             throw new APIManagementException("Platform gateway not found: " + gatewayId,
                     ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
         }
+        Environment env = resolved.environment;
+        String storageOrgId = resolved.storageOrganizationId;
         if (displayName != null) {
             env.setDisplayName(displayName);
         }
@@ -341,18 +343,19 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
             env.setAdditionalProperties(additional);
         }
         new APIAdminImpl().updateEnvironment(storageOrgId, env);
-        return envToApiModel(ApiMgtDAO.getInstance().getEnvironment(storageOrgId, gatewayId));
+        return envToApiModel(env);
     }
 
     @Override
     public void updateGatewayActiveStatus(String gatewayId, String organizationId, boolean active)
             throws APIManagementException {
-        String storageOrgId = resolveStorageOrganizationId(organizationId, gatewayId);
-        Environment env = storageOrgId != null
-                ? ApiMgtDAO.getInstance().getEnvironment(storageOrgId, gatewayId) : null;
-        if (env == null || !APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
+        ResolvedPlatformGatewayEnvironment resolved =
+                resolvePlatformGatewayEnvironment(organizationId, gatewayId);
+        if (resolved == null) {
             return;
         }
+        Environment env = resolved.environment;
+        String storageOrgId = resolved.storageOrganizationId;
         Map<String, String> additional = env.getAdditionalProperties() != null
                 ? new HashMap<>(env.getAdditionalProperties()) : new HashMap<>();
         additional.put("isActive", String.valueOf(active));
@@ -362,19 +365,42 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
     }
 
     /**
-     * Resolves the organization under which a platform gateway environment is stored.
-     * Platform gateways are single-tenant scoped; lookup is limited to {@code requestOrganizationId}.
+     * Resolved platform gateway environment and the organization key under which it is stored.
      */
-    public static String resolveStorageOrganizationId(String requestOrganizationId, String gatewayId)
-            throws APIManagementException {
+    public static final class ResolvedPlatformGatewayEnvironment {
+        public final String storageOrganizationId;
+        public final Environment environment;
+
+        ResolvedPlatformGatewayEnvironment(String storageOrganizationId, Environment environment) {
+            this.storageOrganizationId = storageOrganizationId;
+            this.environment = environment;
+        }
+    }
+
+    /**
+     * Resolves a platform gateway environment with a single DB read under {@code requestOrganizationId}.
+     */
+    public static ResolvedPlatformGatewayEnvironment resolvePlatformGatewayEnvironment(
+            String requestOrganizationId, String gatewayId) throws APIManagementException {
         if (StringUtils.isBlank(gatewayId) || StringUtils.isBlank(requestOrganizationId)) {
             return null;
         }
         Environment env = ApiMgtDAO.getInstance().getEnvironment(requestOrganizationId, gatewayId);
         if (env != null && APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
-            return requestOrganizationId;
+            return new ResolvedPlatformGatewayEnvironment(requestOrganizationId, env);
         }
         return null;
+    }
+
+    /**
+     * Resolves the organization under which a platform gateway environment is stored.
+     * Platform gateways are single-tenant scoped; lookup is limited to {@code requestOrganizationId}.
+     */
+    public static String resolveStorageOrganizationId(String requestOrganizationId, String gatewayId)
+            throws APIManagementException {
+        ResolvedPlatformGatewayEnvironment resolved =
+                resolvePlatformGatewayEnvironment(requestOrganizationId, gatewayId);
+        return resolved != null ? resolved.storageOrganizationId : null;
     }
 
     /**
@@ -536,7 +562,7 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
     }
 
     public static boolean ensurePlatformGatewayFromConnectToken(PlatformGatewayConnectConfig config,
-                                                                String gatewayId, ConnectGatewayConfig entry) {
+                                                                ConnectGatewayConfig entry) {
         if (config == null || entry == null || StringUtils.isBlank(entry.getRegistrationToken())) {
             return false;
         }
@@ -580,9 +606,39 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
                         }
                         return false;
                     }
-                    if (log.isDebugEnabled()) {
-                        log.debug("Connect with token: gateway already exists for token_id=" + tokenId);
+                    Environment bootstrappedEnv = null;
+                    try {
+                        bootstrappedEnv = ApiMgtDAO.getInstance().getEnvironmentByUuid(persistedGatewayId);
+                    } catch (APIManagementException e) {
+                        // ignore
                     }
+                    if (bootstrappedEnv != null) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Connect with token: gateway already exists for token_id=" + tokenId);
+                        }
+                        return true;
+                    }
+                    if (log.isWarnEnabled()) {
+                        log.warn("Connect with token: active token row exists but environment missing for gateway_id="
+                                + persistedGatewayId + "; recreating environment");
+                    }
+                    String displayName = StringUtils.isNotBlank(displayNameOverride) ? displayNameOverride : name;
+                    String description = StringUtils.isNotBlank(descriptionOverride) ? descriptionOverride : "";
+                    Timestamp now = Timestamp.from(Instant.now());
+                    APIAdminImpl apiAdmin = new APIAdminImpl();
+                    Environment env = StringUtils.isNotBlank(urlOverride)
+                            ? toEnvironmentFromUrl(persistedGatewayId, name, displayName, description, urlOverride)
+                            : toEnvironment(persistedGatewayId, name, displayName, description, "default");
+                    Map<String, String> additional = new HashMap<>();
+                    additional.put("organization", orgId);
+                    additional.put("isActive", "false");
+                    additional.put("createdAt", String.valueOf(now.getTime()));
+                    additional.put("updatedAt", String.valueOf(now.getTime()));
+                    if (StringUtils.isNotBlank(urlOverride)) {
+                        additional.put(APIConstants.GatewayNotification.GATEWAY_BASE_URL, urlOverride.trim());
+                    }
+                    env.setAdditionalProperties(additional);
+                    apiAdmin.addEnvironment(orgId, env);
                     return true;
                 }
                 if (StringUtils.isNotBlank(entry.getName())) {
@@ -649,9 +705,15 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
                         }
                     }
                     activeToken = dao.getActiveTokenById(tokenId);
-                    if (activeToken != null
-                            && PlatformGatewayTokenUtil.matchesActiveTokenHash(activeToken, plainToken)) {
-                        return true;
+                    try {
+                        if (activeToken != null
+                                && PlatformGatewayTokenUtil.matchesActiveTokenHash(activeToken, plainToken)) {
+                            return true;
+                        }
+                    } catch (NoSuchAlgorithmException hashEx) {
+                        log.warn("Connect-with-token race recovery: hash verification failed for token_id="
+                                + tokenId, hashEx);
+                        return false;
                     }
                     throw e;
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.apimgt.impl.gateway.PlatformGatewayDeploymentDispatcher;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.PlatformGatewayTokenUtil;
 
+import java.nio.charset.StandardCharsets;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Timestamp;
@@ -51,6 +52,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -60,6 +62,8 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
 
     private static final Log log = LogFactory.getLog(PlatformGatewayServiceImpl.class);
     private static final PlatformGatewayServiceImpl INSTANCE = new PlatformGatewayServiceImpl();
+    private static final ConcurrentHashMap<String, Object> CONNECT_TOKEN_BOOTSTRAP_LOCKS = new ConcurrentHashMap<>();
+    private static final String CONNECT_GATEWAY_ID_NAMESPACE = "platform-gateway-connect:";
 
     public static PlatformGatewayServiceImpl getInstance() {
         return INSTANCE;
@@ -489,30 +493,12 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         }
         String orgId = entry.resolveOrganization();
         String registrationToken = entry.getRegistrationToken();
-        String name = StringUtils.isNotBlank(entry.getName()) ? entry.getName() : gatewayId;
+        String name = StringUtils.isNotBlank(entry.getName()) ? entry.getName() : null;
         String displayNameOverride = entry.getDisplayName();
         String descriptionOverride = entry.getDescription();
         String urlOverride = entry.getUrl();
-        if (StringUtils.isBlank(gatewayId) || StringUtils.isBlank(registrationToken)) {
+        if (StringUtils.isBlank(registrationToken)) {
             return false;
-        }
-        if (StringUtils.isNotBlank(entry.getName())) {
-            try {
-                Environment existingByName = getEnvironmentsForOrganizationMergedWithGlobal(orgId).stream()
-                        .filter(e -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(e.getGatewayType())
-                                && entry.getName().equals(e.getName()))
-                        .findFirst()
-                        .orElse(null);
-                if (existingByName != null && !gatewayId.equals(existingByName.getUuid())) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Connect with token: name '" + entry.getName()
-                                + "' already exists; using gateway_id as name");
-                    }
-                    name = gatewayId;
-                }
-            } catch (APIManagementException e) {
-                // ignore, proceed with requested name
-            }
         }
         if (!registrationToken.contains(PlatformGatewayTokenUtil.COMBINED_TOKEN_SEPARATOR)) {
             if (log.isDebugEnabled()) {
@@ -526,74 +512,110 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         if (StringUtils.isBlank(tokenId) || StringUtils.isBlank(plainToken)) {
             return false;
         }
-        try {
-            PlatformGatewayDAO dao = PlatformGatewayDAO.getInstance();
-            if (dao.getActiveTokenById(tokenId) != null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Connect with token: gateway already exists for token_id=" + tokenId);
+        String persistedGatewayId = resolveConnectGatewayId(tokenId);
+        if (StringUtils.isBlank(persistedGatewayId)) {
+            return false;
+        }
+        if (name == null) {
+            name = persistedGatewayId;
+        }
+        Object bootstrapLock = CONNECT_TOKEN_BOOTSTRAP_LOCKS.computeIfAbsent(tokenId, id -> new Object());
+        synchronized (bootstrapLock) {
+            try {
+                PlatformGatewayDAO dao = PlatformGatewayDAO.getInstance();
+                if (dao.getActiveTokenById(tokenId) != null) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Connect with token: gateway already exists for token_id=" + tokenId);
+                    }
+                    return true;
+                }
+                if (StringUtils.isNotBlank(entry.getName())) {
+                    try {
+                        Environment existingByName = getEnvironmentsForOrganizationMergedWithGlobal(orgId).stream()
+                                .filter(e -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(e.getGatewayType())
+                                        && entry.getName().equals(e.getName()))
+                                .findFirst()
+                                .orElse(null);
+                        if (existingByName != null && !persistedGatewayId.equals(existingByName.getUuid())) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Connect with token: name '" + entry.getName()
+                                        + "' already exists; using gateway_id as name");
+                            }
+                            name = persistedGatewayId;
+                        }
+                    } catch (APIManagementException e) {
+                        // ignore, proceed with requested name
+                    }
+                }
+                String tokenHash = PlatformGatewayTokenUtil.hashToken(plainToken);
+                APIAdminImpl apiAdmin = new APIAdminImpl();
+                Environment existing = null;
+                try {
+                    existing = ApiMgtDAO.getInstance().getEnvironmentByUuid(persistedGatewayId);
+                } catch (APIManagementException e) {
+                    // ignore
+                }
+                String displayName = StringUtils.isNotBlank(displayNameOverride) ? displayNameOverride : name;
+                String description = StringUtils.isNotBlank(descriptionOverride) ? descriptionOverride : "";
+                String vhostForDao = StringUtils.isNotBlank(urlOverride) ? urlOverride : "default";
+                Timestamp now = Timestamp.from(Instant.now());
+                boolean environmentCreated = false;
+                if (existing == null) {
+                    Environment env = StringUtils.isNotBlank(urlOverride)
+                            ? toEnvironmentFromUrl(persistedGatewayId, name, displayName, description, urlOverride)
+                            : toEnvironment(persistedGatewayId, name, displayName, description, "default");
+                    Map<String, String> additional = new HashMap<>();
+                    additional.put("organization", orgId);
+                    additional.put("isActive", "false");
+                    additional.put("createdAt", String.valueOf(now.getTime()));
+                    additional.put("updatedAt", String.valueOf(now.getTime()));
+                    env.setAdditionalProperties(additional);
+                    apiAdmin.addEnvironment(orgId, env);
+                    environmentCreated = true;
+                }
+                try {
+                    PlatformGatewayDAO.PlatformGateway gateway = new PlatformGatewayDAO.PlatformGateway(
+                            persistedGatewayId, orgId, name, displayName, description, vhostForDao,
+                            null, false, now, now);
+                    dao.createGatewayWithTokenAndGatewayInstance(gateway, tokenId, tokenHash,
+                            Collections.singletonList(name));
+                } catch (APIManagementException e) {
+                    if (environmentCreated) {
+                        try {
+                            apiAdmin.deleteEnvironment(orgId, persistedGatewayId);
+                        } catch (Exception rollbackEx) {
+                            log.warn("Rollback failed for connect-with-token environment cleanup: "
+                                    + persistedGatewayId, rollbackEx);
+                        }
+                    }
+                    if (dao.getActiveTokenById(tokenId) != null) {
+                        return true;
+                    }
+                    throw e;
+                }
+                if (log.isInfoEnabled()) {
+                    log.info("Platform gateway connected with token: gateway_id=" + persistedGatewayId + ", name="
+                            + name + ", organization=" + orgId);
+                }
+                return true;
+            } catch (NoSuchAlgorithmException | APIManagementException e) {
+                if (log.isWarnEnabled()) {
+                    log.warn("Connect with token failed for gateway_id=" + persistedGatewayId + ": "
+                            + e.getMessage(), e);
                 }
                 return false;
             }
-            String tokenHash = PlatformGatewayTokenUtil.hashToken(plainToken);
-            APIAdminImpl apiAdmin = new APIAdminImpl();
-            Environment existing = null;
-            try {
-                existing = ApiMgtDAO.getInstance().getEnvironmentByUuid(gatewayId);
-            } catch (APIManagementException e) {
-                // ignore
-            }
-            String displayName = StringUtils.isNotBlank(displayNameOverride) ? displayNameOverride : name;
-            String description = StringUtils.isNotBlank(descriptionOverride) ? descriptionOverride : "";
-            String vhostForDao = StringUtils.isNotBlank(urlOverride) ? urlOverride : "default";
-            Timestamp now = Timestamp.from(Instant.now());
-            boolean environmentCreated = false;
-            if (existing == null) {
-                Environment env = StringUtils.isNotBlank(urlOverride)
-                        ? toEnvironmentFromUrl(gatewayId, name, displayName, description, urlOverride)
-                        : toEnvironment(gatewayId, name, displayName, description, "default");
-                Map<String, String> additional = new HashMap<>();
-                additional.put("organization", orgId);
-                additional.put("isActive", "false");
-                additional.put("createdAt", String.valueOf(now.getTime()));
-                additional.put("updatedAt", String.valueOf(now.getTime()));
-                env.setAdditionalProperties(additional);
-                apiAdmin.addEnvironment(orgId, env);
-                environmentCreated = true;
-            }
-            try {
-                PlatformGatewayDAO.PlatformGateway gateway = new PlatformGatewayDAO.PlatformGateway(
-                        gatewayId, orgId, name, displayName, description, vhostForDao,
-                        null, false, now, now);
-                dao.createGatewayWithTokenAndGatewayInstance(gateway, tokenId, tokenHash,
-                        Collections.singletonList(name));
-            } catch (APIManagementException e) {
-                if (environmentCreated) {
-                    try {
-                        apiAdmin.deleteEnvironment(orgId, gatewayId);
-                    } catch (Exception rollbackEx) {
-                        log.warn("Rollback failed for connect-with-token environment cleanup: " + gatewayId,
-                                rollbackEx);
-                    }
-                }
-                throw e;
-            }
-            if (log.isInfoEnabled()) {
-                log.info("Platform gateway connected with token: gateway_id=" + gatewayId + ", name=" + name
-                        + ", organization=" + orgId);
-            }
-            return true;
-        } catch (NoSuchAlgorithmException | APIManagementException e) {
-            if (log.isWarnEnabled()) {
-                log.warn("Connect with token failed for gateway_id=" + gatewayId + ": " + e.getMessage(), e);
-            }
-            return false;
         }
     }
 
     /**
-     * Startup hook for connect config. Gateway records are created on first connect, not at startup.
+     * Deterministic platform gateway environment UUID for a connect-with-token bootstrap token row ID.
      */
-    public static void ensurePlatformGatewayFromConfigOnStartup(PlatformGatewayConnectConfig config) {
-        // No startup creation; gateway is registered on first connect with registration_token.
+    public static String resolveConnectGatewayId(String tokenId) {
+        if (StringUtils.isBlank(tokenId)) {
+            return null;
+        }
+        return UUID.nameUUIDFromBytes(
+                (CONNECT_GATEWAY_ID_NAMESPACE + tokenId.trim()).getBytes(StandardCharsets.UTF_8)).toString();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
@@ -45,6 +45,8 @@ import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -376,6 +378,90 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
     }
 
     /**
+     * Reconstructs the gateway base URL from a {@link VHost} populated by {@link #toEnvironmentFromUrl(String, String,
+     * String, String, String)}. Uses HTTP when a non-default HTTP port is set and HTTPS port is still the default.
+     */
+    public static String buildGatewayBaseUrlFromVHost(VHost v) {
+        if (v == null || StringUtils.isBlank(v.getHost())) {
+            return "";
+        }
+        int httpPort = v.getHttpPort();
+        int httpsPort = v.getHttpsPort();
+        if (httpPort > 0 && httpPort != VHost.DEFAULT_HTTP_PORT
+                && (httpsPort <= 0 || httpsPort == VHost.DEFAULT_HTTPS_PORT)) {
+            return v.getHttpUrl();
+        }
+        return v.getHttpsUrl();
+    }
+
+    /**
+     * Resolves the gateway base URL for API/admin responses from environment storage.
+     */
+    public static String resolveGatewayBaseUrl(Environment env) {
+        if (env == null) {
+            return "";
+        }
+        Map<String, String> additional = env.getAdditionalProperties();
+        if (additional != null) {
+            String stored = additional.get(APIConstants.GatewayNotification.GATEWAY_BASE_URL);
+            if (StringUtils.isNotBlank(stored)) {
+                return stored.trim();
+            }
+        }
+        if (env.getVhosts() != null && !env.getVhosts().isEmpty()) {
+            return buildGatewayBaseUrlFromVHost(env.getVhosts().get(0));
+        }
+        return "";
+    }
+
+    /**
+     * Gateway base URLs for Dev Portal try-out / endpoint listing on a platform gateway environment.
+     * Uses the configured connect/admin base URL so an {@code http://host:port} entry is not rewritten as
+     * {@code https://host:443} via default {@link VHost#getHttpsUrl()}.
+     */
+    public static Map<String, String> resolveInvocationUrlsForTransports(Environment env, String transports) {
+        if (StringUtils.isBlank(transports)) {
+            return resolveInvocationUrlsForTransports(env, Collections.emptyList());
+        }
+        return resolveInvocationUrlsForTransports(env,
+                Arrays.stream(transports.split(","))
+                        .map(String::trim)
+                        .filter(StringUtils::isNotEmpty)
+                        .collect(Collectors.toList()));
+    }
+
+    public static Map<String, String> resolveInvocationUrlsForTransports(Environment env,
+                                                                          Collection<String> transports) {
+        Map<String, String> urls = new java.util.LinkedHashMap<>();
+        if (env == null || !APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
+            return urls;
+        }
+        String baseUrl = resolveGatewayBaseUrl(env);
+        if (StringUtils.isBlank(baseUrl)) {
+            return urls;
+        }
+        boolean includesHttp = transports != null && transports.stream()
+                .anyMatch(t -> APIConstants.HTTP_PROTOCOL.equalsIgnoreCase(StringUtils.trimToEmpty(t)));
+        boolean includesHttps = transports != null && transports.stream()
+                .anyMatch(t -> APIConstants.HTTPS_PROTOCOL.equalsIgnoreCase(StringUtils.trimToEmpty(t)));
+        if (baseUrl.startsWith(APIConstants.HTTP_PROTOCOL_URL_PREFIX)) {
+            // HTTP-configured gateway: only expose under HTTP. OAS try-out prepends https:// for the HTTPS key,
+            // so putting an http:// base URL there produces malformed URLs like https://http//host:port.
+            if (includesHttp || includesHttps) {
+                urls.put(APIConstants.HTTP_PROTOCOL, baseUrl);
+            }
+        } else if (baseUrl.startsWith(APIConstants.HTTPS_PROTOCOL_URL_PREFIX)) {
+            if (includesHttps) {
+                urls.put(APIConstants.HTTPS_PROTOCOL, baseUrl);
+            }
+            if (includesHttp) {
+                urls.put(APIConstants.HTTP_PROTOCOL, baseUrl);
+            }
+        }
+        return urls;
+    }
+
+    /**
      * Map Environment (AM_GATEWAY_ENVIRONMENT with GATEWAY_TYPE=Platform) to API model.
      * Reads isActive, properties, createdAt, updatedAt from additionalProperties.
      */
@@ -384,14 +470,7 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
             return null;
         }
         Map<String, String> add = env.getAdditionalProperties();
-        String vhost = "";
-        if (env.getVhosts() != null && !env.getVhosts().isEmpty()) {
-            org.wso2.carbon.apimgt.api.model.VHost v = env.getVhosts().get(0);
-            vhost = v.getHost() != null ? v.getHost() : "";
-            if (v.getHttpsPort() > 0) {
-                vhost = vhost + ":" + v.getHttpsPort();
-            }
-        }
+        String vhost = resolveGatewayBaseUrl(env);
         boolean isActive = add != null && "true".equalsIgnoreCase(add.get("isActive"));
         String properties = add != null ? add.get("properties") : null;
         Date createdAt = null;
@@ -540,6 +619,9 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
                     additional.put("isActive", "false");
                     additional.put("createdAt", String.valueOf(now.getTime()));
                     additional.put("updatedAt", String.valueOf(now.getTime()));
+                    if (StringUtils.isNotBlank(urlOverride)) {
+                        additional.put(APIConstants.GatewayNotification.GATEWAY_BASE_URL, urlOverride.trim());
+                    }
                     env.setAdditionalProperties(additional);
                     apiAdmin.addEnvironment(orgId, env);
                     environmentCreated = true;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
@@ -45,7 +45,6 @@ import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -72,32 +71,12 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
     private PlatformGatewayServiceImpl() {
     }
 
-    /**
-     * Gateway environments for an organization plus any stored under the global-tenant scope
-     * ({@link APIConstants.GatewayNotification#WSO2_ALL_TENANTS}), so globally-scoped platform gateways are not
-     * omitted from list/name checks. When {@code organizationId} is already the global scope, only that list is used.
-     */
-    private static List<Environment> getEnvironmentsForOrganizationMergedWithGlobal(String organizationId)
-            throws APIManagementException {
-        return getEnvironmentsForOrganizationMergedWithGlobal(new APIAdminImpl(), organizationId);
-    }
-
-    private static List<Environment> getEnvironmentsForOrganizationMergedWithGlobal(APIAdminImpl apiAdmin,
-                                                                               String organizationId)
-            throws APIManagementException {
-        List<Environment> merged = new ArrayList<>(apiAdmin.getAllEnvironments(organizationId));
-        if (!APIConstants.GatewayNotification.WSO2_ALL_TENANTS.equals(organizationId)) {
-            merged.addAll(apiAdmin.getAllEnvironments(APIConstants.GatewayNotification.WSO2_ALL_TENANTS));
-        }
-        return merged;
-    }
-
     @Override
     public PlatformGatewayRegistrationResult createGateway(String organizationId, String name, String displayName,
                                                      String description, String vhost, String propertiesJson)
             throws APIManagementException {
         APIAdminImpl apiAdmin = new APIAdminImpl();
-        boolean nameExists = getEnvironmentsForOrganizationMergedWithGlobal(apiAdmin, organizationId).stream()
+        boolean nameExists = apiAdmin.getAllEnvironments(organizationId).stream()
                 .anyMatch(e -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(e.getGatewayType())
                         && name.equals(e.getName()));
         if (nameExists) {
@@ -237,7 +216,7 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
     @Override
     public PlatformGateway getGatewayByNameAndOrganization(String name, String organizationId)
             throws APIManagementException {
-        Environment env = getEnvironmentsForOrganizationMergedWithGlobal(organizationId).stream()
+        Environment env = new APIAdminImpl().getAllEnvironments(organizationId).stream()
                 .filter(e -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(e.getGatewayType())
                         && name.equals(e.getName()))
                 .findFirst()
@@ -247,7 +226,7 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
 
     @Override
     public List<PlatformGateway> listGatewaysByOrganization(String organizationId) throws APIManagementException {
-        return getEnvironmentsForOrganizationMergedWithGlobal(organizationId).stream()
+        return new APIAdminImpl().getAllEnvironments(organizationId).stream()
                 .filter(e -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(e.getGatewayType()))
                 .map(PlatformGatewayServiceImpl::envToApiModel)
                 .collect(Collectors.toList());
@@ -288,8 +267,7 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
             throw new APIManagementException("Platform gateway not found: " + gatewayId,
                     ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
         }
-        if (!organizationId.equals(existing.getOrganizationId())
-                && !APIConstants.GatewayNotification.WSO2_ALL_TENANTS.equals(existing.getOrganizationId())) {
+        if (!organizationId.equals(existing.getOrganizationId())) {
             throw new APIManagementException("Platform gateway not found in organization: " + gatewayId,
                     ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
         }
@@ -383,26 +361,16 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
 
     /**
      * Resolves the organization under which a platform gateway environment is stored.
-     * Falls back to {@code WSO2-ALL-TENANTS} when the gateway was created as a shared connect gateway.
+     * Platform gateways are single-tenant scoped; lookup is limited to {@code requestOrganizationId}.
      */
     public static String resolveStorageOrganizationId(String requestOrganizationId, String gatewayId)
             throws APIManagementException {
-        if (StringUtils.isBlank(gatewayId)) {
+        if (StringUtils.isBlank(gatewayId) || StringUtils.isBlank(requestOrganizationId)) {
             return null;
         }
-        ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();
-        if (StringUtils.isNotBlank(requestOrganizationId)) {
-            Environment env = apiMgtDAO.getEnvironment(requestOrganizationId, gatewayId);
-            if (env != null && APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
-                return requestOrganizationId;
-            }
-        }
-        String allTenantsOrg = APIConstants.GatewayNotification.WSO2_ALL_TENANTS;
-        if (!allTenantsOrg.equals(requestOrganizationId)) {
-            Environment env = apiMgtDAO.getEnvironment(allTenantsOrg, gatewayId);
-            if (env != null && APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
-                return allTenantsOrg;
-            }
+        Environment env = ApiMgtDAO.getInstance().getEnvironment(requestOrganizationId, gatewayId);
+        if (env != null && APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
+            return requestOrganizationId;
         }
         return null;
     }
@@ -533,7 +501,8 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
                 }
                 if (StringUtils.isNotBlank(entry.getName())) {
                     try {
-                        Environment existingByName = getEnvironmentsForOrganizationMergedWithGlobal(orgId).stream()
+                        APIAdminImpl apiAdminForNameCheck = new APIAdminImpl();
+                        Environment existingByName = apiAdminForNameCheck.getAllEnvironments(orgId).stream()
                                 .filter(e -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(e.getGatewayType())
                                         && entry.getName().equals(e.getName()))
                                 .findFirst()

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
@@ -34,9 +34,9 @@ import org.wso2.carbon.apimgt.impl.APIAdminImpl;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 import org.wso2.carbon.apimgt.impl.dao.PlatformGatewayDAO;
-import org.wso2.carbon.apimgt.impl.gateway.PlatformGatewayDeploymentDispatcher;
 import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
 import org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig;
+import org.wso2.carbon.apimgt.impl.gateway.PlatformGatewayDeploymentDispatcher;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.PlatformGatewayTokenUtil;
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
@@ -546,6 +546,7 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
             String description = StringUtils.isNotBlank(descriptionOverride) ? descriptionOverride : "";
             String vhostForDao = StringUtils.isNotBlank(urlOverride) ? urlOverride : "default";
             Timestamp now = Timestamp.from(Instant.now());
+            boolean environmentCreated = false;
             if (existing == null) {
                 Environment env = StringUtils.isNotBlank(urlOverride)
                         ? toEnvironmentFromUrl(gatewayId, name, displayName, description, urlOverride)
@@ -557,12 +558,25 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
                 additional.put("updatedAt", String.valueOf(now.getTime()));
                 env.setAdditionalProperties(additional);
                 apiAdmin.addEnvironment(orgId, env);
+                environmentCreated = true;
             }
-            PlatformGatewayDAO.PlatformGateway gateway = new PlatformGatewayDAO.PlatformGateway(
-                    gatewayId, orgId, name, displayName, description, vhostForDao,
-                    null, false, now, now);
-            dao.createGatewayWithTokenAndGatewayInstance(gateway, tokenId, tokenHash,
-                    Collections.singletonList(name));
+            try {
+                PlatformGatewayDAO.PlatformGateway gateway = new PlatformGatewayDAO.PlatformGateway(
+                        gatewayId, orgId, name, displayName, description, vhostForDao,
+                        null, false, now, now);
+                dao.createGatewayWithTokenAndGatewayInstance(gateway, tokenId, tokenHash,
+                        Collections.singletonList(name));
+            } catch (APIManagementException e) {
+                if (environmentCreated) {
+                    try {
+                        apiAdmin.deleteEnvironment(orgId, gatewayId);
+                    } catch (Exception rollbackEx) {
+                        log.warn("Rollback failed for connect-with-token environment cleanup: " + gatewayId,
+                                rollbackEx);
+                    }
+                }
+                throw e;
+            }
             if (log.isInfoEnabled()) {
                 log.info("Platform gateway connected with token: gateway_id=" + gatewayId + ", name=" + name
                         + ", organization=" + orgId);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java
@@ -73,12 +73,12 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
      * ({@link APIConstants.GatewayNotification#WSO2_ALL_TENANTS}), so globally-scoped platform gateways are not
      * omitted from list/name checks. When {@code organizationId} is already the global scope, only that list is used.
      */
-    private List<Environment> getEnvironmentsForOrganizationMergedWithGlobal(String organizationId)
+    private static List<Environment> getEnvironmentsForOrganizationMergedWithGlobal(String organizationId)
             throws APIManagementException {
         return getEnvironmentsForOrganizationMergedWithGlobal(new APIAdminImpl(), organizationId);
     }
 
-    private List<Environment> getEnvironmentsForOrganizationMergedWithGlobal(APIAdminImpl apiAdmin,
+    private static List<Environment> getEnvironmentsForOrganizationMergedWithGlobal(APIAdminImpl apiAdmin,
                                                                                String organizationId)
             throws APIManagementException {
         List<Environment> merged = new ArrayList<>(apiAdmin.getAllEnvironments(organizationId));
@@ -284,7 +284,8 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
             throw new APIManagementException("Platform gateway not found: " + gatewayId,
                     ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
         }
-        if (!organizationId.equals(existing.getOrganizationId())) {
+        if (!organizationId.equals(existing.getOrganizationId())
+                && !APIConstants.GatewayNotification.WSO2_ALL_TENANTS.equals(existing.getOrganizationId())) {
             throw new APIManagementException("Platform gateway not found in organization: " + gatewayId,
                     ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
         }
@@ -307,12 +308,14 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
 
     @Override
     public void deleteGateway(String organizationId, String gatewayId) throws APIManagementException {
-        Environment env = ApiMgtDAO.getInstance().getEnvironment(organizationId, gatewayId);
+        String storageOrgId = resolveStorageOrganizationId(organizationId, gatewayId);
+        Environment env = storageOrgId != null
+                ? ApiMgtDAO.getInstance().getEnvironment(storageOrgId, gatewayId) : null;
         if (env == null || !APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
             throw new APIManagementException("Platform gateway not found: " + gatewayId,
                     ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
         }
-        if (ApiMgtDAO.getInstance().hasExistingAPIRevisions(gatewayId, organizationId)) {
+        if (ApiMgtDAO.getInstance().hasExistingAPIRevisions(gatewayId, storageOrgId)) {
             throw new APIManagementException(
                     "Cannot delete platform gateway: API revisions are currently deployed to it. "
                             + "Undeploy all APIs from this gateway first.",
@@ -324,14 +327,16 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         if (dispatcher != null) {
             dispatcher.closeGatewayConnection(gatewayId);
         }
-        PlatformGatewayDAO.getInstance().deleteGatewayWithReferences(gatewayId, env.getName(), organizationId);
+        PlatformGatewayDAO.getInstance().deleteGatewayWithReferences(gatewayId, env.getName(), storageOrgId);
     }
 
     @Override
     public PlatformGateway updateGateway(String organizationId, String gatewayId, String displayName,
                                          String description, String propertiesJson)
             throws APIManagementException {
-        Environment env = ApiMgtDAO.getInstance().getEnvironment(organizationId, gatewayId);
+        String storageOrgId = resolveStorageOrganizationId(organizationId, gatewayId);
+        Environment env = storageOrgId != null
+                ? ApiMgtDAO.getInstance().getEnvironment(storageOrgId, gatewayId) : null;
         if (env == null || !APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
             throw new APIManagementException("Platform gateway not found: " + gatewayId,
                     ExceptionCodes.PLATFORM_GATEWAY_NOT_FOUND);
@@ -349,14 +354,16 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
             additional.put("updatedAt", String.valueOf(System.currentTimeMillis()));
             env.setAdditionalProperties(additional);
         }
-        new APIAdminImpl().updateEnvironment(organizationId, env);
-        return envToApiModel(ApiMgtDAO.getInstance().getEnvironment(organizationId, gatewayId));
+        new APIAdminImpl().updateEnvironment(storageOrgId, env);
+        return envToApiModel(ApiMgtDAO.getInstance().getEnvironment(storageOrgId, gatewayId));
     }
 
     @Override
     public void updateGatewayActiveStatus(String gatewayId, String organizationId, boolean active)
             throws APIManagementException {
-        Environment env = ApiMgtDAO.getInstance().getEnvironment(organizationId, gatewayId);
+        String storageOrgId = resolveStorageOrganizationId(organizationId, gatewayId);
+        Environment env = storageOrgId != null
+                ? ApiMgtDAO.getInstance().getEnvironment(storageOrgId, gatewayId) : null;
         if (env == null || !APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
             return;
         }
@@ -365,7 +372,33 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         additional.put("isActive", String.valueOf(active));
         additional.put("updatedAt", String.valueOf(System.currentTimeMillis()));
         env.setAdditionalProperties(additional);
-        new APIAdminImpl().updateEnvironment(organizationId, env);
+        new APIAdminImpl().updateEnvironment(storageOrgId, env);
+    }
+
+    /**
+     * Resolves the organization under which a platform gateway environment is stored.
+     * Falls back to {@code WSO2-ALL-TENANTS} when the gateway was created as a shared connect gateway.
+     */
+    public static String resolveStorageOrganizationId(String requestOrganizationId, String gatewayId)
+            throws APIManagementException {
+        if (StringUtils.isBlank(gatewayId)) {
+            return null;
+        }
+        ApiMgtDAO apiMgtDAO = ApiMgtDAO.getInstance();
+        if (StringUtils.isNotBlank(requestOrganizationId)) {
+            Environment env = apiMgtDAO.getEnvironment(requestOrganizationId, gatewayId);
+            if (env != null && APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
+                return requestOrganizationId;
+            }
+        }
+        String allTenantsOrg = APIConstants.GatewayNotification.WSO2_ALL_TENANTS;
+        if (!allTenantsOrg.equals(requestOrganizationId)) {
+            Environment env = apiMgtDAO.getEnvironment(allTenantsOrg, gatewayId);
+            if (env != null && APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType())) {
+                return allTenantsOrg;
+            }
+        }
+        return null;
     }
 
     /**
@@ -454,7 +487,7 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         if (config == null || entry == null || StringUtils.isBlank(entry.getRegistrationToken())) {
             return false;
         }
-        String orgId = APIConstants.GatewayNotification.WSO2_ALL_TENANTS;
+        String orgId = entry.resolveOrganization();
         String registrationToken = entry.getRegistrationToken();
         String name = StringUtils.isNotBlank(entry.getName()) ? entry.getName() : gatewayId;
         String displayNameOverride = entry.getDisplayName();
@@ -465,7 +498,7 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
         }
         if (StringUtils.isNotBlank(entry.getName())) {
             try {
-                Environment existingByName = new APIAdminImpl().getAllEnvironments(orgId).stream()
+                Environment existingByName = getEnvironmentsForOrganizationMergedWithGlobal(orgId).stream()
                         .filter(e -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(e.getGatewayType())
                                 && entry.getName().equals(e.getName()))
                         .findFirst()
@@ -512,20 +545,27 @@ public class PlatformGatewayServiceImpl implements PlatformGatewayService {
             String displayName = StringUtils.isNotBlank(displayNameOverride) ? displayNameOverride : name;
             String description = StringUtils.isNotBlank(descriptionOverride) ? descriptionOverride : "";
             String vhostForDao = StringUtils.isNotBlank(urlOverride) ? urlOverride : "default";
+            Timestamp now = Timestamp.from(Instant.now());
             if (existing == null) {
                 Environment env = StringUtils.isNotBlank(urlOverride)
                         ? toEnvironmentFromUrl(gatewayId, name, displayName, description, urlOverride)
                         : toEnvironment(gatewayId, name, displayName, description, "default");
+                Map<String, String> additional = new HashMap<>();
+                additional.put("organization", orgId);
+                additional.put("isActive", "false");
+                additional.put("createdAt", String.valueOf(now.getTime()));
+                additional.put("updatedAt", String.valueOf(now.getTime()));
+                env.setAdditionalProperties(additional);
                 apiAdmin.addEnvironment(orgId, env);
             }
-            Timestamp now = Timestamp.from(Instant.now());
             PlatformGatewayDAO.PlatformGateway gateway = new PlatformGatewayDAO.PlatformGateway(
                     gatewayId, orgId, name, displayName, description, vhostForDao,
                     null, false, now, now);
             dao.createGatewayWithTokenAndGatewayInstance(gateway, tokenId, tokenHash,
                     Collections.singletonList(name));
             if (log.isInfoEnabled()) {
-                log.info("Platform gateway connected with token: gateway_id=" + gatewayId + ", name=" + name);
+                log.info("Platform gateway connected with token: gateway_id=" + gatewayId + ", name=" + name
+                        + ", organization=" + orgId);
             }
             return true;
         } catch (NoSuchAlgorithmException | APIManagementException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8810,31 +8810,7 @@ public final class APIUtil {
 
         Map<String, Environment> allEnvironments = new LinkedHashMap<>(getReadOnlyEnvironments());
         allEnvironments.putAll(envFromDB);
-
-        // Shared platform gateways stored under WSO2-ALL-TENANTS are merged as fallbacks only.
-        String allTenantsOrg = APIConstants.GatewayNotification.WSO2_ALL_TENANTS;
-        if (organization != null && !organization.equals(allTenantsOrg)) {
-            getSharedPlatformGatewayEnvironments().forEach(allEnvironments::putIfAbsent);
-        }
         return allEnvironments;
-    }
-
-    private static volatile Map<String, Environment> sharedPlatformGatewayEnvironmentCache = Collections.emptyMap();
-    private static volatile long sharedPlatformGatewayEnvironmentCacheAtMs;
-
-    private static Map<String, Environment> getSharedPlatformGatewayEnvironments() throws APIManagementException {
-        long now = System.currentTimeMillis();
-        if (now - sharedPlatformGatewayEnvironmentCacheAtMs < 60_000L
-                && !sharedPlatformGatewayEnvironmentCache.isEmpty()) {
-            return sharedPlatformGatewayEnvironmentCache;
-        }
-        String allTenantsOrg = APIConstants.GatewayNotification.WSO2_ALL_TENANTS;
-        Map<String, Environment> sharedEnvs = ApiMgtDAO.getInstance().getAllEnvironments(allTenantsOrg).stream()
-                .filter(env -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType()))
-                .collect(Collectors.toMap(Environment::getName, env -> env, (a, b) -> a));
-        sharedPlatformGatewayEnvironmentCache = sharedEnvs;
-        sharedPlatformGatewayEnvironmentCacheAtMs = now;
-        return sharedEnvs;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8810,6 +8810,15 @@ public final class APIUtil {
 
         Map<String, Environment> allEnvironments = new LinkedHashMap<>(getReadOnlyEnvironments());
         allEnvironments.putAll(envFromDB);
+
+        // Platform gateways created via connect-with-token are stored under WSO2-ALL-TENANTS.
+        String allTenantsOrg = APIConstants.GatewayNotification.WSO2_ALL_TENANTS;
+        if (organization != null && !organization.equals(allTenantsOrg)) {
+            Map<String, Environment> allTenantEnvs = ApiMgtDAO.getInstance().getAllEnvironments(allTenantsOrg).stream()
+                    .filter(env -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType()))
+                    .collect(Collectors.toMap(Environment::getName, env -> env, (a, b) -> a));
+            allEnvironments.putAll(allTenantEnvs);
+        }
         return allEnvironments;
     }
 

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8811,13 +8811,13 @@ public final class APIUtil {
         Map<String, Environment> allEnvironments = new LinkedHashMap<>(getReadOnlyEnvironments());
         allEnvironments.putAll(envFromDB);
 
-        // Platform gateways created via connect-with-token are stored under WSO2-ALL-TENANTS.
+        // Shared platform gateways stored under WSO2-ALL-TENANTS are merged as fallbacks only.
         String allTenantsOrg = APIConstants.GatewayNotification.WSO2_ALL_TENANTS;
         if (organization != null && !organization.equals(allTenantsOrg)) {
             Map<String, Environment> allTenantEnvs = ApiMgtDAO.getInstance().getAllEnvironments(allTenantsOrg).stream()
                     .filter(env -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType()))
                     .collect(Collectors.toMap(Environment::getName, env -> env, (a, b) -> a));
-            allEnvironments.putAll(allTenantEnvs);
+            allTenantEnvs.forEach(allEnvironments::putIfAbsent);
         }
         return allEnvironments;
     }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/APIUtil.java
@@ -8814,12 +8814,27 @@ public final class APIUtil {
         // Shared platform gateways stored under WSO2-ALL-TENANTS are merged as fallbacks only.
         String allTenantsOrg = APIConstants.GatewayNotification.WSO2_ALL_TENANTS;
         if (organization != null && !organization.equals(allTenantsOrg)) {
-            Map<String, Environment> allTenantEnvs = ApiMgtDAO.getInstance().getAllEnvironments(allTenantsOrg).stream()
-                    .filter(env -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType()))
-                    .collect(Collectors.toMap(Environment::getName, env -> env, (a, b) -> a));
-            allTenantEnvs.forEach(allEnvironments::putIfAbsent);
+            getSharedPlatformGatewayEnvironments().forEach(allEnvironments::putIfAbsent);
         }
         return allEnvironments;
+    }
+
+    private static volatile Map<String, Environment> sharedPlatformGatewayEnvironmentCache = Collections.emptyMap();
+    private static volatile long sharedPlatformGatewayEnvironmentCacheAtMs;
+
+    private static Map<String, Environment> getSharedPlatformGatewayEnvironments() throws APIManagementException {
+        long now = System.currentTimeMillis();
+        if (now - sharedPlatformGatewayEnvironmentCacheAtMs < 60_000L
+                && !sharedPlatformGatewayEnvironmentCache.isEmpty()) {
+            return sharedPlatformGatewayEnvironmentCache;
+        }
+        String allTenantsOrg = APIConstants.GatewayNotification.WSO2_ALL_TENANTS;
+        Map<String, Environment> sharedEnvs = ApiMgtDAO.getInstance().getAllEnvironments(allTenantsOrg).stream()
+                .filter(env -> APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(env.getGatewayType()))
+                .collect(Collectors.toMap(Environment::getName, env -> env, (a, b) -> a));
+        sharedPlatformGatewayEnvironmentCache = sharedEnvs;
+        sharedPlatformGatewayEnvironmentCacheAtMs = now;
+        return sharedEnvs;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
@@ -44,6 +44,8 @@ public class GatewayManagementUtils {
 
     private static final Log log = LogFactory.getLog(GatewayManagementUtils.class);
 
+    private static final Pattern CONNECT_GATEWAY_NAME_PATTERN = Pattern.compile("^[a-z0-9-]+$");
+
     /**
      * Validates the gateway status based on its last updated timestamp.
      * Returns "ACTIVE" if the gateway is live (not expired), "EXPIRED" otherwise.

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
@@ -119,6 +119,11 @@ public class GatewayManagementUtils {
             index++;
             String token = entry.getRegistrationToken();
             String prefix = "[[apim.platform_gateway.connect]] entry " + index + ": ";
+            String org = entry.resolveOrganization();
+            if (APIConstants.GatewayNotification.WSO2_ALL_TENANTS.equals(org)) {
+                errors.add(prefix + "organization must be a single tenant domain; "
+                        + "WSO2-ALL-TENANTS is not supported for platform gateways");
+            }
             if (StringUtils.isBlank(token)) {
                 errors.add(prefix + "mandatory 'registration_token' is missing");
                 if (StringUtils.isBlank(entry.getUrl())) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
@@ -153,18 +153,24 @@ public class GatewayManagementUtils {
             }
             List<ConnectGatewayConfig> connectGateways = config.getConnectGateways();
             int declaredConnectEntryCount = config.getDeclaredConnectEntryCount();
-            if (declaredConnectEntryCount == 0
-                    && (connectGateways == null || connectGateways.isEmpty())) {
+            int loadedConnectEntryCount = 0;
+            if (connectGateways != null) {
+                for (ConnectGatewayConfig connectGateway : connectGateways) {
+                    if (connectGateway != null) {
+                        loadedConnectEntryCount++;
+                    }
+                }
+            }
+            if (declaredConnectEntryCount == 0 && loadedConnectEntryCount == 0) {
                 return;
             }
-            if (declaredConnectEntryCount > 0
-                    && (connectGateways == null || connectGateways.isEmpty())) {
+            if (declaredConnectEntryCount != loadedConnectEntryCount) {
                 throw new IllegalArgumentException(
                         "Platform gateway connect config validation failed at server startup. "
                                 + declaredConnectEntryCount + " [[apim.platform_gateway.connect]] "
-                                + "entr" + (declaredConnectEntryCount == 1 ? "y" : "ies")
-                                + " in api-manager.xml but none were loaded; ensure each entry includes "
-                                + "registration_token and url.");
+                                + "entr" + (declaredConnectEntryCount == 1 ? "y was" : "ies were")
+                                + " declared in deployment.toml but only " + loadedConnectEntryCount
+                                + " loaded; ensure each entry includes registration_token and url.");
             }
             List<String> errors = validateConnectGatewayEntries(connectGateways);
             if (!errors.isEmpty()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
@@ -18,19 +18,21 @@
 
 package org.wso2.carbon.apimgt.impl.utils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.GatewayManagementDAO;
+import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
 import org.wso2.carbon.apimgt.impl.dto.GatewayNotificationConfiguration;
 import org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
-import org.wso2.carbon.apimgt.impl.service.PlatformGatewayServiceImpl;
 
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -38,7 +40,7 @@ import java.util.List;
  * Provides centralized methods for gateway status calculation and data cleanup operations.
  */
 public class GatewayManagementUtils {
-    
+
     private static final Log log = LogFactory.getLog(GatewayManagementUtils.class);
 
     /**
@@ -78,13 +80,13 @@ public class GatewayManagementUtils {
             long currentTime = Instant.now().toEpochMilli();
             GatewayNotificationConfiguration configuration = ServiceReferenceHolder.getInstance()
                     .getAPIManagerConfigurationService().getAPIManagerConfiguration().getGatewayNotificationConfiguration();
-            long retentionThreshold = currentTime - 
+            long retentionThreshold = currentTime -
                     (configuration.getGatewayCleanupConfiguration().getDataRetentionPeriodSeconds() * 1000L);
             Timestamp retentionTimestamp = new Timestamp(retentionThreshold);
 
             GatewayManagementDAO gatewayManagementDAO = GatewayManagementDAO.getInstance();
             int deletedCount = gatewayManagementDAO.deleteOldGatewayRecords(retentionTimestamp);
-            
+
             if (deletedCount > 0) {
                 log.info("Gateway cleanup completed - Deleted: " + deletedCount);
             }
@@ -99,6 +101,45 @@ public class GatewayManagementUtils {
     }
 
     /**
+     * Validates {@code [[apim.platform_gateway.connect]]} entries.
+     *
+     * @return validation error messages; empty when valid
+     */
+    public static List<String> validateConnectGatewayEntries(List<ConnectGatewayConfig> connectGateways) {
+        if (connectGateways == null || connectGateways.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String sep = PlatformGatewayTokenUtil.COMBINED_TOKEN_SEPARATOR;
+        List<String> errors = new ArrayList<>();
+        int index = 0;
+        for (ConnectGatewayConfig entry : connectGateways) {
+            if (entry == null) {
+                continue;
+            }
+            index++;
+            String token = entry.getRegistrationToken();
+            String prefix = "[[apim.platform_gateway.connect]] entry " + index + ": ";
+            if (StringUtils.isBlank(token)) {
+                errors.add(prefix + "mandatory 'registration_token' is missing");
+                if (StringUtils.isBlank(entry.getUrl())) {
+                    errors.add(prefix + "mandatory 'url' is missing (base URL where the gateway will be accessible, "
+                            + "e.g. https://host:8243)");
+                }
+                continue;
+            }
+            if (StringUtils.isBlank(entry.getUrl())) {
+                errors.add(prefix + "mandatory 'url' is missing (base URL where the gateway will be accessible, "
+                        + "e.g. https://host:8243)");
+            }
+            int idx = token.indexOf(sep);
+            if (idx <= 0 || idx >= token.length() - 1) {
+                errors.add(prefix + "invalid registration_token format (expected tokenId" + sep + "plainToken)");
+            }
+        }
+        return errors;
+    }
+
+    /**
      * Validates {@code [[apim.platform_gateway.connect]]} entries at startup when configured.
      * Gateway records are created lazily on first WebSocket connect, not at startup.
      */
@@ -110,37 +151,22 @@ public class GatewayManagementUtils {
             if (config == null) {
                 return;
             }
-            List<org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig> connectGateways = config.getConnectGateways();
-            if (connectGateways == null || connectGateways.isEmpty()) {
+            List<ConnectGatewayConfig> connectGateways = config.getConnectGateways();
+            int declaredConnectEntryCount = config.getDeclaredConnectEntryCount();
+            if (declaredConnectEntryCount == 0
+                    && (connectGateways == null || connectGateways.isEmpty())) {
                 return;
             }
-            String sep = PlatformGatewayTokenUtil.COMBINED_TOKEN_SEPARATOR;
-            List<String> errors = new ArrayList<>();
-            int index = 0;
-            for (org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig entry : connectGateways) {
-                if (entry == null) {
-                    continue;
-                }
-                index++;
-                String token = entry.getRegistrationToken();
-                String prefix = "[[apim.platform_gateway.connect]] entry " + index + ": ";
-                if (org.apache.commons.lang3.StringUtils.isBlank(token)) {
-                    errors.add(prefix + "mandatory 'registration_token' is missing");
-                    if (org.apache.commons.lang3.StringUtils.isBlank(entry.getUrl())) {
-                        errors.add(prefix + "mandatory 'url' is missing (base URL where the gateway will be accessible, "
-                                + "e.g. https://host:8243)");
-                    }
-                    continue;
-                }
-                if (org.apache.commons.lang3.StringUtils.isBlank(entry.getUrl())) {
-                    errors.add(prefix + "mandatory 'url' is missing (base URL where the gateway will be accessible, "
-                            + "e.g. https://host:8243)");
-                }
-                int idx = token.indexOf(sep);
-                if (idx <= 0 || idx >= token.length() - 1) {
-                    errors.add(prefix + "invalid registration_token format (expected tokenId" + sep + "plainToken)");
-                }
+            if (declaredConnectEntryCount > 0
+                    && (connectGateways == null || connectGateways.isEmpty())) {
+                throw new IllegalArgumentException(
+                        "Platform gateway connect config validation failed at server startup. "
+                                + declaredConnectEntryCount + " [[apim.platform_gateway.connect]] "
+                                + "entr" + (declaredConnectEntryCount == 1 ? "y" : "ies")
+                                + " in api-manager.xml but none were loaded; ensure each entry includes "
+                                + "registration_token and url.");
             }
+            List<String> errors = validateConnectGatewayEntries(connectGateways);
             if (!errors.isEmpty()) {
                 for (String err : errors) {
                     log.error(err);
@@ -154,7 +180,6 @@ public class GatewayManagementUtils {
                         + " gateway(s); they can register on first connect "
                         + "(organization defaults to carbon.super when not set in toml).");
             }
-            PlatformGatewayServiceImpl.ensurePlatformGatewayFromConfigOnStartup(config);
         } catch (IllegalArgumentException e) {
             throw e;
         } catch (Exception e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
@@ -24,10 +24,15 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.GatewayManagementDAO;
 import org.wso2.carbon.apimgt.impl.dto.GatewayNotificationConfiguration;
+import org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.service.PlatformGatewayServiceImpl;
+import org.wso2.carbon.apimgt.impl.utils.PlatformGatewayTokenUtil;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Utility class for gateway management operations.
@@ -91,6 +96,65 @@ public class GatewayManagementUtils {
             String errorMessage = "Unexpected error during gateway cleanup: " + e.getMessage();
             log.error(errorMessage, e);
             throw new APIManagementException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Validates {@code [[apim.platform_gateway.connect]]} entries at startup when configured.
+     * Gateway records are created lazily on first WebSocket connect, not at startup.
+     */
+    public static void performPlatformGatewayConnectFromConfigIfConfigured() {
+        try {
+            PlatformGatewayConnectConfig config = ServiceReferenceHolder.getInstance()
+                    .getAPIManagerConfigurationService().getAPIManagerConfiguration()
+                    .getPlatformGatewayConnectConfig();
+            if (config == null) {
+                return;
+            }
+            List<org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig> connectGateways = config.getConnectGateways();
+            if (connectGateways == null || connectGateways.isEmpty()) {
+                return;
+            }
+            String sep = PlatformGatewayTokenUtil.COMBINED_TOKEN_SEPARATOR;
+            List<String> errors = new ArrayList<>();
+            int index = 0;
+            for (org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig entry : connectGateways) {
+                if (entry == null) {
+                    continue;
+                }
+                index++;
+                String token = entry.getRegistrationToken();
+                if (org.apache.commons.lang3.StringUtils.isBlank(token)) {
+                    continue;
+                }
+                String prefix = "[[apim.platform_gateway.connect]] entry " + index + ": ";
+                if (org.apache.commons.lang3.StringUtils.isBlank(entry.getUrl())) {
+                    errors.add(prefix + "mandatory 'url' is missing (base URL where the gateway will be accessible, "
+                            + "e.g. https://host:8243)");
+                }
+                int idx = token.indexOf(sep);
+                if (idx <= 0 || idx >= token.length() - 1) {
+                    errors.add(prefix + "invalid registration_token format (expected tokenId" + sep + "plainToken)");
+                }
+            }
+            if (!errors.isEmpty()) {
+                for (String err : errors) {
+                    log.error(err);
+                }
+                throw new IllegalArgumentException(
+                        "Platform gateway connect config validation failed at server startup. "
+                                + "Fix the following and restart: " + String.join("; ", errors));
+            }
+            if (log.isInfoEnabled()) {
+                log.info("Connect-with-token configured for " + connectGateways.size()
+                        + " gateway(s); they can register on first connect.");
+            }
+            PlatformGatewayServiceImpl.ensurePlatformGatewayFromConfigOnStartup(config);
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Platform gateway connect config failed at startup: " + e.getMessage(), e);
+            throw new IllegalStateException("Platform gateway connect config failed at startup: " + e.getMessage(), e);
         }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
@@ -147,7 +147,8 @@ public class GatewayManagementUtils {
             }
             if (log.isInfoEnabled()) {
                 log.info("Connect-with-token configured for " + connectGateways.size()
-                        + " gateway(s); they can register on first connect.");
+                        + " gateway(s); they can register on first connect "
+                        + "(organization defaults to carbon.super when not set in toml).");
             }
             PlatformGatewayServiceImpl.ensurePlatformGatewayFromConfigOnStartup(config);
         } catch (IllegalArgumentException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Utility class for gateway management operations.
@@ -139,6 +140,11 @@ public class GatewayManagementUtils {
             int idx = token.indexOf(sep);
             if (idx <= 0 || idx >= token.length() - 1) {
                 errors.add(prefix + "invalid registration_token format (expected tokenId" + sep + "plainToken)");
+            }
+            String gatewayName = entry.getName();
+            if (StringUtils.isNotBlank(gatewayName) && !CONNECT_GATEWAY_NAME_PATTERN.matcher(gatewayName).matches()) {
+                errors.add(prefix + "invalid name '" + gatewayName
+                        + "' (use lowercase letters, numbers, and hyphens only)");
             }
         }
         return errors;

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtils.java
@@ -27,7 +27,6 @@ import org.wso2.carbon.apimgt.impl.dto.GatewayNotificationConfiguration;
 import org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.service.PlatformGatewayServiceImpl;
-import org.wso2.carbon.apimgt.impl.utils.PlatformGatewayTokenUtil;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -124,10 +123,15 @@ public class GatewayManagementUtils {
                 }
                 index++;
                 String token = entry.getRegistrationToken();
+                String prefix = "[[apim.platform_gateway.connect]] entry " + index + ": ";
                 if (org.apache.commons.lang3.StringUtils.isBlank(token)) {
+                    errors.add(prefix + "mandatory 'registration_token' is missing");
+                    if (org.apache.commons.lang3.StringUtils.isBlank(entry.getUrl())) {
+                        errors.add(prefix + "mandatory 'url' is missing (base URL where the gateway will be accessible, "
+                                + "e.g. https://host:8243)");
+                    }
                     continue;
                 }
-                String prefix = "[[apim.platform_gateway.connect]] entry " + index + ": ";
                 if (org.apache.commons.lang3.StringUtils.isBlank(entry.getUrl())) {
                     errors.add(prefix + "mandatory 'url' is missing (base URL where the gateway will be accessible, "
                             + "e.g. https://host:8243)");

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtil.java
@@ -162,19 +162,7 @@ public final class PlatformGatewayTokenUtil {
             if (tokenRow == null) {
                 return null;
             }
-            String computedHash = hashToken(plainToken);
-            byte[] computedBytes;
-            byte[] storedBytes;
-            try {
-                computedBytes = Hex.decodeHex(computedHash.toCharArray());
-                storedBytes = Hex.decodeHex(tokenRow.tokenHash.toCharArray());
-            } catch (DecoderException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Token verification failed: invalid hash encoding for token id=" + tokenId);
-                }
-                return null;
-            }
-            if (computedBytes.length != storedBytes.length || !MessageDigest.isEqual(computedBytes, storedBytes)) {
+            if (!matchesActiveTokenHash(tokenRow, plainToken)) {
                 if (log.isDebugEnabled()) {
                     log.debug("Token verification failed: hash mismatch for token id=" + tokenId);
                 }
@@ -194,5 +182,25 @@ public final class PlatformGatewayTokenUtil {
             log.debug("Platform gateway token verified successfully for gateway: " + tokenRow.gatewayId);
         }
         return PlatformGatewayDAO.fromTokenWithGateway(tokenRow);
+    }
+
+    /**
+     * Constant-time comparison of a plain token against a stored active token row hash.
+     */
+    public static boolean matchesActiveTokenHash(PlatformGatewayDAO.TokenWithGateway tokenRow, String plainToken)
+            throws NoSuchAlgorithmException {
+        if (tokenRow == null || plainToken == null) {
+            return false;
+        }
+        String computedHash = hashToken(plainToken);
+        byte[] computedBytes;
+        byte[] storedBytes;
+        try {
+            computedBytes = Hex.decodeHex(computedHash.toCharArray());
+            storedBytes = Hex.decodeHex(tokenRow.tokenHash.toCharArray());
+        } catch (DecoderException e) {
+            return false;
+        }
+        return computedBytes.length == storedBytes.length && MessageDigest.isEqual(computedBytes, storedBytes);
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtil.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.Base64;
 
 /**
@@ -68,7 +69,38 @@ public final class PlatformGatewayTokenUtil {
     }
 
     /**
+     * True when {@code apiKey} matches a connect-config {@code registration_token} and TOML fallback is allowed.
+     * Pre-bootstrap (no active DB row) is allowed; once a row exists the stored hash must match.
+     * <p>
+     * Performs one {@link PlatformGatewayDAO#getActiveTokenById(String)} lookup per call when the TOML
+     * token string matches {@code apiKey}. That read is required so stale TOML credentials are rejected
+     * after Admin token rotation; it runs on every internal API request authenticated via connect config.
+     */
+    public static boolean matchesConnectConfigRegistrationToken(String configRegistrationToken, String apiKey)
+            throws APIManagementException, NoSuchAlgorithmException {
+        if (!constantTimeEquals(configRegistrationToken, apiKey)) {
+            return false;
+        }
+        String tokenId = parseTokenId(apiKey);
+        if (tokenId == null) {
+            return false;
+        }
+        int sep = apiKey.indexOf(COMBINED_TOKEN_SEPARATOR);
+        String plainToken = apiKey.substring(sep + 1);
+        if (plainToken.isEmpty()) {
+            return false;
+        }
+        PlatformGatewayDAO.TokenWithGateway active =
+                PlatformGatewayDAO.getInstance().getActiveTokenById(tokenId);
+        if (active == null) {
+            return true;
+        }
+        return matchesActiveTokenHash(active, plainToken);
+    }
+
+    /**
      * Constant-time comparison for connect registration tokens.
+     * Uses bitwise {@code &} (not {@code &&}) so {@link MessageDigest#isEqual(byte[], byte[])} always runs.
      */
     public static boolean constantTimeEquals(String expected, String actual) {
         if (expected == null || actual == null) {
@@ -76,10 +108,11 @@ public final class PlatformGatewayTokenUtil {
         }
         byte[] expectedBytes = expected.getBytes(StandardCharsets.UTF_8);
         byte[] actualBytes = actual.getBytes(StandardCharsets.UTF_8);
-        if (expectedBytes.length != actualBytes.length) {
-            return false;
-        }
-        return MessageDigest.isEqual(expectedBytes, actualBytes);
+        int maxLen = Math.max(expectedBytes.length, actualBytes.length);
+        byte[] paddedExpected = Arrays.copyOf(expectedBytes, maxLen);
+        byte[] paddedActual = Arrays.copyOf(actualBytes, maxLen);
+        return (expectedBytes.length == actualBytes.length)
+                & MessageDigest.isEqual(paddedExpected, paddedActual);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtil.java
@@ -54,6 +54,35 @@ public final class PlatformGatewayTokenUtil {
     }
 
     /**
+     * Parses the token row ID from a combined {@code tokenId.plainToken} registration token.
+     */
+    public static String parseTokenId(String combinedRegistrationToken) {
+        if (combinedRegistrationToken == null || !combinedRegistrationToken.contains(COMBINED_TOKEN_SEPARATOR)) {
+            return null;
+        }
+        int sep = combinedRegistrationToken.indexOf(COMBINED_TOKEN_SEPARATOR);
+        if (sep <= 0 || sep >= combinedRegistrationToken.length() - 1) {
+            return null;
+        }
+        return combinedRegistrationToken.substring(0, sep);
+    }
+
+    /**
+     * Constant-time comparison for connect registration tokens.
+     */
+    public static boolean constantTimeEquals(String expected, String actual) {
+        if (expected == null || actual == null) {
+            return false;
+        }
+        byte[] expectedBytes = expected.trim().getBytes(StandardCharsets.UTF_8);
+        byte[] actualBytes = actual.trim().getBytes(StandardCharsets.UTF_8);
+        if (expectedBytes.length != actualBytes.length) {
+            return false;
+        }
+        return MessageDigest.isEqual(expectedBytes, actualBytes);
+    }
+
+    /**
      * Generate a time-ordered token row ID (UUID v7, RFC 9562). JDK-only implementation; no external
      * dependency. Sortable by creation time.
      * TODO: When Java 26+ is adopted and the JDK provides native UUID v7 support (e.g. java.util.UUID),

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtil.java
@@ -74,8 +74,8 @@ public final class PlatformGatewayTokenUtil {
         if (expected == null || actual == null) {
             return false;
         }
-        byte[] expectedBytes = expected.trim().getBytes(StandardCharsets.UTF_8);
-        byte[] actualBytes = actual.trim().getBytes(StandardCharsets.UTF_8);
+        byte[] expectedBytes = expected.getBytes(StandardCharsets.UTF_8);
+        byte[] actualBytes = actual.getBytes(StandardCharsets.UTF_8);
         if (expectedBytes.length != actualBytes.length) {
             return false;
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/VHostUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/VHostUtils.java
@@ -62,7 +62,19 @@ public class VHostUtils {
      * ({@code gatewayBaseUrl} or reconstructed VHost) instead of default https port 443.
      */
     public static VHost getInvocationVhostFromEnvironment(Environment environment, String host) {
-        if (environment == null || !APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(environment.getGatewayType())) {
+        if (environment == null) {
+            VHost defaultVhost = new VHost();
+            defaultVhost.setHost(host);
+            defaultVhost.setHttpContext("");
+            defaultVhost.setHttpsPort(APIConstants.HTTPS_PROTOCOL_PORT);
+            defaultVhost.setHttpPort(APIConstants.HTTP_PROTOCOL_PORT);
+            defaultVhost.setWsPort(APIConstants.WS_PROTOCOL_PORT);
+            defaultVhost.setWsHost(host);
+            defaultVhost.setWssPort(APIConstants.WSS_PROTOCOL_PORT);
+            defaultVhost.setWssHost(host);
+            return defaultVhost;
+        }
+        if (!APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(environment.getGatewayType())) {
             return getVhostFromEnvironment(environment, host);
         }
         String baseUrl = PlatformGatewayServiceImpl.resolveGatewayBaseUrl(environment);

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/VHostUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/VHostUtils.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.VHost;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.api.model.Environment;
+import org.wso2.carbon.apimgt.impl.service.PlatformGatewayServiceImpl;
 
 public class VHostUtils {
 
@@ -54,6 +55,25 @@ public class VHostUtils {
                 .filter(v -> StringUtils.equals(v.getHost(), host))
                 .findAny()
                 .orElse(defaultVhost);
+    }
+
+    /**
+     * VHost for try-out / endpoint URL construction. Platform gateways use the configured base URL
+     * ({@code gatewayBaseUrl} or reconstructed VHost) instead of default https port 443.
+     */
+    public static VHost getInvocationVhostFromEnvironment(Environment environment, String host) {
+        if (environment == null || !APIConstants.WSO2_API_PLATFORM_GATEWAY.equals(environment.getGatewayType())) {
+            return getVhostFromEnvironment(environment, host);
+        }
+        String baseUrl = PlatformGatewayServiceImpl.resolveGatewayBaseUrl(environment);
+        if (StringUtils.isBlank(baseUrl) || !baseUrl.contains("://")) {
+            return getVhostFromEnvironment(environment, host);
+        }
+        try {
+            return VHost.fromEndpointUrls(new String[]{baseUrl.trim()});
+        } catch (APIManagementException e) {
+            return getVhostFromEnvironment(environment, host);
+        }
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIManagerConfigurationTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/APIManagerConfigurationTest.java
@@ -23,9 +23,11 @@ import org.junit.Test;
 import org.testng.Assert;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.Environment;
+import org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig;
 
 import javax.xml.stream.XMLStreamException;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 
 public class APIManagerConfigurationTest {
@@ -128,5 +130,32 @@ public class APIManagerConfigurationTest {
         Assert.assertFalse(environmentsList.isEmpty());
         Environment defaultEnv = environmentsList.get("Default");
         Assert.assertFalse(defaultEnv.getAdditionalProperties().isEmpty());
+    }
+
+    @Test
+    public void testPlatformGatewayConnectParsesEntryWithoutRegistrationToken() throws Exception {
+        String gatewayNotificationConfig = "<GatewayNotificationConfiguration>"
+                + "<Enabled>true</Enabled>"
+                + "<PlatformGatewayConnectConfiguration>"
+                + "<ConnectGateways>"
+                + "<Connect>"
+                + "<RegistrationToken></RegistrationToken>"
+                + "<Url>https://gw.example.com:8243</Url>"
+                + "</Connect>"
+                + "</ConnectGateways>"
+                + "</PlatformGatewayConnectConfiguration>"
+                + "</GatewayNotificationConfiguration>";
+        OMElement element = AXIOMUtil.stringToOM(gatewayNotificationConfig);
+        APIManagerConfiguration config = new APIManagerConfiguration();
+        Method method = APIManagerConfiguration.class.getDeclaredMethod(
+                "setGatewayNotificationConfiguration", OMElement.class);
+        method.setAccessible(true);
+        method.invoke(config, element);
+
+        PlatformGatewayConnectConfig connectConfig = config.getPlatformGatewayConnectConfig();
+        Assert.assertEquals(1, connectConfig.getDeclaredConnectEntryCount());
+        Assert.assertEquals(1, connectConfig.getConnectGateways().size());
+        Assert.assertTrue(connectConfig.getConnectGateways().get(0).getRegistrationToken().isEmpty());
+        Assert.assertEquals("https://gw.example.com:8243", connectConfig.getConnectGateways().get(0).getUrl());
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfigTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfigTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.dto;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+public class ConnectGatewayConfigTest {
+
+    @Test
+    public void testResolveOrganizationDefaultsToSuperTenant() {
+        ConnectGatewayConfig config = new ConnectGatewayConfig();
+        Assert.assertEquals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, config.resolveOrganization());
+    }
+
+    @Test
+    public void testSetUrlAcceptsHttpsBaseUrl() {
+        ConnectGatewayConfig config = new ConnectGatewayConfig();
+        config.setUrl("https://gw.example.com:8243");
+        Assert.assertEquals("https://gw.example.com:8243", config.getUrl());
+    }
+
+    @Test
+    public void testSetUrlBlankClearsValue() {
+        ConnectGatewayConfig config = new ConnectGatewayConfig();
+        config.setUrl("https://gw.example.com:8243");
+        config.setUrl("  ");
+        Assert.assertNull(config.getUrl());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetUrlRejectsUserInfo() {
+        ConnectGatewayConfig config = new ConnectGatewayConfig();
+        config.setUrl("https://user:pass@gw.example.com:8243");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetUrlRejectsQuery() {
+        ConnectGatewayConfig config = new ConnectGatewayConfig();
+        config.setUrl("https://gw.example.com:8243?x=1");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetUrlRejectsFragment() {
+        ConnectGatewayConfig config = new ConnectGatewayConfig();
+        config.setUrl("https://gw.example.com:8243#frag");
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayConnectSupportTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayConnectSupportTest.java
@@ -57,19 +57,14 @@ public class PlatformGatewayConnectSupportTest {
     }
 
     @Test
-    public void testResolveStorageOrganizationIdFallsBackToAllTenants() throws Exception {
+    public void testResolveStorageOrganizationIdReturnsNullWhenNotInRequestOrg() throws Exception {
         PowerMockito.mockStatic(ApiMgtDAO.class);
         ApiMgtDAO apiMgtDAO = Mockito.mock(ApiMgtDAO.class);
         PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
 
-        Environment sharedEnv = new Environment();
-        sharedEnv.setGatewayType(APIConstants.WSO2_API_PLATFORM_GATEWAY);
         Mockito.when(apiMgtDAO.getEnvironment("carbon.super", "gw-1")).thenReturn(null);
-        Mockito.when(apiMgtDAO.getEnvironment(APIConstants.GatewayNotification.WSO2_ALL_TENANTS, "gw-1"))
-                .thenReturn(sharedEnv);
 
-        String storageOrg = PlatformGatewayServiceImpl.resolveStorageOrganizationId("carbon.super", "gw-1");
-        Assert.assertEquals(APIConstants.GatewayNotification.WSO2_ALL_TENANTS, storageOrg);
+        Assert.assertNull(PlatformGatewayServiceImpl.resolveStorageOrganizationId("carbon.super", "gw-1"));
     }
 
     @Test

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayConnectSupportTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayConnectSupportTest.java
@@ -27,8 +27,12 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.Environment;
+import org.wso2.carbon.apimgt.api.model.VHost;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ApiMgtDAO.class})
@@ -65,6 +69,82 @@ public class PlatformGatewayConnectSupportTest {
         Mockito.when(apiMgtDAO.getEnvironment("carbon.super", "gw-1")).thenReturn(null);
 
         Assert.assertNull(PlatformGatewayServiceImpl.resolveStorageOrganizationId("carbon.super", "gw-1"));
+    }
+
+    @Test
+    public void testBuildGatewayBaseUrlFromHttpVHostWithPath() {
+        VHost vhost = new VHost();
+        vhost.setHost("gw");
+        vhost.setHttpPort(8280);
+        vhost.setHttpsPort(VHost.DEFAULT_HTTPS_PORT);
+        vhost.setHttpContext("/base");
+
+        Assert.assertEquals("http://gw:8280/base",
+                PlatformGatewayServiceImpl.buildGatewayBaseUrlFromVHost(vhost));
+    }
+
+    @Test
+    public void testBuildGatewayBaseUrlFromHttpsVHostWithPath() {
+        VHost vhost = new VHost();
+        vhost.setHost("gw");
+        vhost.setHttpsPort(8443);
+        vhost.setHttpPort(VHost.DEFAULT_HTTP_PORT);
+        vhost.setHttpContext("/base");
+
+        Assert.assertEquals("https://gw:8443/base",
+                PlatformGatewayServiceImpl.buildGatewayBaseUrlFromVHost(vhost));
+    }
+
+    @Test
+    public void testResolveGatewayBaseUrlPrefersStoredValue() {
+        Environment env = new Environment();
+        Map<String, String> additional = new HashMap<>();
+        additional.put(APIConstants.GatewayNotification.GATEWAY_BASE_URL, "http://gw:8280/base");
+        env.setAdditionalProperties(additional);
+
+        Assert.assertEquals("http://gw:8280/base", PlatformGatewayServiceImpl.resolveGatewayBaseUrl(env));
+    }
+
+    @Test
+    public void testResolveInvocationUrlsForHttpConfiguredGateway() {
+        Environment env = new Environment();
+        env.setGatewayType(APIConstants.WSO2_API_PLATFORM_GATEWAY);
+        Map<String, String> additional = new HashMap<>();
+        additional.put(APIConstants.GatewayNotification.GATEWAY_BASE_URL, "http://localhost:8443");
+        env.setAdditionalProperties(additional);
+
+        Map<String, String> urls = PlatformGatewayServiceImpl.resolveInvocationUrlsForTransports(env, "http,https");
+
+        Assert.assertEquals("http://localhost:8443", urls.get(APIConstants.HTTP_PROTOCOL));
+        Assert.assertFalse(urls.containsKey(APIConstants.HTTPS_PROTOCOL));
+    }
+
+    @Test
+    public void testResolveInvocationUrlsForHttpConfiguredGatewayHttpsTransportOnly() {
+        Environment env = new Environment();
+        env.setGatewayType(APIConstants.WSO2_API_PLATFORM_GATEWAY);
+        Map<String, String> additional = new HashMap<>();
+        additional.put(APIConstants.GatewayNotification.GATEWAY_BASE_URL, "http://localhost:8443");
+        env.setAdditionalProperties(additional);
+
+        Map<String, String> urls = PlatformGatewayServiceImpl.resolveInvocationUrlsForTransports(env, "https");
+
+        Assert.assertEquals("http://localhost:8443", urls.get(APIConstants.HTTP_PROTOCOL));
+        Assert.assertFalse(urls.containsKey(APIConstants.HTTPS_PROTOCOL));
+    }
+
+    @Test
+    public void testResolveInvocationUrlsForHttpsConfiguredGateway() {
+        Environment env = new Environment();
+        env.setGatewayType(APIConstants.WSO2_API_PLATFORM_GATEWAY);
+        Map<String, String> additional = new HashMap<>();
+        additional.put(APIConstants.GatewayNotification.GATEWAY_BASE_URL, "https://localhost:8443");
+        env.setAdditionalProperties(additional);
+
+        Map<String, String> urls = PlatformGatewayServiceImpl.resolveInvocationUrlsForTransports(env, "https");
+
+        Assert.assertEquals("https://localhost:8443", urls.get(APIConstants.HTTPS_PROTOCOL));
+        Assert.assertFalse(urls.containsKey(APIConstants.HTTP_PROTOCOL));
     }
 
     @Test

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayConnectSupportTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayConnectSupportTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.service;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.Environment;
+import org.wso2.carbon.apimgt.impl.APIConstants;
+import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ApiMgtDAO.class})
+public class PlatformGatewayConnectSupportTest {
+
+    @Test
+    public void testResolveConnectGatewayIdIsDeterministic() {
+        String first = PlatformGatewayServiceImpl.resolveConnectGatewayId("token-id-123");
+        String second = PlatformGatewayServiceImpl.resolveConnectGatewayId("token-id-123");
+        Assert.assertNotNull(first);
+        Assert.assertEquals(first, second);
+    }
+
+    @Test
+    public void testResolveStorageOrganizationIdUsesRequestOrg() throws Exception {
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        ApiMgtDAO apiMgtDAO = Mockito.mock(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+
+        Environment env = new Environment();
+        env.setGatewayType(APIConstants.WSO2_API_PLATFORM_GATEWAY);
+        Mockito.when(apiMgtDAO.getEnvironment("carbon.super", "gw-1")).thenReturn(env);
+
+        String storageOrg = PlatformGatewayServiceImpl.resolveStorageOrganizationId("carbon.super", "gw-1");
+        Assert.assertEquals("carbon.super", storageOrg);
+    }
+
+    @Test
+    public void testResolveStorageOrganizationIdFallsBackToAllTenants() throws Exception {
+        PowerMockito.mockStatic(ApiMgtDAO.class);
+        ApiMgtDAO apiMgtDAO = Mockito.mock(ApiMgtDAO.class);
+        PowerMockito.when(ApiMgtDAO.getInstance()).thenReturn(apiMgtDAO);
+
+        Environment sharedEnv = new Environment();
+        sharedEnv.setGatewayType(APIConstants.WSO2_API_PLATFORM_GATEWAY);
+        Mockito.when(apiMgtDAO.getEnvironment("carbon.super", "gw-1")).thenReturn(null);
+        Mockito.when(apiMgtDAO.getEnvironment(APIConstants.GatewayNotification.WSO2_ALL_TENANTS, "gw-1"))
+                .thenReturn(sharedEnv);
+
+        String storageOrg = PlatformGatewayServiceImpl.resolveStorageOrganizationId("carbon.super", "gw-1");
+        Assert.assertEquals(APIConstants.GatewayNotification.WSO2_ALL_TENANTS, storageOrg);
+    }
+
+    @Test
+    public void testResolveStorageOrganizationIdReturnsNullForBlankGatewayId() throws APIManagementException {
+        Assert.assertNull(PlatformGatewayServiceImpl.resolveStorageOrganizationId("carbon.super", " "));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtilsConnectConfigTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtilsConnectConfigTest.java
@@ -86,4 +86,17 @@ public class GatewayManagementUtilsConnectConfigTest {
 
         Assert.assertTrue(errors.isEmpty());
     }
+
+    @Test
+    public void testValidateConnectGatewayEntriesRejectsInvalidName() {
+        ConnectGatewayConfig entry = new ConnectGatewayConfig();
+        entry.setRegistrationToken("token-id.plain-token-value");
+        entry.setUrl("https://gw.example.com:8243");
+        entry.setName("Invalid_Gateway_Name");
+
+        List<String> errors = GatewayManagementUtils.validateConnectGatewayEntries(Collections.singletonList(entry));
+
+        Assert.assertEquals(1, errors.size());
+        Assert.assertTrue(errors.get(0).contains("invalid name"));
+    }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtilsConnectConfigTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtilsConnectConfigTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.impl.utils;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
 
 import java.util.Arrays;
@@ -60,6 +61,19 @@ public class GatewayManagementUtilsConnectConfigTest {
 
         Assert.assertEquals(1, errors.size());
         Assert.assertTrue(errors.get(0).contains("invalid registration_token format"));
+    }
+
+    @Test
+    public void testValidateConnectGatewayEntriesRejectsAllTenantsOrganization() {
+        ConnectGatewayConfig entry = new ConnectGatewayConfig();
+        entry.setRegistrationToken("token-id.plain-token-value");
+        entry.setUrl("https://gw.example.com:8243");
+        entry.setOrganization(APIConstants.GatewayNotification.WSO2_ALL_TENANTS);
+
+        List<String> errors = GatewayManagementUtils.validateConnectGatewayEntries(Collections.singletonList(entry));
+
+        Assert.assertEquals(1, errors.size());
+        Assert.assertTrue(errors.get(0).contains("WSO2-ALL-TENANTS is not supported"));
     }
 
     @Test

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtilsConnectConfigTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/GatewayManagementUtilsConnectConfigTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class GatewayManagementUtilsConnectConfigTest {
+
+    @Test
+    public void testValidateConnectGatewayEntriesReportsMissingToken() {
+        ConnectGatewayConfig entry = new ConnectGatewayConfig();
+        entry.setUrl("https://gw.example.com:8243");
+
+        List<String> errors = GatewayManagementUtils.validateConnectGatewayEntries(Collections.singletonList(entry));
+
+        Assert.assertEquals(1, errors.size());
+        Assert.assertTrue(errors.get(0).contains("mandatory 'registration_token' is missing"));
+    }
+
+    @Test
+    public void testValidateConnectGatewayEntriesReportsMissingUrl() {
+        ConnectGatewayConfig entry = new ConnectGatewayConfig();
+        entry.setRegistrationToken("token-id.plain-token-value");
+
+        List<String> errors = GatewayManagementUtils.validateConnectGatewayEntries(Collections.singletonList(entry));
+
+        Assert.assertEquals(1, errors.size());
+        Assert.assertTrue(errors.get(0).contains("mandatory 'url' is missing"));
+    }
+
+    @Test
+    public void testValidateConnectGatewayEntriesReportsInvalidTokenFormat() {
+        ConnectGatewayConfig entry = new ConnectGatewayConfig();
+        entry.setRegistrationToken("invalid-token-without-separator");
+        entry.setUrl("https://gw.example.com:8243");
+
+        List<String> errors = GatewayManagementUtils.validateConnectGatewayEntries(Collections.singletonList(entry));
+
+        Assert.assertEquals(1, errors.size());
+        Assert.assertTrue(errors.get(0).contains("invalid registration_token format"));
+    }
+
+    @Test
+    public void testValidateConnectGatewayEntriesAcceptsValidEntry() {
+        ConnectGatewayConfig entry = new ConnectGatewayConfig();
+        entry.setRegistrationToken("token-id.plain-token-value");
+        entry.setUrl("https://gw.example.com:8243");
+
+        List<String> errors = GatewayManagementUtils.validateConnectGatewayEntries(Arrays.asList(entry, null));
+
+        Assert.assertTrue(errors.isEmpty());
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtilTest.java
@@ -20,8 +20,15 @@ package org.wso2.carbon.apimgt.impl.utils;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.apimgt.impl.dao.PlatformGatewayDAO;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PlatformGatewayDAO.class})
 public class PlatformGatewayTokenUtilTest {
 
     @Test
@@ -40,6 +47,11 @@ public class PlatformGatewayTokenUtilTest {
     }
 
     @Test
+    public void testConstantTimeEqualsRejectsDifferentLengthWithoutEarlyReturn() {
+        Assert.assertFalse(PlatformGatewayTokenUtil.constantTimeEquals("short", "much-longer-value"));
+    }
+
+    @Test
     public void testMatchesActiveTokenHash() throws Exception {
         String plainToken = "plain-token";
         String hash = PlatformGatewayTokenUtil.hashToken(plainToken);
@@ -47,5 +59,47 @@ public class PlatformGatewayTokenUtilTest {
                 new PlatformGatewayDAO.TokenWithGateway(hash, "gw-1", "carbon.super", "gw");
         Assert.assertTrue(PlatformGatewayTokenUtil.matchesActiveTokenHash(tokenRow, plainToken));
         Assert.assertFalse(PlatformGatewayTokenUtil.matchesActiveTokenHash(tokenRow, "other-token"));
+    }
+
+    @Test
+    public void testMatchesConnectConfigRegistrationTokenAllowsPreBootstrap() throws Exception {
+        PowerMockito.mockStatic(PlatformGatewayDAO.class);
+        PlatformGatewayDAO dao = Mockito.mock(PlatformGatewayDAO.class);
+        PowerMockito.when(PlatformGatewayDAO.getInstance()).thenReturn(dao);
+        Mockito.when(dao.getActiveTokenById("token-id")).thenReturn(null);
+
+        String apiKey = "token-id.plain-token";
+        Assert.assertTrue(PlatformGatewayTokenUtil.matchesConnectConfigRegistrationToken(apiKey, apiKey));
+    }
+
+    @Test
+    public void testMatchesConnectConfigRegistrationTokenRejectsStaleTomlAfterRotation() throws Exception {
+        PowerMockito.mockStatic(PlatformGatewayDAO.class);
+        PlatformGatewayDAO dao = Mockito.mock(PlatformGatewayDAO.class);
+        PowerMockito.when(PlatformGatewayDAO.getInstance()).thenReturn(dao);
+
+        String stalePlain = "old-plain-token";
+        String newPlain = "new-plain-token";
+        String tokenId = "token-id";
+        String staleApiKey = tokenId + "." + stalePlain;
+        String newHash = PlatformGatewayTokenUtil.hashToken(newPlain);
+        PlatformGatewayDAO.TokenWithGateway activeRow =
+                new PlatformGatewayDAO.TokenWithGateway(newHash, "gw-1", "carbon.super", "gw");
+        Mockito.when(dao.getActiveTokenById(tokenId)).thenReturn(activeRow);
+
+        Assert.assertFalse(PlatformGatewayTokenUtil.matchesConnectConfigRegistrationToken(staleApiKey, staleApiKey));
+        Assert.assertTrue(PlatformGatewayTokenUtil.matchesConnectConfigRegistrationToken(
+                tokenId + "." + newPlain, tokenId + "." + newPlain));
+    }
+
+    @Test
+    public void testMatchesConnectConfigRegistrationTokenRejectsMismatchedConfig() throws Exception {
+        PowerMockito.mockStatic(PlatformGatewayDAO.class);
+        PlatformGatewayDAO dao = Mockito.mock(PlatformGatewayDAO.class);
+        PowerMockito.when(PlatformGatewayDAO.getInstance()).thenReturn(dao);
+        Mockito.when(dao.getActiveTokenById("token-id")).thenReturn(null);
+
+        Assert.assertFalse(PlatformGatewayTokenUtil.matchesConnectConfigRegistrationToken(
+                "token-id.plain-a", "token-id.plain-b"));
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtilTest.java
@@ -30,7 +30,12 @@ public class PlatformGatewayTokenUtilTest {
 
     @Test
     public void testConstantTimeEqualsMatchesSameToken() {
-        Assert.assertTrue(PlatformGatewayTokenUtil.constantTimeEquals(" id.plain ", "id.plain"));
+        Assert.assertTrue(PlatformGatewayTokenUtil.constantTimeEquals("id.plain", "id.plain"));
+    }
+
+    @Test
+    public void testConstantTimeEqualsRejectsWhitespacePaddedToken() {
+        Assert.assertFalse(PlatformGatewayTokenUtil.constantTimeEquals(" id.plain ", "id.plain"));
     }
 
     @Test

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtilTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.apimgt.impl.utils;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.wso2.carbon.apimgt.impl.dao.PlatformGatewayDAO;
 
 public class PlatformGatewayTokenUtilTest {
 
@@ -39,7 +40,12 @@ public class PlatformGatewayTokenUtilTest {
     }
 
     @Test
-    public void testConstantTimeEqualsRejectsDifferentToken() {
-        Assert.assertFalse(PlatformGatewayTokenUtil.constantTimeEquals("id.one", "id.two"));
+    public void testMatchesActiveTokenHash() throws Exception {
+        String plainToken = "plain-token";
+        String hash = PlatformGatewayTokenUtil.hashToken(plainToken);
+        PlatformGatewayDAO.TokenWithGateway tokenRow =
+                new PlatformGatewayDAO.TokenWithGateway(hash, "gw-1", "carbon.super", "gw");
+        Assert.assertTrue(PlatformGatewayTokenUtil.matchesActiveTokenHash(tokenRow, plainToken));
+        Assert.assertFalse(PlatformGatewayTokenUtil.matchesActiveTokenHash(tokenRow, "other-token"));
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtilTest.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/test/java/org/wso2/carbon/apimgt/impl/utils/PlatformGatewayTokenUtilTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.apimgt.impl.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PlatformGatewayTokenUtilTest {
+
+    @Test
+    public void testParseTokenId() {
+        Assert.assertEquals("abc-123", PlatformGatewayTokenUtil.parseTokenId("abc-123.plainTokenValue"));
+    }
+
+    @Test
+    public void testConstantTimeEqualsMatchesSameToken() {
+        Assert.assertTrue(PlatformGatewayTokenUtil.constantTimeEquals(" id.plain ", "id.plain"));
+    }
+
+    @Test
+    public void testConstantTimeEqualsRejectsDifferentToken() {
+        Assert.assertFalse(PlatformGatewayTokenUtil.constantTimeEquals("id.one", "id.two"));
+    }
+}

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/dto/PlatformGatewayAPIKeyDTO.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/gen/java/org/wso2/carbon/apimgt/internal/service/dto/PlatformGatewayAPIKeyDTO.java
@@ -1,0 +1,363 @@
+package org.wso2.carbon.apimgt.internal.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.validation.constraints.*;
+
+/**
+ * An active API-scoped key for a platform gateway, returned during bulk sync.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.*;
+import org.wso2.carbon.apimgt.rest.api.common.annotations.Scope;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+@ApiModel(description = "An active API-scoped key for a platform gateway, returned during bulk sync.")
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+
+public class PlatformGatewayAPIKeyDTO   {
+  
+    private String uuid = null;
+    private String name = null;
+    private String maskedApiKey = null;
+    private Map<String, String> apiKeyHashes = new HashMap<>();
+    private String artifactUuid = null;
+    private String status = null;
+    private String createdAt = null;
+    private String createdBy = null;
+    private String updatedAt = null;
+    private String expiresAt = null;
+    private String etag = null;
+    private String source = null;
+    private String externalRefId = null;
+    private String issuer = null;
+
+  /**
+   * Unique identifier of the API key.
+   **/
+  public PlatformGatewayAPIKeyDTO uuid(String uuid) {
+    this.uuid = uuid;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Unique identifier of the API key.")
+  @JsonProperty("uuid")
+  public String getUuid() {
+    return uuid;
+  }
+  public void setUuid(String uuid) {
+    this.uuid = uuid;
+  }
+
+  /**
+   * Human-readable name of the API key.
+   **/
+  public PlatformGatewayAPIKeyDTO name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Human-readable name of the API key.")
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Masked representation of the API key (plaintext is not stored).
+   **/
+  public PlatformGatewayAPIKeyDTO maskedApiKey(String maskedApiKey) {
+    this.maskedApiKey = maskedApiKey;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Masked representation of the API key (plaintext is not stored).")
+  @JsonProperty("maskedApiKey")
+  public String getMaskedApiKey() {
+    return maskedApiKey;
+  }
+  public void setMaskedApiKey(String maskedApiKey) {
+    this.maskedApiKey = maskedApiKey;
+  }
+
+  /**
+   * Map of hash algorithm to hash value, e.g. {\&quot;sha256\&quot;:\&quot;&lt;hex&gt;\&quot;}.
+   **/
+  public PlatformGatewayAPIKeyDTO apiKeyHashes(Map<String, String> apiKeyHashes) {
+    this.apiKeyHashes = apiKeyHashes;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Map of hash algorithm to hash value, e.g. {\"sha256\":\"<hex>\"}.")
+  @JsonProperty("apiKeyHashes")
+  public Map<String, String> getApiKeyHashes() {
+    return apiKeyHashes;
+  }
+  public void setApiKeyHashes(Map<String, String> apiKeyHashes) {
+    this.apiKeyHashes = apiKeyHashes;
+  }
+
+  /**
+   * UUID of the API this key is scoped to.
+   **/
+  public PlatformGatewayAPIKeyDTO artifactUuid(String artifactUuid) {
+    this.artifactUuid = artifactUuid;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "UUID of the API this key is scoped to.")
+  @JsonProperty("artifactUuid")
+  public String getArtifactUuid() {
+    return artifactUuid;
+  }
+  public void setArtifactUuid(String artifactUuid) {
+    this.artifactUuid = artifactUuid;
+  }
+
+  /**
+   * Key status, e.g. ACTIVE.
+   **/
+  public PlatformGatewayAPIKeyDTO status(String status) {
+    this.status = status;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Key status, e.g. ACTIVE.")
+  @JsonProperty("status")
+  public String getStatus() {
+    return status;
+  }
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  /**
+   * ISO-8601 creation timestamp.
+   **/
+  public PlatformGatewayAPIKeyDTO createdAt(String createdAt) {
+    this.createdAt = createdAt;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "ISO-8601 creation timestamp.")
+  @JsonProperty("createdAt")
+  public String getCreatedAt() {
+    return createdAt;
+  }
+  public void setCreatedAt(String createdAt) {
+    this.createdAt = createdAt;
+  }
+
+  /**
+   * Username that created this key.
+   **/
+  public PlatformGatewayAPIKeyDTO createdBy(String createdBy) {
+    this.createdBy = createdBy;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Username that created this key.")
+  @JsonProperty("createdBy")
+  public String getCreatedBy() {
+    return createdBy;
+  }
+  public void setCreatedBy(String createdBy) {
+    this.createdBy = createdBy;
+  }
+
+  /**
+   * ISO-8601 last-updated timestamp.
+   **/
+  public PlatformGatewayAPIKeyDTO updatedAt(String updatedAt) {
+    this.updatedAt = updatedAt;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "ISO-8601 last-updated timestamp.")
+  @JsonProperty("updatedAt")
+  public String getUpdatedAt() {
+    return updatedAt;
+  }
+  public void setUpdatedAt(String updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+
+  /**
+   * ISO-8601 expiry timestamp. Absent if the key never expires.
+   **/
+  public PlatformGatewayAPIKeyDTO expiresAt(String expiresAt) {
+    this.expiresAt = expiresAt;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "ISO-8601 expiry timestamp. Absent if the key never expires.")
+  @JsonProperty("expiresAt")
+  public String getExpiresAt() {
+    return expiresAt;
+  }
+  public void setExpiresAt(String expiresAt) {
+    this.expiresAt = expiresAt;
+  }
+
+  /**
+   * Opaque version tag for cache validation.
+   **/
+  public PlatformGatewayAPIKeyDTO etag(String etag) {
+    this.etag = etag;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Opaque version tag for cache validation.")
+  @JsonProperty("etag")
+  public String getEtag() {
+    return etag;
+  }
+  public void setEtag(String etag) {
+    this.etag = etag;
+  }
+
+  /**
+   * Origin of the key, e.g. &#39;external&#39;.
+   **/
+  public PlatformGatewayAPIKeyDTO source(String source) {
+    this.source = source;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Origin of the key, e.g. 'external'.")
+  @JsonProperty("source")
+  public String getSource() {
+    return source;
+  }
+  public void setSource(String source) {
+    this.source = source;
+  }
+
+  /**
+   * External reference identifier.
+   **/
+  public PlatformGatewayAPIKeyDTO externalRefId(String externalRefId) {
+    this.externalRefId = externalRefId;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "External reference identifier.")
+  @JsonProperty("externalRefId")
+  public String getExternalRefId() {
+    return externalRefId;
+  }
+  public void setExternalRefId(String externalRefId) {
+    this.externalRefId = externalRefId;
+  }
+
+  /**
+   * Issuer identifier.
+   **/
+  public PlatformGatewayAPIKeyDTO issuer(String issuer) {
+    this.issuer = issuer;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "Issuer identifier.")
+  @JsonProperty("issuer")
+  public String getIssuer() {
+    return issuer;
+  }
+  public void setIssuer(String issuer) {
+    this.issuer = issuer;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PlatformGatewayAPIKeyDTO platformGatewayAPIKey = (PlatformGatewayAPIKeyDTO) o;
+    return Objects.equals(uuid, platformGatewayAPIKey.uuid) &&
+        Objects.equals(name, platformGatewayAPIKey.name) &&
+        Objects.equals(maskedApiKey, platformGatewayAPIKey.maskedApiKey) &&
+        Objects.equals(apiKeyHashes, platformGatewayAPIKey.apiKeyHashes) &&
+        Objects.equals(artifactUuid, platformGatewayAPIKey.artifactUuid) &&
+        Objects.equals(status, platformGatewayAPIKey.status) &&
+        Objects.equals(createdAt, platformGatewayAPIKey.createdAt) &&
+        Objects.equals(createdBy, platformGatewayAPIKey.createdBy) &&
+        Objects.equals(updatedAt, platformGatewayAPIKey.updatedAt) &&
+        Objects.equals(expiresAt, platformGatewayAPIKey.expiresAt) &&
+        Objects.equals(etag, platformGatewayAPIKey.etag) &&
+        Objects.equals(source, platformGatewayAPIKey.source) &&
+        Objects.equals(externalRefId, platformGatewayAPIKey.externalRefId) &&
+        Objects.equals(issuer, platformGatewayAPIKey.issuer);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(uuid, name, maskedApiKey, apiKeyHashes, artifactUuid, status, createdAt, createdBy, updatedAt, expiresAt, etag, source, externalRefId, issuer);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class PlatformGatewayAPIKeyDTO {\n");
+    
+    sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    maskedApiKey: ").append(toIndentedString(maskedApiKey)).append("\n");
+    sb.append("    apiKeyHashes: ").append(toIndentedString(apiKeyHashes)).append("\n");
+    sb.append("    artifactUuid: ").append(toIndentedString(artifactUuid)).append("\n");
+    sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
+    sb.append("    createdBy: ").append(toIndentedString(createdBy)).append("\n");
+    sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    expiresAt: ").append(toIndentedString(expiresAt)).append("\n");
+    sb.append("    etag: ").append(toIndentedString(etag)).append("\n");
+    sb.append("    source: ").append(toIndentedString(source)).append("\n");
+    sb.append("    externalRefId: ").append(toIndentedString(externalRefId)).append("\n");
+    sb.append("    issuer: ").append(toIndentedString(issuer)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyGatewayApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyGatewayApiServiceImpl.java
@@ -27,10 +27,12 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.GatewayManagementDAO;
+import org.wso2.carbon.apimgt.impl.dao.PlatformGatewayDAO;
 import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.service.PlatformGatewayServiceImpl;
 import org.wso2.carbon.apimgt.impl.utils.GatewayManagementUtils;
+import org.wso2.carbon.apimgt.impl.utils.PlatformGatewayTokenUtil;
 import org.wso2.carbon.apimgt.internal.service.NotifyGatewayApiService;
 import org.wso2.carbon.apimgt.internal.service.dto.ErrorDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.NotifyGatewayPayloadDTO;
@@ -87,15 +89,27 @@ public class NotifyGatewayApiServiceImpl implements NotifyGatewayApiService {
                 && StringUtils.isNotBlank(gatewayId)) {
             ConnectGatewayConfig matchedEntry =
                     PlatformGatewayApiKeyAuthInterceptor.CONNECT_WITH_TOKEN_MATCHED_ENTRY.get();
-            if (matchedEntry != null) {
-                org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig connectConfig =
-                        ServiceReferenceHolder.getInstance()
-                                .getAPIManagerConfigurationService().getAPIManagerConfiguration()
-                                .getPlatformGatewayConnectConfig();
-                if (connectConfig != null) {
-                    PlatformGatewayServiceImpl.ensurePlatformGatewayFromConnectToken(
-                            connectConfig, gatewayId, matchedEntry);
-                }
+            if (matchedEntry == null) {
+                log.error("Connect-with-token REGISTER missing matched config entry for gateway: " + gatewayId);
+                throw new APIManagementException("Platform gateway bootstrap failed: connect config entry not found",
+                        ExceptionCodes.GATEWAY_NOTIFICATION_INTERNAL_SERVER_ERROR);
+            }
+            org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig connectConfig =
+                    ServiceReferenceHolder.getInstance()
+                            .getAPIManagerConfigurationService().getAPIManagerConfiguration()
+                            .getPlatformGatewayConnectConfig();
+            if (connectConfig == null) {
+                log.error("Connect-with-token REGISTER missing platform gateway connect config for gateway: "
+                        + gatewayId);
+                throw new APIManagementException("Platform gateway bootstrap failed: connect config not loaded",
+                        ExceptionCodes.GATEWAY_NOTIFICATION_INTERNAL_SERVER_ERROR);
+            }
+            boolean bootstrapped = PlatformGatewayServiceImpl.ensurePlatformGatewayFromConnectToken(
+                    connectConfig, gatewayId, matchedEntry);
+            if (!bootstrapped && !isConnectTokenRegistered(matchedEntry)) {
+                log.error("Connect-with-token REGISTER failed to create platform gateway for gateway: " + gatewayId);
+                throw new APIManagementException("Platform gateway bootstrap failed",
+                        ExceptionCodes.GATEWAY_NOTIFICATION_INTERNAL_SERVER_ERROR);
             }
         }
 
@@ -135,6 +149,24 @@ public class NotifyGatewayApiServiceImpl implements NotifyGatewayApiService {
 
         responseDTO.setGatewayId(gatewayId);
         return Response.ok(responseDTO).build();
+    }
+
+    private boolean isConnectTokenRegistered(ConnectGatewayConfig matchedEntry) {
+        String registrationToken = matchedEntry.getRegistrationToken();
+        if (StringUtils.isBlank(registrationToken)) {
+            return false;
+        }
+        String separator = PlatformGatewayTokenUtil.COMBINED_TOKEN_SEPARATOR;
+        int sep = registrationToken.indexOf(separator);
+        if (sep <= 0 || sep >= registrationToken.length() - 1) {
+            return false;
+        }
+        try {
+            return PlatformGatewayDAO.getInstance().getActiveTokenById(registrationToken.substring(0, sep)) != null;
+        } catch (APIManagementException e) {
+            log.warn("Could not verify connect token registration state: " + e.getMessage(), e);
+            return false;
+        }
     }
 
     private Response handleHeartbeat(NotifyGatewayPayloadDTO dto, List<String> organizations)

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyGatewayApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyGatewayApiServiceImpl.java
@@ -19,25 +19,23 @@
 package org.wso2.carbon.apimgt.internal.service.impl;
 
 import com.google.gson.Gson;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.GatewayManagementDAO;
 import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.service.PlatformGatewayServiceImpl;
 import org.wso2.carbon.apimgt.impl.utils.GatewayManagementUtils;
-import org.apache.cxf.jaxrs.ext.MessageContext;
-
 import org.wso2.carbon.apimgt.internal.service.NotifyGatewayApiService;
 import org.wso2.carbon.apimgt.internal.service.dto.ErrorDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.NotifyGatewayPayloadDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.NotifyGatewayStatusResponseDTO;
 import org.wso2.carbon.apimgt.internal.service.interceptors.PlatformGatewayApiKeyAuthInterceptor;
-import org.wso2.carbon.apimgt.api.ExceptionCodes;
-
-import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyGatewayApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyGatewayApiServiceImpl.java
@@ -105,9 +105,7 @@ public class NotifyGatewayApiServiceImpl implements NotifyGatewayApiService {
                         ExceptionCodes.GATEWAY_NOTIFICATION_INTERNAL_SERVER_ERROR);
             }
             boolean bootstrapped = PlatformGatewayServiceImpl.ensurePlatformGatewayFromConnectToken(
-                    connectConfig, PlatformGatewayServiceImpl.resolveConnectGatewayId(
-                            PlatformGatewayTokenUtil.parseTokenId(matchedEntry.getRegistrationToken())),
-                    matchedEntry);
+                    connectConfig, matchedEntry);
             if (!bootstrapped && !isConnectTokenRegistered(matchedEntry)) {
                 log.error("Connect-with-token REGISTER failed to create platform gateway for gateway: " + gatewayId);
                 throw new APIManagementException("Platform gateway bootstrap failed",

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyGatewayApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyGatewayApiServiceImpl.java
@@ -105,7 +105,9 @@ public class NotifyGatewayApiServiceImpl implements NotifyGatewayApiService {
                         ExceptionCodes.GATEWAY_NOTIFICATION_INTERNAL_SERVER_ERROR);
             }
             boolean bootstrapped = PlatformGatewayServiceImpl.ensurePlatformGatewayFromConnectToken(
-                    connectConfig, gatewayId, matchedEntry);
+                    connectConfig, PlatformGatewayServiceImpl.resolveConnectGatewayId(
+                            PlatformGatewayTokenUtil.parseTokenId(matchedEntry.getRegistrationToken())),
+                    matchedEntry);
             if (!bootstrapped && !isConnectTokenRegistered(matchedEntry)) {
                 log.error("Connect-with-token REGISTER failed to create platform gateway for gateway: " + gatewayId);
                 throw new APIManagementException("Platform gateway bootstrap failed",
@@ -152,17 +154,12 @@ public class NotifyGatewayApiServiceImpl implements NotifyGatewayApiService {
     }
 
     private boolean isConnectTokenRegistered(ConnectGatewayConfig matchedEntry) {
-        String registrationToken = matchedEntry.getRegistrationToken();
-        if (StringUtils.isBlank(registrationToken)) {
-            return false;
-        }
-        String separator = PlatformGatewayTokenUtil.COMBINED_TOKEN_SEPARATOR;
-        int sep = registrationToken.indexOf(separator);
-        if (sep <= 0 || sep >= registrationToken.length() - 1) {
+        String tokenId = PlatformGatewayTokenUtil.parseTokenId(matchedEntry.getRegistrationToken());
+        if (StringUtils.isBlank(tokenId)) {
             return false;
         }
         try {
-            return PlatformGatewayDAO.getInstance().getActiveTokenById(registrationToken.substring(0, sep)) != null;
+            return PlatformGatewayDAO.getInstance().getActiveTokenById(tokenId) != null;
         } catch (APIManagementException e) {
             log.warn("Could not verify connect token registration state: " + e.getMessage(), e);
             return false;

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyGatewayApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/impl/NotifyGatewayApiServiceImpl.java
@@ -24,6 +24,9 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.GatewayManagementDAO;
+import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.service.PlatformGatewayServiceImpl;
 import org.wso2.carbon.apimgt.impl.utils.GatewayManagementUtils;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 
@@ -31,7 +34,10 @@ import org.wso2.carbon.apimgt.internal.service.NotifyGatewayApiService;
 import org.wso2.carbon.apimgt.internal.service.dto.ErrorDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.NotifyGatewayPayloadDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.NotifyGatewayStatusResponseDTO;
+import org.wso2.carbon.apimgt.internal.service.interceptors.PlatformGatewayApiKeyAuthInterceptor;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
+
+import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -76,6 +82,23 @@ public class NotifyGatewayApiServiceImpl implements NotifyGatewayApiService {
         if (organizations == null || organizations.isEmpty()) {
             organizations = new ArrayList<>();
             organizations.add(APIConstants.GatewayNotification.WSO2_ALL_TENANTS);
+        }
+
+        // Connect with existing token: create platform gateway on first REGISTER when token matches a connect config
+        if (Boolean.TRUE.equals(PlatformGatewayApiKeyAuthInterceptor.CONNECT_WITH_TOKEN_AUTH.get())
+                && StringUtils.isNotBlank(gatewayId)) {
+            ConnectGatewayConfig matchedEntry =
+                    PlatformGatewayApiKeyAuthInterceptor.CONNECT_WITH_TOKEN_MATCHED_ENTRY.get();
+            if (matchedEntry != null) {
+                org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig connectConfig =
+                        ServiceReferenceHolder.getInstance()
+                                .getAPIManagerConfigurationService().getAPIManagerConfiguration()
+                                .getPlatformGatewayConnectConfig();
+                if (connectConfig != null) {
+                    PlatformGatewayServiceImpl.ensurePlatformGatewayFromConnectToken(
+                            connectConfig, gatewayId, matchedEntry);
+                }
+            }
         }
 
         NotifyGatewayStatusResponseDTO responseDTO = new NotifyGatewayStatusResponseDTO();

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayApiKeyAuthInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayApiKeyAuthInterceptor.java
@@ -115,7 +115,7 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
                 }
             }
             ConnectGatewayConfig matchedEntry = null;
-            if (connectConfig != null) {
+            if (connectConfig != null && connectConfig.getConnectGateways() != null) {
                 for (ConnectGatewayConfig entry : connectConfig.getConnectGateways()) {
                     if (entry == null || StringUtils.isBlank(entry.getRegistrationToken())) {
                         continue;

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayApiKeyAuthInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayApiKeyAuthInterceptor.java
@@ -25,7 +25,6 @@ import org.apache.cxf.interceptor.security.AuthenticationException;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
-import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.PlatformGatewayDAO;
 import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
 import org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig;
@@ -126,7 +125,7 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
                 message.put(MESSAGE_PROPERTY_CONNECT_WITH_TOKEN, Boolean.TRUE);
                 CONNECT_WITH_TOKEN_AUTH.set(Boolean.TRUE);
                 CONNECT_WITH_TOKEN_MATCHED_ENTRY.set(matchedEntry);
-                String org = getCurrentOrganization();
+                String org = matchedEntry.resolveOrganization();
                 message.put(RestApiConstants.REQUEST_AUTHENTICATION_SCHEME, RestApiConstants.PLATFORM_GATEWAY_API_KEY);
                 message.put(RestApiConstants.ORGANIZATION, org);
                 PrivilegedCarbonContext.startTenantFlow();
@@ -185,14 +184,6 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
         } finally {
             // endTenantFlow() is called in PlatformGatewayTenantFlowCleanupInterceptor (POST_INVOKE) so tenant remains set for resource invocation
         }
-    }
-
-    /**
-     * When config does not provide an explicit org, use the current APIM tenant or WSO2-ALL-TENANTS.
-     */
-    private static String getCurrentOrganization() {
-        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        return StringUtils.isNotBlank(tenantDomain) ? tenantDomain : APIConstants.GatewayNotification.WSO2_ALL_TENANTS;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayApiKeyAuthInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayApiKeyAuthInterceptor.java
@@ -25,7 +25,11 @@ import org.apache.cxf.interceptor.security.AuthenticationException;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.PlatformGatewayDAO;
+import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
+import org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig;
+import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.impl.utils.PlatformGatewayTokenUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
@@ -49,6 +53,15 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
 
     /** Message property set when this interceptor started the tenant flow; cleanup interceptor uses it to call endTenantFlow(). */
     public static final String MESSAGE_PROPERTY_TENANT_FLOW_STARTED = "PlatformGatewayTenantFlowStarted";
+
+    /** Set when request is allowed using config registration_token (gateway will be created on first REGISTER). */
+    public static final String MESSAGE_PROPERTY_CONNECT_WITH_TOKEN = "PlatformGatewayConnectWithToken";
+
+    /** ThreadLocal set when auth used config token so notify impl can create gateway on first REGISTER. */
+    public static final ThreadLocal<Boolean> CONNECT_WITH_TOKEN_AUTH = new ThreadLocal<>();
+
+    /** ThreadLocal set to the connect config that matched (for multiple gateways). */
+    public static final ThreadLocal<ConnectGatewayConfig> CONNECT_WITH_TOKEN_MATCHED_ENTRY = new ThreadLocal<>();
 
     /**
      * Path segments for which platform gateway api-key auth is allowed (no leading slash; matched
@@ -89,6 +102,54 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
             throw new AuthenticationException("Unauthenticated request");
         }
         if (gateway == null) {
+            PlatformGatewayConnectConfig connectConfig = null;
+            try {
+                connectConfig = ServiceReferenceHolder.getInstance()
+                        .getAPIManagerConfigurationService().getAPIManagerConfiguration()
+                        .getPlatformGatewayConnectConfig();
+            } catch (Exception e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Could not get platform gateway connect config", e);
+                }
+            }
+            ConnectGatewayConfig matchedEntry = null;
+            if (connectConfig != null) {
+                for (ConnectGatewayConfig entry : connectConfig.getConnectGateways()) {
+                    if (entry != null && StringUtils.isNotBlank(entry.getRegistrationToken())
+                            && apiKey.trim().equals(entry.getRegistrationToken().trim())) {
+                        matchedEntry = entry;
+                        break;
+                    }
+                }
+            }
+            if (matchedEntry != null) {
+                message.put(MESSAGE_PROPERTY_CONNECT_WITH_TOKEN, Boolean.TRUE);
+                CONNECT_WITH_TOKEN_AUTH.set(Boolean.TRUE);
+                CONNECT_WITH_TOKEN_MATCHED_ENTRY.set(matchedEntry);
+                String org = getCurrentOrganization();
+                message.put(RestApiConstants.REQUEST_AUTHENTICATION_SCHEME, RestApiConstants.PLATFORM_GATEWAY_API_KEY);
+                message.put(RestApiConstants.ORGANIZATION, org);
+                PrivilegedCarbonContext.startTenantFlow();
+                try {
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(org);
+                    try {
+                        int tenantId = APIUtil.getTenantIdFromTenantDomain(org);
+                        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(tenantId);
+                    } catch (Exception e) {
+                        log.error("Could not resolve tenant id for org " + org + "; rejecting request", e);
+                        PrivilegedCarbonContext.endTenantFlow();
+                        throw new AuthenticationException("Unauthenticated request");
+                    }
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername("admin@" + org);
+                    message.put(MESSAGE_PROPERTY_TENANT_FLOW_STARTED, Boolean.TRUE);
+                } finally {
+                    // endTenantFlow in cleanup interceptor
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug("Request allowed via connect-with-token config; gateway will be created on REGISTER");
+                }
+                return;
+            }
             throw new AuthenticationException("Unauthenticated request");
         }
         message.put(RestApiConstants.REQUEST_AUTHENTICATION_SCHEME, RestApiConstants.PLATFORM_GATEWAY_API_KEY);
@@ -124,6 +185,14 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
         } finally {
             // endTenantFlow() is called in PlatformGatewayTenantFlowCleanupInterceptor (POST_INVOKE) so tenant remains set for resource invocation
         }
+    }
+
+    /**
+     * When config does not provide an explicit org, use the current APIM tenant or WSO2-ALL-TENANTS.
+     */
+    private static String getCurrentOrganization() {
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        return StringUtils.isNotBlank(tenantDomain) ? tenantDomain : APIConstants.GatewayNotification.WSO2_ALL_TENANTS;
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayApiKeyAuthInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayApiKeyAuthInterceptor.java
@@ -137,6 +137,7 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
                     } catch (Exception e) {
                         log.error("Could not resolve tenant id for org " + org + "; rejecting request", e);
                         PrivilegedCarbonContext.endTenantFlow();
+                        clearConnectWithTokenAuthState();
                         throw new AuthenticationException("Unauthenticated request");
                     }
                     PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername("admin@" + org);
@@ -219,5 +220,10 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
             }
         }
         return null;
+    }
+
+    private static void clearConnectWithTokenAuthState() {
+        CONNECT_WITH_TOKEN_AUTH.remove();
+        CONNECT_WITH_TOKEN_MATCHED_ENTRY.remove();
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayApiKeyAuthInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayApiKeyAuthInterceptor.java
@@ -115,7 +115,7 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
             if (connectConfig != null) {
                 for (ConnectGatewayConfig entry : connectConfig.getConnectGateways()) {
                     if (entry != null && StringUtils.isNotBlank(entry.getRegistrationToken())
-                            && apiKey.trim().equals(entry.getRegistrationToken().trim())) {
+                            && PlatformGatewayTokenUtil.constantTimeEquals(entry.getRegistrationToken(), apiKey)) {
                         matchedEntry = entry;
                         break;
                     }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayApiKeyAuthInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayApiKeyAuthInterceptor.java
@@ -84,6 +84,9 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
         if (!isPlatformGatewayAllowedPath(message)) {
             return;
         }
+        // Clear stale connect-auth state from a prior request on this pooled thread (e.g. if a fault
+        // skipped the cleanup interceptor before outFaultInterceptors was registered).
+        clearConnectWithTokenAuthState();
         @SuppressWarnings("unchecked")
         Map<String, List<String>> headers = (Map<String, List<String>>) message.get(Message.PROTOCOL_HEADERS);
         if (headers == null) {
@@ -114,10 +117,18 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
             ConnectGatewayConfig matchedEntry = null;
             if (connectConfig != null) {
                 for (ConnectGatewayConfig entry : connectConfig.getConnectGateways()) {
-                    if (entry != null && StringUtils.isNotBlank(entry.getRegistrationToken())
-                            && PlatformGatewayTokenUtil.constantTimeEquals(entry.getRegistrationToken(), apiKey)) {
-                        matchedEntry = entry;
-                        break;
+                    if (entry == null || StringUtils.isBlank(entry.getRegistrationToken())) {
+                        continue;
+                    }
+                    try {
+                        if (PlatformGatewayTokenUtil.matchesConnectConfigRegistrationToken(
+                                entry.getRegistrationToken(), apiKey)) {
+                            matchedEntry = entry;
+                            break;
+                        }
+                    } catch (Exception e) {
+                        log.warn("Connect-with-token config match failed for entry name="
+                                + entry.getName(), e);
                     }
                 }
             }
@@ -128,23 +139,7 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
                 String org = matchedEntry.resolveOrganization();
                 message.put(RestApiConstants.REQUEST_AUTHENTICATION_SCHEME, RestApiConstants.PLATFORM_GATEWAY_API_KEY);
                 message.put(RestApiConstants.ORGANIZATION, org);
-                PrivilegedCarbonContext.startTenantFlow();
-                try {
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(org);
-                    try {
-                        int tenantId = APIUtil.getTenantIdFromTenantDomain(org);
-                        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(tenantId);
-                    } catch (Exception e) {
-                        log.error("Could not resolve tenant id for org " + org + "; rejecting request", e);
-                        PrivilegedCarbonContext.endTenantFlow();
-                        clearConnectWithTokenAuthState();
-                        throw new AuthenticationException("Unauthenticated request");
-                    }
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername("admin@" + org);
-                    message.put(MESSAGE_PROPERTY_TENANT_FLOW_STARTED, Boolean.TRUE);
-                } finally {
-                    // endTenantFlow in cleanup interceptor
-                }
+                startPlatformGatewayTenantFlow(message, org);
                 if (log.isDebugEnabled()) {
                     log.debug("Request allowed via connect-with-token config; gateway will be created on REGISTER");
                 }
@@ -162,29 +157,38 @@ public class PlatformGatewayApiKeyAuthInterceptor extends AbstractPhaseIntercept
         message.put(RestApiConstants.ORGANIZATION, org);
 
         // Set CarbonContext so getLoggedInUserProvider() and Registry/tenant lookups use this org (avoids "organizationnull").
-        PrivilegedCarbonContext.startTenantFlow();
-        try {
-            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(org);
-            try {
-                int tenantId = APIUtil.getTenantIdFromTenantDomain(org);
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(tenantId);
-            } catch (Exception e) {
-                log.error("Could not resolve tenant id for org " + org + "; rejecting request", e);
-                PrivilegedCarbonContext.endTenantFlow();
-                throw new AuthenticationException("Unauthenticated request");
-            }
-            // Username format expected by getAPIProvider: e.g. admin@carbon.super so tenant is derived correctly.
-            String systemUser = "admin@" + org;
-            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(systemUser);
+        startPlatformGatewayTenantFlow(message, org);
 
-            message.put(MESSAGE_PROPERTY_TENANT_FLOW_STARTED, Boolean.TRUE);
-
-            if (log.isDebugEnabled()) {
-                log.debug("Request authenticated via platform gateway api-key for gateway: " + gateway.id);
-            }
-        } finally {
-            // endTenantFlow() is called in PlatformGatewayTenantFlowCleanupInterceptor (POST_INVOKE) so tenant remains set for resource invocation
+        if (log.isDebugEnabled()) {
+            log.debug("Request authenticated via platform gateway api-key for gateway: " + gateway.id);
         }
+    }
+
+    /**
+     * Starts tenant flow for platform-gateway internal API calls using the tenant's configured admin
+     * username from the user realm (not a hardcoded {@code admin@<org>}).
+     */
+    private void startPlatformGatewayTenantFlow(Message message, String org) {
+        String tenantAdminUsername;
+        try {
+            tenantAdminUsername = APIUtil.getTenantAdminUserName(org);
+        } catch (Exception e) {
+            log.error("Could not resolve tenant admin username for org " + org + "; rejecting request", e);
+            clearConnectWithTokenAuthState();
+            throw new AuthenticationException("Unauthenticated request");
+        }
+        PrivilegedCarbonContext.startTenantFlow();
+        message.put(MESSAGE_PROPERTY_TENANT_FLOW_STARTED, Boolean.TRUE);
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(org);
+        try {
+            int tenantId = APIUtil.getTenantIdFromTenantDomain(org);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(tenantId);
+        } catch (Exception e) {
+            log.error("Could not resolve tenant id for org " + org + "; rejecting request", e);
+            clearConnectWithTokenAuthState();
+            throw new AuthenticationException("Unauthenticated request");
+        }
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(tenantAdminUsername);
     }
 
     /**

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayTenantFlowCleanupInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayTenantFlowCleanupInterceptor.java
@@ -29,7 +29,8 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
  * a message property. This interceptor calls {@link PrivilegedCarbonContext#endTenantFlow()}
  * so the tenant flow started there is properly closed and the thread-local is cleared.
  * {@link #handleFault(Message)} runs on fault responses so cleanup also occurs when
- * an exception is thrown after the auth interceptor started the tenant flow.
+ * an exception is thrown after the auth interceptor started the tenant flow. Registered as a
+ * CXF out-interceptor ({@code jaxrs.outInterceptors}) so it runs after every request completes.
  */
 public class PlatformGatewayTenantFlowCleanupInterceptor extends AbstractPhaseInterceptor<Message> {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayTenantFlowCleanupInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayTenantFlowCleanupInterceptor.java
@@ -53,13 +53,14 @@ public class PlatformGatewayTenantFlowCleanupInterceptor extends AbstractPhaseIn
      * handleMessage (success path) and handleFault (exception path).
      */
     private void ensureTenantFlowCleanedUp(Message message) {
-        if (!Boolean.TRUE.equals(message.get(PlatformGatewayApiKeyAuthInterceptor.MESSAGE_PROPERTY_TENANT_FLOW_STARTED))) {
-            return;
-        }
         try {
-            PrivilegedCarbonContext.endTenantFlow();
+            if (Boolean.TRUE.equals(
+                    message.get(PlatformGatewayApiKeyAuthInterceptor.MESSAGE_PROPERTY_TENANT_FLOW_STARTED))) {
+                PrivilegedCarbonContext.endTenantFlow();
+            }
         } finally {
             message.remove(PlatformGatewayApiKeyAuthInterceptor.MESSAGE_PROPERTY_TENANT_FLOW_STARTED);
+            message.remove(PlatformGatewayApiKeyAuthInterceptor.MESSAGE_PROPERTY_CONNECT_WITH_TOKEN);
             PlatformGatewayApiKeyAuthInterceptor.CONNECT_WITH_TOKEN_AUTH.remove();
             PlatformGatewayApiKeyAuthInterceptor.CONNECT_WITH_TOKEN_MATCHED_ENTRY.remove();
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayTenantFlowCleanupInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayTenantFlowCleanupInterceptor.java
@@ -60,6 +60,8 @@ public class PlatformGatewayTenantFlowCleanupInterceptor extends AbstractPhaseIn
             PrivilegedCarbonContext.endTenantFlow();
         } finally {
             message.remove(PlatformGatewayApiKeyAuthInterceptor.MESSAGE_PROPERTY_TENANT_FLOW_STARTED);
+            PlatformGatewayApiKeyAuthInterceptor.CONNECT_WITH_TOKEN_AUTH.remove();
+            PlatformGatewayApiKeyAuthInterceptor.CONNECT_WITH_TOKEN_MATCHED_ENTRY.remove();
         }
     }
 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayTenantFlowCleanupInterceptor.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/interceptors/PlatformGatewayTenantFlowCleanupInterceptor.java
@@ -28,9 +28,10 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
  * via platform gateway api-key, {@link PlatformGatewayApiKeyAuthInterceptor} sets
  * a message property. This interceptor calls {@link PrivilegedCarbonContext#endTenantFlow()}
  * so the tenant flow started there is properly closed and the thread-local is cleared.
- * {@link #handleFault(Message)} runs on fault responses so cleanup also occurs when
- * an exception is thrown after the auth interceptor started the tenant flow. Registered as a
- * CXF out-interceptor ({@code jaxrs.outInterceptors}) so it runs after every request completes.
+ * {@link #handleFault(Message)} runs on the out-fault chain when an exception is thrown after the
+ * auth interceptor started the tenant flow (CXF does not invoke {@code jaxrs.outInterceptors} on
+ * faults). Register in both {@code jaxrs.outInterceptors} (success path) and
+ * {@code jaxrs.outFaultInterceptors} (fault path).
  */
 public class PlatformGatewayTenantFlowCleanupInterceptor extends AbstractPhaseInterceptor<Message> {
 

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/websocket/GatewayConnectEndpoint.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/websocket/GatewayConnectEndpoint.java
@@ -187,16 +187,16 @@ public class GatewayConnectEndpoint {
             }
             if (matchedEntry != null && connectConfig != null) {
                 String newGatewayId = UUID.randomUUID().toString();
-                if (PlatformGatewayServiceImpl.ensurePlatformGatewayFromConnectToken(
-                        connectConfig, newGatewayId, matchedEntry)) {
-                    try {
-                        gateway = PlatformGatewayTokenUtil.verifyToken(apiKey);
-                    } catch (APIManagementException | NoSuchAlgorithmException e) {
-                        log.warn("Re-verify after connect-with-token failed: " + e.getMessage());
-                        closeWithUnauthorized(session, "Invalid or expired API key");
-                        return;
-                    }
-                } else {
+                PlatformGatewayServiceImpl.ensurePlatformGatewayFromConnectToken(
+                        connectConfig, newGatewayId, matchedEntry);
+                try {
+                    gateway = PlatformGatewayTokenUtil.verifyToken(apiKey);
+                } catch (APIManagementException | NoSuchAlgorithmException e) {
+                    log.warn("Re-verify after connect-with-token failed: " + e.getMessage());
+                    closeWithUnauthorized(session, "Invalid or expired API key");
+                    return;
+                }
+                if (gateway == null) {
                     log.warn("Connect-with-token gateway creation failed; ensure registration_token is "
                             + "tokenId.plainToken format and url is set in [[apim.platform_gateway.connect]]");
                 }

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/websocket/GatewayConnectEndpoint.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/websocket/GatewayConnectEndpoint.java
@@ -174,11 +174,18 @@ public class GatewayConnectEndpoint {
                         }
                     } else {
                         for (ConnectGatewayConfig entry : list) {
-                            if (entry != null && StringUtils.isNotBlank(entry.getRegistrationToken())
-                                    && PlatformGatewayTokenUtil.constantTimeEquals(
-                                            entry.getRegistrationToken(), apiKey)) {
-                                matchedEntry = entry;
-                                break;
+                            if (entry == null || StringUtils.isBlank(entry.getRegistrationToken())) {
+                                continue;
+                            }
+                            try {
+                                if (PlatformGatewayTokenUtil.matchesConnectConfigRegistrationToken(
+                                        entry.getRegistrationToken(), apiKey)) {
+                                    matchedEntry = entry;
+                                    break;
+                                }
+                            } catch (APIManagementException | NoSuchAlgorithmException e) {
+                                log.warn("Connect-with-token config match failed for entry name="
+                                        + entry.getName() + ": " + e.getMessage());
                             }
                         }
                         if (matchedEntry == null) {
@@ -195,10 +202,13 @@ public class GatewayConnectEndpoint {
                 log.warn("Could not get platform gateway connect config: " + e.getMessage(), e);
             }
             if (matchedEntry != null && connectConfig != null) {
-                String tokenId = PlatformGatewayTokenUtil.parseTokenId(matchedEntry.getRegistrationToken());
-                String connectGatewayId = PlatformGatewayServiceImpl.resolveConnectGatewayId(tokenId);
-                PlatformGatewayServiceImpl.ensurePlatformGatewayFromConnectToken(
-                        connectConfig, connectGatewayId, matchedEntry);
+                boolean created = PlatformGatewayServiceImpl.ensurePlatformGatewayFromConnectToken(
+                        connectConfig, matchedEntry);
+                if (!created) {
+                    log.warn("Connect-with-token bootstrap failed; closing connection");
+                    closeWithUnauthorized(session, "Invalid or expired API key");
+                    return;
+                }
                 try {
                     gateway = PlatformGatewayTokenUtil.verifyToken(apiKey);
                 } catch (APIManagementException | NoSuchAlgorithmException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/websocket/GatewayConnectEndpoint.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/websocket/GatewayConnectEndpoint.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.apimgt.internal.service.websocket;
 
 import com.google.gson.JsonSyntaxException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
@@ -29,13 +30,11 @@ import org.wso2.carbon.apimgt.impl.dao.PlatformGatewayDAO;
 import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
 import org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.service.PlatformGatewayServiceImpl;
+import org.wso2.carbon.apimgt.impl.utils.PlatformGatewayTokenUtil;
 import org.wso2.carbon.apimgt.internal.service.dto.GatewayDeploymentStatusAcknowledgmentDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.GatewayDeploymentStatusAcknowledgmentListDTO;
 import org.wso2.carbon.apimgt.internal.service.impl.NotifyApiDeploymentStatusApiServiceImpl;
-import org.wso2.carbon.apimgt.impl.service.PlatformGatewayServiceImpl;
-import org.wso2.carbon.apimgt.impl.utils.PlatformGatewayTokenUtil;
-
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/websocket/GatewayConnectEndpoint.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/websocket/GatewayConnectEndpoint.java
@@ -26,6 +26,8 @@ import org.wso2.carbon.apimgt.api.PlatformGatewayDeploymentEventService;
 import org.wso2.carbon.apimgt.api.model.PlatformGatewayDeploymentEventRecord;
 import org.wso2.carbon.apimgt.impl.dao.PlatformGatewayArtifactDAO;
 import org.wso2.carbon.apimgt.impl.dao.PlatformGatewayDAO;
+import org.wso2.carbon.apimgt.impl.dto.ConnectGatewayConfig;
+import org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.internal.service.dto.GatewayDeploymentStatusAcknowledgmentDTO;
 import org.wso2.carbon.apimgt.internal.service.dto.GatewayDeploymentStatusAcknowledgmentListDTO;
@@ -65,9 +67,12 @@ import javax.websocket.server.ServerEndpoint;
  * <p>
  * The gateway must send the registration token in the {@code api-key} HTTP header when opening
  * the WebSocket. The token is verified via {@link PlatformGatewayTokenUtil#verifyToken(String)}.
- * On success, the connection is associated with the gateway and the gateway's active status is
- * set to true; on close it is set to false. On verification failure, the connection is closed
- * with code 4401 (Unauthorized).
+ * If not found in the database, the token is checked against
+ * {@code [[apim.platform_gateway.connect]]} {@code registration_token} (deployment.toml); when
+ * it matches, a new platform gateway is created and the connection is accepted. On success, the
+ * connection is associated with the gateway and the gateway's active status is set to true; on
+ * close it is set to false. On verification failure, the connection is closed with code 4401
+ * (Unauthorized).
  */
 @ServerEndpoint(
         value = "/ws/gateways/connect",
@@ -148,8 +153,60 @@ public class GatewayConnectEndpoint {
         }
 
         if (gateway == null) {
-            closeWithUnauthorized(session, "Invalid or expired API key");
-            return;
+            log.info("Gateway WebSocket token not in DB; checking [[apim.platform_gateway.connect]] config");
+            ConnectGatewayConfig matchedEntry = null;
+            PlatformGatewayConnectConfig connectConfig = null;
+            try {
+                connectConfig = ServiceReferenceHolder.getInstance()
+                        .getAPIManagerConfigurationService().getAPIManagerConfiguration()
+                        .getPlatformGatewayConnectConfig();
+                if (connectConfig != null) {
+                    List<ConnectGatewayConfig> list = connectConfig.getConnectGateways();
+                    if (list == null || list.isEmpty()) {
+                        log.info("Connect config present but ConnectGateways list is empty; ensure api-manager.xml "
+                                + "contains PlatformGatewayConnectConfiguration/ConnectGateways from deployment.toml");
+                    } else {
+                        for (ConnectGatewayConfig entry : list) {
+                            if (entry != null && StringUtils.isNotBlank(entry.getRegistrationToken())
+                                    && apiKey.trim().equals(entry.getRegistrationToken().trim())) {
+                                matchedEntry = entry;
+                                break;
+                            }
+                        }
+                        if (matchedEntry == null) {
+                            log.info("No [[apim.platform_gateway.connect]] entry matched api-key; check "
+                                    + "registration_token in deployment.toml");
+                        }
+                    }
+                } else {
+                    log.info("Platform gateway connect config is null; ensure api-manager.xml has "
+                            + "PlatformGatewayConnectConfiguration (from deployment.toml "
+                            + "apim.platform_gateway.connect)");
+                }
+            } catch (Exception e) {
+                log.warn("Could not get platform gateway connect config: " + e.getMessage(), e);
+            }
+            if (matchedEntry != null && connectConfig != null) {
+                String newGatewayId = UUID.randomUUID().toString();
+                if (PlatformGatewayServiceImpl.ensurePlatformGatewayFromConnectToken(
+                        connectConfig, newGatewayId, matchedEntry)) {
+                    try {
+                        gateway = PlatformGatewayTokenUtil.verifyToken(apiKey);
+                    } catch (APIManagementException | NoSuchAlgorithmException e) {
+                        log.warn("Re-verify after connect-with-token failed: " + e.getMessage());
+                        closeWithUnauthorized(session, "Invalid or expired API key");
+                        return;
+                    }
+                } else {
+                    log.warn("Connect-with-token gateway creation failed; ensure registration_token is "
+                            + "tokenId.plainToken format and url is set in [[apim.platform_gateway.connect]]");
+                }
+            }
+            if (gateway == null) {
+                log.info("Gateway WebSocket connection rejected: token did not match any gateway or config");
+                closeWithUnauthorized(session, "Invalid or expired API key");
+                return;
+            }
         }
 
         session.getUserProperties().put(GATEWAY_PROPERTY, gateway);

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/websocket/GatewayConnectEndpoint.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/java/org/wso2/carbon/apimgt/internal/service/websocket/GatewayConnectEndpoint.java
@@ -162,12 +162,21 @@ public class GatewayConnectEndpoint {
                 if (connectConfig != null) {
                     List<ConnectGatewayConfig> list = connectConfig.getConnectGateways();
                     if (list == null || list.isEmpty()) {
-                        log.info("Connect config present but ConnectGateways list is empty; ensure api-manager.xml "
-                                + "contains PlatformGatewayConnectConfiguration/ConnectGateways from deployment.toml");
+                        int declared = connectConfig.getDeclaredConnectEntryCount();
+                        if (declared > 0) {
+                            log.error(declared + " [[apim.platform_gateway.connect]] entr"
+                                    + (declared == 1 ? "y" : "ies")
+                                    + " in api-manager.xml but none loaded at runtime; "
+                                    + "check registration_token and url, then restart APIM");
+                        } else {
+                            log.info("No [[apim.platform_gateway.connect]] entries loaded; ensure deployment.toml "
+                                    + "defines connect gateways and api-manager.xml was regenerated");
+                        }
                     } else {
                         for (ConnectGatewayConfig entry : list) {
                             if (entry != null && StringUtils.isNotBlank(entry.getRegistrationToken())
-                                    && apiKey.trim().equals(entry.getRegistrationToken().trim())) {
+                                    && PlatformGatewayTokenUtil.constantTimeEquals(
+                                            entry.getRegistrationToken(), apiKey)) {
                                 matchedEntry = entry;
                                 break;
                             }
@@ -186,9 +195,10 @@ public class GatewayConnectEndpoint {
                 log.warn("Could not get platform gateway connect config: " + e.getMessage(), e);
             }
             if (matchedEntry != null && connectConfig != null) {
-                String newGatewayId = UUID.randomUUID().toString();
+                String tokenId = PlatformGatewayTokenUtil.parseTokenId(matchedEntry.getRegistrationToken());
+                String connectGatewayId = PlatformGatewayServiceImpl.resolveConnectGatewayId(tokenId);
                 PlatformGatewayServiceImpl.ensurePlatformGatewayFromConnectToken(
-                        connectConfig, newGatewayId, matchedEntry);
+                        connectConfig, connectGatewayId, matchedEntry);
                 try {
                     gateway = PlatformGatewayTokenUtil.verifyToken(apiKey);
                 } catch (APIManagementException | NoSuchAlgorithmException e) {

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/webapp/WEB-INF/web.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/webapp/WEB-INF/web.xml
@@ -92,13 +92,13 @@
                 org.wso2.carbon.apimgt.rest.api.util.interceptors.auth.BasicAuthenticationInterceptor,
                 org.wso2.carbon.apimgt.rest.api.util.interceptors.auth.PermissionValidationInterceptor(permissions=/permission/admin/ permissions=/permission/protected/),
                 org.wso2.carbon.apimgt.rest.api.util.interceptors.PostAuthenticationInterceptor,
-                org.wso2.carbon.apimgt.rest.api.util.interceptors.OrganizationInterceptor,
-                org.wso2.carbon.apimgt.internal.service.interceptors.PlatformGatewayTenantFlowCleanupInterceptor
+                org.wso2.carbon.apimgt.rest.api.util.interceptors.OrganizationInterceptor
             </param-value>
         </init-param>
         <init-param>
             <param-name>jaxrs.outInterceptors</param-name>
             <param-value>
+                org.wso2.carbon.apimgt.internal.service.interceptors.PlatformGatewayTenantFlowCleanupInterceptor,
                 org.apache.cxf.transport.common.gzip.GZIPOutInterceptor
             </param-value>
         </init-param>

--- a/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/webapp/WEB-INF/web.xml
+++ b/components/apimgt/org.wso2.carbon.apimgt.internal.service/src/main/webapp/WEB-INF/web.xml
@@ -102,6 +102,12 @@
                 org.apache.cxf.transport.common.gzip.GZIPOutInterceptor
             </param-value>
         </init-param>
+        <init-param>
+            <param-name>jaxrs.outFaultInterceptors</param-name>
+            <param-value>
+                org.wso2.carbon.apimgt.internal.service.interceptors.PlatformGatewayTenantFlowCleanupInterceptor
+            </param-value>
+        </init-param>
     </servlet>
     <servlet-mapping>
         <servlet-name>CXFServlet</servlet-name>

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
@@ -445,7 +445,6 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
                     description != null ? gateway.getDescription() : null);
         }
         GatewayVisibilityPermissionConfigurationDTO permissions = null;
-        APIAdmin apiAdmin = new APIAdminImpl();
         Environment env = getStoredPlatformGatewayEnvironment(organization, gateway.getId());
         if (env != null) {
             permissions = env.getPermissions();
@@ -487,7 +486,6 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
 
         // Fetch permissions from environment
         GatewayVisibilityPermissionConfigurationDTO permissions = null;
-        APIAdmin apiAdmin = new APIAdminImpl();
         Environment env = getStoredPlatformGatewayEnvironment(organization, gateway.getId());
         if (env != null) {
             permissions = env.getPermissions();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
@@ -138,12 +138,16 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
         }
     }
 
-    /** Build gateway URL from stored host (DB stores host only). */
-    private static String toGatewayUrl(String host) {
-        if (StringUtils.isBlank(host)) {
+    /** Build gateway URL from stored value (full URL or legacy host[:port]). */
+    private static String toGatewayUrl(String vhost) {
+        if (StringUtils.isBlank(vhost)) {
             return null;
         }
-        return "https://" + host.trim();
+        String trimmed = vhost.trim();
+        if (trimmed.contains("://")) {
+            return trimmed;
+        }
+        return "https://" + trimmed;
     }
 
     /** VHost in request DTOs is URI; convert to string for parsing. */

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
@@ -250,9 +250,17 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
     }
 
     /**
+     * Canonical host:port key for immutable vhost checks. GET returns a full gateway URL; PUT sends that URL back,
+     * while persistence may store host:port or a full URL in {@code GATEWAY_BASE_URL}.
+     */
+    private static String normalizeImmutableVhost(String gatewayUrl, Map<String, Object> properties) {
+        return resolveHostFromGatewayUrl(gatewayUrl, properties);
+    }
+
+    /**
      * Resolve host from vhost URL or, as fallback, from properties.gatewayController.baseUrl.
      */
-    private String resolveHostFromGatewayUrl(String gatewayUrl, Map<String, Object> properties) {
+    private static String resolveHostFromGatewayUrl(String gatewayUrl, Map<String, Object> properties) {
         if (StringUtils.isNotBlank(gatewayUrl)) {
             ParsedGatewayUrl parsed = parseGatewayUrl(gatewayUrl);
             if (parsed != null) {
@@ -429,11 +437,13 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
         if (!Objects.equals(body.getName(), existing.getName())) {
             throw RestApiUtil.buildBadRequestException("name in body must match existing gateway (immutable)");
         }
-        String bodyHost = resolveHostFromGatewayUrl(vhostString(body.getVhost()), body.getProperties());
-        if (bodyHost == null || bodyHost.isEmpty()) {
+        String bodyVhostKey = normalizeImmutableVhost(vhostString(body.getVhost()), body.getProperties());
+        if (bodyVhostKey == null || bodyVhostKey.isEmpty()) {
             throw RestApiUtil.buildBadRequestException("vhost is required for PUT");
         }
-        if (!Objects.equals(bodyHost, existing.getVhost())) {
+        String existingVhostKey = normalizeImmutableVhost(existing.getVhost(),
+                deserializeProperties(existing.getProperties()));
+        if (!Objects.equals(bodyVhostKey, existingVhostKey)) {
             throw RestApiUtil.buildBadRequestException("vhost in body must match existing gateway (immutable)");
         }
         log.info("Updating platform gateway: " + gatewayId);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
@@ -234,8 +234,10 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
             return;
         }
 
-        // Update fields that weren't set during initial creation
-        Map<String, String> environmentAdditionalProperties = new HashMap<>();
+        // Update fields that weren't set during initial creation; preserve existing metadata.
+        Map<String, String> environmentAdditionalProperties = existingEnvironment.getAdditionalProperties() != null
+                ? new HashMap<>(existingEnvironment.getAdditionalProperties())
+                : new HashMap<>();
         environmentAdditionalProperties.put("platformGatewayId", platformGatewayId);
         existingEnvironment.setAdditionalProperties(environmentAdditionalProperties);
 

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
@@ -590,7 +590,9 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
             UpdatePlatformGatewayRequestPermissionsDTO requestPermissions, String newDisplayName, String newDescription)
             throws APIManagementException {
         APIAdmin apiAdmin = new APIAdminImpl();
-        Environment existingEnvironment = getStoredPlatformGatewayEnvironment(organization, gateway.getId());
+        String storageOrg = PlatformGatewayServiceImpl.resolveStorageOrganizationId(organization, gateway.getId());
+        Environment existingEnvironment =
+                storageOrg != null ? apiAdmin.getEnvironment(storageOrg, gateway.getId()) : null;
         if (existingEnvironment == null) {
             log.warn("Environment not found for platform gateway ID: " + gateway.getId() + ", skipping environment update");
             return;
@@ -623,8 +625,7 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
             }
             existingEnvironment.setPermissions(visibility);
         }
-        String storageOrg = PlatformGatewayServiceImpl.resolveStorageOrganizationId(organization, gateway.getId());
-        apiAdmin.updateEnvironment(storageOrg != null ? storageOrg : organization, existingEnvironment);
+        apiAdmin.updateEnvironment(storageOrg, existingEnvironment);
     }
 
     private Environment getStoredPlatformGatewayEnvironment(String organization, String gatewayId)

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/impl/GatewaysApiServiceImpl.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.apimgt.api.model.VHost;
 import org.wso2.carbon.apimgt.impl.APIAdminImpl;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
+import org.wso2.carbon.apimgt.impl.service.PlatformGatewayServiceImpl;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.GatewaysApiService;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.CreatePlatformGatewayRequestDTO;
@@ -445,7 +446,7 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
         }
         GatewayVisibilityPermissionConfigurationDTO permissions = null;
         APIAdmin apiAdmin = new APIAdminImpl();
-        Environment env = apiAdmin.getEnvironment(organization, gateway.getId());
+        Environment env = getStoredPlatformGatewayEnvironment(organization, gateway.getId());
         if (env != null) {
             permissions = env.getPermissions();
         }
@@ -487,7 +488,7 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
         // Fetch permissions from environment
         GatewayVisibilityPermissionConfigurationDTO permissions = null;
         APIAdmin apiAdmin = new APIAdminImpl();
-        Environment env = apiAdmin.getEnvironment(organization, gateway.getId());
+        Environment env = getStoredPlatformGatewayEnvironment(organization, gateway.getId());
         if (env != null) {
             permissions = env.getPermissions();
         }
@@ -591,7 +592,7 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
             UpdatePlatformGatewayRequestPermissionsDTO requestPermissions, String newDisplayName, String newDescription)
             throws APIManagementException {
         APIAdmin apiAdmin = new APIAdminImpl();
-        Environment existingEnvironment = apiAdmin.getEnvironment(organization, gateway.getId());
+        Environment existingEnvironment = getStoredPlatformGatewayEnvironment(organization, gateway.getId());
         if (existingEnvironment == null) {
             log.warn("Environment not found for platform gateway ID: " + gateway.getId() + ", skipping environment update");
             return;
@@ -624,7 +625,17 @@ public class GatewaysApiServiceImpl implements GatewaysApiService {
             }
             existingEnvironment.setPermissions(visibility);
         }
-        apiAdmin.updateEnvironment(organization, existingEnvironment);
+        String storageOrg = PlatformGatewayServiceImpl.resolveStorageOrganizationId(organization, gateway.getId());
+        apiAdmin.updateEnvironment(storageOrg != null ? storageOrg : organization, existingEnvironment);
+    }
+
+    private Environment getStoredPlatformGatewayEnvironment(String organization, String gatewayId)
+            throws APIManagementException {
+        String storageOrg = PlatformGatewayServiceImpl.resolveStorageOrganizationId(organization, gatewayId);
+        if (storageOrg == null) {
+            return null;
+        }
+        return new APIAdminImpl().getEnvironment(storageOrg, gatewayId);
     }
 
     /** Serialize properties map to JSON string for DB storage; null if empty/null. */

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
@@ -17,10 +17,13 @@
 
 package org.wso2.carbon.apimgt.rest.api.admin.v1.utils.mappings;
 
+import org.apache.commons.lang3.StringUtils;
+import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.dto.GatewayVisibilityPermissionConfigurationDTO;
 import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.PlatformGateway;
 import org.wso2.carbon.apimgt.api.model.VHost;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dto.PlatformGatewayConnectConfig;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.rest.api.admin.v1.dto.AdditionalPropertyDTO;
@@ -102,23 +105,33 @@ public class EnvironmentMappingUtil {
         envDTO.setMode(EnvironmentDTO.ModeEnum.WRITE_ONLY);
         envDTO.setType("hybrid");
 
-        // Populate vhosts from platform gateway's vhost
+        // Populate vhosts from platform gateway base URL
         List<VHostDTO> vhosts = new ArrayList<>();
-        if (gateway.getVhost() != null && !gateway.getVhost().isEmpty()) {
-            VHostDTO vhostDTO = new VHostDTO();
-            vhostDTO.setHost(gateway.getVhost());
-            vhostDTO.setHttpPort(80);
-            vhostDTO.setHttpsPort(443);
-            vhostDTO.setWsPort(9099);
-            vhostDTO.setWssPort(8099);
-            vhosts.add(vhostDTO);
+        String baseUrl = gateway.getVhost();
+        if (StringUtils.isNotBlank(baseUrl)) {
+            try {
+                if (baseUrl.contains("://")) {
+                    VHost vhost = VHost.fromEndpointUrls(new String[]{baseUrl.trim()});
+                    vhosts.add(fromVHostToVHostDTO(vhost));
+                    envDTO.setVhost(java.net.URI.create(baseUrl.trim()));
+                } else {
+                    VHostDTO vhostDTO = new VHostDTO();
+                    vhostDTO.setHost(baseUrl.trim());
+                    vhostDTO.setHttpPort(VHost.DEFAULT_HTTP_PORT);
+                    vhostDTO.setHttpsPort(VHost.DEFAULT_HTTPS_PORT);
+                    vhostDTO.setWsPort(9099);
+                    vhostDTO.setWssPort(8099);
+                    vhosts.add(vhostDTO);
+                    envDTO.setVhost(java.net.URI.create(APIConstants.HTTPS_PROTOCOL_URL_PREFIX + baseUrl.trim()));
+                }
+            } catch (APIManagementException e) {
+                VHostDTO vhostDTO = new VHostDTO();
+                vhostDTO.setHost(baseUrl.trim());
+                vhosts.add(vhostDTO);
+            }
         }
         envDTO.setVhosts(vhosts);
         envDTO.setEndpointURIs(new ArrayList<>());
-        // Gateway URL for platform gateways (same shape as Platform Gateways API vhost)
-        if (gateway.getVhost() != null && !gateway.getVhost().isEmpty()) {
-            envDTO.setVhost(java.net.URI.create("https://" + gateway.getVhost().trim()));
-        }
 
         // Include platform gateway metadata in additionalProperties for UI consumption
         List<AdditionalPropertyDTO> additionalProps = new ArrayList<>();

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/admin/v1/utils/mappings/EnvironmentMappingUtil.java
@@ -127,6 +127,10 @@ public class EnvironmentMappingUtil {
             } catch (APIManagementException e) {
                 VHostDTO vhostDTO = new VHostDTO();
                 vhostDTO.setHost(baseUrl.trim());
+                vhostDTO.setHttpPort(VHost.DEFAULT_HTTP_PORT);
+                vhostDTO.setHttpsPort(VHost.DEFAULT_HTTPS_PORT);
+                vhostDTO.setWsPort(9099);
+                vhostDTO.setWssPort(8099);
                 vhosts.add(vhostDTO);
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -675,54 +675,56 @@ public class APIMappingUtil {
         boolean isWs = StringUtils.equalsIgnoreCase("WS", apidto.getType());
         boolean isGQLSubscription = StringUtils.equalsIgnoreCase(APIConstants.GRAPHQL_API, apidto.getType())
                 && isGraphQLSubscriptionsAvailable(apidto);
-        Map<String, String> platformInvocationUrls =
-                PlatformGatewayServiceImpl.resolveInvocationUrlsForTransports(environment, apidto.getTransport());
-        if (!platformInvocationUrls.isEmpty()) {
-            if (platformInvocationUrls.containsKey(APIConstants.HTTP_PROTOCOL)) {
-                apiurLsDTO.setHttp(platformInvocationUrls.get(APIConstants.HTTP_PROTOCOL) + context);
-            }
-            if (platformInvocationUrls.containsKey(APIConstants.HTTPS_PROTOCOL)) {
-                apiurLsDTO.setHttps(platformInvocationUrls.get(APIConstants.HTTPS_PROTOCOL) + context);
-            }
-            if (isGQLSubscription) {
-                apiurLsDTO.setWs(vHost.getWsUrl() + context);
-                apiurLsDTO.setWss(vHost.getWssUrl() + context);
-            }
-            if (isWs) {
-                if (vHost.getWsHost() != null) {
-                    apiurLsDTO.setWs(vHost.getWsUrl() + context);
+        if (StringUtils.isEmpty(customGatewayUrl)) {
+            Map<String, String> platformInvocationUrls =
+                    PlatformGatewayServiceImpl.resolveInvocationUrlsForTransports(environment, apidto.getTransport());
+            if (!platformInvocationUrls.isEmpty()) {
+                if (platformInvocationUrls.containsKey(APIConstants.HTTP_PROTOCOL)) {
+                    apiurLsDTO.setHttp(platformInvocationUrls.get(APIConstants.HTTP_PROTOCOL) + context);
                 }
-                if (vHost.getWssHost() != null) {
-                    apiurLsDTO.setWss(vHost.getWssUrl() + context);
-                }
-            }
-            apiEndpointURLsDTO.setUrLs(apiurLsDTO);
-            if (apidto.isIsDefaultVersion() != null && apidto.isIsDefaultVersion()) {
-                APIDefaultVersionURLsDTO apiDefaultVersionURLsDTO = new APIDefaultVersionURLsDTO();
-                String defaultContext = context.replaceAll("/" + Pattern.quote(apidto.getVersion()) + "$", "");
-                if (apiurLsDTO.getHttp() != null) {
-                    apiDefaultVersionURLsDTO.setHttp(
-                            platformInvocationUrls.get(APIConstants.HTTP_PROTOCOL) + defaultContext);
-                }
-                if (apiurLsDTO.getHttps() != null) {
-                    apiDefaultVersionURLsDTO.setHttps(
-                            platformInvocationUrls.get(APIConstants.HTTPS_PROTOCOL) + defaultContext);
+                if (platformInvocationUrls.containsKey(APIConstants.HTTPS_PROTOCOL)) {
+                    apiurLsDTO.setHttps(platformInvocationUrls.get(APIConstants.HTTPS_PROTOCOL) + context);
                 }
                 if (isGQLSubscription) {
-                    apiDefaultVersionURLsDTO.setWs(vHost.getWsUrl() + defaultContext);
-                    apiDefaultVersionURLsDTO.setWss(vHost.getWssUrl() + defaultContext);
+                    apiurLsDTO.setWs(vHost.getWsUrl() + context);
+                    apiurLsDTO.setWss(vHost.getWssUrl() + context);
                 }
                 if (isWs) {
                     if (vHost.getWsHost() != null) {
-                        apiDefaultVersionURLsDTO.setWs(vHost.getWsUrl() + defaultContext);
+                        apiurLsDTO.setWs(vHost.getWsUrl() + context);
                     }
                     if (vHost.getWssHost() != null) {
-                        apiDefaultVersionURLsDTO.setWss(vHost.getWssUrl() + defaultContext);
+                        apiurLsDTO.setWss(vHost.getWssUrl() + context);
                     }
                 }
-                apiEndpointURLsDTO.setDefaultVersionURLs(apiDefaultVersionURLsDTO);
+                apiEndpointURLsDTO.setUrLs(apiurLsDTO);
+                if (apidto.isIsDefaultVersion() != null && apidto.isIsDefaultVersion()) {
+                    APIDefaultVersionURLsDTO apiDefaultVersionURLsDTO = new APIDefaultVersionURLsDTO();
+                    String defaultContext = context.replaceAll("/" + Pattern.quote(apidto.getVersion()) + "$", "");
+                    if (apiurLsDTO.getHttp() != null) {
+                        apiDefaultVersionURLsDTO.setHttp(
+                                platformInvocationUrls.get(APIConstants.HTTP_PROTOCOL) + defaultContext);
+                    }
+                    if (apiurLsDTO.getHttps() != null) {
+                        apiDefaultVersionURLsDTO.setHttps(
+                                platformInvocationUrls.get(APIConstants.HTTPS_PROTOCOL) + defaultContext);
+                    }
+                    if (isGQLSubscription) {
+                        apiDefaultVersionURLsDTO.setWs(vHost.getWsUrl() + defaultContext);
+                        apiDefaultVersionURLsDTO.setWss(vHost.getWssUrl() + defaultContext);
+                    }
+                    if (isWs) {
+                        if (vHost.getWsHost() != null) {
+                            apiDefaultVersionURLsDTO.setWs(vHost.getWsUrl() + defaultContext);
+                        }
+                        if (vHost.getWssHost() != null) {
+                            apiDefaultVersionURLsDTO.setWss(vHost.getWssUrl() + defaultContext);
+                        }
+                    }
+                    apiEndpointURLsDTO.setDefaultVersionURLs(apiDefaultVersionURLsDTO);
+                }
+                return apiEndpointURLsDTO;
             }
-            return apiEndpointURLsDTO;
         }
         if (!isWs) {
             if (apidto.isInitiatedFromGateway()) {

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -672,6 +672,9 @@ public class APIMappingUtil {
         apiEndpointURLsDTO.setEnvironmentType(environment.getType());
 
         APIURLsDTO apiurLsDTO = new APIURLsDTO();
+        boolean isWs = StringUtils.equalsIgnoreCase("WS", apidto.getType());
+        boolean isGQLSubscription = StringUtils.equalsIgnoreCase(APIConstants.GRAPHQL_API, apidto.getType())
+                && isGraphQLSubscriptionsAvailable(apidto);
         Map<String, String> platformInvocationUrls =
                 PlatformGatewayServiceImpl.resolveInvocationUrlsForTransports(environment, apidto.getTransport());
         if (!platformInvocationUrls.isEmpty()) {
@@ -680,6 +683,18 @@ public class APIMappingUtil {
             }
             if (platformInvocationUrls.containsKey(APIConstants.HTTPS_PROTOCOL)) {
                 apiurLsDTO.setHttps(platformInvocationUrls.get(APIConstants.HTTPS_PROTOCOL) + context);
+            }
+            if (isGQLSubscription) {
+                apiurLsDTO.setWs(vHost.getWsUrl() + context);
+                apiurLsDTO.setWss(vHost.getWssUrl() + context);
+            }
+            if (isWs) {
+                if (vHost.getWsHost() != null) {
+                    apiurLsDTO.setWs(vHost.getWsUrl() + context);
+                }
+                if (vHost.getWssHost() != null) {
+                    apiurLsDTO.setWss(vHost.getWssUrl() + context);
+                }
             }
             apiEndpointURLsDTO.setUrLs(apiurLsDTO);
             if (apidto.isIsDefaultVersion() != null && apidto.isIsDefaultVersion()) {
@@ -693,13 +708,22 @@ public class APIMappingUtil {
                     apiDefaultVersionURLsDTO.setHttps(
                             platformInvocationUrls.get(APIConstants.HTTPS_PROTOCOL) + defaultContext);
                 }
+                if (isGQLSubscription) {
+                    apiDefaultVersionURLsDTO.setWs(vHost.getWsUrl() + defaultContext);
+                    apiDefaultVersionURLsDTO.setWss(vHost.getWssUrl() + defaultContext);
+                }
+                if (isWs) {
+                    if (vHost.getWsHost() != null) {
+                        apiDefaultVersionURLsDTO.setWs(vHost.getWsUrl() + defaultContext);
+                    }
+                    if (vHost.getWssHost() != null) {
+                        apiDefaultVersionURLsDTO.setWss(vHost.getWssUrl() + defaultContext);
+                    }
+                }
                 apiEndpointURLsDTO.setDefaultVersionURLs(apiDefaultVersionURLsDTO);
             }
             return apiEndpointURLsDTO;
         }
-        boolean isWs = StringUtils.equalsIgnoreCase("WS", apidto.getType());
-        boolean isGQLSubscription = StringUtils.equalsIgnoreCase(APIConstants.GRAPHQL_API, apidto.getType())
-                && isGraphQLSubscriptionsAvailable(apidto);
         if (!isWs) {
             if (apidto.isInitiatedFromGateway()) {
                 APIURLsDTO extractedURLs;

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.apimgt.rest.api.store.v1.mappings;
 
+import java.util.regex.Pattern;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -683,7 +684,7 @@ public class APIMappingUtil {
             apiEndpointURLsDTO.setUrLs(apiurLsDTO);
             if (apidto.isIsDefaultVersion() != null && apidto.isIsDefaultVersion()) {
                 APIDefaultVersionURLsDTO apiDefaultVersionURLsDTO = new APIDefaultVersionURLsDTO();
-                String defaultContext = context.replaceAll("/" + apidto.getVersion() + "$", "");
+                String defaultContext = context.replaceAll("/" + Pattern.quote(apidto.getVersion()) + "$", "");
                 if (apiurLsDTO.getHttp() != null) {
                     apiDefaultVersionURLsDTO.setHttp(
                             platformInvocationUrls.get(APIConstants.HTTP_PROTOCOL) + defaultContext);
@@ -751,7 +752,7 @@ public class APIMappingUtil {
 
         APIDefaultVersionURLsDTO apiDefaultVersionURLsDTO = new APIDefaultVersionURLsDTO();
         if (apidto.isIsDefaultVersion() != null && apidto.isIsDefaultVersion()) {
-            String defaultContext = context.replaceAll("/" + apidto.getVersion() + "$", "");
+            String defaultContext = context.replaceAll("/" + Pattern.quote(apidto.getVersion()) + "$", "");
             if (!isWs) {
                 if (apidto.getTransport().contains(APIConstants.HTTP_PROTOCOL)) {
                     apiDefaultVersionURLsDTO.setHttp(vHost.getHttpUrl() + defaultContext);

--- a/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.rest.api.store.v1/src/main/java/org/wso2/carbon/apimgt/rest/api/store/v1/mappings/APIMappingUtil.java
@@ -50,6 +50,7 @@ import org.wso2.carbon.apimgt.impl.factory.GatewayHolder;
 import org.wso2.carbon.apimgt.impl.internal.ServiceReferenceHolder;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.impl.utils.VHostUtils;
+import org.wso2.carbon.apimgt.impl.service.PlatformGatewayServiceImpl;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiCommonUtil;
 import org.wso2.carbon.apimgt.rest.api.common.RestApiConstants;
 import org.wso2.carbon.apimgt.rest.api.store.v1.dto.APIBusinessInformationDTO;
@@ -636,7 +637,7 @@ public class APIMappingUtil {
         VHost vHost;
         String context = apidto.getContext();
         if (StringUtils.isEmpty(customGatewayUrl)) {
-            vHost = VHostUtils.getVhostFromEnvironment(environment, host);
+            vHost = VHostUtils.getInvocationVhostFromEnvironment(environment, host);
         } else {
             if (!StringUtils.contains(customGatewayUrl, "://")) {
                 customGatewayUrl = APIConstants.HTTPS_PROTOCOL_URL_PREFIX + customGatewayUrl;
@@ -670,6 +671,31 @@ public class APIMappingUtil {
         apiEndpointURLsDTO.setEnvironmentType(environment.getType());
 
         APIURLsDTO apiurLsDTO = new APIURLsDTO();
+        Map<String, String> platformInvocationUrls =
+                PlatformGatewayServiceImpl.resolveInvocationUrlsForTransports(environment, apidto.getTransport());
+        if (!platformInvocationUrls.isEmpty()) {
+            if (platformInvocationUrls.containsKey(APIConstants.HTTP_PROTOCOL)) {
+                apiurLsDTO.setHttp(platformInvocationUrls.get(APIConstants.HTTP_PROTOCOL) + context);
+            }
+            if (platformInvocationUrls.containsKey(APIConstants.HTTPS_PROTOCOL)) {
+                apiurLsDTO.setHttps(platformInvocationUrls.get(APIConstants.HTTPS_PROTOCOL) + context);
+            }
+            apiEndpointURLsDTO.setUrLs(apiurLsDTO);
+            if (apidto.isIsDefaultVersion() != null && apidto.isIsDefaultVersion()) {
+                APIDefaultVersionURLsDTO apiDefaultVersionURLsDTO = new APIDefaultVersionURLsDTO();
+                String defaultContext = context.replaceAll("/" + apidto.getVersion() + "$", "");
+                if (apiurLsDTO.getHttp() != null) {
+                    apiDefaultVersionURLsDTO.setHttp(
+                            platformInvocationUrls.get(APIConstants.HTTP_PROTOCOL) + defaultContext);
+                }
+                if (apiurLsDTO.getHttps() != null) {
+                    apiDefaultVersionURLsDTO.setHttps(
+                            platformInvocationUrls.get(APIConstants.HTTPS_PROTOCOL) + defaultContext);
+                }
+                apiEndpointURLsDTO.setDefaultVersionURLs(apiDefaultVersionURLsDTO);
+            }
+            return apiEndpointURLsDTO;
+        }
         boolean isWs = StringUtils.equalsIgnoreCase("WS", apidto.getType());
         boolean isGQLSubscription = StringUtils.equalsIgnoreCase(APIConstants.GRAPHQL_API, apidto.getType())
                 && isGraphQLSubscriptionsAvailable(apidto);

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -2140,7 +2140,9 @@
               <ConnectGateways>
               {% for c in apim.platform_gateway.connect %}
                 <Connect>
+                    {% if c.registration_token is defined and c.registration_token %}
                     <RegistrationToken>{{ c.registration_token }}</RegistrationToken>
+                    {% endif %}
                     {% if c.name is defined and c.name %}
                     <Name>{{ c.name }}</Name>
                     {% endif %}

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -2127,13 +2127,36 @@
               <ExpireTimeSeconds>{{apim.gateway_notification.cleanup.expiry_time}}</ExpireTimeSeconds>
               <DataRetentionPeriodSeconds>{{apim.gateway_notification.cleanup.data_retention_period}}</DataRetentionPeriodSeconds>
           </GatewayCleanup>
-          {% if apim.platform_gateway.versions is defined and apim.platform_gateway.versions | length > 0 %}
+          {% if (apim.platform_gateway.versions is defined and apim.platform_gateway.versions | length > 0) or (apim.platform_gateway.connect is defined and apim.platform_gateway.connect | length > 0) %}
           <PlatformGatewayConnectConfiguration>
+              {% if apim.platform_gateway.versions is defined and apim.platform_gateway.versions | length > 0 %}
               <PlatformGatewayVersions>
               {% for version in apim.platform_gateway.versions %}
                   <Version>{{ version }}</Version>
               {% endfor %}
               </PlatformGatewayVersions>
+              {% endif %}
+              {% if apim.platform_gateway.connect is defined and apim.platform_gateway.connect | length > 0 %}
+              <ConnectGateways>
+              {% for c in apim.platform_gateway.connect %}
+                <Connect>
+                    <RegistrationToken>{{ c.registration_token }}</RegistrationToken>
+                    {% if c.name is defined and c.name %}
+                    <Name>{{ c.name }}</Name>
+                    {% endif %}
+                    {% if c.display_name is defined and c.display_name %}
+                    <DisplayName>{{ c.display_name }}</DisplayName>
+                    {% endif %}
+                    {% if c.description is defined and c.description %}
+                    <Description>{{ c.description }}</Description>
+                    {% endif %}
+                    {% if c.url is defined and c.url %}
+                    <Url>{{ c.url }}</Url>
+                    {% endif %}
+                </Connect>
+              {% endfor %}
+              </ConnectGateways>
+              {% endif %}
           </PlatformGatewayConnectConfiguration>
           {% endif %}
           <APIKeyNotification>

--- a/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
+++ b/features/apimgt/org.wso2.carbon.apimgt.core.feature/src/main/resources/conf_templates/templates/repository/conf/api-manager.xml.j2
@@ -2153,6 +2153,9 @@
                     {% if c.url is defined and c.url %}
                     <Url>{{ c.url }}</Url>
                     {% endif %}
+                    {% if c.organization is defined and c.organization %}
+                    <Organization>{{ c.organization }}</Organization>
+                    {% endif %}
                 </Connect>
               {% endfor %}
               </ConnectGateways>


### PR DESCRIPTION
### Description

This pull request introduces support for configuring and connecting multiple self-hosted Platform Gateways using a new "connect-with-token" mechanism. It adds new configuration structures, parsing logic, and supporting DTOs, and updates service logic to handle organization scoping more robustly. The changes enable administrators to register multiple gateways via configuration, each with its own metadata and access token, and ensure correct organization handling for gateway operations.

**Platform Gateway connect-with-token configuration:**

- Added a new DTO, `ConnectGatewayConfig`, to represent individual connect-with-token gateway entries, including validation for the gateway URL and support for optional organization scoping. (`components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/ConnectGatewayConfig.java`)
- Extended `PlatformGatewayConnectConfig` to include a list of `ConnectGatewayConfig` objects, representing all configured connect-with-token gateways. (`components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/dto/PlatformGatewayConnectConfig.java`) [[1]](diffhunk://#diff-050a6dd4e247f89efdd3b2450c3f7ccbd297e6dd615ebea06e2818fe17579ba6L26-R35) [[2]](diffhunk://#diff-050a6dd4e247f89efdd3b2450c3f7ccbd297e6dd615ebea06e2818fe17579ba6R49-R62)

**Configuration parsing and initialization:**

- Updated the configuration parsing logic in `APIManagerConfiguration` to read and construct connect-with-token gateway entries from the config file, populating the new `PlatformGatewayConnectConfig`. (`components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIManagerConfiguration.java`) [[1]](diffhunk://#diff-6ad5a30e0da551268318842e70c7a6e235b4e71a5985b57b662723142c8d9ff9R3647-R3697) [[2]](diffhunk://#diff-6ad5a30e0da551268318842e70c7a6e235b4e71a5985b57b662723142c8d9ff9L3655-R3707)
- Added new constants for connect-with-token configuration keys in `APIConstants`. (`components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIConstants.java`)
- On component activation, added a call to perform platform gateway connect initialization if configured. (`components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/internal/APIManagerComponent.java`) [[1]](diffhunk://#diff-c16b45897441f222c922fdd27a30fe9162086a2c3484faaed73ed0473ada35efR97) [[2]](diffhunk://#diff-c16b45897441f222c922fdd27a30fe9162086a2c3484faaed73ed0473ada35efR239)

**Service and environment handling improvements:**

- Added a utility method to convert a connect-with-token config entry to an `Environment` object, including vhost and port handling. (`components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java`)
- Refactored organization handling in gateway CRUD operations to properly resolve the storage organization, supporting global and per-tenant gateways and ensuring correct API revision checks and updates. (`components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java`) [[1]](diffhunk://#diff-bb6128497bbcaa51282dc6600ef8be58ddd15a5a8e506885ba89a89f2f04b9b8L241-R288) [[2]](diffhunk://#diff-bb6128497bbcaa51282dc6600ef8be58ddd15a5a8e506885ba89a89f2f04b9b8L264-R318) [[3]](diffhunk://#diff-bb6128497bbcaa51282dc6600ef8be58ddd15a5a8e506885ba89a89f2f04b9b8L281-R339) [[4]](diffhunk://#diff-bb6128497bbcaa51282dc6600ef8be58ddd15a5a8e506885ba89a89f2f04b9b8L306-R366)
- Minor refactoring to make some helper methods static and improve clarity. (`components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/service/PlatformGatewayServiceImpl.java`)

### Goal
Fixes: https://github.com/wso2/api-manager/issues/5119

### Configuration
Add entries under `[[apim.platform_gateway.connect]]` in `deployment.toml`:
```
apim.platform_gateway.versions = ["1.0.0"]
[[apim.platform_gateway.connect]]
registration_token = "tokenId.plainToken"
name = "platform-gw-1"
display_name = "Production Platform Gateway"
url = "https://gw.example.com:8243"
organization = "carbon.super"   # optional
```

Field | Required | Description
-- | -- | --
registration_token | Yes | tokenId.plainToken format
url | Yes | Gateway base URL (http/https)
name | No | Environment name; falls back to gateway UUID
display_name | No | Display name in Admin/Publisher
description | No | Gateway description
organization | No | Tenant org domain; defaults to carbon.super; set WSO2-ALL-TENANTS for a shared gateway visible to all tenants


