### PR TITLE
Validate MCP backend operations against the referenced API on update

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.api/src/main/java/org/wso2/carbon/apimgt/api/ExceptionCodes.java
@@ -923,6 +923,8 @@ public enum ExceptionCodes implements ErrorHandler {
             "Referenced API is not supported for MCP Server."),
     DUPLICATE_MCP_TOOLS(904013, "Duplicate MCP tools", 400,
             "One or more MCP tools are duplicated."),
+    INVALID_MCP_BACKEND_OPERATION(904014, "Invalid MCP backend operation", 400,
+            "The backend operation '%s %s' does not match any resource in the referenced API '%s'."),
 
     // gateway notification related codes
     GATEWAY_NOTIFICATION_BAD_REQUEST(902052, "Invalid request for gateway notification", 400,

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/APIProviderImpl.java
@@ -1405,6 +1405,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
     private void updateAPI(API api, int tenantId, String username) throws APIManagementException {
 
         MCPUtils.validateMCPResources(api.getUuid(), api.getOrganization(), api.getUriTemplates());
+        MCPUtils.validateMCPBackendOperations(api);
         apiMgtDAO.updateAPI(api, username);
         if (log.isDebugEnabled()) {
             log.debug("Successfully updated the API: " + api.getId() + " metadata in the database");

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/MCPUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/MCPUtils.java
@@ -22,7 +22,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
+import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
+import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
 
 import java.util.Map;
@@ -71,6 +73,47 @@ public class MCPUtils {
                 if (!resourceFound) {
                     throw new APIManagementException("Cannot delete MCP attached resources from API",
                             ExceptionCodes.API_UPDATE_FORBIDDEN_PER_MCP_USAGE);
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates that each backend operation of an MCP server (created from an existing API) maps to a resource
+     * that exists in the referenced API, rejecting invalid operations before any persistence or deletion.
+     *
+     * @param api the MCP server to validate
+     * @throws APIManagementException if a backend operation has no matching resource in the referenced API
+     */
+    public static void validateMCPBackendOperations(API api) throws APIManagementException {
+
+        if (!APIConstants.API_TYPE_MCP.equals(api.getType())
+                || !APIConstants.API_SUBTYPE_EXISTING_API.equals(api.getSubtype())) {
+            return;
+        }
+        Set<URITemplate> uriTemplates = api.getUriTemplates();
+        if (uriTemplates == null || uriTemplates.isEmpty()) {
+            return;
+        }
+        URITemplate firstTemplate = uriTemplates.iterator().next();
+        if (firstTemplate.getAPIOperationMapping() == null) {
+            return;
+        }
+        String referencedApiId = firstTemplate.getAPIOperationMapping().getApiUuid();
+        Set<URITemplate> referencedUriTemplates = ApiMgtDAO.getInstance().getURITemplatesOfAPI(referencedApiId);
+        if (referencedUriTemplates == null || referencedUriTemplates.isEmpty()) {
+            return;
+        }
+        for (URITemplate uriTemplate : uriTemplates) {
+            if (uriTemplate.getAPIOperationMapping() != null) {
+                String target = uriTemplate.getAPIOperationMapping().getBackendOperation().getTarget();
+                String verb = uriTemplate.getAPIOperationMapping().getBackendOperation().getVerb().toString();
+                if (ApiMgtDAO.findMatchingTemplate(referencedUriTemplates, target, verb) == null) {
+                    throw new APIManagementException(
+                            "No matching resource found in the referenced API '" + referencedApiId
+                                    + "' for backend operation: " + verb + " " + target,
+                            ExceptionCodes.from(ExceptionCodes.INVALID_MCP_BACKEND_OPERATION, verb, target,
+                                    referencedApiId));
                 }
             }
         }

--- a/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/MCPUtils.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.impl/src/main/java/org/wso2/carbon/apimgt/impl/utils/MCPUtils.java
@@ -23,6 +23,8 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.ExceptionCodes;
 import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIOperationMapping;
+import org.wso2.carbon.apimgt.api.model.BackendOperation;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.dao.ApiMgtDAO;
@@ -95,26 +97,37 @@ public class MCPUtils {
         if (uriTemplates == null || uriTemplates.isEmpty()) {
             return;
         }
-        URITemplate firstTemplate = uriTemplates.iterator().next();
-        if (firstTemplate.getAPIOperationMapping() == null) {
+        String referencedApiId = null;
+        for (URITemplate uriTemplate : uriTemplates) {
+            if (uriTemplate.getAPIOperationMapping() != null) {
+                referencedApiId = uriTemplate.getAPIOperationMapping().getApiUuid();
+                break;
+            }
+        }
+        if (referencedApiId == null) {
             return;
         }
-        String referencedApiId = firstTemplate.getAPIOperationMapping().getApiUuid();
         Set<URITemplate> referencedUriTemplates = ApiMgtDAO.getInstance().getURITemplatesOfAPI(referencedApiId);
         if (referencedUriTemplates == null || referencedUriTemplates.isEmpty()) {
             return;
         }
         for (URITemplate uriTemplate : uriTemplates) {
-            if (uriTemplate.getAPIOperationMapping() != null) {
-                String target = uriTemplate.getAPIOperationMapping().getBackendOperation().getTarget();
-                String verb = uriTemplate.getAPIOperationMapping().getBackendOperation().getVerb().toString();
-                if (ApiMgtDAO.findMatchingTemplate(referencedUriTemplates, target, verb) == null) {
-                    throw new APIManagementException(
-                            "No matching resource found in the referenced API '" + referencedApiId
-                                    + "' for backend operation: " + verb + " " + target,
-                            ExceptionCodes.from(ExceptionCodes.INVALID_MCP_BACKEND_OPERATION, verb, target,
-                                    referencedApiId));
-                }
+            APIOperationMapping operationMapping = uriTemplate.getAPIOperationMapping();
+            if (operationMapping == null) {
+                continue;
+            }
+            BackendOperation backendOperation = operationMapping.getBackendOperation();
+            if (backendOperation == null || backendOperation.getVerb() == null) {
+                continue;
+            }
+            String target = backendOperation.getTarget();
+            String verb = backendOperation.getVerb().toString();
+            if (ApiMgtDAO.findMatchingTemplate(referencedUriTemplates, target, verb) == null) {
+                throw new APIManagementException(
+                        "No matching resource found in the referenced API '" + referencedApiId
+                                + "' for backend operation: " + verb + " " + target,
+                        ExceptionCodes.from(ExceptionCodes.INVALID_MCP_BACKEND_OPERATION, verb, target,
+                                referencedApiId));
             }
         }
     }


### PR DESCRIPTION
## Problem
For an MCP server created from an existing API, each tool maps to a resource via its backend operation (`target` + `verb`). Updating a tool's `verb` to one the referenced API doesn't expose (e.g., `PUT /books` when only `GET /books` exists) was accepted with HTTP 200, but the mapping was silently dropped - leaving `apiOperationMapping` `null` and crashing the Publisher Tools page with `TypeError: ... reading 'toLowerCase'`.

Related Issue : https://github.com/wso2/api-manager/issues/5106

## Fix
Validate each MCP backend operation against the referenced API's resources up front in `updateAPI`, before any mapping is deleted, and reject invalid ones with an HTTP 400 `INVALID_MCP_BACKEND_OPERATION` error.

## Changes
* `ExceptionCodes`: add `INVALID_MCP_BACKEND_OPERATION` (400)
* `MCPUtils.validateMCPBackendOperations(api)`: validate each tool's (`target`, `verb`)
* `APIProviderImpl.updateAPI`: call the validator before persistence