### PR TITLE
Fix governance ZIP-entry matching for API/MCP metadata and Windows documentation extraction

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/APIGovernanceHandler.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.governance.impl/src/main/java/org/wso2/carbon/apimgt/governance/impl/APIGovernanceHandler.java
@@ -523,8 +523,8 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
         try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(apiProjectZip))) {
             ZipEntry entry;
             while ((entry = zipInputStream.getNextEntry()) != null) {
-                if (entry.getName().contains(APIMGovernanceConstants.API_FILE_NAME) ||
-                        entry.getName().contains(APIMGovernanceConstants.MCP_FILE_NAME)) {
+                if (entry.getName().contains("/" + APIMGovernanceConstants.API_FILE_NAME) ||
+                        entry.getName().contains("/" + APIMGovernanceConstants.MCP_FILE_NAME)) {
                     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                     byte[] buffer = new byte[1024];
                     int length;
@@ -598,7 +598,7 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
                         && ExtendedArtifactType.REST_API.equals(extendedArtifactType))
                         || (entry.getName().contains(asyncAPIPath) &&
                         ExtendedArtifactType.ASYNC_API.equals(extendedArtifactType))
-                        || (entry.getName().contains(APIMGovernanceConstants.MCP_FILE_NAME) &&
+                        || (entry.getName().contains("/" + APIMGovernanceConstants.MCP_FILE_NAME) &&
                         ExtendedArtifactType.MCP.equals(extendedArtifactType))) {
                     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                     byte[] buffer = new byte[1024];
@@ -626,7 +626,7 @@ public class APIGovernanceHandler implements ArtifactGovernanceHandler {
     public static String extractDocData(byte[] apiProjectZip) throws APIMGovernanceException {
         ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 
-        String rootFolder = APIMGovernanceConstants.DOCS_FOLDER + File.separator;
+        String rootFolder = APIMGovernanceConstants.DOCS_FOLDER + "/";
         String docMetadataFile = APIMGovernanceConstants.DOC_META_DATA_FILE_NAME;
         List<Object> docsList = new ArrayList<>();
         int count = 0;


### PR DESCRIPTION
## Problem
Governance ZIP-entry matching used a bare `contains(...)`, meaning a policy artifact ending in `_api.yaml` or `_mcp_server.yaml` could be selected instead of the real `api.yaml` or `mcp_server.yaml`. This produced a null `extendedArtifactType` and caused the compliance evaluation to fail.

Additionally, `extractDocData` matched the `Docs` folder using `File.separator` (which resolves to `\` on Windows). Because ZIP entries are always `/`-normalized, this never matched, and API documentation was silently excluded from governance on Windows.

Resolves: https://github.com/wso2/api-manager/issues/5089

## Fix
* `extractAPIMetadata` / `extractAPIDefinition`: Anchored `api.yaml` and `mcp_server.yaml` matches to a leading `/` (since ZIP entries are always `/`-normalized).
* `extractDocData`: Updated to use a hardcoded `/` instead of `File.separator`.

## Testing
* Verified decoy rejection for API and MCP metadata, as well as MCP definition (the real file is selected, and `*_api.yaml` / `*_mcp_server.yaml` decoys are properly rejected).
* Verified that normal REST API, MCP server, and documentation extraction behavior remains unchanged.